### PR TITLE
fix: various cross-module secret sharing issues

### DIFF
--- a/.changes/unreleased/Fixed-20240911-105222.yaml
+++ b/.changes/unreleased/Fixed-20240911-105222.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix setting secrets on module object in constructor
+time: 2024-09-11T10:52:22.201566784+01:00
+custom:
+  Author: sipsma
+  PR: "8149"

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -332,15 +332,14 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 
 	// If the function returned anything that's isolated per-client, this caller client should
 	// have access to it now since it was returned to them (i.e. secrets/sockets/etc).
-	if fn.metadata.Name != "" {
-		returnedIDs := map[digest.Digest]*call.ID{}
-		if err := fn.returnType.CollectCoreIDs(ctx, returnValueTyped, returnedIDs); err != nil {
-			return nil, fmt.Errorf("failed to collect IDs: %w", err)
-		}
-		for _, id := range returnedIDs {
-			if err := fn.root.AddClientResourcesFromID(ctx, id, execMD.ClientID, false); err != nil {
-				return nil, fmt.Errorf("failed to add client resources from ID: %w", err)
-			}
+	returnedIDs := map[digest.Digest]*call.ID{}
+	if err := fn.returnType.CollectCoreIDs(ctx, returnValueTyped, returnedIDs); err != nil {
+		return nil, fmt.Errorf("failed to collect IDs: %w", err)
+	}
+
+	for _, id := range returnedIDs {
+		if err := fn.root.AddClientResourcesFromID(ctx, id, execMD.ClientID, false); err != nil {
+			return nil, fmt.Errorf("failed to add client resources from ID: %w", err)
 		}
 	}
 

--- a/engine/server/client_resources.go
+++ b/engine/server/client_resources.go
@@ -72,7 +72,7 @@ func (srv *Server) addClientResourcesFromID(ctx context.Context, destClient *dag
 		}
 		for _, secret := range secrets {
 			if err := destClient.secretStore.AddSecretFromOtherStore(secret, srcClient.secretStore); err != nil {
-				return fmt.Errorf("failed to add secret: %w", err)
+				return fmt.Errorf("failed to add secret from source client %s: %w", srcClient.clientID, err)
 			}
 		}
 	}
@@ -84,7 +84,7 @@ func (srv *Server) addClientResourcesFromID(ctx context.Context, destClient *dag
 		}
 		for _, socket := range sockets {
 			if err := destClient.socketStore.AddSocketFromOtherStore(socket, srcClient.socketStore); err != nil {
-				return fmt.Errorf("failed to add socket: %w", err)
+				return fmt.Errorf("failed to add socket from source client %s: %w", srcClient.clientID, err)
 			}
 		}
 	}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -920,7 +920,14 @@ func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opt
 	default:
 		client, cleanup, err := srv.getOrInitClient(ctx, opts)
 		if err != nil {
-			return fmt.Errorf("get or init client: %w", err)
+			err = fmt.Errorf("get or init client: %w", err)
+			switch r.URL.Path {
+			case engine.QueryEndpoint:
+				err = gqlErr(err, http.StatusInternalServerError)
+			default:
+				err = httpErr(err, http.StatusInternalServerError)
+			}
+			return err
 		}
 		defer func() {
 			err := cleanup()


### PR DESCRIPTION
Thanks @sagikazarmark for the original bug report :tada: (I *think* this is the same issue? it does have a slightly different error message).

```
invoke: input: dep.secretMount.mount resolve: failed to add client resources from ID: failed to add secret: secret xxh3:bc7dcced26cc08c7 not found in other store
```

The issue appears to be that the `SecretMount.Secret` is marked as `// +private` - if this is removed, the test appears to pass with no issues. I'm *guessing* that what's happening is that because the field is marked as private, it's not appearing as a field in the typedef.

Then, when we iterate to `CollectCoreIDs`, we don't manage to see this field:

https://github.com/dagger/dagger/blob/3c52de5cd5daf202f57d4879f914dac3d2bc3ccf/core/object.go#L103

I think that makes rough sense - note `PBDefinitions` has this same issue - potentially this could cause bugs in `linkDependencyBlobs`? Maybe, but I'm not sure what the symptoms of that would even look like.

There are a couple things that I think probably need fixing:
- Typedefs should be extended to have private fields - the engine should know about these private fields, SDKs shouldn't be hiding them. I think this is the only way we can reasonable fix the `linkDependencyBlobs` thing from above as well.
- It seems odd that the returned container with the mounted secret isn't detected as a secret? Is there an issue in our ID walking code? I think the secret ID *should* appear in the returned container right?

cc @sipsma