### PR TITLE
fix: `Directory.digest` should not panic on scratch directory

### DIFF
--- a/.changes/unreleased/Fixed-20240913-110529.yaml
+++ b/.changes/unreleased/Fixed-20240913-110529.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix `Directory.digest` on scratch directory
+time: 2024-09-13T11:05:29.343367542+01:00
+custom:
+  Author: jedevc
+  PR: "8445"

--- a/core/directory.go
+++ b/core/directory.go
@@ -80,15 +80,8 @@ func NewDirectory(query *Query, def *pb.Definition, dir string, platform Platfor
 	}
 }
 
-func NewScratchDirectory(query *Query, platform Platform) *Directory {
-	if query == nil {
-		panic("query must be non-nil")
-	}
-	return &Directory{
-		Query:    query,
-		Dir:      "/",
-		Platform: platform,
-	}
+func NewScratchDirectory(ctx context.Context, query *Query, platform Platform) (*Directory, error) {
+	return NewDirectorySt(ctx, query, llb.Scratch(), "/", platform, nil)
 }
 
 func NewDirectorySt(ctx context.Context, query *Query, st llb.State, dir string, platform Platform, services ServiceBindings) (*Directory, error) {

--- a/core/file.go
+++ b/core/file.go
@@ -84,7 +84,11 @@ func NewFileWithContents(
 	ownership *Ownership,
 	platform Platform,
 ) (*File, error) {
-	dir, err := NewScratchDirectory(query, platform).WithNewFile(ctx, name, content, permissions, ownership)
+	dir, err := NewScratchDirectory(ctx, query, platform)
+	if err != nil {
+		return nil, err
+	}
+	dir, err = dir.WithNewFile(ctx, name, content, permissions, ownership)
 	if err != nil {
 		return nil, err
 	}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1187,4 +1187,12 @@ func (DirectorySuite) TestDigest(ctx context.Context, t *testctx.T) {
 
 		require.NotEqual(t, digestFileWithOverwrittenMetadata, digestFileWithDefaultMetadata)
 	})
+
+	t.Run("scratch directory", func(ctx context.Context, t *testctx.T) {
+		dir := c.Directory()
+
+		digest, err := dir.Digest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", digest)
+	})
 }

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -268,7 +268,10 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 
 	ctr := fn.runtime
 
-	metaDir := NewScratchDirectory(mod.Query, mod.Query.Platform())
+	metaDir, err := NewScratchDirectory(ctx, mod.Query, mod.Query.Platform())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mod metadata directory: %w", err)
+	}
 	ctr, err = ctr.WithMountedDirectory(ctx, modMetaDirPath, metaDir, "", false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount mod metadata directory: %w", err)

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -136,7 +136,7 @@ func (s *directorySchema) pipeline(ctx context.Context, parent *core.Directory, 
 
 func (s *directorySchema) directory(ctx context.Context, parent *core.Query, _ struct{}) (*core.Directory, error) {
 	platform := parent.Platform()
-	return core.NewScratchDirectory(parent, platform), nil
+	return core.NewScratchDirectory(ctx, parent, platform)
 }
 
 type subdirectoryArgs struct {

--- a/engine/buildkit/llbdefinition.go
+++ b/engine/buildkit/llbdefinition.go
@@ -14,6 +14,10 @@ import (
 )
 
 func DefToDAG(def *pb.Definition) (*OpDAG, error) {
+	if len(def.Def) == 0 {
+		return nil, nil
+	}
+
 	digestToOp := map[digest.Digest]*pb.Op{}
 	digestToMetadata := map[digest.Digest]*pb.OpMetadata{}
 	for _, dt := range def.Def {
@@ -129,6 +133,9 @@ func (dag *OpDAG) toString(builder *strings.Builder, indent string) string {
 }
 
 func (dag *OpDAG) Walk(f func(*OpDAG) error) error {
+	if dag == nil {
+		return nil
+	}
 	return dag.walk(f, map[*OpDAG]struct{}{})
 }
 

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -94,13 +94,14 @@ func (r *ref) ToState() (llb.State, error) {
 }
 
 func (r *ref) Digest(ctx context.Context, path string) (digest.Digest, error) {
+	if r == nil {
+		return contenthash.Checksum(ctx, nil, path, contenthash.ChecksumOpts{}, nil)
+	}
 	cacheRef, err := r.CacheRef(ctx)
 	if err != nil {
 		return "", err
 	}
-
 	sessionGroup := bksession.NewGroup(r.c.ID())
-
 	return contenthash.Checksum(ctx, cacheRef, path, contenthash.ChecksumOpts{}, sessionGroup)
 }
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8441