### PR TITLE
Exec Resource Monitoring + OTEL Metrics support

### DIFF
--- a/.changes/unreleased/Added-20241017-165039.yaml
+++ b/.changes/unreleased/Added-20241017-165039.yaml
@@ -1,0 +1,13 @@
+kind: Added
+body: |-
+  Show disk usage metrics for execs in TUI
+
+  The engine now supports collecting metrics from individual execs and publishing them as OTel metrics.
+
+  To start, just disk read/write byte totals and IO pressure time are supported, but more like CPU/memory/network/etc. will be added soon.
+
+  Currently, metrics will be displayed in the TUI at verbosity level 4 (`-vvv`).
+time: 2024-10-17T16:50:39.650366368-07:00
+custom:
+  Author: sipsma
+  PR: "8506"

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -45,6 +46,8 @@ func withEngine(
 		params.EngineLogs = telemetry.LogForwarder{
 			Processors: telemetry.LogProcessors,
 		}
+		params.EngineMetrics = telemetry.MetricExporters
+
 		params.WithTerminal = withTerminal
 		params.Interactive = interactive
 		params.InteractiveCommand = interactiveCommandParsed
@@ -66,12 +69,14 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 		Detect:   true,
 		Resource: Resource(),
 
-		LiveTraceExporters: []sdktrace.SpanExporter{Frontend.SpanExporter()},
-		LiveLogExporters:   []sdklog.Exporter{Frontend.LogExporter()},
+		LiveTraceExporters:  []sdktrace.SpanExporter{Frontend.SpanExporter()},
+		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},
+		LiveMetricExporters: []sdkmetric.Exporter{Frontend.MetricExporter()},
 	}
 	if spans, logs, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
 		telemetryCfg.LiveTraceExporters = append(telemetryCfg.LiveTraceExporters, spans)
 		telemetryCfg.LiveLogExporters = append(telemetryCfg.LiveLogExporters, logs)
+		// TODO: metrics to cloud
 	}
 	ctx = telemetry.Init(ctx, telemetryCfg)
 

--- a/core/integration/telemetry_test.go
+++ b/core/integration/telemetry_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -42,28 +41,4 @@ func (TelemetrySuite) TestInternalVertexes(ctx context.Context, t *testctx.T) {
 		require.NoError(t, c.Close()) // close + flush logs
 		require.NotContains(t, logs.String(), "merge (")
 	})
-}
-
-func (TelemetrySuite) TestMetrics(ctx context.Context, t *testctx.T) {
-	var logs safeBuffer
-	c := connect(ctx, t,
-		dagger.WithLogOutput(&logs),
-		dagger.WithVerbosity(3), // bump to -vvv so metrics show up
-	)
-
-	cmd := "dd if=/f of=/f2 iflag=direct oflag=direct bs=1M count=1 && sync && sleep 10"
-	_, err := c.Container().From(alpineImage).
-		WithEnvVariable("BUST", fmt.Sprintf("%d", time.Now().UTC().UnixNano())).
-		WithExec([]string{"sh", "-c",
-			"dd if=/dev/zero of=/f bs=1M count=1",
-		}).
-		WithExec([]string{"sh", "-c", cmd}).
-		Sync(ctx)
-	require.NoError(t, err)
-
-	require.NoError(t, c.Close()) // close + flush logs
-	require.Regexp(t,
-		regexp.MustCompile(`.*exec sh -c `+cmd+`.*\Disk Read Bytes:\s*\d{7}.*Disk Write Bytes:\s*\d{7}.*`),
-		logs.String(),
-	)
 }

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -6,14 +6,16 @@ import (
 	"sort"
 	"time"
 
-	"dagger.io/dagger/telemetry"
 	"go.opentelemetry.io/otel/attribute"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
+	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 	"github.com/dagger/dagger/engine/slog"
-	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
 type DB struct {
@@ -129,6 +131,55 @@ func (db *DB) Shutdown(ctx context.Context) error {
 
 func (db *DB) ForceFlush(ctx context.Context) error {
 	return nil // noop
+}
+
+func (db *DB) MetricExporter() sdkmetric.Exporter {
+	return DBMetricExporter{db}
+}
+
+func (db *DB) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.DeltaTemporality
+}
+
+func (db *DB) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.AggregationDefault{}
+}
+
+type DBMetricExporter struct {
+	*DB
+}
+
+func (db DBMetricExporter) Export(ctx context.Context, resourceMetrics *metricdata.ResourceMetrics) error {
+	for _, scopeMetric := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scopeMetric.Metrics {
+			metricData, ok := metric.Data.(metricdata.Gauge[int64])
+			if !ok {
+				continue
+			}
+
+			for _, point := range metricData.DataPoints {
+				spanIDStr, ok := point.Attributes.Value(telemetry.MetricsSpanID)
+				if !ok {
+					continue
+				}
+				spanID, err := trace.SpanIDFromHex(spanIDStr.AsString())
+				if err != nil {
+					continue
+				}
+				span, ok := db.Spans[spanID]
+				if !ok {
+					continue
+				}
+
+				if span.MetricsByName == nil {
+					span.MetricsByName = make(map[string][]metricdata.DataPoint[int64])
+				}
+				span.MetricsByName[metric.Name] = append(span.MetricsByName[metric.Name], point)
+			}
+		}
+	}
+
+	return nil
 }
 
 // SetPrimarySpan allows the primary span to be explicitly set to a particular

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -158,7 +158,7 @@ func (db DBMetricExporter) Export(ctx context.Context, resourceMetrics *metricda
 			}
 
 			for _, point := range metricData.DataPoints {
-				spanIDStr, ok := point.Attributes.Value(telemetry.MetricsSpanID)
+				spanIDStr, ok := point.Attributes.Value(telemetry.MetricsSpanIDAttr)
 				if !ok {
 					continue
 				}

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
@@ -42,6 +43,10 @@ type Span struct {
 	Mask         bool
 	Passthrough  bool
 	Ignore       bool
+
+	// NOTE: this is hard coded for Gauge int64 metricdata essentially right now,
+	// needs generalization as more metric types get added
+	MetricsByName map[string][]metricdata.DataPoint[int64]
 
 	db    *DB
 	trace *Trace

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 
@@ -26,7 +25,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
-	resourcestypes "github.com/moby/buildkit/executor/resources/types"
+	bkresourcestypes "github.com/moby/buildkit/executor/resources/types"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
 	randid "github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver"
@@ -144,7 +143,7 @@ func (w *Worker) Run(
 	mounts []executor.Mount,
 	procInfo executor.ProcessInfo,
 	started chan<- struct{},
-) (_ resourcestypes.Recorder, rerr error) {
+) (_ bkresourcestypes.Recorder, rerr error) {
 	if id == "" {
 		id = randid.NewID()
 	}
@@ -153,8 +152,8 @@ func (w *Worker) Run(
 		return nil, err
 	}
 
-	state := newExecState(id, &procInfo, rootMount, mounts)
-	return nil, w.run(ctx, state, started,
+	state := newExecState(id, &procInfo, rootMount, mounts, started)
+	return nil, w.run(ctx, state,
 		w.setupNetwork,
 		w.injectDumbInit,
 		w.generateBaseSpec,
@@ -170,16 +169,15 @@ func (w *Worker) Run(
 		w.createCWD,
 		w.setupNestedClient,
 		w.installCACerts,
+		w.runContainer,
 	)
 }
 
 func (w *Worker) run(
 	ctx context.Context,
 	state *execState,
-	started chan<- struct{},
 	setupFuncs ...executorSetupFunc,
 ) (rerr error) {
-	startedOnce := sync.Once{}
 	w.mu.Lock()
 	w.running[state.id] = state
 	w.mu.Unlock()
@@ -195,80 +193,21 @@ func (w *Worker) run(
 		}
 		state.doneErr = rerr
 
-		if started != nil {
-			startedOnce.Do(func() {
-				close(started)
+		if state.startedCh != nil {
+			state.startedOnce.Do(func() {
+				close(state.startedCh)
 			})
 		}
 	}()
 
 	for _, f := range setupFuncs {
 		if err := f(ctx, state); err != nil {
-			bklog.G(ctx).Errorf("executor setup failed: %v", err)
+			bklog.G(ctx).WithError(err).Error("executor run")
 			return err
 		}
 	}
 
-	bundle := filepath.Join(w.executorRoot, state.id)
-	if err := os.Mkdir(bundle, 0o711); err != nil {
-		return err
-	}
-	defer os.RemoveAll(bundle)
-
-	configPath := filepath.Join(bundle, "config.json")
-	f, err := os.Create(configPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if err := json.NewEncoder(f).Encode(state.spec); err != nil {
-		return fmt.Errorf("failed to encode spec: %w", err)
-	}
-	f.Close()
-
-	lg := bklog.G(ctx).
-		WithField("id", state.id).
-		WithField("args", state.spec.Process.Args)
-	if w.execMD != nil {
-		lg = lg.WithField("caller_client_id", w.execMD.CallerClientID)
-		if w.execMD.CallID != nil {
-			lg = lg.WithField("call_id", w.execMD.CallID.Display())
-		}
-		if w.execMD.ClientID != "" {
-			lg = lg.WithField("nested_client_id", w.execMD.ClientID)
-		}
-	}
-	lg.Debug("starting container")
-	defer func() {
-		lg.WithError(rerr).Debug("container done")
-	}()
-
-	trace.SpanFromContext(ctx).AddEvent("Container created")
-	killer := newRunProcKiller(w.runc, state.id)
-	startedCallback := func() {
-		startedOnce.Do(func() {
-			trace.SpanFromContext(ctx).AddEvent("Container started")
-			if started != nil {
-				close(started)
-			}
-		})
-	}
-	runcCall := func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
-		_, err := w.runc.Run(ctx, state.id, bundle, &runc.CreateOpts{
-			Started:   started,
-			IO:        io,
-			ExtraArgs: []string{"--keep"},
-		})
-		return err
-	}
-	err = exitError(ctx, state.exitCodePath, w.callWithIO(ctx, state.procInfo, startedCallback, killer, runcCall))
-	if err != nil {
-		w.runc.Delete(context.TODO(), state.id, &runc.DeleteOpts{})
-		return err
-	}
-
-	return w.runc.Delete(context.TODO(), state.id, &runc.DeleteOpts{})
+	return nil
 }
 
 // Namespaced is something that has Linux namespaces set up.

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -1200,12 +1200,12 @@ func (w *Worker) runContainer(ctx context.Context, state *execState) (rerr error
 		spanContext := trace.SpanContextFromContext(ctx)
 		if spanContext.HasSpanID() {
 			commonAttrs = append(commonAttrs,
-				attribute.String(telemetry.MetricsSpanID, spanContext.SpanID().String()),
+				attribute.String(telemetry.MetricsSpanIDAttr, spanContext.SpanID().String()),
 			)
 		}
 		if spanContext.HasTraceID() {
 			commonAttrs = append(commonAttrs,
-				attribute.String(telemetry.MetricsTraceID, spanContext.TraceID().String()),
+				attribute.String(telemetry.MetricsTraceIDAttr, spanContext.TraceID().String()),
 			)
 		}
 

--- a/engine/buildkit/linux_namespace.go
+++ b/engine/buildkit/linux_namespace.go
@@ -89,7 +89,7 @@ func (w *Worker) runNetNSWorkers(ctx context.Context, state *execState) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	p := pool.New().WithContext(ctx)
 	state.cleanups.Add("stopping namespace workers", p.Wait)
-	state.cleanups.Add("canceling namespace workers", Infallible(func() { cancel(errors.New("cleanup container")) }))
+	state.cleanups.Add("canceling namespace workers", Infallible(func() { cancel(fmt.Errorf("cleanup container: %w", context.Canceled)) }))
 
 	for i := 0; i < workerPoolSize; i++ {
 		p.Go(func(ctx context.Context) (rerr error) {

--- a/engine/buildkit/resources/iostat.go
+++ b/engine/buildkit/resources/iostat.go
@@ -1,0 +1,175 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"dagger.io/dagger/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	ioStatFile     = "io.stat"
+	ioPressureFile = "io.pressure"
+)
+
+const (
+	ioReadBytes  = "rbytes"
+	ioWriteBytes = "wbytes"
+)
+
+type ioStatSampler struct {
+	ioStatFilePath string
+	commonAttrs    attribute.Set
+
+	readBytes  metric.Int64Gauge
+	writeBytes metric.Int64Gauge
+}
+
+func newIOStatSampler(cgroupPath string, meter metric.Meter, commonAttrs attribute.Set) (*ioStatSampler, error) {
+	s := &ioStatSampler{
+		ioStatFilePath: filepath.Join(cgroupPath, ioStatFile),
+		commonAttrs:    commonAttrs,
+	}
+	var err error
+
+	s.readBytes, err = meter.Int64Gauge(telemetry.IOStatDiskReadBytes, metric.WithUnit(telemetry.ByteUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create readBytes metric: %w", err)
+	}
+
+	s.writeBytes, err = meter.Int64Gauge(telemetry.IOStatDiskWriteBytes, metric.WithUnit(telemetry.ByteUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create writeBytes metric: %w", err)
+	}
+
+	return s, nil
+}
+
+type ioStatSample struct {
+	readBytes  int64GaugeSample
+	writeBytes int64GaugeSample
+}
+
+func (s *ioStatSampler) sample(ctx context.Context) error {
+	sample := ioStatSample{
+		readBytes:  newInt64GaugeSample(s.readBytes, s.commonAttrs),
+		writeBytes: newInt64GaugeSample(s.writeBytes, s.commonAttrs),
+	}
+
+	fileBytes, err := os.ReadFile(s.ioStatFilePath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.ioStatFilePath, err)
+	}
+
+	// Format here: https://docs.kernel.org/admin-guide/cgroup-v2.html#io-interface-files
+	lines := strings.Split(string(fileBytes), "\n")
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		for _, part := range parts[1:] {
+			key, value := parseKeyValue(part)
+			if key == "" {
+				continue
+			}
+
+			switch key {
+			case ioReadBytes:
+				sample.readBytes.add(value)
+			case ioWriteBytes:
+				sample.writeBytes.add(value)
+			}
+		}
+	}
+
+	sample.readBytes.record(ctx)
+	sample.writeBytes.record(ctx)
+
+	return nil
+}
+
+type ioPressureSampler struct {
+	ioPressureFilePath string
+	commonAttrs        attribute.Set
+
+	someTotal metric.Int64Gauge
+}
+
+func newIOPressureSampler(cgroupPath string, meter metric.Meter, commonAttrs attribute.Set) (*ioPressureSampler, error) {
+	s := &ioPressureSampler{
+		ioPressureFilePath: filepath.Join(cgroupPath, ioPressureFile),
+		commonAttrs:        commonAttrs,
+	}
+	var err error
+
+	s.someTotal, err = meter.Int64Gauge(telemetry.IOStatPressureSomeTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create some total metric: %w", err)
+	}
+
+	return s, nil
+}
+
+type ioPressureSample struct {
+	someTotal int64GaugeSample
+}
+
+func (s *ioPressureSampler) sample(ctx context.Context) error {
+	sample := ioPressureSample{
+		someTotal: newInt64GaugeSample(s.someTotal, s.commonAttrs),
+	}
+
+	fileBytes, err := os.ReadFile(s.ioPressureFilePath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.ioPressureFilePath, err)
+	}
+
+	// Format here: https://docs.kernel.org/accounting/psi.html#psi
+	lines := strings.Split(string(fileBytes), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 5 {
+			continue
+		}
+		pressureKind := fields[0]
+		if pressureKind != "some" {
+			continue
+		}
+		k, v := parseKeyValue(fields[4])
+		if k != "total" {
+			continue
+		}
+		sample.someTotal.add(v)
+	}
+
+	sample.someTotal.record(ctx)
+
+	return nil
+}
+
+func parseKeyValue(kv string) (string, int64) {
+	key, valueStr, ok := strings.Cut(kv, "=")
+	if !ok {
+		return "", 0
+	}
+	value, err := strconv.ParseInt(valueStr, 10, 64)
+	if err != nil {
+		return "", 0
+	}
+	return key, value
+}

--- a/engine/buildkit/resources/sampler.go
+++ b/engine/buildkit/resources/sampler.go
@@ -1,0 +1,88 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	defaultMountpoint = "/sys/fs/cgroup"
+)
+
+type Sampler struct {
+	cgroupPath  string
+	commonAttrs attribute.Set
+
+	ioStat     *ioStatSampler
+	ioPressure *ioPressureSampler
+}
+
+func NewSampler(
+	cgroupNSSubpath string,
+	meter metric.Meter,
+	commonAttrs attribute.Set,
+) (*Sampler, error) {
+	s := &Sampler{
+		cgroupPath:  filepath.Join(defaultMountpoint, cgroupNSSubpath),
+		commonAttrs: commonAttrs,
+	}
+	var err error
+
+	s.ioStat, err = newIOStatSampler(s.cgroupPath, meter, s.commonAttrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ioStat sampler: %w", err)
+	}
+
+	s.ioPressure, err = newIOPressureSampler(s.cgroupPath, meter, s.commonAttrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ioPressure sampler: %w", err)
+	}
+
+	return s, nil
+}
+
+func (s *Sampler) Sample(ctx context.Context) error {
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		return s.ioStat.sample(ctx)
+	})
+
+	eg.Go(func() error {
+		return s.ioPressure.sample(ctx)
+	})
+
+	return eg.Wait()
+}
+
+type int64GaugeSample struct {
+	gauge metric.Int64Gauge
+	attrs attribute.Set
+	value *int64
+}
+
+func (s *int64GaugeSample) add(value int64) {
+	if s.value == nil {
+		s.value = new(int64)
+	}
+	*s.value += value
+}
+
+func (s *int64GaugeSample) record(ctx context.Context) {
+	if s.value == nil {
+		return
+	}
+	s.gauge.Record(ctx, *s.value, metric.WithAttributeSet(s.attrs))
+}
+
+func newInt64GaugeSample(gauge metric.Int64Gauge, attrs attribute.Set) int64GaugeSample {
+	return int64GaugeSample{
+		gauge: gauge,
+		attrs: attrs,
+	}
+}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -320,7 +320,8 @@ func (c *Client) subscribeTelemetry(ctx context.Context) (rerr error) {
 	}
 	if c.EngineMetrics != nil {
 		if err := c.exportMetrics(ctx, httpClient); err != nil {
-			return fmt.Errorf("export metrics: %w", err)
+			// metrics are best effort and only in newer engines, so don't fail the client if they aren't found
+			slog.Error("export metrics failed", "err", err)
 		}
 	}
 	return nil

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -34,6 +34,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/net/http2"
 	"golang.org/x/sync/errgroup"
@@ -52,6 +53,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 type Params struct {
@@ -73,8 +75,9 @@ type Params struct {
 	EngineCallback   func(context.Context, string, string, string)
 	CloudURLCallback func(context.Context, string, string, bool)
 
-	EngineTrace sdktrace.SpanExporter
-	EngineLogs  sdklog.Exporter
+	EngineTrace   sdktrace.SpanExporter
+	EngineLogs    sdklog.Exporter
+	EngineMetrics []sdkmetric.Exporter
 
 	// Log level (0 = INFO)
 	LogLevel slog.Level
@@ -313,6 +316,11 @@ func (c *Client) subscribeTelemetry(ctx context.Context) (rerr error) {
 	if c.EngineLogs != nil {
 		if err := c.exportLogs(ctx, httpClient); err != nil {
 			return fmt.Errorf("export logs: %w", err)
+		}
+	}
+	if c.EngineMetrics != nil {
+		if err := c.exportMetrics(ctx, httpClient); err != nil {
+			return fmt.Errorf("export metrics: %w", err)
 		}
 	}
 	return nil
@@ -680,6 +688,31 @@ func (c *Client) exportLogs(ctx context.Context, httpClient *httpClient) error {
 		}
 		if err := enginetel.ReexportLogsFromPB(ctx, c.EngineLogs, &req); err != nil {
 			return fmt.Errorf("re-export logs: %w", err)
+		}
+		return nil
+	})
+}
+
+func (c *Client) exportMetrics(ctx context.Context, httpClient *httpClient) error {
+	// NB: we never actually want to interrupt this, since it's relied upon for
+	// seeing what's going on, even during shutdown
+	ctx = context.WithoutCancel(ctx)
+
+	exp := &otlpConsumer{
+		path:       "/v1/metrics",
+		traceID:    trace.SpanContextFromContext(ctx).TraceID(),
+		clientID:   c.ID,
+		httpClient: httpClient,
+		eg:         c.telemetry,
+	}
+
+	return exp.Consume(ctx, func(data []byte) error {
+		var req colmetricspb.ExportMetricsServiceRequest
+		if err := protojson.Unmarshal(data, &req); err != nil {
+			return fmt.Errorf("unmarshal metrics: %w", err)
+		}
+		if err := enginetel.ReexportMetricsFromPB(ctx, c.EngineMetrics, &req); err != nil {
+			return fmt.Errorf("re-export metrics: %w", err)
 		}
 		return nil
 	})

--- a/engine/clientdb/metric.go
+++ b/engine/clientdb/metric.go
@@ -1,0 +1,76 @@
+package clientdb
+
+import (
+	"log/slog"
+
+	"dagger.io/dagger/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	otlpmetricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func MetricsToPB(dbMetrics []Metric) []*otlpmetricsv1.ResourceMetrics {
+	if len(dbMetrics) == 0 {
+		return nil
+	}
+
+	resourceMetrics := make(map[attribute.Distinct]*otlpmetricsv1.ResourceMetrics)
+
+	type key struct {
+		r  attribute.Distinct
+		is instrumentation.Scope
+	}
+	scopeMetrics := make(map[key]*otlpmetricsv1.ScopeMetrics)
+
+	for _, dbMetric := range dbMetrics {
+		var metricResourcePB otlpmetricsv1.ResourceMetrics
+		if err := protojson.Unmarshal(dbMetric.Data, &metricResourcePB); err != nil {
+			slog.Error("failed to unmarshal metric resource", "error", err, "metric", dbMetric)
+			continue
+		}
+
+		res := telemetry.ResourceFromPB(metricResourcePB.SchemaUrl, metricResourcePB.Resource)
+
+		for _, scopeMetricPB := range metricResourcePB.ScopeMetrics {
+			scope := telemetry.InstrumentationScopeFromPB(scopeMetricPB.Scope)
+
+			rKey := res.Equivalent()
+			k := key{
+				r:  rKey,
+				is: scope,
+			}
+			scopeMetric, iOk := scopeMetrics[k]
+			if !iOk {
+				// Either the resource or instrumentation scope were unknown.
+				scopeMetric = &otlpmetricsv1.ScopeMetrics{
+					Scope:     scopeMetricPB.Scope,
+					Metrics:   []*otlpmetricsv1.Metric{},
+					SchemaUrl: scope.SchemaURL,
+				}
+			}
+			scopeMetric.Metrics = append(scopeMetric.Metrics, scopeMetricPB.Metrics...)
+			scopeMetrics[k] = scopeMetric
+
+			rs, rOk := resourceMetrics[rKey]
+			if !rOk {
+				rs = &otlpmetricsv1.ResourceMetrics{
+					Resource:     metricResourcePB.Resource,
+					ScopeMetrics: []*otlpmetricsv1.ScopeMetrics{scopeMetric},
+					SchemaUrl:    res.SchemaURL(),
+				}
+				resourceMetrics[rKey] = rs
+				continue
+			}
+			if !iOk {
+				rs.ScopeMetrics = append(rs.ScopeMetrics, scopeMetric)
+			}
+		}
+	}
+
+	results := make([]*otlpmetricsv1.ResourceMetrics, 0, len(resourceMetrics))
+	for _, rm := range resourceMetrics {
+		results = append(results, rm)
+	}
+	return results
+}

--- a/engine/clientdb/models.go
+++ b/engine/clientdb/models.go
@@ -22,6 +22,11 @@ type Log struct {
 	ResourceSchemaUrl    string
 }
 
+type Metric struct {
+	ID   int64
+	Data []byte
+}
+
 type Span struct {
 	ID                     int64
 	TraceID                string

--- a/engine/clientdb/queries.sql
+++ b/engine/clientdb/queries.sql
@@ -40,15 +40,18 @@ INSERT INTO logs (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 ) RETURNING id;
 
--- -- name: InsertMetric :one
--- INSERT INTO metrics (
---     name, description, unit, type, timestamp, data_points
--- ) VALUES (
---     ?, ?, ?, ?, ?, ?
--- ) RETURNING id;
+-- name: InsertMetric :one
+INSERT INTO metrics (
+    data
+) VALUES (
+    ?
+) RETURNING id;
 
 -- name: SelectSpansSince :many
 SELECT * FROM spans WHERE id > ? ORDER BY id ASC LIMIT ?;
 
 -- name: SelectLogsSince :many
 SELECT * FROM logs WHERE id > ? ORDER BY id ASC LIMIT ?;
+
+-- name: SelectMetricsSince :many
+SELECT * FROM metrics WHERE id > ? ORDER BY id ASC LIMIT ?;

--- a/engine/clientdb/schema.sql
+++ b/engine/clientdb/schema.sql
@@ -42,3 +42,8 @@ CREATE TABLE IF NOT EXISTS logs (
     resource BLOB, -- JSON encoded *otlpresourcev1.Resource
     resource_schema_url TEXT NOT NULL
 ) STRICT;
+
+CREATE TABLE IF NOT EXISTS metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    data BLOB -- JSON encoded otlpmetricsv1.ResourceMetrics
+) STRICT;

--- a/engine/telemetry/metrics.go
+++ b/engine/telemetry/metrics.go
@@ -1,0 +1,36 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"golang.org/x/sync/errgroup"
+
+	"dagger.io/dagger/telemetry"
+)
+
+func ReexportMetricsFromPB(ctx context.Context, exps []sdkmetric.Exporter, req *colmetricspb.ExportMetricsServiceRequest) error {
+	for _, reqResourceMetrics := range req.GetResourceMetrics() {
+		var eg errgroup.Group
+		for _, exp := range exps {
+			eg.Go(func() error {
+				resourceMetrics, err := telemetry.ResourceMetricsFromPB(reqResourceMetrics)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal resource metrics: %w", err)
+				}
+				err = exp.Export(ctx, resourceMetrics)
+				if err != nil {
+					return fmt.Errorf("failed to export resource metrics: %w", err)
+				}
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -251,8 +251,8 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
-	go.opentelemetry.io/otel/metric v1.27.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.27.0 // indirect
+	go.opentelemetry.io/otel/metric v1.27.0
+	go.opentelemetry.io/otel/sdk/metric v1.27.0
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -63,6 +63,13 @@ func WithVersionOverride(version string) ClientOpt {
 	})
 }
 
+// WithVerbosity sets the verbosity level for the progress output
+func WithVerbosity(level int) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.Verbosity = level
+	})
+}
+
 // WithRunnerHost sets the runner host URL for provisioning and connecting to
 // an engine.
 //

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -19,11 +19,15 @@ require (
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
 	go.opentelemetry.io/otel/log v0.3.0
+	go.opentelemetry.io/otel/metric v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/log v0.3.0
+	go.opentelemetry.io/otel/sdk/metric v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
 	go.opentelemetry.io/proto/otlp v1.3.1
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
@@ -41,7 +45,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect
-	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -45,6 +45,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-2024051809000
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88/go.mod h1:JGG8ebaMO5nXOPnvKEl+DiA4MGwFjCbjsxT1WHIEBPY=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0 h1:ccBrA8nCY5mM0y5uO7FT0ze4S0TuFcWdDB2FxGMTjkI=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0/go.mod h1:/9pb6634zi2Lk8LYg9Q0X8Ar6jka4dkFOylBLbVQPCE=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0 h1:bFgvUr3/O4PHj3VQcFEuYKvRZJX1SJDQ+11JXuSB3/w=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0/go.mod h1:xJntEd2KL6Qdg5lwp97HMLQDVeAhrYxmzFseAMDPQ8I=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0 h1:CIHWikMsN3wO+wq1Tp5VGdVRTcON+DmOJSfDjXypKOc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0/go.mod h1:TNupZ6cxqyFEpLXAZW7On+mLFL0/g0TE3unIYL91xWc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 h1:R9DE4kQ4k+YtfLI2ULwX82VtNQ2J8yZmA7ZIF/D+7Mc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0/go.mod h1:OQFyQVrDlbe+R7xrEyDr/2Wr67Ol0hRUgsfA+V5A95s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 h1:qFffATk0X+HD+f1Z8lswGiOQYKHRlzfmdJm0wEaVrFA=
@@ -59,6 +63,8 @@ go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kT
 go.opentelemetry.io/otel/sdk v1.27.0/go.mod h1:Ha9vbLwJE6W86YstIywK2xFfPjbWlCuwPtMkKdz/Y4A=
 go.opentelemetry.io/otel/sdk/log v0.3.0 h1:GEjJ8iftz2l+XO1GF2856r7yYVh74URiF9JMcAacr5U=
 go.opentelemetry.io/otel/sdk/log v0.3.0/go.mod h1:BwCxtmux6ACLuys1wlbc0+vGBd+xytjmjajwqqIul2g=
+go.opentelemetry.io/otel/sdk/metric v1.27.0 h1:5uGNOlpXi+Hbo/DRoI31BSb1v+OGcpv2NemcCrOL8gI=
+go.opentelemetry.io/otel/sdk/metric v1.27.0/go.mod h1:we7jJVrYN2kh3mVBlswtPU22K0SA+769l93J6bsyvqw=
 go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -26,6 +26,7 @@ type Config struct {
 	RunnerHost      string
 	Conn            EngineConn
 	VersionOverride string
+	Verbosity       int
 }
 
 type ConnectParams struct {

--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -90,6 +90,10 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 		}
 	}
 
+	if cfg.Verbosity > 0 {
+		args = append(args, "-"+strings.Repeat("v", cfg.Verbosity))
+	}
+
 	env := os.Environ()
 
 	if cfg.RunnerHost != "" {

--- a/sdk/go/telemetry/attrs.go
+++ b/sdk/go/telemetry/attrs.go
@@ -83,4 +83,28 @@ const (
 
 	// Indicates whether the log should be shown globally.
 	LogsGlobalAttr = "dagger.io/logs.global"
+
+	// OTel metric attribute so we can correlate metrics with spans
+	MetricsSpanID = "dagger.io/metrics.span"
+
+	// OTel metric attribute so we can correlate metrics with traces
+	MetricsTraceID = "dagger.io/metrics.trace"
+
+	// OTel metric for number of bytes read from disk by a container, as parsed from its cgroup
+	IOStatDiskReadBytes = "dagger.io/metrics.iostat.disk.readbytes"
+
+	// OTel metric for number of bytes written to disk by a container, as parsed from its cgroup
+	IOStatDiskWriteBytes = "dagger.io/metrics.iostat.disk.writebytes"
+
+	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on IO
+	IOStatPressureSomeTotal = "dagger.io/metrics.iostat.pressure.some.total"
+
+	// OTel metric units should be in UCUM format
+	// https://unitsofmeasure.org/ucum
+
+	// Bytes unit for OTel metrics
+	ByteUnitName = "byte"
+
+	// Microseconds unit for OTel metrics
+	MicrosecondUnitName = "us"
 )

--- a/sdk/go/telemetry/attrs.go
+++ b/sdk/go/telemetry/attrs.go
@@ -85,26 +85,8 @@ const (
 	LogsGlobalAttr = "dagger.io/logs.global"
 
 	// OTel metric attribute so we can correlate metrics with spans
-	MetricsSpanID = "dagger.io/metrics.span"
+	MetricsSpanIDAttr = "dagger.io/metrics.span"
 
 	// OTel metric attribute so we can correlate metrics with traces
-	MetricsTraceID = "dagger.io/metrics.trace"
-
-	// OTel metric for number of bytes read from disk by a container, as parsed from its cgroup
-	IOStatDiskReadBytes = "dagger.io/metrics.iostat.disk.readbytes"
-
-	// OTel metric for number of bytes written to disk by a container, as parsed from its cgroup
-	IOStatDiskWriteBytes = "dagger.io/metrics.iostat.disk.writebytes"
-
-	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on IO
-	IOStatPressureSomeTotal = "dagger.io/metrics.iostat.pressure.some.total"
-
-	// OTel metric units should be in UCUM format
-	// https://unitsofmeasure.org/ucum
-
-	// Bytes unit for OTel metrics
-	ByteUnitName = "byte"
-
-	// Microseconds unit for OTel metrics
-	MicrosecondUnitName = "us"
+	MetricsTraceIDAttr = "dagger.io/metrics.trace"
 )

--- a/sdk/go/telemetry/init.go
+++ b/sdk/go/telemetry/init.go
@@ -14,10 +14,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
@@ -65,6 +68,7 @@ func ConfiguredSpanExporter(ctx context.Context) (sdktrace.SpanExporter, bool) {
 			return
 		}
 
+		//nolint:dupl
 		switch proto {
 		case "http/protobuf", "http":
 			headers := map[string]string{}
@@ -81,7 +85,7 @@ func ConfiguredSpanExporter(ctx context.Context) (sdktrace.SpanExporter, bool) {
 			var u *url.URL
 			u, err = url.Parse(endpoint)
 			if err != nil {
-				slog.Warn("bad OTLP logs endpoint %q: %w", endpoint, err)
+				slog.Warn("bad OTLP span endpoint %q: %w", endpoint, err)
 				return
 			}
 			opts := []otlptracegrpc.Option{
@@ -182,6 +186,81 @@ func ConfiguredLogExporter(ctx context.Context) (sdklog.Exporter, bool) {
 	return configuredLogExporter, configuredLogExporter != nil
 }
 
+var configuredMetricExporter sdkmetric.Exporter
+var configuredMetricExporterOnce sync.Once
+
+func ConfiguredMetricExporter(ctx context.Context) (sdkmetric.Exporter, bool) {
+	ctx = context.WithoutCancel(ctx)
+
+	configuredMetricExporterOnce.Do(func() {
+		var err error
+
+		var endpoint string
+		if v := os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"); v != "" {
+			endpoint = v
+		} else if v := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); v != "" {
+			// we can't assume all OTLP endpoints support metrics. better to be explicit
+			// than have noisy otel errors.
+			return
+		}
+		if endpoint == "" {
+			return
+		}
+
+		var proto string
+		if v := os.Getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"); v != "" {
+			proto = v
+		} else if v := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"); v != "" {
+			proto = v
+		} else {
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md#specify-protocol
+			proto = "http/protobuf"
+		}
+
+		//nolint:dupl
+		switch proto {
+		case "http/protobuf", "http":
+			headers := map[string]string{}
+			if hs := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"); hs != "" {
+				for _, header := range strings.Split(hs, ",") {
+					name, value, _ := strings.Cut(header, "=")
+					headers[name] = value
+				}
+			}
+			configuredMetricExporter, err = otlpmetrichttp.New(ctx,
+				otlpmetrichttp.WithEndpointURL(endpoint),
+				otlpmetrichttp.WithHeaders(headers))
+
+		case "grpc":
+			var u *url.URL
+			u, err = url.Parse(endpoint)
+			if err != nil {
+				slog.Warn("bad OTLP metrics endpoint %q: %w", endpoint, err)
+				return
+			}
+			opts := []otlpmetricgrpc.Option{
+				otlpmetricgrpc.WithEndpointURL(endpoint),
+			}
+			if u.Scheme == "unix" {
+				dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+					return net.Dial(u.Scheme, u.Path)
+				}
+				opts = append(opts,
+					otlpmetricgrpc.WithDialOption(grpc.WithContextDialer(dialer)),
+					otlpmetricgrpc.WithInsecure())
+			}
+			configuredMetricExporter, err = otlpmetricgrpc.New(ctx, opts...)
+
+		default:
+			err = fmt.Errorf("unknown OTLP protocol: %s", proto)
+		}
+		if err != nil {
+			slog.Warn("failed to configure metrics", "error", err)
+		}
+	})
+	return configuredMetricExporter, configuredMetricExporter != nil
+}
+
 // fallbackResource is the fallback resource definition. A more specific
 // resource should be set in Init.
 func fallbackResource() *resource.Resource {
@@ -218,6 +297,9 @@ type Config struct {
 	// LiveLogExporters are exporters that receive logs in batches of ~100ms.
 	LiveLogExporters []sdklog.Exporter
 
+	// LiveMetricExporters are exporters that receive metrics in batches of ~1s.
+	LiveMetricExporters []sdkmetric.Exporter
+
 	// Resource is the resource describing this component and runtime
 	// environment.
 	Resource *resource.Resource
@@ -234,6 +316,7 @@ var LiveTracesEnabled = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_LIVE") != ""
 var Resource *resource.Resource
 var SpanProcessors = []sdktrace.SpanProcessor{}
 var LogProcessors = []sdklog.Processor{}
+var MetricExporters = []sdkmetric.Exporter{}
 
 func InitEmbedded(ctx context.Context, res *resource.Resource) context.Context {
 	traceCfg := Config{
@@ -245,6 +328,9 @@ func InitEmbedded(ctx context.Context, res *resource.Resource) context.Context {
 	}
 	if exp, ok := ConfiguredLogExporter(ctx); ok {
 		traceCfg.LiveLogExporters = append(traceCfg.LiveLogExporters, exp)
+	}
+	if exp, ok := ConfiguredMetricExporter(ctx); ok {
+		traceCfg.LiveMetricExporters = append(traceCfg.LiveMetricExporters, exp)
 	}
 	return Init(ctx, traceCfg)
 }
@@ -304,6 +390,9 @@ func Init(ctx context.Context, cfg Config) context.Context {
 		if exp, ok := ConfiguredLogExporter(ctx); ok {
 			cfg.LiveLogExporters = append(cfg.LiveLogExporters, exp)
 		}
+		if exp, ok := ConfiguredMetricExporter(ctx); ok {
+			cfg.LiveMetricExporters = append(cfg.LiveMetricExporters, exp)
+		}
 	}
 
 	traceOpts := []sdktrace.TracerProviderOption{
@@ -345,6 +434,24 @@ func Init(ctx context.Context, cfg Config) context.Context {
 			logOpts = append(logOpts, sdklog.WithProcessor(processor))
 		}
 		ctx = WithLoggerProvider(ctx, sdklog.NewLoggerProvider(logOpts...))
+	}
+
+	// Set up a metric provider if configured.
+	if len(cfg.LiveMetricExporters) > 0 {
+		meterOpts := []sdkmetric.Option{
+			sdkmetric.WithResource(cfg.Resource),
+		}
+		const metricsExportInterval = 1 * time.Second
+		const metricsExportTimeout = 1 * time.Second
+		for _, exp := range cfg.LiveMetricExporters {
+			MetricExporters = append(MetricExporters, exp)
+			reader := sdkmetric.NewPeriodicReader(exp,
+				sdkmetric.WithInterval(metricsExportInterval),
+				sdkmetric.WithTimeout(metricsExportTimeout),
+			)
+			meterOpts = append(meterOpts, sdkmetric.WithReader(reader))
+		}
+		ctx = WithMeterProvider(ctx, sdkmetric.NewMeterProvider(meterOpts...))
 	}
 
 	closeCtx = ctx

--- a/sdk/go/telemetry/metrics.go
+++ b/sdk/go/telemetry/metrics.go
@@ -7,6 +7,26 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
+const (
+	// OTel metric for number of bytes read from disk by a container, as parsed from its cgroup
+	IOStatDiskReadBytes = "dagger.io/metrics.iostat.disk.readbytes"
+
+	// OTel metric for number of bytes written to disk by a container, as parsed from its cgroup
+	IOStatDiskWriteBytes = "dagger.io/metrics.iostat.disk.writebytes"
+
+	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on IO
+	IOStatPressureSomeTotal = "dagger.io/metrics.iostat.pressure.some.total"
+
+	// OTel metric units should be in UCUM format
+	// https://unitsofmeasure.org/ucum
+
+	// Bytes unit for OTel metrics
+	ByteUnitName = "byte"
+
+	// Microseconds unit for OTel metrics
+	MicrosecondUnitName = "us"
+)
+
 type meterProviderKey struct{}
 
 func WithMeterProvider(ctx context.Context, provider *sdkmetric.MeterProvider) context.Context {

--- a/sdk/go/telemetry/metrics.go
+++ b/sdk/go/telemetry/metrics.go
@@ -1,0 +1,26 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+type meterProviderKey struct{}
+
+func WithMeterProvider(ctx context.Context, provider *sdkmetric.MeterProvider) context.Context {
+	return context.WithValue(ctx, meterProviderKey{}, provider)
+}
+
+func MeterProvider(ctx context.Context) *sdkmetric.MeterProvider {
+	meterProvider := sdkmetric.NewMeterProvider()
+	if val := ctx.Value(meterProviderKey{}); val != nil {
+		meterProvider = val.(*sdkmetric.MeterProvider)
+	}
+	return meterProvider
+}
+
+func Meter(ctx context.Context, name string) metric.Meter {
+	return MeterProvider(ctx).Meter(name)
+}


### PR DESCRIPTION
This PR adds support for OTel metrics to the engine+CLI (TUI specifically) and publishes some initial metrics for exec-ops that's parsed from their cgroup.
* For now, the metrics are just total bytes read/written from/to the disk and IO pressure
* More metrics can easily be added iteratively as desired.

Metrics are currently only shown in the TUI on `-vvv` verbosity or above.

Example of building the engine (metrics show up in green after exec has been running for at least 3 seconds or has finished):
[![asciicast](https://asciinema.org/a/zVcmVMv3CEsu1Ko6Vt6r98T7z.svg)](https://asciinema.org/a/zVcmVMv3CEsu1Ko6Vt6r98T7z)

## OTel Metrics Primer
Braindump of what I've learned about OTel metrics:
1. To publish metrics, you need a `Meter`, which you get from a `MeterProvider` (described more below).
   * A `Meter` is associated with a particular `Resource` and lets you create all sorts of different `Instrument` kinds for recording different types of data ([link to different kinds](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points))
   * Currently, I only use an `Int64Gauge` since it fits the collected data so far, but we'll likely need to use more in time.
   * Usage in code
     * [Create a meter](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/engine/buildkit/executor_spec.go#L1195-L1195)
     * [Create an instrument from a meter](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/engine/buildkit/resources/iostat.go#L42-L42)
2. `Meter`s have an associated `Aggregation` and `Temporality` that controls whether/how data points are aggregated/summarized before continuing down the pipeline.
   * Currently, this PR just configures everything everywhere to use default Aggregation for instruments, which for an `Int64Gauge` means we just publish the most recent value seen in a given sampling interval (more on that below).
   * Usage in code
     * [Configuration of `Aggregation`/`Temporality` in the engine](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/engine/server/telemetry.go#L574-L580)
     * [Configuration of `Aggregation`/`Temporality` in the CLI](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/dagql/dagui/db.go#L140-L146)
3. On the other side of the pipeline there's an `Exporter`, which is the same as the rest of OTel: it's an interface to a place you can push metrics (OTLP, etc.)
   * Usage in code
      * [Engine-side exporter to sqlite db](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/engine/server/telemetry.go#L538-L538)
      * [OTLP exporter setup](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/sdk/go/telemetry/init.go#L197-L197)
5. There's two components that connect together a `Meter` and an `Exporter`: a `Reader` and `MeterProvider`.
   * A `MeterProvider` is created directly from a `Reader` and as we currently use it is boilerplate for adapting the two interfaces. It lets you create `Meter`s that are hooked up to the `Reader`
   * One thing I didn't use yet are [`View`s, which get associated with the `MeterProvider` and allow you to customize the metrics stream](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) created by `Meter`s/`Instrument`s created from the `MeterProvider`.
   * The `Reader` is somewhat more meaningful. There's two implementation of it:
      * `ManualReader`: metrics will be collected and returned to the user by calling the `Collect` method on the `Reader`. The user then needs to publish them to an `Exporter` (or whatever)
      * `PeriodicReader`: metrics will be automatically collected on an interval and published to a given `Exporter` in the background
    * For now, I've just used a `PeriodicReader` everywhere applicable since it's simplest. Wouldn't be surprised if we want a `ManualReader` with custom logic in the future (i.e. to optimize by exporting based on both time+buffer size)
    * Usage in code:
      * [engine-side metric provider + reader setup for each client](https://github.com/sipsma/dagger/blob/7c0e94c674db3299426fe2a89c2aa90f06ca8754/engine/server/session.go#L632-L632)

Useful links:
* [Metrics Overview](https://opentelemetry.io/docs/concepts/signals/metrics/)
* [Metrics Data Model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/)

## Cgroup based metrics
I ended up going with our own custom implementation of cgroup monitoring rather than re-using upstream's code. This allowed us to simplify and specialize it for OTel metrics integration more easily.

Monitoring the cgroup amounts to just periodically parsing some files under `/sys/fs/cgroup` for the exec and publishing them on some OTel metric `Instrument`s.
* The format of the files being parsed can be found in kernel docs [here](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)

I started with Disk bytes read/written and IO pressure because:
* They are simple `Int64Gauge`s that don't require deltas, aggregation, etc.
* They are most immediately relevant to bottlenecks we are currently investigating

Adding support for more exec metrics will mostly be a matter of parsing more files.
* One notable exception is network usage, which instead needs to be sampled from the CNI netns interface, but otherwise it should be the same idea.

Misc notes:
* The metrics are currently sampled:
   * Every 3 seconds while the exec is running
   * A single time after the exec exits to get final values (or the only values if the exec lasted less than 3s)
* I found that you will often get inconsistent/unexpectedly-low read/write disk bytes if you don't include a `sync` in the exec and don't use direct io for reading.
   * This is because it's counting actual read/writes that hit the disk, *not counting* the kernels read/write cache in memory.
   * This is fine, but cgroups do appear to also give info on read/write caches, so we could consider aggregating if needed

---


Basically working, just doing cleanup

TODO (mostly notes for self):
- [x] Try using span id instead of call digest (keep call digest as attr though)
- [x] Add tests
- [x] Fix plain progress
- [x] Fix forwarding from nested sessions (so we can get data from dagger call test)
- [x] Add io pressure
- [x] Doc a bit more
- [x] Remove extraneous `// TODO:`s
- [x] Cleanup commit history
- [x] Hide metrics behind some verbosity level (TBD which)
   - this happened as a side effect of displaying it alongside spans rather than calls; only shows up at `-vvv` now which seems reasonable to start
- [x] Check performance impact on CI, tune various intervals if needed
- [x] Double check if any duplicate code ended up in `transform.go` (there was a lot of copypasta from internal otel packages, may have duplicated something existing on accident)
- [ ] Fix flaky test (or remove for now pending https://github.com/dagger/dagger/pull/8442)