### PR TITLE
fix: correctly resolve relative path for git module

### DIFF
--- a/.changes/unreleased/Fixed-20240925-131536.yaml
+++ b/.changes/unreleased/Fixed-20240925-131536.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correctly resolve relative path for modules fetched from git
+time: 2024-09-25T13:15:36.071971+02:00
+custom:
+  Author: TomChv
+  PR: "8565"

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -367,6 +367,10 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 		// Use the Git context directory.
 		ctxDir := src.AsGitSource.Value.ContextDirectory.Self
 
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(src.AsGitSource.Value.RootSubpath, path)
+		} 
+
 		dir, err := ctxDir.Directory(ctx, path)
 		if err != nil {
 			return inst, fmt.Errorf("failed to load contextual directory %q: %w", path, err)

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -369,7 +369,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(src.AsGitSource.Value.RootSubpath, path)
-		} 
+		}
 
 		dir, err := ctxDir.Directory(ctx, path)
 		if err != nil {


### PR DESCRIPTION
Based on https://discord.com/channels/707636530424053791/1003718839739105300/1288200722948558922

Tested on https://github.com/TomChv/dagger-git-ctx-dir

**Before**:

```
dagger call -m https://github.com/TomChv/dagger-git-ctx-dir/go rel

_type: Directory
digest: sha256:d2a243922ee5ddef94022fdaf7f6159020750476eae9fb9784df5c9362aa0904
entries:
    - go
```

**After**:

```
dagger call -m https://github.com/TomChv/dagger-git-ctx-dir/go rel

_type: Directory
digest: sha256:b013fc11f9f38ad24478c1c3b011fd376856cb2ddf9573e3ee21186eae1c3a42
entries:
    - LICENSE
    - dagger.json
    - src
```