### PR TITLE
chore(ts): don't export pnpm store

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -152,7 +152,7 @@ func (t *TypescriptSdk) Codegen(ctx context.Context, modSource *dagger.ModuleSou
 		WithDirectory(
 			"/",
 			ctr.Directory(ModSourceDirPath),
-			dagger.DirectoryWithDirectoryOpts{Exclude: []string{"**/node_modules"}},
+			dagger.DirectoryWithDirectoryOpts{Exclude: []string{"**/node_modules", "**/.pnpm-store"}},
 		)
 
 	return dag.GeneratedCode(
@@ -164,6 +164,7 @@ func (t *TypescriptSdk) Codegen(ctx context.Context, modSource *dagger.ModuleSou
 		WithVCSIgnoredPaths([]string{
 			GenDir,
 			"**/node_modules/**",
+			"**/.pnpm-store/**",
 		}), nil
 }
 


### PR DESCRIPTION
This is the node_modules equivalent for pnpm - we should never export it, just in our tests these can end up at 100MB, which causes our exports to sometimes hang.