### PR TITLE
fix: allow optional enum arguments in user functions

### DIFF
--- a/.changes/unreleased/Fixed-20240813-170412.yaml
+++ b/.changes/unreleased/Fixed-20240813-170412.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  Fixed using custom enum types as optional arguments
+
+  Previously, function calls that defined an optional argument would not be callable.
+time: 2024-08-13T17:04:12.719272966+01:00
+custom:
+  Author: jedevc
+  PR: "8115"

--- a/core/enum.go
+++ b/core/enum.go
@@ -59,22 +59,11 @@ func (m *ModuleEnumType) ConvertToSDKInput(ctx context.Context, value dagql.Type
 	if value == nil {
 		return nil, nil
 	}
-
-	var val string
-	switch x := value.(type) {
-	case *ModuleEnum:
-		val = x.Value
-	case dagql.Scalar[dagql.String]:
-		val = string(x.Value)
-	default:
-		return nil, fmt.Errorf("%T.ConvertToSDKInput cannot handle type %T", m, x)
-	}
-
 	decoder, err := m.getDecoder(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%T.ConvertToSDKInput: failed to get decoder: %w", m, err)
 	}
-	return decoder.DecodeInput(val)
+	return decoder.DecodeInput(value)
 }
 
 func (m *ModuleEnumType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
@@ -163,6 +152,8 @@ func (e *ModuleEnum) DecodeInput(val any) (dagql.Input, error) {
 		return e.Lookup(x)
 	case dagql.Scalar[dagql.String]:
 		return e.Lookup(string(x.Value))
+	case *ModuleEnum:
+		return e.Lookup(x.Value)
 	default:
 		return nil, fmt.Errorf("cannot create dynamic Enum from %T", x)
 	}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3134,6 +3134,13 @@ func (m *Test) FromStatus(status Status) string {
 	return string(status)
 }
 
+func (m *Test) FromStatusOpt(
+	// +optional
+	status Status,
+) string {
+	return string(status)
+}
+
 func (m *Test) ToStatus(status string) Status {
 	return Status(status)
 }
@@ -3156,6 +3163,10 @@ class Test:
     @dagger.function
     def from_status(self, status: Status) -> str:
         return str(status)
+
+    @dagger.function
+    def from_status_opt(self, status: Status | None) -> str:
+        return str(status) if status else ""
 
     @dagger.function
     def to_status(self, status: str) -> Status:
@@ -3196,6 +3207,14 @@ export class Test {
   }
 
   @func()
+  fromStatusOpt(status?: Status): string {
+	if (status) {
+		return status as string
+	}
+    return ""
+  }
+
+  @func()
   toStatus(status: string): Status {
     return status as Status
   }
@@ -3209,6 +3228,7 @@ export class Test {
 				c := connect(ctx, t)
 				modGen := modInit(t, c, tc.sdk, tc.source)
 
+				// fromStatus
 				out, err := modGen.With(daggerQuery(`{test{fromStatus(status: "ACTIVE")}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatus").String())
@@ -3216,6 +3236,19 @@ export class Test {
 				_, err = modGen.With(daggerQuery(`{test{fromStatus(status: "INVALID")}}`)).Stdout(ctx)
 				require.ErrorContains(t, err, "invalid enum value")
 
+				// fromStatusOpt
+				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt}}`)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "", gjson.Get(out, "test.fromStatusOpt").String())
+
+				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "ACTIVE")}}`)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatusOpt").String())
+
+				_, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "INVALID")}}`)).Stdout(ctx)
+				require.ErrorContains(t, err, "invalid enum value")
+
+				// toStatus
 				out, err = modGen.With(daggerQuery(`{test{toStatus(status: "INACTIVE")}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.toStatus").String())
@@ -3223,6 +3256,7 @@ export class Test {
 				_, err = modGen.With(daggerQuery(`{test{toStatus(status: "INVALID")}}`)).Sync(ctx)
 				require.ErrorContains(t, err, "invalid enum value")
 
+				// introspection
 				mod := inspectModule(ctx, t, modGen)
 				statusEnum := mod.Get("enums.#.asEnum|#(name=TestStatus)")
 				require.Equal(t, "Enum for Status", statusEnum.Get("description").String())


### PR DESCRIPTION
This was broken from the beginning when user-defined enums were introduced in #7498. `ModTypeFor` was refactored, and essentially always returned early before the handling of `typeDef.Optional`. This was incorrect, and meant that we ended up with `DynamicOptional`s during enum conversion - see https://github.com/dagger/dagger/pull/7498/files#diff-5eb7740241ddbf3efbef98d43f59b2081a4b6f7bfd00a3daba69d36f107d53bbL262-R287.

To resolve this, we can only return early when we've loaded the mod type directly from the deps - when we've executed the load ourselves, we need to complete the rest of the function.