### PR TITLE
chore: increase verbosity of codegen error

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -117,7 +117,7 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) { //nolint: gocyclo
 	}
 
 	if ps.daggerObjectIfaceType == nil {
-		return "", fmt.Errorf("cannot find default codegen %s interface", daggerObjectIfaceName)
+		return "", fmt.Errorf("cannot find default codegen %s interface in:\n[%s]", daggerObjectIfaceName, strings.Join(pkgScope.Names(), ", "))
 	}
 
 	if pkgDoc := ps.pkgDoc(); pkgDoc != "" {

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -81,9 +81,8 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) { //nolint: gocyclo
 	for _, name := range pkgScope.Names() {
 		obj := pkgScope.Lookup(name)
 		if obj == nil {
-			continue
+			return "", fmt.Errorf("%q should exist in scope, but doesn't", name)
 		}
-
 		ps.objs = append(ps.objs, obj)
 	}
 


### PR DESCRIPTION
This error seems to appear as a weird little flake (see https://github.com/dagger/dagger/issues/8031#issuecomment-2260352601) - and never seems to appear legitimately.

Because of this, we should crank the verbosity up to try and understand what the go parser is *actually* seeing when this happens, which might give us a hint as to what is really going on.