### PR TITLE
tests: try killing subprocesses harder if they misbehave

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -6986,10 +6987,42 @@ func cleanupExec(t testing.TB, cmd *exec.Cmd) {
 			t.Logf("never started: %v", cmd.Args)
 			return
 		}
-		t.Logf("interrupting: %v", cmd.Args)
-		cmd.Process.Signal(os.Interrupt)
-		t.Logf("waiting: %v", cmd.Args)
-		cmd.Wait()
+
+		done := make(chan struct{})
+		go func() {
+			cmd.Wait()
+			close(done)
+		}()
+
+		signals := []syscall.Signal{
+			syscall.SIGINT,
+			syscall.SIGTERM,
+			syscall.SIGKILL,
+		}
+		doSignal := func() {
+			if len(signals) == 0 {
+				return
+			}
+			var signal syscall.Signal
+			signal, signals = signals[0], signals[1:]
+			t.Logf("sending %s: %v", signal, cmd.Args)
+			cmd.Process.Signal(signal)
+		}
+		doSignal()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(30 * time.Second):
+				if !t.Failed() {
+					t.Errorf("process did not exit immediately")
+				}
+
+				// the process *still* isn't dead? try killing it harder.
+				doSignal()
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
Part of https://github.com/dagger/dagger/issues/8184, and split out of https://github.com/dagger/dagger/pull/8168, since my general approach there turns out to not be possible :cry: 

Somehow, we see weird timeouts because calls to the dagger cli aren't properly exiting out: https://dagger.cloud/dagger/traces/da4d9c2d21aef7f3eb8ff0856946c0c1#7e1bbffd12a2fbe1

This is it's own problem, but we shouldn't hang the test while waiting for this, we should actually exit and fail after a timeout.