### PR TITLE
💥 Breaking(helm): Remove appVersion - this is now the chart version

### DIFF
--- a/.dagger/helm.go
+++ b/.dagger/helm.go
@@ -97,7 +97,7 @@ func (h *Helm) chart() *dagger.Container {
 func (h *Helm) SetVersion(
 	ctx context.Context,
 
-	// Version to set the chart & app to, e.g. --version=v0.12.0
+	// Version to set the chart to, e.g. --version=v0.12.0
 	version string,
 ) (*dagger.File, error) {
 	c := h.chart()
@@ -113,7 +113,6 @@ func (h *Helm) SetVersion(
 
 	version = strings.TrimPrefix(version, "v")
 	meta.Version = version
-	meta.AppVersion = version
 
 	err = meta.Validate()
 	if err != nil {

--- a/helm/dagger/.changes/unreleased/Breaking-20240905-175439.yaml
+++ b/helm/dagger/.changes/unreleased/Breaking-20240905-175439.yaml
@@ -1,5 +1,5 @@
 kind: Breaking
-body: Remove appVersion - this is now the chart version
+body: Remove appVersion - this is now the chart version. Customizing the Engine image is now done via `engine.image.ref` and requires the full image reference, including the registry URL. If you configure this value, you must ensure that this Engine image is compatible with the chart.
 time: 2024-09-05T17:54:39.703345+01:00
 custom:
     Author: gerhard

--- a/helm/dagger/.changes/unreleased/Breaking-20240905-175439.yaml
+++ b/helm/dagger/.changes/unreleased/Breaking-20240905-175439.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Remove appVersion - this is now the chart version
+time: 2024-09-05T17:54:39.703345+01:00
+custom:
+    Author: gerhard
+    PR: "8348"

--- a/helm/dagger/Chart.yaml
+++ b/helm/dagger/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v2
-appVersion: 0.12.7
 description: Dagger Helm chart
 name: dagger-helm
 type: application

--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "dagger.labels" -}}
 helm.sh/chart: {{ include "dagger.chart" . }}
 {{ include "dagger.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: v{{ .Chart.AppVersion }}
-{{- end }}
+app.kubernetes.io/version: v{{ .Chart.Version }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}
 {{- if .Values.engine.labels }}

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: dagger-engine
-          image: {{ .Values.engine.image.repository }}:{{ if .Values.engine.image.tag }}{{ .Values.engine.image.tag }}{{ else }}v{{ .Chart.AppVersion }}{{ end }}
+          image: {{ if .Values.engine.image.ref }}{{ .Values.engine.image.ref }}{{ else }}registry.dagger.io/engine:v{{ .Chart.Version }}{{ end }}
           imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
           {{- if .Values.engine.args }}
           args:
@@ -58,9 +58,9 @@ spec:
           - secretRef:
               {{- if .Values.magicache.secretName }}
               name: {{ .Values.magicache.secretName }}
-              {{- else}}
+              {{- else }}
               name: {{ include "dagger.fullname" . }}-magicache-token
-              {{- end}}
+              {{- end }}
           {{- end }}
           securityContext:
             privileged: true

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -74,7 +74,7 @@ spec:
                 - sh
                 - -exc
                 - |-
-                  echo '{ version }' | dagger query
+                  dagger core version
             {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -3,7 +3,8 @@ fullnameOverride: ""
 
 engine:
   ### Customize your Dagger Engine
-  # https://github.com/moby/buildkit/blob/5997099827e676c4b6ce5774c98ade2483e0afe7/cmd/buildkitd/config/config.go
+  #   https://github.com/moby/buildkit/blob/5997099827e676c4b6ce5774c98ade2483e0afe7/cmd/buildkitd/config/config.go
+  #
   # config: |
   #   debug = true
   #   insecure-entitlements = ["security.insecure"]
@@ -14,12 +15,14 @@ engine:
   #   [log]
   #     format = "json"
   labels: {}
+
   ### Customize Dagger Engine start args
-  # "--oci-max-parallelism num-cpu" is kept as the default behaviour so that we don't surprise users.
-  # You may want to remove it in your deployments. FTR: https://github.com/dagger/dagger/pull/7395
+  #   "--oci-max-parallelism num-cpu" is kept as the default behaviour so that we don't surprise users.
+  #   You may want to remove it in your deployments. FTR: https://github.com/dagger/dagger/pull/7395
   args:
     - "--oci-max-parallelism"
     - "num-cpu"
+
   resources:
     limits: {}
     # limits:
@@ -29,6 +32,7 @@ engine:
     # requests:
     #    cpu: "1"
     #    memory: 1Gi
+
   image:
     ### Set a ref if you want to use a custom Dagger image
     #   NOTE: you will need to ensure that a compatible dagger CLI is embedded in the image, otherwise readiness probes will fail
@@ -36,7 +40,9 @@ engine:
     #
     # ref: registry.dagger.io/engine:main
     pullPolicy: IfNotPresent
+
   ### Set taints & tolerations for this workload
+  #
   # tolerations:
   #   - effect: NoSchedule
   #     key: dagger-runner
@@ -48,25 +54,37 @@ engine:
   #       - matchExpressions:
   #         - key: actions-runner
   #           operator: Exists
+
   ### Set priorityClassName to avoid eviction
   priorityClassName: ""
+
   readinessProbeSettings: 
     initialDelaySeconds: 5
     timeoutSeconds: 30
     periodSeconds: 15
     successThreshold: 1
     failureThreshold: 10
+
+  ### The Engine may need to finish operations in flight, or sync its state to a remote destination.
+  #   We give it ample time by setting this value to 5 mins by default.
+  #   You may want to adjust this to fit your workloads so that the Engine stops quicker.
   terminationGracePeriodSeconds: 300
+
   newServiceAccount:
     # name: "dagger-helm"
     create: false
     annotations: []
+
   existingServiceAccount: {}
     # name: "default"
+
 magicache:
   enabled: false
   url: https://api.dagger.cloud/magicache
-  ### Create your token via https://docs.dagger.io/cloud/572923/get-started#step-2-connect-dagger-cloud-with-your-ci
+  ### Create your token via https://docs.dagger.io/manuals/user/cloud-get-started/#step-2-connect-to-dagger-cloud
+  #
   # token: YOUR_DAGGER_CLOUD_TOKEN
+
   ### If secretName is set, a new secret will NOT be created
+  #
   # secretName: EXISTING_SECRET_NAME

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -30,10 +30,11 @@ engine:
     #    cpu: "1"
     #    memory: 1Gi
   image:
-    repository: registry.dagger.io/engine
-    ### See https://github.com/dagger/dagger/blob/main/CHANGELOG.md for a list of available versions.
-    ### You can also use a specific git sha from https://github.com/dagger/dagger/commits/main/
-    # tag: PICK_A_CUSTOM_VERSION
+    ### Set a ref if you want to use a custom Dagger image
+    #   NOTE: you will need to ensure that a compatible dagger CLI is embedded in the image, otherwise readiness probes will fail
+    #   In the example below, we are configuring the latest, unreleased bleeding edge version
+    #
+    # ref: registry.dagger.io/engine:main
     pullPolicy: IfNotPresent
   ### Set taints & tolerations for this workload
   # tolerations:

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -60,7 +60,7 @@ engine:
 
   readinessProbeSettings: 
     initialDelaySeconds: 5
-    timeoutSeconds: 30
+    timeoutSeconds: 14
     periodSeconds: 15
     successThreshold: 1
     failureThreshold: 10

--- a/modules/golangci/lint.go
+++ b/modules/golangci/lint.go
@@ -107,7 +107,7 @@ func (run LintRun) Report() *dagger.File {
 	cmd := []string{
 		"golangci-lint", "run",
 		"-v",
-		"--timeout", "5m",
+		"--timeout", "10m",
 		// Disable limits, we can filter the report instead
 		"--max-issues-per-linter", "0",
 		"--max-same-issues", "0",


### PR DESCRIPTION
Now that the chart version moves in lock-step with the app version, we want to remove the app version so that we minimize the change for incompatibilities, as was the case in https://github.com/dagger/dagger/issues/8301.

The options are:
A. You want a custom app image. You need to ensure that the chart is compatible with this image.
B. You use the default image. We are responsible for ensuring compatibility with the chart.

The third option is to use this YAML as inspiration, and manage your own raw manifests, which give you full control, and also responsibility.

Fixes https://github.com/dagger/dagger/issues/8301