### PR TITLE
tests: big deflake attempt

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -6969,10 +6970,38 @@ func cleanupExec(t testing.TB, cmd *exec.Cmd) {
 			t.Logf("never started: %v", cmd.Args)
 			return
 		}
-		t.Logf("interrupting: %v", cmd.Args)
-		cmd.Process.Signal(os.Interrupt)
-		t.Logf("waiting: %v", cmd.Args)
-		cmd.Wait()
+
+		done := make(chan struct{})
+		go func() {
+			cmd.Wait()
+			close(done)
+		}()
+
+		signals := []syscall.Signal{
+			syscall.SIGINT,
+			syscall.SIGTERM,
+			syscall.SIGKILL,
+		}
+		doSignal := func() {
+			if len(signals) == 0 {
+				return
+			}
+			var signal syscall.Signal
+			signal, signals = signals[0], signals[1:]
+			t.Logf("sending %s: %v", signal, cmd.Args)
+			cmd.Process.Signal(signal)
+		}
+		doSignal()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(10 * time.Second):
+				// the process *still* isn't dead? try killing it harder.
+				doSignal()
+			}
+		}
 	})
 }
 

--- a/testctx/testctx_test.go
+++ b/testctx/testctx_test.go
@@ -1,0 +1,49 @@
+package testctx
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTestCtx(t *testing.T) {
+	// NOTE: these tests are demos for testctx, but don't actually run them,
+	// some of them are expected to really fail
+
+	Run(context.Background(), t, TestCtxSuite{})
+}
+
+type TestCtxSuite struct{}
+
+var testRepeatsCounter = 3
+
+func (TestCtxSuite) TestRepeats(ctx context.Context, t *T) {
+	t.Retry(10)
+
+	testRepeatsCounter--
+	if testRepeatsCounter == 0 {
+		return
+	}
+	t.Fail()
+}
+
+var testRepeatsPanicCounter = 3
+
+func (TestCtxSuite) TestRepeatsPanic(ctx context.Context, t *T) {
+	t.Retry(10)
+
+	testRepeatsPanicCounter--
+	if testRepeatsPanicCounter == 0 {
+		return
+	}
+	panic("panic")
+}
+
+func (TestCtxSuite) TestRepeatsMax(ctx context.Context, t *T) {
+	t.Retry(10)
+	t.Fail()
+}
+
+func (TestCtxSuite) TestRepeatsMaxPanic(ctx context.Context, t *T) {
+	t.Retry(10)
+	panic("panic")
+}


### PR DESCRIPTION
Includes:
- Attempt to kill misbehaving subprocesses in `TestDaggerUp` and similar *harder*, see https://dagger.cloud/dagger/traces/3e12c1a3aa6b40119ab74e136dad9e50?span=1e20b5449908ff06#0f8f4e636ab28886:L198
- `testctx.T` should have a way to allow tests to repeat

Getting test repetition working is not very fun, unsurprisingly, go's wonderous test framework does not want such a convenience.