### PR TITLE
ci: Stop using spot instances

### DIFF
--- a/.github/.github/.gitattributes
+++ b/.github/.github/.gitattributes
@@ -1,6 +1,0 @@
-/dagger.gen.go linguist-generated
-/internal/dagger/** linguist-generated
-/internal/querybuilder/** linguist-generated
-/internal/telemetry/** linguist-generated
-
-**.gen.yml linguist-generated

--- a/.github/dagger.json
+++ b/.github/dagger.json
@@ -3,14 +3,14 @@
   "sdk": "go",
   "dependencies": [
     {
-      "name": "gha",
-      "source": "github.com/shykes/gha@f0c4da95fb3e7e5351d17dfb1d20362d3ae8b2a2"
-    },
-    {
       "name": "dirdiff",
       "source": "../modules/dirdiff"
+    },
+    {
+      "name": "gha",
+      "source": "github.com/shykes/gha@f0c4da95fb3e7e5351d17dfb1d20362d3ae8b2a2"
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.6"
+  "engineVersion": "v0.13.5"
 }

--- a/.github/main.go
+++ b/.github/main.go
@@ -101,7 +101,6 @@ func (ci *CI) Runner(
 	daggerVersion string,
 	cpus int,
 	singleTenant bool,
-	noSpot bool,
 	dind bool,
 ) string {
 	runner := fmt.Sprintf(
@@ -115,10 +114,7 @@ func (ci *CI) Runner(
 	if singleTenant {
 		runner += "-st"
 	}
-	if noSpot {
-		// "on demand instances" are the opposite of spot instances in AWS jargon
-		runner += "-od"
-	}
+
 	// Fall back to default runner if repository is not upstream
 	// (this is GHA DSL and will be evaluated by the GHA runner)
 	return fmt.Sprintf(
@@ -129,40 +125,40 @@ func (ci *CI) Runner(
 	)
 }
 
-// Bronze runner: Multi-tenant spot instance, 4 cpu
+// Bronze runner: Multi-tenant instance, 4 cpu
 func (ci *CI) BronzeRunner(
 	// Enable docker-in-docker
 	// +optional
 	dind bool,
 ) string {
-	return ci.Runner(2, daggerVersion, 4, false, false, dind)
+	return ci.Runner(2, daggerVersion, 4, false, dind)
 }
 
-// Silver runner: Multi-tenant spot instance, 8 cpu
+// Silver runner: Multi-tenant instance, 8 cpu
 func (ci *CI) SilverRunner(
 	// Enable docker-in-docker
 	// +optional
 	dind bool,
 ) string {
-	return ci.Runner(2, daggerVersion, 8, false, false, dind)
+	return ci.Runner(2, daggerVersion, 8, false, dind)
 }
 
-// Gold runner: Single-tenant on-demand instance, 16 cpu
+// Gold runner: Single-tenant instance, 16 cpu
 func (ci *CI) GoldRunner(
 	// Enable docker-in-docker
 	// +optional
 	dind bool,
 ) string {
-	return ci.Runner(2, daggerVersion, 16, true, true, dind)
+	return ci.Runner(2, daggerVersion, 16, true, dind)
 }
 
-// Platinum runner: Single-tenant on-demand instance, 32 cpu
+// Platinum runner: Single-tenant instance, 32 cpu
 func (ci *CI) PlatinumRunner(
 	// Enable docker-in-docker
 	// +optional
 	dind bool,
 ) string {
-	return ci.Runner(2, daggerVersion, 32, true, true, dind)
+	return ci.Runner(2, daggerVersion, 32, true, dind)
 }
 
 // Generate Github Actions pipelines to call our Dagger pipelines

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-g2-v0-13-5-16c-od
+    runs-on: dagger-g2-v0-13-5-16c
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/engine-and-cli-split.yml
+++ b/.github/workflows/engine-and-cli-split.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
           upload-logs: true
 
   test-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           upload-logs: true
 
   test-cli-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           upload-logs: true
 
   test-everything-else:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
           upload-logs: true
 
   testdev-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           upload-logs: true
 
   testdev-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
           upload-logs: true
 
   testdev-container:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
           upload-logs: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
@@ -32,7 +32,7 @@ jobs:
     # only run this on tag push events, not in PRs
     if: github.event_name == 'push' && github.repository == 'dagger/dagger' && github.ref_type == 'tag'
     needs: test
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/sdk-elixir-publish.yml
+++ b/.github/workflows/sdk-elixir-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"

--- a/.github/workflows/sdk-go-publish.yml
+++ b/.github/workflows/sdk-go-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-php-publish.yml
+++ b/.github/workflows/sdk-php-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-5-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"


### PR DESCRIPTION
> [!NOTE]
> Already includes changes from https://github.com/dagger/dagger/pull/8643

They are getting disrupted often, and that becomes annoying after a few weeks of turbulence.

Before we can merge this, need to introduce `dind-od` instances.