### PR TITLE
ci: bump bun version to v1.1.26

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -171,7 +171,7 @@ jobs:
           node-version: 18
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.x
+          bun-version: 1.1.26
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
@@ -325,7 +325,7 @@ jobs:
           node-version: 18
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.x
+          bun-version: 1.1.26
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript


### PR DESCRIPTION
`1.0.x` works. `1.1.x` doesn't. https://github.com/dagger/dagger/actions/runs/10813822787/job/29999504355

:cry: 