### PR TITLE
chore: upgrade goreleaser

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -46,7 +46,7 @@ func (cli *CLI) Binary(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v1.26.0"
+	goReleaserVersion = "v2.2.0"
 )
 
 // Publish the CLI using GoReleaser
@@ -90,7 +90,7 @@ func (cli *CLI) Publish(
 		ctr = ctr.WithExec([]string{"git", "tag", "0.0.0"})
 	}
 
-	args := []string{"release", "--clean", "--skip-validate", "--debug"}
+	args := []string{"release", "--clean", "--skip=validate", "--verbose"}
 	if tag != "" {
 		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", tag))
 	} else {

--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: dagger
 
 before:

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,11 +1,13 @@
+version: 2
+
 includes:
   - from_file:
       path: ./.goreleaser.common.yml
 
 nightly:
-  # name_template will override .Version for nightly builds:
+  # version_template will override .Version for nightly builds:
   # https://goreleaser.com/customization/nightlies/#how-it-works
-  name_template: "{{ .FullCommit }}"
+  version_template: "{{ .FullCommit }}"
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
@@ -29,10 +31,10 @@ blobs:
       - sha
     region: "{{ .Env.AWS_REGION }}"
     bucket: "{{ .Env.AWS_BUCKET }}"
-    folder: "dagger/main/{{ .Version }}"
+    directory: "dagger/main/{{ .Version }}"
   - provider: s3
     ids:
       - head
     region: "{{ .Env.AWS_REGION }}"
     bucket: "{{ .Env.AWS_BUCKET }}"
-    folder: "dagger/main/head"
+    directory: "dagger/main/head"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
+version: 2
+
 includes:
   - from_file:
       path: ./.goreleaser.common.yml
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
@@ -51,7 +53,7 @@ blobs:
   - provider: s3
     region: "{{ .Env.AWS_REGION }}"
     bucket: "{{ .Env.AWS_BUCKET }}"
-    folder: "dagger/releases/{{ .Version }}"
+    directory: "dagger/releases/{{ .Version }}"
 
 publishers:
   - name: publish-latest-version


### PR DESCRIPTION
To get go 1.23 in goreleaser, we need to bump goreleaser up to the latest release - there are also breaking changes and deprecations we need to resolve.

This should fix the broken cli and engine publish on main: https://github.com/dagger/dagger/actions/runs/10594823172/job/29359279613