### PR TITLE
ci: cleanup and extend checks api

### DIFF
--- a/.dagger/checks.go
+++ b/.dagger/checks.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/codes"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	CheckDocs          = "docs"
+	CheckGoSDK         = "sdk/go"
+	CheckPythonSDK     = "sdk/python"
+	CheckTypescriptSDK = "sdk/typescript"
+	CheckPHPSDK        = "sdk/php"
+	CheckJavaSDK       = "sdk/java"
+	CheckRustSDK       = "sdk/rust"
+	CheckElixirSDK     = "sdk/elixir"
+)
+
+// Check that everything works. Use this as CI entrypoint.
+func (dev *DaggerDev) Check(ctx context.Context,
+	// Directories to check
+	// +optional
+	targets []string,
+) error {
+	var routes checkRouter
+	routes.Add(Check{"docs", (&Docs{Dagger: dev}).Lint})
+	routes.Add(dev.checksForSDK(CheckGoSDK, dev.SDK().Go)...)
+	routes.Add(dev.checksForSDK(CheckPythonSDK, dev.SDK().Python)...)
+	routes.Add(dev.checksForSDK(CheckTypescriptSDK, dev.SDK().Typescript)...)
+	routes.Add(dev.checksForSDK(CheckPHPSDK, dev.SDK().PHP)...)
+	routes.Add(dev.checksForSDK(CheckJavaSDK, dev.SDK().Java)...)
+	routes.Add(dev.checksForSDK(CheckRustSDK, dev.SDK().Rust)...)
+	routes.Add(dev.checksForSDK(CheckElixirSDK, dev.SDK().Elixir)...)
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, check := range routes.Get(targets...) {
+		ctx, span := Tracer().Start(ctx, check.Name)
+		eg.Go(func() (rerr error) {
+			defer func() {
+				if rerr != nil {
+					span.SetStatus(codes.Error, rerr.Error())
+				}
+				span.End()
+			}()
+			return check.Check(ctx)
+		})
+	}
+	return eg.Wait()
+}
+
+type Check struct {
+	Name  string
+	Check func(context.Context) error
+}
+
+func (dev *DaggerDev) checksForSDK(name string, sdk sdkBase) []Check {
+	return []Check{
+		{
+			Name:  name + "/lint",
+			Check: sdk.Lint,
+		},
+		{
+			Name:  name + "/test",
+			Check: sdk.Test,
+		},
+		{
+			Name: name + "/test-publish",
+			Check: func(ctx context.Context) error {
+				// Inspect .git to avoid dependencing on $GITHUB_REF
+				ref, err := dev.Ref(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to introspect git ref: %s", err.Error())
+				}
+				return sdk.TestPublish(ctx, ref)
+			},
+		},
+	}
+}
+
+// checkRouter allows easily storing and fetching checks
+// It's similar in style to go-test, where specifying a prefix will match all children.
+type checkRouter struct {
+	check    Check
+	children map[string]*checkRouter
+}
+
+func (r *checkRouter) Add(checks ...Check) {
+	for _, check := range checks {
+		r.add(check.Name, check)
+	}
+}
+
+func (r *checkRouter) Get(targets ...string) []Check {
+	var checks []Check
+	for _, target := range targets {
+		checks = append(checks, r.get(target).all()...)
+	}
+	return checks
+}
+
+func (r *checkRouter) add(target string, check Check) {
+	if target == "" {
+		r.check = check
+		return
+	}
+
+	target, rest, _ := strings.Cut(target, "/")
+	if r.children == nil {
+		r.children = make(map[string]*checkRouter)
+	}
+	if _, ok := r.children[target]; !ok {
+		r.children[target] = &checkRouter{}
+	}
+	r.children[target].add(rest, check)
+}
+
+func (r *checkRouter) get(target string) *checkRouter {
+	if r == nil {
+		return nil
+	}
+	if target == "" {
+		return r
+	}
+
+	target, rest, _ := strings.Cut(target, "/")
+	if r.children == nil {
+		return nil
+	}
+	if _, ok := r.children[target]; !ok {
+		return nil
+	}
+	return r.children[target].get(rest)
+}
+
+func (r *checkRouter) all() []Check {
+	if r == nil {
+		return nil
+	}
+	var checks []Check
+	if r.check.Check != nil {
+		checks = append(checks, r.check)
+	}
+	for _, child := range r.children {
+		checks = append(checks, child.all()...)
+	}
+	return checks
+}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/dagger/dagger/.dagger/internal/dagger"
-	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/sync/errgroup"
 )
 
 // A dev environment for the DaggerDev Engine
@@ -96,15 +94,6 @@ func (dev *DaggerDev) WithModCodegen() *DaggerDev {
 	return &clone
 }
 
-type Check func(context.Context) error
-
-// Wrap 3 SDK-specific checks into a single check
-type SDKChecks interface {
-	Lint(ctx context.Context) error
-	Test(ctx context.Context) error
-	TestPublish(ctx context.Context, tag string) error
-}
-
 func (dev *DaggerDev) Ref(ctx context.Context) (string, error) {
 	// Said .git introspection logic:
 	ref, err := dag.
@@ -127,120 +116,6 @@ func (dev *DaggerDev) Ref(ctx context.Context) (string, error) {
 		return dev.GitRef, nil
 	}
 	return ref, nil
-}
-
-func (dev *DaggerDev) sdkCheck(sdk string) Check {
-	var checks SDKChecks
-	switch sdk {
-	case "python":
-		checks = &PythonSDK{Dagger: dev}
-	case "go":
-		checks = &GoSDK{Dagger: dev}
-	case "typescript":
-		checks = &TypescriptSDK{Dagger: dev}
-	case "php":
-		checks = &PHPSDK{Dagger: dev}
-	case "java":
-		checks = &JavaSDK{Dagger: dev}
-	case "rust":
-		checks = &RustSDK{Dagger: dev}
-	case "elixir":
-		checks = &ElixirSDK{Dagger: dev}
-	}
-	return func(ctx context.Context) (rerr error) {
-		lint := func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, fmt.Sprintf("lint sdk/%s", sdk))
-			defer func() {
-				if rerr != nil {
-					span.SetStatus(codes.Error, rerr.Error())
-				}
-				span.End()
-			}()
-			return checks.Lint(ctx)
-		}
-		test := func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, fmt.Sprintf("test sdk/%s", sdk))
-			defer func() {
-				if rerr != nil {
-					span.SetStatus(codes.Error, rerr.Error())
-				}
-				span.End()
-			}()
-			return checks.Test(ctx)
-		}
-		testPublish := func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, fmt.Sprintf("test-publish sdk/%s", sdk))
-			defer func() {
-				if rerr != nil {
-					span.SetStatus(codes.Error, rerr.Error())
-				}
-				span.End()
-			}()
-			// Inspect .git to avoid dependencing on $GITHUB_REF
-			ref, err := dev.Ref(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to introspect git ref: %s", err.Error())
-			}
-			fmt.Printf("===> ref = \"%s\"\n", ref)
-			return checks.TestPublish(ctx, ref)
-		}
-		if err := lint(); err != nil {
-			return err
-		}
-		if err := test(); err != nil {
-			return err
-		}
-		if err := testPublish(); err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
-const (
-	CheckDocs          = "docs"
-	CheckPythonSDK     = "sdk/python"
-	CheckGoSDK         = "sdk/go"
-	CheckTypescriptSDK = "sdk/typescript"
-	CheckPHPSDK        = "sdk/php"
-	CheckJavaSDK       = "sdk/java"
-	CheckRustSDK       = "sdk/rust"
-	CheckElixirSDK     = "sdk/elixir"
-)
-
-// Check that everything works. Use this as CI entrypoint.
-func (dev *DaggerDev) Check(ctx context.Context,
-	// Directories to check
-	// +optional
-	targets []string,
-) error {
-	var routes = map[string]Check{
-		CheckDocs:          (&Docs{Dagger: dev}).Lint,
-		CheckPythonSDK:     dev.sdkCheck("python"),
-		CheckGoSDK:         dev.sdkCheck("go"),
-		CheckTypescriptSDK: dev.sdkCheck("typescript"),
-		CheckPHPSDK:        dev.sdkCheck("php"),
-		CheckJavaSDK:       dev.sdkCheck("java"),
-		CheckRustSDK:       dev.sdkCheck("rust"),
-		CheckElixirSDK:     dev.sdkCheck("elixir"),
-	}
-	if len(targets) == 0 {
-		targets = make([]string, 0, len(routes))
-		for key := range routes {
-			targets = append(targets, key)
-		}
-	}
-	for _, target := range targets {
-		if _, exists := routes[target]; !exists {
-			return fmt.Errorf("no such target: %s", target)
-		}
-	}
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, target := range targets {
-		check := routes[target]
-		eg.Go(func() error { return check(ctx) })
-	}
-	return eg.Wait()
 }
 
 // Develop the Dagger CLI

--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -41,6 +41,7 @@ func (sdk *SDK) All() *AllSDK {
 type sdkBase interface {
 	Lint(ctx context.Context) error
 	Test(ctx context.Context) error
+	TestPublish(ctx context.Context, tag string) error
 	Generate(ctx context.Context) (*dagger.Directory, error)
 	Bump(ctx context.Context, version string) (*dagger.Directory, error)
 }

--- a/.dagger/sdk_all.go
+++ b/.dagger/sdk_all.go
@@ -33,6 +33,16 @@ func (t AllSDK) Test(ctx context.Context) error {
 	return eg.Wait()
 }
 
+func (t AllSDK) TestPublish(ctx context.Context, tag string) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, sdk := range t.SDK.allSDKs() {
+		eg.Go(func() error {
+			return sdk.TestPublish(ctx, tag)
+		})
+	}
+	return eg.Wait()
+}
+
 func (t AllSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	dirs := make([]*dagger.Directory, len(t.SDK.allSDKs()))


### PR DESCRIPTION
Extended the checks api, so now we have `sdk/go` (and others), which contain `sdk/go/lint`, `sdk/go/test` and `sdk/go/test-publish`.