### PR TITLE
chore: change DirectConn host to "dagger"

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1148,7 +1148,7 @@ func (f DirectConn) Do(r *http.Request) (*http.Response, error) {
 }
 
 func (f DirectConn) Host() string {
-	return ":mem:"
+	return "dagger"
 }
 
 func (f DirectConn) Close() error {


### PR DESCRIPTION
*Partially* fix for https://github.com/dagger/dagger/issues/8329.

The `:mem:` host here is *really* weird, I don't know the logic for it, but it makes for some very confusing error messages, so we should fix it to something more reasonable and recognizable.