### PR TITLE
engine: sync cache volumes on-demand

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -412,13 +412,6 @@ func main() { //nolint:gocyclo
 			go logTraceMetrics(context.Background())
 		}
 
-		bklog.G(ctx).Debug("starting optional cache mount synchronization")
-		err = srv.SolverCache.StartCacheMountSynchronization(ctx)
-		if err != nil {
-			bklog.G(ctx).WithError(err).Error("failed to start cache mount synchronization")
-			// continue on, doesn't need to be fatal
-		}
-
 		// start serving on the listeners for actual clients
 		bklog.G(ctx).Debug("starting main engine api listeners")
 		srv.Register(grpcServer)

--- a/core/cache.go
+++ b/core/cache.go
@@ -14,7 +14,7 @@ import (
 
 // CacheVolume is a persistent volume with a globally scoped identifier.
 type CacheVolume struct {
-	Keys []string `json:"keys"`
+	Key string `json:"keys"`
 }
 
 func (*CacheVolume) Type() *ast.Type {
@@ -28,23 +28,19 @@ func (*CacheVolume) TypeDescription() string {
 	return "A directory whose contents persist across runs."
 }
 
-func NewCache(keys ...string) *CacheVolume {
-	return &CacheVolume{Keys: keys}
+func NewCache(key string) *CacheVolume {
+	return &CacheVolume{Key: key}
 }
 
 func (cache *CacheVolume) Clone() *CacheVolume {
 	cp := *cache
-	cp.Keys = cloneSlice(cp.Keys)
 	return &cp
 }
 
 // Sum returns a checksum of the cache tokens suitable for use as a cache key.
 func (cache *CacheVolume) Sum() string {
 	hash := sha256.New()
-	for _, tok := range cache.Keys {
-		_, _ = hash.Write([]byte(tok + "\x00"))
-	}
-
+	_, _ = hash.Write([]byte(cache.Key + "\x00"))
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 

--- a/core/container.go
+++ b/core/container.go
@@ -240,7 +240,7 @@ type ContainerMount struct {
 	CacheVolumeID string `json:"cache_volume_id,omitempty"`
 
 	// Name of the underlying cache volume for this container mount.
-	CacheVolumeName string `json:"-"`
+	CacheVolumeName string `json:"cache_volume_name,omitempty"`
 
 	// How to share the cache across concurrent runs.
 	CacheSharingMode CacheSharingMode `json:"cache_sharing,omitempty"`

--- a/core/container.go
+++ b/core/container.go
@@ -240,6 +240,9 @@ type ContainerMount struct {
 	// Persist changes to the mount under this cache ID.
 	CacheVolumeID string `json:"cache_volume_id,omitempty"`
 
+	// Name of the underlying cache volume for this container mount.
+	CacheVolumeName string `json:"-"`
+
 	// How to share the cache across concurrent runs.
 	CacheSharingMode CacheSharingMode `json:"cache_sharing,omitempty"`
 
@@ -654,9 +657,18 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 		sharingMode = CacheSharingModeShared
 	}
 
+	// NOTE: cache volume has a list of keys even though we do not allow setting
+	// more than one in our graphql API. In spite of that we want to be defensive
+	// and not panic in case there is not even a single key.
+	var cacheVolumeName string
+	if len(cache.Keys) > 0 {
+		cacheVolumeName = cache.Keys[0]
+	}
+
 	mount := ContainerMount{
 		Target:           target,
 		CacheVolumeID:    cache.Sum(),
+		CacheVolumeName:  cacheVolumeName,
 		CacheSharingMode: sharingMode,
 	}
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/cache"
 	"github.com/dagger/dagger/network"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/identity"
@@ -255,7 +256,10 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 		if mnt.CacheVolumeID != "" {
 			// append the list of cache volumes
-			execMD.CacheVolumes = append(execMD.CacheVolumes, mnt.CacheVolumeName)
+			execMD.CacheVolumes = append(execMD.CacheVolumes, &cache.CacheVolume{
+				Name:   mnt.CacheVolumeName,
+				Target: mnt.Target,
+			})
 
 			var sharingMode llb.CacheMountSharingMode
 			switch mnt.CacheSharingMode {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -254,6 +254,9 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		}
 
 		if mnt.CacheVolumeID != "" {
+			// append the list of cache volumes
+			execMD.CacheVolumes = append(execMD.CacheVolumes, mnt.CacheVolumeName)
+
 			var sharingMode llb.CacheMountSharingMode
 			switch mnt.CacheSharingMode {
 			case CacheSharingModeShared:

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/console"
 	runc "github.com/containerd/go-runc"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/cache"
 	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
@@ -103,7 +104,7 @@ type ExecutionMetadata struct {
 	// If true, skip injecting dagger-init into the container.
 	NoInit bool
 
-	CacheVolumes []string
+	CacheVolumes []*cache.CacheVolume
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -102,6 +102,8 @@ type ExecutionMetadata struct {
 
 	// If true, skip injecting dagger-init into the container.
 	NoInit bool
+
+	CacheVolumes []string
 }
 
 const executionMetadataKey = "dagger.executionMetadata"
@@ -162,6 +164,7 @@ func (w *Worker) Run(
 		w.injectInit,
 		w.generateBaseSpec,
 		w.filterEnvs,
+		w.setupCacheVolumes,
 		w.setupRootfs,
 		w.setUserGroup,
 		w.setExitCodePath,

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -413,6 +413,18 @@ func (w *Worker) setupCacheVolumes(ctx context.Context, state *execState) error 
 		return nil
 	}
 
+	for _, m := range state.spec.Mounts {
+		for _, cv := range w.execMD.CacheVolumes {
+			if cv.Target == m.Destination {
+				cv.Mount = &mount.Mount{
+					Type:    m.Type,
+					Source:  m.Source,
+					Options: m.Options,
+				}
+			}
+		}
+	}
+
 	if err := w.daggerCacheManager.DownloadCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
 		bklog.G(ctx).Warnf("optional cache volume synchronization failed: %v", err)
 	}

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -405,6 +405,15 @@ func (w *Worker) filterEnvs(_ context.Context, state *execState) error {
 	return nil
 }
 
+// setupCacheVolumes synchronizes the cache volumes that are in use for this
+// execution
+func (w *Worker) setupCacheVolumes(ctx context.Context, state *execState) error {
+	if err := w.daggerCacheManager.SynchronizeCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
+		bklog.G(ctx).Warnf("optional cache volume synchronization failed: %v", err)
+	}
+	return nil
+}
+
 func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 	var err error
 	state.rootfsPath, err = os.MkdirTemp("", "rootfs")

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -408,6 +408,10 @@ func (w *Worker) filterEnvs(_ context.Context, state *execState) error {
 // setupCacheVolumes synchronizes the cache volumes that are in use for this
 // execution
 func (w *Worker) setupCacheVolumes(ctx context.Context, state *execState) error {
+	if w.execMD == nil || len(w.execMD.CacheVolumes) == 0 {
+		return nil
+	}
+
 	if err := w.daggerCacheManager.SynchronizeCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
 		bklog.G(ctx).Warnf("optional cache volume synchronization failed: %v", err)
 	}

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -408,11 +408,12 @@ func (w *Worker) filterEnvs(_ context.Context, state *execState) error {
 // setupCacheVolumes synchronizes the cache volumes that are in use for this
 // execution
 func (w *Worker) setupCacheVolumes(ctx context.Context, state *execState) error {
-	if w.execMD == nil || len(w.execMD.CacheVolumes) == 0 {
+	// only sync if there are cache volumes and the `daggerCacheManager` was set
+	if w.execMD == nil || len(w.execMD.CacheVolumes) == 0 || w.daggerCacheManager == nil {
 		return nil
 	}
 
-	if err := w.daggerCacheManager.SynchronizeCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
+	if err := w.daggerCacheManager.DownloadCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
 		bklog.G(ctx).Warnf("optional cache volume synchronization failed: %v", err)
 	}
 	return nil

--- a/engine/buildkit/worker.go
+++ b/engine/buildkit/worker.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	runc "github.com/containerd/go-runc"
+	"github.com/dagger/dagger/engine/cache"
 	"github.com/docker/docker/pkg/idtools"
 	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/executor"
@@ -58,6 +59,8 @@ type sharedWorkerState struct {
 	parallelismSem   *semaphore.Weighted
 	workerCache      bkcache.Manager
 
+	daggerCacheManager cache.Manager
+
 	running map[string]*execState
 	mu      sync.RWMutex
 }
@@ -110,6 +113,11 @@ func NewWorker(opts *NewWorkerOpts) *Worker {
 
 		running: make(map[string]*execState),
 	}}
+}
+
+func (w *Worker) SetCacheManager(manager cache.Manager) *Worker {
+	w.daggerCacheManager = manager
+	return w
 }
 
 func (w *Worker) Executor() executor.Executor {

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -467,6 +467,7 @@ func (m *manager) Import(ctx context.Context) error {
 // Close will block until the final export has finished or ctx is canceled.
 func (m *manager) Close(ctx context.Context) (rerr error) {
 	close(m.startCloseCh)
+	m.UploadCacheMounts(ctx)
 	select {
 	case <-m.doneCh:
 	case <-ctx.Done():
@@ -546,6 +547,7 @@ func (m *manager) descriptorProviderPair(layerMetadata remotecache.CacheLayer) (
 type Manager interface {
 	solver.CacheManager
 	DownloadCacheMounts(context.Context, []string) error
+	UploadCacheMounts(context.Context) error
 	ReleaseUnreferenced(context.Context) error
 	Close(context.Context) error
 }
@@ -557,6 +559,10 @@ type defaultCacheManager struct {
 var _ Manager = defaultCacheManager{}
 
 func (defaultCacheManager) DownloadCacheMounts(ctx context.Context, _ []string) error {
+	return nil
+}
+
+func (defaultCacheManager) UploadCacheMounts(ctx context.Context) error {
 	return nil
 }
 

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -32,11 +32,19 @@ type manager struct {
 	runtimeConfig Config
 	localCache    solver.CacheManager
 
-	mu                 sync.RWMutex
-	inner              solver.CacheManager
-	startCloseCh       chan struct{} // closed when shutdown should start
-	doneCh             chan struct{} // closed when shutdown is complete
-	stopCacheMountSync func(context.Context) error
+	mu           sync.RWMutex
+	inner        solver.CacheManager
+	startCloseCh chan struct{} // closed when shutdown should start
+	doneCh       chan struct{} // closed when shutdown is complete
+
+	cacheMountsInit   sync.Once
+	syncedCacheMounts map[string]*syncedCacheMount
+	seenCacheMounts   *sync.Map
+}
+
+type syncedCacheMount struct {
+	init  sync.Once
+	mount SyncedCacheMountConfig
 }
 
 type ManagerConfig struct {
@@ -444,9 +452,6 @@ func (m *manager) Import(ctx context.Context) error {
 // Close will block until the final export has finished or ctx is canceled.
 func (m *manager) Close(ctx context.Context) (rerr error) {
 	close(m.startCloseCh)
-	if m.stopCacheMountSync != nil {
-		rerr = m.stopCacheMountSync(ctx)
-	}
 	select {
 	case <-m.doneCh:
 	case <-ctx.Done():

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -3,12 +3,15 @@ package cache
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd/archive"
@@ -23,185 +26,222 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/dagger/dagger/core"
 )
 
-func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
-	getCacheMountConfigResp, err := m.cacheClient.GetCacheMountConfig(ctx, GetCacheMountConfigRequest{})
-	if err != nil {
-		return fmt.Errorf("failed to get cache mount config: %w", err)
-	}
-	syncedCacheMounts := getCacheMountConfigResp.SyncedCacheMounts
+// SynchronizeCacheMounts synchronizes the specified list of cache mounts.
+// NOTE: this is a synchronous operation that will download data from object storage
+// providers.
+func (m *manager) SynchronizeCacheMounts(ctx context.Context, cacheMounts []string) error {
+	m.cacheMountsInit.Do(func() {
+		m.seenCacheMounts = &sync.Map{}
+
+		response, err := m.cacheClient.GetCacheMountConfig(ctx, GetCacheMountConfigRequest{})
+		if err != nil {
+			bklog.G(ctx).Warnf("(optional) failed to download cache mount config: %v", err)
+			return
+		}
+
+		m.syncedCacheMounts = map[string]*syncedCacheMount{}
+		for _, mount := range response.SyncedCacheMounts {
+			m.syncedCacheMounts[mount.Name] = &syncedCacheMount{
+				init:  sync.Once{},
+				mount: mount,
+			}
+		}
+	})
 
 	var eg errgroup.Group
-	for _, syncedCacheMount := range syncedCacheMounts {
-		if syncedCacheMount.URL == "" {
-			// nothing to download, have to start fresh, skip it until we sync back to cloud at shutdown
+	for _, cacheMountName := range cacheMounts {
+		m.seenCacheMounts.Store(cacheMountName, true)
+
+		bklog.G(ctx).Infof("syncing cache volume %s", cacheMountName)
+		cacheMount, ok := m.syncedCacheMounts[cacheMountName]
+		if !ok {
+			bklog.G(ctx).Infof("cache mount %s not in config", cacheMountName)
 			continue
 		}
-		eg.Go(func() error {
-			bklog.G(ctx).Debugf("syncing cache mount locally %s", syncedCacheMount.Name)
-			cacheKey := cacheKeyFromMountName(syncedCacheMount.Name)
-			return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
-				cacheMountDir := mnt.Source // relies on our check that this is a bind mount in withCacheMount
 
-				// if there's any existing data in the cache mount, we'll just leave it alone
-				// NOTE: there's cases in which this heuristic isn't ideal, such as when a
-				// remote cache mount has "better" contents than this one, but this will suffice
-				// for now
-				dirents, err := os.ReadDir(cacheMountDir)
-				if err != nil {
-					return fmt.Errorf("failed to read cache mount dir: %w", err)
+		eg.Go(func() error {
+			cacheMount.init.Do(func() {
+				// NOTE: synchronizing cache mounts is optional and we do not want
+				// the engine to fail if this fail. This function is being called
+				// while a container is being executed so its important we handle
+				// errors gracefully.
+				if err := m.downloadCacheMount(ctx, cacheMount.mount); err != nil {
+					bklog.G(ctx).Warnf("(optional) failed to sync cache mount %s: %v", cacheMount.mount.Name, err)
 				}
-				if len(dirents) > 0 {
-					bklog.G(ctx).Debugf("cache mount %q already has data, skipping", syncedCacheMount.Name)
+			})
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}
+
+func (m *manager) downloadCacheMount(ctx context.Context, syncedCacheMount SyncedCacheMountConfig) error {
+	bklog.G(ctx).Debugf("downloading cache mount %s", syncedCacheMount.Name)
+
+	cacheKey := cacheKeyFromMountName(syncedCacheMount.Name)
+	return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
+		cacheMountDir := mnt.Source // relies on our check that this is a bind mount in withCacheMount
+
+		// if there's any existing data in the cache mount, we'll just leave it alone
+		// NOTE: there's cases in which this heuristic isn't ideal, such as when a
+		// remote cache mount has "better" contents than this one, but this will suffice
+		// for now
+		dirents, err := os.ReadDir(cacheMountDir)
+		if err != nil {
+			return fmt.Errorf("failed to read cache mount dir: %w", err)
+		}
+		if len(dirents) > 0 {
+			bklog.G(ctx).Debugf("cache mount %q already has data, skipping", syncedCacheMount.Name)
+			return nil
+		}
+
+		fsApplier := apply.NewFileSystemApplier(&cacheMountProvider{
+			httpClient: m.httpClient,
+			url:        syncedCacheMount.URL,
+		})
+		_, err = fsApplier.Apply(ctx, ocispecs.Descriptor{
+			Digest:    syncedCacheMount.Digest,
+			Size:      syncedCacheMount.Size,
+			MediaType: syncedCacheMount.MediaType,
+		}, []mount.Mount{mnt})
+		if err != nil {
+			if removeErr := removeAllUnderDir(cacheMountDir); removeErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to empty out cache mount dir after failure %q: %w", cacheMountDir, removeErr))
+			}
+			return fmt.Errorf("failed to apply cache mount: %w", err)
+		}
+
+		bklog.G(ctx).Debugf("downloaded cache mount %s", syncedCacheMount.Name)
+		return nil
+	})
+}
+
+// syncSeenCacheMounts uploads to object storage all cache mounts that were seen
+// whose digest is different than the one stored upstream.
+func (m *manager) syncSeenCacheMounts(ctx context.Context) error {
+	// if seenCacheMounts is not set then are no cache mounts that should be synced
+	if m.seenCacheMounts == nil {
+		return nil
+	}
+
+	seenCacheMounts := map[string]struct{}{}
+	m.seenCacheMounts.Range(func(k any, v any) bool {
+		seenCacheMounts[k.(string)] = struct{}{}
+		return true
+	})
+
+	var eg errgroup.Group
+	for cacheMountName := range seenCacheMounts {
+		eg.Go(func() error {
+			bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
+			cacheKey := cacheKeyFromMountName(cacheMountName)
+
+			return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
+				// First compress the mount into the content store. We can't stream direct to S3 because we want
+				// to tell S3 the checksum of the whole thing when we open the request there. Apparently there
+				// is a way to include the checksum as a trailer, but it is poorly documented and seems to require
+				// a different streaming request type, which is giving me a headache right now. Can optimize in future.
+
+				// add a temporary lease so our content doesn't get pruned immediately from the store
+				ctx, done, err := leaseutil.WithLease(ctx, m.Worker.LeaseManager(), leaseutil.MakeTemporary)
+				if err != nil {
+					return fmt.Errorf("failed to create lease: %w", err)
+				}
+				defer done(ctx)
+
+				// compress the mount to a tar.zstd and write to the content store
+				contentRef := "dagger-cachemount-" + cacheMountName
+				contentWriter, err := m.Worker.ContentStore().Writer(ctx, content.WithRef(contentRef))
+				if err != nil {
+					return fmt.Errorf("failed to create content writer: %w", err)
+				}
+				defer contentWriter.Close()
+				writeBuffer := bufio.NewWriterSize(contentWriter, 1024*1024)
+				compressor, err := zstd.NewWriter(writeBuffer, zstd.WithEncoderLevel(zstd.SpeedDefault))
+				if err != nil {
+					return fmt.Errorf("failed to create compressor: %w", err)
+				}
+				defer compressor.Close()
+				// mnt.Source relies on our check that this is a bind mount in withCacheMount
+				err = archive.WriteDiff(ctx, compressor, "", mnt.Source)
+				if err != nil {
+					return fmt.Errorf("failed to write diff: %w", err)
+				}
+				if err := compressor.Close(); err != nil {
+					return fmt.Errorf("failed to close compressor: %w", err)
+				}
+				writeBuffer.Flush()
+				if err := contentWriter.Commit(ctx, 0, ""); err != nil {
+					if errors.Is(err, errdefs.ErrAlreadyExists) {
+						// we should be releasing these, but if it was already there, that's weird but fine
+						bklog.G(ctx).Debugf("cache mount %q already committed", cacheMountName)
+					} else {
+						return fmt.Errorf("failed to commit content: %w", err)
+					}
+				}
+				contentDigest := contentWriter.Digest()
+
+				// now that we have the digest we can upload from the content store to the url
+				contentReaderAt, err := m.Worker.ContentStore().ReaderAt(ctx, ocispecs.Descriptor{
+					Digest: contentDigest,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to create content reader: %w", err)
+				}
+				defer contentReaderAt.Close()
+				contentLength := contentReaderAt.Size()
+				getURLResp, err := m.cacheClient.GetCacheMountUploadURL(ctx, GetCacheMountUploadURLRequest{
+					CacheName: cacheMountName,
+					Digest:    contentDigest,
+					Size:      contentLength,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get cache mount upload url: %w", err)
+				}
+
+				if getURLResp.Skip {
+					bklog.G(ctx).Debugf("skipped pushing cache mount %s", cacheMountName)
 					return nil
 				}
 
-				fsApplier := apply.NewFileSystemApplier(&cacheMountProvider{
-					httpClient: m.httpClient,
-					url:        syncedCacheMount.URL,
-				})
-				_, err = fsApplier.Apply(ctx, ocispecs.Descriptor{
-					Digest:    syncedCacheMount.Digest,
-					Size:      syncedCacheMount.Size,
-					MediaType: syncedCacheMount.MediaType,
-				}, []mount.Mount{mnt})
+				contentReader := io.NewSectionReader(contentReaderAt, 0, contentLength)
+				httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, getURLResp.URL, contentReader)
 				if err != nil {
-					if removeErr := removeAllUnderDir(cacheMountDir); removeErr != nil {
-						err = errors.Join(err, fmt.Errorf("failed to empty out cache mount dir after failure %q: %w", cacheMountDir, removeErr))
-					}
-					return fmt.Errorf("failed to apply cache mount: %w", err)
+					return fmt.Errorf("failed to create http request: %w", err)
+				}
+				httpReq.ContentLength = contentLength // set it here, go stdlib will ignore if set on Header (??!!)
+				for k, v := range getURLResp.Headers {
+					httpReq.Header.Set(k, v)
+				}
+				resp, err := m.httpClient.Do(httpReq)
+				if err != nil {
+					return fmt.Errorf("failed to upload cache mount: %w", err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
 				}
 
-				bklog.G(ctx).Debugf("synced cache mount locally %s", syncedCacheMount.Name)
+				bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
 				return nil
 			})
 		})
 	}
-	err = eg.Wait()
-	if err != nil {
-		return err
-	}
-
-	m.stopCacheMountSync = func(ctx context.Context) error {
-		var eg errgroup.Group
-
-		seenCacheMounts := map[string]struct{}{}
-		core.SeenCacheKeys.Range(func(k any, v any) bool {
-			seenCacheMounts[k.(string)] = struct{}{}
-			return true
-		})
-
-		for cacheMountName := range seenCacheMounts {
-			eg.Go(func() error {
-				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
-				cacheKey := cacheKeyFromMountName(cacheMountName)
-
-				return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
-					// First compress the mount into the content store. We can't stream direct to S3 because we want
-					// to tell S3 the checksum of the whole thing when we open the request there. Apparently there
-					// is a way to include the checksum as a trailer, but it is poorly documented and seems to require
-					// a different streaming request type, which is giving me a headache right now. Can optimize in future.
-
-					// add a temporary lease so our content doesn't get pruned immediately from the store
-					ctx, done, err := leaseutil.WithLease(ctx, m.Worker.LeaseManager(), leaseutil.MakeTemporary)
-					if err != nil {
-						return fmt.Errorf("failed to create lease: %w", err)
-					}
-					defer done(ctx)
-
-					// compress the mount to a tar.zstd and write to the content store
-					contentRef := "dagger-cachemount-" + cacheMountName
-					contentWriter, err := m.Worker.ContentStore().Writer(ctx, content.WithRef(contentRef))
-					if err != nil {
-						return fmt.Errorf("failed to create content writer: %w", err)
-					}
-					defer contentWriter.Close()
-					writeBuffer := bufio.NewWriterSize(contentWriter, 1024*1024)
-					compressor, err := zstd.NewWriter(writeBuffer, zstd.WithEncoderLevel(zstd.SpeedDefault))
-					if err != nil {
-						return fmt.Errorf("failed to create compressor: %w", err)
-					}
-					defer compressor.Close()
-					// mnt.Source relies on our check that this is a bind mount in withCacheMount
-					err = archive.WriteDiff(ctx, compressor, "", mnt.Source)
-					if err != nil {
-						return fmt.Errorf("failed to write diff: %w", err)
-					}
-					if err := compressor.Close(); err != nil {
-						return fmt.Errorf("failed to close compressor: %w", err)
-					}
-					writeBuffer.Flush()
-					if err := contentWriter.Commit(ctx, 0, ""); err != nil {
-						if errors.Is(err, errdefs.ErrAlreadyExists) {
-							// we should be releasing these, but if it was already there, that's weird but fine
-							bklog.G(ctx).Debugf("cache mount %q already committed", cacheMountName)
-						} else {
-							return fmt.Errorf("failed to commit content: %w", err)
-						}
-					}
-					contentDigest := contentWriter.Digest()
-
-					// now that we have the digest we can upload from the content store to the url
-					contentReaderAt, err := m.Worker.ContentStore().ReaderAt(ctx, ocispecs.Descriptor{
-						Digest: contentDigest,
-					})
-					if err != nil {
-						return fmt.Errorf("failed to create content reader: %w", err)
-					}
-					defer contentReaderAt.Close()
-					contentLength := contentReaderAt.Size()
-					getURLResp, err := m.cacheClient.GetCacheMountUploadURL(ctx, GetCacheMountUploadURLRequest{
-						CacheName: cacheMountName,
-						Digest:    contentDigest,
-						Size:      contentLength,
-					})
-					if err != nil {
-						return fmt.Errorf("failed to get cache mount upload url: %w", err)
-					}
-
-					if getURLResp.Skip {
-						bklog.G(ctx).Debugf("skipped pushing cache mount %s", cacheMountName)
-						return nil
-					}
-
-					contentReader := io.NewSectionReader(contentReaderAt, 0, contentLength)
-					httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, getURLResp.URL, contentReader)
-					if err != nil {
-						return fmt.Errorf("failed to create http request: %w", err)
-					}
-					httpReq.ContentLength = contentLength // set it here, go stdlib will ignore if set on Header (??!!)
-					for k, v := range getURLResp.Headers {
-						httpReq.Header.Set(k, v)
-					}
-					resp, err := m.httpClient.Do(httpReq)
-					if err != nil {
-						return fmt.Errorf("failed to upload cache mount: %w", err)
-					}
-					defer resp.Body.Close()
-					if resp.StatusCode != http.StatusOK {
-						return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
-					}
-
-					bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
-					return nil
-				})
-			})
-		}
-		return eg.Wait()
-	}
-
-	return nil
+	return eg.Wait()
 }
 
+// cacheKeyFromMountName is a copy of core.NewCache().Sum(). This is because
+// we cannot import `core` here without creating an import cycle:
+// - engine/buildkit imports cache
+//   - cache imports core
+//   - core imports engine/buildkit
 func cacheKeyFromMountName(name string) string {
-	// Turn the human-readable name into the key we use internally
-	// NOTE: this will be problematic if backwards incompatible changes are made
-	// to the key format and client<->server are out of sync. That's a general
-	// problem though too, so just accepting it for now.
-	return core.NewCache(name).Sum()
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(name + "\x00"))
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 
 func withCacheMount(ctx context.Context, mountManager *mounts.MountManager, cacheKey string, cb func(ctx context.Context, mnt mount.Mount) error) error {

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -148,9 +148,13 @@ func (m *manager) downloadCacheMount(ctx context.Context, syncedCacheMount Synce
 	})
 }
 
-// syncSeenCacheMounts uploads to object storage all cache mounts that were seen
+func (m *manager) UploadCacheMounts(ctx context.Context) error {
+	return m.uploadSeenCacheMounts(ctx)
+}
+
+// uploadSeenCacheMounts uploads to object storage all cache mounts that were seen
 // whose digest is different than the one stored upstream.
-func (m *manager) syncSeenCacheMounts(ctx context.Context) error {
+func (m *manager) uploadSeenCacheMounts(ctx context.Context) error {
 	// if seenCacheMounts is not set then are no cache mounts that should be synced
 	if m.seenCacheMounts == nil {
 		return nil

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -499,6 +499,7 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 
 	cacheServiceURL := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_URL")
 	cacheServiceToken := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN")
+	cacheServiceSyncOnBoot := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_SYNC_ON_BOOT")
 	// add DAGGER_CLOUD_TOKEN in a backwards compat way.
 	// TODO: deprecate in a future release
 	if v, ok := os.LookupEnv("DAGGER_CLOUD_TOKEN"); ok {
@@ -516,6 +517,7 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		ServiceURL:   cacheServiceURL,
 		Token:        cacheServiceToken,
 		EngineID:     opts.Name,
+		SyncOnBoot:   cacheServiceSyncOnBoot == "true",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Currently cache volumes are being synchronized during engine startup. For organizations that have large cache volumes (or a large amount) this dramatically slows down their pipelines. Similar to what we do for layers, we want cache mounts to be synced on-demand.

When a container gets executed we will download the cache volumes that will be used for it. This will only happen once per cache volume during the lifetime of the engine.

> [!CAUTION]
> This change will make individual `dagger call` operations slower since cache mounts now gets downloaded and applied while the call itself happens. This is something we want to explicitly communicate to our users.

## Changes

Thanks to @sipsma [guide](https://discord.com/channels/707636530424053791/1265063659424583700/1265063660955373730) on how to approach these changes. The changes involve:
1. In `container#WithExec` we collect the list of `ContainerMount` that are cache volumes and store that in the `ExecutionMetadata`
2. This metadata reaches the `worker` and when setting up the container we call `setupCacheVolumes` with the list of cache volumes that was collected before
3. We then use the `cache.Manager` to synchronize that list of cache mounts. This manager is a global instance that stores the list of cache mounts that are being synchronized. Each cache mount has its own `sync.Once` so that we only download a cache mount once during the lifetime of the engine (also acts as a lock).

The main problem we faced when implementing this were import cycles:
- `engine/buildkit` imported `cache`
  - `cache` imported `core`
  - `core` imported `engine/buildkit`
 
The best workaround we found was to remove the dependency of `core` from `cache`. `core` was being used for two things:
- `core.SeenCacheKeys`: used by `cache` to only upload the cache mounts that were seen. We fixed this by tracking the seen cache mounts in the `manager` itself.
- `core.NewCache().Sum()`: used by `cache` to get the cache key from a cache mount name. The function is small and straightforward so we decided to copy it.

With those fixes in place we were able to import `cache` from `engine/buildkit` and leave all the logic of synchronizing cache mounts isolated in the `cache` package.

## Tests

We are working on implementing integration tests on our internal cache provider. The tests we did for this were manual. We used the following module:
```go
package main

import (
	"dagger/rmcache/internal/dagger"
	"fmt"
	"time"
)

type Rmcache struct{}

func (m *Rmcache) Create(file string) *dagger.Container {
	return dag.Container().
		From("alpine:latest").
		WithEnvVariable("CACHE_BUST", time.Now().String()).
		WithMountedCache("/cache", dag.CacheVolume("lazy-cache")).
		WithExec([]string{"sh", "-c", fmt.Sprintf("head -c 50m /dev/urandom > /cache/%s.txt", file)})
}

func (m *Rmcache) Rm() *dagger.Container {
	return dag.Container().
		From("alpine:latest").
		WithEnvVariable("CACHE_BUST", time.Now().String()).
		WithMountedCache("/cache", dag.CacheVolume("lazy-cache")).
		WithExec([]string{"sh", "-c", "rm -rf /cache/*"})
}

func (m *Rmcache) Ls() *dagger.Container {
	return dag.Container().
		From("alpine:latest").
		WithEnvVariable("CACHE_BUST", time.Now().String()).
		WithMountedCache("/cache", dag.CacheVolume("lazy-cache")).
		WithExec([]string{"sh", "-c", "ls -lh /cache/"})
}
```

This module allowed us to easily create, list and remove contents from a cache volume. We then started an engine in an org that has many cache volumes and confirmed to volumes get synchronized:

![2024-09-03-17:04:39](https://github.com/user-attachments/assets/5d56b220-ec3d-4429-a279-bc48886a903a)

We then made a call to list the files to see the contents of the cache volume (`dagger call ls stdout`) and confirmed that the cache mount was downloaded on-demand:

![2024-09-03-17:07:50](https://github.com/user-attachments/assets/b331633b-602d-477f-bc38-c8b39f8a33c1)

Now  we re-run the list and confirm the cache mount does not get downloaded again:

![2024-09-03-17:22:22](https://github.com/user-attachments/assets/c9e17493-cc2c-4330-b90a-f14e7152f344)

And we finally confirm that it gets uploaded when exiting the engine:

![2024-09-03-17:22:32](https://github.com/user-attachments/assets/f687b939-9416-4e1e-bdaa-c1479bf9b7fb)