### PR TITLE
use '.dagger' as source dir during 'init' and 'develop' when current dir is not empty

### DIFF
--- a/.changes/unreleased/Breaking-20241021-160603.yaml
+++ b/.changes/unreleased/Breaking-20241021-160603.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: use .dagger folder during init if current directory is not empty.
+time: 2024-10-21T16:06:03.457218+05:30
+custom:
+    Author: rajatjindal
+    PR: "8557"

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1920,7 +1920,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 			`,
 			).
 			WithWorkdir("/work").
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "--name", "foo", "./mod-a")).
 			With(daggerExec("install", "--name", "bar", "./mod-b"))
 
@@ -1965,7 +1965,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 			`,
 			).
 			WithWorkdir("/work").
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "--name", "foo", "/work/mod-a")).
 			With(daggerExec("install", "--name", "bar", "/work/mod-b"))
 
@@ -2028,7 +2028,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 			`,
 			).
 			WithWorkdir("/work").
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "--name", "foo", "/outside/mod-a"))
 
 		// call main module at /work path
@@ -2055,7 +2055,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 			}
 			`,
 			).
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "--name", "foo", "/work/test@test"))
 
 		// call main module at /work path
@@ -2074,7 +2074,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work").
 				With(mountedSocket).
-				With(daggerExec("init")).
+				With(daggerExec("init", "--source=.")).
 				With(daggerExec("install", "--name", "foo", testGitModuleRef(tc, ""))).
 				With(daggerExec("install", "--name", "bar", testGitModuleRef(tc, "subdir/dep2")))
 

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -185,7 +185,7 @@ func (CLISuite) TestDaggerInitLICENSE(ctx context.Context, t *testctx.T) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=no-license"))
+			With(daggerExec("init", "--name=no-license", "--source=."))
 
 		files, err := modGen.Directory(".").Entries(ctx)
 		require.NoError(t, err)
@@ -361,7 +361,7 @@ func (CLISuite) TestDaggerInitGit(ctx context.Context, t *testctx.T) {
 
 			t.Run("does not configure .gitignore if disabled", func(ctx context.Context, t *testctx.T) {
 				modGen := goGitBase(t, c).
-					With(daggerExec("init", "--name=bare"))
+					With(daggerExec("init", "--name=bare", "--source=."))
 
 				// TODO: use dagger config to set this once support is added there
 				modCfgContents, err := modGen.File("dagger.json").Contents(ctx)
@@ -406,7 +406,7 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 			`,
 			).
 			WithWorkdir("/work").
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "./dep"))
 
 		// should be able to invoke dep without name+sdk set yet
@@ -474,7 +474,7 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 			`,
 			).
 			WithWorkdir("/work").
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "./dep")).
 			WithWorkdir("/var").
 			With(daggerExec("develop", "-m", "../work", "--source=../work/some/subdir", "--sdk=go")).
@@ -536,7 +536,7 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
         `,
 			).
 			WithWorkdir(absPath).
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("install", "./dep")).
 			WithWorkdir("/var").
 			With(daggerExec("develop", "-m", absPath, "--source="+absPath+"/some/subdir", "--sdk=go")).

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1026,7 +1026,7 @@ func (ConfigSuite) TestDaggerGitWithSources(ctx context.Context, t *testctx.T) {
 				ctr := goGitBase(t, c).
 					With(mountedSocket).
 					WithWorkdir("/work").
-					With(daggerExec("init")).
+					With(daggerExec("init", "--source=.")).
 					With(daggerExec("install", "--name", "foo", testGitModuleRef(tc, "various-source-values/"+modSubpath)))
 
 				out, err := ctr.With(daggerCallAt("foo", "container-echo", "--string-arg", "hi", "stdout")).Stdout(ctx)

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -53,7 +53,7 @@ func (PythonSuite) TestInit(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(daggerExec("develop", "--sdk=python", "--source=.")).
 			With(daggerCall("container-echo", "--string-arg", "hello", "stdout")).
 			Stdout(ctx)
@@ -66,7 +66,7 @@ func (PythonSuite) TestInit(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
 		_, err := daggerCliBase(t, c).
-			With(daggerExec("init")).
+			With(daggerExec("init", "--source=.")).
 			With(pyprojectExtra(nil, "")).
 			With(daggerExec("develop", "--sdk=python", "--source=.")).
 			Sync(ctx)
@@ -117,6 +117,58 @@ func (PythonSuite) TestInit(ctx context.Context, t *testctx.T) {
 			Stdout(ctx)
 
 		require.ErrorContains(t, err, "merge is only supported")
+	})
+
+	t.Run("init module in .dagger if files present in current dir", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithNewFile("hello.py", `
+                from dagger import field, function, object_type
+
+                @object_type
+                class HelloWorld:
+                    my_name: str = field(default="World")
+
+                    @function
+                    def message(self) -> str:
+                        return f"Hello, {self.my_name}!"
+            `).
+			With(daggerExec("init", "--name=bare", "--sdk=python"))
+
+		daggerDirEnts, err := modGen.Directory("/work/.dagger").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, daggerDirEnts, "pyproject.toml", "sdk", "src", "uv.lock")
+
+		out, err := modGen.
+			WithWorkdir("/work").
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
+	t.Run("init module when current dir only has hidden dirs", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithExec([]string{"mkdir", "-p", ".git"}).
+			With(daggerExec("init", "--name=bare", "--sdk=python"))
+
+		daggerDirEnts, err := modGen.Directory("/work").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, daggerDirEnts, "pyproject.toml", "sdk", "src", "uv.lock")
+
+		out, err := modGen.
+			WithWorkdir("/work").
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -943,7 +943,7 @@ func (ModuleSuite) TestUseLocal(ctx context.Context, t *testctx.T) {
 				With(daggerExec("init", "--name=dep", "--sdk=go")).
 				With(sdkSource("go", useInner)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk)).
+				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk, "--source=.")).
 				With(sdkSource(tc.sdk, tc.source)).
 				With(daggerExec("install", "./dep"))
 
@@ -998,7 +998,7 @@ func (ModuleSuite) TestCodegenOnDepChange(ctx context.Context, t *testctx.T) {
 				With(daggerExec("init", "--name=dep", "--sdk=go")).
 				With(sdkSource("go", useInner)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk)).
+				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk, "--source=.")).
 				With(sdkSource(tc.sdk, tc.source)).
 				With(daggerExec("install", "./dep"))
 
@@ -1059,7 +1059,7 @@ func (ModuleSuite) TestSyncDeps(ctx context.Context, t *testctx.T) {
 				With(daggerExec("init", "--name=dep", "--sdk=go")).
 				With(sdkSource("go", useInner)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk)).
+				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk, "--source=.")).
 				With(sdkSource(tc.sdk, tc.source)).
 				With(daggerExec("install", "./dep"))
 
@@ -1164,7 +1164,7 @@ export class Use {
 				).
 				With(daggerExec("init", "--source=.", "--name=bar", "--sdk=go")).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk)).
+				With(daggerExec("init", "--name=use", "--sdk="+tc.sdk, "--source=.")).
 				With(daggerExec("install", "./foo")).
 				With(daggerExec("install", "./bar")).
 				With(sdkSource(tc.sdk, tc.source)).
@@ -1811,7 +1811,7 @@ export class PotatoSack {
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(sdkSource("typescript", mainSrc)).
-			With(daggerExec("init", "--name=potatoSack", "--sdk=typescript"))
+			With(daggerExec("init", "--name=potatoSack", "--sdk=typescript", "--source=."))
 
 		var eg errgroup.Group
 		for i := 0; i < funcCount; i++ {
@@ -3629,7 +3629,7 @@ func (m *Dep) DepFn(s *dagger.Secret) string {
 }
 `)).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
 		With(sdkSource("go", `package main
 
 import (


### PR DESCRIPTION
fixes #8123 