### PR TITLE
chore: use ContextCause everywhere

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -245,10 +245,10 @@ func main() { //nolint:gocyclo
 
 	addFlags(app)
 
-	ctx, cancel := context.WithCancel(appcontext.Context())
+	ctx, cancel := context.WithCancelCause(appcontext.Context())
 
 	app.Action = func(c *cli.Context) error {
-		defer cancel()
+		defer cancel(errors.New("main done"))
 		// TODO: On Windows this always returns -1. The actual "are you admin" check is very Windows-specific.
 		// See https://github.com/golang/go/issues/28804#issuecomment-505326268 for the "short" version.
 		if os.Geteuid() > 0 {
@@ -274,8 +274,8 @@ func main() { //nolint:gocyclo
 		}
 
 		bklog.G(ctx).Debug("setting up engine networking")
-		networkContext, cancelNetworking := context.WithCancel(context.Background())
-		defer cancelNetworking()
+		networkContext, cancelNetworking := context.WithCancelCause(context.Background())
+		defer cancelNetworking(errors.New("main done"))
 		netConf, err := setupNetwork(networkContext,
 			c.GlobalString("network-name"),
 			c.GlobalString("network-cidr"),
@@ -424,7 +424,7 @@ func main() { //nolint:gocyclo
 		select {
 		case serverErr := <-errCh:
 			err = serverErr
-			cancel()
+			cancel(fmt.Errorf("server error: %w", serverErr))
 		case <-ctx.Done():
 			// context should only be cancelled when a signal is received, which
 			// isn't an error
@@ -442,7 +442,7 @@ func main() { //nolint:gocyclo
 			bklog.G(ctx).WithError(stopCacheErr).Error("failed to stop cache")
 		}
 		err = errors.Join(err, stopCacheErr)
-		cancelNetworking()
+		cancelNetworking(errors.New("shutdown"))
 
 		bklog.G(ctx).Infof("stopping server")
 		if os.Getenv("NOTIFY_SOCKET") != "" {

--- a/core/c2h.go
+++ b/core/c2h.go
@@ -22,13 +22,13 @@ type c2hTunnel struct {
 func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("tunnel finished"))
 	listenerPool := pool.New().WithContext(ctx)
 	proxyConnPool := pool.New().WithContext(ctx)
 	for _, sock := range d.socks {
 		listenerPool.Go(func(ctx context.Context) error {
-			defer cancel() // if one exits, all should exit
+			defer cancel(errors.New("tunnel listener done")) // if one exits, all should exit
 
 			port, ok := d.sockStore.GetSocketPortForward(sock.IDDigest)
 			if !ok {

--- a/core/services.go
+++ b/core/services.go
@@ -173,11 +173,11 @@ dance:
 		}
 	}
 
-	svcCtx, stop := context.WithCancel(context.WithoutCancel(ctx))
+	svcCtx, stop := context.WithCancelCause(context.WithoutCancel(ctx))
 
 	running, err := svc.Start(svcCtx, id, false, nil, nil, nil)
 	if err != nil {
-		stop()
+		stop(err)
 		ss.l.Lock()
 		delete(ss.starting, key)
 		ss.l.Unlock()

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -76,14 +76,14 @@ type Client struct {
 	*Opts
 
 	closeCtx context.Context
-	cancel   context.CancelFunc
+	cancel   context.CancelCauseFunc
 	closeMu  sync.RWMutex
 	execMap  sync.Map
 }
 
 func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 	// override the outer cancel, we will manage cancellation ourselves here
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	ctx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 	client := &Client{
 		Opts:     opts,
 		closeCtx: ctx,
@@ -98,7 +98,7 @@ func (c *Client) ID() string {
 	return c.BkSession.ID()
 }
 
-func (c *Client) withClientCloseCancel(ctx context.Context) (context.Context, context.CancelFunc, error) {
+func (c *Client) withClientCloseCancel(ctx context.Context) (context.Context, context.CancelCauseFunc, error) {
 	c.closeMu.RLock()
 	defer c.closeMu.RUnlock()
 	select {
@@ -106,11 +106,11 @@ func (c *Client) withClientCloseCancel(ctx context.Context) (context.Context, co
 		return nil, nil, errors.New("client closed")
 	default:
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	go func() {
 		select {
 		case <-c.closeCtx.Done():
-			cancel()
+			cancel(context.Cause(c.closeCtx))
 		case <-ctx.Done():
 		}
 	}()
@@ -122,7 +122,7 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("solve done"))
 	ctx = withOutgoingContext(ctx)
 
 	// include upstream cache imports, if any
@@ -166,7 +166,7 @@ func (c *Client) ResolveImageConfig(ctx context.Context, ref string, opt sourcer
 	if err != nil {
 		return "", "", nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("resolve image config done"))
 	ctx = withOutgoingContext(ctx)
 
 	imr := sourceresolver.NewImageMetaResolver(c.LLBBridge)
@@ -178,7 +178,7 @@ func (c *Client) ResolveSourceMetadata(ctx context.Context, op *bksolverpb.Sourc
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("resolve source metadata done"))
 	ctx = withOutgoingContext(ctx)
 
 	return c.LLBBridge.ResolveSourceMetadata(ctx, op, opt)
@@ -213,7 +213,7 @@ func (c *Client) NewContainer(ctx context.Context, req NewContainerRequest) (*Co
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("new container done"))
 	ctx = withOutgoingContext(ctx)
 	ctrReq := bkcontainer.NewContainerRequest{
 		ContainerID: containerID,
@@ -348,7 +348,7 @@ func (c *Client) UpstreamCacheExport(ctx context.Context, cacheExportFuncs []Res
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer cancel(errors.New("upstream cache export done"))
 
 	if len(cacheExportFuncs) == 0 {
 		return nil
@@ -463,8 +463,9 @@ func (c *Client) ListenHostToContainer(
 
 	clientCaller, err := c.GetSessionCaller(ctx, false)
 	if err != nil {
-		cancel()
-		return nil, nil, fmt.Errorf("failed to get requester session: %w", err)
+		err = fmt.Errorf("failed to get requester session: %w", err)
+		cancel(fmt.Errorf("listen host to container error: %w", err))
+		return nil, nil, err
 	}
 
 	conn := clientCaller.Conn()
@@ -473,8 +474,9 @@ func (c *Client) ListenHostToContainer(
 
 	listener, err := tunnelClient.Listen(ctx)
 	if err != nil {
-		cancel()
-		return nil, nil, fmt.Errorf("failed to listen: %w", err)
+		err = fmt.Errorf("failed to listen: %w", err)
+		cancel(fmt.Errorf("listen host to container error: %w", err))
+		return nil, nil, err
 	}
 
 	err = listener.Send(&session.ListenRequest{
@@ -482,14 +484,16 @@ func (c *Client) ListenHostToContainer(
 		Protocol: proto,
 	})
 	if err != nil {
-		cancel()
-		return nil, nil, fmt.Errorf("failed to send listen request: %w", err)
+		err = fmt.Errorf("failed to send listen request: %w", err)
+		cancel(fmt.Errorf("listen host to container error: %w", err))
+		return nil, nil, err
 	}
 
 	listenRes, err := listener.Recv()
 	if err != nil {
-		cancel()
-		return nil, nil, fmt.Errorf("failed to receive listen response: %w", err)
+		err = fmt.Errorf("failed to receive listen response: %w", err)
+		cancel(fmt.Errorf("listen host to container error: %w", err))
+		return nil, nil, err
 	}
 
 	conns := map[string]net.Conn{}
@@ -561,7 +565,7 @@ func (c *Client) ListenHostToContainer(
 	}()
 
 	return listenRes, func() error {
-		defer cancel()
+		defer cancel(errors.New("listen host to container done"))
 		sendL.Lock()
 		err := listener.CloseSend()
 		sendL.Unlock()

--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -3,6 +3,7 @@ package buildkit
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -35,7 +36,7 @@ func (c *Client) PublishContainerImage(
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("publish container image done"))
 
 	combinedResult, err := c.getContainerResult(ctx, inputByPlatform)
 	if err != nil {
@@ -73,7 +74,7 @@ func (c *Client) ExportContainerImage(
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("export container image done"))
 
 	destPath = path.Clean(destPath)
 	if destPath == ".." || strings.HasPrefix(destPath, "../") {
@@ -132,7 +133,7 @@ func (c *Client) ContainerImageToTarball(
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
+	defer cancel(errors.New("container image to tarball done"))
 
 	combinedResult, err := c.getContainerResult(ctx, inputByPlatform)
 	if err != nil {

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -557,7 +557,7 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 	// shorter timeout but here as a fail-safe for future refactoring.
 	ctx, cancel := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, context.DeadlineExceeded)
-	defer cancel(context.Canceled)
+	defer cancel(nil)
 
 	if k.pidfile == "" {
 		// for `runc run` process we use `runc kill` to terminate the process

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -115,7 +115,7 @@ func (c *Client) diffcopy(ctx context.Context, opts engine.LocalImportOpts, msg 
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer cancel(errors.New("diff copy done"))
 
 	ctx = opts.AppendToOutgoingContext(ctx)
 
@@ -182,7 +182,7 @@ func (c *Client) LocalDirExport(
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer cancel(errors.New("local dir export done"))
 
 	destPath = path.Clean(destPath)
 	if destPath == ".." || strings.HasPrefix(destPath, "../") {
@@ -253,7 +253,7 @@ func (c *Client) LocalFileExport(
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer cancel(errors.New("local file export done"))
 
 	destPath = path.Clean(destPath)
 	if destPath == ".." || strings.HasPrefix(destPath, "../") {

--- a/engine/buildkit/linux_namespace.go
+++ b/engine/buildkit/linux_namespace.go
@@ -86,10 +86,10 @@ func (w *Worker) runNetNSWorkers(ctx context.Context, state *execState) error {
 	}
 	state.cleanups.Add("close container netns file", ctrFile.Close)
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	p := pool.New().WithContext(ctx)
 	state.cleanups.Add("stopping namespace workers", p.Wait)
-	state.cleanups.Add("canceling namespace workers", Infallible(cancel))
+	state.cleanups.Add("canceling namespace workers", Infallible(func() { cancel(errors.New("cleanup container")) }))
 
 	for i := 0; i < workerPoolSize; i++ {
 		p.Go(func(ctx context.Context) (rerr error) {

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -89,10 +90,10 @@ func NewManager(ctx context.Context, managerConfig ManagerConfig) (Manager, erro
 	}
 	m.runtimeConfig = *config
 
-	importParentCtx, cancelImport := context.WithCancel(context.Background())
+	importParentCtx, cancelImport := context.WithCancelCause(context.Background())
 	go func() {
 		<-m.startCloseCh
-		cancelImport()
+		cancelImport(errors.New("cache manager closing"))
 	}()
 
 	// do an initial synchronous import at start

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -270,10 +270,10 @@ func (srv *Server) initializeDaggerSession(
 }
 
 func (sess *daggerSession) withShutdownCancel(ctx context.Context) context.Context {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	go func() {
 		<-sess.shutdownCh
-		cancel()
+		cancel(errors.New("session shutdown called"))
 	}()
 	return ctx
 }
@@ -882,8 +882,8 @@ const InstrumentationLibrary = "dagger.io/engine.server"
 
 func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opts *ClientInitOpts) (rerr error) {
 	ctx := r.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("http request done for client %q", opts.ClientID))
 
 	clientMetadata := opts.ClientMetadata
 	ctx = engine.ContextWithClientMetadata(ctx, clientMetadata)

--- a/engine/session/terminal.go
+++ b/engine/session/terminal.go
@@ -53,8 +53,8 @@ func (s TerminalAttachable) Session(srv Terminal_SessionServer) error {
 }
 
 func (s TerminalAttachable) session(srv Terminal_SessionServer, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
-	ctx, cancel := context.WithCancel(srv.Context())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(srv.Context())
+	defer cancel(errors.New("terminal session finished"))
 
 	if err := s.sendSize(srv, stdout); err != nil {
 		return fmt.Errorf("sending initial size: %w", err)


### PR DESCRIPTION
There's a chance this could help us diagnose [ephemeral context canceled flakes](https://github.com/dagger/dagger/issues/7699). 

I have a[ similar change upstream in buildkit](https://github.com/moby/buildkit/pull/5278) that I think is much more likely to be useful, but this is a best practice anyways for providing more context to errors than "canceled" so may as well make this change in our code too.