### PR TITLE
fix: annotations on `Container.Export` and `Container.AsTarball`

### DIFF
--- a/.changes/unreleased/Fixed-20240923-134323.yaml
+++ b/.changes/unreleased/Fixed-20240923-134323.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Include container annotations on `Export` and `AsTarball`
+time: 2024-09-23T13:43:23.656447187+01:00
+custom:
+  Author: jedevc
+  PR: "8543"


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6999 (actually this time).

This PR follows-up on https://github.com/dagger/dagger/pull/8409, and ensures annotations are correctly attached for `Container.Export` and `Container.AsTarball` as well.