### PR TITLE
feat(sdk/elixir): add support for optional argument

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20240907-173230.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20240907-173230.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Module can now specific argument as an optional
+time: 2024-09-07T17:32:30.861807874+07:00
+custom:
+    Author: wingyplus
+    PR: "8367"

--- a/sdk/elixir/lib/dagger/mod.ex
+++ b/sdk/elixir/lib/dagger/mod.ex
@@ -60,7 +60,7 @@ defmodule Dagger.Mod do
       end)
 
     for {name, _} <- args_def do
-      Map.fetch!(args, name)
+      Map.get(args, name)
     end
   end
 
@@ -91,6 +91,9 @@ defmodule Dagger.Mod do
 
     {:ok, values}
   end
+
+  defp cast(nil, {:optional, _type}, _dag), do: {:ok, nil}
+  defp cast(value, {:optional, type}, dag), do: cast(value, type, dag)
 
   defp cast(value, module, dag) when is_binary(value) and is_atom(module) do
     # NOTE: It feels like we really need a protocol for the module to 

--- a/sdk/elixir/lib/dagger/mod/function.ex
+++ b/sdk/elixir/lib/dagger/mod/function.ex
@@ -32,19 +32,10 @@ defmodule Dagger.Mod.Function do
       type_def =
         dag
         |> define_type(Dagger.Client.type_def(dag), type)
-        |> maybe_with_optional(arg_def[:optional])
 
       fun
       |> Dagger.Function.with_arg(name, type_def)
     end)
-  end
-
-  defp maybe_with_optional(type_def, optional?) do
-    if optional? do
-      Dagger.TypeDef.with_optional(type_def, true)
-    else
-      type_def
-    end
   end
 
   defp define_type(_dag, type_def, :integer) do
@@ -65,6 +56,12 @@ defmodule Dagger.Mod.Function do
   defp define_type(dag, type_def, {:list, type}) do
     type_def
     |> Dagger.TypeDef.with_list_of(define_type(dag, Dagger.Client.type_def(dag), type))
+  end
+
+  defp define_type(dag, type_def, {:optional, type}) do
+    dag
+    |> define_type(type_def, type)
+    |> Dagger.TypeDef.with_optional(true)
   end
 
   defp define_type(_dag, type_def, module) do

--- a/sdk/elixir/lib/dagger/mod/object.ex
+++ b/sdk/elixir/lib/dagger/mod/object.ex
@@ -44,7 +44,8 @@ defmodule Dagger.Mod.Object do
   2. `boolean()` for a boolean type.
   3. `String.t()` or `binary()` for a string type.
   4. `list(type)` or `[type]` for a list type.
-  5. Any type that generated under `Dagger` namespace (`Dagger.Container.t()`,
+  5. `type | nil` for optional type.
+  6. Any type that generated under `Dagger` namespace (`Dagger.Container.t()`,
      `Dagger.Directory.t()`, etc.).
 
   The function also support documentation by using Elixir standard documentation,
@@ -171,14 +172,13 @@ defmodule Dagger.Mod.Object do
     end
   end
 
-  # binary()
-  defp compile_typespec!({:binary, _, []}), do: :string
-  # integer()
   defp compile_typespec!({:integer, _, []}), do: :integer
-  # boolean()
   defp compile_typespec!({:boolean, _, []}), do: :boolean
 
-  # String.t() 
+  ## String
+
+  defp compile_typespec!({:binary, _, []}), do: :string
+
   defp compile_typespec!(
          {{:., _,
            [
@@ -193,12 +193,20 @@ defmodule Dagger.Mod.Object do
     Module.concat(module)
   end
 
+  ## List
+
   defp compile_typespec!({:list, _, [type]}) do
     {:list, compile_typespec!(type)}
   end
 
   defp compile_typespec!([type]) do
     {:list, compile_typespec!(type)}
+  end
+
+  ## Optional
+
+  defp compile_typespec!({:|, _, [type, nil]}) do
+    {:optional, compile_typespec!(type)}
   end
 
   defp compile_typespec!(unsupported_type) do

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -1,0 +1,16 @@
+defmodule Dagger.Mod.ModuleTest do
+  use ExUnit.Case, async: true
+
+  alias Dagger.Mod.Module
+
+  setup_all do
+    dag = Dagger.connect!(connect_timeout: :timer.seconds(60))
+    on_exit(fn -> Dagger.close(dag) end)
+
+    %{dag: dag}
+  end
+
+  test "define/1", %{dag: dag} do
+    assert {:ok, _} = Module.define(dag, ObjectMod) |> Dagger.Module.id()
+  end
+end

--- a/sdk/elixir/test/dagger/mod/object_test.exs
+++ b/sdk/elixir/test/dagger/mod/object_test.exs
@@ -3,43 +3,7 @@ defmodule Dagger.Mod.ObjectTest do
 
   describe "defn/2" do
     test "store function information" do
-      defmodule A do
-        use Dagger.Mod.Object, name: "A"
-
-        defn accept_string(name: String.t()) :: String.t() do
-          "Hello, #{name}"
-        end
-
-        defn accept_string2(name: binary()) :: binary() do
-          "Hello, #{name}"
-        end
-
-        defn accept_integer(name: integer()) :: integer() do
-          "Hello, #{name}"
-        end
-
-        defn accept_boolean(name: boolean()) :: String.t() do
-          "Hello, #{name}"
-        end
-
-        defn empty_args() :: String.t() do
-          "Empty args"
-        end
-
-        defn accept_and_return_module(container: Dagger.Container.t()) :: Dagger.Container.t() do
-          container
-        end
-
-        defn accept_list(alist: list(String.t())) :: String.t() do
-          Enum.join(alist, ",")
-        end
-
-        defn accept_list2(alist: [String.t()]) :: String.t() do
-          Enum.join(alist, ",")
-        end
-      end
-
-      assert A.__object__(:functions) == [
+      assert ObjectMod.__object__(:functions) == [
                accept_string: [
                  {:self, false},
                  {:args, [name: [type: :string]]},
@@ -75,6 +39,11 @@ defmodule Dagger.Mod.ObjectTest do
                  {:self, false},
                  {:args, [alist: [type: {:list, :string}]]},
                  {:return, :string}
+               ],
+               optional_arg: [
+                 self: false,
+                 args: [s: [type: {:optional, :string}]],
+                 return: :string
                ]
              ]
     end

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -1,0 +1,41 @@
+defmodule ObjectMod do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "ObjectMod"
+
+  defn accept_string(name: String.t()) :: String.t() do
+    "Hello, #{name}"
+  end
+
+  defn accept_string2(name: binary()) :: binary() do
+    "Hello, #{name}"
+  end
+
+  defn accept_integer(name: integer()) :: integer() do
+    "Hello, #{name}"
+  end
+
+  defn accept_boolean(name: boolean()) :: String.t() do
+    "Hello, #{name}"
+  end
+
+  defn empty_args() :: String.t() do
+    "Empty args"
+  end
+
+  defn accept_and_return_module(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+  end
+
+  defn accept_list(alist: list(String.t())) :: String.t() do
+    Enum.join(alist, ",")
+  end
+
+  defn accept_list2(alist: [String.t()]) :: String.t() do
+    Enum.join(alist, ",")
+  end
+
+  defn optional_arg(s: String.t() | nil) :: String.t() do
+    "Hello, #{s}"
+  end
+end


### PR DESCRIPTION
This changeset add support for optional argument when user defined type of the argument as `AType | nil`.  Let see the example:

```elixir
defmodule Potato do
  @moduledoc """
  Potato module
  """

  use Dagger.Mod.Object, name: "Potato"

  defn hello(name: String.t() | nil) :: String.t() do
    if is_nil(name) do
      "Please give me a name. 😊"
    else
      "Hello, #{name}"
    end
  end
end
```

When calling `hello` function without argument:

```
wingyplus@WINGYMOMO ~/s/g/d/d/s/e/potato (optional-arg)> dagger call hello
Full trace at https://dagger.cloud/dagger-elixir-sdk/traces/25e8d8da160122f5d108996adad14d01

✔ connect 1.8s
✔ initialize 15.7s
✔ prepare 0.0s
✔ potato: Potato! 0.0s
✔ Potato.hello: String! 7.3s                                                                                                                                                                                      
Please give me a name. 😊
```

And when calling with `--name`:

```
wingyplus@WINGYMOMO ~/s/g/d/d/s/e/potato (optional-arg)> dagger call hello --name=wingyplus
Full trace at https://dagger.cloud/dagger-elixir-sdk/traces/ea1a3b4b6cb0b10b17d651b39d46f83f

✔ connect 1.4s
✔ initialize 1.2s
✔ prepare 0.0s
✔ potato: Potato! 0.0s
✔ Potato.hello(name: "wingyplus"): String! 7.0s                                                                                                                                                                   
Hello, wingyplus
```