### PR TITLE
fix: make Git.tags url parsing consistent with Git.tree

### DIFF
--- a/.changes/unreleased/Fixed-20240902-130323.yaml
+++ b/.changes/unreleased/Fixed-20240902-130323.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  make Git.tags url parsing consistent with Git.tree
+time: 2024-09-02T13:03:23.920914271+01:00
+custom:
+  Author: jedevc
+  PR: "8298"

--- a/.changes/unreleased/Fixed-20240902-130441.yaml
+++ b/.changes/unreleased/Fixed-20240902-130441.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fixed regression in module ref parsing for no-protocol refs that had version suffixes
+time: 2024-09-02T13:04:41.979514041+01:00
+custom:
+  Author: jedevc
+  PR: "8298"

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -197,7 +197,7 @@ var moduleInstallCmd = &cobra.Command{
 	Aliases: []string{"use"},
 	Short:   "Install a dependency",
 	Long:    "Install another module as a dependency to the current module. The target module must be local.",
-	Example: "dagger install github.com/shykes/hello@v0.1.0",
+	Example: "dagger install github.com/shykes/daggerverse/hello@v0.3.0",
 	GroupID: moduleGroup.ID,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -343,6 +343,13 @@ func (GitSuite) TestGitTags(ctx context.Context, t *testctx.T) {
 		require.Contains(t, tags, "sdk/go/v0.9.3")
 	})
 
+	t.Run("all tags (short url)", func(ctx context.Context, t *testctx.T) {
+		tags, err := c.Git("github.com/dagger/dagger").Tags(ctx)
+		require.NoError(t, err)
+		require.Contains(t, tags, "v0.9.3")
+		require.Contains(t, tags, "sdk/go/v0.9.3")
+	})
+
 	t.Run("tag pattern", func(ctx context.Context, t *testctx.T) {
 		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
 			Patterns: []string{"v*"},

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -303,7 +303,7 @@ dagger install [options] <module>
 ### Examples
 
 ```
-dagger install github.com/shykes/hello@v0.1.0
+dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
 
 ### Options


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8291, regression from https://github.com/dagger/dagger/pull/7708.

Previously, extracting the git tags from a URL skipped a level of url pre-processing that was in buildkit (essentially, one that allowed no protocols in URLs). We need to add this level of pre-processing manually.

Without this, parsing module refs of the form `github.com/<org>/<repo>@<version>` would fail with:

	! failed to resolve git tags: select: git command failed: exit status 128
	Error: failed to get module ref kind: input: moduleSource resolve: failed to resolve git tags: select: git command failed: exit status 128
	stdout:
	stderr: fatal: 'github.com/<org>/<repo>' does not appear to be a git repository
	fatal: Could not read from remote repository.

This is because it's not a repo - it needs that same processing to be consistent with `Git.Tree`.

> [!WARNING]
>
> We *need* to add a module source test for this, but I could not see a super easy way to do this without tagging in every `dagger-test-modules` repo. As a follow-up, we should do this, and additionally, make sure that everyone has access to those repos, sharing those creds in 1password.