### PR TITLE
POC: Apply `.gitignore` patterns on module load by default

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/engine/vcs"
@@ -823,7 +824,8 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 	sourceRootRelPath = "./" + sourceRootRelPath
 
 	collectedDeps := dagql.NewCacheMap[string, *callerLocalDep]()
-	if err := s.collectCallerLocalDeps(ctx, src.Query, contextAbsPath, sourceRootAbsPath, true, src, collectedDeps); err != nil {
+	collectedIgnores := dagql.NewCacheMap[string, []string]()
+	if err := s.collectCallerLocalDeps(ctx, src.Query, contextAbsPath, sourceRootAbsPath, true, src, collectedDeps, collectedIgnores); err != nil {
 		return inst, fmt.Errorf("failed to collect local module source deps: %w", err)
 	}
 
@@ -1122,8 +1124,10 @@ func (s *moduleSchema) collectCallerLocalDeps(
 	src *core.ModuleSource,
 	// cache of sourceRootAbsPath -> *callerLocalDep
 	collectedDeps dagql.CacheMap[string, *callerLocalDep],
+	// cache of .gitignore file path to list of patterns
+	collectedIgnores dagql.CacheMap[string, []string],
 ) error {
-	_, _, err := collectedDeps.GetOrInitialize(ctx, sourceRootAbsPath, func(ctx context.Context) (_ *callerLocalDep, rerr error) {
+	_, _, err := collectedDeps.GetOrInitialize(ctx, sourceRootAbsPath, func(ctx context.Context) (*callerLocalDep, error) {
 		sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get source root relative path: %w", err)
@@ -1196,7 +1200,7 @@ func (s *moduleSchema) collectCallerLocalDeps(
 				continue
 			}
 			depAbsPath := filepath.Join(sourceRootAbsPath, parsed.modPath)
-			err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, depAbsPath, false, src, collectedDeps)
+			err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, depAbsPath, false, src, collectedDeps, collectedIgnores)
 			if err != nil {
 				return nil, fmt.Errorf("failed to collect local module source dep: %w", err)
 			}
@@ -1226,7 +1230,7 @@ func (s *moduleSchema) collectCallerLocalDeps(
 					return nil, getInvalidBuiltinSDKError(modCfg.SDK)
 				}
 
-				err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, sdkPath, false, src, collectedDeps)
+				err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, sdkPath, false, src, collectedDeps, collectedIgnores)
 				if err != nil {
 					return nil, fmt.Errorf("failed to collect local sdk: %w", err)
 				}
@@ -1291,69 +1295,18 @@ func (s *moduleSchema) collectCallerLocalDeps(
 
 			for i := 0; i <= len(pathParts); i++ {
 				currentRelPath := filepath.Join(pathParts[:i]...)
-				currentAbsPath := filepath.Join(contextAbsPath, currentRelPath)
 
-				// NB(helder): Considered a single bk.ImportLocal with the list of
-				// paths to .gitgnore files to include, but would then have to iterate
-				// the files in the core Directory object and get their contents.
-				// Not sure if that's better.
+				fmt.Fprintln(stdio.Stdout, fmt.Sprintf("reading %s", filepath.Join(contextAbsPath, currentRelPath, ".gitignore")))
 
-				// No stat because we want the contents, otherwise it would be two calls
-				// for each file that exists.
-				// TODO: Each .gitignore should be cached to avoid reading it multiple times
-				ignoreBytes, err := bk.ReadCallerHostFile(ctx, filepath.Join(currentAbsPath, ".gitignore"))
-				switch {
-				case err == nil:
-					fmt.Fprintln(stdio.Stdout, fmt.Sprintf("reading %s", filepath.Join(currentAbsPath, ".gitignore")))
-
-					reader := bytes.NewReader(ignoreBytes)
-					scanner := bufio.NewScanner(reader)
-
-					for scanner.Scan() {
-						pattern := strings.TrimSpace(scanner.Text())
-						// ignore comments and empty lines
-						if pattern == "" || strings.HasPrefix(pattern, "#") {
-							continue
-						}
-
-						isNegation := strings.HasPrefix(pattern, "!")
-						isDirectory := strings.HasSuffix(pattern, "/")
-
-						// If there is a separator at the end of the pattern then
-						// it will match only directories. However, filepath.Join
-						// removes it, and we need to check beginning and middle
-						// next, so doing it in advance.
-						pattern = strings.TrimPrefix(strings.TrimSuffix(pattern, "/"), "!")
-
-						// If the pattern doesn't have a separator at the beginning
-						// or middle (or both), then it's recursive.
-						if pattern != "**" && pattern != "*" && !strings.Contains(pattern, "/") {
-							pattern = "**/" + pattern
-						}
-
-						rebased := filepath.Join(currentRelPath, pattern)
-						if isNegation {
-							rebased = "!" + rebased
-						}
-						if isDirectory {
-							rebased = rebased + "/"
-						}
-
-						localDep.ignores = append(localDep.ignores, rebased)
-					}
-
-				case status.Code(err) == codes.NotFound:
-					fmt.Fprintln(stdio.Stderr, fmt.Sprintf("doesn't exist %s", filepath.Join(currentAbsPath, ".gitignore")))
-				default:
-					return fmt.Errorf("error reading .gitignore file %q: %w", currentAbsPath, err)
+				patterns, err := getGitignore(ctx, bk, contextAbsPath, currentRelPath, collectedIgnores)
+				if err != nil {
+					return err
 				}
-			}
 
+				localDep.ignores = append(localDep.ignores, patterns...)
+			}
 			return nil
 		}()
-		if err != nil {
-			return nil, err
-		}
 
 		return localDep, nil
 	})
@@ -1361,6 +1314,65 @@ func (s *moduleSchema) collectCallerLocalDeps(
 		return fmt.Errorf("local module at %q has a circular dependency", sourceRootAbsPath)
 	}
 	return err
+}
+
+func getGitignore(ctx context.Context, bk *buildkit.Client, baseAbsPath, currentRelPath string, collectedIgnores dagql.CacheMap[string, []string]) ([]string, error) {
+	currentAbsPath := filepath.Join(baseAbsPath, currentRelPath)
+
+	r, _, err := collectedIgnores.GetOrInitialize(ctx, currentAbsPath, func(ctx context.Context) ([]string, error) {
+		// No stat because we want the contents, otherwise it would be two calls
+		// for each file that exists.
+		// TODO: Each .gitignore should be cached to avoid reading it multiple times
+		ignoreBytes, err := bk.ReadCallerHostFile(ctx, filepath.Join(currentAbsPath, ".gitignore"))
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("error reading .gitignore file %q: %w", currentAbsPath, err)
+		}
+
+		var patterns []string
+
+		reader := bytes.NewReader(ignoreBytes)
+		scanner := bufio.NewScanner(reader)
+
+		for scanner.Scan() {
+			pattern := strings.TrimSpace(scanner.Text())
+			// ignore comments and empty lines
+			if pattern == "" || strings.HasPrefix(pattern, "#") {
+				continue
+			}
+
+			isNegation := strings.HasPrefix(pattern, "!")
+			isDirectory := strings.HasSuffix(pattern, "/")
+
+			// If there is a separator at the end of the pattern then
+			// it will match only directories. However, filepath.Join
+			// removes it, and we need to check beginning and middle
+			// next, so doing it in advance.
+			pattern = strings.TrimPrefix(strings.TrimSuffix(pattern, "/"), "!")
+
+			// If the pattern doesn't have a separator at the beginning
+			// or middle (or both), then it's recursive.
+			if pattern != "**" && pattern != "*" && !strings.Contains(pattern, "/") {
+				pattern = "**/" + pattern
+			}
+
+			rebased := filepath.Join(currentRelPath, pattern)
+			if isNegation {
+				rebased = "!" + rebased
+			}
+			if isDirectory {
+				rebased = rebased + "/"
+			}
+
+			patterns = append(patterns, rebased)
+		}
+
+		return patterns, nil
+	})
+
+	return r, err
 }
 
 func (s *moduleSchema) moduleSourceResolveDirectoryFromCaller(

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,6 +1,4 @@
 .DS_Store
-.mypy_cache
-.pytest_cache
-.ruff_cache
-dist
-docs/_build
+.*_cache
+dist/
+_build/


### PR DESCRIPTION
This is a proof of concept for:
- https://github.com/dagger/dagger/issues/6627

It reads all the `.gitignore` files from a git repo root, up to a module being loaded, and adds the patterns inside to the list of "excludes" in `dagger.json` automatically, to limit the files getting uploaded from the host.

## Example

Consider these `.gitignore` files:

- `.gitignore`
  - `.venv`
  - `__pycache__`
- `sdk/python/.gitignore`
  -  `.*_cache`
  -  `dist/`
  - `docs/_ build`
- `sdk/python/dev/.gitignore`
  - `/sdk`

Running the following command, which requires loading the module:
```
dagger functions -m sdk/python/dev
```

Will add the following patterns, before the module's own `excludes` in `dagger.json`:
```
**/.venv
**/__pycache__
sdk/python/**/.*_cache
sdk/python/**/dist/
sdk/python/docs/_build
sdk/python/dev/sdk
```

> [!NOTE]
> - The patterns on each `.gitignore` are prefixed with the path to its directory
> - Like git, patterns that don't have a slash in the beginning or middle of the pattern are recursive, so `**` is added
> - In "excludes" in `dagger.json`, it's possible to negate a pattern from `.gitignore` if necessary prefixing the pattern with `!`

The result is that for this module, with no excludes in `dagger.json`, the following won't be uploaded anymore:
- `sdk/python/dev/.venv` (python's virtual environment)
- `sdk/python/dev/sdk` (generated SDK library for the module)
- `sdk/python/dev/.../__pycache__` (compiled bytecode)

Today, those directories are added because they match an implicit include of `<module source>/**/*`.

### Before

On first run for this module:

<img width="636" alt="Screenshot 2024-09-19 at 17 20 58" src="https://github.com/user-attachments/assets/90b8c09f-28da-4800-aeb9-cbfce83e99f5">


### After

On first run for this module:

<img width="949" alt="Screenshot 2024-09-19 at 17 22 58" src="https://github.com/user-attachments/assets/d4a32e3c-fc3b-46c4-94d9-c5a7bd07cd48">

\cc @TomChv 