### PR TITLE
ci: add linting for generated api snippets

### DIFF
--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -3215,9 +3215,16 @@
             <div class="operation-group-name">
               <a href="#group-Queries">Queries</a>
             </div>
-            <h2 class="operation-heading ">
+            <h2 class="operation-heading operation-deprecated">
               <code>pipeline</code>
             </h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="doc-copy-section">
+                  <div class="deprecation-reason"> Explicit pipeline creation is now a no-op </div>
+                </div>
+              </div>
+            </div>
             <div class="doc-row">
               <div class="doc-copy">
                 <div class="operation-description doc-copy-section">
@@ -3947,8 +3954,9 @@
                         <td> Retrieves the list of paths where a directory is mounted. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="Container-pipeline" href="#Container-pipeline"><code>pipeline</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td> Creates a named sub-pipeline. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="Container-pipeline" href="#Container-pipeline"><code>pipeline</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td> Creates a named sub-pipeline. <span class="deprecation-reason">Explicit pipeline creation is now a no-op</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -5422,8 +5430,9 @@
                         <td> A unique identifier for this Directory. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="Directory-pipeline" href="#Directory-pipeline"><code>pipeline</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
-                        <td> Creates a named sub-pipeline. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="Directory-pipeline" href="#Directory-pipeline"><code>pipeline</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
+                        <td> Creates a named sub-pipeline. <span class="deprecation-reason">Explicit pipeline creation is now a no-op</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -8106,8 +8115,8 @@
                   <html>
                     <head></head>
                     <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"xyz789"</span>
+  <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"value"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"abc123"</span>
 <span class="hljs-punctuation">}</span>
 </code></pre>
                     </body>


### PR DESCRIPTION
@helderco noticed that https://github.com/dagger/dagger/pull/7937 introduced an issue in https://github.com/dagger/dagger/pull/7948#discussion_r1682570312:

> Is this now always producing a diff on generate due to random ids? Might make sense to discard changes if so.

This makes sure we actually run the docs generate step! (which it doesn't look like we've been doing enough!)
    
To do this though we need to use a temporary fork of spectaql that has reproducible example snippets. See https://github.com/anvilco/spectaql/issues/976 for the upstream PR.