### PR TITLE
docker driver: Use tags instead of digests to avoid registry lookups

### DIFF
--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -34,6 +34,8 @@ func sessionCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.Flags().StringVar(&sessionVersion, "version", "", "")
+	// This is not used by kept for backward compatibility.
+	// We don't want SDKs failing because this flag is not defined.
 	cmd.Flags().Var(&sessionLabels, "label", "label that identifies the source of this session (e.g, --label 'dagger.io/sdk.name:python' --label 'dagger.io/sdk.version:0.5.2' --label 'dagger.io/sdk.async:true')")
 	return cmd
 }
@@ -56,8 +58,6 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	labelsFlag := &sessionLabels
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
@@ -83,7 +83,6 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 
 	return withEngine(ctx, client.Params{
 		SecretToken: sessionToken.String(),
-		UserAgent:   labelsFlag.Labels.WithCILabels().WithAnonymousGitLabels(workdir).UserAgent(),
 		Version:     sessionVersion,
 	}, func(ctx context.Context, sess *client.Client) error {
 		// Requests maintain their original trace context from the client, rather

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -67,7 +67,6 @@ type Params struct {
 	SecretToken string
 
 	RunnerHost string // host of dagger engine runner serving buildkit apis
-	UserAgent  string
 
 	DisableHostRW bool
 
@@ -259,7 +258,6 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	provisionCtx, provisionSpan := Tracer(ctx).Start(ctx, "starting engine")
 	provisionCtx, provisionCancel := context.WithTimeout(provisionCtx, 10*time.Minute)
 	c.connector, err = driver.Provision(provisionCtx, remote, &drivers.DriverOpts{
-		UserAgent:        c.UserAgent,
 		DaggerCloudToken: cloudToken,
 		GPUSupport:       os.Getenv(drivers.EnvGPUSupport),
 	})

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -23,8 +23,6 @@ type Connector interface {
 }
 
 type DriverOpts struct {
-	UserAgent string
-
 	DaggerCloudToken string
 	GPUSupport       string
 }


### PR DESCRIPTION
See https://github.com/dagger/dagger/pull/8232 for context

Alternative of #8340

This is a much simpler alternative that works as follows:

- If the `docker-image://` contains a digest, it uses that as the container ID (same behavior as before)
- Otherwise, it will use the image tag as container ID (as opposed to reaching out to a registry to convert tag to digest)