### PR TITLE
fix: allow field access with default constructor

### DIFF
--- a/.changes/unreleased/Fixed-20240911-101724.yaml
+++ b/.changes/unreleased/Fixed-20240911-101724.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  Allow top-level field access with no constructor
+
+  Previously, if a field access was made immediately after the default constructor was called, then the access would fail.
+time: 2024-09-11T10:17:24.388632197+01:00
+custom:
+  Author: jedevc
+  PR: "8331"

--- a/core/enum.go
+++ b/core/enum.go
@@ -148,6 +148,8 @@ func (e *ModuleEnum) Decoder() dagql.InputDecoder {
 
 func (e *ModuleEnum) DecodeInput(val any) (dagql.Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return e.Lookup("")
 	case string:
 		return e.Lookup(x)
 	case dagql.Scalar[dagql.String]:

--- a/core/json.go
+++ b/core/json.go
@@ -73,6 +73,8 @@ var _ dagql.ScalarType = JSON{}
 
 func (JSON) DecodeInput(val any) (res dagql.Input, err error) {
 	switch x := val.(type) {
+	case nil:
+		return nil, nil
 	case string:
 		if x == "" {
 			return nil, nil

--- a/core/object.go
+++ b/core/object.go
@@ -360,7 +360,9 @@ func objField(mod *Module, field *FieldTypeDef) dagql.Field[*ModuleObject] {
 			}
 			fieldVal, found := obj.Self.Fields[field.OriginalName]
 			if !found {
-				return nil, fmt.Errorf("field %q not found on object %q", field.Name, obj.Class.TypeName())
+				// the field *might* not have been set yet on the object (even
+				// though the typedef has it) - so just pick a suitable zero value
+				fieldVal = nil
 			}
 			return modType.ConvertFromSDKResult(ctx, fieldVal)
 		},

--- a/core/platform.go
+++ b/core/platform.go
@@ -54,6 +54,9 @@ func (p Platform) ToLiteral() call.Literal {
 var _ dagql.ScalarType = Platform{}
 
 func (Platform) DecodeInput(val any) (dagql.Input, error) {
+	if val == nil {
+		val = ""
+	}
 	switch x := val.(type) {
 	case string:
 		plat, err := platforms.Parse(x)

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -239,6 +239,9 @@ func (d DynamicID) TypeName() string {
 var _ dagql.InputDecoder = DynamicID{}
 
 func (d DynamicID) DecodeInput(val any) (dagql.Input, error) {
+	if val == nil {
+		val = ""
+	}
 	switch x := val.(type) {
 	case string:
 		var idp call.ID

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -173,6 +173,9 @@ type DynamicArrayInput struct {
 var _ InputDecoder = DynamicArrayInput{}
 
 func (d DynamicArrayInput) DecodeInput(val any) (Input, error) {
+	if val == nil {
+		val = []any{}
+	}
 	switch x := val.(type) {
 	case []any:
 		arr := DynamicArrayInput{

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -142,6 +142,8 @@ func (i Int) TypeDefinition(views ...string) *ast.Definition {
 
 func (Int) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return NewInt(0), nil
 	case int:
 		return NewInt(x), nil
 	case int32:
@@ -239,6 +241,8 @@ func (f Float) TypeDefinition(views ...string) *ast.Definition {
 
 func (Float) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return NewFloat(float64(0)), nil
 	case float32:
 		return NewFloat(float64(x)), nil
 	case float64:
@@ -340,6 +344,8 @@ func (b Boolean) TypeDefinition(views ...string) *ast.Definition {
 
 func (Boolean) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return NewBoolean(false), nil
 	case bool:
 		return NewBoolean(x), nil
 	case string: // from default
@@ -425,6 +431,8 @@ func (s String) TypeDefinition(views ...string) *ast.Definition {
 
 func (String) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return NewString(""), nil
 	case string:
 		return NewString(x), nil
 	default:
@@ -760,6 +768,10 @@ var _ InputDecoder = ArrayInput[Input]{}
 func (a ArrayInput[I]) DecodeInput(val any) (Input, error) {
 	var zero I
 	decoder := zero.Decoder()
+
+	if val == nil {
+		val = []any{}
+	}
 	switch x := val.(type) {
 	case []any:
 		arr := make(ArrayInput[I], len(x))
@@ -902,6 +914,8 @@ func (e *EnumValues[T]) TypeDefinition(views ...string) *ast.Definition {
 
 func (e *EnumValues[T]) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
+	case nil:
+		return e.Lookup("")
 	case string:
 		return e.Lookup(x)
 	case Scalar[String]:


### PR DESCRIPTION
Previously, if a field access was made immediately after the default constructor was called, then the access would fail (because the field had not been set).

So, in this case, we try and convert a nil value, to get the default value for this.

---

Genuinely not quite sure how we never managed to hit this before, it's very easy - I just found it while playing around with some tests in #8149.