### PR TITLE
feat: automatically generate sync methods for user objects

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1035,7 +1035,13 @@ func (container *Container) WithGPU(ctx context.Context, gpuOpts ContainerGPUOpt
 	return container, nil
 }
 
-func (container Container) Evaluate(ctx context.Context) (*buildkit.Result, error) {
+func (container Container) Evaluate(ctx context.Context) error {
+	_, err := container.evaluate(ctx)
+	return err
+}
+
+//noline:unparam
+func (container Container) evaluate(ctx context.Context) (*buildkit.Result, error) {
 	if container.FS == nil {
 		return nil, nil
 	}

--- a/core/directory.go
+++ b/core/directory.go
@@ -145,7 +145,12 @@ func (dir *Directory) WithPipeline(ctx context.Context, name, description string
 	return dir, nil
 }
 
-func (dir *Directory) Evaluate(ctx context.Context) (*buildkit.Result, error) {
+func (dir *Directory) Evaluate(ctx context.Context) error {
+	_, err := dir.evaluate(ctx)
+	return err
+}
+
+func (dir *Directory) evaluate(ctx context.Context) (*buildkit.Result, error) {
 	if dir.LLB == nil {
 		return nil, nil
 	}
@@ -172,7 +177,7 @@ func (dir *Directory) Evaluate(ctx context.Context) (*buildkit.Result, error) {
 }
 
 func (dir *Directory) Digest(ctx context.Context) (string, error) {
-	result, err := dir.Evaluate(ctx)
+	result, err := dir.evaluate(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to evaluate file: %w", err)
 	}

--- a/core/file.go
+++ b/core/file.go
@@ -116,7 +116,12 @@ func (file *File) State() (llb.State, error) {
 	return defToState(file.LLB)
 }
 
-func (file *File) Evaluate(ctx context.Context) (*buildkit.Result, error) {
+func (file *File) Evaluate(ctx context.Context) error {
+	_, err := file.evaluate(ctx)
+	return err
+}
+
+func (file *File) evaluate(ctx context.Context) (*buildkit.Result, error) {
 	svcs, err := file.Query.Services(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get services: %w", err)
@@ -201,7 +206,7 @@ func (file *File) Contents(ctx context.Context) ([]byte, error) {
 func (file *File) Digest(ctx context.Context, excludeMetadata bool) (string, error) {
 	// If metadata are included, directly compute the digest of the file
 	if !excludeMetadata {
-		result, err := file.Evaluate(ctx)
+		result, err := file.evaluate(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to evaluate file: %w", err)
 		}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -287,7 +287,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		return nil, fmt.Errorf("failed to exec function: %w", err)
 	}
 
-	_, err = ctr.Evaluate(ctx)
+	_, err = ctr.evaluate(ctx)
 	if err != nil {
 		if fn.metadata.OriginalName == "" {
 			return nil, fmt.Errorf("call constructor: %w", err)
@@ -301,7 +301,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		return nil, fmt.Errorf("failed to get function output directory: %w", err)
 	}
 
-	result, err := ctrOutputDir.Evaluate(ctx)
+	result, err := ctrOutputDir.evaluate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate function: %w", err)
 	}

--- a/core/module.go
+++ b/core/module.go
@@ -438,6 +438,9 @@ func (mod *Module) validateObjectTypeDef(ctx context.Context, typeDef *TypeDef) 
 		if gqlFieldName(field.Name) == "id" {
 			return fmt.Errorf("cannot define field with reserved name %q on object %q", field.Name, obj.Name)
 		}
+		if gqlFieldName(field.Name) == "sync" {
+			return fmt.Errorf("cannot define field with reserved name %q on object %q", field.Name, obj.Name)
+		}
 		fieldType, ok, err := mod.Deps.ModTypeFor(ctx, field.TypeDef)
 		if err != nil {
 			return fmt.Errorf("failed to get mod type for type def: %w", err)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -38,7 +38,7 @@ func (s *containerSchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*core.Container]{
-		Syncer[*core.Container]().
+		core.Syncer[*core.Container]().
 			Doc(`Forces evaluation of the pipeline in the engine.`,
 				`It doesn't run the default command if no exec has been set.`),
 
@@ -617,7 +617,7 @@ func (s *containerSchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*coreTerminalLegacy]{
-		Syncer[*coreTerminalLegacy]().
+		core.Syncer[*coreTerminalLegacy]().
 			Doc(`Forces evaluation of the pipeline in the engine.`,
 				`It doesn't run the default command if no exec has been set.`),
 
@@ -1744,8 +1744,8 @@ func (*coreTerminalLegacy) TypeDescription() string {
 	return "An interactive terminal that clients can connect to."
 }
 
-func (*coreTerminalLegacy) Evaluate(ctx context.Context) (*buildkit.Result, error) {
-	return nil, nil
+func (*coreTerminalLegacy) Evaluate(ctx context.Context) error {
+	return nil
 }
 
 func (s *containerSchema) terminalLegacyWebsocketEndpoint(ctx context.Context, parent *coreTerminalLegacy, args struct{}) (string, error) {

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -143,6 +143,9 @@ func (m *CoreMod) TypeDefs(ctx context.Context) ([]*core.TypeDef, error) {
 					isIdable = true
 					continue
 				}
+				if introspectionField.Name == "sync" {
+					continue
+				}
 
 				fn := &core.Function{
 					Name:        introspectionField.Name,

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -22,7 +22,7 @@ func (s *directorySchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*core.Directory]{
-		Syncer[*core.Directory]().
+		core.Syncer[*core.Directory]().
 			Doc(`Force evaluation in the engine.`),
 		dagql.Func("pipeline", s.pipeline).
 			View(BeforeVersion("v0.13.0")).

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -17,7 +17,7 @@ var _ SchemaResolvers = &fileSchema{}
 
 func (s *fileSchema) Install() {
 	dagql.Fields[*core.File]{
-		Syncer[*core.File]().
+		core.Syncer[*core.File]().
 			Doc(`Force evaluation in the engine.`),
 		dagql.Func("contents", s.contents).
 			Doc(`Retrieves the contents of the file.`),

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -10,27 +10,10 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/introspection"
-	"github.com/dagger/dagger/engine/buildkit"
 )
 
 type SchemaResolvers interface {
 	Install()
-}
-
-type Evaluatable interface {
-	dagql.Typed
-	Evaluate(context.Context) (*buildkit.Result, error)
-}
-
-func Syncer[T Evaluatable]() dagql.Field[T] {
-	return dagql.NodeFunc("sync", func(ctx context.Context, self dagql.Instance[T], _ struct{}) (dagql.ID[T], error) {
-		_, err := self.Self.Evaluate(ctx)
-		if err != nil {
-			var zero dagql.ID[T]
-			return zero, err
-		}
-		return dagql.NewID[T](self.ID()), nil
-	})
 }
 
 func collectInputsSlice[T dagql.Type](inputs []dagql.InputObject[T]) []T {

--- a/core/sync.go
+++ b/core/sync.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"context"
+
+	"github.com/dagger/dagger/dagql"
+)
+
+type Evaluatable interface {
+	dagql.Typed
+	Evaluate(context.Context) error
+}
+
+func Syncer[T Evaluatable]() dagql.Field[T] {
+	return dagql.NodeFunc("sync", func(ctx context.Context, self dagql.Instance[T], _ struct{}) (dagql.ID[T], error) {
+		err := self.Self.Evaluate(ctx)
+		if err != nil {
+			var zero dagql.ID[T]
+			return zero, err
+		}
+		return dagql.NewID[T](self.ID()), nil
+	})
+}
+
+func DynamicSyncer[T Evaluatable](t dagql.Typed) dagql.Field[T] {
+	field := dagql.NodeFunc("sync", func(ctx context.Context, self dagql.Instance[T], _ struct{}) (dagql.ID[T], error) {
+		err := self.Self.Evaluate(ctx)
+		if err != nil {
+			var zero dagql.ID[T]
+			return zero, err
+		}
+		return dagql.NewDynamicID[T](self.ID(), self.Self), nil
+	})
+	field.Spec.Type = dagql.NewDynamicID(nil, t)
+	return field
+}


### PR DESCRIPTION
We've chatted about something like this before - the idea is that we should automagically generate `Sync` methods for user defined types.

Today, users can kind of fake this by calling `id` on an object. However, this is really hacky, and additionally with the kind of changes suggested in https://github.com/dagger/dagger/pull/7761 this would no longer be possible.

Instead, we should have a real way of forcing evaluation for a specific user object, by automatically generating `Sync` methods for all user objects. Additionally, `Sync` should also ensure that all other `Sync`able fields of a user object are also `Sync`ed - I think this is mostly expected?

