### PR TITLE
core: make `SSH_AUTH_SOCK` absolute + handle shell expansion in `SSH_AUTH_SOCK` env var

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5509,7 +5509,7 @@ func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T
 
 	repoURL := "git@gitlab.com:dagger-modules/private/test/more/dagger-test-modules-private.git"
 
-	t.Run("SSH auth with home expansion and symlink", func(ctx context.Context, t *testctx.T) {
+	t.Run("SSH auth with symlink", func(ctx context.Context, t *testctx.T) {
 		mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 		defer cleanup()
 
@@ -5519,7 +5519,7 @@ func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T
 			WithExec([]string{"mkdir", "-p", "/home/dagger"}).
 			WithExec([]string{"ln", "-s", "/sock/unix-socket", "/home/dagger/.ssh-sock"}).
 			WithEnvVariable("HOME", "/home/dagger").
-			WithEnvVariable("SSH_AUTH_SOCK", "~/.ssh-sock")
+			WithEnvVariable("SSH_AUTH_SOCK", "/home/dagger/.ssh-sock")
 
 		out, err := ctr.
 			WithWorkdir("/work/some/subdir").

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5503,3 +5503,67 @@ func (ModuleSuite) TestSSHAgentConnection(ctx context.Context, t *testctx.T) {
 		})
 	})
 }
+
+func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	repoURL := "git@gitlab.com:dagger-modules/private/test/more/dagger-test-modules-private.git"
+
+	t.Run("SSH auth with home expansion and symlink", func(ctx context.Context, t *testctx.T) {
+		mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
+		defer cleanup()
+
+		ctr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			With(mountedSocket).
+			WithExec([]string{"mkdir", "-p", "/home/dagger"}).
+			WithExec([]string{"ln", "-s", "/sock/unix-socket", "/home/dagger/.ssh-sock"}).
+			WithEnvVariable("HOME", "/home/dagger").
+			WithEnvVariable("SSH_AUTH_SOCK", "~/.ssh-sock")
+
+		out, err := ctr.
+			WithWorkdir("/work/some/subdir").
+			With(daggerFunctions("-m", repoURL)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		require.Contains(t, lines, "fn     -")
+	})
+
+	t.Run("SSH auth from different relative paths", func(ctx context.Context, t *testctx.T) {
+		mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
+		defer cleanup()
+
+		ctr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			With(mountedSocket).
+			WithExec([]string{"mkdir", "-p", "/work/subdir"})
+
+		// Test from same directory as the socket
+		out, err := ctr.
+			WithWorkdir("/sock").
+			With(daggerFunctions("-m", repoURL)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		require.Contains(t, lines, "fn     -")
+
+		// Test from a subdirectory
+		out, err = ctr.
+			WithWorkdir("/work/subdir").
+			With(daggerFunctions("-m", repoURL)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		lines = strings.Split(out, "\n")
+		require.Contains(t, lines, "fn     -")
+
+		// Test from parent directory
+		out, err = ctr.
+			WithWorkdir("/").
+			With(daggerFunctions("-m", repoURL)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		lines = strings.Split(out, "\n")
+		require.Contains(t, lines, "fn     -")
+	})
+}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1034,10 +1034,15 @@ func allCacheConfigsFromEnv() (cacheImportConfigs []*controlapi.CacheOptionsEntr
 
 func (c *Client) clientMetadata() engine.ClientMetadata {
 	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
-
-	expandedPath, err := expandPath(sshAuthSock)
+	// expand ~ into absolute path for consistent behavior with CLI
+	// ⚠️ When updating clientMetadata's logic, please also update setupNestedClient
+	// for consistent behavior of CLI inside nested execution
+	homeDir, err := os.UserHomeDir()
 	if err == nil {
-		sshAuthSock = expandedPath
+		expandedPath, err := ExpandHomeDir(homeDir, sshAuthSock)
+		if err == nil {
+			sshAuthSock = expandedPath
+		}
 	}
 
 	clientVersion := c.Version

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1033,18 +1033,11 @@ func allCacheConfigsFromEnv() (cacheImportConfigs []*controlapi.CacheOptionsEntr
 }
 
 func (c *Client) clientMetadata() engine.ClientMetadata {
-	// retrieve SSH_AUTH_SOCK path and make it relative
 	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
-	if sshAuthSock != "" {
-		expandedPath, err := expandPath(sshAuthSock)
-		if err == nil {
-			sshAuthSock = expandedPath
-			if cwd, err := os.Getwd(); err == nil {
-				if relPath, err := LexicalRelativePath(cwd, sshAuthSock); err == nil {
-					sshAuthSock = relPath
-				}
-			}
-		}
+
+	expandedPath, err := expandPath(sshAuthSock)
+	if err == nil {
+		sshAuthSock = expandedPath
 	}
 
 	clientVersion := c.Version

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1036,9 +1036,13 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 	// retrieve SSH_AUTH_SOCK path and make it relative
 	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
 	if sshAuthSock != "" {
-		if cwd, err := os.Getwd(); err == nil {
-			if relPath, err := LexicalRelativePath(cwd, sshAuthSock); err == nil {
-				sshAuthSock = relPath
+		expandedPath, err := expandPath(sshAuthSock)
+		if err == nil {
+			sshAuthSock = expandedPath
+			if cwd, err := os.Getwd(); err == nil {
+				if relPath, err := LexicalRelativePath(cwd, sshAuthSock); err == nil {
+					sshAuthSock = relPath
+				}
 			}
 		}
 	}

--- a/engine/client/pathutil.go
+++ b/engine/client/pathutil.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -55,4 +56,24 @@ func getDrive(path string) string {
 	}
 
 	return ""
+}
+
+// expandPath expands a given path to its absolute form, handling home directory
+// expansion (~ or ~user) and environment variable expansion. It aims to be cross-platform
+func expandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	// the ~ expansion is a unix convention
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, path[1:])
+	}
+
+	path = os.ExpandEnv(path)
+	return filepath.Abs(path)
 }

--- a/engine/client/pathutil.go
+++ b/engine/client/pathutil.go
@@ -1,8 +1,8 @@
 package client
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -58,22 +58,22 @@ func getDrive(path string) string {
 	return ""
 }
 
-// expandPath expands a given path to its absolute form, handling home directory
-// expansion (~ or ~user) and environment variable expansion. It aims to be cross-platform
-func expandPath(path string) (string, error) {
+// ExpandHomeDir expands a given path to its absolute form, handling home directory
+func ExpandHomeDir(homeDir string, path string) (string, error) {
+	if homeDir == "" {
+		return "", fmt.Errorf("homeDir is empty")
+	}
+
 	if path == "" {
-		return "", nil
+		return path, nil
 	}
 
-	// the ~ expansion is a unix convention
-	if strings.HasPrefix(path, "~") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		path = filepath.Join(home, path[1:])
+	if path[0] != '~' {
+		return path, nil
+	}
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand home directory")
 	}
 
-	path = os.ExpandEnv(path)
-	return filepath.Abs(path)
+	return strings.Replace(path, "~", homeDir, 1), nil
 }

--- a/engine/client/pathutil_test.go
+++ b/engine/client/pathutil_test.go
@@ -33,6 +33,18 @@ func TestLexicalRelativePath(t *testing.T) {
 			expected: ".",
 		},
 		{
+			name:     "Auth Sock",
+			cwdPath:  "/Users/user/project",
+			modPath:  "/Users/user/.ssh/auth.sock",
+			expected: "../.ssh/auth.sock",
+		},
+		{
+			name:     "Auth Sock",
+			cwdPath:  "/Users/user/project",
+			modPath:  "/Users/user/./.1password/agent.sock",
+			expected: "../.1password/agent.sock",
+		},
+		{
 			name:     "Windows style paths",
 			cwdPath:  `C:\Users\user`,
 			modPath:  `C:\Users\user\project`,


### PR DESCRIPTION
Fixes #8337 AND fixes some relative path issues

This PR addresses issues with SSH_AUTH_SOCK handling and improves test coverage:
1. Expands shell variables in SSH_AUTH_SOCK path
2. Make SSH_AUTH_SOCK path absolute
3. Adds integration tests for shell expansion handling and relative path calls

https://discord.com/channels/707636530424053791/1281294189463732244/1281294189463732244

### Detailed explanation for not making SSH_AUTH_SOCK path relative:

The decision to avoid making the SSH_AUTH_SOCK path relative is based on several factors:

Users have been complaining of some parsing issues regarding the SSH_AUTH_SOCK. After some digging in the codebase, it seems better not to handle it relatively:

#### 1. Client - Host interaction

On the engine side, we [URL encode](https://github.com/dagger/dagger/blob/main/core/socket.go#L174-L189) the socket Path in order to forward it from the client to the engine
    
On the client side, we decode it with [url.Parse()](https://github.com/dagger/dagger/blob/main/engine/client/socket.go#L40) and retrieve the [u.Path](https://github.com/dagger/dagger/blob/main/engine/client/socket.go#L46)
    
This operation is destructive of all relative Path: ../.test/socket becomes /.test/socket

This leads to some bugs such as the one the user got in the thread
    
#### 2. Nested execs

In order to handle nested execs, we rely on [UnixPathMapper](https://github.com/dagger/dagger/blob/main/engine/client/socket.go#L48) to retrieve the socket at the path inside the rootfs.

The current implementation [does not seem to expect relative paths](https://github.com/dagger/dagger/blob/main/engine/buildkit/executor_spec.go#L948-L951)
 
 
cc @jedevc I am not sure about the UnixPathMapper implementation. This was the main reason I preferred to rollback to an absolute path. The first implementation relied on encoding / decoding the path with `url.PathEscape()`: https://go.dev/play/p/hj8PeEwtUfL. I also added a test suite to test those relative path handling, in case UnixPathMapper is not necessarily expecting an absolute path