### PR TITLE
chore: use features introduced recently in go 1.22

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -140,7 +140,6 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 	sdks := []sdkContentF{build.goSDKContent, build.pythonSDKContent, build.typescriptSDKContent}
 	sdkContents := make([]*sdkContent, len(sdks))
 	for i, sdk := range sdks {
-		i, sdk := i, sdk
 		eg.Go(func() error {
 			content, err := sdk(ctx)
 			if err != nil {
@@ -254,7 +253,6 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 
 	ctr := base
 	for _, bin := range bins {
-		bin := bin
 		ctr = ctr.WithFile(bin.path, bin.file)
 		eg.Go(func() error {
 			return build.verifyPlatform(ctx, bin.file)

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -294,7 +294,6 @@ func (e *Engine) TestPublish(
 
 	var eg errgroup.Group
 	for _, platform := range platform {
-		platform := platform
 		eg.Go(func() error {
 			ctr, err := e.Container(ctx, platform)
 			if err != nil {

--- a/.dagger/sdk_all.go
+++ b/.dagger/sdk_all.go
@@ -16,7 +16,6 @@ var _ sdkBase = AllSDK{}
 func (t AllSDK) Lint(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, sdk := range t.SDK.allSDKs() {
-		sdk := sdk
 		eg.Go(func() error {
 			return sdk.Lint(ctx)
 		})
@@ -27,7 +26,6 @@ func (t AllSDK) Lint(ctx context.Context) error {
 func (t AllSDK) Test(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, sdk := range t.SDK.allSDKs() {
-		sdk := sdk
 		eg.Go(func() error {
 			return sdk.Test(ctx)
 		})
@@ -39,7 +37,6 @@ func (t AllSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	dirs := make([]*dagger.Directory, len(t.SDK.allSDKs()))
 	for i, sdk := range t.SDK.allSDKs() {
-		i, sdk := i, sdk
 		eg.Go(func() error {
 			dir, err := sdk.Generate(ctx)
 			if err != nil {
@@ -69,7 +66,6 @@ func (t AllSDK) Bump(ctx context.Context, version string) (*dagger.Directory, er
 	eg, ctx := errgroup.WithContext(ctx)
 	dirs := make([]*dagger.Directory, len(t.SDK.allSDKs()))
 	for i, sdk := range t.SDK.allSDKs() {
-		i, sdk := i, sdk
 		eg.Go(func() error {
 			dir, err := sdk.Bump(ctx, version)
 			if err != nil {

--- a/cmd/codegen/generator/go/templates/module_interfaces.go
+++ b/cmd/codegen/generator/go/templates/module_interfaces.go
@@ -28,13 +28,13 @@ func (ps *parseState) parseGoIface(t *types.Interface, named *types.Named) (*par
 	// (search "objects are routinely compared by the addresses of the underlying pointers")
 	daggerObjectIfaceMethods := make(map[types.Object]bool)
 	daggerObjectMethodSet := types.NewMethodSet(ps.daggerObjectIfaceType)
-	for i := 0; i < daggerObjectMethodSet.Len(); i++ {
+	for i := range daggerObjectMethodSet.Len() {
 		daggerObjectIfaceMethods[daggerObjectMethodSet.At(i).Obj()] = false
 	}
 
 	goFuncTypes := []*types.Func{}
 	methodSet := types.NewMethodSet(named)
-	for i := 0; i < methodSet.Len(); i++ {
+	for i := range methodSet.Len() {
 		methodObj := methodSet.At(i).Obj()
 
 		// check if this is a method from the embedded DaggerObject interface

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -34,7 +34,7 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 
 	goFuncTypes := []*types.Func{}
 	methodSet := types.NewMethodSet(types.NewPointer(named))
-	for i := 0; i < methodSet.Len(); i++ {
+	for i := range methodSet.Len() {
 		methodObj := methodSet.At(i).Obj()
 
 		if ps.isDaggerGenerated(methodObj) {
@@ -91,7 +91,7 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 
 	// Fill out the static fields of the struct (if any)
 	astFields := unpackASTFields(astStructType.Fields)
-	for i := 0; i < t.NumFields(); i++ {
+	for i := range t.NumFields() {
 		field := t.Field(i)
 		if !field.Exported() {
 			continue

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -80,7 +80,7 @@ func (ps *parseState) parseGoTypeReference(typ types.Type, named *types.Named, i
 
 			if ps.isDaggerGenerated(named.Obj()) {
 				isEnum := false
-				for i := 0; i < named.NumMethods(); i++ {
+				for i := range named.NumMethods() {
 					method := named.Method(i)
 					if method.Name() == "IsEnum" {
 						isEnum = true

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -417,7 +417,7 @@ func (ps *parseState) renderNameOrStruct(t types.Type) string {
 	}
 	if st, ok := t.(*types.Struct); ok {
 		result := "struct {\n"
-		for i := 0; i < st.NumFields(); i++ {
+		for i := range st.NumFields() {
 			if !st.Field(i).Embedded() {
 				result += st.Field(i).Name() + " "
 			}
@@ -448,7 +448,7 @@ func (ps *parseState) renderNameOrStruct(t types.Type) string {
 		}
 		if typeArgs := named.TypeArgs(); typeArgs.Len() > 0 {
 			base += "["
-			for i := 0; i < typeArgs.Len(); i++ {
+			for i := range typeArgs.Len() {
 				if i > 0 {
 					base += ", "
 				}

--- a/cmd/dagger/cloud.go
+++ b/cmd/dagger/cloud.go
@@ -94,7 +94,6 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 			return Fail
 		}
 		for _, org := range user.Orgs {
-			org := org
 			if org.Name == orgName {
 				selectedOrg = &org
 				break

--- a/core/c2h.go
+++ b/core/c2h.go
@@ -27,7 +27,6 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 	listenerPool := pool.New().WithContext(ctx)
 	proxyConnPool := pool.New().WithContext(ctx)
 	for _, sock := range d.socks {
-		sock := sock
 		listenerPool.Go(func(ctx context.Context) error {
 			defer cancel() // if one exits, all should exit
 

--- a/core/interface.go
+++ b/core/interface.go
@@ -188,7 +188,6 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 
 	fields := make([]dagql.Field[*InterfaceAnnotatedValue], 0, len(iface.typeDef.Functions))
 	for _, fnTypeDef := range iface.typeDef.Functions {
-		fnTypeDef := fnTypeDef
 		fnName := gqlFieldName(fnTypeDef.Name)
 
 		// check whether this is a pre-existing object from a dependency module
@@ -220,7 +219,6 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 
 		argTypeDefsByName := map[string]*TypeDef{}
 		for _, argMetadata := range fnTypeDef.Args {
-			argMetadata := argMetadata
 			argTypeDefsByName[argMetadata.Name] = argMetadata.TypeDef
 
 			// check whether this is a pre-existing object from a dependency module

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -191,8 +191,6 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context) (
 			if !obj.IsSubtypeOf(iface) {
 				continue
 			}
-			objType := objType
-			ifaceType := ifaceType
 			asIfaceFieldName := gqlFieldName(fmt.Sprintf("as%s", iface.Name))
 			class.Extend(
 				dagql.FieldSpec{

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -817,7 +817,6 @@ func (s *moduleSchema) updateDeps(
 	mod.DependenciesField = make([]dagql.Instance[*core.Module], len(deps))
 	var eg errgroup.Group
 	for i, dep := range deps {
-		i, dep := i, dep
 		eg.Go(func() error {
 			err := s.dag.Select(ctx, dep.Self.Source, &mod.DependenciesField[i],
 				dagql.Selector{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -385,7 +385,6 @@ func (s *moduleSchema) moduleSourceDependencies(
 		existingDeps = make([]dagql.Instance[*core.ModuleDependency], len(modCfg.Dependencies))
 		var eg errgroup.Group
 		for i, depCfg := range modCfg.Dependencies {
-			i, depCfg := i, depCfg
 			eg.Go(func() error {
 				var depSrc dagql.Instance[*core.ModuleSource]
 				err := s.dag.Select(ctx, s.dag.Root(), &depSrc,
@@ -436,7 +435,6 @@ func (s *moduleSchema) moduleSourceDependencies(
 	newDeps := make([]dagql.Instance[*core.ModuleDependency], len(src.Self.WithDependencies))
 	var eg errgroup.Group
 	for i, dep := range src.Self.WithDependencies {
-		i, dep := i, dep
 		eg.Go(func() error {
 			var resolvedDepSrc dagql.Instance[*core.ModuleSource]
 			err := s.dag.Select(ctx, src, &resolvedDepSrc,

--- a/core/services.go
+++ b/core/services.go
@@ -216,7 +216,6 @@ func (ss *Services) StartBindings(ctx context.Context, bindings ServiceBindings)
 	// NB: don't use errgroup.WithCancel; we don't want to cancel on Wait
 	eg := new(errgroup.Group)
 	for i, bnd := range bindings {
-		i, bnd := i, bnd
 		eg.Go(func() error {
 			runningSvc, err := ss.Start(ctx, bnd.ID, bnd.Service)
 			if err != nil {
@@ -293,7 +292,6 @@ func (ss *Services) StopSessionServices(ctx context.Context, sessionID string) e
 
 	eg := new(errgroup.Group)
 	for _, svc := range svcs {
-		svc := svc
 		eg.Go(func() error {
 			bklog.G(ctx).Debugf("shutting down service %s", svc.Host)
 			// force kill the service, users should manually shutdown services if they're

--- a/core/services_test.go
+++ b/core/services_test.go
@@ -240,7 +240,7 @@ func TestServicesStartConcurrentSadThenHappy(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// start a few more attempts
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		go func() {
 			_, err := services.Start(ctx, stub.ID(), stub)
 			errs <- err

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -44,7 +44,7 @@ func builtinOrTyped(val any) (Typed, error) {
 			arr := DynamicArrayOutput{
 				Elem: elem,
 			}
-			for i := 0; i < valV.Len(); i++ {
+			for i := range valV.Len() {
 				elem, err := builtinOrTyped(valV.Index(i).Interface())
 				if err != nil {
 					return nil, fmt.Errorf("slice elem %d: %w", i, err)

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -647,7 +647,7 @@ func sampleContext(rows []*TraceTree) []int {
 	result := []int{}
 
 	// find the first call
-	for i := 0; i < len(rows); i++ {
+	for i := range len(rows) {
 		row := rows[i]
 		result = append(result, i)
 		if row.Span.Call != nil {

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -109,8 +109,6 @@ func (class Class[T]) Install(fields ...Field[T]) {
 	class.fieldsL.Lock()
 	defer class.fieldsL.Unlock()
 	for _, field := range fields {
-		field := field
-
 		if field.Spec.extend {
 			fields := class.fields[field.Spec.Name]
 			if len(fields) == 0 {

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -820,7 +820,7 @@ func reflectFieldsForType[T any](obj any, optIn bool, init func(any) (T, error))
 	if objT.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("inputs must be a struct, got %T (%s)", obj, objT.Kind())
 	}
-	for i := 0; i < objT.NumField(); i++ {
+	for i := range objT.NumField() {
 		fieldT := objT.Field(i)
 		if fieldT.Anonymous {
 			fieldI := reflect.New(fieldT.Type).Elem().Interface()
@@ -877,7 +877,7 @@ func getField(obj any, optIn bool, fieldName string) (res Typed, found bool, rer
 	if objT.Kind() != reflect.Struct {
 		return nil, false, fmt.Errorf("get field %q: object must be a struct, got %T (%s)", fieldName, obj, objT.Kind())
 	}
-	for i := 0; i < objT.NumField(); i++ {
+	for i := range objT.NumField() {
 		fieldT := objT.Field(i)
 		if fieldT.Anonymous {
 			fieldI := objV.Field(i).Interface()
@@ -925,7 +925,7 @@ func setInputFields(specs InputSpecs, inputs map[string]Input, dest any) error {
 	if destT.Kind() != reflect.Struct {
 		return fmt.Errorf("inputs must be a struct, got %T (%s)", dest, destT.Kind())
 	}
-	for i := 0; i < destT.NumField(); i++ {
+	for i := range destT.NumField() {
 		fieldT := destT.Field(i)
 		fieldV := destV.Field(i)
 		if fieldT.Anonymous {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -914,7 +914,7 @@ func setInputObjectFields(obj any, vals map[string]any) error {
 		// TODO handle pointer?
 		return fmt.Errorf("object must be a struct, got %T", obj)
 	}
-	for i := 0; i < objT.NumField(); i++ {
+	for i := range objT.NumField() {
 		fieldT := objT.Field(i)
 		fieldV := objV.Elem().Field(i)
 		name := fieldT.Tag.Get("name")
@@ -980,7 +980,7 @@ func collectLiteralArgs(obj any) ([]*call.Argument, error) {
 		return nil, fmt.Errorf("object must be a struct, got %T", obj)
 	}
 	args := []*call.Argument{}
-	for i := 0; i < objV.NumField(); i++ {
+	for i := range objV.NumField() {
 		fieldT := objT.Field(i)
 		name := fieldT.Tag.Get("name")
 		if name == "" {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -403,7 +403,6 @@ func (s *Server) Resolve(ctx context.Context, self Object, sels ...Selection) (m
 
 	pool := pool.New().WithErrors()
 	for _, sel := range sels {
-		sel := sel
 		pool.Go(func() error {
 			res, err := s.resolvePath(ctx, self, sel)
 			if err != nil {
@@ -540,8 +539,6 @@ func LoadIDs[T Typed](ctx context.Context, srv *Server, ids []ID[T]) ([]T, error
 	out := make([]T, len(ids))
 	eg := new(errgroup.Group)
 	for i, id := range ids {
-		i := i
-		id := id
 		eg.Go(func() error {
 			val, err := id.Load(ctx, srv)
 			if err != nil {

--- a/engine/buildkit/cacerts/cacerts.go
+++ b/engine/buildkit/cacerts/cacerts.go
@@ -57,7 +57,6 @@ func NewInstaller(
 		&debianLike{},
 		&rhelLike{},
 	} {
-		installer := installer
 		eg.Go(func() error {
 			if err := installer.initialize(ctrFS); err != nil {
 				return err

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -223,7 +223,6 @@ func (c *Client) NewContainer(ctx context.Context, req NewContainerRequest) (*Co
 	// get the input mounts in parallel in case they need to be evaluated, which can be expensive
 	eg, egctx := errgroup.WithContext(ctx)
 	for i, m := range req.Mounts {
-		i, m := i, m
 		eg.Go(func() error {
 			workerRef := m.WorkerRef
 			if workerRef == nil && m.Ref != nil {
@@ -375,7 +374,6 @@ func (c *Client) UpstreamCacheExport(ctx context.Context, cacheExportFuncs []Res
 	eg, ctx := errgroup.WithContext(ctx)
 	// TODO: send progrock statuses for cache export progress
 	for _, exporterFunc := range cacheExportFuncs {
-		exporterFunc := exporterFunc
 		eg.Go(func() error {
 			bklog.G(ctx).Debugf("getting exporter")
 			exporter, err := exporterFunc(ctx, sessionGroup)

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -411,7 +411,6 @@ func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 	for _, mnt := range state.spec.Mounts {
 		switch {
 		case mnt.Destination == MetaMountDestPath:
-			mnt := mnt
 			state.metaMount = &mnt
 
 		case mnt.Destination == buildkitQemuEmulatorMountPoint:

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -36,7 +36,6 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 
 	var eg errgroup.Group
 	for _, syncedCacheMount := range syncedCacheMounts {
-		syncedCacheMount := syncedCacheMount
 		if syncedCacheMount.URL == "" {
 			// nothing to download, have to start fresh, skip it until we sync back to cloud at shutdown
 			continue
@@ -96,7 +95,6 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 		})
 
 		for cacheMountName := range seenCacheMounts {
-			cacheMountName := cacheMountName
 			eg.Go(func() error {
 				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
 				cacheKey := cacheKeyFromMountName(cacheMountName)

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -196,7 +196,6 @@ func (sess *daggerSession) FlushTelemetry(ctx context.Context) error {
 	eg := new(errgroup.Group)
 	sess.clientMu.Lock()
 	for _, client := range sess.clients {
-		client := client
 		eg.Go(func() error {
 			return client.FlushTelemetry(ctx)
 		})
@@ -314,7 +313,6 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	defer sess.containersMu.Unlock()
 	for ctr := range sess.containers {
 		if ctr != nil {
-			ctr := ctr
 			releaseGroup.Go(func() error {
 				return ctr.Release(ctx)
 			})
@@ -322,7 +320,6 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	}
 
 	for _, client := range sess.clients {
-		client := client
 		releaseGroup.Go(func() error {
 			var errs error
 			client.job.Discard()
@@ -354,7 +351,6 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	var refReleaseGroup errgroup.Group
 	for rf := range sess.refs {
 		if rf != nil {
-			rf := rf
 			refReleaseGroup.Go(func() error {
 				return rf.Release(ctx)
 			})
@@ -1095,7 +1091,6 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 			bklog.G(ctx).Debugf("running cache export for client %s", client.clientID)
 			cacheExporterFuncs := make([]buildkit.ResolveCacheExporterFunc, len(sess.cacheExporterCfgs))
 			for i, cacheExportCfg := range sess.cacheExporterCfgs {
-				cacheExportCfg := cacheExportCfg
 				cacheExporterFuncs[i] = func(ctx context.Context, sessionGroup bksession.Group) (remotecache.Exporter, error) {
 					exporterFunc, ok := srv.cacheExporters[cacheExportCfg.Type]
 					if !ok {

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -84,7 +84,6 @@ func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) { //nol
 
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
-		c := c
 		eg.Go(func() error {
 			if err := ps.Spans(c).ExportSpans(r.Context(), spans); err != nil {
 				return fmt.Errorf("export to %s: %w", c.clientID, err)
@@ -131,7 +130,6 @@ func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) { //nolin
 
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
-		c := c
 		eg.Go(func() error {
 			if err := ps.Logs(c).Export(r.Context(), logs); err != nil {
 				return fmt.Errorf("export to %s: %w", c.clientID, err)

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -81,7 +81,6 @@ func (p *Go) Lint(
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, pkg := range packages {
-		pkg := pkg
 		eg.Go(func() error {
 			ctx, span := Tracer().Start(ctx, "lint "+path.Clean(pkg))
 			defer span.End()

--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -120,7 +120,7 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 		fmt.Fprintf(cfg.LogOutput, "Creating new Engine session... ")
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		proc = exec.CommandContext(cmdCtx, binPath, args...)
 		proc.Env = env
 

--- a/testctx/testctx.go
+++ b/testctx/testctx.go
@@ -33,7 +33,7 @@ func Run(ctx context.Context, testingT *testing.T, suite any, middleware ...Midd
 	suiteT := reflect.TypeOf(suite)
 	suiteV := reflect.ValueOf(suite)
 
-	for i := 0; i < suiteV.NumMethod(); i++ {
+	for i := range suiteV.NumMethod() {
 		methT := suiteT.Method(i)
 		if !strings.HasPrefix(methT.Name, "Test") {
 			continue


### PR DESCRIPTION
We've been using go 1.22 for a while now: #6637. However, this introduced some really interesting features, and we've not really converted any code to use it.

This PR starts using the two main changes in the language from https://go.dev/doc/go1.22:
- Use `range <int>` syntax wherever possible
- Avoid explicit loop capture, this is now the default

Hopefully, after #8150 lands, we can also start using the new func iterators :tada: