### PR TITLE
feat(sdk/elixir): make error message be more readable

### DIFF
--- a/sdk/elixir/lib/dagger/core/error.ex
+++ b/sdk/elixir/lib/dagger/core/error.ex
@@ -1,5 +1,55 @@
-defmodule Dagger.Core.QueryError do
-  @moduledoc false
+defmodule Dagger.Core.ExecError do
+  @moduledoc """
+  API error from an exec operation.
+  """
 
-  defstruct [:errors]
+  defexception [:original_error, :cmd, :exit_code, :stdout, :stderr]
+
+  def from_map(map) do
+    %__MODULE__{
+      cmd: map["cmd"],
+      exit_code: map["exitCode"],
+      stdout: map["stdout"],
+      stderr: map["stderr"]
+    }
+  end
+
+  def with_original_error(exec_error, error) do
+    %{exec_error | original_error: error}
+  end
+
+  @impl true
+  def message(exception) do
+    stdout =
+      if String.trim(exception.stdout) != "" do
+        [
+          "Stdout:",
+          ?\n,
+          exception.stdout
+        ]
+      else
+        ""
+      end
+
+    stderr =
+      if String.trim(exception.stderr) != "" do
+        [
+          "Stderr:",
+          ?\n,
+          exception.stderr
+        ]
+      else
+        ""
+      end
+
+    [
+      Exception.message(exception.original_error),
+      ?\n,
+      stdout,
+      ?\n,
+      stderr,
+      ?\n
+    ]
+    |> IO.iodata_to_binary()
+  end
 end

--- a/sdk/elixir/lib/dagger/core/graphql/response.ex
+++ b/sdk/elixir/lib/dagger/core/graphql/response.ex
@@ -1,0 +1,45 @@
+defmodule Dagger.Core.GraphQL.Response.Error do
+  defexception [:message, :path, :locations, :extensions]
+
+  def from_map(map) do
+    %__MODULE__{
+      message: map["message"],
+      path: map["path"],
+      locations: map["locations"],
+      extensions: map["extensions"]
+    }
+  end
+
+  @impl true
+  def message(exception) do
+    input = Enum.join(exception.path, ".")
+    message = exception.message
+
+    "input: #{input} #{message}"
+  end
+end
+
+defmodule Dagger.Core.GraphQL.Response do
+  @moduledoc """
+  GraphQL Response type.
+  """
+
+  alias Dagger.Core.GraphQL.Response.Error
+
+  defstruct [:data, :extensions, :errors]
+
+  @doc """
+  Serialize response from map to struct.
+  """
+  def from_map(%{} = map) do
+    errors = map["errors"]
+
+    %__MODULE__{
+      data: map["data"],
+      errors:
+        unless is_nil(errors) do
+          Enum.map(errors, &Error.from_map/1)
+        end
+    }
+  end
+end

--- a/sdk/elixir/lib/dagger/mod.ex
+++ b/sdk/elixir/lib/dagger/mod.ex
@@ -22,9 +22,9 @@ defmodule Dagger.Mod do
          {:ok, json} <- invoke(dag, module, parent, parent_name, fn_name, input_args) do
       Dagger.FunctionCall.return_value(fn_call, json)
     else
-      {:error, reason} ->
-        IO.puts(inspect(reason))
-        System.halt(2)
+      {:error, error} ->
+        IO.puts(:stderr, format_error(error))
+        exit({:shutdown, 2})
     end
   after
     Dagger.Global.close()
@@ -147,4 +147,8 @@ defmodule Dagger.Mod do
   defp dump(value, type) do
     {:error, "cannot dump value #{value} to type #{type}"}
   end
+
+  defp format_error(%{__exception__: true} = exception), do: Exception.message(exception)
+  defp format_error(error) when is_binary(error) or is_atom(error), do: error
+  defp format_error(error), do: inspect(error)
 end


### PR DESCRIPTION
In this patch, the Elixir SDK look up an extensions from GraphQL error and converting it to `ExecError` and then translate an error into readable message  like Go and TypeScript does. 

Consider this function:

```elixir
defn sample() :: Dagger.Container.t() do
    dag()
    |> Dagger.Client.container()
    |> Dagger.Container.from("alpine:latest")
    |> Dagger.Container.with_exec(~w"foobar")
end
```

Before this patch, the SDK returns an error that come from inspecting struct, which's quite hard to read:

![Screenshot 2024-08-28 003703](https://github.com/user-attachments/assets/f178be60-0986-412d-b778-019c69ce192d)

But after this patch, it's returns an error like Go or TypeScript:

![Screenshot 2024-08-28 002549](https://github.com/user-attachments/assets/8a2ac559-0424-49e2-9ff6-a0d90c0487b0)

Closes #8187