### PR TITLE
chore: trim full stop from end of first line of changelog

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/helm/dagger/.changie.yaml
+++ b/helm/dagger/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/elixir/.changie.yaml
+++ b/sdk/elixir/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/elixir/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/go/.changie.yaml
+++ b/sdk/go/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/go/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/php/.changie.yaml
+++ b/sdk/php/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/php/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/python/.changie.yaml
+++ b/sdk/python/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/python/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/rust/.changie.yaml
+++ b/sdk/rust/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/rust/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}

--- a/sdk/typescript/.changie.yaml
+++ b/sdk/typescript/.changie.yaml
@@ -7,7 +7,7 @@ versionFormat: '## sdk/typescript/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: |
   {{- $lines := .Body | splitn "\n" 2 -}}
-  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  - {{ $lines._0 | trimSuffix "." }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
   {{- with $lines._1 -}}
     {{ " " }}\{{ "\n" }}
     {{- . | trim | indent 2 }}


### PR DESCRIPTION
It's pretty easily to accidentally add a full-stop at the end of a changelog line (e.g. https://github.com/dagger/dagger/pull/8163/files#diff-47044aed7a447d259a5a7a88046f34e4cc36740e18e64da88b4fa178a7349360L3).

We can trim this out during changelog generation pretty easily.