### PR TITLE
docs: Add module name warning in quickstart

### DIFF
--- a/docs/current_docs/quickstart/daggerize.mdx
+++ b/docs/current_docs/quickstart/daggerize.mdx
@@ -142,6 +142,10 @@ In this Dagger module, each Dagger Function performs a different operation:
 </TabItem>
 </Tabs>
 
+:::warning
+A Dagger module's name is automatically generated based on the name of the directory where `dagger init` was executed. If you cloned the example application into a directory other than the default (`hello-dagger`), your generated module name will be different and the code samples above will not work until you update them to use the correct module name. Alternatively, you can override Dagger's default module names by specifying a name via the `--name` argument to `dagger init`.
+:::
+
 ### Run the pipeline
 
 Call a Dagger Function to run the pipeline:


### PR DESCRIPTION
This change is based on feedback received in the docs survey