### PR TITLE
fix: handle comment parsing with windows line endings

### DIFF
--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -38,6 +38,14 @@ func TestParsePragmaComment(t *testing.T) {
 			rest: "",
 		},
 		{
+			name:    "single key with leading whitespace",
+			comment: " \t +foo",
+			expected: map[string]string{
+				"foo": "",
+			},
+			rest: "",
+		},
+		{
 			name:    "single key-value",
 			comment: "+foo=bar",
 			expected: map[string]string{

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -89,8 +89,10 @@ func (m *Minimal) EchoOpts(
 	// String to append to the echoed message
 	// +optional
 	suffix string,
-	// Number of times to repeat the message
-	// +optional
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
 	times int,
 ) string {
 	msg += suffix
@@ -107,8 +109,10 @@ func (m *Minimal) EchoOptsInline(opts struct {
 	// String to append to the echoed message
 	// +optional
 	Suffix string
-	// Number of times to repeat the message
-	// +optional
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
 	Times int
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
@@ -120,8 +124,10 @@ func (m *Minimal) EchoOptsInlinePointer(opts *struct {
 	// String to append to the echoed message
 	// +optional
 	Suffix string
-	// Number of times to repeat the message
-	// +optional
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
 	Times int
 }) string {
 	return m.EchoOptsInline(*opts)
@@ -133,8 +139,10 @@ func (m *Minimal) EchoOptsInlineCtx(ctx context.Context, opts struct {
 	// String to append to the echoed message
 	// +optional
 	Suffix string
-	// Number of times to repeat the message
-	// +optional
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
 	Times int
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
@@ -146,8 +154,10 @@ func (m *Minimal) EchoOptsInlineTags(ctx context.Context, opts struct {
 	// String to append to the echoed message
 	// +optional
 	Suffix string `tag:"hello"`
-	// Number of times to repeat the message
-	// +optional
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
 	Times int `tag:"hello again"`
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
@@ -160,9 +170,11 @@ func (m *Minimal) EchoOptsPragmas(
 	// +optional=true
 	// +default="..."
 	suffix string,
-	// Number of times to repeat the message
-	// +optional
-	times int, // +default=3
+	/*
+		Number of times to repeat the message
+		+optional
+	*/
+	times int, /* +default=3 */
 ) string {
 	return strings.Repeat(msg+suffix, times)
 }


### PR DESCRIPTION
Our comment parsing code was previously very inflexible, and didn't handle carriage returns in the comment. I *originally* thought I fixed this in https://github.com/dagger/dagger/pull/7121, but I guess not :cry: 

This is because of this helpful little note in go's comment ast struct declaration:

	// The Text field contains the comment text without carriage returns (\r) that
	// may have been present in the source. Because a comment's end position is
	// computed using len(Text), the position reported by [Comment.End] does not match the
	// true source end position for comments containing carriage returns.

So calling `.End()` on a comment essentially returns absolutely nonsense when there are carriage returns - there is no good way of recovering these.

Instead, we switch to another approach of detecting comment doc+line comments - instead of attempting to look for the last element of the line in the comment, we perform an entirely line-based approach, by checking if the comment starts/ends on the correct line.

This is relatively fiddly, and is a bit fragile, so added some more tests as well. Also, handling block comments `/* */` becomes a bit trickier, so extended tests to handle those as well.