### PR TITLE
[DISCUSSION]: move `dagger core` to `dagger call -c`

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -12,21 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var funcCmds = []*FuncCommand{
-	callModCmd,
-	callCoreCmd,
-}
-
-var callCoreCmd = &FuncCommand{
-	Name:              "core [options]",
-	Short:             "Call a core function",
-	DisableModuleLoad: true,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
-}
-
-var callModCmd = &FuncCommand{
+var callCmd = &FuncCommand{
 	Name:  "call [options]",
 	Short: "Call one or more functions, interconnected into a pipeline",
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -157,6 +157,9 @@ func (fc *FuncCommand) Command() *cobra.Command {
 				}
 				c.FParseErrWhitelist.UnknownFlags = false
 
+				// If `--core` is used, don't load user modules.
+				fc.DisableModuleLoad = loadCoreFuncs
+
 				return nil
 			},
 

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -81,8 +81,7 @@ func init() {
 		moduleDevelopCmd,
 		modulePublishCmd,
 		funcListCmd,
-		callCoreCmd.Command(),
-		callModCmd.Command(),
+		callCmd.Command(),
 		sessionCmd(),
 		newGenCmd(),
 	)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -36,6 +36,9 @@ var (
 	moduleURL   string
 	moduleFlags = pflag.NewFlagSet("module", pflag.ContinueOnError)
 
+	loadCoreFuncs bool
+	functionFlags = pflag.NewFlagSet("functions", pflag.ContinueOnError)
+
 	sdk           string
 	licenseID     string
 	compatVersion string
@@ -59,12 +62,11 @@ const (
 
 func init() {
 	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to the module directory. Either local path or a remote git repo")
+	functionFlags.BoolVarP(&loadCoreFuncs, "core", "c", false, "Load core functions instead of a module (mutually exclusive with -m)")
 
-	for _, fc := range funcCmds {
-		if !fc.DisableModuleLoad {
-			fc.Command().PersistentFlags().AddFlagSet(moduleFlags)
-		}
-	}
+	callCmd.Command().PersistentFlags().AddFlagSet(functionFlags)
+	callCmd.Command().PersistentFlags().AddFlagSet(moduleFlags)
+	callCmd.Command().MarkFlagsMutuallyExclusive("core", "mod")
 
 	funcListCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	listenCmd.PersistentFlags().AddFlagSet(moduleFlags)

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -25,7 +25,6 @@ A tool to run CI/CD pipelines in containers, anywhere
 
 * [dagger call](#dagger-call)	 - Call one or more functions, interconnected into a pipeline
 * [dagger config](#dagger-config)	 - Get or set module configuration
-* [dagger core](#dagger-core)	 - Call a core function
 * [dagger develop](#dagger-develop)	 - Prepare a local module for development
 * [dagger functions](#dagger-functions)	 - List available functions
 * [dagger init](#dagger-init)	 - Initialize a new module
@@ -47,6 +46,7 @@ dagger call [options]
 ### Options
 
 ```
+  -c, --core            Load core functions instead of a module (mutually exclusive with -m)
   -j, --json            Present result as JSON
   -m, --mod string      Path to the module directory. Either local path or a remote git repo
   -o, --output string   Save the result to a local file or directory
@@ -92,37 +92,6 @@ dagger config -m github.com/dagger/hello-dagger
 ```
       --json         output in JSON format
   -m, --mod string   Path to the module directory. Either local path or a remote git repo
-```
-
-### Options inherited from parent commands
-
-```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
-```
-
-### SEE ALSO
-
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
-
-## dagger core
-
-Call a core function
-
-```
-dagger core [options]
-```
-
-### Options
-
-```
-  -j, --json            Present result as JSON
-  -o, --output string   Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This changes the way you call core functions in the CLI (currently `dagger core <function>`):

- `dagger call -c <function>` → Core function
- `dagger call -m <module> <function>` → Module function

## Why?

TL;DR: Consistency.

This relates to:
- https://github.com/dagger/dagger/issues/6947

In that issue there was a lot of discussion on the DX to call core functions from the CLI. In the end, we were left with three main options:

- `dagger core <function>` → Merged in https://github.com/dagger/dagger/pull/7310
- `dagger call -c <function>` → This PR
- `dagger <function>` → There's interest in it, but not for now

The first option had a few advantages:
- Slightly shorter to type
- Stepping stone to the third option (future possibility)
- Was ready to merge (after going through a refactor to support multiple top-level commands that behave like `dagger call`)

However, it has the disadvantage that it can feel [inconsistent](https://github.com/dagger/dagger/issues/6947#issuecomment-2264107770) with `dagger call`. As I mentioned in https://github.com/dagger/dagger/pull/7310#issuecomment-2276640860, it’s very easy to preserve the refactor that simplified the code, while changing back to using a flag (`--core`).

So we still get the stepping stone (implementation wise) to `dagger container`, thus **the only advantage at this time of keeping `dagger core` is being slightly shorter to type, at the cost of feeling inconsistent with `dagger call`**.

## Next

Since I’m going away on PTO, I leave this alternative implementation **so the team has a little more time to consider the DX before the next release**, without blocking the feature (which is already merged).

Feel free to close or merge this change.

\cc @samalba @shykes @aluzzardi @jedevc