### PR TITLE
fix(core): drop leading slash from paths in withVCSGeneratedPaths API

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"dagger.io/dagger/telemetry"
 	"golang.org/x/sync/errgroup"
@@ -1125,6 +1126,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 				// already has some config for the file
 				continue
 			}
+			fileName := strings.TrimPrefix(fileName, "/")
 			gitAttrsContents = append(gitAttrsContents,
 				[]byte(fmt.Sprintf("/%s linguist-generated\n", fileName))...,
 			)


### PR DESCRIPTION
This fix comes from accidentally add a leading slash in the generated paths during fix the Elixir issue like this:

```go
modName := "potato" // assume the name is this.
dag.GeneratedCode(directory).
    WithVCSGeneratedPaths([]string{"/src/"+modName+"/lib/mix/tasks/dagger.invoke.ex"})
```

The `.gitattributes` produces as:

```
//src/potato/...
```

It's happens because the API prepending it without detecting the path that user given. This fixes by dropping it if the path already contained.