### PR TITLE
remove 'check for updates' span

### DIFF
--- a/.changes/unreleased/Fixed-20240918-182949.yaml
+++ b/.changes/unreleased/Fixed-20240918-182949.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: removed noisy "check for updates" span
+time: 2024-09-18T18:29:49.196859053-04:00
+custom:
+    Author: vito
+    PR: "8491"

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime"
 
-	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/distconsts"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
@@ -83,9 +82,6 @@ func updateAvailable(ctx context.Context) (string, error) {
 }
 
 func latestVersion(ctx context.Context) (v string, rerr error) {
-	ctx, span := Tracer().Start(ctx, "check for updates")
-	defer telemetry.End(span, func() error { return rerr })
-
 	imageRef := fmt.Sprintf("%s:latest", engine.EngineImageRepo)
 
 	ref, err := name.ParseReference(imageRef)


### PR DESCRIPTION
This isn't set up right - it ends up stranded, establishing itself as the root span of its own trace.

I'm not sure if we got much from this span, but if we want to bring it back we might need to wait to do it until after we set up the frontend + root span (in `cmd/dagger/engine.go`).