### PR TITLE
Add dependabot configuration to update Elixir packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -147,3 +147,19 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+
+  - package-ecosystem: "mix"
+    directory: "/sdk/elixir"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
+    labels:
+      - "kind/dependencies"
+      - "area/sdk/elixir"
+    groups:
+      sdk-elixir:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Like other SDKs. It'll update every week with `area/sdk/elixir` label.