### PR TITLE
chore: remove noisy "failed to get repo HEAD" error

### DIFF
--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -147,7 +147,7 @@ func (labels Labels) WithGitLabels(workdir string) Labels {
 
 	head, err := repo.Head()
 	if err != nil {
-		slog.Warn("failed to get repo HEAD", "err", err)
+		slog.Debug("failed to get repo HEAD", "err", err)
 		return labels
 	}
 


### PR DESCRIPTION
Fixes #7918.

This just moves the warning down to a debug log - this can happen legitimately if there is a git directory (initialized with `git init`), but no commits have been created.

We don't need to warn in this case, we can just log a debug error (since it might *still* be useful for debugging).