### PR TITLE
fix: allow engine entrypoint to fail to set ulimit fd limit

### DIFF
--- a/.dagger/config.go
+++ b/.dagger/config.go
@@ -40,7 +40,7 @@ fi
 
 # expect more open files due to per-client SQLite databases
 # many systems default to 1024 which is far too low
-ulimit -n 1048576
+ulimit -n 1048576 || echo "cannot increase open FDs with ulimit, ignoring"
 
 exec {{.EngineBin}} --config {{.EngineConfig}} {{ range $key := .EntrypointArgKeys -}}--{{ $key }}="{{ index $.EntrypointArgs $key }}" {{ end -}} "$@"
 `


### PR DESCRIPTION
Dagger v0.12.5 added a ulimit call in the engine entrypoint, breaking podman running in rootless.

This allows the call to fail with a warning (the ulimit can be done manually by the user if needed).

It's tricky to test because the latest version of dagger (v0.12.7) does not run on podman rootless (both root mode VMs do not share any data), so you cannot build the engine in rootless to test this change. I had to build the engine in rootful, export the `dagger-engine.dev` container, export it from a rootless VM and check the logs that the ulimit gracefully failed.

Fixes #8210 