### PR TITLE
fix: split out sdk init

### DIFF
--- a/cmd/codegen/codegen.go
+++ b/cmd/codegen/codegen.go
@@ -16,20 +16,41 @@ import (
 )
 
 func Init(ctx context.Context, cfg generator.Config, dag *dagger.Client) (err error) {
-	return do(ctx, cfg, dag, doInit)
+	return generate(ctx, cfg, dag, generator.Generator.Init)
 }
 
 func Generate(ctx context.Context, cfg generator.Config, dag *dagger.Client) (err error) {
-	return do(ctx, cfg, dag, doGenerate)
+	return generate(ctx, cfg, dag, generator.Generator.Generate)
 }
 
-func do(ctx context.Context, cfg generator.Config, dag *dagger.Client, dothing doThing) (err error) {
+type generatorFunc func(generator generator.Generator, ctx context.Context, introspectionSchema *introspection.Schema, introspectionSchemaVersion string) (*generator.GeneratedState, error)
+
+func generate(ctx context.Context, cfg generator.Config, dag *dagger.Client, generateF generatorFunc) (err error) {
 	logsW := os.Stdout
 
 	if cfg.ModuleName != "" {
 		fmt.Fprintf(logsW, "generating %s module: %s\n", cfg.Lang, cfg.ModuleName)
 	} else {
 		fmt.Fprintf(logsW, "generating %s SDK client\n", cfg.Lang)
+	}
+
+	var gen generator.Generator
+	switch cfg.Lang {
+	case generator.SDKLangGo:
+		gen = &gogenerator.GoGenerator{
+			Config: cfg,
+		}
+	case generator.SDKLangTypeScript:
+		gen = &typescriptgenerator.TypeScriptGenerator{
+			Config: cfg,
+		}
+
+	default:
+		sdks := []string{
+			string(generator.SDKLangGo),
+			string(generator.SDKLangTypeScript),
+		}
+		return fmt.Errorf("use target SDK language: %s: %w", sdks, generator.ErrUnknownSDKLang)
 	}
 
 	var introspectionSchema *introspection.Schema
@@ -47,9 +68,10 @@ func do(ctx context.Context, cfg generator.Config, dag *dagger.Client, dothing d
 			return err
 		}
 	}
+	generator.SetSchemaParents(introspectionSchema)
 
 	for ctx.Err() == nil {
-		generated, err := dothing(ctx, introspectionSchema, introspectionSchemaVersion, cfg)
+		generated, err := generateF(gen, ctx, introspectionSchema, introspectionSchemaVersion)
 		if err != nil {
 			return err
 		}
@@ -82,56 +104,4 @@ func do(ctx context.Context, cfg generator.Config, dag *dagger.Client, dothing d
 	}
 
 	return ctx.Err()
-}
-
-type doThing func(ctx context.Context, introspectionSchema *introspection.Schema, introspectionSchemaVersion string, cfg generator.Config) (*generator.GeneratedState, error)
-
-func doInit(ctx context.Context, introspectionSchema *introspection.Schema, introspectionSchemaVersion string, cfg generator.Config) (*generator.GeneratedState, error) {
-	generator.SetSchemaParents(introspectionSchema)
-
-	var gen generator.Generator
-	switch cfg.Lang {
-	case generator.SDKLangGo:
-		gen = &gogenerator.GoGenerator{
-			Config: cfg,
-		}
-	case generator.SDKLangTypeScript:
-		gen = &typescriptgenerator.TypeScriptGenerator{
-			Config: cfg,
-		}
-
-	default:
-		sdks := []string{
-			string(generator.SDKLangGo),
-			string(generator.SDKLangTypeScript),
-		}
-		return nil, fmt.Errorf("use target SDK language: %s: %w", sdks, generator.ErrUnknownSDKLang)
-	}
-
-	return gen.Init(ctx, introspectionSchema, introspectionSchemaVersion)
-}
-
-func doGenerate(ctx context.Context, introspectionSchema *introspection.Schema, introspectionSchemaVersion string, cfg generator.Config) (*generator.GeneratedState, error) {
-	generator.SetSchemaParents(introspectionSchema)
-
-	var gen generator.Generator
-	switch cfg.Lang {
-	case generator.SDKLangGo:
-		gen = &gogenerator.GoGenerator{
-			Config: cfg,
-		}
-	case generator.SDKLangTypeScript:
-		gen = &typescriptgenerator.TypeScriptGenerator{
-			Config: cfg,
-		}
-
-	default:
-		sdks := []string{
-			string(generator.SDKLangGo),
-			string(generator.SDKLangTypeScript),
-		}
-		return nil, fmt.Errorf("use target SDK language: %s: %w", sdks, generator.ErrUnknownSDKLang)
-	}
-
-	return gen.Generate(ctx, introspectionSchema, introspectionSchemaVersion)
 }

--- a/cmd/codegen/generator/generator.go
+++ b/cmd/codegen/generator/generator.go
@@ -43,6 +43,8 @@ type Config struct {
 }
 
 type Generator interface {
+	Init(ctx context.Context, schema *introspection.Schema, schemaVersion string) (*GeneratedState, error)
+
 	// Generate runs codegen and returns a map of default filename to content for that file.
 	Generate(ctx context.Context, schema *introspection.Schema, schemaVersion string) (*GeneratedState, error)
 }

--- a/cmd/codegen/generator/typescript/generator.go
+++ b/cmd/codegen/generator/typescript/generator.go
@@ -19,6 +19,10 @@ type TypeScriptGenerator struct {
 	Config generator.Config
 }
 
+func (g *TypeScriptGenerator) Init(ctx context.Context, schema *introspection.Schema, schemaVersion string) (*generator.GeneratedState, error) {
+	return nil, nil
+}
+
 // Generate will generate the TypeScript SDK code and might modify the schema to reorder types in a alphanumeric fashion.
 func (g *TypeScriptGenerator) Generate(_ context.Context, schema *introspection.Schema, schemaVersion string) (*generator.GeneratedState, error) {
 	generator.SetSchema(schema)

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -27,8 +27,7 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:  "codegen",
-	RunE: ClientGen,
+	Use: "codegen",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// if we got this far, CLI parsing worked just fine; no
 		// need to show usage for runtime errors
@@ -41,31 +40,34 @@ var introspectCmd = &cobra.Command{
 	RunE: Introspect,
 }
 
+var generateCmd = &cobra.Command{
+	Use:  "generate",
+	RunE: ClientGen,
+}
+
 var initCmd = &cobra.Command{
 	Use:  "init",
 	RunE: ClientInit,
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&lang, "lang", "go", "language to generate")
-	rootCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
-	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
-
-	rootCmd.Flags().StringVar(&modulePath, "module-context-path", "", "path to context directory of the module")
-	rootCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
-	rootCmd.Flags().BoolVar(&merge, "merge", false, "merge module deps with project's")
-
-	introspectCmd.Flags().StringVarP(&outputSchema, "output", "o", "", "save introspection result to file")
-	rootCmd.AddCommand(introspectCmd)
+	generateCmd.Flags().StringVar(&lang, "lang", "go", "language to generate")
+	generateCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
+	generateCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
+	generateCmd.Flags().StringVar(&modulePath, "module-context-path", "", "path to context directory of the module")
+	generateCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
+	rootCmd.AddCommand(generateCmd)
 
 	initCmd.Flags().StringVar(&lang, "lang", "go", "language to generate")
 	initCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
 	initCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
-
 	initCmd.Flags().StringVar(&modulePath, "module-context-path", "", "path to context directory of the module")
 	initCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
 	initCmd.Flags().BoolVar(&merge, "merge", false, "merge module deps with project's")
 	rootCmd.AddCommand(initCmd)
+
+	introspectCmd.Flags().StringVarP(&outputSchema, "output", "o", "", "save introspection result to file")
+	rootCmd.AddCommand(introspectCmd)
 }
 
 func ClientGen(cmd *cobra.Command, args []string) error {
@@ -75,19 +77,9 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// we're checking for the flag existence here as not setting the flag and
-	// setting it to false doesn't produce the same behavior.
-	var mergePtr *bool
-	if cmd.Flags().Changed("merge") {
-		mergePtr = &merge
-	}
-
 	cfg := generator.Config{
-		Lang: generator.SDKLang(lang),
-
+		Lang:      generator.SDKLang(lang),
 		OutputDir: outputDir,
-
-		Merge: mergePtr,
 	}
 
 	if moduleName != "" {
@@ -132,11 +124,9 @@ func ClientInit(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := generator.Config{
-		Lang: generator.SDKLang(lang),
-
+		Lang:      generator.SDKLang(lang),
 		OutputDir: outputDir,
-
-		Merge: mergePtr,
+		Merge:     mergePtr,
 	}
 
 	if moduleName != "" {

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -386,6 +386,29 @@ func (CLISuite) TestDaggerInitGit(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (CLISuite) TestDaggerInitWithNoSource(ctx context.Context, t *testctx.T) {
+	for _, tc := range []string{"go"} {
+		t.Run(tc, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+
+			modGen := goGitBase(t, c).With(daggerExec("init", "--name=bare", "--sdk="+tc))
+
+			out, err := modGen.
+				With(daggerCall("container-echo", "--string-arg=hello there!", "stdout")).
+				Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, "hello there!")
+
+			_, err = modGen.
+				WithoutFile(sdkSourceFile(tc)).
+				With(daggerCall("container-echo", "--string-arg=hello there!", "stdout")).
+				Stdout(ctx)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "main object not found")
+		})
+	}
+}
+
 func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 	t.Run("name and sdk", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/module.go
+++ b/core/module.go
@@ -671,23 +671,38 @@ to be used without hard dependencies on the internet. They are loaded w/ the `lo
 loads them as modules from the engine container.
 */
 type SDK interface {
-	/* Codegen generates code for the module at the given source directory and subpath.
+	// Init generates the base code for the module at the given source
+	// directory and subpath.
+	//
+	// The Code field of the returned GeneratedCode object should be the
+	// generated contents of the module sourceDirSubpath, in the case where
+	// that's different than the root of the sourceDir.
+	//
+	// The provided Module is not fully initialized; the Runtime field will not
+	// be set yet.
+	Init(context.Context, *ModDeps, dagql.Instance[*ModuleSource]) (*dagql.Instance[*Directory], error)
 
-	The Code field of the returned GeneratedCode object should be the generated contents of the module sourceDirSubpath,
-	in the case where that's different than the root of the sourceDir.
-
-	The provided Module is not fully initialized; the Runtime field will not be set yet.
-	*/
+	// Codegen generates code for the module at the given source directory and
+	// subpath.
+	//
+	// The Code field of the returned GeneratedCode object should be the
+	// generated contents of the module sourceDirSubpath, in the case where
+	// that's different than the root of the sourceDir.
+	//
+	// The provided Module is not fully initialized; the Runtime field will not
+	// be set yet.
 	Codegen(context.Context, *ModDeps, dagql.Instance[*ModuleSource]) (*GeneratedCode, error)
 
-	/* Runtime returns a container that is used to execute module code at runtime in the Dagger engine.
-
-	The provided Module is not fully initialized; the Runtime field will not be set yet.
-	*/
+	// Runtime returns a container that is used to execute module code at
+	// runtime in the Dagger engine.
+	//
+	// The provided Module is not fully initialized; the Runtime field will not
+	// be set yet.
 	Runtime(context.Context, *ModDeps, dagql.Instance[*ModuleSource]) (*Container, error)
 
-	// Paths that should always be loaded from module sources using this SDK. Ensures that e.g. main.go
-	// in the Go SDK is always loaded even if dagger.json has include settings that don't include it.
+	// Paths that should always be loaded from module sources using this SDK.
+	// Ensures that e.g. main.go in the Go SDK is always loaded even if
+	// dagger.json has include settings that don't include it.
 	RequiredPaths(context.Context) ([]string, error)
 }
 

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -593,6 +593,8 @@ func (sdk *goSDK) baseWithCodegen(
 	var codegenArgs dagql.ArrayInput[dagql.String]
 	if init {
 		codegenArgs = append(codegenArgs, "init")
+	} else {
+		codegenArgs = append(codegenArgs, "generate")
 	}
 	codegenArgs = append(codegenArgs,
 		"--output", dagql.String(goSDKUserModContextDirPath),
@@ -600,10 +602,8 @@ func (sdk *goSDK) baseWithCodegen(
 		"--module-name", dagql.String(modName),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
 	)
-
-	if src.Self.WithInitConfig != nil {
-		codegenArgs = append(codegenArgs,
-			dagql.String("--merge="+strconv.FormatBool(src.Self.WithInitConfig.Merge)))
+	if init && src.Self.WithInitConfig != nil {
+		codegenArgs = append(codegenArgs, dagql.String("--merge="+strconv.FormatBool(src.Self.WithInitConfig.Merge)))
 	}
 
 	if err := sdk.dag.Select(ctx, ctr, &ctr, dagql.Selector{

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -365,6 +365,7 @@ func (t *TypescriptSdk) generateClient(ctr *dagger.Container, introspectionJSON 
 		// Execute the code generator using the given introspection file.
 		WithExec([]string{
 			codegenBinPath,
+			"generate",
 			"--lang", "typescript",
 			"--output", ModSourceDirPath,
 			"--module-name", t.moduleConfig.name,


### PR DESCRIPTION
- Fixes #6621
- Fixes #7834
- Kind of generally part of #7707.

The idea is to more explicitly break down each SDKs initialization steps - we should only generate the base template in `Init`. This avoids the annoying implicit generation of `main.go` when no source files exist.

TODO:
- [ ] Implement for all the core SDKs
- [ ] Implement for the community SDKs and/or introduce a fallback if the SDK doesn't define `init`
- [ ] Cleanup

