### PR TITLE
initialize: trace docker ps command

### DIFF
--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -220,20 +220,20 @@ func traceExec(ctx context.Context, cmd *exec.Cmd, opts ...trace.SpanStartOption
 }
 
 func collectLeftoverEngines(ctx context.Context) ([]string, error) {
-	output, err := exec.CommandContext(ctx,
+	cmd := exec.CommandContext(ctx,
 		"docker", "ps",
 		"-a",
 		"--no-trunc",
 		"--filter", "name=^/"+containerNamePrefix,
 		"--format", "{{.Names}}",
-	).CombinedOutput()
-	output = bytes.TrimSpace(output)
-
-	if len(output) == 0 {
-		return nil, err
+	)
+	output, err := traceExec(ctx, cmd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list containers: %s", output)
 	}
 
-	engineNames := strings.Split(string(output), "\n")
+	output = strings.TrimSpace(output)
+	engineNames := strings.Split(output, "\n")
 	return engineNames, err
 }
 


### PR DESCRIPTION
@sipsma @helderco Unsure how to test this since using the dev engine bypasses this code

Context: Over 1 second is lost on every dagger command (at least on macOS with d4m). Trying to fo figure out what's up. Example: https://dagger.cloud/dagger/traces/6642af8fb7e4308be318136ff67c83b5?span=e5599dec41cad509

Most of the time is spent in unaccounted parts of `starting engine` (there's only ~200ms out of ~900ms that are "spanned").