### PR TITLE
Fix secret transfer issues between modules

### DIFF
--- a/.changes/unreleased/Fixed-20240913-134016.yaml
+++ b/.changes/unreleased/Fixed-20240913-134016.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Allow private secrets to pass between different modules
+time: 2024-09-13T13:40:16.517262613+01:00
+custom:
+  Author: jedevc
+  PR: "8358"

--- a/.changes/unreleased/Fixed-20240913-134354.yaml
+++ b/.changes/unreleased/Fixed-20240913-134354.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Handle session-wide cached functions that return secrets
+time: 2024-09-13T13:43:54.343379515+01:00
+custom:
+  Author: jedevc
+  PR: "8358"

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -335,6 +335,10 @@ func (container *Container) Stderr(ctx context.Context) (string, error) {
 	return container.metaFileContents(ctx, buildkit.MetaMountStderrPath)
 }
 
+func (container *Container) usedClientID(ctx context.Context) (string, error) {
+	return container.metaFileContents(ctx, buildkit.MetaMountClientIDPath)
+}
+
 func (container *Container) metaFileContents(ctx context.Context, filePath string) (string, error) {
 	if container.Meta == nil {
 		return "", fmt.Errorf("%w: %s requires an exec", ErrNoCommand, filePath)

--- a/core/enum.go
+++ b/core/enum.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -66,7 +67,7 @@ func (m *ModuleEnumType) ConvertToSDKInput(ctx context.Context, value dagql.Type
 	return decoder.DecodeInput(value)
 }
 
-func (m *ModuleEnumType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (m *ModuleEnumType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	return nil
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2804,6 +2804,132 @@ func (t *Test) GetCensored(ctx context.Context) (string, error) {
 			require.NoError(t, err)
 			require.Equal(t, "***\n", censoredOut)
 		})
+
+		t.Run("embedded through struct field", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+			ctr := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c))
+
+			ctr = ctr.
+				WithWorkdir("/work/dep").
+				With(daggerExec("init", "--name=dep", "--sdk=go", "--source=.")).
+				WithNewFile("main.go", `package main
+
+import (
+	"dagger/dep/internal/dagger"
+)
+
+type Dep struct {}
+
+type SecretMount struct {
+	Secret *dagger.Secret
+	Path string
+}
+
+func (m *Dep) SecretMount(path string) *SecretMount {
+	return &SecretMount{
+		Secret: dag.SetSecret("foo", "hello from foo"),
+		Path:   path,
+	}
+}
+
+func (m *SecretMount) Mount(ctr *dagger.Container) *dagger.Container {
+	return ctr.WithMountedSecret(m.Path, m.Secret)
+}
+`,
+				)
+
+			ctr = ctr.
+				WithWorkdir("/work").
+				With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+				With(daggerExec("install", "./dep")).
+				WithNewFile("main.go", `package main
+
+import (
+	"context"
+)
+
+type Test struct {}
+
+func (m *Test) Test(ctx context.Context) (string, error) {
+	mount := dag.Dep().SecretMount("/mnt/secret")
+	return dag.Container().
+		From("alpine").
+		With(mount.Mount).
+		WithExec([]string{"sh", "-c", "cat /mnt/secret | tr [a-z] [A-Z]"}).
+		Stdout(ctx)
+}
+`,
+				)
+
+			out, err := ctr.With(daggerCall("test")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "HELLO FROM FOO", out)
+		})
+
+		t.Run("embedded through private struct field", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+			ctr := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c))
+
+			ctr = ctr.
+				WithWorkdir("/work/dep").
+				With(daggerExec("init", "--name=dep", "--sdk=go", "--source=.")).
+				WithNewFile("main.go", `package main
+
+import (
+	"dagger/dep/internal/dagger"
+)
+
+type Dep struct {}
+
+type SecretMount struct {
+	// +private
+	Secret *dagger.Secret
+	// +private
+	Path string
+}
+
+func (m *Dep) SecretMount(path string) *SecretMount {
+	return &SecretMount{
+		Secret: dag.SetSecret("foo", "hello from foo"),
+		Path:   path,
+	}
+}
+
+func (m *SecretMount) Mount(ctr *dagger.Container) *dagger.Container {
+	return ctr.WithMountedSecret(m.Path, m.Secret)
+}
+`,
+				)
+
+			ctr = ctr.
+				WithWorkdir("/work").
+				With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+				With(daggerExec("install", "./dep")).
+				WithNewFile("main.go", `package main
+
+import (
+	"context"
+)
+
+type Test struct {}
+
+func (m *Test) Test(ctx context.Context) (string, error) {
+	mount := dag.Dep().SecretMount("/mnt/secret")
+	return dag.Container().
+		From("alpine").
+		With(mount.Mount).
+		WithExec([]string{"sh", "-c", "cat /mnt/secret | tr [a-z] [A-Z]"}).
+		Stdout(ctx)
+}
+`,
+				)
+
+			out, err := ctr.With(daggerCall("test")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "HELLO FROM FOO", out)
+		})
 	})
 
 	t.Run("parent fields", func(ctx context.Context, t *testctx.T) {
@@ -2822,6 +2948,48 @@ import (
 )
 
 type Test struct {
+	Ctr *dagger.Container
+}
+
+func (t *Test) FnA() *Test {
+	secret := dag.SetSecret("FOO", "omg")
+	t.Ctr = dag.Container().From("`+alpineImage+`").
+		WithSecretVariable("SECRET", secret)
+	return t
+}
+
+func (t *Test) FnB(ctx context.Context) (string, error) {
+	return t.Ctr.
+		WithExec([]string{"sh", "-c", "echo $SECRET | base64"}).
+		Stdout(ctx)
+}
+`,
+			)
+
+		encodedOut, err := ctr.With(daggerCall("fn-a", "fn-b")).Stdout(ctx)
+		require.NoError(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encodedOut))
+		require.NoError(t, err)
+		require.Equal(t, "omg\n", string(decoded))
+	})
+
+	t.Run("private parent fields", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c))
+
+		ctr = ctr.
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			WithNewFile("main.go", `package main
+
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	// +private
 	Ctr *dagger.Container
 }
 

--- a/core/interface.go
+++ b/core/interface.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 )
 
@@ -115,7 +116,7 @@ func (iface *InterfaceType) loadImpl(ctx context.Context, id *call.ID) (*loadedI
 	return loadedImpl, nil
 }
 
-func (iface *InterfaceType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (iface *InterfaceType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	switch value := value.(type) {
 	case dagql.Instance[*InterfaceAnnotatedValue]:
 		mod, ok := value.Self.UnderlyingType.SourceMod().(*Module)

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 )
 
@@ -242,7 +242,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		if !ok {
 			return nil, fmt.Errorf("failed to find mod type for parent %q", fn.objDef.Name)
 		}
-		execMD.ParentIDs = map[digest.Digest]*call.ID{}
+		execMD.ParentIDs = map[digest.Digest]*resource.ID{}
 		if err := parentModType.CollectCoreIDs(ctx, opts.ParentTyped, execMD.ParentIDs); err != nil {
 			return nil, fmt.Errorf("failed to collect IDs from parent fields: %w", err)
 		}
@@ -332,7 +332,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 
 	// If the function returned anything that's isolated per-client, this caller client should
 	// have access to it now since it was returned to them (i.e. secrets/sockets/etc).
-	returnedIDs := map[digest.Digest]*call.ID{}
+	returnedIDs := map[digest.Digest]*resource.ID{}
 	if err := fn.returnType.CollectCoreIDs(ctx, returnValueTyped, returnedIDs); err != nil {
 		return nil, fmt.Errorf("failed to collect IDs: %w", err)
 	}

--- a/core/modtypes.go
+++ b/core/modtypes.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/opencontainers/go-digest"
 )
@@ -24,7 +24,7 @@ type ModType interface {
 
 	// CollectCoreIDs collects all the call IDs from core objects in the given value, whether
 	// it's idable itself or is a list/object containing idable values (recursively)
-	CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error
+	CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error
 
 	// SourceMod is the module in which this type was originally defined
 	SourceMod() Mod
@@ -47,7 +47,7 @@ func (t *PrimitiveType) ConvertToSDKInput(ctx context.Context, value dagql.Typed
 	return value, nil
 }
 
-func (t *PrimitiveType) CollectCoreIDs(context.Context, dagql.Typed, map[digest.Digest]*call.ID) error {
+func (t *PrimitiveType) CollectCoreIDs(context.Context, dagql.Typed, map[digest.Digest]*resource.ID) error {
 	return nil
 }
 
@@ -110,7 +110,7 @@ func (t *ListType) ConvertToSDKInput(ctx context.Context, value dagql.Typed) (an
 	return resultList, nil
 }
 
-func (t *ListType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (t *ListType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	if value == nil {
 		return nil
 	}
@@ -182,7 +182,7 @@ func (t *NullableType) ConvertToSDKInput(ctx context.Context, value dagql.Typed)
 	return result, nil
 }
 
-func (t *NullableType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (t *NullableType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	if value == nil {
 		return nil
 	}

--- a/core/query.go
+++ b/core/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/server/resource"
 )
 
 // Query forms the root of the DAG and houses all necessary state and
@@ -61,7 +62,7 @@ type Server interface {
 	// Add client-isolated resources like secrets, sockets, etc. to the current client's session based
 	// on anything embedded in the given ID. skipTopLevel, if true, will result in the leaf selection
 	// of the ID to be skipped when walking the ID to find these resources.
-	AddClientResourcesFromID(ctx context.Context, id *call.ID, sourceClientID string, skipTopLevel bool) error
+	AddClientResourcesFromID(ctx context.Context, id *resource.ID, sourceClientID string, skipTopLevel bool) error
 
 	// The auth provider for the current client
 	Auth(context.Context) (*auth.RegistryAuthProvider, error)

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/opencontainers/go-digest"
 )
@@ -270,7 +271,7 @@ func (obj *CoreModScalar) ConvertToSDKInput(ctx context.Context, value dagql.Typ
 	return s.DecodeInput(string(val.Value))
 }
 
-func (obj *CoreModScalar) CollectCoreIDs(context.Context, dagql.Typed, map[digest.Digest]*call.ID) error {
+func (obj *CoreModScalar) CollectCoreIDs(context.Context, dagql.Typed, map[digest.Digest]*resource.ID) error {
 	return nil
 }
 
@@ -330,7 +331,7 @@ func (obj *CoreModObject) ConvertToSDKInput(ctx context.Context, value dagql.Typ
 	}
 }
 
-func (obj *CoreModObject) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (obj *CoreModObject) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	if value == nil {
 		return nil
 	}
@@ -338,7 +339,7 @@ func (obj *CoreModObject) CollectCoreIDs(ctx context.Context, value dagql.Typed,
 	case dagql.Input:
 		return nil
 	case dagql.Object:
-		ids[x.ID().Digest()] = x.ID()
+		ids[x.ID().Digest()] = &resource.ID{ID: *x.ID()}
 		return nil
 	default:
 		return fmt.Errorf("%T.CollectCoreIDs: unknown type %T", obj, value)
@@ -383,7 +384,7 @@ func (enum *CoreModEnum) ConvertToSDKInput(ctx context.Context, value dagql.Type
 	return s.DecodeInput(value)
 }
 
-func (enum *CoreModEnum) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*call.ID) error {
+func (enum *CoreModEnum) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	return nil
 }
 

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -76,9 +76,11 @@ func (fn *Function) FieldSpec() (dagql.FieldSpec, error) {
 		// NB: functions actually _are_ cached per-session, which matches the
 		// lifetime of the server, so we might as well consider them pure. That way
 		// there will be locking around concurrent calls, so the user won't see
-		// multiple in parallel. Reconsider if/when we have a global cache and/or
-		// figure out function caching.
-		ImpurityReason: "",
+		// multiple in parallel.
+		//
+		// However, we can't *quite* mark them as pure, since Call has special
+		// logic for transferring secrets between cached calls.
+		ImpurityReason: "secrets still need transferring on cached calls",
 	}
 	for _, arg := range fn.Args {
 		input := arg.TypeDef.ToInput()

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -549,7 +549,7 @@ func LoadIDs[T Typed](ctx context.Context, srv *Server, ids []ID[T]) ([]T, error
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return out, err
 	}
 	return out, nil
 }

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/console"
 	runc "github.com/containerd/go-runc"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
@@ -72,7 +73,7 @@ type ExecutionMetadata struct {
 	// Needed to handle finding any secrets, sockets or other client resources
 	// that this client should have access to due to being set in the parent
 	// object.
-	ParentIDs map[digest.Digest]*call.ID
+	ParentIDs map[digest.Digest]*resource.ID
 
 	CachePerSession bool
 

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -879,6 +879,11 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 		return nil
 	}
 
+	clientIDPath := filepath.Join(state.metaMount.Source, MetaMountClientIDPath)
+	if err := os.WriteFile(clientIDPath, []byte(w.execMD.ClientID), 0o600); err != nil {
+		return fmt.Errorf("failed to write client id %s to %s: %w", w.execMD.ClientID, clientIDPath, err)
+	}
+
 	if w.execMD.SecretToken == "" {
 		w.execMD.SecretToken = randid.NewID()
 	}

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -57,6 +57,7 @@ const (
 	MetaMountStdinPath    = "stdin"
 	MetaMountStdoutPath   = "stdout"
 	MetaMountStderrPath   = "stderr"
+	MetaMountClientIDPath = "clientID"
 )
 
 type Result = solverresult.Result[*ref]

--- a/engine/server/resource/id.go
+++ b/engine/server/resource/id.go
@@ -1,0 +1,8 @@
+package resource
+
+import "github.com/dagger/dagger/dagql/call"
+
+type ID struct {
+	call.ID
+	Optional bool
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -47,6 +47,7 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/cache"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 )
@@ -395,7 +396,7 @@ type ClientInitOpts struct {
 	// Needed to handle finding any secrets, sockets or other client resources
 	// that this client should have access to due to being set in the parent
 	// object.
-	ParentIDs map[digest.Digest]*call.ID
+	ParentIDs map[digest.Digest]*resource.ID
 }
 
 // requires that client.stateMu is held
@@ -412,7 +413,7 @@ func (srv *Server) initializeDaggerClient(
 		if opts.CallerClientID == "" {
 			return fmt.Errorf("caller client ID is not set")
 		}
-		if err := srv.addClientResourcesFromID(ctx, client, opts.CallID, opts.CallerClientID, true); err != nil {
+		if err := srv.addClientResourcesFromID(ctx, client, &resource.ID{ID: *opts.CallID}, opts.CallerClientID, true); err != nil {
 			return fmt.Errorf("failed to add client resources from ID: %w", err)
 		}
 	}


### PR DESCRIPTION
This PR contains a few fixes, extracted out of #8149, and others.

Added two changelogs, since there are two distinct fixes here, but not worth splitting them out into separate PRs, since they're both part of the same effort here :laughing: 

Both issues were introduced in https://github.com/dagger/dagger/pull/7804.

---

There's a rather nasty bug with `// +private` fields (and the equivalent in python/typescript). If an ID is stored in there, we have no way of knowing it's there.

As discussed [in discord](https://discord.com/channels/707636530424053791/1281246101487353917), it's not feasible to expose each private field to the API - there may be data in there that cannot be exposed to the API (e.g. today maps are a big case), but there may definitely be others. For backwards-compat reasons, it's probably way too much effort to try and expose the structure of those private fields - we've made our bed, now we have to lie in it.

This PR is a draft idea to do a "best-effort" detection - we look through the returned JSON objects, and scan for things that look enough like IDs - then we try and grab secrets and sockets from there. This resolves the issue, but I'm also not entirely convinced it's the right approach - it feels very hacky, and I'm somewhat worried we might misinterpret something as an ID when it shouldn't be.

Some alternative ideas I've considered (ranging from worse->better, easier->harder):
- Update all IDs to have a prefix - something like `id:` - this hopefully reduces false positives, but also strings could legitimately have this prefix.
- Don't encode IDs passed to modules as strings, encode them as a special object, something like `{ "_dagger.id": "<id>" }`. Again, we're just reducing false positives, modules could definitely still produce these.
- Dump all the IDs that we know about to a side-channel (any time we get an ID, record it, then when we're traversing fields, we know exactly what we're looking for)
- Roll our own module interchange format (or find one) that allows for typed data. This is very tricky, since it needs to be supported in each language natively.

---

Also, we have a caching bug, described in more detail [here](https://github.com/dagger/dagger/pull/8358#issuecomment-2346006330), which we also fix here as well.