### PR TITLE
ci: remove TestDev reference

### DIFF
--- a/.github/workflows/engine-and-cli-split.yml
+++ b/.github/workflows/engine-and-cli-split.yml
@@ -73,7 +73,7 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestModule' --skip='TestDev' --race=true --parallel=16"
+          function: "test specific --run='TestModule' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 
@@ -85,7 +85,7 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --skip='TestDev' --race=true --parallel=16"
+          function: "test specific --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 
@@ -97,6 +97,6 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestContainer' --skip='TestDev' --race=true --parallel=16"
+          function: "test specific --run='TestContainer' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestModule|TestContainer' --skip='TestDev' --race=true --parallel=16"
+          function: "test specific --run='TestModule|TestContainer' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 


### PR DESCRIPTION
`TestDev` is not a suite that exists. Not sure what this is doing here, I don't think this has an effect?

Even if it did have an effect, it looks like it would be doing the *opposite*?

Looks like this was introduced here: [`8ec2238` (#8212)](https://github.com/dagger/dagger/pull/8212/commits/8ec22381d85f88654e356bf2fd57591537aaf6ec)