### PR TITLE
ci: bump bun version to v1.1.x

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -171,7 +171,7 @@ jobs:
           node-version: 18
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.0.x
+          bun-version: 1.1.x
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript


### PR DESCRIPTION
This needs to match the bun version that we use in the SDK code.

Fixes the failing `main` provision tests: https://discord.com/channels/707636530424053791/1280818249633890365/1283423301762551916

This likely broke after merging #8237.