### PR TITLE
fix(python): use unique module paths to avoid uv cache conflict

### DIFF
--- a/core/integration/testdata/modules/python/extended/src/main/__init__.py
+++ b/core/integration/testdata/modules/python/extended/src/main/__init__.py
@@ -7,15 +7,12 @@ class ExtPythonSdk:
     required_paths: list[str] = field(default=list)
 
     @function
-    def codegen(
+    async def codegen(
         self, mod_source: dagger.ModuleSource, introspection_json: dagger.File
     ) -> dagger.GeneratedCode:
+        sdk = self.common(mod_source, introspection_json)
         return (
-            dag.generated_code(
-                self.common(mod_source, introspection_json)
-                .container()
-                .directory("/src")
-            )
+            dag.generated_code(sdk.container().directory(await sdk.source_path()))
             .with_vcs_generated_paths(["sdk/**"])
             .with_vcs_ignored_paths(["sdk"])
         )


### PR DESCRIPTION
Attempts to fix https://github.com/dagger/dagger/issues/7662, follow-up to https://github.com/dagger/dagger/pull/8051.

I *think* https://github.com/dagger/dagger/pull/8051 was the right approach - however, the tests weren't the issue. The paths in the tests aren't actually part of the uv cache key, so the underlying issue remains.

The real fix for this needs to be in the python sdk runtime, where we can correctly set these paths - based on the module id (or some other "unique enough" id, that can guarantee that we're not going to get weird horrible conflicts).

cc @sipsma @helderco 