### PR TITLE
clientdb: preserve more OTLP data

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -681,13 +681,8 @@ func (c *Client) exportLogs(ctx context.Context, httpClient *httpClient) error {
 		if err := protojson.Unmarshal(data, &req); err != nil {
 			return fmt.Errorf("unmarshal spans: %w", err)
 		}
-
-		logs := telemetry.LogsFromPB(req.GetResourceLogs())
-
-		slog.ExtraDebug("received logs from engine", "len", len(logs))
-
-		if err := c.EngineLogs.Export(ctx, logs); err != nil {
-			return fmt.Errorf("export %d logs: %w", len(logs), err)
+		if err := enginetel.ReexportLogsFromPB(ctx, c.EngineLogs, &req); err != nil {
+			return fmt.Errorf("re-export logs: %w", err)
 		}
 		return nil
 	})

--- a/engine/clientdb/log.go
+++ b/engine/clientdb/log.go
@@ -90,8 +90,8 @@ func LogsToPB(dbLog []Log) []*otlplogsv1.ResourceLogs {
 			SeverityText:   sd.SeverityText,
 			Body:           &bodyPb,
 			Attributes:     attrs,
-			TraceId:        []byte(tid[:]),
-			SpanId:         []byte(sid[:]),
+			TraceId:        tid[:],
+			SpanId:         sid[:],
 		})
 		ssm[k] = scopeLog
 

--- a/engine/clientdb/log.go
+++ b/engine/clientdb/log.go
@@ -2,50 +2,126 @@ package clientdb
 
 import (
 	"log/slog"
-	"time"
 
 	"dagger.io/dagger/telemetry"
-	"go.opentelemetry.io/otel/log"
-	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 	otlpcommonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	otlplogsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	otlpresourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
-func (dbLog *Log) Record() sdklog.Record {
-	var rec sdklog.Record
-
-	rec.SetTimestamp(time.Unix(0, dbLog.Timestamp))
-
-	rec.SetSeverity(log.Severity(dbLog.Severity))
-
-	if dbLog.TraceID.Valid {
-		tid, _ := trace.TraceIDFromHex(dbLog.TraceID.String)
-		rec.SetTraceID(tid)
+func LogsToPB(dbLog []Log) []*otlplogsv1.ResourceLogs {
+	if len(dbLog) == 0 {
+		return nil
 	}
 
-	if dbLog.SpanID.Valid {
-		sid, _ := trace.SpanIDFromHex(dbLog.SpanID.String)
-		rec.SetSpanID(sid)
-	}
+	rsm := make(map[attribute.Distinct]*otlplogsv1.ResourceLogs)
 
-	if len(dbLog.Body) > 0 {
-		body := &otlpcommonv1.AnyValue{}
-		if err := proto.Unmarshal(dbLog.Body, body); err != nil {
-			slog.Warn("failed to unmarshal log body", "error", err)
+	type key struct {
+		r  attribute.Distinct
+		is instrumentation.Scope
+	}
+	ssm := make(map[key]*otlplogsv1.ScopeLogs)
+
+	var resources int
+	for _, sd := range dbLog {
+		var res *sdkresource.Resource
+		var resPb otlpresourcev1.Resource
+		if err := protojson.Unmarshal(sd.Resource, &resPb); err != nil {
+			slog.Error("failed to unmarshal log resource", "error", err, "log", sd)
+			continue
 		} else {
-			rec.SetBody(telemetry.LogValueFromPB(body))
+			res = telemetry.ResourceFromPB(sd.ResourceSchemaUrl, &resPb)
 		}
-	}
-
-	if len(dbLog.Attributes) > 0 {
+		if res.SchemaURL() == "" {
+			slog.Error("log has no resource", "log", sd)
+			continue
+		}
+		var scope instrumentation.Scope
+		var scopePb otlpcommonv1.InstrumentationScope
+		if err := protojson.Unmarshal(sd.InstrumentationScope, &scopePb); err != nil {
+			slog.Error("failed to unmarshal instrumentation scope", "error", err, "log", sd)
+			continue
+		} else {
+			scope = telemetry.InstrumentationScopeFromPB(&scopePb)
+		}
+		rKey := res.Equivalent()
+		k := key{
+			r:  rKey,
+			is: scope,
+		}
+		scopeLog, iOk := ssm[k]
+		if !iOk {
+			// Either the resource or instrumentation scope were unknown.
+			scopeLog = &otlplogsv1.ScopeLogs{
+				Scope:      &scopePb,
+				LogRecords: []*otlplogsv1.LogRecord{},
+				SchemaUrl:  scope.SchemaURL,
+			}
+		}
+		var bodyPb otlpcommonv1.AnyValue
+		if err := proto.Unmarshal(sd.Body, &bodyPb); err != nil {
+			slog.Warn("failed to unmarshal log body", "error", err, "log", sd)
+			continue
+		}
 		var attrs []*otlpcommonv1.KeyValue
-		if err := UnmarshalProtos(dbLog.Attributes, &otlpcommonv1.KeyValue{}, &attrs); err != nil {
+		if err := UnmarshalProtoJSONs(sd.Attributes, &otlpcommonv1.KeyValue{}, &attrs); err != nil {
 			slog.Warn("failed to unmarshal log attributes", "error", err)
-		} else {
-			rec.SetAttributes(telemetry.LogKeyValuesFromPB(attrs)...)
+			continue
+		}
+		tid, err := trace.TraceIDFromHex(sd.TraceID.String)
+		if err != nil {
+			slog.Error("failed to unmarshal trace id", "error", err)
+			continue
+		}
+		sid, err := trace.SpanIDFromHex(sd.SpanID.String)
+		if err != nil {
+			slog.Error("failed to unmarshal span id", "error", err)
+			continue
+		}
+		scopeLog.LogRecords = append(scopeLog.LogRecords, &otlplogsv1.LogRecord{
+			TimeUnixNano:   uint64(sd.Timestamp),
+			SeverityNumber: otlplogsv1.SeverityNumber(sd.SeverityNumber),
+			SeverityText:   sd.SeverityText,
+			Body:           &bodyPb,
+			Attributes:     attrs,
+			TraceId:        []byte(tid[:]),
+			SpanId:         []byte(sid[:]),
+		})
+		ssm[k] = scopeLog
+
+		rs, rOk := rsm[rKey]
+		if !rOk {
+			resources++
+			// The resource was unknown.
+			rs = &otlplogsv1.ResourceLogs{
+				Resource:  &resPb,
+				ScopeLogs: []*otlplogsv1.ScopeLogs{scopeLog},
+				SchemaUrl: res.SchemaURL(),
+			}
+			rsm[rKey] = rs
+			continue
+		}
+
+		// The resource has been seen before. Check if the instrumentation
+		// library lookup was unknown because if so we need to add it to the
+		// ResourceSpans. Otherwise, the instrumentation library has already
+		// been seen and the append we did above will be included it in the
+		// ScopeSpans reference.
+		if !iOk {
+			rs.ScopeLogs = append(rs.ScopeLogs, scopeLog)
 		}
 	}
 
-	return rec
+	// Transform the categorized map into a slice
+	rss := make([]*otlplogsv1.ResourceLogs, 0, resources)
+	for _, rs := range rsm {
+		rss = append(rss, rs)
+	}
+	return rss
 }

--- a/engine/clientdb/models.go
+++ b/engine/clientdb/models.go
@@ -9,13 +9,17 @@ import (
 )
 
 type Log struct {
-	ID         int64
-	TraceID    sql.NullString
-	SpanID     sql.NullString
-	Timestamp  int64
-	Severity   int64
-	Body       []byte
-	Attributes []byte
+	ID                   int64
+	TraceID              sql.NullString
+	SpanID               sql.NullString
+	Timestamp            int64
+	SeverityNumber       int64
+	SeverityText         string
+	Body                 []byte
+	Attributes           []byte
+	InstrumentationScope []byte
+	Resource             []byte
+	ResourceSchemaUrl    string
 }
 
 type Span struct {
@@ -39,4 +43,5 @@ type Span struct {
 	StatusMessage          string
 	InstrumentationScope   []byte
 	Resource               []byte
+	ResourceSchemaUrl      string
 }

--- a/engine/clientdb/queries.sql
+++ b/engine/clientdb/queries.sql
@@ -1,15 +1,43 @@
 -- name: InsertSpan :one
 INSERT INTO spans (
-    trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time, end_time, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, instrumentation_scope, resource
+    trace_id,
+    span_id,
+    trace_state,
+    parent_span_id,
+    flags,
+    name,
+    kind,
+    start_time,
+    end_time,
+    attributes,
+    dropped_attributes_count,
+    events,
+    dropped_events_count,
+    links,
+    dropped_links_count,
+    status_code,
+    status_message,
+    instrumentation_scope,
+    resource,
+    resource_schema_url
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 ) RETURNING id;
 
 -- name: InsertLog :one
 INSERT INTO logs (
-    trace_id, span_id, timestamp, severity, body, attributes
+    trace_id,
+    span_id,
+    timestamp,
+    severity_number,
+    severity_text,
+    body,
+    attributes,
+    instrumentation_scope,
+    resource,
+    resource_schema_url
 ) VALUES (
-    ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 ) RETURNING id;
 
 -- -- name: InsertMetric :one

--- a/engine/clientdb/schema.sql
+++ b/engine/clientdb/schema.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS spans (
     status_code INTEGER NOT NULL,
     status_message TEXT NOT NULL,
     instrumentation_scope BLOB, -- JSON encoded *otlpcommonv1.InstrumentationScope
-    resource BLOB -- JSON encoded *otlpresourcev1.Resource
+    resource BLOB, -- JSON encoded *otlpresourcev1.Resource
+    resource_schema_url TEXT NOT NULL
 ) STRICT;
 
 CREATE TABLE IF NOT EXISTS logs (
@@ -33,7 +34,11 @@ CREATE TABLE IF NOT EXISTS logs (
     trace_id TEXT,
     span_id TEXT,
     timestamp INTEGER NOT NULL, -- Nanoseconds from epoch
-    severity INTEGER NOT NULL,
+    severity_number INTEGER NOT NULL,
+    severity_text TEXT NOT NULL,
     body BLOB, -- *Protobuf* encoded otlpcommon.v1.Any
-    attributes BLOB -- JSON encoded otlpcommon.v1.Key
+    attributes BLOB, -- JSON encoded []*otlpcommonv1.KeyValue
+    instrumentation_scope BLOB, -- JSON encoded *otlpcommonv1.InstrumentationScope
+    resource BLOB, -- JSON encoded *otlpresourcev1.Resource
+    resource_schema_url TEXT NOT NULL
 ) STRICT;

--- a/engine/clientdb/span.go
+++ b/engine/clientdb/span.go
@@ -97,7 +97,7 @@ func (ros *readOnlySpan) EndTime() time.Time {
 	return time.Time{}
 }
 
-func UnmarshalProtos[T proto.Message](pb []byte, base T, out *[]T) error {
+func UnmarshalProtoJSONs[T proto.Message](pb []byte, base T, out *[]T) error {
 	var msgs []json.RawMessage
 	if err := json.Unmarshal(pb, &msgs); err != nil {
 		return fmt.Errorf("failed to json unmarshal: %w", err)
@@ -114,7 +114,7 @@ func UnmarshalProtos[T proto.Message](pb []byte, base T, out *[]T) error {
 	return nil
 }
 
-func MarshalProtos[T proto.Message](protos []T) ([]byte, error) {
+func MarshalProtoJSONs[T proto.Message](protos []T) ([]byte, error) {
 	msgs := make([]json.RawMessage, len(protos))
 	for i, msg := range protos {
 		pl, err := protojson.Marshal(msg)
@@ -129,7 +129,7 @@ func MarshalProtos[T proto.Message](protos []T) ([]byte, error) {
 // Attributes returns the attributes of the span
 func (ros *readOnlySpan) Attributes() []attribute.KeyValue {
 	var attrs []*otlpcommonv1.KeyValue
-	if err := UnmarshalProtos(ros.DB.Attributes, &otlpcommonv1.KeyValue{}, &attrs); err != nil {
+	if err := UnmarshalProtoJSONs(ros.DB.Attributes, &otlpcommonv1.KeyValue{}, &attrs); err != nil {
 		slog.Warn("failed to unmarshal attributes", "error", err)
 	}
 	return telemetry.AttributesFromProto(attrs)
@@ -138,7 +138,7 @@ func (ros *readOnlySpan) Attributes() []attribute.KeyValue {
 // Links returns the links of the span
 func (ros *readOnlySpan) Links() []sdktrace.Link {
 	var links []*otlptracev1.Span_Link
-	if err := UnmarshalProtos(ros.DB.Links, &otlptracev1.Span_Link{}, &links); err != nil {
+	if err := UnmarshalProtoJSONs(ros.DB.Links, &otlptracev1.Span_Link{}, &links); err != nil {
 		slog.Warn("failed to unmarshal links", "error", err)
 	}
 	return telemetry.SpanLinksFromPB(links)
@@ -147,7 +147,7 @@ func (ros *readOnlySpan) Links() []sdktrace.Link {
 // Events returns the events of the span
 func (ros *readOnlySpan) Events() []sdktrace.Event {
 	var events []*otlptracev1.Span_Event
-	if err := UnmarshalProtos(ros.DB.Events, &otlptracev1.Span_Event{}, &events); err != nil {
+	if err := UnmarshalProtoJSONs(ros.DB.Events, &otlptracev1.Span_Event{}, &events); err != nil {
 		slog.Warn("failed to unmarshal events", "error", err)
 	}
 	return telemetry.SpanEventsFromPB(events)

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -606,6 +606,7 @@ func (srv *Server) initializeDaggerClient(
 		)),
 	}
 	loggerOpts := []sdklog.LoggerProviderOption{
+		sdklog.WithResource(telemetry.Resource),
 		sdklog.WithProcessor(
 			sdklog.NewBatchProcessor(
 				srv.telemetryPubSub.Logs(client),

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dagger/dagger/engine/clientdb"
 	"github.com/dagger/dagger/engine/slog"
+	enginetel "github.com/dagger/dagger/engine/telemetry"
 	"github.com/vito/go-sse/sse"
 )
 
@@ -124,14 +125,12 @@ func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) { //nolin
 		return
 	}
 
-	logs := telemetry.LogsFromPB(req.ResourceLogs)
-
-	slog.Debug("exporting logs to clients", "logs", len(logs), "clients", len(client.parents)+1)
+	slog.Debug("exporting logs to clients", "clients", len(client.parents)+1)
 
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
 		eg.Go(func() error {
-			if err := ps.Logs(c).Export(r.Context(), logs); err != nil {
+			if err := enginetel.ReexportLogsFromPB(r.Context(), ps.Logs(c), &req); err != nil {
 				return fmt.Errorf("export to %s: %w", c.clientID, err)
 			}
 			return nil
@@ -208,14 +207,10 @@ func (ps *PubSub) LogsSubscribeHandler(w http.ResponseWriter, r *http.Request, c
 		if len(logs) == 0 {
 			return nil, false, nil
 		}
-		recs := make([]sdklog.Record, len(logs))
-		for i, log := range logs {
-			recs[i] = log.Record()
-			since = log.ID
-		}
+		since = logs[len(logs)-1].ID
 		// Marshal the logs to OTLP.
 		payload, err := protojson.Marshal(&collogspb.ExportLogsServiceRequest{
-			ResourceLogs: telemetry.LogsToPB(recs),
+			ResourceLogs: clientdb.LogsToPB(logs),
 		})
 		if err != nil {
 			return nil, false, fmt.Errorf("marshal logs: %w", err)
@@ -280,19 +275,19 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 			endTime.Int64 = 0
 			endTime.Valid = false
 		}
-		attributes, err := clientdb.MarshalProtos(telemetry.KeyValues(span.Attributes()))
+		attributes, err := clientdb.MarshalProtoJSONs(telemetry.KeyValues(span.Attributes()))
 		if err != nil {
 			slog.Warn("failed to marshal attributes", "error", err)
 			continue
 		}
 		droppedAttributesCount := int64(span.DroppedAttributes())
-		events, err := clientdb.MarshalProtos(telemetry.SpanEventsToPB(span.Events()))
+		events, err := clientdb.MarshalProtoJSONs(telemetry.SpanEventsToPB(span.Events()))
 		if err != nil {
 			slog.Warn("failed to marshal events", "error", err)
 			continue
 		}
 		droppedEventsCount := int64(span.DroppedEvents())
-		links, err := clientdb.MarshalProtos(telemetry.SpanLinksToPB(span.Links()))
+		links, err := clientdb.MarshalProtoJSONs(telemetry.SpanLinksToPB(span.Links()))
 		if err != nil {
 			slog.Warn("failed to marshal links", "error", err)
 			continue
@@ -300,12 +295,12 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 		droppedLinksCount := int64(span.DroppedLinks())
 		statusCode := int64(span.Status().Code)
 		statusMessage := span.Status().Description
-		instrumentationScope, err := protojson.Marshal(telemetry.InstrumentationScope(span.InstrumentationScope()))
+		instrumentationScope, err := protojson.Marshal(telemetry.InstrumentationScopeToPB(span.InstrumentationScope()))
 		if err != nil {
 			slog.Warn("failed to marshal instrumentation scope", "error", err)
 			continue
 		}
-		resource, err := protojson.Marshal(telemetry.ResourcePtr(span.Resource()))
+		resource, err := protojson.Marshal(telemetry.ResourcePtrToPB(span.Resource()))
 		if err != nil {
 			slog.Warn("failed to marshal resource", "error", err)
 			continue
@@ -396,7 +391,20 @@ func (ps LogsPubSub) Export(ctx context.Context, logs []sdklog.Record) error {
 			})
 			return true
 		})
-		attributes, err := clientdb.MarshalProtos(attrs)
+		attributes, err := clientdb.MarshalProtoJSONs(attrs)
+		if err != nil {
+			slog.Warn("failed to marshal log record attributes", "error", err)
+			continue
+		}
+
+		scope, err := protojson.Marshal(telemetry.InstrumentationScopeToPB(rec.InstrumentationScope()))
+		if err != nil {
+			slog.Warn("failed to marshal log record attributes", "error", err)
+			continue
+		}
+
+		res := rec.Resource()
+		resource, err := protojson.Marshal(telemetry.ResourceToPB(res))
 		if err != nil {
 			slog.Warn("failed to marshal log record attributes", "error", err)
 			continue
@@ -411,10 +419,14 @@ func (ps LogsPubSub) Export(ctx context.Context, logs []sdklog.Record) error {
 				String: spanID,
 				Valid:  rec.SpanID().IsValid(),
 			},
-			Timestamp:  timestamp,
-			Severity:   severity,
-			Body:       body,
-			Attributes: attributes,
+			Timestamp:            timestamp,
+			SeverityNumber:       severity,
+			SeverityText:         rec.SeverityText(),
+			Body:                 body,
+			Attributes:           attributes,
+			InstrumentationScope: scope,
+			Resource:             resource,
+			ResourceSchemaUrl:    res.SchemaURL(),
 		})
 		if err != nil {
 			return fmt.Errorf("insert log: %w", err)

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -56,7 +56,7 @@ func (ps *PubSub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ps.mux.ServeHTTP(w, r)
 }
 
-func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) { //nolint: dupl
+func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) {
 	sessionID := r.Header.Get("X-Dagger-Session-ID")
 	clientID := r.Header.Get("X-Dagger-Client-ID")
 	client, err := ps.srv.getClient(sessionID, clientID)
@@ -101,7 +101,7 @@ func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) { //nol
 	rw.WriteHeader(http.StatusCreated)
 }
 
-func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) { //nolint: dupl
+func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) {
 	sessionID := r.Header.Get("X-Dagger-Session-ID")
 	clientID := r.Header.Get("X-Dagger-Client-ID")
 	client, err := ps.srv.getClient(sessionID, clientID)
@@ -147,7 +147,7 @@ func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) { //nolin
 
 const otlpBatchSize = 1000
 
-func (ps *PubSub) TracesSubscribeHandler(w http.ResponseWriter, r *http.Request, client *daggerClient) error { //nolint: dupl
+func (ps *PubSub) TracesSubscribeHandler(w http.ResponseWriter, r *http.Request, client *daggerClient) error {
 	return ps.sseHandler(w, r, client, func(ctx context.Context, db *sql.DB, lastID string) (*sse.Event, bool, error) {
 		var since int64
 		if lastID != "" {
@@ -187,7 +187,7 @@ func (ps *PubSub) TracesSubscribeHandler(w http.ResponseWriter, r *http.Request,
 	})
 }
 
-func (ps *PubSub) LogsSubscribeHandler(w http.ResponseWriter, r *http.Request, client *daggerClient) error { //nolint: dupl
+func (ps *PubSub) LogsSubscribeHandler(w http.ResponseWriter, r *http.Request, client *daggerClient) error {
 	return ps.sseHandler(w, r, client, func(ctx context.Context, db *sql.DB, lastID string) (*sse.Event, bool, error) {
 		var since int64
 		if lastID != "" {

--- a/engine/telemetry/logs.go
+++ b/engine/telemetry/logs.go
@@ -1,0 +1,75 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"dagger.io/dagger/telemetry"
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/trace"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+)
+
+func ReexportLogsFromPB(ctx context.Context, exp sdklog.Exporter, req *collogspb.ExportLogsServiceRequest) error {
+	processor := &collectLogProcessor{}
+
+	for _, rl := range req.GetResourceLogs() {
+		resource := telemetry.ResourceFromPB(rl.GetSchemaUrl(), rl.GetResource())
+
+		provider := sdklog.NewLoggerProvider(
+			sdklog.WithResource(resource),
+			sdklog.WithProcessor(processor),
+		)
+
+		for _, scopeLog := range rl.GetScopeLogs() {
+			logger := provider.Logger(scopeLog.GetScope().GetName(),
+				log.WithInstrumentationVersion(scopeLog.GetScope().GetVersion()),
+				log.WithInstrumentationAttributes(
+					telemetry.AttributesFromProto(scopeLog.GetScope().GetAttributes())...,
+				),
+				log.WithSchemaURL(scopeLog.GetSchemaUrl()),
+			)
+			for _, rec := range scopeLog.GetLogRecords() {
+				var logRec log.Record
+				tid := trace.TraceID(rec.GetTraceId())
+				sid := trace.SpanID(rec.GetSpanId())
+				emitCtx := trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: tid,
+					SpanID:  sid,
+				}))
+				logRec.SetTimestamp(time.Unix(0, int64(rec.GetTimeUnixNano())))
+				logRec.SetBody(telemetry.LogValueFromPB(rec.GetBody()))
+				logRec.SetSeverity(log.Severity(rec.GetSeverityNumber()))
+				logRec.SetSeverityText(rec.GetSeverityText())
+				logRec.SetObservedTimestamp(time.Unix(0, int64(rec.GetObservedTimeUnixNano())))
+				logRec.AddAttributes(telemetry.LogKeyValuesFromPB(rec.GetAttributes())...)
+				logger.Emit(emitCtx, logRec)
+			}
+		}
+	}
+	return exp.Export(ctx, processor.logs)
+}
+
+type collectLogProcessor struct {
+	logs []sdklog.Record
+}
+
+var _ sdklog.Processor = (*collectLogProcessor)(nil)
+
+func (p *collectLogProcessor) OnEmit(ctx context.Context, record sdklog.Record) error {
+	p.logs = append(p.logs, record)
+	return nil
+}
+
+func (p *collectLogProcessor) Enabled(ctx context.Context, record sdklog.Record) bool {
+	return true
+}
+
+func (p *collectLogProcessor) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (p *collectLogProcessor) ForceFlush(ctx context.Context) error {
+	return nil
+}

--- a/sdk/go/telemetry/logging.go
+++ b/sdk/go/telemetry/logging.go
@@ -40,7 +40,7 @@ func Logger(ctx context.Context, name string) log.Logger {
 // stdout/stderr and terminates them with an EOF, to confirm that all data has
 // been received. It should not be used for general-purpose logging.
 //
-// Both streamsm must be closed to ensure that draining completes.
+// Both streams must be closed to ensure that draining completes.
 func SpanStdio(ctx context.Context, name string, attrs ...log.KeyValue) SpanStreams {
 	logger := Logger(ctx, name)
 	return SpanStreams{


### PR DESCRIPTION
Previously OTLP log data recorded into the client's SQLite database was dropping somewhat important information such as the OTel resource that generated the logs. I noticed this while investigating duplicate logs in Cloud, since half of them had a blank resource, and half of them didn't - the root cause of that ended up being https://github.com/open-telemetry/opentelemetry-go/issues/5782 but that blank resource value seemed worth fixing anyway, and led to a few other refactors which I'll explain inline.

(No behavior change is expected here - just some housekeeping)