### PR TITLE
fix: use sdkVersion when loading aliased sdk

### DIFF
--- a/.changes/unreleased/Fixed-20240902-160036.yaml
+++ b/.changes/unreleased/Fixed-20240902-160036.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Load specified version when loading `php` or `elixir` sdk
+time: 2024-09-02T16:00:36.648915+05:30
+custom:
+    Author: rajatjindal
+    PR: "8297"

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -104,7 +104,7 @@ func (s *moduleSchema) builtinSDK(ctx context.Context, root *core.Query, sdkName
 		}
 		sdkSuffix := ""
 		if sdkVersion != "" {
-			sdkSuffix = "@" + sdkSuffix
+			sdkSuffix = "@" + sdkVersion
 		}
 
 		switch sdkName {


### PR DESCRIPTION
while working on a different [issue](https://github.com/dagger/dagger/issues/6655), I found what seems like we are not using `sdkVersion` when loading aliased sdk. 

