### PR TITLE
chore: Upgrade Go to v1.23.1 in GoReleaser Pro

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -37,7 +37,9 @@ func (cli *CLI) Binary(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v2.3.0"
+	goReleaserVersion = "v2.2.0"
+	// TODO: remove go1_23_1 👇 after upgrading to v2.3.0
+	// https://github.com/goreleaser/goreleaser/pull/5126#issuecomment-2338622698
 )
 
 // Publish the CLI using GoReleaser
@@ -167,8 +169,13 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 }
 
 func publishEnv(ctx context.Context) (*dagger.Container, error) {
+	// TODO: remove after upgrading to GoReleaser Pro v2.3.0
+	// https://github.com/goreleaser/goreleaser/pull/5126#issuecomment-2338622698
+	go1_23_1 := dag.Container().From("golang:1.23.1-alpine@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06").Directory("/usr/local/go")
+
 	ctr := dag.Container().
 		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s-pro", goReleaserVersion)).
+		WithDirectory("/usr/local/go", go1_23_1).
 		WithEntrypoint([]string{}).
 		WithExec([]string{"apk", "add", "aws-cli"})
 

--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -37,7 +37,7 @@ func (cli *CLI) Binary(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v2.2.0"
+	goReleaserVersion = "v2.3.0"
 )
 
 // Publish the CLI using GoReleaser


### PR DESCRIPTION
While this is hacky, it's necessary as it Fixes the Go v1.23.1 requirement when publishing the CLI: https://dagger.cloud/dagger/traces/5b2e5658cf5f372fc6efb57b385f608a#309ba7d23cd65cbd:L84

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/aff9ec09-6d23-4c77-b1be-34b9d96a7b41">

As soon as https://github.com/goreleaser/goreleaser/pull/5126 ships in GoReleaser `v2.3.0`, we can upgrade to that and remove this change.

---
Follow-up to:
- https://github.com/dagger/dagger/pull/8371