### PR TITLE
allow '=' to also increase verbosity

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -706,7 +706,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 			fe.zoomed = fe.db.PrimarySpan
 			fe.recalculateViewLocked()
 			return fe, nil
-		case "+":
+		case "+", "=":
 			fe.FrontendOpts.Verbosity++
 			fe.recalculateViewLocked()
 			return fe, nil


### PR DESCRIPTION
On a US keyboard, `-` does not require shift to be pressed, but `+` does (on the `=` key).  This makes it annoying to adjust the verbosity quickly.  This adds `=` as an alias for `+` so either can be used to increase the verbosity, and you can avoid using the shift key altogether.

This has been a paper cut for me as I try to turn up the verbosity to learn what dagger is doing and then trying to dial it back down to the default.