### PR TITLE
feat: add `Directory.digest` and `ModuleSource.digest`

### DIFF
--- a/.changes/unreleased/Added-20240905-154130.yaml
+++ b/.changes/unreleased/Added-20240905-154130.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: |-
+  Added new `Directory.digest` and `ModuleSource.digest` fields
+
+  These fields mirror the behavior of the `File.digest` field, computing a unique cryptographic digest over the contents of the object.
+time: 2024-09-05T15:41:30.256818315+01:00
+custom:
+  Author: jedevc
+  PR: "8282"

--- a/core/directory.go
+++ b/core/directory.go
@@ -178,6 +178,20 @@ func (dir *Directory) Evaluate(ctx context.Context) (*buildkit.Result, error) {
 	})
 }
 
+func (dir *Directory) Digest(ctx context.Context) (string, error) {
+	result, err := dir.Evaluate(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate file: %w", err)
+	}
+
+	digest, err := result.Ref.Digest(ctx, dir.Dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute digest: %w", err)
+	}
+
+	return digest.String(), nil
+}
+
 func (dir *Directory) Stat(ctx context.Context, bk *buildkit.Client, svcs *Services, src string) (*fstypes.Stat, error) {
 	src = path.Join(dir.Dir, src)
 

--- a/core/interface.go
+++ b/core/interface.go
@@ -217,10 +217,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 			Module:      iface.mod.IDModule(),
 		}
 
-		argTypeDefsByName := map[string]*TypeDef{}
 		for _, argMetadata := range fnTypeDef.Args {
-			argTypeDefsByName[argMetadata.Name] = argMetadata.TypeDef
-
 			// check whether this is a pre-existing object from a dependency module
 			argModType, ok, err := iface.mod.Deps.ModTypeFor(ctx, argMetadata.TypeDef)
 			if err != nil {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -128,6 +128,22 @@ func (src *ModuleSource) PBDefinitions(ctx context.Context) ([]*pb.Definition, e
 	}
 }
 
+func (src *ModuleSource) Digest(ctx context.Context) (string, error) {
+	switch src.Kind {
+	case ModuleSourceKindLocal:
+		dir, err := src.ContextDirectory()
+		if err != nil {
+			return "", err
+		}
+		return dir.Self.Digest(ctx)
+	case ModuleSourceKindGit:
+		// git uses sha1 hex digests
+		return "sha1:" + src.AsGitSource.Value.Commit, nil
+	default:
+		return "", fmt.Errorf("unknown module src kind: %q", src.Kind)
+	}
+}
+
 func (src *ModuleSource) RefString() (string, error) {
 	switch src.Kind {
 	case ModuleSourceKindLocal:

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -37,6 +37,12 @@ func (s *directorySchema) Install() {
 		dagql.Func("glob", s.glob).
 			Doc(`Returns a list of files and directories that matche the given pattern.`).
 			ArgDoc("pattern", `Pattern to match (e.g., "*.md").`),
+		dagql.Func("digest", s.digest).
+			Doc(
+				`Return the directory's digest.
+				The format of the digest is not guaranteed to be stable between releases of Dagger.
+				It is guaranteed to be stable between invocations of the same Dagger engine.`,
+			),
 		dagql.Func("file", s.file).
 			Doc(`Retrieves a file at the given path.`).
 			ArgDoc("path", `Location of the file to retrieve (e.g., "README.md").`),
@@ -191,6 +197,15 @@ type globArgs struct {
 
 func (s *directorySchema) glob(ctx context.Context, parent *core.Directory, args globArgs) ([]string, error) {
 	return parent.Glob(ctx, args.Pattern)
+}
+
+func (s *directorySchema) digest(ctx context.Context, parent *core.Directory, args struct{}) (dagql.String, error) {
+	digest, err := parent.Digest(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return dagql.NewString(digest), nil
 }
 
 type dirFileArgs struct {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -169,6 +169,13 @@ func (s *moduleSchema) Install() {
 			ArgDoc("name", `The name of the view to set.`).
 			ArgDoc("patterns", `The patterns to set as the view filters.`).
 			Doc(`Update the module source with a new named view.`),
+
+		dagql.Func("digest", s.moduleSourceDigest).
+			Doc(
+				`Return the module source's content digest.
+				The format of the digest is not guaranteed to be stable between releases of Dagger.
+				It is guaranteed to be stable between invocations of the same Dagger engine.`,
+			),
 	}.Install(s.dag)
 
 	dagql.Fields[*core.ModuleSourceView]{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1320,6 +1320,14 @@ func (s *moduleSchema) moduleSourceWithView(
 	return src, nil
 }
 
+func (s *moduleSchema) moduleSourceDigest(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (string, error) {
+	return src.Digest(ctx)
+}
+
 func (s *moduleSchema) moduleSourceViewName(
 	ctx context.Context,
 	view *core.ModuleSourceView,

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1046,6 +1046,13 @@ type Directory {
     other: DirectoryID!
   ): Directory!
 
+  """
+  Return the directory's digest. The format of the digest is not guaranteed to
+  be stable between releases of Dagger. It is guaranteed to be stable between
+  invocations of the same Dagger engine.
+  """
+  digest: String!
+
   """Retrieves a directory at the given path."""
   directory(
     """Location of the directory to retrieve (e.g., "/src")."""
@@ -2052,6 +2059,13 @@ type ModuleSource {
   configuration and any extras from withDependencies calls.
   """
   dependencies: [ModuleDependency!]!
+
+  """
+  Return the module source's content digest. The format of the digest is not
+  guaranteed to be stable between releases of Dagger. It is guaranteed to be
+  stable between invocations of the same Dagger engine.
+  """
+  digest: String!
 
   """
   The directory containing the module configuration and source code (source code may be in a subdir).

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -5197,6 +5197,10 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Directory-digest" href="#Directory-digest"><code>digest</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine. </td>
+                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Directory-directory" href="#Directory-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td> Retrieves a directory at the given path. </td>
@@ -7521,6 +7525,10 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-dependencies" href="#ModuleSource-dependencies"><code>dependencies</code></a> - <span class="property-type"><a href="#definition-ModuleDependency"><code>[ModuleDependency!]!</code></a></span> </td>
                         <td> The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-digest" href="#ModuleSource-digest"><code>digest</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="ModuleSource-directory" href="#ModuleSource-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -41,6 +41,15 @@ defmodule Dagger.Directory do
     }
   end
 
+  @doc "Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine."
+  @spec digest(t()) :: {:ok, String.t()} | {:error, term()}
+  def digest(%__MODULE__{} = directory) do
+    query_builder =
+      directory.query_builder |> QB.select("digest")
+
+    Client.execute(directory.client, query_builder)
+  end
+
   @doc "Retrieves a directory at the given path."
   @spec directory(t(), String.t()) :: Dagger.Directory.t()
   def directory(%__MODULE__{} = directory, path) do

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -99,6 +99,15 @@ defmodule Dagger.ModuleSource do
     end
   end
 
+  @doc "Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine."
+  @spec digest(t()) :: {:ok, String.t()} | {:error, term()}
+  def digest(%__MODULE__{} = module_source) do
+    query_builder =
+      module_source.query_builder |> QB.select("digest")
+
+    Client.execute(module_source.client, query_builder)
+  end
+
   @doc "The directory containing the module configuration and source code (source code may be in a subdir)."
   @spec directory(t(), String.t()) :: Dagger.Directory.t()
   def directory(%__MODULE__{} = module_source, path) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -2221,6 +2221,7 @@ func (r *DaggerEngineCacheEntrySet) MarshalJSON() ([]byte, error) {
 type Directory struct {
 	query *querybuilder.Selection
 
+	digest *string
 	export *string
 	id     *DirectoryID
 	sync   *DirectoryID
@@ -2280,6 +2281,19 @@ func (r *Directory) Diff(other *Directory) *Directory {
 	return &Directory{
 		query: q,
 	}
+}
+
+// Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+func (r *Directory) Digest(ctx context.Context) (string, error) {
+	if r.digest != nil {
+		return *r.digest, nil
+	}
+	q := r.query.Select("digest")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves a directory at the given path.
@@ -5373,6 +5387,7 @@ type ModuleSource struct {
 
 	asString                     *string
 	configExists                 *bool
+	digest                       *string
 	id                           *ModuleSourceID
 	kind                         *ModuleSourceKind
 	moduleName                   *string
@@ -5501,6 +5516,19 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, er
 	}
 
 	return convert(response), nil
+}
+
+// Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+func (r *ModuleSource) Digest(ctx context.Context) (string, error) {
+	if r.digest != nil {
+		return *r.digest, nil
+	}
+	q := r.query.Select("digest")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The directory containing the module configuration and source code (source code may be in a subdir).

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -39,6 +39,15 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+     */
+    public function digest(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('digest');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'digest');
+    }
+
+    /**
      * Retrieves a directory at the given path.
      */
     public function directory(string $path): Directory

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -80,6 +80,15 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+     */
+    public function digest(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('digest');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'digest');
+    }
+
+    /**
      * The directory containing the module configuration and source code (source code may be in a subdir).
      */
     public function directory(string $path): Directory

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2462,6 +2462,29 @@ class Directory(Type):
         _ctx = self._select("diff", _args)
         return Directory(_ctx)
 
+    async def digest(self) -> str:
+        """Return the directory's digest. The format of the digest is not
+        guaranteed to be stable between releases of Dagger. It is guaranteed
+        to be stable between invocations of the same Dagger engine.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("digest", _args)
+        return await _ctx.execute(str)
+
     def directory(self, path: str) -> Self:
         """Retrieves a directory at the given path.
 
@@ -5505,6 +5528,29 @@ class ModuleSource(Type):
             )
             for v in _ids
         ]
+
+    async def digest(self) -> str:
+        """Return the module source's content digest. The format of the digest is
+        not guaranteed to be stable between releases of Dagger. It is
+        guaranteed to be stable between invocations of the same Dagger engine.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("digest", _args)
+        return await _ctx.execute(str)
 
     def directory(self, path: str) -> Directory:
         """The directory containing the module configuration and source code

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3698,6 +3698,11 @@ impl Directory {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+    pub async fn digest(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("digest");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Retrieves a directory at the given path.
     ///
     /// # Arguments
@@ -5665,6 +5670,11 @@ impl ModuleSource {
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }]
+    }
+    /// Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+    pub async fn digest(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("digest");
+        query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing the module configuration and source code (source code may be in a subdir).
     ///

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -3350,6 +3350,7 @@ export class DaggerEngineCacheEntrySet extends BaseClient {
  */
 export class Directory extends BaseClient {
   private readonly _id?: DirectoryID = undefined
+  private readonly _digest?: string = undefined
   private readonly _export?: string = undefined
   private readonly _sync?: DirectoryID = undefined
 
@@ -3359,12 +3360,14 @@ export class Directory extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: DirectoryID,
+    _digest?: string,
     _export?: string,
     _sync?: DirectoryID,
   ) {
     super(parent)
 
     this._id = _id
+    this._digest = _digest
     this._export = _export
     this._sync = _sync
   }
@@ -3427,6 +3430,27 @@ export class Directory extends BaseClient {
       ],
       ctx: this._ctx,
     })
+  }
+
+  /**
+   * Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+   */
+  digest = async (): Promise<string> => {
+    if (this._digest) {
+      return this._digest
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "digest",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
   }
 
   /**
@@ -6932,6 +6956,7 @@ export class ModuleSource extends BaseClient {
   private readonly _id?: ModuleSourceID = undefined
   private readonly _asString?: string = undefined
   private readonly _configExists?: boolean = undefined
+  private readonly _digest?: string = undefined
   private readonly _kind?: ModuleSourceKind = undefined
   private readonly _moduleName?: string = undefined
   private readonly _moduleOriginalName?: string = undefined
@@ -6947,6 +6972,7 @@ export class ModuleSource extends BaseClient {
     _id?: ModuleSourceID,
     _asString?: string,
     _configExists?: boolean,
+    _digest?: string,
     _kind?: ModuleSourceKind,
     _moduleName?: string,
     _moduleOriginalName?: string,
@@ -6959,6 +6985,7 @@ export class ModuleSource extends BaseClient {
     this._id = _id
     this._asString = _asString
     this._configExists = _configExists
+    this._digest = _digest
     this._kind = _kind
     this._moduleName = _moduleName
     this._moduleOriginalName = _moduleOriginalName
@@ -7128,6 +7155,27 @@ export class ModuleSource extends BaseClient {
           r.id,
         ),
     )
+  }
+
+  /**
+   * Return the module source's content digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+   */
+  digest = async (): Promise<string> => {
+    if (this._digest) {
+      return this._digest
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "digest",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
   }
 
   /**


### PR DESCRIPTION
Builds on #8114, adding `Digest` to `Directory` and `ModuleSource`.

The original need for these is internal, see the discussion in https://github.com/dagger/dagger/pull/8245#discussion_r1733172781. However, there's still a use for these in the public API as well, and it's just generally good consistency :tada:

I guess this actually validates our idea of keeping the digest with the metadata as the default - since it doesn't really make sense to compute a `Directory.digest` *without* metadata, so we can just leave off that parameter.