### PR TITLE
Benchmark SDKs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p /tmp/benchmark
           cd /tmp/benchmark
 
-          dagger --debug init --source=. --name=test --sdk=${{ matrix.sdk }}
+          dagger init --name=benchmark --sdk=${{ matrix.sdk }}
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
@@ -42,7 +42,7 @@ jobs:
           source /tmp/local-envs
           cd /tmp/benchmark
 
-          dagger --debug functions
+          dagger functions
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
@@ -52,7 +52,7 @@ jobs:
           source /tmp/local-envs
           cd /tmp/benchmark
 
-          dagger --debug functions
+          dagger functions
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
@@ -67,6 +67,6 @@ jobs:
             [ -f "$file" ] && echo >> $file
           done
 
-          dagger --debug functions
+          dagger functions
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   benchmark:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-5-4c' || 'ubuntu-latest' }}"
+    runs-on: "dagger-g2-main-4c"
     timeout-minutes: 10
 
     strategy:
@@ -25,70 +25,11 @@ jobs:
         sdk: [go, python, typescript] # The SDKs you want to test
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install go
-        uses: actions/setup-go@v5
-        if: inputs.dev-engine == 'true'
-        with:
-          go-version: "1.22"
-          cache-dependency-path: "dev/go.sum"
-
-      - name: Install dagger
-        shell: bash
-        env:
-          DAGGER_VERSION: "v0.12.5"
-        run: |
-          if [[ -x "$(command -v dagger)" ]]; then
-            echo "::group::Checking dagger"
-            version="$(dagger --silent version | cut --fields 2 --delimiter ' ')"
-            if [[ "$version" != "$DAGGER_VERSION" ]]; then
-              echo "dagger ${version} is installed, but needed ${DAGGER_VERSION}"
-              exit 1
-            fi
-            echo "::endgroup::"
-          else
-            echo "::group::Installing dagger"
-            curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
-            echo "::endgroup::"
-          fi
-
-      - name: Build dev dagger
-        shell: bash
-        run: |
-          echo "::group::Starting dev engine"
-          if ! [[ -x "$(command -v docker)" ]]; then
-            echo "docker is not installed"
-            exit 1
-          fi
-
-          # put env variables in /tmp/local-envs instead of
-          # $GITHUB_ENV to avoid leaking into parent workflow
-          (cd .dagger/mage; go run main.go -w ../.. engine:dev) | tee /tmp/local-envs
-
-          echo "::endgroup::"
-
-      - name: Wait for dagger to be ready
-        shell: bash
-        run: |
-          source /tmp/local-envs
-          mkdir -p /tmp/benchmark
-          cd /tmp/benchmark
-
-          echo "::group::Dagger client version"
-          dagger version
-          echo "::endgroup::"
-
-          echo "::group::Dagger server version"
-          echo "{version}" | dagger query
-          echo "::endgroup::"
-        env:
-          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
-
       - name: dagger init (${{ matrix.sdk }})
         shell: bash
         run: |
           source /tmp/local-envs
+          mkdir -p /tmp/benchmark
           cd /tmp/benchmark
 
           dagger --debug init --source=. --name=test --sdk=${{ matrix.sdk }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   benchmark:
     runs-on: "dagger-g2-main-4c"
+    if: ${{ github.repository == 'dagger/dagger' }}
     timeout-minutes: 10
 
     strategy:
@@ -28,7 +29,6 @@ jobs:
       - name: dagger init (${{ matrix.sdk }})
         shell: bash
         run: |
-          source /tmp/local-envs
           mkdir -p /tmp/benchmark
           cd /tmp/benchmark
 
@@ -39,34 +39,28 @@ jobs:
       - name: dagger functions@initial (${{ matrix.sdk }})
         shell: bash
         run: |
-          source /tmp/local-envs
-          cd /tmp/benchmark
-
           dagger functions
+        working-directory: /tmp/benchmark
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
       - name: dagger functions@cached (${{ matrix.sdk }})
         shell: bash
         run: |
-          source /tmp/local-envs
-          cd /tmp/benchmark
-
           dagger functions
+        working-directory: /tmp/benchmark
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
       - name: dagger functions@modified (${{ matrix.sdk }})
         shell: bash
         run: |
-          source /tmp/local-envs
-          cd /tmp/benchmark
-
           # invalidate the cache by modifying the source files
           for file in "main.go" "src/index.ts" "src/main/__init__.py"; do
             [ -f "$file" ] && echo >> $file
           done
 
           dagger functions
+        working-directory: /tmp/benchmark
         env:
           DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,131 @@
+name: Benchmark
+
+on:
+  # Run the workflow every day at midnight (00:00) UTC
+  schedule:
+    - cron: "0 0 * * *"
+  # Enable manual trigger for easy debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-5-4c' || 'ubuntu-latest' }}"
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        sdk: [go, python, typescript] # The SDKs you want to test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install go
+        uses: actions/setup-go@v5
+        if: inputs.dev-engine == 'true'
+        with:
+          go-version: "1.22"
+          cache-dependency-path: "dev/go.sum"
+
+      - name: Install dagger
+        shell: bash
+        env:
+          DAGGER_VERSION: "v0.12.5"
+        run: |
+          if [[ -x "$(command -v dagger)" ]]; then
+            echo "::group::Checking dagger"
+            version="$(dagger --silent version | cut --fields 2 --delimiter ' ')"
+            if [[ "$version" != "$DAGGER_VERSION" ]]; then
+              echo "dagger ${version} is installed, but needed ${DAGGER_VERSION}"
+              exit 1
+            fi
+            echo "::endgroup::"
+          else
+            echo "::group::Installing dagger"
+            curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
+            echo "::endgroup::"
+          fi
+
+      - name: Build dev dagger
+        shell: bash
+        run: |
+          echo "::group::Starting dev engine"
+          if ! [[ -x "$(command -v docker)" ]]; then
+            echo "docker is not installed"
+            exit 1
+          fi
+
+          # put env variables in /tmp/local-envs instead of
+          # $GITHUB_ENV to avoid leaking into parent workflow
+          (cd .dagger/mage; go run main.go -w ../.. engine:dev) | tee /tmp/local-envs
+
+          echo "::endgroup::"
+
+      - name: Wait for dagger to be ready
+        shell: bash
+        run: |
+          source /tmp/local-envs
+          mkdir -p /tmp/benchmark
+          cd /tmp/benchmark
+
+          echo "::group::Dagger client version"
+          dagger version
+          echo "::endgroup::"
+
+          echo "::group::Dagger server version"
+          echo "{version}" | dagger query
+          echo "::endgroup::"
+        env:
+          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
+
+      - name: dagger init (${{ matrix.sdk }})
+        shell: bash
+        run: |
+          source /tmp/local-envs
+          cd /tmp/benchmark
+
+          dagger --debug init --source=. --name=test --sdk=${{ matrix.sdk }}
+        env:
+          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
+
+      - name: dagger functions@initial (${{ matrix.sdk }})
+        shell: bash
+        run: |
+          source /tmp/local-envs
+          cd /tmp/benchmark
+
+          dagger --debug functions
+        env:
+          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
+
+      - name: dagger functions@cached (${{ matrix.sdk }})
+        shell: bash
+        run: |
+          source /tmp/local-envs
+          cd /tmp/benchmark
+
+          dagger --debug functions
+        env:
+          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
+
+      - name: dagger functions@modified (${{ matrix.sdk }})
+        shell: bash
+        run: |
+          source /tmp/local-envs
+          cd /tmp/benchmark
+
+          # invalidate the cache by modifying the source files
+          for file in "main.go" "src/index.ts" "src/main/__init__.py"; do
+            [ -f "$file" ] && echo >> $file
+          done
+
+          dagger --debug functions
+        env:
+          DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -6,7 +6,7 @@ on:
       - "Docs"
       - "Engine & CLI"
       - "Helm"
-      - "Publish CLI & Engine"    
+      - "Publish CLI & Engine"
       - "Publish Elixir SDK"
       - "Publish Go SDK"
       - "Publish Helm Chart"
@@ -15,6 +15,7 @@ on:
       - "Publish Rust SDK"
       - "Publish TypeScript SDK"
       - "SDK"
+      - "Benchmark"
     types:
       - completed
 


### PR DESCRIPTION
Using a freshly built dagger engine, for each of the Go, Python and Typescript SDK, benchmark the following operations:

- `dagger init`
- `dagger functions`
- `dagger functions` (**cached**)
- `dagger functions` (after modifying the source code)