### PR TITLE
fix OTel `sdk/log` and `telemetry.Close` breaking changes

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -295,7 +295,7 @@ func dispatch(ctx context.Context) error {
 		semconv.ServiceNameKey.String("dagger-go-sdk"),
 		// TODO version?
 	))
-	defer telemetry.Close(ctx)
+	defer telemetry.Close()
 
 	// A lot of the "work" actually happens when we're marshalling the return
 	// value, which entails getting object IDs, which happens in MarshalJSON,

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -96,6 +96,6 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 	return ctx, func(rerr error) {
 		stdio.Close()
 		telemetry.End(span, func() error { return rerr })
-		telemetry.Close(ctx)
+		telemetry.Close()
 	}
 }

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -454,7 +454,7 @@ func main() { //nolint:gocyclo
 	}
 
 	app.After = func(*cli.Context) error {
-		telemetry.Close(ctx)
+		telemetry.Close()
 		return nil
 	}
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -403,7 +403,16 @@ func (m *HasNotMainGo) Hello() string { return "Hello, world!" }
 		goMod, err := modGen.File("go.mod").Contents(ctx)
 		require.NoError(t, err)
 		require.Regexp(t, regexp.QuoteMeta(
-			`replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0`,
+			`go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0`,
+		), goMod)
+		require.Regexp(t, regexp.QuoteMeta(
+			`go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0`,
+		), goMod)
+		require.Regexp(t, regexp.QuoteMeta(
+			`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88`,
+		), goMod)
+		require.Regexp(t, regexp.QuoteMeta(
+			`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0`,
 		), goMod)
 	})
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 	testCtx = telemetry.InitEmbedded(testCtx, nil)
 	res := m.Run()
-	telemetry.Close(testCtx)
+	telemetry.Close()
 
 	if origAuthSock != "" {
 		os.Setenv("SSH_AUTH_SOCK", origAuthSock)

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -30,7 +30,12 @@ require (
 	google.golang.org/grpc v1.64.0
 )
 
-replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0
+replace (
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+	go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+	go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0
+)
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -30,6 +30,8 @@ require (
 	google.golang.org/grpc v1.64.0
 )
 
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0
+
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
* Pin `sdk/go` + module's `go.opentelemetry.io/otel/sdk/log` dependency to v0.3.0 (not a bump) to avoid `OnEmit` breaking API change (`log.Record` -> `*log.Record`).
  * Alternatively we could bump the version but that's more work and doesn't fix the root problem - the logging SDK is pre-1.0, so we can expect turbulence like this. Despite the version in `go.mod` it seems that it's too easy to stray ahead to v0.5.0 which breaks everything. Pinning with a `replace` rule seems to be the solution until they ship v1.0.
* Undoes the `telemetry.Close` breaking change from #7996 
  * Not actually necessary, so not worth the breakage.
  * Fixes https://github.com/dagger/dagger/issues/8206