### PR TITLE
Enhanced debugging errors for `context cancelled` from Buildkit

### DIFF
--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -784,6 +784,7 @@ func (gw *filteringGateway) Solve(ctx context.Context, req bkfrontend.SolveReque
 		if err != nil {
 			// writing log w/ %+v so that we can see stack traces embedded in err by buildkit's usage of pkg/errors
 			bklog.G(ctx).Errorf("solve error: %+v", err)
+			err = includeBuildkitContextCancelledLine(err)
 			return nil, err
 		}
 		return res, nil

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -112,8 +112,6 @@ func (r *ref) Evaluate(ctx context.Context) error {
 	}
 	_, err := r.Result(ctx)
 	if err != nil {
-		// writing log w/ %+v so that we can see stack traces embedded in err by buildkit's usage of pkg/errors
-		bklog.G(ctx).Errorf("ref evaluate error: %+v", err)
 		return err
 	}
 	return nil
@@ -231,6 +229,8 @@ func (r *ref) Result(ctx context.Context) (bksolver.CachedResult, error) {
 	ctx = withOutgoingContext(ctx)
 	res, err := r.resultProxy.Result(ctx)
 	if err != nil {
+		// writing log w/ %+v so that we can see stack traces embedded in err by buildkit's usage of pkg/errors
+		bklog.G(ctx).Errorf("ref evaluate error: %+v", err)
 		return nil, wrapError(ctx, err, r.c)
 	}
 	return res, nil


### PR DESCRIPTION
Related to https://github.com/dagger/dagger/issues/7699

Two related commits here:

---

[engine: log buildkit errors in right place to reveal stack traces](https://github.com/dagger/dagger/commit/64a236448dac51b92d35f2f35899aa3a38b3d079)

Previously we started logging buildkit solve errors with a `%+v` in
order to reveal the stack traces embedded in the errors by buildkit's
usage of github.com/pkg/errors, which in many places in buildkit is the
only way to get any extra information on where an error is actually
coming from (needed for debugging "context cancelled" errors
specifically).

This did not quite work for a pretty dumb reason: it turns out that if
you wrap an error from github.com/pkg/errors using fmt.Errorf (i.e. the
standard library) then the trick for extracting the stack trace from
the github.com/pkg/errors annotated error doesn't work anymore.

This is all quite silly, but in the interest of being able to debug
these context cancelled errors the change in this commit moves the log
statements of the errors with `%+v` to places *before* we do any
wrapping with the standard library, allowing us to see the stack traces.

I tested this by modifying buildkit locally to return errors from the
compute cache key step where we see this flake in CI and then verifying
the logs actually reveal the stack trace now.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

[engine: extract buildkit error stack trace lines into err msgs](https://github.com/dagger/dagger/commit/e807ac6aa2542f370a6ba6e2abbbc19c4b447ec7)

There's reluctance upstream in buildkit to include messages in each
context cancel cause error, so instead we have to extract out the
embedded stack trace in each error, attempt to parse a line number from
the stack trace and include that in the user facing error message.

This keeps the user facing error somewhat succinct (i.e. not a huge
stack trace) while still making it a bit easier to debug this if users
hit this and can't/won't send us their full engine logs.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>