### PR TITLE
chore: print http url for tunneled services

### DIFF
--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -181,6 +181,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 			"tunnel started",
 			"port", port.Port,
 			"protocol", port.Protocol.Network(),
+			"http_url", fmt.Sprintf("http://%s:%d", "localhost", port.Port),
 			"description", *port.Description,
 		)
 	}


### PR DESCRIPTION
this helps to easily open tunnel http endpoints from the terminal

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
