### PR TITLE
fix void types from core incorrectly being seen as named scalar types

### DIFF
--- a/.changes/unreleased/Fixed-20240904-191701.yaml
+++ b/.changes/unreleased/Fixed-20240904-191701.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed void types from core incorrectly being seen as named scalars
+time: 2024-09-04T19:17:01.089095Z
+custom:
+    Author: helderco
+    PR: "8336"

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -426,6 +426,8 @@ func introspectionRefToTypeDef(introspectionType *introspection.TypeRef, nonNull
 			typeDef.Kind = core.TypeDefKindInteger
 		case string(introspection.ScalarBoolean):
 			typeDef.Kind = core.TypeDefKindBoolean
+		case string(introspection.ScalarVoid):
+			typeDef.Kind = core.TypeDefKindVoid
 		default:
 			// assume that all core scalars are strings
 			typeDef.Kind = core.TypeDefKindScalar


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8326