### PR TITLE
fix(sdk/elixir): fix from_map crash because of description can be optional

### DIFF
--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
@@ -10,13 +10,12 @@ defmodule Dagger.Codegen.Introspection.Types.Type do
 
   def from_map(
         %{
-          "description" => description,
           "kind" => kind,
           "name" => name
         } = type
       ) do
     %__MODULE__{
-      description: description,
+      description: type["description"],
       enum_values:
         Enum.map(
           type["enumValues"] || [],


### PR DESCRIPTION
Fix `Type.from_map/1` crash when the `description` may not present in the schema json file when that schema generated from module.