### PR TITLE
feat(engine): support expanding variables in more functions

### DIFF
--- a/.changes/unreleased/Added-20240916-192525.yaml
+++ b/.changes/unreleased/Added-20240916-192525.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Allow expanding environment variables in more `Container` functions.
+time: 2024-09-16T19:25:25.589722+05:30
+custom:
+    Author: rajatjindal
+    PR: "8427"

--- a/.dagger/sdk_php.go
+++ b/.dagger/sdk_php.go
@@ -66,8 +66,18 @@ func (t PHPSDK) Lint(ctx context.Context) error {
 
 // Test the PHP SDK
 func (t PHPSDK) Test(ctx context.Context) error {
+	installer, err := t.Dagger.installer(ctx, "sdk")
+	if err != nil {
+		return err
+	}
+
 	src := t.Dagger.Source().Directory(phpSDKPath)
-	_, err := dag.PhpSDKDev().Test(src).Sync(ctx)
+	base := t.phpBase().
+		With(installer).
+		WithEnvVariable("PATH", "./vendor/bin:$PATH", dagger.ContainerWithEnvVariableOpts{Expand: true})
+
+	dev := dag.PhpSDKDev(dagger.PhpSDKDevOpts{Container: base})
+	_, err = dev.Test(src).Sync(ctx)
 	return err
 }
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -44,6 +44,9 @@ type ContainerExecOpts struct {
 
 	// (Internal-only) If this is a nested exec, exec metadata to use for it
 	NestedExecMetadata *buildkit.ExecutionMetadata `name:"-"`
+
+	// Expand the environment variables in args
+	Expand bool `default:"false"`
 }
 
 func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts) (*Container, error) { //nolint:gocyclo

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -81,11 +81,17 @@ func (s *containerSchema) Install() {
 		dagql.Func("directory", s.directory).
 			Doc(`Retrieves a directory at the given path.`,
 				`Mounts are included.`).
-			ArgDoc("path", `The path of the directory to retrieve (e.g., "./src").`),
+			ArgDoc("path", `The path of the directory to retrieve (e.g., "./src").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("file", s.file).
 			Doc(`Retrieves a file at the given path.`, `Mounts are included.`).
-			ArgDoc("path", `The path of the file to retrieve (e.g., "./README.md").`),
+			ArgDoc("path", `The path of the file to retrieve (e.g., "./README.md").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 
 		dagql.Func("user", s.user).
 			Doc("Retrieves the user to be set for all commands."),
@@ -103,7 +109,10 @@ func (s *containerSchema) Install() {
 
 		dagql.Func("withWorkdir", s.withWorkdir).
 			Doc(`Retrieves this container with a different working directory.`).
-			ArgDoc("path", `The path to set as the working directory (e.g., "/app").`),
+			ArgDoc("path", `The path to set as the working directory (e.g., "/app").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withoutWorkdir", s.withoutWorkdir).
 			Doc(`Retrieves this container with an unset working directory.`,
@@ -121,9 +130,8 @@ func (s *containerSchema) Install() {
 			ArgDoc("name", `The name of the environment variable (e.g., "HOST").`).
 			ArgDoc("value", `The value of the environment variable. (e.g., "localhost").`).
 			ArgDoc("expand",
-				"Replace `${VAR}` or `$VAR` in the value according to the current "+
-					`environment variables defined in the container (e.g.,
-				"/opt/bin:$PATH").`),
+				"Replace ${VAR} or $VAR in the value according to the current "+
+					`environment variables defined in the container (e.g. "/opt/bin:$PATH").`),
 
 		// NOTE: this is internal-only for now (hidden from codegen via the __ prefix) as we
 		// currently only want to use it for allowing the Go SDK to inherit custom GOPROXY
@@ -193,7 +201,10 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the mounted directory and its contents.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withMountedFile", s.withMountedFile).
 			Doc(`Retrieves this container plus a file mounted at the given path.`).
@@ -202,11 +213,17 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user or user:group to set for the mounted file.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 
 		dagql.Func("withMountedTemp", s.withMountedTemp).
 			Doc(`Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.`).
-			ArgDoc("path", `Location of the temporary directory (e.g., "/tmp/temp_dir").`),
+			ArgDoc("path", `Location of the temporary directory (e.g., "/tmp/temp_dir").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withMountedCache", s.withMountedCache).
 			Doc(`Retrieves this container plus a cache volume mounted at the given path.`).
@@ -220,7 +237,10 @@ func (s *containerSchema) Install() {
 				the initial filesystem provided by source (if any). It does not have
 				any effect if/when the cache has already been created.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withMountedSecret", s.withMountedSecret).
 			Doc(`Retrieves this container plus a secret mounted into a file at the given path.`).
@@ -231,7 +251,10 @@ func (s *containerSchema) Install() {
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 				`If the group is omitted, it defaults to the same as the user.`).
 			ArgDoc("mode", `Permission given to the mounted secret (e.g., 0600).`,
-				`This option requires an owner to be set to be active.`),
+				`This option requires an owner to be set to be active.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withUnixSocket", s.withUnixSocket).
 			Doc(`Retrieves this container plus a socket forwarded to the given Unix socket path.`).
@@ -240,15 +263,24 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the mounted socket.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withoutUnixSocket", s.withoutUnixSocket).
 			Doc(`Retrieves this container with a previously added Unix socket removed.`).
-			ArgDoc("path", `Location of the socket to remove (e.g., "/tmp/socket").`),
+			ArgDoc("path", `Location of the socket to remove (e.g., "/tmp/socket").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withoutMount", s.withoutMount).
 			Doc(`Retrieves this container after unmounting everything at the given path.`).
-			ArgDoc("path", `Location of the cache directory (e.g., "/cache/node_modules").`),
+			ArgDoc("path", `Location of the cache directory (e.g., "/cache/node_modules").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withFile", s.withFile).
 			Doc(`Retrieves this container plus the contents of the given file copied to the given path.`).
@@ -258,14 +290,24 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the file.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 
 		dagql.Func("withoutFile", s.withoutFile).
 			Doc(`Retrieves this container with the file at the given path removed.`).
-			ArgDoc("path", `Location of the file to remove (e.g., "/file.txt").`),
+			ArgDoc("path", `Location of the file to remove (e.g., "/file.txt").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
+
 		dagql.Func("withoutFiles", s.withoutFiles).
 			Doc(`Retrieves this container with the files at the given paths removed.`).
-			ArgDoc("paths", `Location of the files to remove (e.g., ["/file.txt"]).`),
+			ArgDoc("paths", `Location of the files to remove (e.g., ["/file.txt"]).`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of paths according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 
 		dagql.Func("withFiles", s.withFiles).
 			Doc(`Retrieves this container plus the contents of the given files copied to the given path.`).
@@ -275,7 +317,10 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the files.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 
 		dagql.Func("withNewFile", s.withNewFile).
 			View(AllVersion).
@@ -286,7 +331,10 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the file.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 		dagql.Func("withNewFile", s.withNewFileLegacy).
 			View(BeforeVersion("v0.12.0")).
 			Doc(`Retrieves this container plus a new file written at the given path.`).
@@ -307,11 +355,17 @@ func (s *containerSchema) Install() {
 			ArgDoc("owner",
 				`A user:group to set for the directory and its contents.`,
 				`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
-				`If the group is omitted, it defaults to the same as the user.`),
+				`If the group is omitted, it defaults to the same as the user.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withoutDirectory", s.withoutDirectory).
 			Doc(`Retrieves this container with the directory at the given path removed.`).
-			ArgDoc("path", `Location of the directory to remove (e.g., ".github/").`),
+			ArgDoc("path", `Location of the directory to remove (e.g., ".github/").`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withExec", s.withExec).
 			View(AllVersion).
@@ -341,7 +395,10 @@ func (s *containerSchema) Install() {
 				running a command with "sudo" or executing "docker run" with the
 				"--privileged" flag. Containerization does not provide any security
 				guarantees when using this option. It should only be used when
-				absolutely necessary and only with trusted commands.`),
+				absolutely necessary and only with trusted commands.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the args according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 
 		dagql.Func("withExec", s.withExec).
 			View(BeforeVersion("v0.13.0")).
@@ -481,7 +538,10 @@ func (s *containerSchema) Install() {
 				`Use the specified media types for the exported image's layers.`,
 				`Defaults to OCI, which is largely compatible with most recent
 				container runtimes, but Docker may be needed for older runtimes without
-				OCI support.`),
+				OCI support.`).
+			ArgDoc("expand",
+				"Replace ${VAR} or $VAR in the value of path according to the current "+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 		dagql.Func("export", s.exportLegacy).
 			View(BeforeVersion("v0.12.0")).
 			Extend(),
@@ -726,6 +786,18 @@ func (s *containerSchema) withExec(ctx context.Context, parent *core.Container, 
 			args.ContainerExecOpts.UseEntrypoint = true
 		}
 	}
+
+	expandedArgs := make([]string, len(args.Args))
+	for i, arg := range args.Args {
+		expandedArg, err := expandEnvVar(ctx, parent, arg, args.Expand)
+		if err != nil {
+			return nil, err
+		}
+
+		expandedArgs[i] = expandedArg
+	}
+	args.Args = expandedArgs
+
 	return parent.WithExec(ctx, args.ContainerExecOpts)
 }
 
@@ -916,12 +988,18 @@ func (s *containerSchema) user(ctx context.Context, parent *core.Container, args
 }
 
 type containerWithWorkdirArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withWorkdir(ctx context.Context, parent *core.Container, args containerWithWorkdirArgs) (*core.Container, error) {
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
 	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
-		cfg.WorkingDir = absPath(cfg.WorkingDir, args.Path)
+		cfg.WorkingDir = absPath(cfg.WorkingDir, path)
 		return cfg
 	})
 }
@@ -1109,6 +1187,7 @@ type containerWithMountedDirectoryArgs struct {
 	Path   string
 	Source core.DirectoryID
 	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withMountedDirectory(ctx context.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
@@ -1116,7 +1195,13 @@ func (s *containerSchema) withMountedDirectory(ctx context.Context, parent *core
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithMountedDirectory(ctx, args.Path, dir.Self, args.Owner, false)
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithMountedDirectory(ctx, path, dir.Self, args.Owner, false)
 }
 
 type containerWithAnnotationArgs struct {
@@ -1165,6 +1250,7 @@ type containerWithMountedFileArgs struct {
 	Path   string
 	Source core.FileID
 	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withMountedFile(ctx context.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
@@ -1172,7 +1258,13 @@ func (s *containerSchema) withMountedFile(ctx context.Context, parent *core.Cont
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithMountedFile(ctx, args.Path, file.Self, args.Owner, false)
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithMountedFile(ctx, path, file.Self, args.Owner, false)
 }
 
 type containerWithMountedCacheArgs struct {
@@ -1181,6 +1273,7 @@ type containerWithMountedCacheArgs struct {
 	Source  dagql.Optional[core.DirectoryID]
 	Sharing core.CacheSharingMode `default:"SHARED"`
 	Owner   string                `default:""`
+	Expand  bool                  `default:"false"`
 }
 
 func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Container, args containerWithMountedCacheArgs) (*core.Container, error) {
@@ -1198,9 +1291,14 @@ func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Con
 		return nil, err
 	}
 
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
 	return parent.WithMountedCache(
 		ctx,
-		args.Path,
+		path,
 		cache.Self,
 		dir,
 		args.Sharing,
@@ -1209,19 +1307,31 @@ func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Con
 }
 
 type containerWithMountedTempArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withMountedTemp(ctx context.Context, parent *core.Container, args containerWithMountedTempArgs) (*core.Container, error) {
-	return parent.WithMountedTemp(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithMountedTemp(ctx, path)
 }
 
 type containerWithoutMountArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withoutMount(ctx context.Context, parent *core.Container, args containerWithoutMountArgs) (*core.Container, error) {
-	return parent.WithoutMount(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithoutMount(ctx, path)
 }
 
 func (s *containerSchema) mounts(ctx context.Context, parent *core.Container, _ struct{}) (dagql.Array[dagql.String], error) {
@@ -1259,19 +1369,31 @@ func (s *containerSchema) withoutLabel(ctx context.Context, parent *core.Contain
 }
 
 type containerDirectoryArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) directory(ctx context.Context, parent *core.Container, args containerDirectoryArgs) (*core.Directory, error) {
-	return parent.Directory(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.Directory(ctx, path)
 }
 
 type containerFileArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) file(ctx context.Context, parent *core.Container, args containerFileArgs) (*core.File, error) {
-	return parent.File(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.File(ctx, path)
 }
 
 func absPath(workDir string, containerPath string) string {
@@ -1284,6 +1406,22 @@ func absPath(workDir string, containerPath string) string {
 	}
 
 	return path.Join(workDir, containerPath)
+}
+
+func expandEnvVar(ctx context.Context, parent *core.Container, input string, expand bool) (string, error) {
+	if !expand {
+		return input, nil
+	}
+
+	cfg, err := parent.ImageConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return os.Expand(input, func(k string) string {
+		v, _ := core.LookupEnv(cfg.Env, k)
+		return v
+	}), nil
 }
 
 type containerWithSecretVariableArgs struct {
@@ -1312,6 +1450,7 @@ type containerWithMountedSecretArgs struct {
 	Source core.SecretID
 	Owner  string `default:""`
 	Mode   int    `default:"0400"` // FIXME(vito): verify octal
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withMountedSecret(ctx context.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
@@ -1319,12 +1458,19 @@ func (s *containerSchema) withMountedSecret(ctx context.Context, parent *core.Co
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithMountedSecret(ctx, args.Path, secret.Self, args.Owner, fs.FileMode(args.Mode))
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithMountedSecret(ctx, path, secret.Self, args.Owner, fs.FileMode(args.Mode))
 }
 
 type containerWithDirectoryArgs struct {
 	WithDirectoryArgs
-	Owner string `default:""`
+	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withDirectory(ctx context.Context, parent *core.Container, args containerWithDirectoryArgs) (*core.Container, error) {
@@ -1332,12 +1478,19 @@ func (s *containerSchema) withDirectory(ctx context.Context, parent *core.Contai
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithDirectory(ctx, args.Path, dir.Self, args.CopyFilter, args.Owner)
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithDirectory(ctx, path, dir.Self, args.CopyFilter, args.Owner)
 }
 
 type containerWithFileArgs struct {
 	WithFileArgs
-	Owner string `default:""`
+	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withFile(ctx context.Context, parent *core.Container, args containerWithFileArgs) (*core.Container, error) {
@@ -1345,12 +1498,19 @@ func (s *containerSchema) withFile(ctx context.Context, parent *core.Container, 
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithFile(ctx, args.Path, file.Self, args.Permissions, args.Owner)
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithFile(ctx, path, file.Self, args.Permissions, args.Owner)
 }
 
 type containerWithFilesArgs struct {
 	WithFilesArgs
-	Owner string `default:""`
+	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withFiles(ctx context.Context, parent *core.Container, args containerWithFilesArgs) (*core.Container, error) {
@@ -1363,31 +1523,58 @@ func (s *containerSchema) withFiles(ctx context.Context, parent *core.Container,
 		files = append(files, file.Self)
 	}
 
-	return parent.WithFiles(ctx, args.Path, files, args.Permissions, args.Owner)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithFiles(ctx, path, files, args.Permissions, args.Owner)
 }
 
 type containerWithoutDirectoryArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withoutDirectory(ctx context.Context, parent *core.Container, args containerWithoutDirectoryArgs) (*core.Container, error) {
-	return parent.WithoutPaths(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithoutPaths(ctx, path)
 }
 
 type containerWithoutFileArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withoutFile(ctx context.Context, parent *core.Container, args containerWithoutFileArgs) (*core.Container, error) {
-	return parent.WithoutPaths(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithoutPaths(ctx, path)
 }
 
 type containerWithoutFilesArgs struct {
-	Paths []string
+	Paths  []string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withoutFiles(ctx context.Context, parent *core.Container, args containerWithoutFilesArgs) (*core.Container, error) {
-	return parent.WithoutPaths(ctx, args.Paths...)
+	paths := args.Paths
+	var err error
+	for i, p := range args.Paths {
+		paths[i], err = expandEnvVar(ctx, parent, p, args.Expand)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return parent.WithoutPaths(ctx, paths...)
 }
 
 type containerWithNewFileArgs struct {
@@ -1395,10 +1582,16 @@ type containerWithNewFileArgs struct {
 	Contents    string
 	Permissions int    `default:"0644"`
 	Owner       string `default:""`
+	Expand      bool   `default:"false"`
 }
 
 func (s *containerSchema) withNewFile(ctx context.Context, parent *core.Container, args containerWithNewFileArgs) (*core.Container, error) {
-	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), fs.FileMode(args.Permissions), args.Owner)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithNewFile(ctx, path, []byte(args.Contents), fs.FileMode(args.Permissions), args.Owner)
 }
 
 type containerWithNewFileArgsLegacy struct {
@@ -1416,6 +1609,7 @@ type containerWithUnixSocketArgs struct {
 	Path   string
 	Source core.SocketID
 	Owner  string `default:""`
+	Expand bool   `default:"false"`
 }
 
 func (s *containerSchema) withUnixSocket(ctx context.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
@@ -1423,15 +1617,27 @@ func (s *containerSchema) withUnixSocket(ctx context.Context, parent *core.Conta
 	if err != nil {
 		return nil, err
 	}
-	return parent.WithUnixSocket(ctx, args.Path, socket.Self, args.Owner)
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithUnixSocket(ctx, path, socket.Self, args.Owner)
 }
 
 type containerWithoutUnixSocketArgs struct {
-	Path string
+	Path   string
+	Expand bool `default:"false"`
 }
 
 func (s *containerSchema) withoutUnixSocket(ctx context.Context, parent *core.Container, args containerWithoutUnixSocketArgs) (*core.Container, error) {
-	return parent.WithoutUnixSocket(ctx, args.Path)
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent.WithoutUnixSocket(ctx, path)
 }
 
 func (s *containerSchema) platform(ctx context.Context, parent *core.Container, args struct{}) (core.Platform, error) {
@@ -1443,6 +1649,7 @@ type containerExportArgs struct {
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
 	MediaTypes        core.ImageMediaTypes `default:"OCIMediaTypes"`
+	Expand            bool                 `default:"false"`
 }
 
 func (s *containerSchema) export(ctx context.Context, parent *core.Container, args containerExportArgs) (dagql.String, error) {
@@ -1450,9 +1657,15 @@ func (s *containerSchema) export(ctx context.Context, parent *core.Container, ar
 	if err != nil {
 		return "", err
 	}
+
+	path, err := expandEnvVar(ctx, parent, args.Path, args.Expand)
+	if err != nil {
+		return "", err
+	}
+
 	err = parent.Export(
 		ctx,
-		args.Path,
+		path,
 		variants,
 		args.ForcedCompression.Value,
 		args.MediaTypes,
@@ -1464,7 +1677,7 @@ func (s *containerSchema) export(ctx context.Context, parent *core.Container, ar
 	if err != nil {
 		return "", fmt.Errorf("failed to get buildkit: %w", err)
 	}
-	stat, err := bk.StatCallerHostPath(ctx, args.Path, true)
+	stat, err := bk.StatCallerHostPath(ctx, path, true)
 	if err != nil {
 		return "", err
 	}

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -46,12 +46,16 @@ func TestCoreModTypeDefs(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, core.TypeDefKindObject, fileFn.ReturnType.Kind)
 	require.Equal(t, "File", fileFn.ReturnType.AsObject.Value.Name)
-	require.Len(t, fileFn.Args, 1)
+	require.Len(t, fileFn.Args, 2)
 
 	fileFnPathArg := fileFn.Args[0]
 	require.Equal(t, "path", fileFnPathArg.Name)
 	require.Equal(t, core.TypeDefKindString, fileFnPathArg.TypeDef.Kind)
 	require.False(t, fileFnPathArg.TypeDef.Optional)
+
+	fileFnExpandArg := fileFn.Args[1]
+	require.Equal(t, "expand", fileFnExpandArg.Name)
+	require.Equal(t, core.TypeDefKindBoolean, fileFnExpandArg.TypeDef.Kind)
 
 	withMountedDirectoryFn, ok := ctrObj.FunctionByName("withMountedDirectory")
 	require.True(t, ok)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -124,6 +124,12 @@ type Container {
   Mounts are included.
   """
   directory(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """The path of the directory to retrieve (e.g., "./src")."""
     path: String!
   ): Directory!
@@ -167,6 +173,12 @@ type Container {
   It can also export platform variants.
   """
   export(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """
     Force each layer of the exported image to use the specified compression algorithm.
     
@@ -213,6 +225,12 @@ type Container {
   Mounts are included.
   """
   file(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
     """The path of the file to retrieve (e.g., "./README.md")."""
     path: String!
   ): File!
@@ -425,6 +443,12 @@ type Container {
     exclude: [String!] = []
 
     """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
     Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
     """
     include: [String!] = []
@@ -454,8 +478,8 @@ type Container {
   """Retrieves this container plus the given environment variable."""
   withEnvVariable(
     """
-    Replace `${VAR}` or `$VAR` in the value according to the current environment
-    variables defined in the container (e.g., "/opt/bin:$PATH").
+    Replace ${VAR} or $VAR in the value according to the current environment
+    variables defined in the container (e.g. "/opt/bin:$PATH").
     """
     expand: Boolean = false
 
@@ -476,6 +500,12 @@ type Container {
     If empty, the container's default command is used.
     """
     args: [String!]!
+
+    """
+    Replace ${VAR} or $VAR in the args according to the current environment
+    variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
 
     """
     Provides Dagger access to the executed command.
@@ -541,6 +571,12 @@ type Container {
   """
   withFile(
     """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
+    """
     A user:group to set for the file.
     
     The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -563,6 +599,12 @@ type Container {
   Retrieves this container plus the contents of the given files copied to the given path.
   """
   withFiles(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
     """
     A user:group to set for the files.
     
@@ -604,6 +646,12 @@ type Container {
     cache: CacheVolumeID!
 
     """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
     A user:group to set for the mounted cache directory.
     
     Note that this changes the ownership of the specified mount along with the
@@ -629,6 +677,12 @@ type Container {
   """Retrieves this container plus a directory mounted at the given path."""
   withMountedDirectory(
     """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
     A user:group to set for the mounted directory and its contents.
     
     The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -646,6 +700,12 @@ type Container {
 
   """Retrieves this container plus a file mounted at the given path."""
   withMountedFile(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
     """
     A user or user:group to set for the mounted file.
     
@@ -666,6 +726,12 @@ type Container {
   Retrieves this container plus a secret mounted into a file at the given path.
   """
   withMountedSecret(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """
     Permission given to the mounted secret (e.g., 0600).
     
@@ -695,6 +761,12 @@ type Container {
   persisted to subsequent withExecs.
   """
   withMountedTemp(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """Location of the temporary directory (e.g., "/tmp/temp_dir")."""
     path: String!
   ): Container!
@@ -703,6 +775,12 @@ type Container {
   withNewFile(
     """Content of the file to write (e.g., "Hello world!")."""
     contents: String!
+
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
 
     """
     A user:group to set for the file.
@@ -733,6 +811,12 @@ type Container {
 
   """Retrieves this container with the directory at the given path removed."""
   withoutDirectory(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """Location of the directory to remove (e.g., ".github/")."""
     path: String!
   ): Container!
@@ -760,12 +844,24 @@ type Container {
 
   """Retrieves this container with the file at the given path removed."""
   withoutFile(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
     """Location of the file to remove (e.g., "/file.txt")."""
     path: String!
   ): Container!
 
   """Retrieves this container with the files at the given paths removed."""
   withoutFiles(
+    """
+    Replace ${VAR} or $VAR in the value of paths according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    """
+    expand: Boolean = false
+
     """Location of the files to remove (e.g., ["/file.txt"])."""
     paths: [String!]!
   ): Container!
@@ -789,6 +885,12 @@ type Container {
   Retrieves this container after unmounting everything at the given path.
   """
   withoutMount(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """Location of the cache directory (e.g., "/cache/node_modules")."""
     path: String!
   ): Container!
@@ -815,6 +917,12 @@ type Container {
 
   """Retrieves this container with a previously added Unix socket removed."""
   withoutUnixSocket(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """Location of the socket to remove (e.g., "/tmp/socket")."""
     path: String!
   ): Container!
@@ -891,6 +999,12 @@ type Container {
   """
   withUnixSocket(
     """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
     A user:group to set for the mounted socket.
     
     The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -914,6 +1028,12 @@ type Container {
 
   """Retrieves this container with a different working directory."""
   withWorkdir(
+    """
+    Replace ${VAR} or $VAR in the value of path according to the current
+    environment variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
     """The path to set as the working directory (e.g., "/app")."""
     path: String!
   ): Container!

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -3682,6 +3682,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>The path of the directory to retrieve (e.g., &quot;./src&quot;).</p>
                               </div>
@@ -3756,6 +3760,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>forcedCompression</code></span> - <span class="property-type"><a href="#definition-ImageLayerCompression"><code>ImageLayerCompression</code></a></span></h6>
                                 <p>Force each layer of the exported image to use the specified compression algorithm.</p>
                                 <p>If this is unset, then if a layer already has a compressed blob in the engine&#39;s cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine&#39;s cache, then it will be compressed using Gzip.</p>
@@ -3798,6 +3806,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>The path of the file to retrieve (e.g., &quot;./README.md&quot;).</p>
@@ -4081,6 +4093,10 @@
                                 <p>Patterns to exclude in the written directory (e.g. [&quot;node_modules/**&quot;, &quot;.gitignore&quot;, &quot;.git/&quot;]).</p>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Patterns to include in the written directory (e.g. [&quot;*.go&quot;, &quot;go.mod&quot;, &quot;go.sum&quot;]).</p>
                               </div>
@@ -4130,7 +4146,7 @@
                             <div class="field-argument-list">
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Replace <code>${VAR}</code> or <code>$VAR</code> in the value according to the current environment variables defined in the container (e.g., &quot;/opt/bin:$PATH&quot;).</p>
+                                <p>Replace ${VAR} or $VAR in the value according to the current environment variables defined in the container (e.g. &quot;/opt/bin:$PATH&quot;).</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
@@ -4157,6 +4173,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>args</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
                                 <p>Command to run instead of the container&#39;s default command (e.g., [&quot;run&quot;, &quot;main.go&quot;]).</p>
                                 <p>If empty, the container&#39;s default command is used.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -4237,6 +4257,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the file.</p>
                                 <p>The user and group can either be an ID (1000:1000) or a name (foo:bar).</p>
@@ -4267,6 +4291,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the files.</p>
@@ -4328,6 +4356,10 @@
                                 <p>Identifier of the cache volume to mount.</p>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the mounted cache directory.</p>
                                 <p>Note that this changes the ownership of the specified mount along with the initial filesystem provided by source (if any). It does not have any effect if/when the cache has already been created.</p>
@@ -4360,6 +4392,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the mounted directory and its contents.</p>
                                 <p>The user and group can either be an ID (1000:1000) or a name (foo:bar).</p>
@@ -4387,6 +4423,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user or user:group to set for the mounted file.</p>
                                 <p>The user and group can either be an ID (1000:1000) or a name (foo:bar).</p>
@@ -4413,6 +4453,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>mode</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span></h6>
                                 <p>Permission given to the mounted secret (e.g., 0600).</p>
@@ -4446,6 +4490,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the temporary directory (e.g., &quot;/tmp/temp_dir&quot;).</p>
                               </div>
@@ -4465,6 +4513,10 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>contents</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Content of the file to write (e.g., &quot;Hello world!&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
@@ -4514,6 +4566,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the directory to remove (e.g., &quot;.github/&quot;).</p>
@@ -4587,6 +4643,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the file to remove (e.g., &quot;/file.txt&quot;).</p>
                               </div>
@@ -4603,6 +4663,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of paths according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo.txt&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>paths</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
                                 <p>Location of the files to remove (e.g., [&quot;/file.txt&quot;]).</p>
@@ -4644,6 +4708,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the cache directory (e.g., &quot;/cache/node_modules&quot;).</p>
@@ -4696,6 +4764,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the socket to remove (e.g., &quot;/tmp/socket&quot;).</p>
@@ -4818,6 +4890,10 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the mounted socket.</p>
                                 <p>The user and group can either be an ID (1000:1000) or a name (foo:bar).</p>
@@ -4861,6 +4937,10 @@
                           <div class="field-arguments">
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>The path to set as the working directory (e.g., &quot;/app&quot;).</p>

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -96,10 +96,13 @@ defmodule Dagger.Container do
 
   Mounts are included.
   """
-  @spec directory(t(), String.t()) :: Dagger.Directory.t()
-  def directory(%__MODULE__{} = container, path) do
+  @spec directory(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Directory.t()
+  def directory(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("directory") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("directory")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Directory{
       query_builder: query_builder,
@@ -191,7 +194,8 @@ defmodule Dagger.Container do
   @spec export(t(), String.t(), [
           {:platform_variants, [Dagger.ContainerID.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
-          {:media_types, Dagger.ImageMediaTypes.t() | nil}
+          {:media_types, Dagger.ImageMediaTypes.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
@@ -207,6 +211,7 @@ defmodule Dagger.Container do
       )
       |> QB.maybe_put_arg("forcedCompression", optional_args[:forced_compression])
       |> QB.maybe_put_arg("mediaTypes", optional_args[:media_types])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     Client.execute(container.client, query_builder)
   end
@@ -240,10 +245,13 @@ defmodule Dagger.Container do
 
   Mounts are included.
   """
-  @spec file(t(), String.t()) :: Dagger.File.t()
-  def file(%__MODULE__{} = container, path) do
+  @spec file(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.File.t()
+  def file(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("file") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("file")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.File{
       query_builder: query_builder,
@@ -538,7 +546,8 @@ defmodule Dagger.Container do
   @spec with_directory(t(), String.t(), Dagger.Directory.t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
-          {:owner, String.t() | nil}
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_directory(%__MODULE__{} = container, path, directory, optional_args \\ []) do
     query_builder =
@@ -549,6 +558,7 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -596,7 +606,8 @@ defmodule Dagger.Container do
           {:redirect_stdout, String.t() | nil},
           {:redirect_stderr, String.t() | nil},
           {:experimental_privileged_nesting, boolean() | nil},
-          {:insecure_root_capabilities, boolean() | nil}
+          {:insecure_root_capabilities, boolean() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_exec(%__MODULE__{} = container, args, optional_args \\ []) do
     query_builder =
@@ -612,6 +623,7 @@ defmodule Dagger.Container do
         optional_args[:experimental_privileged_nesting]
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -654,7 +666,8 @@ defmodule Dagger.Container do
   @doc "Retrieves this container plus the contents of the given file copied to the given path."
   @spec with_file(t(), String.t(), Dagger.File.t(), [
           {:permissions, integer() | nil},
-          {:owner, String.t() | nil}
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
     query_builder =
@@ -664,6 +677,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("permissions", optional_args[:permissions])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -674,7 +688,8 @@ defmodule Dagger.Container do
   @doc "Retrieves this container plus the contents of the given files copied to the given path."
   @spec with_files(t(), String.t(), [Dagger.FileID.t()], [
           {:permissions, integer() | nil},
-          {:owner, String.t() | nil}
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_files(%__MODULE__{} = container, path, sources, optional_args \\ []) do
     query_builder =
@@ -684,6 +699,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("sources", sources)
       |> QB.maybe_put_arg("permissions", optional_args[:permissions])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -722,7 +738,8 @@ defmodule Dagger.Container do
   @spec with_mounted_cache(t(), String.t(), Dagger.CacheVolume.t(), [
           {:source, Dagger.DirectoryID.t() | nil},
           {:sharing, Dagger.CacheSharingMode.t() | nil},
-          {:owner, String.t() | nil}
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_mounted_cache(%__MODULE__{} = container, path, cache, optional_args \\ []) do
     query_builder =
@@ -733,6 +750,7 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg("source", optional_args[:source])
       |> QB.maybe_put_arg("sharing", optional_args[:sharing])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -741,8 +759,10 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus a directory mounted at the given path."
-  @spec with_mounted_directory(t(), String.t(), Dagger.Directory.t(), [{:owner, String.t() | nil}]) ::
-          Dagger.Container.t()
+  @spec with_mounted_directory(t(), String.t(), Dagger.Directory.t(), [
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
+        ]) :: Dagger.Container.t()
   def with_mounted_directory(%__MODULE__{} = container, path, source, optional_args \\ []) do
     query_builder =
       container.query_builder
@@ -750,6 +770,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("path", path)
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -758,8 +779,10 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus a file mounted at the given path."
-  @spec with_mounted_file(t(), String.t(), Dagger.File.t(), [{:owner, String.t() | nil}]) ::
-          Dagger.Container.t()
+  @spec with_mounted_file(t(), String.t(), Dagger.File.t(), [
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
+        ]) :: Dagger.Container.t()
   def with_mounted_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
     query_builder =
       container.query_builder
@@ -767,6 +790,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("path", path)
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -777,7 +801,8 @@ defmodule Dagger.Container do
   @doc "Retrieves this container plus a secret mounted into a file at the given path."
   @spec with_mounted_secret(t(), String.t(), Dagger.Secret.t(), [
           {:owner, String.t() | nil},
-          {:mode, integer() | nil}
+          {:mode, integer() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_mounted_secret(%__MODULE__{} = container, path, source, optional_args \\ []) do
     query_builder =
@@ -787,6 +812,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("owner", optional_args[:owner])
       |> QB.maybe_put_arg("mode", optional_args[:mode])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -795,10 +821,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs."
-  @spec with_mounted_temp(t(), String.t()) :: Dagger.Container.t()
-  def with_mounted_temp(%__MODULE__{} = container, path) do
+  @spec with_mounted_temp(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def with_mounted_temp(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withMountedTemp") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withMountedTemp")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -809,7 +838,8 @@ defmodule Dagger.Container do
   @doc "Retrieves this container plus a new file written at the given path."
   @spec with_new_file(t(), String.t(), String.t(), [
           {:permissions, integer() | nil},
-          {:owner, String.t() | nil}
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_new_file(%__MODULE__{} = container, path, contents, optional_args \\ []) do
     query_builder =
@@ -819,6 +849,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("contents", contents)
       |> QB.maybe_put_arg("permissions", optional_args[:permissions])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -895,8 +926,10 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus a socket forwarded to the given Unix socket path."
-  @spec with_unix_socket(t(), String.t(), Dagger.Socket.t(), [{:owner, String.t() | nil}]) ::
-          Dagger.Container.t()
+  @spec with_unix_socket(t(), String.t(), Dagger.Socket.t(), [
+          {:owner, String.t() | nil},
+          {:expand, boolean() | nil}
+        ]) :: Dagger.Container.t()
   def with_unix_socket(%__MODULE__{} = container, path, source, optional_args \\ []) do
     query_builder =
       container.query_builder
@@ -904,6 +937,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("path", path)
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("owner", optional_args[:owner])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -924,10 +958,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container with a different working directory."
-  @spec with_workdir(t(), String.t()) :: Dagger.Container.t()
-  def with_workdir(%__MODULE__{} = container, path) do
+  @spec with_workdir(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def with_workdir(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withWorkdir") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withWorkdir")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -960,10 +997,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container with the directory at the given path removed."
-  @spec without_directory(t(), String.t()) :: Dagger.Container.t()
-  def without_directory(%__MODULE__{} = container, path) do
+  @spec without_directory(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def without_directory(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withoutDirectory") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withoutDirectory")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -1014,10 +1054,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container with the file at the given path removed."
-  @spec without_file(t(), String.t()) :: Dagger.Container.t()
-  def without_file(%__MODULE__{} = container, path) do
+  @spec without_file(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def without_file(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withoutFile") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withoutFile")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -1026,10 +1069,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container with the files at the given paths removed."
-  @spec without_files(t(), [String.t()]) :: Dagger.Container.t()
-  def without_files(%__MODULE__{} = container, paths) do
+  @spec without_files(t(), [String.t()], [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def without_files(%__MODULE__{} = container, paths, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withoutFiles") |> QB.put_arg("paths", paths)
+      container.query_builder
+      |> QB.select("withoutFiles")
+      |> QB.put_arg("paths", paths)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -1066,10 +1112,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container after unmounting everything at the given path."
-  @spec without_mount(t(), String.t()) :: Dagger.Container.t()
-  def without_mount(%__MODULE__{} = container, path) do
+  @spec without_mount(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def without_mount(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withoutMount") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withoutMount")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -1104,10 +1153,13 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container with a previously added Unix socket removed."
-  @spec without_unix_socket(t(), String.t()) :: Dagger.Container.t()
-  def without_unix_socket(%__MODULE__{} = container, path) do
+  @spec without_unix_socket(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  def without_unix_socket(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("withoutUnixSocket") |> QB.put_arg("path", path)
+      container.query_builder
+      |> QB.select("withoutUnixSocket")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -460,11 +460,23 @@ func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
 	return response, q.Execute(ctx)
 }
 
+// ContainerDirectoryOpts contains options for Container.Directory
+type ContainerDirectoryOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves a directory at the given path.
 //
 // Mounts are included.
-func (r *Container) Directory(path string) *Directory {
+func (r *Container) Directory(path string, opts ...ContainerDirectoryOpts) *Directory {
 	q := r.query.Select("directory")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Directory{
@@ -570,6 +582,8 @@ type ContainerExportOpts struct {
 	//
 	// Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
 	MediaTypes ImageMediaTypes
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Writes the container as an OCI tarball to the destination file path on the host.
@@ -592,6 +606,10 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 		// `mediaTypes` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
 			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -637,11 +655,23 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	return convert(response), nil
 }
 
+// ContainerFileOpts contains options for Container.File
+type ContainerFileOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
+}
+
 // Retrieves a file at the given path.
 //
 // Mounts are included.
-func (r *Container) File(path string) *File {
+func (r *Container) File(path string, opts ...ContainerFileOpts) *File {
 	q := r.query.Select("file")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &File{
@@ -1050,6 +1080,8 @@ type ContainerWithDirectoryOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container plus a directory written at the given path.
@@ -1068,6 +1100,10 @@ func (r *Container) WithDirectory(path string, directory *Directory, opts ...Con
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1102,7 +1138,7 @@ func (r *Container) WithEntrypoint(args []string, opts ...ContainerWithEntrypoin
 
 // ContainerWithEnvVariableOpts contains options for Container.WithEnvVariable
 type ContainerWithEnvVariableOpts struct {
-	// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+	// Replace ${VAR} or $VAR in the value according to the current environment variables defined in the container (e.g. "/opt/bin:$PATH").
 	Expand bool
 }
 
@@ -1139,6 +1175,8 @@ type ContainerWithExecOpts struct {
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
+	// Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container after executing the specified command inside it.
@@ -1168,6 +1206,10 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
 			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("args", args)
@@ -1227,6 +1269,8 @@ type ContainerWithFileOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
 }
 
 // Retrieves this container plus the contents of the given file copied to the given path.
@@ -1241,6 +1285,10 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1261,6 +1309,8 @@ type ContainerWithFilesOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
 }
 
 // Retrieves this container plus the contents of the given files copied to the given path.
@@ -1274,6 +1324,10 @@ func (r *Container) WithFiles(path string, sources []*File, opts ...ContainerWit
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1318,6 +1372,8 @@ type ContainerWithMountedCacheOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container plus a cache volume mounted at the given path.
@@ -1337,6 +1393,10 @@ func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...Co
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
 		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
 	}
 	q = q.Arg("path", path)
 	q = q.Arg("cache", cache)
@@ -1354,6 +1414,8 @@ type ContainerWithMountedDirectoryOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container plus a directory mounted at the given path.
@@ -1364,6 +1426,10 @@ func (r *Container) WithMountedDirectory(path string, source *Directory, opts ..
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1382,6 +1448,8 @@ type ContainerWithMountedFileOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
 }
 
 // Retrieves this container plus a file mounted at the given path.
@@ -1392,6 +1460,10 @@ func (r *Container) WithMountedFile(path string, source *File, opts ...Container
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1414,6 +1486,8 @@ type ContainerWithMountedSecretOpts struct {
 	//
 	// This option requires an owner to be set to be active.
 	Mode int
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container plus a secret mounted into a file at the given path.
@@ -1429,6 +1503,10 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 		if !querybuilder.IsZeroValue(opts[i].Mode) {
 			q = q.Arg("mode", opts[i].Mode)
 		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
 	}
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
@@ -1438,9 +1516,21 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 	}
 }
 
+// ContainerWithMountedTempOpts contains options for Container.WithMountedTemp
+type ContainerWithMountedTempOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
-func (r *Container) WithMountedTemp(path string) *Container {
+func (r *Container) WithMountedTemp(path string, opts ...ContainerWithMountedTempOpts) *Container {
 	q := r.query.Select("withMountedTemp")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{
@@ -1458,6 +1548,8 @@ type ContainerWithNewFileOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
 }
 
 // Retrieves this container plus a new file written at the given path.
@@ -1471,6 +1563,10 @@ func (r *Container) WithNewFile(path string, contents string, opts ...ContainerW
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1543,6 +1639,8 @@ type ContainerWithUnixSocketOpts struct {
 	//
 	// If the group is omitted, it defaults to the same as the user.
 	Owner string
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // Retrieves this container plus a socket forwarded to the given Unix socket path.
@@ -1553,6 +1651,10 @@ func (r *Container) WithUnixSocket(path string, source *Socket, opts ...Containe
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
 			q = q.Arg("owner", opts[i].Owner)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1573,9 +1675,21 @@ func (r *Container) WithUser(name string) *Container {
 	}
 }
 
+// ContainerWithWorkdirOpts contains options for Container.WithWorkdir
+type ContainerWithWorkdirOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves this container with a different working directory.
-func (r *Container) WithWorkdir(path string) *Container {
+func (r *Container) WithWorkdir(path string, opts ...ContainerWithWorkdirOpts) *Container {
 	q := r.query.Select("withWorkdir")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{
@@ -1602,9 +1716,21 @@ func (r *Container) WithoutDefaultArgs() *Container {
 	}
 }
 
+// ContainerWithoutDirectoryOpts contains options for Container.WithoutDirectory
+type ContainerWithoutDirectoryOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves this container with the directory at the given path removed.
-func (r *Container) WithoutDirectory(path string) *Container {
+func (r *Container) WithoutDirectory(path string, opts ...ContainerWithoutDirectoryOpts) *Container {
 	q := r.query.Select("withoutDirectory")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{
@@ -1665,9 +1791,21 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 	}
 }
 
+// ContainerWithoutFileOpts contains options for Container.WithoutFile
+type ContainerWithoutFileOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
+}
+
 // Retrieves this container with the file at the given path removed.
-func (r *Container) WithoutFile(path string) *Container {
+func (r *Container) WithoutFile(path string, opts ...ContainerWithoutFileOpts) *Container {
 	q := r.query.Select("withoutFile")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{
@@ -1675,9 +1813,21 @@ func (r *Container) WithoutFile(path string) *Container {
 	}
 }
 
+// ContainerWithoutFilesOpts contains options for Container.WithoutFiles
+type ContainerWithoutFilesOpts struct {
+	// Replace ${VAR} or $VAR in the value of paths according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+	Expand bool
+}
+
 // Retrieves this container with the files at the given paths removed.
-func (r *Container) WithoutFiles(paths []string) *Container {
+func (r *Container) WithoutFiles(paths []string, opts ...ContainerWithoutFilesOpts) *Container {
 	q := r.query.Select("withoutFiles")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("paths", paths)
 
 	return &Container{
@@ -1706,9 +1856,21 @@ func (r *Container) WithoutLabel(name string) *Container {
 	}
 }
 
+// ContainerWithoutMountOpts contains options for Container.WithoutMount
+type ContainerWithoutMountOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves this container after unmounting everything at the given path.
-func (r *Container) WithoutMount(path string) *Container {
+func (r *Container) WithoutMount(path string, opts ...ContainerWithoutMountOpts) *Container {
 	q := r.query.Select("withoutMount")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{
@@ -1736,9 +1898,21 @@ func (r *Container) WithoutSecretVariable(name string) *Container {
 	}
 }
 
+// ContainerWithoutUnixSocketOpts contains options for Container.WithoutUnixSocket
+type ContainerWithoutUnixSocketOpts struct {
+	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+}
+
 // Retrieves this container with a previously added Unix socket removed.
-func (r *Container) WithoutUnixSocket(path string) *Container {
+func (r *Container) WithoutUnixSocket(path string, opts ...ContainerWithoutUnixSocketOpts) *Container {
 	q := r.query.Select("withoutUnixSocket")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Container{

--- a/sdk/php/dev/dagger.json
+++ b/sdk/php/dev/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "php-sdk-dev",
-  "sdk": "php",
+  "sdk": "php@05cab0d6502599671a9da7d338011edd3a76129c",
   "dependencies": [
     {
       "name": "always-exec",

--- a/sdk/php/dev/src/PhpSdkDev.php
+++ b/sdk/php/dev/src/PhpSdkDev.php
@@ -17,7 +17,12 @@ use function Dagger\dag;
 #[Doc("The PHP SDK's development module.")]
 final class PhpSdkDev
 {
-    private const SDK_ROOT='/src/sdk/php';
+    private const SDK_ROOT = '/src/sdk/php';
+
+    #[DaggerFunction]
+    public function __construct(
+        private ?Container $container = null,
+    ) {}
 
     #[DaggerFunction]
     #[Doc('Run tests from source directory')]
@@ -28,8 +33,7 @@ final class PhpSdkDev
         ?string $group = null,
     ): Container {
         return $this->base($source)->withExec(
-            is_null($group) ? ['phpunit'] : ['phpunit', "--group=$group"],
-            experimentalPrivilegedNesting: true,
+            is_null($group) ? ['phpunit'] : ['phpunit', "--group=$group"]
         );
     }
 
@@ -88,7 +92,7 @@ final class PhpSdkDev
 
     private function base(Directory $source): Container
     {
-        return dag()
+        return $this->container ?? dag()
             ->container()
             ->from('php:8.3-cli-alpine')
             ->withFile('/usr/bin/composer', dag()

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -86,10 +86,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
      *
      * Mounts are included.
      */
-    public function directory(string $path): Directory
+    public function directory(string $path, ?bool $expand = false): Directory
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -158,6 +161,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?array $platformVariants = null,
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
+        ?bool $expand = false,
     ): string {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
@@ -169,6 +173,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $mediaTypes) {
         $leafQueryBuilder->setArgument('mediaTypes', $mediaTypes);
+        }
+        if (null !== $expand) {
+        $leafQueryBuilder->setArgument('expand', $expand);
         }
         return (string)$this->queryLeaf($leafQueryBuilder, 'export');
     }
@@ -189,10 +196,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
      *
      * Mounts are included.
      */
-    public function file(string $path): File
+    public function file(string $path, ?bool $expand = false): File
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -439,6 +449,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?array $exclude = null,
         ?array $include = null,
         ?string $owner = '',
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDirectory');
         $innerQueryBuilder->setArgument('path', $path);
@@ -451,6 +462,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -493,6 +507,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?string $redirectStderr = '',
         ?bool $experimentalPrivilegedNesting = false,
         ?bool $insecureRootCapabilities = false,
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withExec');
         $innerQueryBuilder->setArgument('args', $args);
@@ -513,6 +528,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -554,6 +572,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         FileId|File $source,
         ?int $permissions = null,
         ?string $owner = '',
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFile');
         $innerQueryBuilder->setArgument('path', $path);
@@ -564,14 +583,22 @@ class Container extends Client\AbstractObject implements Client\IdAble
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Retrieves this container plus the contents of the given files copied to the given path.
      */
-    public function withFiles(string $path, array $sources, ?int $permissions = null, ?string $owner = ''): Container
-    {
+    public function withFiles(
+        string $path,
+        array $sources,
+        ?int $permissions = null,
+        ?string $owner = '',
+        ?bool $expand = false,
+    ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFiles');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('sources', $sources);
@@ -580,6 +607,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -613,6 +643,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         DirectoryId|Directory|null $source = null,
         ?CacheSharingMode $sharing = null,
         ?string $owner = '',
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedCache');
         $innerQueryBuilder->setArgument('path', $path);
@@ -626,19 +657,29 @@ class Container extends Client\AbstractObject implements Client\IdAble
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Retrieves this container plus a directory mounted at the given path.
      */
-    public function withMountedDirectory(string $path, DirectoryId|Directory $source, ?string $owner = ''): Container
-    {
+    public function withMountedDirectory(
+        string $path,
+        DirectoryId|Directory $source,
+        ?string $owner = '',
+        ?bool $expand = false,
+    ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedDirectory');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -646,13 +687,20 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container plus a file mounted at the given path.
      */
-    public function withMountedFile(string $path, FileId|File $source, ?string $owner = ''): Container
-    {
+    public function withMountedFile(
+        string $path,
+        FileId|File $source,
+        ?string $owner = '',
+        ?bool $expand = false,
+    ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedFile');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -665,6 +713,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         SecretId|Secret $source,
         ?string $owner = '',
         ?int $mode = 256,
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedSecret');
         $innerQueryBuilder->setArgument('path', $path);
@@ -675,16 +724,22 @@ class Container extends Client\AbstractObject implements Client\IdAble
         if (null !== $mode) {
         $innerQueryBuilder->setArgument('mode', $mode);
         }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
      */
-    public function withMountedTemp(string $path): Container
+    public function withMountedTemp(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedTemp');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -696,6 +751,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         string $contents,
         ?int $permissions = 420,
         ?string $owner = '',
+        ?bool $expand = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withNewFile');
         $innerQueryBuilder->setArgument('path', $path);
@@ -705,6 +761,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -762,13 +821,20 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container plus a socket forwarded to the given Unix socket path.
      */
-    public function withUnixSocket(string $path, SocketId|Socket $source, ?string $owner = ''): Container
-    {
+    public function withUnixSocket(
+        string $path,
+        SocketId|Socket $source,
+        ?string $owner = '',
+        ?bool $expand = false,
+    ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withUnixSocket');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -786,10 +852,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container with a different working directory.
      */
-    public function withWorkdir(string $path): Container
+    public function withWorkdir(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withWorkdir');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -815,10 +884,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container with the directory at the given path removed.
      */
-    public function withoutDirectory(string $path): Container
+    public function withoutDirectory(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutDirectory');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -860,20 +932,26 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container with the file at the given path removed.
      */
-    public function withoutFile(string $path): Container
+    public function withoutFile(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutFile');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Retrieves this container with the files at the given paths removed.
      */
-    public function withoutFiles(array $paths): Container
+    public function withoutFiles(array $paths, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutFiles');
         $innerQueryBuilder->setArgument('paths', $paths);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -901,10 +979,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container after unmounting everything at the given path.
      */
-    public function withoutMount(string $path): Container
+    public function withoutMount(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutMount');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -931,10 +1012,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container with a previously added Unix socket removed.
      */
-    public function withoutUnixSocket(string $path): Container
+    public function withoutUnixSocket(string $path, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutUnixSocket');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -501,7 +501,12 @@ class Container(Type):
         _ctx = self._select("defaultArgs", _args)
         return await _ctx.execute(list[str])
 
-    def directory(self, path: str) -> "Directory":
+    def directory(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> "Directory":
         """Retrieves a directory at the given path.
 
         Mounts are included.
@@ -510,9 +515,14 @@ class Container(Type):
         ----------
         path:
             The path of the directory to retrieve (e.g., "./src").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -625,6 +635,7 @@ class Container(Type):
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        expand: bool | None = False,
     ) -> str:
         """Writes the container as an OCI tarball to the destination file path on
         the host.
@@ -652,6 +663,10 @@ class Container(Type):
             Defaults to OCI, which is largely compatible with most recent
             container runtimes, but Docker may be needed for older runtimes
             without OCI support.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
 
         Returns
         -------
@@ -675,6 +690,7 @@ class Container(Type):
             ),
             Arg("forcedCompression", forced_compression, None),
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(str)
@@ -704,7 +720,12 @@ class Container(Type):
             for v in _ids
         ]
 
-    def file(self, path: str) -> "File":
+    def file(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> "File":
         """Retrieves a file at the given path.
 
         Mounts are included.
@@ -713,9 +734,14 @@ class Container(Type):
         ----------
         path:
             The path of the file to retrieve (e.g., "./README.md").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -1211,6 +1237,7 @@ class Container(Type):
         exclude: list[str] | None = None,
         include: list[str] | None = None,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a directory written at the given path.
 
@@ -1231,6 +1258,10 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
@@ -1238,6 +1269,7 @@ class Container(Type):
             Arg("exclude", [] if exclude is None else exclude),
             Arg("include", [] if include is None else include),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withDirectory", _args)
         return Container(_ctx)
@@ -1280,8 +1312,8 @@ class Container(Type):
         value:
             The value of the environment variable. (e.g., "localhost").
         expand:
-            Replace `${VAR}` or `$VAR` in the value according to the current
-            environment variables defined in the container (e.g.,
+            Replace ${VAR} or $VAR in the value according to the current
+            environment variables defined in the container (e.g.
             "/opt/bin:$PATH").
         """
         _args = [
@@ -1302,6 +1334,7 @@ class Container(Type):
         redirect_stderr: str | None = "",
         experimental_privileged_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container after executing the specified command inside
         it.
@@ -1334,6 +1367,9 @@ class Container(Type):
             --privileged" flag. Containerization does not provide any security
             guarantees when using this option. It should only be used when
             absolutely necessary and only with trusted commands.
+        expand:
+            Replace ${VAR} or $VAR in the args according to the current
+            environment variables defined in the container (e.g. "/$VAR/foo").
         """
         _args = [
             Arg("args", args),
@@ -1345,6 +1381,7 @@ class Container(Type):
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)
@@ -1392,6 +1429,7 @@ class Container(Type):
         *,
         permissions: int | None = None,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -1409,12 +1447,17 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("permissions", permissions, None),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withFile", _args)
         return Container(_ctx)
@@ -1426,6 +1469,7 @@ class Container(Type):
         *,
         permissions: int | None = None,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus the contents of the given files copied
         to the given path.
@@ -1443,12 +1487,17 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
             Arg("sources", sources),
             Arg("permissions", permissions, None),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withFiles", _args)
         return Container(_ctx)
@@ -1487,6 +1536,7 @@ class Container(Type):
         source: "Directory | None" = None,
         sharing: CacheSharingMode | None = CacheSharingMode.SHARED,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1509,6 +1559,10 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
@@ -1516,6 +1570,7 @@ class Container(Type):
             Arg("source", source, None),
             Arg("sharing", sharing, CacheSharingMode.SHARED),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedCache", _args)
         return Container(_ctx)
@@ -1526,6 +1581,7 @@ class Container(Type):
         source: "Directory",
         *,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a directory mounted at the given path.
 
@@ -1540,11 +1596,16 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedDirectory", _args)
         return Container(_ctx)
@@ -1555,6 +1616,7 @@ class Container(Type):
         source: "File",
         *,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a file mounted at the given path.
 
@@ -1569,11 +1631,16 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedFile", _args)
         return Container(_ctx)
@@ -1585,6 +1652,7 @@ class Container(Type):
         *,
         owner: str | None = "",
         mode: int | None = 256,
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a secret mounted into a file at the
         given path.
@@ -1603,17 +1671,27 @@ class Container(Type):
         mode:
             Permission given to the mounted secret (e.g., 0600).
             This option requires an owner to be set to be active.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("owner", owner, ""),
             Arg("mode", mode, 256),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedSecret", _args)
         return Container(_ctx)
 
-    def with_mounted_temp(self, path: str) -> Self:
+    def with_mounted_temp(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container plus a temporary directory mounted at the
         given path. Any writes will be ephemeral to a single withExec call;
         they will not be persisted to subsequent withExecs.
@@ -1622,9 +1700,14 @@ class Container(Type):
         ----------
         path:
             Location of the temporary directory (e.g., "/tmp/temp_dir").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedTemp", _args)
         return Container(_ctx)
@@ -1636,6 +1719,7 @@ class Container(Type):
         *,
         permissions: int | None = 420,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a new file written at the given path.
 
@@ -1652,12 +1736,17 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
             Arg("contents", contents),
             Arg("permissions", permissions, 420),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withNewFile", _args)
         return Container(_ctx)
@@ -1755,6 +1844,7 @@ class Container(Type):
         source: "Socket",
         *,
         owner: str | None = "",
+        expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
@@ -1770,11 +1860,16 @@ class Container(Type):
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("owner", owner, ""),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withUnixSocket", _args)
         return Container(_ctx)
@@ -1793,16 +1888,26 @@ class Container(Type):
         _ctx = self._select("withUser", _args)
         return Container(_ctx)
 
-    def with_workdir(self, path: str) -> Self:
+    def with_workdir(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container with a different working directory.
 
         Parameters
         ----------
         path:
             The path to set as the working directory (e.g., "/app").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withWorkdir", _args)
         return Container(_ctx)
@@ -1829,16 +1934,26 @@ class Container(Type):
         _ctx = self._select("withoutDefaultArgs", _args)
         return Container(_ctx)
 
-    def without_directory(self, path: str) -> Self:
+    def without_directory(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container with the directory at the given path removed.
 
         Parameters
         ----------
         path:
             Location of the directory to remove (e.g., ".github/").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutDirectory", _args)
         return Container(_ctx)
@@ -1897,30 +2012,50 @@ class Container(Type):
         _ctx = self._select("withoutExposedPort", _args)
         return Container(_ctx)
 
-    def without_file(self, path: str) -> Self:
+    def without_file(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container with the file at the given path removed.
 
         Parameters
         ----------
         path:
             Location of the file to remove (e.g., "/file.txt").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutFile", _args)
         return Container(_ctx)
 
-    def without_files(self, paths: list[str]) -> Self:
+    def without_files(
+        self,
+        paths: list[str],
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container with the files at the given paths removed.
 
         Parameters
         ----------
         paths:
             Location of the files to remove (e.g., ["/file.txt"]).
+        expand:
+            Replace ${VAR} or $VAR in the value of paths according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo.txt").
         """
         _args = [
             Arg("paths", paths),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutFiles", _args)
         return Container(_ctx)
@@ -1950,7 +2085,12 @@ class Container(Type):
         _ctx = self._select("withoutLabel", _args)
         return Container(_ctx)
 
-    def without_mount(self, path: str) -> Self:
+    def without_mount(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container after unmounting everything at the given
         path.
 
@@ -1958,9 +2098,14 @@ class Container(Type):
         ----------
         path:
             Location of the cache directory (e.g., "/cache/node_modules").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutMount", _args)
         return Container(_ctx)
@@ -1997,16 +2142,26 @@ class Container(Type):
         _ctx = self._select("withoutSecretVariable", _args)
         return Container(_ctx)
 
-    def without_unix_socket(self, path: str) -> Self:
+    def without_unix_socket(
+        self,
+        path: str,
+        *,
+        expand: bool | None = False,
+    ) -> Self:
         """Retrieves this container with a previously added Unix socket removed.
 
         Parameters
         ----------
         path:
             Location of the socket to remove (e.g., "/tmp/socket").
+        expand:
+            Replace ${VAR} or $VAR in the value of path according to the
+            current environment variables defined in the container (e.g.
+            "/$VAR/foo").
         """
         _args = [
             Arg("path", path),
+            Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutUnixSocket", _args)
         return Container(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1479,7 +1479,16 @@ pub struct ContainerBuildOpts<'a> {
     pub target: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ContainerDirectoryOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerExportOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// Force each layer of the exported image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -1492,6 +1501,12 @@ pub struct ContainerExportOpts {
     /// Used for multi-platform image.
     #[builder(setter(into, strip_option), default)]
     pub platform_variants: Option<Vec<ContainerId>>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerFileOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerImportOpts<'a> {
@@ -1552,6 +1567,9 @@ pub struct ContainerWithDirectoryOpts<'a> {
     /// Patterns to exclude in the written directory (e.g. ["node_modules/**", ".gitignore", ".git/"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
@@ -1569,12 +1587,15 @@ pub struct ContainerWithEntrypointOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEnvVariableOpts {
-    /// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+    /// Replace ${VAR} or $VAR in the value according to the current environment variables defined in the container (e.g. "/opt/bin:$PATH").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
+    /// Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
@@ -1609,6 +1630,9 @@ pub struct ContainerWithExposedPortOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFileOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1620,6 +1644,9 @@ pub struct ContainerWithFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFilesOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the files.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1631,6 +1658,9 @@ pub struct ContainerWithFilesOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedCacheOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the mounted cache directory.
     /// Note that this changes the ownership of the specified mount along with the initial filesystem provided by source (if any). It does not have any effect if/when the cache has already been created.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -1646,6 +1676,9 @@ pub struct ContainerWithMountedCacheOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedDirectoryOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the mounted directory and its contents.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1654,6 +1687,9 @@ pub struct ContainerWithMountedDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedFileOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user or user:group to set for the mounted file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1662,6 +1698,9 @@ pub struct ContainerWithMountedFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedSecretOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// Permission given to the mounted secret (e.g., 0600).
     /// This option requires an owner to be set to be active.
     #[builder(setter(into, strip_option), default)]
@@ -1673,7 +1712,16 @@ pub struct ContainerWithMountedSecretOpts<'a> {
     pub owner: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithMountedTempOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithNewFileOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1685,11 +1733,26 @@ pub struct ContainerWithNewFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithUnixSocketOpts<'a> {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
     /// A user:group to set for the mounted socket.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
     #[builder(setter(into, strip_option), default)]
     pub owner: Option<&'a str>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithWorkdirOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutDirectoryOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutEntrypointOpts {
@@ -1702,6 +1765,30 @@ pub struct ContainerWithoutExposedPortOpts {
     /// Port protocol to unexpose
     #[builder(setter(into, strip_option), default)]
     pub protocol: Option<NetworkProtocol>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutFileOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutFilesOpts {
+    /// Replace ${VAR} or $VAR in the value of paths according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutMountOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutUnixSocketOpts {
+    /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
 }
 impl Container {
     /// Turn the container into a Service.
@@ -1818,9 +1905,33 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - The path of the directory to retrieve (e.g., "./src").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
         query = query.arg("path", path.into());
+        Directory {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves a directory at the given path.
+    /// Mounts are included.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path of the directory to retrieve (e.g., "./src").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn directory_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerDirectoryOpts,
+    ) -> Directory {
+        let mut query = self.selection.select("directory");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1923,6 +2034,9 @@ impl Container {
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
@@ -1941,9 +2055,29 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - The path of the file to retrieve (e.g., "./README.md").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
         query = query.arg("path", path.into());
+        File {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves a file at the given path.
+    /// Mounts are included.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path of the file to retrieve (e.g., "./README.md").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn file_opts(&self, path: impl Into<String>, opts: ContainerFileOpts) -> File {
+        let mut query = self.selection.select("file");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -2333,6 +2467,9 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2487,6 +2624,9 @@ impl Container {
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2593,6 +2733,9 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2637,6 +2780,9 @@ impl Container {
         }
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
+        }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
         }
         Container {
             proc: self.proc.clone(),
@@ -2727,6 +2873,9 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2785,6 +2934,9 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2842,6 +2994,9 @@ impl Container {
         );
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
+        }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
         }
         Container {
             proc: self.proc.clone(),
@@ -2904,6 +3059,9 @@ impl Container {
         if let Some(mode) = opts.mode {
             query = query.arg("mode", mode);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2915,9 +3073,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withMountedTemp");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn with_mounted_temp_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithMountedTempOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withMountedTemp");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2962,6 +3143,9 @@ impl Container {
         }
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
+        }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
         }
         Container {
             proc: self.proc.clone(),
@@ -3127,6 +3311,9 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3152,9 +3339,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - The path to set as the working directory (e.g., "/app").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_workdir(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withWorkdir");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container with a different working directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to set as the working directory (e.g., "/app").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn with_workdir_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithWorkdirOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withWorkdir");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3189,9 +3399,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - Location of the directory to remove (e.g., ".github/").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_directory(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutDirectory");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container with the directory at the given path removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory to remove (e.g., ".github/").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_directory_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithoutDirectoryOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withoutDirectory");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3283,9 +3516,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - Location of the file to remove (e.g., "/file.txt").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_file(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutFile");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container with the file at the given path removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the file to remove (e.g., "/file.txt").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_file_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithoutFileOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withoutFile");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3297,12 +3553,38 @@ impl Container {
     /// # Arguments
     ///
     /// * `paths` - Location of the files to remove (e.g., ["/file.txt"]).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_files(&self, paths: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withoutFiles");
         query = query.arg(
             "paths",
             paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container with the files at the given paths removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `paths` - Location of the files to remove (e.g., ["/file.txt"]).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_files_opts(
+        &self,
+        paths: Vec<impl Into<String>>,
+        opts: ContainerWithoutFilesOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withoutFiles");
+        query = query.arg(
+            "paths",
+            paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3338,9 +3620,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_mount(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutMount");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container after unmounting everything at the given path.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_mount_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithoutMountOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withoutMount");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3382,9 +3687,32 @@ impl Container {
     /// # Arguments
     ///
     /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
         query = query.arg("path", path.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container with a previously added Unix socket removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_unix_socket_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerWithoutUnixSocketOpts,
+    ) -> Container {
+        let mut query = self.selection.select("withoutUnixSocket");
+        query = query.arg("path", path.into());
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -132,6 +132,13 @@ export type ContainerBuildOpts = {
   secrets?: Secret[]
 }
 
+export type ContainerDirectoryOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
 export type ContainerExportOpts = {
   /**
    * Identifiers for other platform specific containers.
@@ -153,6 +160,18 @@ export type ContainerExportOpts = {
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
    */
   mediaTypes?: ImageMediaTypes
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
+export type ContainerFileOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
 }
 
 export type ContainerImportOpts = {
@@ -251,6 +270,11 @@ export type ContainerWithDirectoryOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithEntrypointOpts = {
@@ -262,7 +286,7 @@ export type ContainerWithEntrypointOpts = {
 
 export type ContainerWithEnvVariableOpts = {
   /**
-   * Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+   * Replace ${VAR} or $VAR in the value according to the current environment variables defined in the container (e.g. "/opt/bin:$PATH").
    */
   expand?: boolean
 }
@@ -299,6 +323,11 @@ export type ContainerWithExecOpts = {
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   insecureRootCapabilities?: boolean
+
+  /**
+   * Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithExposedPortOpts = {
@@ -332,6 +361,11 @@ export type ContainerWithFileOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithFilesOpts = {
@@ -348,6 +382,11 @@ export type ContainerWithFilesOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithMountedCacheOpts = {
@@ -371,6 +410,11 @@ export type ContainerWithMountedCacheOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithMountedDirectoryOpts = {
@@ -382,6 +426,11 @@ export type ContainerWithMountedDirectoryOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithMountedFileOpts = {
@@ -393,6 +442,11 @@ export type ContainerWithMountedFileOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithMountedSecretOpts = {
@@ -411,6 +465,18 @@ export type ContainerWithMountedSecretOpts = {
    * This option requires an owner to be set to be active.
    */
   mode?: number
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithMountedTempOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithNewFileOpts = {
@@ -427,6 +493,11 @@ export type ContainerWithNewFileOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithUnixSocketOpts = {
@@ -438,6 +509,25 @@ export type ContainerWithUnixSocketOpts = {
    * If the group is omitted, it defaults to the same as the user.
    */
   owner?: string
+
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithWorkdirOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithoutDirectoryOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 export type ContainerWithoutEntrypointOpts = {
@@ -452,6 +542,34 @@ export type ContainerWithoutExposedPortOpts = {
    * Port protocol to unexpose
    */
   protocol?: NetworkProtocol
+}
+
+export type ContainerWithoutFileOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithoutFilesOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of paths according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithoutMountOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+}
+
+export type ContainerWithoutUnixSocketOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
 }
 
 /**
@@ -1400,14 +1518,15 @@ export class Container extends BaseClient {
    *
    * Mounts are included.
    * @param path The path of the directory to retrieve (e.g., "./src").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  directory = (path: string): Directory => {
+  directory = (path: string, opts?: ContainerDirectoryOpts): Directory => {
     return new Directory({
       queryTree: [
         ...this._queryTree,
         {
           operation: "directory",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -1548,6 +1667,7 @@ export class Container extends BaseClient {
    * @param opts.mediaTypes Use the specified media types for the exported image's layers.
    *
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   export = async (
     path: string,
@@ -1621,14 +1741,15 @@ export class Container extends BaseClient {
    *
    * Mounts are included.
    * @param path The path of the file to retrieve (e.g., "./README.md").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
-  file = (path: string): File => {
+  file = (path: string, opts?: ContainerFileOpts): File => {
     return new File({
       queryTree: [
         ...this._queryTree,
         {
           operation: "file",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2064,6 +2185,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withDirectory = (
     path: string,
@@ -2107,7 +2229,7 @@ export class Container extends BaseClient {
    * Retrieves this container plus the given environment variable.
    * @param name The name of the environment variable (e.g., "HOST").
    * @param value The value of the environment variable. (e.g., "localhost").
-   * @param opts.expand Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+   * @param opts.expand Replace ${VAR} or $VAR in the value according to the current environment variables defined in the container (e.g. "/opt/bin:$PATH").
    */
   withEnvVariable = (
     name: string,
@@ -2139,6 +2261,7 @@ export class Container extends BaseClient {
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+   * @param opts.expand Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withExec = (args: string[], opts?: ContainerWithExecOpts): Container => {
     return new Container({
@@ -2196,6 +2319,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
   withFile = (
     path: string,
@@ -2224,6 +2348,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
   withFiles = (
     path: string,
@@ -2288,6 +2413,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withMountedCache = (
     path: string,
@@ -2319,6 +2445,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withMountedDirectory = (
     path: string,
@@ -2346,6 +2473,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
   withMountedFile = (
     path: string,
@@ -2376,6 +2504,7 @@ export class Container extends BaseClient {
    * @param opts.mode Permission given to the mounted secret (e.g., 0600).
    *
    * This option requires an owner to be set to be active.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withMountedSecret = (
     path: string,
@@ -2397,14 +2526,18 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
    * @param path Location of the temporary directory (e.g., "/tmp/temp_dir").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  withMountedTemp = (path: string): Container => {
+  withMountedTemp = (
+    path: string,
+    opts?: ContainerWithMountedTempOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withMountedTemp",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2421,6 +2554,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
   withNewFile = (
     path: string,
@@ -2532,6 +2666,7 @@ export class Container extends BaseClient {
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withUnixSocket = (
     path: string,
@@ -2570,14 +2705,15 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container with a different working directory.
    * @param path The path to set as the working directory (e.g., "/app").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  withWorkdir = (path: string): Container => {
+  withWorkdir = (path: string, opts?: ContainerWithWorkdirOpts): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withWorkdir",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2619,14 +2755,18 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container with the directory at the given path removed.
    * @param path Location of the directory to remove (e.g., ".github/").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  withoutDirectory = (path: string): Container => {
+  withoutDirectory = (
+    path: string,
+    opts?: ContainerWithoutDirectoryOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutDirectory",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2695,14 +2835,15 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container with the file at the given path removed.
    * @param path Location of the file to remove (e.g., "/file.txt").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
-  withoutFile = (path: string): Container => {
+  withoutFile = (path: string, opts?: ContainerWithoutFileOpts): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutFile",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2712,14 +2853,18 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container with the files at the given paths removed.
    * @param paths Location of the files to remove (e.g., ["/file.txt"]).
+   * @param opts.expand Replace ${VAR} or $VAR in the value of paths according to the current environment variables defined in the container (e.g. "/$VAR/foo.txt").
    */
-  withoutFiles = (paths: string[]): Container => {
+  withoutFiles = (
+    paths: string[],
+    opts?: ContainerWithoutFilesOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutFiles",
-          args: { paths },
+          args: { paths, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2763,14 +2908,18 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container after unmounting everything at the given path.
    * @param path Location of the cache directory (e.g., "/cache/node_modules").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  withoutMount = (path: string): Container => {
+  withoutMount = (
+    path: string,
+    opts?: ContainerWithoutMountOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutMount",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,
@@ -2816,14 +2965,18 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container with a previously added Unix socket removed.
    * @param path Location of the socket to remove (e.g., "/tmp/socket").
+   * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
-  withoutUnixSocket = (path: string): Container => {
+  withoutUnixSocket = (
+    path: string,
+    opts?: ContainerWithoutUnixSocketOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutUnixSocket",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       ctx: this._ctx,


### PR DESCRIPTION
This adds expanding environment variables in `WithNewFile`.  ref: #7951. If this looks OK, I will add similar changes to other API's in this same PR.