### PR TITLE
chore: bump Go to 1.23.1 to fix CVE-2024-34156

### DIFF
--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.23.0-alpine").
+		From("golang:1.23.1-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -25,6 +25,6 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.23.0"
+	GolangVersion = "1.23.1"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger
 
-go 1.23
+go 1.23.1
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -15,7 +15,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.23.0"
+	// +default="1.23.1"
 	version string,
 ) *Go {
 	if source == nil {


### PR DESCRIPTION
Addresses a high severity stdlib vulnerability that could cause panics in deeply nested gob decoding. Trivy flagged this in our engine image scan.

We do not seem to be relying on it, but this triggers a Trivy scan