### PR TITLE
client: set less aggressive minimum connect timeout for buildkit

### DIFF
--- a/.changes/unreleased/Changed-20240909-113139.yaml
+++ b/.changes/unreleased/Changed-20240909-113139.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: "client: Increase the min connect timeout from 1s to 3s (otherwise connecting to distant Engines fails)"
+time: 2024-09-09T11:31:39.442814+01:00
+custom:
+    Author: neutronth
+    PR: "8328"

--- a/engine/client/buildkit.go
+++ b/engine/client/buildkit.go
@@ -31,7 +31,7 @@ func newBuildkitClient(ctx context.Context, remote *url.URL, connector drivers.C
 		}),
 		bkclient.WithGRPCDialOption(grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff:           backoffConfig,
-			MinConnectTimeout: 1 * time.Second,
+			MinConnectTimeout: 3 * time.Second,
 		})),
 	}
 


### PR DESCRIPTION
* The MinConnectTimeout was set to 1s which is good for a fast recovering from the situation that the engine is not ready to accept connections, while at the same time, it's too aggressive for a remote engine, eg. Dagger Engine on a Kubernetes [1], the engine may not complete the connect phase within the deadline and always failed in the connection checking loop [2].

  Until the buildkit implements the better way of client creation [3], increase the timeout with a less aggressive 3s could mitigate this issue.

  [1] https://docs.dagger.io/integrations/kubernetes
  [2] https://github.com/dagger/dagger/blob/main/engine/client/buildkit.go#L45
  [3] https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md