### PR TITLE
chore: update verbose DaggerObject message

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -513,7 +513,7 @@ func (ps *parseState) checkDaggerObjectIface(obj types.Object) (bool, error) {
 	}
 	iface, isIface := named.Underlying().(*types.Interface)
 	if !isIface {
-		return false, fmt.Errorf("exected %s to be %T, but got %T (%s)", daggerObjectIfaceName, &types.Interface{}, named.Underlying(), named.String())
+		return false, fmt.Errorf("expected %s to be %T, but got %T (%s)", daggerObjectIfaceName, &types.Interface{}, named.Underlying(), named.Underlying().String())
 	}
 
 	ps.daggerObjectIfaceType = iface


### PR DESCRIPTION
We were printing the string of the wrong type :thinking: