### PR TITLE
Fix syntax error in environment config

### DIFF
--- a/docs/current_docs/integrations/snippets/gitlab-runner-config.yml
+++ b/docs/current_docs/integrations/snippets/gitlab-runner-config.yml
@@ -6,7 +6,7 @@ data:
   config.toml: |
     concurrent = 10
     [[runners]]
-      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST"="unix:///var/run/dagger/buildkitd.sock"]
+      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST=unix:///var/run/dagger/buildkitd.sock"]
       pre_build_script = "export PATH=\"/tmp/:$PATH\""
       name = "GitLab Runner with Dagger"
       url = YOUR-GITLAB-URL


### PR DESCRIPTION
When using config from docs, got this error:

[31;1mFATAL: Could not handle configuration merging from template file[0;m  [31;1merror[0;m=couldn't load configuration template file: toml: line 2 (last key "runners.environment"): expected a comma (',') or array terminator (']'), but got '='

Based on other vars set in the array, the last item seems to have 2 additional "