### PR TITLE
chore(php): update php module example to match others

### DIFF
--- a/sdk/php/runtime/template/README.md
+++ b/sdk/php/runtime/template/README.md
@@ -62,7 +62,7 @@ use function Dagger\dag;
 class Example
 {
      #[DaggerFunction('Echo the value to standard output')]
-     public function echo(string $value): Container
+     public function containerEcho(string $stringArg): Container
      {
          return dag()
              ->container()
@@ -79,7 +79,7 @@ You'll notice it uses a function called `dag`; this is how you get the currently
 ### Call Module Functions
 
 ```text
-dagger call -m <path-to-module> echo --value="hello world"
+dagger call -m <path-to-module> container-echo --string-arg="hello world"
 ```
 
 ## How Dagger Finds Available Functions

--- a/sdk/php/runtime/template/src/Example.php
+++ b/sdk/php/runtime/template/src/Example.php
@@ -15,8 +15,8 @@ use function Dagger\dag;
 #[DaggerObject]
 class Example
 {
-     #[DaggerFunction('Echo the value to standard output')]
-     public function echo(string $value): Container
+     #[DaggerFunction('Returns a container that echoes whatever string argument is provided')]
+     public function containerEcho(string $stringArg): Container
      {
          return dag()
              ->container()
@@ -24,10 +24,10 @@ class Example
              ->withExec(['echo', $value]);
      }
 
-    #[DaggerFunction('Search a directory for lines matching a pattern')]
+    #[DaggerFunction('Returns lines that match a pattern in the files of the provided Directory')]
      public function grepDir(
          #[Argument('The directory to search')]
-         Directory $directory,
+         Directory $directoryArg,
          #[Argument('The pattern to search for')]
          string $pattern
     ): string {


### PR DESCRIPTION
The other SDKs are all consistent in their naming of their autogenerated example methods - PHP should be the same.