### PR TITLE
.dagger: fix gitDir glob pattern to ignore all but `.git`

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -43,7 +43,7 @@ func New(
 	// Git directory, for metadata introspection
 	// +optional
 	// +defaultPath="/"
-	// +ignore=["!.git"]
+	// +ignore=["*", "!.git"]
 	gitDir *dagger.Directory,
 
 	// +optional


### PR DESCRIPTION
right now this is uploading everything which takes quite a while