### PR TITLE
ci: Restore testdev to the same coverage as it had before #8212

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestModule|TestContainer' --skip='TestDev' --race=true --parallel=16"
+          function: "test specific --run='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestContainer' --skip='TestDev' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 


### PR DESCRIPTION
During https://github.com/dagger/dagger/pull/8212, `testdev` was refactored and I missed these important test suites. This puts them back. We should expect it to get slower and more flaky, but at least the coverage will be the same as before.

We were still running the same tests in the split `testdev-module-runtimes`, so were not really missing on anything test
coverage-wise, just the comparison between the original `testdev` and the split one was less accurate.
