### PR TITLE
DNM: Revert "workaround hanging `TestTypeScriptPackageManagerDetection` test"

### DIFF
--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -150,8 +150,7 @@ func (t *Test) testCmd(ctx context.Context) (*dagger.Container, error) {
 		WithConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`).
 		WithConfig(`grpc`, `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).
 		WithArg(`network-name`, `dagger-dev`).
-		WithArg(`network-cidr`, `10.88.0.0/16`).
-		WithArg(`debugaddr`, `0.0.0.0:6060`)
+		WithArg(`network-cidr`, `10.88.0.0/16`)
 	devEngine, err := engine.Container(ctx, "")
 	if err != nil {
 		return nil, err

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -697,8 +697,9 @@ func (ModuleSuite) TestTypescriptRuntimeDetection(ctx context.Context, t *testct
 }
 
 func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
 	t.Run("should default to yarn", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -720,7 +721,6 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use pnpm if set in package.json", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -748,7 +748,6 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use npm if set in package.json", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -776,7 +775,6 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use npm if package-lock.json is present", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -804,7 +802,6 @@ func (ModuleSuite) TestTypeScriptPackageManagerDetection(ctx context.Context, t 
 	})
 
 	t.Run("should use pnpm if pnpm-lock.yaml is present", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").


### PR DESCRIPTION
Undoing the fix so I can demo troubleshooting it