### PR TITLE
fix(python): use ModuleSource.digest for stable unique path

### DIFF
--- a/sdk/python/runtime/dagger.json
+++ b/sdk/python/runtime/dagger.json
@@ -2,5 +2,5 @@
   "name": "python-sdk",
   "sdk": "go",
   "source": ".",
-  "engineVersion": "v0.12.7"
+  "engineVersion": "v0.13.0"
 }

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -4,9 +4,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	_ "embed"
-	"encoding/hex"
 	"fmt"
 	"path"
 	"python-sdk/internal/dagger"
@@ -167,14 +165,10 @@ func (m *PythonSdk) Load(ctx context.Context, modSource *dagger.ModuleSource) (*
 		return nil, fmt.Errorf("runtime module load: %w", err)
 	}
 
-	// FIXME: ModuleSource.id is not stable
-	modID, err := m.Discovery.ModSource.ID(ctx)
+	modDigest, err := m.Discovery.ModSource.Digest(ctx)
 	if err != nil {
 		return nil, err
 	}
-	h := sha256.New()
-	fmt.Fprint(h, modID)
-	modDigest := hex.EncodeToString(h.Sum(nil))
 	m.SourcePath = path.Join(ModSourceDirPath, modDigest)
 
 	return m, nil


### PR DESCRIPTION
See https://github.com/dagger/dagger/pull/8245#discussion_r1733172781 for context.

The previous module ID hashing just really isn't very stable - we can hash the contents for *way* better results.