### PR TITLE
feat: implements --interactive-command for overriding the default command used in interactive mode

### DIFF
--- a/.changes/unreleased/Added-20240819-133821.yaml
+++ b/.changes/unreleased/Added-20240819-133821.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: implements call argument `--interactive-command` for overriding the default command used in interactive mode
+time: 2024-08-19T13:38:21.847023-07:00
+custom:
+    Author: samalba
+    PR: "8171"

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -47,6 +47,7 @@ func withEngine(
 		}
 		params.WithTerminal = withTerminal
 		params.Interactive = interactive
+		params.InteractiveCommand = interactiveCommandParsed
 
 		// Connect to and run with the engine
 		sess, ctx, err := client.Connect(ctx, params)

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -551,8 +551,6 @@ type Test struct {
 		err = cmd.Start()
 		require.NoError(t, err)
 
-		go console.ExpectEOF()
-
 		// We expect the command to fail
 		err = cmd.Wait()
 		require.Error(t, err)

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -544,6 +544,18 @@ type Test struct {
 
 		err = cmd.Wait()
 		require.Error(t, err)
+
+		//  We try again with an invalid shell to confirm we replaced the default command
+		cmd = hostDaggerCommand(ctx, t, modDir, "--interactive", "--interactive-command", "/bin/noexist", "call", "ctr")
+
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		go console.ExpectEOF()
+
+		// We expect the command to fail
+		err = cmd.Wait()
+		require.Error(t, err)
 	})
 }
 

--- a/docs/current_docs/manuals/developer/debugging.mdx
+++ b/docs/current_docs/manuals/developer/debugging.mdx
@@ -15,6 +15,10 @@ Pipeline failures can be both frustrating and lead to wasted resources as the te
 
 Run `dagger call` with the `--interactive` (`-i` for short) flag to open a terminal in the context of a pipeline failure. No changes are required to your Dagger Function code.
 
+:::tip
+Interactive mode defaults executing `/bin/sh` when opening a terminal. Change the command to execute with the `--interactive-command` flag.
+:::
+
 ## Use the `Terminal()` method to inspect the pipeline live
 
 As an alternative to the `--interactive` flag, use the `Terminal()` method to set one or more explicit breakpoints in your Dagger pipeline. Dagger then starts an interactive terminal session at each breakpoint. This lets you inspect a `Directory` or a `Container` at any point in your pipeline run, with all the necessary context available to you.

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -12,13 +12,14 @@ A tool to run CI/CD pipelines in containers, anywhere
 ### Options
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -55,13 +56,14 @@ dagger call [options]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -97,13 +99,14 @@ dagger config -m github.com/dagger/hello-dagger
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -128,13 +131,14 @@ dagger core [options]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -182,13 +186,14 @@ dagger develop [options]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -220,13 +225,14 @@ dagger functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -268,13 +274,14 @@ dagger init --sdk=python
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -309,13 +316,14 @@ dagger install github.com/shykes/hello@v0.1.0
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -333,13 +341,14 @@ dagger login [options] [org]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -357,13 +366,14 @@ dagger logout
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -417,13 +427,14 @@ EOF
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -474,13 +485,14 @@ dagger run python main.py
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO
@@ -498,13 +510,14 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             Show debug logs and full verbosity
-  -i, --interactive       Spawn a terminal on container exec failure
-      --progress string   Progress output format (auto, plain, tty) (default "auto")
-  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent            Do not show progress at all
-  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
-  -w, --web               Open trace URL in a web browser
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
 ```
 
 ### SEE ALSO

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -65,7 +65,8 @@ type Opts struct {
 	Containers   map[bkgw.Container]struct{}
 	ContainersMu *sync.Mutex
 
-	Interactive bool
+	Interactive        bool
+	InteractiveCommand []string
 }
 
 type ResolveCacheExporterFunc func(ctx context.Context, g bksession.Group) (remotecache.Exporter, error)

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -459,12 +459,14 @@ func debugContainer(ctx context.Context, execOp *bksolverpb.ExecOp, execErr *llb
 		output.String("! %s").Foreground(termenv.ANSIYellow).String(), execErr.Error())
 	fmt.Fprint(term.Stderr, dump.Newline)
 
+	// We default to "/bin/sh" if the client doesn't provide a command.
+	debugCommand := []string{"/bin/sh"}
+	if len(client.Opts.InteractiveCommand) > 0 {
+		debugCommand = client.Opts.InteractiveCommand
+	}
+
 	dbgShell, err := dbgCtr.Start(ctx, bkgw.StartRequest{
-		// We need to hardcode a shell since we don't have access to `withDefaultTerminalCmd` here.
-		//
-		// We could use `sh` instead of `/bin/sh`, but then we'd be relying on $PATH to be set up correctly.
-		// It's more likely for `sh` to be in `/bin/sh` than for the container to have a correct $PATH.
-		Args: []string{"/bin/sh"},
+		Args: debugCommand,
 
 		Env:          execOp.Meta.Env,
 		Cwd:          execOp.Meta.Cwd,

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -78,7 +78,8 @@ type Params struct {
 	// Log level (0 = INFO)
 	LogLevel slog.Level
 
-	Interactive bool
+	Interactive        bool
+	InteractiveCommand []string
 
 	WithTerminal session.WithTerminalFunc
 }
@@ -1060,6 +1061,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		CloudToken:                os.Getenv("DAGGER_CLOUD_TOKEN"),
 		DoNotTrack:                analytics.DoNotTrack(),
 		Interactive:               c.Interactive,
+		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
 	}
 }

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -65,6 +65,9 @@ type ClientMetadata struct {
 	// Interactive mode
 	Interactive bool `json:"interactive"`
 
+	// InteractiveCommand changes the command that is run in interactive mode.
+	InteractiveCommand []string `json:"interactive_command"`
+
 	// Import configuration for Buildkit's remote cache
 	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -90,7 +90,8 @@ type daggerSession struct {
 	dagqlCache       dagql.Cache
 	cacheEntrySetMap *sync.Map
 
-	interactive bool
+	interactive        bool
+	interactiveCommand []string
 }
 
 type daggerSessionState string
@@ -226,6 +227,7 @@ func (srv *Server) initializeDaggerSession(
 	sess.cacheEntrySetMap = &sync.Map{}
 	sess.telemetryPubSub = srv.telemetryPubSub
 	sess.interactive = clientMetadata.Interactive
+	sess.interactiveCommand = clientMetadata.InteractiveCommand
 
 	sess.analytics = analytics.New(analytics.Config{
 		DoNotTrack: clientMetadata.DoNotTrack || analytics.DoNotTrack(),
@@ -525,7 +527,8 @@ func (srv *Server) initializeDaggerClient(
 		Containers:   client.daggerSession.containers,
 		ContainersMu: &client.daggerSession.containersMu,
 
-		Interactive: client.daggerSession.interactive,
+		Interactive:        client.daggerSession.interactive,
+		InteractiveCommand: client.daggerSession.interactiveCommand,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create buildkit client: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hanwen/go-fuse/v2 v2.4.0 // indirect


### PR DESCRIPTION
Adds the ability to override the default command (`/bin/sh`) when entering in interactive mode when something fails.

Fixes #7974

Note: I added shlex on the command so we can support fancy stuff like: `dagger call --interactive --interactive-command='sh -c "apk update && apk add bash && bash"'` (for example to setup the debug container with an external script).

Remaining:

- [x] add an integration test
- [x] add a changie entry (feature)