### PR TITLE
docs: Update MacOS sudo instructions

### DIFF
--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -30,7 +30,7 @@ If you do not have Homebrew installed, or you want to install a specific version
 
 ```shell
 cd /usr/local
-curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.13.3 sh
+curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.13.3 sudo -E sh
 
 ./bin/dagger version
 dagger v0.13.3 (registry.dagger.io/engine:v0.13.3) darwin/arm64


### PR DESCRIPTION
The instructions we have for MacOS will not work because it tells you to `cd /usr/local` and then run the install script, but users do not have permission to install things in `/usr/local` by default.