### PR TITLE
docs: fix sudo sh install example

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -186,7 +186,7 @@ func publishEnv(ctx context.Context) (*dagger.Container, error) {
 		WithExec([]string{"apk", "add", "xz"}).
 		WithDirectory("/nix", dag.Directory()).
 		WithNewFile("/etc/nix/nix.conf", `build-users-group =`).
-		WithExec([]string{"sh", "-c", "curl -L https://nixos.org/nix/install | sh -s -- --no-daemon"})
+		WithExec([]string{"sh", "-c", "curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon"})
 	path, err := ctr.EnvVariable(ctx, "PATH")
 	if err != nil {
 		return nil, err

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -55,7 +55,7 @@ runs:
           echo "::endgroup::"
         else
           echo "::group::Installing dagger"
-          curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
           echo "::endgroup::"
         fi
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -347,7 +347,7 @@ which publishes:
       `dev` module updated below will get `dagger.json`'s engine version bumped.
 
 ```console
-curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.4 sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.4 sh
 # install the cli to dagger-0.12.4, and symlink dagger to it
 mv ~/.local/bin/dagger{,-0.12.4}
 ln -s ~/.local/bin/dagger{-0.12.4,}

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -26,7 +26,7 @@ Refer to the documentation for information on how to install the [Dagger CLI](./
 To install a Dagger CLI that matches your OS & architecture, run the following:
 
 ```shell
-curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
 ```
 
 This installs `dagger` in `$HOME/.local/bin`:

--- a/docs/current_docs/integrations/snippets/Jenkinsfile
+++ b/docs/current_docs/integrations/snippets/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     stage("dagger") {
       steps {
         sh '''
-          curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/tmp/dagger/bin DAGGER_VERSION=$DAGGER_VERSION sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/tmp/dagger/bin DAGGER_VERSION=$DAGGER_VERSION sh
           dagger call -m github.com/shykes/hello hello --greeting "bonjour" --name "from jenkins"
         '''
       }

--- a/docs/current_docs/integrations/snippets/azure-pipelines.yml
+++ b/docs/current_docs/integrations/snippets/azure-pipelines.yml
@@ -6,7 +6,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-- script: curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+- script: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
   displayName: 'Install Dagger CLI'
   # assumes a Go project
   # modify to use different function(s) as needed

--- a/docs/current_docs/integrations/snippets/buildspec.yml
+++ b/docs/current_docs/integrations/snippets/buildspec.yml
@@ -11,7 +11,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing Dagger CLI"
-      - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+      - curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
 
   # assumes a Go project
   # modify to use different function(s) as needed

--- a/docs/current_docs/integrations/snippets/circle.yml
+++ b/docs/current_docs/integrations/snippets/circle.yml
@@ -14,7 +14,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Install Dagger CLI
-          command: curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+          command: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - run:
           # assumes a Go project
           # modify to use different function(s) as needed

--- a/docs/current_docs/integrations/snippets/gitlab-docker.yml
+++ b/docs/current_docs/integrations/snippets/gitlab-docker.yml
@@ -17,7 +17,7 @@
   extends: [.docker]
   before_script:
     - apk add curl
-    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
+    - curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
 build:
   extends: [.dagger]
   script:

--- a/docs/current_docs/integrations/snippets/gitlab-kubernetes.yml
+++ b/docs/current_docs/integrations/snippets/gitlab-kubernetes.yml
@@ -7,7 +7,7 @@
     DAGGER_CLOUD_TOKEN: $DAGGER_CLOUD_TOKEN
   before_script:
     - apk add curl
-    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/tmp sh
+    - curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/tmp sh
 build:
   extends: [.dagger]
   script:

--- a/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
+++ b/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
@@ -41,7 +41,7 @@ spec:
     script: |
       #!/usr/bin/env sh
       apk add curl
-      curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
+      curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
       dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
     volumeMounts:
       - mountPath: /var/run/dagger

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -41,7 +41,7 @@ If your user account doesn't have sufficient privileges to install in `/usr/loca
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sudo sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sudo -E sh
 ```
 
 </TabItem>

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -30,7 +30,7 @@ If you do not have Homebrew installed, or you want to install a specific version
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sh
 
 ./bin/dagger version
 dagger v0.12.5 (registry.dagger.io/engine:v0.12.5) darwin/arm64
@@ -41,7 +41,7 @@ If your user account doesn't have sufficient privileges to install in `/usr/loca
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sudo -E sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sudo -E sh
 ```
 
 </TabItem>
@@ -51,7 +51,7 @@ curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sudo -E s
 The quickest way of installing `dagger` on Linux is to run the following command:
 
 ```shell
-curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
 ```
 [View source](https://github.com/dagger/dagger/blob/main/install.sh)
 
@@ -65,7 +65,7 @@ dagger is $HOME/.local/bin/dagger
 If you want to install a specific version of `dagger`, you can run:
 
 ```shell
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.5 sh
 
 ./bin/dagger version
 dagger v0.12.5 (registry.dagger.io/engine:v0.12.5) linux/amd64


### PR DESCRIPTION
The install example has been broken for some time! `sudo` doesn't forward environment variables by default for security purposes, and requires the `-E` flag to do this correctly.