### PR TITLE
Add Doc Attribute

### DIFF
--- a/sdk/php/dev/src/PhpSdkDev.php
+++ b/sdk/php/dev/src/PhpSdkDev.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace DaggerModule;
 
-use Dagger\Attribute\Argument;
 use Dagger\Attribute\DaggerFunction;
 use Dagger\Attribute\DaggerObject;
+use Dagger\Attribute\Doc;
 use Dagger\Container;
 use Dagger\Directory;
 use GraphQL\Exception\QueryError;
@@ -14,15 +14,17 @@ use GraphQL\Exception\QueryError;
 use function Dagger\dag;
 
 #[DaggerObject]
+#[Doc("The PHP SDK's development module.")]
 final class PhpSdkDev
 {
     private const SDK_ROOT='/src/sdk/php';
 
-    #[DaggerFunction('Run tests from source directory')]
+    #[DaggerFunction]
+    #[Doc('Run tests from source directory')]
     public function test(
-        #[Argument('Run tests from the given source directory')]
+        #[Doc('Run tests from the given source directory')]
         Directory $source,
-        #[Argument('Only run tests in the given group')]
+        #[Doc('Only run tests in the given group')]
         ?string $group = null,
     ): Container {
         return $this->base($source)->withExec(
@@ -31,8 +33,10 @@ final class PhpSdkDev
         );
     }
 
-    #[DaggerFunction('Lint the source directory')]
-    public function lint(Directory $source): Container {
+    #[DaggerFunction]
+    #[Doc('Run linter in source directory')]
+    public function lint(Directory $source): Container
+    {
         return $this->base($source)->withExec(['phpcs']);
     }
 
@@ -51,7 +55,8 @@ final class PhpSdkDev
      * This will most likely occur on a 4.0 release:
      * https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/184
      */
-    #[DaggerFunction('Format the source directory')]
+    #[DaggerFunction]
+    #[Doc('Return diff from formatting source directory')]
     public function format(Directory $source): Directory
     {
         $result = dag()->alwaysExec()->exec($this->base($source), ['phpcbf']);
@@ -66,7 +71,8 @@ final class PhpSdkDev
         return $original->diff($result->directory(self::SDK_ROOT));
     }
 
-    #[DaggerFunction('Format the source directory')]
+    #[DaggerFunction]
+    #[Doc('Return stdout from formatting source directory')]
     public function formatStdout(Directory $source): string
     {
         $result = dag()->alwaysExec()->exec($this->base($source), ['phpcbf']);

--- a/sdk/php/runtime/scripts/init-template.sh
+++ b/sdk/php/runtime/scripts/init-template.sh
@@ -6,7 +6,7 @@ CLASS=$(/sdk/scripts/codegen.php dagger:generate-module-classname "$1")
 
 if ! [ -f composer.json ]; then
     cp -r /opt/template/* .
-    sed -i "s/class Example/class $CLASS/g" ./src/Example.php
+    sed -i "s/Example/$CLASS/g" ./src/Example.php
     mv ./src/Example.php ./src/$CLASS.php
 
     PACKAGE_NAME=$(echo $1 | tr '[:upper:]' '[:lower:]' | tr -s '[:blank:]' '\-')

--- a/sdk/php/runtime/template/src/Example.php
+++ b/sdk/php/runtime/template/src/Example.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace DaggerModule;
 
-use Dagger\Attribute\Argument;
 use Dagger\Attribute\DaggerFunction;
 use Dagger\Attribute\DaggerObject;
+use Dagger\Attribute\Doc;
 use Dagger\Container;
 use Dagger\Directory;
 
 use function Dagger\dag;
 
 #[DaggerObject]
+#[Doc('A generated module for Example functions')]
 class Example
 {
-    #[DaggerFunction('Returns a container that echoes whatever string argument is provided')]
+    #[DaggerFunction]
+    #[Doc('Returns a container that echoes whatever string argument is provided')]
     public function containerEcho(string $stringArg): Container
     {
         return dag()
@@ -24,11 +26,12 @@ class Example
             ->withExec(['echo', $stringArg]);
     }
 
-    #[DaggerFunction('Returns lines that match a pattern in the files of the provided Directory')]
+    #[DaggerFunction]
+    #[Doc('Returns lines that match a pattern in the files of the provided Directory')]
     public function grepDir(
-        #[Argument('The directory to search')]
+        #[Doc('The directory to search')]
         Directory $directoryArg,
-        #[Argument('The pattern to search for')]
+        #[Doc('The pattern to search for')]
         string $pattern
     ): string {
         return dag()

--- a/sdk/php/src/Attribute/Argument.php
+++ b/sdk/php/src/Attribute/Argument.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dagger\Attribute;
 
+/** @deprecated use #[Doc]*/
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final readonly class Argument
 {

--- a/sdk/php/src/Attribute/DaggerFunction.php
+++ b/sdk/php/src/Attribute/DaggerFunction.php
@@ -8,6 +8,10 @@ namespace Dagger\Attribute;
 final readonly class DaggerFunction
 {
     //@TODO support renaming argument with public string $name
+
+    /**
+     * @param string|null $description deprecated, use #[Doc]
+     */
     public function __construct(
         public ?string $description = null,
     ) {

--- a/sdk/php/src/Attribute/Doc.php
+++ b/sdk/php/src/Attribute/Doc.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Attribute;
+
+use Attribute;
+
+#[Attribute(
+    Attribute::TARGET_CLASS |
+    Attribute::TARGET_METHOD |
+    Attribute::TARGET_PARAMETER
+)]
+final readonly class Doc
+{
+    public function __construct(
+        public string $description,
+    ) {
+    }
+}

--- a/sdk/php/src/Command/EntrypointCommand.php
+++ b/sdk/php/src/Command/EntrypointCommand.php
@@ -38,9 +38,9 @@ class EntrypointCommand extends Command
         $functionCall = dag()->currentFunctionCall();
 
         try {
-                return $functionCall->parentName() === '' ?
-                    $this->registerModule($functionCall) :
-                    $this->callFunctionOnParent($output, $functionCall);
+            return $functionCall->parentName() === '' ?
+                $this->registerModule($functionCall) :
+                $this->callFunctionOnParent($output, $functionCall);
         } catch (\Throwable $t) {
             $this->outputErrorInformation($input, $output, $t);
 
@@ -56,9 +56,10 @@ class EntrypointCommand extends Command
         $daggerObjects = (new FindsDaggerObjects())($src);
 
         foreach ($daggerObjects as $daggerObject) {
-            $objectTypeDef = dag()
-                ->typeDef()
-                ->withObject($this->normalizeClassname($daggerObject->name));
+            $objectTypeDef = dag()->typeDef()->withObject(
+                $this->normalizeClassname($daggerObject->name),
+                $daggerObject->description,
+            );
 
             foreach ($daggerObject->daggerFunctions as $daggerFunction) {
                 $func = dag()->function(

--- a/sdk/php/src/ValueObject/DaggerFunction.php
+++ b/sdk/php/src/ValueObject/DaggerFunction.php
@@ -32,28 +32,34 @@ final readonly class DaggerFunction
      */
     public static function fromReflection(ReflectionMethod $method): self
     {
-        $attribute = (current($method
+        $daggerFunction = (current($method
             ->getAttributes(Attribute\DaggerFunction::class)) ?: null)
-            ?->newInstance() ??
-            throw new RuntimeException('method is not a DaggerFunction');
+            ?->newInstance()
+            ?? throw new RuntimeException('method is not a DaggerFunction');
+
+        $description = (current($method
+            ->getAttributes(Attribute\Doc::class)) ?: null)
+            ?->newInstance()
+            ?->description;
 
         $parameters = array_map(
             fn($p) => Argument::fromReflection($p),
             $method->getParameters(),
         );
 
+
         return $method->isConstructor() ?
             new self(
-                '',
-                null,
-                $parameters,
-                new Type($method->getDeclaringClass()->name)
+                name: '',
+                description: null,
+                arguments: $parameters,
+                returnType: new Type($method->getDeclaringClass()->name)
             ) :
             new self(
-                $method->name,
-                $attribute->description,
-                $parameters,
-                self::getReturnType($method),
+                name: $method->name,
+                description: $description ?? $daggerFunction?->description,
+                arguments: $parameters,
+                returnType: self::getReturnType($method),
             );
     }
 

--- a/sdk/php/tests/Unit/Fixture/DaggerObjectWithDaggerFunctions.php
+++ b/sdk/php/tests/Unit/Fixture/DaggerObjectWithDaggerFunctions.php
@@ -105,186 +105,190 @@ final class DaggerObjectWithDaggerFunctions
 
     public static function getValueObjectEquivalent(): ValueObject\DaggerObject
     {
-        return new ValueObject\DaggerObject(DaggerObjectWithDaggerFunctions::class, [
-            new ValueObject\DaggerFunction(
-                '',
-                null,
-                [],
-                new ValueObject\Type(self::class)
-            ),
-            new ValueObject\DaggerFunction(
-                'returnBool',
-                null,
-                [],
-                new ValueObject\Type('bool')
-            ),
-            new ValueObject\DaggerFunction(
-                'returnInt',
-                'this method returns 1',
-                [],
-                new ValueObject\Type('int')
-            ),
-            new ValueObject\DaggerFunction(
-                'returnString',
-                null,
-                [],
-                new ValueObject\Type('string')
-            ),
-            new ValueObject\DaggerFunction(
-                'requiredBool',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('bool'),
-                        null,
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'requiredInt',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('int'),
-                        null,
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'requiredString',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('string'),
-                        null,
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'implicitlyOptionalString',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('string', true),
-                        new Json('null'),
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'explicitlyOptionalString',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('string', true),
-                        new Json('null'),
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'stringWithDefault',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type('string', true),
-                        new Json('"test"'),
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'annotatedString',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        'this value should have a description',
-                        new ValueObject\Type('string'),
-                        null,
-                    ),
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'requiredStrings',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'first',
-                        null,
-                        new ValueObject\Type('string'),
-                        null,
-                    ),
-                    new ValueObject\Argument(
-                        'second',
-                        null,
-                        new ValueObject\Type('string'),
-                        null,
-                    ),
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'stringsWithDefaults',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'first',
-                        null,
-                        new ValueObject\Type('string'),
-                        new Json('"first"'),
-                    ),
-                    new ValueObject\Argument(
-                        'second',
-                        null,
-                        new ValueObject\Type('string'),
-                        new Json('"second"'),
-                    )
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'implicitlyOptionalContainer',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type(Container::class, true),
-                        new Json('null'),
-                    ),
-                ],
-                new ValueObject\Type('void'),
-            ),
-            new ValueObject\DaggerFunction(
-                'explicitlyOptionalFile',
-                null,
-                [
-                    new ValueObject\Argument(
-                        'value',
-                        null,
-                        new ValueObject\Type(File::class, true),
-                        new Json('null'),
-                    ),
-                ],
-                new ValueObject\Type('void'),
-            ),
-        ]);
+        return new ValueObject\DaggerObject(
+            DaggerObjectWithDaggerFunctions::class,
+            '',
+            [
+                new ValueObject\DaggerFunction(
+                    '',
+                    null,
+                    [],
+                    new ValueObject\Type(self::class)
+                ),
+                new ValueObject\DaggerFunction(
+                    'returnBool',
+                    '',
+                    [],
+                    new ValueObject\Type('bool')
+                ),
+                new ValueObject\DaggerFunction(
+                    'returnInt',
+                    'this method returns 1',
+                    [],
+                    new ValueObject\Type('int')
+                ),
+                new ValueObject\DaggerFunction(
+                    'returnString',
+                    '',
+                    [],
+                    new ValueObject\Type('string')
+                ),
+                new ValueObject\DaggerFunction(
+                    'requiredBool',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('bool'),
+                            null,
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'requiredInt',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('int'),
+                            null,
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'requiredString',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('string'),
+                            null,
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'implicitlyOptionalString',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('string', true),
+                            new Json('null'),
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'explicitlyOptionalString',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('string', true),
+                            new Json('null'),
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'stringWithDefault',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type('string', true),
+                            new Json('"test"'),
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'annotatedString',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            'this value should have a description',
+                            new ValueObject\Type('string'),
+                            null,
+                        ),
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'requiredStrings',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'first',
+                            '',
+                            new ValueObject\Type('string'),
+                            null,
+                        ),
+                        new ValueObject\Argument(
+                            'second',
+                            '',
+                            new ValueObject\Type('string'),
+                            null,
+                        ),
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'stringsWithDefaults',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'first',
+                            '',
+                            new ValueObject\Type('string'),
+                            new Json('"first"'),
+                        ),
+                        new ValueObject\Argument(
+                            'second',
+                            '',
+                            new ValueObject\Type('string'),
+                            new Json('"second"'),
+                        )
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'implicitlyOptionalContainer',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type(Container::class, true),
+                            new Json('null'),
+                        ),
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+                new ValueObject\DaggerFunction(
+                    'explicitlyOptionalFile',
+                    null,
+                    [
+                        new ValueObject\Argument(
+                            'value',
+                            '',
+                            new ValueObject\Type(File::class, true),
+                            new Json('null'),
+                        ),
+                    ],
+                    new ValueObject\Type('void'),
+                ),
+            ]
+        );
     }
 }

--- a/sdk/php/tests/Unit/Fixture/NoDaggerFunctions.php
+++ b/sdk/php/tests/Unit/Fixture/NoDaggerFunctions.php
@@ -17,6 +17,6 @@ final class NoDaggerFunctions
 
     public static function getValueObjectEquivalent(): ValueObject\DaggerObject
     {
-        return new ValueObject\DaggerObject(self::class, []);
+        return new ValueObject\DaggerObject(self::class, '', []);
     }
 }

--- a/sdk/php/tests/Unit/ValueObject/ArgumentTest.php
+++ b/sdk/php/tests/Unit/ValueObject/ArgumentTest.php
@@ -54,7 +54,7 @@ class ArgumentTest extends TestCase
     public static function provideReflectionParameters(): Generator
     {
         yield 'bool' => [
-            new Argument('value', null, new Type('bool'), null),
+            new Argument('value', '', new Type('bool'), null),
             self::getReflectionParameter(
                 DaggerObjectWithDaggerFunctions::class,
                 'requiredBool',
@@ -65,7 +65,7 @@ class ArgumentTest extends TestCase
         yield 'implicitly optional string' => [
             new Argument(
                 'value',
-                null,
+                '',
                 new Type('string', true),
                 new Json('null'),
             ),
@@ -79,7 +79,7 @@ class ArgumentTest extends TestCase
         yield 'explicitly optional string' => [
             new Argument(
                 'value',
-                null,
+                '',
                 new Type('string', true),
                 new Json('null'),
             ),
@@ -107,7 +107,7 @@ class ArgumentTest extends TestCase
         yield 'implicitly optional Container' => [
             new Argument(
                 'value',
-                null,
+                '',
                 new Type(Container::class, true),
                 new Json('null'),
             ),
@@ -121,7 +121,7 @@ class ArgumentTest extends TestCase
         yield 'explicitly optional File' => [
             new Argument(
                 'value',
-                null,
+                '',
                 new Type(File::class, true),
                 new Json('null'),
             ),

--- a/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
+++ b/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
@@ -127,7 +127,7 @@ class DaggerFunctionTest extends TestCase
             new DaggerFunction(
                 'requiredString',
                 null,
-                [new Argument('value', null, new Type('string'))],
+                [new Argument('value', '', new Type('string'))],
                 new Type('void'),
             ),
             new ReflectionMethod(
@@ -159,7 +159,7 @@ class DaggerFunctionTest extends TestCase
                 null,
                 [new Argument(
                     'value',
-                    null,
+                    '',
                     new Type(Container::class, true),
                     new Json('null'),
                 )],
@@ -177,7 +177,7 @@ class DaggerFunctionTest extends TestCase
                 null,
                 [new Argument(
                     'value',
-                    null,
+                    '',
                     new Type(File::class, true),
                     new Json('null'),
                 )],

--- a/sdk/php/tests/Unit/ValueObject/DaggerObjectTest.php
+++ b/sdk/php/tests/Unit/ValueObject/DaggerObjectTest.php
@@ -39,7 +39,7 @@ class DaggerObjectTest extends TestCase
     public static function provideReflectionClasses(): Generator
     {
         yield 'DaggerObject without DaggerFunctions' => [
-            new DaggerObject(NoDaggerFunctions::class, []),
+            NoDaggerFunctions::getValueObjectEquivalent(),
             new ReflectionClass(NoDaggerFunctions::class),
         ];
 


### PR DESCRIPTION
Apologies, my previous PR closed and I can't seem to reopen it even with the branch having the commit re-added.

Related to https://github.com/dagger/dagger/pull/8411#discussion_r1764090130

## Changes

Deprecate Argument attribute.

Doc attribute has a single responsibility and is reusable.

Objects can have descriptions now. [Demonstrated on this example module](https://daggerverse.dev/mod/github.com/charjr/dagger-modules/test-php-doc@150bdd93729eb4cf2769f88f1f577487ea25a6a8#TestPhpDoc)



## Follow up PR

Support description for base module. #8495