### PR TITLE
feat: Bundle CLI in the Engine image (a.k.a. One True Artefact)

### DIFF
--- a/.changes/unreleased/Added-20240813-161514.yaml
+++ b/.changes/unreleased/Added-20240813-161514.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Bundle CLI in the Engine image so that both parts of Dagger (CLI+Engine) ship as a single artefact
+time: 2024-08-13T16:15:14.821633+01:00
+custom:
+    Author: gerhard
+    PR: "8147"

--- a/.dagger/config.go
+++ b/.dagger/config.go
@@ -16,6 +16,8 @@ import (
 const (
 	engineTomlPath       = "/etc/dagger/engine.toml"
 	engineEntrypointPath = "/usr/local/bin/dagger-entrypoint.sh"
+	engineUnixSocketPath = "/var/run/buildkit/buildkitd.sock"
+	cliPath              = "/usr/local/bin/dagger"
 )
 
 const engineEntrypointTmpl = `#!/bin/sh

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -117,6 +117,15 @@ func (e *Engine) Container(
 		WithFile(engineTomlPath, cfg).
 		WithFile(engineEntrypointPath, entrypoint).
 		WithEntrypoint([]string{filepath.Base(engineEntrypointPath)})
+
+	cli, err := builder.CLI(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctr = ctr.
+		WithFile(cliPath, cli).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "unix://"+engineUnixSocketPath)
+
 	return ctr, nil
 }
 


### PR DESCRIPTION
So that the Engine image already ships with the matching CLI, all configured and ready to go.
- It addresses the primary issues raised in https://github.com/dagger/dagger/issues/6887

This change adds an extra `27MB` to the final container image:
- `466MB` before this change
- `493MB` after this change (`~6%` larger)

## FOLLOW-UPs
- Use a `dagger query` to test the healthiness of the Engine in the Helm chart
  - What would make a good default query?
  - Tie this to https://github.com/dagger/dagger/issues/7733
- **Maybe** publish a CLI image with git preinstalled **DISCUSS**
- Close the initial issue