### PR TITLE
chore: fix linting

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -8232,5 +8232,4 @@ func (ModuleSuite) TestSSHAgentConnection(ctx context.Context, t *testctx.T) {
 			wg.Wait()
 		})
 	})
-
 }

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -381,7 +381,7 @@ func moduleAnalyticsProps(mod *Module, prefix string, props map[string]string) {
 		props[prefix+"git_subpath"] = git.RootSubpath
 		props[prefix+"git_version"] = git.Version
 		props[prefix+"git_commit"] = git.Commit
-		props[prefix+"git_html_repo_url"] = git.HtmlRepoURL
+		props[prefix+"git_html_repo_url"] = git.HTMLRepoURL
 	}
 }
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -683,7 +683,7 @@ type GitModuleSource struct {
 	CloneURL string `field:"true" name:"cloneURL" doc:"The URL to clone the root of the git repo from" deprecated:"Use CloneRef instead. CloneRef supports both URL-style and SCP-like SSH references"`
 	CloneRef string `field:"true" name:"cloneRef" doc:"The ref to clone the root of the git repo from"`
 
-	HtmlRepoURL string `field:"true" name:"htmlRepoURL" doc:"The URL to access the web view of the repository (e.g., GitHub, GitLab, Bitbucket)"`
+	HTMLRepoURL string `field:"true" name:"htmlRepoURL" doc:"The URL to access the web view of the repository (e.g., GitHub, GitLab, Bitbucket)"`
 
 	ContextDirectory dagql.Instance[*Directory] `field:"true" doc:"The directory containing everything needed to load load and use the module."`
 }
@@ -729,21 +729,21 @@ func (src *GitModuleSource) Symbolic() string {
 }
 
 func (src *GitModuleSource) HTMLURL() string {
-	parsedURL, err := url.Parse(src.HtmlRepoURL)
+	parsedURL, err := url.Parse(src.HTMLRepoURL)
 	if err != nil {
-		return src.HtmlRepoURL + path.Join("/src", src.Commit, src.RootSubpath)
+		return src.HTMLRepoURL + path.Join("/src", src.Commit, src.RootSubpath)
 	}
 
 	switch parsedURL.Host {
 	case "github.com", "gitlab.com":
-		return src.HtmlRepoURL + path.Join("/tree", src.Commit, src.RootSubpath)
+		return src.HTMLRepoURL + path.Join("/tree", src.Commit, src.RootSubpath)
 	case "dev.azure.com":
 		if src.RootSubpath != "" {
-			return fmt.Sprintf("%s/commit/%s?path=/%s", src.HtmlRepoURL, src.Commit, src.RootSubpath)
+			return fmt.Sprintf("%s/commit/%s?path=/%s", src.HTMLRepoURL, src.Commit, src.RootSubpath)
 		}
-		return src.HtmlRepoURL + path.Join("/commit", src.Commit)
+		return src.HTMLRepoURL + path.Join("/commit", src.Commit)
 	default:
-		return src.HtmlRepoURL + path.Join("/src", src.Commit, src.RootSubpath)
+		return src.HTMLRepoURL + path.Join("/src", src.Commit, src.RootSubpath)
 	}
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -73,7 +73,7 @@ func (s *moduleSchema) moduleSource(ctx context.Context, query *core.Query, args
 		src.AsGitSource = dagql.NonNull(&core.GitModuleSource{})
 
 		src.AsGitSource.Value.Root = parsed.repoRoot.Root
-		src.AsGitSource.Value.HtmlRepoURL = parsed.repoRoot.Repo
+		src.AsGitSource.Value.HTMLRepoURL = parsed.repoRoot.Repo
 
 		// Determine usernames for source reference and actual cloning
 		sourceUser, cloneUser := parsed.sshusername, parsed.sshusername

--- a/engine/distconsts/go.mod
+++ b/engine/distconsts/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/engine/distconsts
 
-go 1.21.7
+go 1.22
 
 // This package is a separate module to avoid weird dependency issues.
 //

--- a/modules/go/go.mod
+++ b/modules/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/go
 
-go 1.21.7
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/modules/golangci/lint-config.yml
+++ b/modules/golangci/lint-config.yml
@@ -4,7 +4,6 @@ linters:
     - bodyclose
     - dogsled
     - dupl
-    - exportloopref
     - errorlint
     - gocritic
     - gocyclo

--- a/modules/graphql/go.mod
+++ b/modules/graphql/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/graphql
 
-go 1.21.7
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/modules/markdown/go.mod
+++ b/modules/markdown/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/markdown
 
-go 1.21.7
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/modules/wolfi/go.mod
+++ b/modules/wolfi/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/wolfi
 
-go 1.21.7
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.49


### PR DESCRIPTION
Fixes these issues on `main`: https://github.com/dagger/dagger/actions/runs/10596511181/job/29364633106, which was introduced in #8151.

Some of these lints had stopped working, since the paths had gotten mixed up - this was because we were taking loop references (which is safe in go 1.22 - but requires that all the modules actually *use* go 1.22 in their go.mods).

This fixes that issue by updating go.mods, disables the loop capture checker (since this isn't required anymore in go 1.22), and also fixes the linting issues that we hadn't been catching anymore!



