### PR TITLE
fix: TS regression introduce by grapql-request dep bump

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240916-201247.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240916-201247.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Correctly forward traces with a customer propagator due to a changes in `graphql-request`
+  package on the header types that broke the propagation.
+time: 2024-09-16T20:12:47.344009+02:00
+custom:
+  Author: TomChv
+  PR: "8467"

--- a/sdk/typescript/graphql/client.ts
+++ b/sdk/typescript/graphql/client.ts
@@ -1,6 +1,17 @@
 import * as opentelemetry from "@opentelemetry/api"
 import { GraphQLClient } from "graphql-request"
 
+/**
+ * Customer setter to inject trace parent into the request headers
+ * This is required because `graphql-request` 7.0.1 changes its header
+ * type to `Headers` which break the default open telemetry propagator.
+ */
+class CustomSetter {
+  set(carrier: Headers, key: string, value: string): void {
+    carrier.set(key, value)
+  }
+}
+
 export function createGQLClient(port: number, token: string): GraphQLClient {
   const client = new GraphQLClient(`http://127.0.0.1:${port}/query`, {
     headers: {
@@ -11,6 +22,7 @@ export function createGQLClient(port: number, token: string): GraphQLClient {
       opentelemetry.propagation.inject(
         opentelemetry.context.active(),
         req.headers,
+        new CustomSetter(),
       )
 
       return req


### PR DESCRIPTION
Rawcode spotted an issue https://discord.com/channels/707636530424053791/1284180822135406656 where traces where no longer published to traces.
The issue is introduced by a change of the type from a plain JSON object to `Headers` which break the current opentelemetry propagator. This PR fixes that issue by using a custom injector to set the `traceparent` header