### PR TITLE
fix: correctly handle carriage returns for plain progress

### DIFF
--- a/.changes/unreleased/Fixed-20240911-102046.yaml
+++ b/.changes/unreleased/Fixed-20240911-102046.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  Plain progress correctly displays carriage returns
+
+  Carriage returns could previously render weirdly in the output, displaying empty lines, and similar visual glitches.
+time: 2024-09-11T10:20:46.00360597+01:00
+custom:
+  Author: jedevc
+  PR: "8347"

--- a/dagql/idtui/vterm_lite.go
+++ b/dagql/idtui/vterm_lite.go
@@ -1,0 +1,40 @@
+package idtui
+
+type cursorBuffer struct {
+	buf    []byte
+	cursor int
+}
+
+func newCursorBuffer(s []byte) cursorBuffer {
+	return cursorBuffer{
+		buf:    s,
+		cursor: len(s),
+	}
+}
+
+func (l *cursorBuffer) String() string {
+	return string(l.buf)
+}
+
+func (l *cursorBuffer) Write(s []byte) (int, error) {
+	// grow the buffer capacity to include space for the entire input (which is
+	// the most common case, carriage returns are pretty uncommon)
+	if cap(l.buf) < len(l.buf)+len(s) {
+		l.buf = append(l.buf, make([]byte, len(s))...)[:len(l.buf)]
+	}
+
+	for _, ch := range s {
+		if ch == '\r' {
+			// go back to the beginning, and start overwriting output
+			l.cursor = 0
+			continue
+		}
+		if l.cursor < len(l.buf) {
+			l.buf[l.cursor] = ch
+		} else {
+			l.buf = append(l.buf, ch)
+		}
+		l.cursor++
+	}
+	return len(s), nil
+}

--- a/dagql/idtui/vterm_lite_test.go
+++ b/dagql/idtui/vterm_lite_test.go
@@ -1,0 +1,16 @@
+package idtui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCursorBuffer(t *testing.T) {
+	l := cursorBuffer{}
+	l.Write([]byte("hello "))
+	l.Write([]byte("world"))
+	require.Equal(t, "hello world", l.String())
+	l.Write([]byte("!\r'"))
+	require.Equal(t, "'ello world!", l.String())
+}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8259

This was incorrectly rendering some carriage return output (outside of certain test cases). To handle this, we need to track a proper cursor, which is a bit annoying, but unavoidable.

The approach in https://github.com/dagger/dagger/issues/7653 wasn't *quite* right (since `\r\n` would essentially wipe the entire contents of the line). But also, what silly unix tool would produce windows-style newlines like that? (apt, that's who)