### PR TITLE
Add exceptions for missing typehints in PHP Module

### DIFF
--- a/sdk/php/src/ValueObject/DaggerFunction.php
+++ b/sdk/php/src/ValueObject/DaggerFunction.php
@@ -48,16 +48,22 @@ final readonly class DaggerFunction
     private static function getReturnType(
         ReflectionMethod $method
     ): ListOfType|Type {
+        $type = $method->getReturnType() ??
+            throw new RuntimeException(sprintf(
+                'DaggerFunction "%s" cannot be supported without a return type',
+                $method->name,
+            ));
+
         $attribute = (current($method
             ->getAttributes(Attribute\ReturnsListOfType::class)) ?: null)
             ?->newInstance();
 
         if (!isset($attribute)) {
-            return Type::fromReflection($method->getReturnType());
+            return Type::fromReflection($type);
         }
 
         return ListOfType::fromReflection(
-            $method->getReturnType(),
+            $type,
             $attribute,
         );
     }

--- a/sdk/php/tests/Unit/ValueObject/ArgumentTest.php
+++ b/sdk/php/tests/Unit/ValueObject/ArgumentTest.php
@@ -16,14 +16,29 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
+use RuntimeException;
 
 #[Group('unit')]
 #[CoversClass(Argument::class)]
 class ArgumentTest extends TestCase
 {
+    #[Test]
+    public function ItRequiresTypeHint(): void
+    {
+        $reflection = (new ReflectionFunction(fn ($noTypeHint) => null))
+            ->getParameters()[0];
+
+        self::expectExceptionMessage(
+            'Argument "noTypeHint" cannot be supported without a typehint'
+        );
+
+        Argument::fromReflection($reflection);
+    }
+
     #[Test]
     #[DataProvider('provideReflectionParameters')]
     public function ItBuildsFromReflectionParameter(

--- a/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
+++ b/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dagger\Tests\Unit\ValueObject;
 
+use Dagger\Attribute\DaggerObject;
 use Dagger\Container;
 use Dagger\File;
 use Dagger\Json;
@@ -17,6 +18,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 use RuntimeException;
 
@@ -33,6 +36,24 @@ class DaggerFunctionTest extends TestCase
         );
 
         self::expectException(RuntimeException::class);
+
+        DaggerFunction::fromReflection($reflection);
+    }
+
+    #[Test]
+    public function ItRequiresReturnType(): void
+    {
+        $reflection = (new ReflectionClass(new #[DaggerObject] class () {
+                #[\Dagger\Attribute\DaggerFunction]
+                public function noReturnType()
+                {
+                    return 'hello world';
+                }
+            }))->getMethod('noReturnType');
+
+        self::expectExceptionMessage(
+            'DaggerFunction "noReturnType" cannot be supported without a return type',
+        );
 
         DaggerFunction::fromReflection($reflection);
     }


### PR DESCRIPTION
## What This PR Changes

Clearer exception messages whilst developing PHP Modules. Specifically, exceptions for missing typehints.

## Current Behaviour

If you create a DaggerFunction, with an argument `source`, missing a typehint:

```
[ERROR] Dagger\ValueObject\Type::fromReflection(): Argument #1 ($type) must be 
         of type ReflectionType, null given, called in                          
         /src/sdk/php/dev/sdk/src/ValueObject/Argument.php on line 34
```

If you create a DaggerFunction `format` without a return type:

```
[ERROR] Dagger\ValueObject\Type::fromReflection(): Argument #1 ($type) must be 
         of type ReflectionType, null given, called in                          
         /src/sdk/php/dev/sdk/src/ValueObject/DaggerFunction.php on line 56 
```

## PR Behaviour

If you create a DaggerFunction, with an argument `source`, missing a typehint:

```
[ERROR] Argument "source" cannot be supported without a typehint   
```

If you create a DaggerFunction `format` without a return type:

```
[ERROR] DaggerFunction "format" cannot be supported without a return type 
```