### PR TITLE
chore: return more specific error when provided sdk is invalid

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1155,6 +1155,14 @@ func (s *moduleSchema) collectCallerLocalDeps(
 				// SDK is a local custom one, it needs to be included
 				sdkPath := filepath.Join(sourceRootAbsPath, parsed.modPath)
 
+				// this check here enable us to send more specific error
+				// if the sdk provided by user is neither an inbuiltsdk,
+				// nor a valid sdk available on local path.
+				_, err = bk.StatCallerHostPath(ctx, sdkPath, true)
+				if err != nil {
+					return nil, getInvalidBuiltinSDKError(modCfg.SDK)
+				}
+
 				err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, sdkPath, false, src, collectedDeps)
 				if err != nil {
 					return nil, fmt.Errorf("failed to collect local sdk: %w", err)

--- a/core/schema/sdk_test.go
+++ b/core/schema/sdk_test.go
@@ -1,0 +1,79 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSDKName(t *testing.T) {
+	testcases := []struct {
+		sdkName       string
+		parsedSDKName string
+		parsedSuffix  string
+	}{
+		{
+			sdkName:       SDKGo,
+			parsedSDKName: SDKGo,
+		},
+		{
+			sdkName:       SDKTypescript,
+			parsedSDKName: SDKTypescript,
+		},
+		{
+			sdkName:       SDKPython,
+			parsedSDKName: SDKPython,
+		},
+		{
+			sdkName:       SDKPHP,
+			parsedSDKName: SDKPHP,
+		},
+		{
+			sdkName:       SDKElixir,
+			parsedSDKName: SDKElixir,
+		},
+		{
+			sdkName:       "php@foo",
+			parsedSDKName: "php",
+			parsedSuffix:  "@foo",
+		},
+		{
+			sdkName:       "elixir@foo",
+			parsedSDKName: "elixir",
+			parsedSuffix:  "@foo",
+		},
+		{
+			sdkName:       "elixir@",
+			parsedSDKName: "elixir",
+		},
+		{
+			sdkName:       "php@",
+			parsedSDKName: "php",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.sdkName, func(t *testing.T) {
+			sdkName, suffix := parseSDKName(tc.sdkName)
+			require.Equal(t, tc.parsedSDKName, sdkName)
+			require.Equal(t, tc.parsedSuffix, suffix)
+		})
+	}
+}
+
+func TestInvalidBuiltinSDKError(t *testing.T) {
+	err := getInvalidBuiltinSDKError("foobar")
+	expected := fmt.Errorf(`unknown builtin sdk
+The "foobar" SDK does not exist. The available SDKs are:
+- go
+- python
+- typescript
+- php
+- elixir
+- any non-bundled SDK from its git ref (e.g. github.com/dagger/dagger/sdk/elixir@main)`)
+
+	require.Equal(t, expected.Error(), err.Error())
+	require.True(t, errors.Is(err, errUnknownBuiltinSDK))
+}


### PR DESCRIPTION
fixes #6655 

As discussed on the ticket, we are now using a static list of supported sdk to come up with the error msg (to keep it in sync with the actual builtin sdk's) and doing it on server side.

```
~/go/src/github.com/dagger/testme (cloud-docker/ap-south-1) 
$ ../dagger/hack/with-dev dagger init --name testme --sdk foobar
Full trace at https://dagger.cloud/rajatjindal/traces/ffb2887ad89ec3fb95c8d4c98f12ea6f

✔ connect 0.2s
✔ cache request: mkfile /schema.json 0.0s
✔ mkfile /schema.json 0.0s
✔ cache request: blob://sha256:2ba0e05274fd9ab3542a01e42193dedd3e2361419941dd4ac4f79022be14e000 0.0s
✔ blob://sha256:2ba0e05274fd9ab3542a01e42193dedd3e2361419941dd4ac4f79022be14e000 0.0s
✔ moduleSource(refString: "."): ModuleSource! 0.0s
✔ ModuleSource.kind: ModuleSourceKind! 0.0s
✔ ModuleSource.resolveContextPathFromCaller: String! 0.0s
✔ ModuleSource.withName(name: "testme"): ModuleSource! 0.0s
✔ ModuleSource.withSDK(sdk: "foobar"): ModuleSource! 0.0s
✔ ModuleSource.withInit: ModuleSource! 0.0s
✔ ModuleSource.withSourceSubpath(path: "."): ModuleSource! 0.0s
✘ ModuleSource.resolveFromCaller: ModuleSource! 0.0s
! failed to collect local module source deps: 
Error: failed to generate code: input: moduleSource.withName.withSDK.withInit.withSourceSubpath.resolveFromCaller resolve: failed to collect local module source deps: 
The "foobar" SDK does not exist.

Available SDKs:

- go
- python
- typescript
- php
- elixir

You can also use a non-bundled SDK from its github URL (e.g. github.com/dagger/dagger/sdk/elixir@main)
```