### PR TITLE
sdk(go): simplify DaggerObject aliasing slightly

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	daggerGenFilename     = "dagger.gen.go"
-	contextTypename       = "context.Context"
-	constructorFuncName   = "New"
-	daggerObjectIfaceName = "DaggerObject"
+	daggerGenFilename   = "dagger.gen.go"
+	contextTypename     = "context.Context"
+	constructorFuncName = "New"
+	// this is aliased as `type DaggerObject = querybuilder.GraphQLMarshaller`
+	daggerObjectIfaceName = "GraphQLMarshaller"
 )
 
 func (funcs goTemplateFuncs) isModuleCode() bool {

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -52,7 +52,7 @@ func assertNotNil(argName string, value any) {
 	}
 }
 
-type DaggerObject querybuilder.GraphQLMarshaller
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 // getCustomError parses a GraphQL error into a more specific error type.
 func getCustomError(err error) error {

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -30,7 +30,7 @@ func setMarshalContext(ctx context.Context) {
 	dagger.SetMarshalContext(ctx)
 }
 
-type DaggerObject = dagger.DaggerObject
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 type ExecError = dagger.ExecError
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -36,7 +36,7 @@ func assertNotNil(argName string, value any) {
 	}
 }
 
-type DaggerObject querybuilder.GraphQLMarshaller
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 // getCustomError parses a GraphQL error into a more specific error type.
 func getCustomError(err error) error {


### PR DESCRIPTION
This gets rid of the multiple levels of type aliasing used to be just one level.

This is a very mild simplification that worst case seems harmless, but the motivation right now is a shot in the dark attempt at seeing if it avoids [some of the flakes](https://github.com/dagger/dagger/issues/8207) we have been getting in the Go SDK with this object.
* Obviously if this *does* indeed get rid of the flakes then it's not great in that we've probably just temporarily avoided a bug, but at this point that seems worth it.

I have been running with this change in my deflaking PR for a while now and haven't seen the flake since, so figured it didn't hurt to spin out at this point.
* 90% of time I've said something like this in the past the flake suddenly reappears, so 🤞

