### PR TITLE
ci: Move the Engine & CLI split test suites to a separate workflow

### DIFF
--- a/.github/workflows/engine-and-cli-split.yml
+++ b/.github/workflows/engine-and-cli-split.yml
@@ -1,0 +1,102 @@
+name: Engine & CLI split
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  # Enable manual trigger for easy debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-modules:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run=TestModule --race=true --parallel=16"
+          upload-logs: true
+
+  test-module-runtimes:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --race=true --parallel=16"
+          upload-logs: true
+
+  test-cli-engine:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run='TestCLI|TestEngine' --race=true --parallel=16"
+          upload-logs: true
+
+  test-everything-else:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --skip='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestCLI|TestEngine' --race=true --parallel=16"
+          upload-logs: true
+
+  testdev-modules:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "testdev"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run='TestModule' --skip='TestDev' --race=true --parallel=16"
+          dev-engine: true
+          upload-logs: true
+
+  testdev-module-runtimes:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "testdev"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --skip='TestDev' --race=true --parallel=16"
+          dev-engine: true
+          upload-logs: true
+
+  testdev-container:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "testdev"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run='TestContainer' --skip='TestDev' --race=true --parallel=16"
+          dev-engine: true
+          upload-logs: true

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -46,50 +46,6 @@ jobs:
           function: "test all --race=true --parallel=16"
           upload-logs: true
 
-  test-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "test"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run=TestModule --race=true --parallel=16"
-          upload-logs: true
-
-  test-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "test"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --race=true --parallel=16"
-          upload-logs: true
-
-  test-cli-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "test"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run='TestCLI|TestEngine' --race=true --parallel=16"
-          upload-logs: true
-
-  test-everything-else:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-16c-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "test"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --skip='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestCLI|TestEngine' --race=true --parallel=16"
-          upload-logs: true
-
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
@@ -102,42 +58,6 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: "test specific --run='TestModule|TestContainer' --skip='TestDev' --race=true --parallel=16"
-          dev-engine: true
-          upload-logs: true
-
-  testdev-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "testdev"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run='TestModule' --skip='TestDev' --race=true --parallel=16"
-          dev-engine: true
-          upload-logs: true
-
-  testdev-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "testdev"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --skip='TestDev' --race=true --parallel=16"
-          dev-engine: true
-          upload-logs: true
-
-  testdev-container:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-7-32c-dind-st-od' || 'ubuntu-latest' }}"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: "testdev"
-        uses: ./.github/actions/call
-        with:
-          function: "test specific --run='TestContainer' --skip='TestDev' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 


### PR DESCRIPTION
So that we can compare the two different workflows side-by-side. This is something that we have learned ~2 weeks after the last test suite split:
- https://github.com/dagger/dagger/pull/8212

We know that the split suites are faster & more reliable, but without this change, we cannot compare the two workflows side-by-side. All that we know is that the Engine & CLI workflow is failing more often (flakes are now 2x as likely to happen). This change will show us how all the tests, but split differently, compare.

This is part of a wider effort captured in:
- https://github.com/dagger/dagger/issues/8184