### PR TITLE
feat: optimize TS SDK runtime

### DIFF
--- a/sdk/typescript/.changes/unreleased/Changed-20240827-020027.yaml
+++ b/sdk/typescript/.changes/unreleased/Changed-20240827-020027.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |-
+  Improve TypeScript SDK runtime performances by reordering operation to trigger more cache hits.
+
+  Add module's code as final step to avoid cache burst when changing codes.
+time: 2024-08-27T02:00:27.865659+02:00
+custom:
+  Author: TomChv
+  PR: "8236"

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -193,7 +193,7 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 		WithDirectory(filepath.Join(t.moduleConfig.modulePath(), GenDir), sdk).
 		WithWorkdir(t.moduleConfig.modulePath())
 
-	base, err = t.configureModule(ctx, base)
+	base, err = t.configureModule(base)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup module: %w", err)
 	}
@@ -317,7 +317,7 @@ func (t *TypescriptSdk) addTemplate(ctx context.Context, ctr *dagger.Container) 
 //
 // If there's no src directory or no typescript files in it, it will create one
 // and copy the template index.ts file in it.
-func (t *TypescriptSdk) configureModule(ctx context.Context, ctr *dagger.Container) (*dagger.Container, error) {
+func (t *TypescriptSdk) configureModule(ctr *dagger.Container) (*dagger.Container, error) {
 	runtime := t.moduleConfig.runtime
 
 	// If there's a package.json, run the tsconfig updator script and install the genDir.

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -212,13 +212,14 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 	// Add user's source files
 	base = base.WithDirectory(ModSourceDirPath,
 		dag.Directory().WithDirectory("/", modSource.ContextDirectory(), dagger.DirectoryWithDirectoryOpts{
-			// Include the rest of the user's module except config files to not override previous steps.
+			// Include the rest of the user's module except config files to not override previous steps & SDKs.
 			Exclude: []string{
 				fmt.Sprintf("%s/package.json", t.moduleConfig.subPath),
 				fmt.Sprintf("%s/*lock*", t.moduleConfig.subPath),
 				fmt.Sprintf("%s/tsconfig.json", t.moduleConfig.subPath),
 				fmt.Sprintf("%s/pnpm-workspace.yaml", t.moduleConfig.subPath),
 				fmt.Sprintf("%s/.yarnrc.yml", t.moduleConfig.subPath),
+				fmt.Sprintf("%s/sdk", t.moduleConfig.subPath),
 			},
 		}),
 	)

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -212,9 +212,13 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 	// Add user's source files
 	base = base.WithDirectory(ModSourceDirPath,
 		dag.Directory().WithDirectory("/", modSource.ContextDirectory(), dagger.DirectoryWithDirectoryOpts{
-			// Only include the user's source files
-			Include: []string{
-				fmt.Sprintf("%s/src", t.moduleConfig.subPath),
+			// Include the rest of the user's module except config files to not override previous steps.
+			Exclude: []string{
+				fmt.Sprintf("%s/package.json", t.moduleConfig.subPath),
+				fmt.Sprintf("%s/*lock*", t.moduleConfig.subPath),
+				fmt.Sprintf("%s/tsconfig.json", t.moduleConfig.subPath),
+				fmt.Sprintf("%s/pnpm-workspace.yaml", t.moduleConfig.subPath),
+				fmt.Sprintf("%s/.yarnrc.yml", t.moduleConfig.subPath),
 			},
 		}),
 	)

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -193,10 +193,7 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 		WithDirectory(filepath.Join(t.moduleConfig.modulePath(), GenDir), sdk).
 		WithWorkdir(t.moduleConfig.modulePath())
 
-	base, err = t.configureModule(base)
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup module: %w", err)
-	}
+	base = t.configureModule(base)
 
 	// Generate the appropriate lock file
 	base, err = t.generateLockFile(base)
@@ -317,7 +314,7 @@ func (t *TypescriptSdk) addTemplate(ctx context.Context, ctr *dagger.Container) 
 //
 // If there's no src directory or no typescript files in it, it will create one
 // and copy the template index.ts file in it.
-func (t *TypescriptSdk) configureModule(ctr *dagger.Container) (*dagger.Container, error) {
+func (t *TypescriptSdk) configureModule(ctr *dagger.Container) *dagger.Container {
 	runtime := t.moduleConfig.runtime
 
 	// If there's a package.json, run the tsconfig updator script and install the genDir.
@@ -336,7 +333,7 @@ func (t *TypescriptSdk) configureModule(ctr *dagger.Container) (*dagger.Containe
 		ctr = ctr.WithDirectory(".", ctr.Directory("/opt/module/template"), dagger.ContainerWithDirectoryOpts{Include: []string{"*.json"}})
 	}
 
-	return ctr, nil
+	return ctr
 }
 
 // addSDK returns a directory with the SDK sources.


### PR DESCRIPTION
Reorder steps to not list all entries when configuring modules. Move install dependencies step & corepack init before mounting sources.
Add template after initializing dependencies.

It seems that it really improve the cache hit, putting the TS SDK near Go speed when cache hits.

I updated the sources between the 2 runs and we can see that initialize kept being quick! We need more tests but it looks really promising.

<img width="796" alt="Screenshot 2024-08-27 at 00 58 24" src="https://github.com/user-attachments/assets/1c51c5d1-0aed-4008-ac1d-72186ff43e92">
