### PR TITLE
feat: ts-sdk now print error cause in error case

### DIFF
--- a/sdk/typescript/entrypoint/entrypoint.ts
+++ b/sdk/typescript/entrypoint/entrypoint.ts
@@ -59,7 +59,7 @@ export async function entrypoint() {
           })
         } catch (e) {
           if (e instanceof Error) {
-            console.error(`Error: ${e.message}`)
+            console.error(`Error: ${e.message}, ${e.cause}`)
           } else {
             console.error(e)
           }

--- a/sdk/typescript/entrypoint/entrypoint.ts
+++ b/sdk/typescript/entrypoint/entrypoint.ts
@@ -59,7 +59,10 @@ export async function entrypoint() {
           })
         } catch (e) {
           if (e instanceof Error) {
-            console.error(`Error: ${e.message}, ${e.cause}`)
+            if (e.cause) {
+              console.error(`${e.cause}`)
+            }
+            console.error(`Error: ${e.message}`)
           } else {
             console.error(e)
           }


### PR DESCRIPTION
To have a better understanding of https://github.com/dagger/dagger/issues/8524 this PR display the `cause` field from the error object.

Test function:

```typescript
  @func()
  error(): string {
    throw new Error("foo", { cause: new Error("bar") })

    return 'a'
  }
```

Before

```
$ dagger call error

Stderr:
Error: foo
```

Now: 

```
$ dagger call error

Stderr:
Error: foo, Error: bar
```