### PR TITLE
💥 Breaking(helm): Remove default oci-max-parallelism num-cpu

### DIFF
--- a/helm/dagger/.changes/unreleased/Breaking-20240911-114157.yaml
+++ b/helm/dagger/.changes/unreleased/Breaking-20240911-114157.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Removes default `oci-max-parallelism` `num-cpu` Engine setting. This options is known to be problematic in certain scenarios.
+time: 2024-09-11T11:41:57.264663+01:00
+custom:
+    Author: gerhard
+    PR: "8406"

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -17,11 +17,8 @@ engine:
   labels: {}
 
   ### Customize Dagger Engine start args
-  #   "--oci-max-parallelism num-cpu" is kept as the default behaviour so that we don't surprise users.
-  #   You may want to remove it in your deployments. FTR: https://github.com/dagger/dagger/pull/7395
-  args:
-    - "--oci-max-parallelism"
-    - "num-cpu"
+  #
+  args: []
 
   resources:
     limits: {}


### PR DESCRIPTION
This may result in a surprising behaviour, as captured in:
- https://github.com/dagger/dagger/pull/7395

You can still set this if needed, we are just removing it as the default option.

---

Follow-up to:
- https://github.com/dagger/dagger/pull/8348#discussion_r1750138175

---

> [!NOTE]
> The more I think about this, it's not **technically** a breaking change. We change the default behaviour of the Engine provisioned with the Helm chart. We are emphasising the importance of this change, but it's not breaking. OK to leave as is, just clarifying for anyone that might stumble across this PR and wonder what exactly is breaking.