### PR TITLE
Fix `failed to collect IDs from parent fields`

### DIFF
--- a/.changes/unreleased/Fixed-20240809-125822.yaml
+++ b/.changes/unreleased/Fixed-20240809-125822.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix "failed to collect IDs from parent fields" error when module objects contain
+  fields with nil values.
+time: 2024-08-09T12:58:22.740097751-07:00
+custom:
+  Author: jedevc/sipsma
+  PR: "8132"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6368,6 +6368,38 @@ func (m *Test) Fn() string {
 	require.NoError(t, err)
 }
 
+func (ModuleSuite) TestReturnNilField(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	_, err := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(sdkSource("go", `package main
+
+type Test struct {
+	A *Thing
+	B *Thing
+}
+
+type Thing struct{}
+
+func New() *Test {
+	return &Test{
+		A: &Thing{},
+	}
+}
+
+func (m *Test) Hello() string {
+	return "Hello"
+}
+
+`)).
+		With(daggerCall("hello")).
+		Sync(ctx)
+	require.NoError(t, err)
+}
+
 func (ModuleSuite) TestModuleSchemaVersion(ctx context.Context, t *testctx.T) {
 	t.Run("standalone", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/object.go
+++ b/core/object.go
@@ -84,6 +84,8 @@ func (t *ModuleObjectType) ConvertToSDKInput(ctx context.Context, value dagql.Ty
 func (t *ModuleObjectType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
 	var obj *ModuleObject
 	switch value := value.(type) {
+	case nil:
+		return nil
 	case *ModuleObject:
 		obj = value
 	case dagql.Instance[*ModuleObject]:


### PR DESCRIPTION
When returning an object from a module function that contains a nil field, we can get the following error:

```
Error: response from query: input: test.hello resolve: failed to collect IDs from parent fields: failed to collect IDs for field "<name>": expected *ModuleObject, got <nil>
```

cc @sipsma 