### PR TITLE
Docs: Update PHP integration page

### DIFF
--- a/docs/current_docs/integrations/php.mdx
+++ b/docs/current_docs/integrations/php.mdx
@@ -7,7 +7,17 @@ import TabItem from '@theme/TabItem';
 
 # PHP
 
-Dagger can be used to perform common CI tasks - testing, containerizing, publishing and more - for any PHP application.
+Dagger can be used to perform common CI tasks - testing, containerizing, publishing and more - for any PHP application. If programing in PHP is your favorite, you are in luck. A group of Daggernauts have created an experimental Dagger PHP SDK for you to use. 
+
+# How it Works
+
+Before you get started with the experimental SDK, we suggest that you try out our [quickstart](https://docs.dagger.io/quickstart) first. 
+
+# Prerequisites
+
+NEED TO FILL OUT --- What should be already installed and configured? Links to third-party install/configuration docs.
+
+# Examples
 
 The following code sample demonstrates how these CI tasks can be encapsulated as Dagger Functions in a Dagger module. It assumes:
 
@@ -93,3 +103,16 @@ To use such a script, uncomment the relevant lines in the code sample above and 
 php artisan migrate
 apache2-foreground
 ```
+
+# Resources
+
+Below are some resources from the Dagger community that may help as well. If
+you have any questions about additional ways to use PHP with
+Dagger, join our [Discord](https://discord.gg/dagger-io) and ask your questions
+in our [PHP channel](https://discord.com/channels/707636530424053791/1162025276872609832).
+
+- [Introduction to the experimental Dagger PHP SDK](https://youtu.be/mhumTAlyEeQ) by Chris Riley
+
+# About PHP
+
+PHP (Hypertext Preprocessor) is an open-source scripting language widely used for web development. It is designed to be embedded into HTML, making it especially suited for server-side web applications. Originally created by Rasmus Lerdorf in 1994, PHP has grown to be a cornerstone of modern web development, and is maintained by a large community of developers.


### PR DESCRIPTION
Transition PHP integration page to the new integration template and add community call demo

Fixes https://linear.app/dagger/issue/DOCS-300/update-php-integration-page-to-match-new-format