### PR TITLE
structural refactor: split dagui package out of idtui

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/dagger/dagger/analytics"
+	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
@@ -251,11 +252,11 @@ func (e ExitError) Error() string {
 
 const InstrumentationLibrary = "dagger.io/cli"
 
-var opts idtui.FrontendOpts
+var opts dagui.FrontendOpts
 
 func main() {
 	parseGlobalFlags()
-	opts.Verbosity += idtui.ShowCompletedVerbosity // keep progress by default
+	opts.Verbosity += dagui.ShowCompletedVerbosity // keep progress by default
 	opts.Verbosity += verbose                      // raise verbosity with -v
 	opts.Verbosity -= quiet                        // lower verbosity with -q
 	opts.Silent = silent                           // show no progress

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -1,4 +1,4 @@
-package idtui
+package dagui
 
 import (
 	"context"

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -1,0 +1,70 @@
+package dagui
+
+import "time"
+
+type FrontendOpts struct {
+	// Debug tells the frontend to show everything and do one big final render.
+	Debug bool
+
+	// Silent tells the frontend to not display progress at all.
+	Silent bool
+
+	// Verbosity is the level of detail to show in the TUI.
+	Verbosity int
+
+	// Don't show things that completed beneath this duration. (default 100ms)
+	TooFastThreshold time.Duration
+
+	// Remove completed things after this duration. (default 1s)
+	GCThreshold time.Duration
+
+	// Open web browser with the trace URL as soon as pipeline starts.
+	OpenWeb bool
+
+	// RevealAllSpans tells the frontend to show all spans, not just the spans
+	// beneath the primary span.
+	RevealAllSpans bool
+}
+
+const (
+	HideCompletedVerbosity    = 0
+	ShowCompletedVerbosity    = 1
+	ExpandCompletedVerbosity  = 2
+	ShowInternalVerbosity     = 3
+	ShowEncapsulatedVerbosity = 3
+	ShowSpammyVerbosity       = 4
+	ShowDigestsVerbosity      = 4
+)
+
+func (opts FrontendOpts) ShouldShow(tree *TraceTree) bool {
+	if opts.Debug {
+		// debug reveals all
+		return true
+	}
+	span := tree.Span
+	if span.IsInternal() && opts.Verbosity < ShowInternalVerbosity {
+		// internal steps are hidden by default
+		return false
+	}
+	if tree.Parent != nil && (span.Encapsulated || tree.Parent.Span.Encapsulate) && tree.Parent.Span.Err() == nil && opts.Verbosity < ShowEncapsulatedVerbosity {
+		// encapsulated steps are hidden (even on error) unless their parent errors
+		return false
+	}
+	if span.Err() != nil {
+		// show errors
+		return true
+	}
+	if tree.IsRunningOrChildRunning {
+		// show running steps
+		return true
+	}
+	if tree.Parent != nil && (opts.TooFastThreshold > 0 && span.ActiveDuration(time.Now()) < opts.TooFastThreshold && opts.Verbosity < ShowSpammyVerbosity) {
+		// ignore fast steps; signal:noise is too poor
+		return false
+	}
+	if opts.GCThreshold > 0 && time.Since(span.EndTime()) > opts.GCThreshold && opts.Verbosity < ShowCompletedVerbosity {
+		// stop showing steps that ended after a given threshold
+		return false
+	}
+	return true
+}

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -1,4 +1,4 @@
-package idtui
+package dagui
 
 import (
 	"errors"
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/a-h/templ"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -207,22 +206,6 @@ func (span *Span) Bar() SpanBar {
 	return bar
 }
 
-func (bar SpanBar) Render() templ.Component {
-	var dur string
-	if bar.Duration > 10*time.Millisecond {
-		dur = fmtDuration(bar.Duration)
-	}
-	return templ.Raw(
-		fmt.Sprintf(
-			`<div class="bar %s" style="left: %f%%; width: %f%%"><span class="duration">%s</span></div>`,
-			bar.Span.Classes(),
-			bar.OffsetPercent*100,
-			bar.WidthPercent*100,
-			dur,
-		),
-	)
-}
-
 func (span *Span) Classes() string {
 	classes := []string{}
 	if span.Cached {
@@ -240,7 +223,7 @@ func (span *Span) Classes() string {
 	return strings.Join(classes, " ")
 }
 
-func fmtDuration(d time.Duration) string {
+func FormatDuration(d time.Duration) string {
 	days := int64(d.Hours()) / 24
 	hours := int64(d.Hours()) % 24
 	minutes := int64(d.Minutes()) % 60

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -1,4 +1,4 @@
-package idtui
+package dagui
 
 import (
 	"time"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Khan/genqlient v0.7.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/a-h/templ v0.2.731
 	github.com/adrg/xdg v0.4.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/bubbletea v0.26.6

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/a-h/templ v0.2.731 h1:yiv4C7whSUsa36y65O06DPr/U/j3+WGB0RmvLOoVFXc=
-github.com/a-h/templ v0.2.731/go.mod h1:IejA/ecDD0ul0dCvgCwp9t7bUZXVpGClEAdsqZQigi8=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=


### PR DESCRIPTION
This is purely structural refactor so that a WebAssembly-based frontend can reuse this code without choking on the Bubbletea package dependency.

I'll have a lot more diffs on top of this later, so wanted to split it out so they don't get lost in all the other code being tossed around.

NB: the naming here isn't amazing but would rather just blindly stick to it for now to make my life easier trying to land all the other changes on top.