### PR TITLE
Literally run Dagger docs

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -1,3 +1,8 @@
+---
+cwd: ..
+terminalRows: 16
+---
+
 # Developing Dagger with Dagger
 
 This Dagger module defines pipelines to develop the Dagger itself, including building and releasing the CLI, engine and SDKs.
@@ -12,34 +17,51 @@ A module is a collection of functions (and types) which can be used by `dagger c
 
 To discover available functions in a given module: `dagger functions`.
 
-With that in mind: this document includes examples of *typical pipelines* that are useful while developing Dagger. But remember, you are free to compose your own pipelines, either by modifying the examples, of starting from scratch. This flexibility is one of the killer features of Dagger.
+```sh {"id":"01J5Y82842KAER30RGCN96HH6M"}
+dagger functions
+```
+
+With that in mind: this document includes examples of _typical pipelines_ that are useful while developing Dagger. But remember, you are free to compose your own pipelines, either by modifying the examples, of starting from scratch. This flexibility is one of the killer features of Dagger.
 
 ## Running pipelines in a local checkout
 
 All the pipelines in this document can be run against a local or remote source directory. We will assume a local checkout, unless explicitly stated otherwise.
 
-To keep the example commands shorter, let's use a convenience environment variable to designate the current git repository as the source.
+## Literally run this README
 
-  # Run anywhere inside a local checkout of github.com/dagger/dagger
-  export SRC="$(git rev-parse --show-toplevel):default"
+Be sure to install Runme first via homebrew on macOS.
 
-That variable has no meaning outside of this document, it is for convenience only.
+```sh {"id":"01J5Y84809NWNP74YV0Y1MVFN4"}
+brew install runme
+```
+
+Or install the VS Code extension that comes bundled with the runme binary.
+
+```sh {"id":"01J5Y85Y7DVWMW8NB80BVNEFH7"}
+code --install-extension stateful.runme
+```
 
 ## Tests
 
 Run all tests:
 
-    dagger call --source="$SRC" test all
+```sh {"id":"01J5EG1EXCHRB5J8ZEGZZXWE5H","name":"dev-dagger-test"}
+dagger call --source=".:default" test all
+```
 
 Run a specific test (e.g. `TestModuleNamespacing`):
 
-    dagger call --source="$SRC" test custom --pkg="./core/integration" --run="^TestModule/TestNamespacing"
+```sh {"id":"01J5EG1JNRB987MSB7SPM0EXGA"}
+dagger call --source=".:default" test custom --pkg="./core/integration" --run="^TestModule/TestNamespacing"
+```
 
 ## Dev shell
 
 Start a dev shell with dagger-in-dagger:
 
-    dagger call --source="$SRC" dev terminal
+```sh {"id":"01J5EG1QD02ZN97W42BMG57Q8A","name":"dev-dagger-terminal"}
+dagger call --source=".:default" dev terminal
+```
 
 ## Engine & CLI
 
@@ -47,42 +69,53 @@ Start a dev shell with dagger-in-dagger:
 
 Run the engine linter:
 
-    dagger call --source="$SRC" engine lint
+```sh {"id":"01J5EG1VKBMG5X165Z7NMTX1ZZ","name":"dev-dagger-lint"}
+dagger call --source=".:default" engine lint
+```
 
 ### Build the CLI
 
 Build the CLI:
 
-    dagger call --source="$SRC" cli binary -o ./bin/dagger
+```sh {"id":"01J5EFASD4HADA1XKEHPK27WJ4","name":"dev-dagger-cli"}
+dagger call --source=".:default" cli binary -o ./bin/dagger
+```
 
 ### Run the engine service
 
 Run the engine as a service:
 
-    dagger call --source="$SRC" engine service --name=dagger-engine up --ports=1234:1234
+```sh {"background":"true","id":"01J5EFDBTC31PM0RKA1X3ZZM0F","name":"dev-engine-service"}
+dagger call --source=".:default" engine service --name=dagger-engine up --ports=1234:1234
+```
 
 Connect to it from a dagger cli:
 
-    export _EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://0.0.0.0:1234
-    dagger call -m github.com/shykes/daggerverse/hello@main hello
-    # hello, world!
+```sh {"id":"01J5EG220PWZVQREPZ7RWT8QRH","name":"dev-engine-hello"}
+export _EXPERIMENTAL_DAGGER_RUNNER_HOST="tcp://0.0.0.0:1234"
+dagger call -m github.com/shykes/daggerverse/hello@main hello
+# hello, world!
+```
 
 ## Docs
 
 Lint the docs:
 
-    dagger call --source="$SRC" docs lint
+```sh {"id":"01J5EG2748AAH2FYQ8WXAWV9XY","name":"dev-docs-lint"}
+dagger call --source=".:default" docs lint
+```
 
 Auto-generate docs components:
 
-    dagger call --source="$SRC" docs generate -o .
+```sh {"id":"01J5EG2A6R51NYZ5RJX63P5NEF","name":"dev-docs-generate"}
+dagger call --source=".:default" docs generate -o .
+```
 
 ## SDKs
 
 ### List available SDKs
 
     dagger functions sdk
-
 
 All SDKs have the same functions defined:
 
@@ -91,38 +124,37 @@ All SDKs have the same functions defined:
 - `generate`: generates any auto-generated files against a dev engine
 - `bump`: bumps the SDK version number
 - `publish`: publishes the SDK to a registry
-    - Note: options for this function are SDK-specific
+   - Note: options for this function are SDK-specific
 
 ### Linting
 
 Run an SDK linter (replace `<sdk>` with one of the supported SDKs):
 
-    dagger call --source="$SRC" sdk <sdk> lint
+    dagger call --source=".:default" sdk <sdk> lint
 
 ### Tests
 
 Run SDK tests (replace `<sdk>` with one of the supported SDKs):
 
-    dagger call --source="$SRC" sdk <sdk> test
+    dagger call --source=".:default" sdk <sdk> test
 
 ### Generate
 
 Generate SDK static files (replace `<sdk>` with one of the supported SDKs):
 
-    dagger call --source="$SRC" sdk <sdk> generate export --path=.
+    dagger call --source=".:default" sdk <sdk> generate export --path=.
 
 ### Publish
 
 Dry-run an SDK publishing step (replace `<sdk>` with one of the supported SDKs):
 
-    dagger call --source="$SRC" sdk <sdk> publish --dry-run
+    dagger call --source=".:default" sdk <sdk> publish --dry-run
 
 ### Bump
 
 Bump an SDK version for releasing (replace `<sdk>` with one of the supported SDKs):
 
-    dagger call --source="$SRC" sdk <sdk> bump --version=$VERSION export --path=.
-
+    dagger call --source=".:default" sdk <sdk> bump --version=$VERSION export --path=.
 
 ## Contributing to this module
 
@@ -133,7 +165,7 @@ Bump an SDK version for releasing (replace `<sdk>` with one of the supported SDK
 
 If you want to develop this module, remember to run the following one-off command after a repository clone:
 
-```
+```sh {"id":"01J5EF8SWVX7KGC4YF6DXW5A7T"}
 dagger develop
 ```
 

--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -17,7 +17,7 @@ A module is a collection of functions (and types) which can be used by `dagger c
 
 To discover available functions in a given module: `dagger functions`.
 
-```sh {"id":"01J5Y82842KAER30RGCN96HH6M"}
+```sh
 dagger functions
 ```
 
@@ -31,13 +31,13 @@ All the pipelines in this document can be run against a local or remote source d
 
 Be sure to install Runme first via homebrew on macOS.
 
-```sh {"id":"01J5Y84809NWNP74YV0Y1MVFN4"}
+```sh
 brew install runme
 ```
 
 Or install the VS Code extension that comes bundled with the runme binary.
 
-```sh {"id":"01J5Y85Y7DVWMW8NB80BVNEFH7"}
+```sh
 code --install-extension stateful.runme
 ```
 
@@ -45,13 +45,13 @@ code --install-extension stateful.runme
 
 Run all tests:
 
-```sh {"id":"01J5EG1EXCHRB5J8ZEGZZXWE5H","name":"dev-dagger-test"}
+```sh {"name":"dev-dagger-test"}
 dagger call --source=".:default" test all
 ```
 
 Run a specific test (e.g. `TestModuleNamespacing`):
 
-```sh {"id":"01J5EG1JNRB987MSB7SPM0EXGA"}
+```sh
 dagger call --source=".:default" test custom --pkg="./core/integration" --run="^TestModule/TestNamespacing"
 ```
 
@@ -59,7 +59,7 @@ dagger call --source=".:default" test custom --pkg="./core/integration" --run="^
 
 Start a dev shell with dagger-in-dagger:
 
-```sh {"id":"01J5EG1QD02ZN97W42BMG57Q8A","name":"dev-dagger-terminal"}
+```sh {"name":"dev-dagger-terminal"}
 dagger call --source=".:default" dev terminal
 ```
 
@@ -69,7 +69,7 @@ dagger call --source=".:default" dev terminal
 
 Run the engine linter:
 
-```sh {"id":"01J5EG1VKBMG5X165Z7NMTX1ZZ","name":"dev-dagger-lint"}
+```sh {"name":"dev-dagger-lint"}
 dagger call --source=".:default" engine lint
 ```
 
@@ -77,7 +77,7 @@ dagger call --source=".:default" engine lint
 
 Build the CLI:
 
-```sh {"id":"01J5EFASD4HADA1XKEHPK27WJ4","name":"dev-dagger-cli"}
+```sh {"name":"dev-dagger-cli"}
 dagger call --source=".:default" cli binary -o ./bin/dagger
 ```
 
@@ -85,13 +85,13 @@ dagger call --source=".:default" cli binary -o ./bin/dagger
 
 Run the engine as a service:
 
-```sh {"background":"true","id":"01J5EFDBTC31PM0RKA1X3ZZM0F","name":"dev-engine-service"}
+```sh {"background":"true","name":"dev-engine-service"}
 dagger call --source=".:default" engine service --name=dagger-engine up --ports=1234:1234
 ```
 
 Connect to it from a dagger cli:
 
-```sh {"id":"01J5EG220PWZVQREPZ7RWT8QRH","name":"dev-engine-hello"}
+```sh {"name":"dev-engine-hello"}
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST="tcp://0.0.0.0:1234"
 dagger call -m github.com/shykes/daggerverse/hello@main hello
 # hello, world!
@@ -101,13 +101,13 @@ dagger call -m github.com/shykes/daggerverse/hello@main hello
 
 Lint the docs:
 
-```sh {"id":"01J5EG2748AAH2FYQ8WXAWV9XY","name":"dev-docs-lint"}
+```sh {"name":"dev-docs-lint"}
 dagger call --source=".:default" docs lint
 ```
 
 Auto-generate docs components:
 
-```sh {"id":"01J5EG2A6R51NYZ5RJX63P5NEF","name":"dev-docs-generate"}
+```sh {"name":"dev-docs-generate"}
 dagger call --source=".:default" docs generate -o .
 ```
 
@@ -165,7 +165,7 @@ Bump an SDK version for releasing (replace `<sdk>` with one of the supported SDK
 
 If you want to develop this module, remember to run the following one-off command after a repository clone:
 
-```sh {"id":"01J5EF8SWVX7KGC4YF6DXW5A7T"}
+```sh
 dagger develop
 ```
 


### PR DESCRIPTION
I'm curious to hear feedback on this DevX concept. It's a throwback to the Magefile (or Taskfile/Makefile, etc.).

However, instead of maintaining some separate task definitions, the "tasks" are lifted out of the documentation (as long as they are cells "exported" with a name). The description is a cell's preceding paragraph in the markdown AST. Made some minimal edits to the existing `.dagger/README.md`.

https://github.com/user-attachments/assets/df858c80-6bb3-4508-b9d9-7151319ab911

It's trivial to run individual tasks, e.g. `runme run dev-dagger-cli` (from `runme list`) and use them as test targets in CI/CD (via https://github.com/stateful/runme-action or first-class Dagger function) effectively testing your DevX and documentation.

PS: I'm working on bringing `export SRC="$(git rev-parse --show-toplevel):default"` back. However, I wanted to share the concept first.