### PR TITLE
fix(engine): properly encode / decode socket path

### DIFF
--- a/core/socket.go
+++ b/core/socket.go
@@ -180,6 +180,7 @@ func (store *SocketStore) getSocketURLEncoded(sock *storedSocket) string {
 	case sock.HostPath != "":
 		u.Scheme = "unix"
 		u.Path = sock.HostPath
+		u.RawPath = u.EscapedPath()
 	default:
 		u.Scheme = sock.PortForward.Protocol.Network()
 		u.Host = fmt.Sprintf("%s:%d", sock.HostEndpoint, sock.PortForward.Backend)

--- a/engine/client/socket.go
+++ b/engine/client/socket.go
@@ -43,7 +43,15 @@ func (p SocketProvider) CheckAgent(ctx context.Context, req *sshforward.CheckAge
 	}
 	switch u.Scheme {
 	case "unix":
-		path := u.Path
+		var path string
+		if u.RawPath != "" {
+			path, err = url.PathUnescape(u.RawPath)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "Error unescaping path: %s", err)
+			}
+		} else {
+			path = u.Path
+		}
 		if p.UnixPathMapper != nil {
 			path, err = p.UnixPathMapper(path)
 			if err != nil {
@@ -87,7 +95,16 @@ func (p SocketProvider) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) e
 	switch connURL.Scheme {
 	case "unix":
 		network = "unix"
-		addr = connURL.Path
+	
+		if connURL.RawPath != "" {
+			addr, err = url.PathUnescape(connURL.RawPath)
+			if err != nil {
+				return status.Errorf(codes.Internal, "Error unescaping path: %s", err)
+			}
+		} else {
+			addr = connURL.Path
+		}
+
 		if p.UnixPathMapper != nil {
 			addr, err = p.UnixPathMapper(addr)
 			if err != nil {


### PR DESCRIPTION
Current engine / client communication relies on the url.URL type to encode / decode different kinds of socket path:
- unix
- tcp/udp

However, this leads to some encoding issues for the unix path: spaces are converted to %20, special chars are escaped.

This PR fixes it and adds a corresponding test