### PR TITLE
chore: bump golangci-lint timeout

### DIFF
--- a/modules/golangci/lint.go
+++ b/modules/golangci/lint.go
@@ -107,7 +107,6 @@ func (run LintRun) Report() *dagger.File {
 	cmd := []string{
 		"golangci-lint", "run",
 		"-v",
-		"--timeout", "5m",
 		// Disable limits, we can filter the report instead
 		"--max-issues-per-linter", "0",
 		"--max-same-issues", "0",


### PR DESCRIPTION
This is currently failing out on `main` - by doing #8264, we have massively increased the number of packages we're linting, so resources on the machine are now more contested. I think it's definitely reasonable to bump this up now.