### PR TITLE
feat(sdk/elixir): apply `+ignore` to sdkSourceDir

### DIFF
--- a/sdk/elixir/dagger.json
+++ b/sdk/elixir/dagger.json
@@ -1,16 +1,6 @@
 {
   "name": "elixir-sdk",
   "sdk": "go",
-  "include": [
-    "LICENSE",
-    "lib/**/*.ex",
-    ".formatter.exs",
-    "mix.exs",
-    "mix.lock",
-    "dagger_codegen/lib/**/*.ex",
-    "dagger_codegen/mix.exs",
-    "dagger_codegen/mix.lock"
-  ],
   "source": "runtime",
-  "engineVersion": "v0.12.6"
+  "engineVersion": "v0.13.0"
 }

--- a/sdk/elixir/runtime/go.mod
+++ b/sdk/elixir/runtime/go.mod
@@ -39,3 +39,11 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"elixir-sdk/internal/dagger"
@@ -18,37 +19,20 @@ const (
 )
 
 func New(
+	// Directory with the Elixir SDK source code.
 	// +optional
 	// +defaultPath="/sdk/elixir"
+	// +ignore=["**","!LICENSE","!lib/**/*.ex","!.formatter.exs","!mix.exs","!mix.lock","!dagger_codegen/lib/**/*.ex","!dagger_codegen/mix.exs","!dagger_codegen/mix.lock"]
 	sdkSourceDir *dagger.Directory,
-) *ElixirSdk {
+) (*ElixirSdk, error) {
+	if sdkSourceDir == nil {
+		return nil, fmt.Errorf("sdk source directory not provided")
+	}
 	return &ElixirSdk{
-		SdkSourceDir: dag.Directory().
-			// NB: these patterns should match those in `dagger.json`.
-			// When `--sdk` points to a git remote the files aren't filtered
-			// using `dagger.json` include/exclude patterns since the whole
-			// repo is cloned. It's still useful to have the same patterns in
-			// `dagger.json` though, to avoid the unnecessary uploads when
-			// loading the SDK from a local path.
-			WithDirectory(
-				"/",
-				sdkSourceDir,
-				dagger.DirectoryWithDirectoryOpts{
-					Include: []string{
-						"LICENSE",
-						"lib/**/*.ex",
-						".formatter.exs",
-						"mix.exs",
-						"mix.lock",
-						"dagger_codegen/lib/**/*.ex",
-						"dagger_codegen/mix.exs",
-						"dagger_codegen/mix.lock",
-					},
-				},
-			),
+		SdkSourceDir:  sdkSourceDir,
 		RequiredPaths: []string{},
 		Container:     dag.Container(),
-	}
+	}, nil
 }
 
 type ElixirSdk struct {


### PR DESCRIPTION
Make Elixir SDK consistent with PHP (in #8369), the include patterns is now moved to `+ignore` directive.