### PR TITLE
workaround hanging `TestTypeScriptPackageManagerDetection` test

### DIFF
--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -150,7 +150,8 @@ func (t *Test) testCmd(ctx context.Context) (*dagger.Container, error) {
 		WithConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`).
 		WithConfig(`grpc`, `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).
 		WithArg(`network-name`, `dagger-dev`).
-		WithArg(`network-cidr`, `10.88.0.0/16`)
+		WithArg(`network-cidr`, `10.88.0.0/16`).
+		WithArg(`debugaddr`, `0.0.0.0:6060`)
 	devEngine, err := engine.Container(ctx, "")
 	if err != nil {
 		return nil, err

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -647,9 +647,8 @@ func (ModuleSuite) TestTypescriptRuntimeDetection(ctx context.Context, t *testct
 }
 
 func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-
 	t.Run("should default to yarn", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -671,6 +670,7 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use pnpm if set in package.json", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -698,6 +698,7 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use npm if set in package.json", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -725,6 +726,7 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use npm if package-lock.json is present", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -752,6 +754,7 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use pnpm if pnpm-lock.yaml is present", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").


### PR DESCRIPTION
This test creates a single client and uses it for 4 tests in parallel. Each test runs `dagger develop` at some point, and we're seeing this part hang in the export step:

![image](https://github.com/user-attachments/assets/a6bd4126-fe49-4cee-b002-43fe311e6c36)

Giving each test its own seems to work around the issue (0/2 runs hang with the fix, 2/2 hang without).

It doesn't seem to be a regression related to the test or the feature being tested, and it's better for each test to open its own client anyway so we don't leave one hanging around until they run.

### Deadlock analysis

tl;dr: it appears we've found a repro for #6355 🎉 - so after merging this PR we can just revert locally to investigate it.

Here are some runs that demonstrate the hang:

* https://dagger.cloud/dagger/traces/03b9d7e773d03d5323334f5d3da2177b?span=35610e5c887dc49e
* https://dagger.cloud/dagger/traces/10f31bb9e437e889577e7b61939a3df5?span=d01eb9cf70822eae
* https://dagger.cloud/dagger/traces/419926ad0eb9749dd0c0c354db14f204?span=dc5a8b811ba5a8b9
* https://dagger.cloud/dagger/traces/5629f35bfe59bc3f4489dc9ca190e3e4?span=0b8319c0a87c416c
* https://dagger.cloud/dagger/traces/ee425d99d4354819ee699656727365ad?span=69ff424763e0e8a8

For the last one I managed to capture a stack dump of the engine, with the help of @gerhard and @matipan. 🙏

Which is blocked on these calls:

![image](https://github.com/user-attachments/assets/b77da209-ea23-4c91-b55c-3a523b4db660)

=>

![image](https://github.com/user-attachments/assets/207443fd-cc86-4b68-a124-a21e8f9bfd5d)

=>

![image](https://github.com/user-attachments/assets/00ade0ef-0be9-48a2-8855-202e74458097)

=> this is holding a lock which these other goroutines want real bad:

![image](https://github.com/user-attachments/assets/9b805a01-8e55-4390-80b4-0055771ab4b8)
