### PR TITLE
fix version nag

### DIFF
--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -78,7 +78,8 @@ func updateAvailable(ctx context.Context) (string, error) {
 		return latest, nil
 	}
 
-	return latest, nil
+	// We're already up to date, so there isn't a new version available
+	return "", nil
 }
 
 func latestVersion(ctx context.Context) (v string, rerr error) {


### PR DESCRIPTION
tested manually locally:

```
dagger on  fix-version-nag [$] via 🐹 v1.23.1 
❯ go build -ldflags "-X github.com/dagger/dagger/engine.Version=v0.13.2 -X github.com/dagger/dagger/engine.Tag=v0.13.2" -o ./bin ./cmd/dagger

dagger on  fix-version-nag [$] via 🐹 v1.23.1 took 2s 
❯ ./bin/dagger version
dagger v0.13.2 (registry.dagger.io/engine:v0.13.2) linux/amd64

dagger on  fix-version-nag [$] via 🐹 v1.23.1 
❯ ./bin/dagger core version
✔ connect 0.3s
✔ initialize 0.4s
✔ prepare 0.0s
✔ version: String! 0.0s

Full trace at https://dagger.cloud/dagger/traces/26922b4f39051af2af9dd68bd93f9640

v0.13.2

dagger on  fix-version-nag [$] via 🐹 v1.23.1 
❯ gst
On branch fix-version-nag
nothing to commit, working tree clean

dagger on  fix-version-nag [$] via 🐹 v1.23.1 
❯ gst
On branch fix-version-nag
nothing to commit, working tree clean

dagger on  fix-version-nag [$] via 🐹 v1.23.1 
❯ go build -ldflags "-X github.com/dagger/dagger/engine.Version=v0.13.1 -X github.com/dagger/dagger/engine.Tag=v0.13.1" -o ./bin ./cmd/dagger

dagger on  fix-version-nag [$] via 🐹 v1.23.1 took 2s 
❯ ./bin/dagger core version
✔ connect 14.9s
✔ initialize 0.4s
✔ prepare 0.0s
✔ version: String! 0.0s

Full trace at https://dagger.cloud/dagger/traces/dc1ce54d86baafb5c2340f1f44c1fe88

v0.13.1

A new release of dagger is available: v0.13.1 → v0.13.2
To upgrade, see https://docs.dagger.io/install
https://github.com/dagger/dagger/releases/tag/v0.13.2
```