### PR TITLE
fix: ts sdk, ignore context dir during setup

### DIFF
--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -186,13 +186,13 @@ func (ModuleSuite) TestTypescriptInit(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "hello world\n", out)
 
-		parentPackageJson, err := modGen.File("./package.json").Contents(ctx)
+		parentPackageJSON, err := modGen.File("./package.json").Contents(ctx)
 		require.NoError(t, err)
-		require.Contains(t, parentPackageJson, `"packageManager": "pnpm@`) // We don't check the exact version because it's a SHA
+		require.Contains(t, parentPackageJSON, `"packageManager": "pnpm@`) // We don't check the exact version because it's a SHA
 
-		sourcePackageJson, err := modGen.File("./dagger/package.json").Contents(ctx)
+		sourcePackageJSON, err := modGen.File("./dagger/package.JSON").Contents(ctx)
 		require.NoError(t, err)
-		require.Contains(t, sourcePackageJson, `"packageManager": "yarn@`) // We don't check the exact version because it's a SHA
+		require.Contains(t, sourcePackageJSON, `"packageManager": "yarn@`) // We don't check the exact version because it's a SHA
 	})
 }
 

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -190,7 +190,7 @@ func (ModuleSuite) TestTypescriptInit(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Contains(t, parentPackageJSON, `"packageManager": "pnpm@`) // We don't check the exact version because it's a SHA
 
-		sourcePackageJSON, err := modGen.File("./dagger/package.JSON").Contents(ctx)
+		sourcePackageJSON, err := modGen.File("./dagger/package.json").Contents(ctx)
 		require.NoError(t, err)
 		require.Contains(t, sourcePackageJSON, `"packageManager": "yarn@`) // We don't check the exact version because it's a SHA
 	})

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -170,6 +170,30 @@ func (ModuleSuite) TestTypescriptInit(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.NotContains(t, sourceRootEnts, "src")
 	})
+
+	t.Run("ignore parent directory package manager", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From("node:20-alpine").
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithExec([]string{"npm", "init", "-y"}).
+			WithExec([]string{"corepack", "enable"}).
+			WithExec([]string{"corepack", "use", "pnpm@9.6.0"}).
+			With(daggerExec("init", "--sdk=typescript", "--source=dagger"))
+
+		out, err := modGen.With(daggerCall("container-echo", "--string-arg", "hello world", "stdout")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello world\n", out)
+
+		parentPackageJson, err := modGen.File("./package.json").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, parentPackageJson, `"packageManager": "pnpm@`) // We don't check the exact version because it's a SHA
+
+		sourcePackageJson, err := modGen.File("./dagger/package.json").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, sourcePackageJson, `"packageManager": "yarn@`) // We don't check the exact version because it's a SHA
+	})
 }
 
 //go:embed testdata/modules/typescript/syntax/index.ts

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -184,9 +184,13 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 		// Add template directory
 		WithMountedDirectory("/opt/module", dag.CurrentModule().Source().Directory(".")).
 		// Mount users' module with SDK sources and generated client in it.
-		WithMountedDirectory(ModSourceDirPath, modSource.
-			ContextDirectory().
-			WithDirectory(filepath.Join(t.moduleConfig.subPath, GenDir), sdk),
+		WithMountedDirectory(ModSourceDirPath,
+			dag.Directory().WithDirectory("/", modSource.ContextDirectory(), dagger.DirectoryWithDirectoryOpts{
+				Include: []string{
+					fmt.Sprintf("%s/**", t.moduleConfig.subPath),
+				},
+			}).
+				WithDirectory(filepath.Join(t.moduleConfig.subPath, GenDir), sdk),
 		).
 		WithWorkdir(t.moduleConfig.modulePath())
 


### PR DESCRIPTION
Fixes an issue raised by @marcosnils when using dagger ts SDK inside a ts repo that has a package.json at its root.