### PR TITLE
chore(ci): share dagger sdk services

### DIFF
--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -42,7 +42,7 @@ func (t ElixirSDK) Lint(ctx context.Context) error {
 			span.End()
 		}()
 
-		installer, err := t.Dagger.installer(ctx, "sdk-elixir-lint")
+		installer, err := t.Dagger.installer(ctx, "sdk")
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func (t ElixirSDK) Lint(ctx context.Context) error {
 
 // Test the Elixir SDK
 func (t ElixirSDK) Test(ctx context.Context) error {
-	installer, err := t.Dagger.installer(ctx, "sdk-elixir-test")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (t ElixirSDK) Test(ctx context.Context) error {
 
 // Regenerate the Elixir SDK API
 func (t ElixirSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-elixir-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_go.go
+++ b/.dagger/sdk_go.go
@@ -50,7 +50,7 @@ func (t GoSDK) Lint(ctx context.Context) (rerr error) {
 
 // Test the Go SDK
 func (t GoSDK) Test(ctx context.Context) (rerr error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-go-test")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (t GoSDK) Test(ctx context.Context) (rerr error) {
 
 // Regenerate the Go SDK API
 func (t GoSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-go-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_java.go
+++ b/.dagger/sdk_java.go
@@ -32,7 +32,7 @@ func (t JavaSDK) Lint(ctx context.Context) error {
 
 // Test the Java SDK
 func (t JavaSDK) Test(ctx context.Context) error {
-	installer, err := t.Dagger.installer(ctx, "sdk-java-test")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (t JavaSDK) Test(ctx context.Context) error {
 
 // Regenerate the Java SDK API
 func (t JavaSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-java-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_php.go
+++ b/.dagger/sdk_php.go
@@ -73,7 +73,7 @@ func (t PHPSDK) Test(ctx context.Context) error {
 
 // Regenerate the PHP SDK API
 func (t PHPSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-php-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_python.go
+++ b/.dagger/sdk_python.go
@@ -107,7 +107,7 @@ func (t PythonSDK) Lint(ctx context.Context) (rerr error) {
 
 // Test the Python SDK
 func (t PythonSDK) Test(ctx context.Context) (rerr error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-python-test")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (t PythonSDK) Test(ctx context.Context) (rerr error) {
 
 // Regenerate the Python SDK API
 func (t PythonSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-python-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_rust.go
+++ b/.dagger/sdk_rust.go
@@ -58,7 +58,7 @@ func (r RustSDK) Lint(ctx context.Context) error {
 
 // Test the Rust SDK
 func (r RustSDK) Test(ctx context.Context) error {
-	installer, err := r.Dagger.installer(ctx, "sdk-rust-test")
+	installer, err := r.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (r RustSDK) Test(ctx context.Context) error {
 
 // Regenerate the Rust SDK API
 func (r RustSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := r.Dagger.installer(ctx, "sdk-rust-generate")
+	installer, err := r.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk_typescript.go
+++ b/.dagger/sdk_typescript.go
@@ -112,7 +112,7 @@ func (t TypescriptSDK) Lint(ctx context.Context) (rerr error) {
 
 // Test the Typescript SDK
 func (t TypescriptSDK) Test(ctx context.Context) (rerr error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-typescript-test")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (t TypescriptSDK) Test(ctx context.Context) (rerr error) {
 
 // Regenerate the Typescript SDK API
 func (t TypescriptSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	installer, err := t.Dagger.installer(ctx, "sdk-typescript-generate")
+	installer, err := t.Dagger.installer(ctx, "sdk")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We don't need separate services for each sdk test/generate/lint step - they can just all share together :heart: 