### PR TITLE
 feat(sdk/elixir): type argument can now annotate the metadata

### DIFF
--- a/sdk/elixir/lib/dagger/mod/function.ex
+++ b/sdk/elixir/lib/dagger/mod/function.ex
@@ -33,8 +33,14 @@ defmodule Dagger.Mod.Function do
         dag
         |> define_type(Dagger.Client.type_def(dag), type)
 
+      opts =
+        arg_def
+        |> Keyword.take([:doc, :default_path, :ignore])
+        |> Enum.reject(fn {_, value} -> is_nil(value) end)
+        |> Enum.map(&normalize_arg_option/1)
+
       fun
-      |> Dagger.Function.with_arg(name, type_def)
+      |> Dagger.Function.with_arg(name, type_def, opts)
     end)
   end
 
@@ -76,4 +82,7 @@ defmodule Dagger.Mod.Function do
         |> Dagger.TypeDef.with_object(name)
     end
   end
+
+  defp normalize_arg_option({:doc, doc}), do: {:description, doc}
+  defp normalize_arg_option(opt), do: opt
 end

--- a/sdk/elixir/lib/dagger/mod/object.ex
+++ b/sdk/elixir/lib/dagger/mod/object.ex
@@ -56,6 +56,7 @@ defmodule Dagger.Mod.Object do
   @type function_def() :: {function_name(), keyword()}
 
   alias Dagger.Mod.Object.Defn
+  alias Dagger.Mod.Object.Meta
 
   @doc """
   Get module documentation.
@@ -168,7 +169,9 @@ defmodule Dagger.Mod.Object do
 
   defp compile_args(args) do
     for {name, spec} <- args do
-      {name, [type: compile_typespec!(spec)]}
+      type = compile_typespec!(spec)
+      meta = spec |> extract_options() |> Keyword.put(:type, type)
+      {name, Meta.validate!(meta)}
     end
   end
 
@@ -209,7 +212,16 @@ defmodule Dagger.Mod.Object do
     {:optional, compile_typespec!(type)}
   end
 
+  ## Type with options
+
+  defp compile_typespec!({type, _}) do
+    compile_typespec!(type)
+  end
+
   defp compile_typespec!(unsupported_type) do
     raise ArgumentError, "type `#{Macro.to_string(unsupported_type)}` is not supported"
   end
+
+  defp extract_options({_, options}), do: options
+  defp extract_options(_), do: []
 end

--- a/sdk/elixir/lib/dagger/mod/object/defn.ex
+++ b/sdk/elixir/lib/dagger/mod/object/defn.ex
@@ -44,6 +44,10 @@ defmodule Dagger.Mod.Object.Defn do
     var(v)
   end
 
+  defp typespec_arg({name, {type, _}}) do
+    typespec_arg({name, type})
+  end
+
   defp typespec_arg({_, type} = arg) do
     arg = var(arg)
 

--- a/sdk/elixir/lib/dagger/mod/object/meta.ex
+++ b/sdk/elixir/lib/dagger/mod/object/meta.ex
@@ -1,0 +1,18 @@
+defmodule Dagger.Mod.Object.Meta do
+  @moduledoc false
+
+  def from_options(options) when is_list(options) do
+  end
+
+  def validate!(meta) do
+    meta = Keyword.validate!(meta, [:type, doc: nil, default_path: nil, ignore: nil])
+    :ok = Enum.each(meta, &validate/1)
+
+    meta
+  end
+
+  defp validate({:type, type}) when is_atom(type) or is_tuple(type), do: :ok
+  defp validate({:doc, doc}) when is_binary(doc) or is_nil(doc), do: :ok
+  defp validate({:default_path, path}) when is_binary(path) or is_nil(path), do: :ok
+  defp validate({:ignore, patterns}) when is_list(patterns) or is_nil(patterns), do: :ok
+end

--- a/sdk/elixir/test/dagger/mod/object_test.exs
+++ b/sdk/elixir/test/dagger/mod/object_test.exs
@@ -5,44 +5,92 @@ defmodule Dagger.Mod.ObjectTest do
     test "store function information" do
       assert ObjectMod.__object__(:functions) == [
                accept_string: [
-                 {:self, false},
-                 {:args, [name: [type: :string]]},
-                 {:return, :string}
+                 self: false,
+                 args: [
+                   name: [{:ignore, nil}, {:default_path, nil}, {:doc, nil}, {:type, :string}]
+                 ],
+                 return: :string
                ],
                accept_string2: [
-                 {:self, false},
-                 {:args, [name: [type: :string]]},
-                 {:return, :string}
+                 self: false,
+                 args: [
+                   name: [{:ignore, nil}, {:default_path, nil}, {:doc, nil}, {:type, :string}]
+                 ],
+                 return: :string
                ],
                accept_integer: [
-                 {:self, false},
-                 {:args, [name: [type: :integer]]},
-                 {:return, :integer}
+                 self: false,
+                 args: [
+                   name: [{:ignore, nil}, {:default_path, nil}, {:doc, nil}, {:type, :integer}]
+                 ],
+                 return: :integer
                ],
                accept_boolean: [
-                 {:self, false},
-                 {:args, [name: [type: :boolean]]},
-                 {:return, :string}
+                 self: false,
+                 args: [
+                   name: [{:ignore, nil}, {:default_path, nil}, {:doc, nil}, {:type, :boolean}]
+                 ],
+                 return: :string
                ],
-               empty_args: [{:self, false}, {:args, []}, {:return, :string}],
+               empty_args: [self: false, args: [], return: :string],
                accept_and_return_module: [
-                 {:self, false},
-                 {:args, [container: [type: Dagger.Container]]},
-                 {:return, Dagger.Container}
+                 self: false,
+                 args: [
+                   container: [
+                     {:ignore, nil},
+                     {:default_path, nil},
+                     {:doc, nil},
+                     {:type, Dagger.Container}
+                   ]
+                 ],
+                 return: Dagger.Container
                ],
                accept_list: [
-                 {:self, false},
-                 {:args, [alist: [type: {:list, :string}]]},
-                 {:return, :string}
+                 self: false,
+                 args: [
+                   alist: [
+                     {:ignore, nil},
+                     {:default_path, nil},
+                     {:doc, nil},
+                     {:type, {:list, :string}}
+                   ]
+                 ],
+                 return: :string
                ],
                accept_list2: [
-                 {:self, false},
-                 {:args, [alist: [type: {:list, :string}]]},
-                 {:return, :string}
+                 self: false,
+                 args: [
+                   alist: [
+                     {:ignore, nil},
+                     {:default_path, nil},
+                     {:doc, nil},
+                     {:type, {:list, :string}}
+                   ]
+                 ],
+                 return: :string
                ],
                optional_arg: [
                  self: false,
-                 args: [s: [type: {:optional, :string}]],
+                 args: [
+                   s: [
+                     {:ignore, nil},
+                     {:default_path, nil},
+                     {:doc, nil},
+                     {:type, {:optional, :string}}
+                   ]
+                 ],
+                 return: :string
+               ],
+               type_option: [
+                 self: false,
+                 args: [
+                   dir: [
+                     {:ignore, ["deps", "_build"]},
+                     {:default_path, "/sdk/elixir"},
+                     {:doc, "The directory to run on."},
+                     {:type, {:optional, Dagger.Directory}}
+                   ]
+                 ],
                  return: :string
                ]
              ]
@@ -89,6 +137,38 @@ defmodule Dagger.Mod.ObjectTest do
                "@spec hidden_fun_doc() :: String.t()",
                "@spec echo(name :: String.t()) :: String.t()"
              ]
+    end
+
+    test "type option validation" do
+      assert_raise FunctionClauseError, fn ->
+        defmodule TypeOptDoc do
+          use Dagger.Mod.Object, name: "TypeOptDoc"
+
+          defn should_fail(v: {Dagger.String.t(), doc: 1}) :: String.t() do
+            v
+          end
+        end
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        defmodule TypeOptDefaultPath do
+          use Dagger.Mod.Object, name: "TypeOptDoc"
+
+          defn should_fail(v: {Dagger.String.t(), default_path: 1}) :: String.t() do
+            v
+          end
+        end
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        defmodule TypeOptIgnore do
+          use Dagger.Mod.Object, name: "TypeOptDoc"
+
+          defn should_fail(v: {Dagger.String.t(), ignore: 1}) :: String.t() do
+            v
+          end
+        end
+      end
     end
   end
 

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -38,4 +38,14 @@ defmodule ObjectMod do
   defn optional_arg(s: String.t() | nil) :: String.t() do
     "Hello, #{s}"
   end
+
+  defn type_option(
+         dir:
+           {Dagger.Directory.t() | nil,
+            doc: "The directory to run on.",
+            default_path: "/sdk/elixir",
+            ignore: ["deps", "_build"]}
+       ) :: String.t() do
+    Dagger.Directory.id(dir)
+  end
 end


### PR DESCRIPTION
~⚠️ Needs #8367~ 

The function arguments can now annotate metadata by using a tuple
(`{}`). The current metadata now support only:

* `:doc` - The argument description.
* `:default_path` - The context directory.
* `:ignore` - The ignore patterns.

The default value is not included in this commit.