### PR TITLE
Indent Php template correctly

### DIFF
--- a/sdk/php/runtime/template/src/Example.php
+++ b/sdk/php/runtime/template/src/Example.php
@@ -15,28 +15,28 @@ use function Dagger\dag;
 #[DaggerObject]
 class Example
 {
-     #[DaggerFunction('Returns a container that echoes whatever string argument is provided')]
-     public function containerEcho(string $stringArg): Container
-     {
-         return dag()
-             ->container()
-             ->from('alpine:latest')
-             ->withExec(['echo', $stringArg]);
-     }
+    #[DaggerFunction('Returns a container that echoes whatever string argument is provided')]
+    public function containerEcho(string $stringArg): Container
+    {
+        return dag()
+            ->container()
+            ->from('alpine:latest')
+            ->withExec(['echo', $stringArg]);
+    }
 
     #[DaggerFunction('Returns lines that match a pattern in the files of the provided Directory')]
-     public function grepDir(
-         #[Argument('The directory to search')]
-         Directory $directoryArg,
-         #[Argument('The pattern to search for')]
-         string $pattern
+    public function grepDir(
+        #[Argument('The directory to search')]
+        Directory $directoryArg,
+        #[Argument('The pattern to search for')]
+        string $pattern
     ): string {
-         return dag()
-             ->container()
-             ->from('alpine:latest')
-             ->withMountedDirectory('/mnt', $directoryArg)
-             ->withWorkdir('/mnt')
-             ->withExec(["grep", '-R', $pattern, '.'])
-             ->stdout();
-     }
+        return dag()
+            ->container()
+            ->from('alpine:latest')
+            ->withMountedDirectory('/mnt', $directoryArg)
+            ->withWorkdir('/mnt')
+            ->withExec(["grep", '-R', $pattern, '.'])
+            ->stdout();
+    }
 }


### PR DESCRIPTION
Indents first level of indentation to 4 spaces,
This level of indentation matches standards: PSR2, PSR12, PER2

Was indented to 5 spaces for some reason. 

_Downside of leaving it at 5 spaces:_ it confuses a lot of IDE's and new code is misaligned until you manually correct the whole file.