### PR TITLE
feat: apply ignore pattern on context directory git source

### DIFF
--- a/.changes/unreleased/Added-20240913-122008.yaml
+++ b/.changes/unreleased/Added-20240913-122008.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: '`ignore` combined with `defaultPath` now works if the module is fetch from
+  git instead of local.'
+time: 2024-09-13T12:20:08.722733+02:00
+custom:
+  Author: TomChv
+  PR: "8430"

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -309,9 +309,6 @@ func (src *ModuleSource) AutomaticGitignore(ctx context.Context) (*bool, error) 
 // If the module is git, it will load the directory from the git repository
 // using its context directory.
 func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, path string, ignore []string) (inst dagql.Instance[*Directory], err error) {
-	excludes := ignore
-	includes := []string{}
-
 	switch src.Kind {
 	case ModuleSourceKindLocal:
 		bk, err := src.Query.Buildkit(ctx)
@@ -353,7 +350,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 			return inst, fmt.Errorf("path %q is outside of context directory %q, path should be relative to the context directory", path, ctxPath)
 		}
 
-		_, desc, err := bk.LocalImport(localSourceCtx, src.Query.Platform().Spec(), path, excludes, includes)
+		_, desc, err := bk.LocalImport(localSourceCtx, src.Query.Platform().Spec(), path, ignore, []string{})
 		if err != nil {
 			return inst, fmt.Errorf("failed to import local module src: %w", err)
 		}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -377,7 +377,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 			return inst, fmt.Errorf("failed to get dir instance: %w", err)
 		}
 
-		if ignore == nil || len(ignore) == 0 {
+		if len(ignore) == 0 {
 			return loadedDir, nil
 		}
 


### PR DESCRIPTION
Fixe based https://github.com/dagger/dagger/pull/8369 and @helderco feedbacks
 
**Without this fix**

```
dagger call -m github.com/wingyplus/dagger/sdk/php/runtime@cd3a3e724aa5a2ce259fe6b217f0efe5abaaabcb source-dir

_type: Directory
digest: sha256:4efcbbc3978405e30f078b41ff5acb6a0d1f6084906a42d3cf32d4377190a414
entries:
    - .changes
    - .changie.yaml
    - .gitattributes
    - .gitignore
    - .php-cs-fixer.dist.php
    - CHANGELOG.md
    - LICENSE
    - README.md
    - composer.json
    - composer.lock
    - dev
    - docker
    - docker-compose.yml
    - generated
    - phpcs.xml
    - phpunit.xml.dist
    - psalm.xml
    - runtime
    - scripts
    - src
    - tests
```

**With that fix**

```
dagger call -m github.com/wingyplus/dagger/sdk/php/runtime@cd3a3e724aa5a2ce259fe6b217f0efe5abaaabcb source-dir

_type: Directory
digest: sha256:87f768c76fbf1901d1b036461fc9207d82f7eccfc26d892540ef276e332aafbb
entries:
    - LICENSE
    - README.md
    - composer.json
    - composer.lock
    - generated
    - scripts
    - src
```