### PR TITLE
fix readthedocs command

### DIFF
--- a/sdk/python/.readthedocs.yaml
+++ b/sdk/python/.readthedocs.yaml
@@ -10,4 +10,4 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - cd sdk/python && uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
The `sdk/python/.readthedocs.yaml` isn't being used yet. It's meant to replace the [one at the root](https://github.com/dagger/dagger/blob/5ec03a604d50b721aaa65ba7c4db8c875696ac72/.readthedocs.yaml), but needs this fix before switching.