### PR TITLE
fix: fix the parseBuiltinSDK function when engine.Tag is not empty value

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -944,7 +944,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 
 	if src.Self.WithInitConfig != nil &&
 		src.Self.WithInitConfig.Merge &&
-		mod.SDKConfig != SDKGo {
+		mod.SDKConfig != string(SDKGo) {
 		return fmt.Errorf("merge is only supported for Go SDKs")
 	}
 


### PR DESCRIPTION
I realized that the sdkVersion defaults to `engine.Tag` and in a released version it would be a semver release version. The unit tests didn't consider that in the original implementation.

The unit tests have now been modified to set an `engine.Tag` to simulate real usage, and validation logic has been fixed to account for that correctly. I have also added several additional tests to cover these scenarios.

This PR also modifies the function `parseSDKName` to include basic validation, which was done earlier in the `builtinSDK` function. Therefore, it also renames the function to `parseAndValidateBuiltinSDKName`.