### PR TITLE
chore: enhance version error messages

### DIFF
--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -324,7 +324,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.0",
 			clientMinVersion: "v3.0.0",
 			errs: []string{
-				"incompatible client version",
+				"incompatible client version v2.0.0",
 			},
 		},
 		{
@@ -335,7 +335,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.0",
 			clientMinVersion: "v1.0.0",
 			errs: []string{
-				"incompatible engine version",
+				"incompatible engine version v2.0.0",
 			},
 		},
 		{
@@ -346,7 +346,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.0",
 			clientMinVersion: "v3.0.0",
 			errs: []string{
-				"incompatible engine version",
+				"incompatible engine version v2.0.0",
 			},
 		},
 		{
@@ -365,7 +365,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.0-foobar",
 			clientMinVersion: "v2.0.0",
 			errs: []string{
-				"incompatible engine version",
+				"incompatible engine version v2.0.0-foobar",
 			},
 		},
 
@@ -386,7 +386,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.1-dev-456",
 			clientMinVersion: "v2.0.0-dev-123",
 			errs: []string{
-				"incompatible engine version",
+				"incompatible engine version v2.0.0-dev-123",
 			},
 		},
 
@@ -406,7 +406,7 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			clientVersion:    "v2.0.0-foo-456",
 			clientMinVersion: "v2.0.0-foo-123",
 			errs: []string{
-				"incompatible engine version",
+				"incompatible engine version v2.0.0-foo-123",
 			},
 		},
 
@@ -480,10 +480,6 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 				for _, tcerr := range tc.errs {
 					require.Contains(t, stderr, tcerr)
 				}
-				// check that both the client and engine versions are present
-				// in the error message
-				require.Contains(t, stderr, tc.clientVersion)
-				require.Contains(t, stderr, tc.engineVersion)
 			}
 		})
 	}
@@ -519,8 +515,8 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 			moduleVersion:    "v0.9.0",
 			moduleMinVersion: "v1.0.0",
 			errs: []string{
-				"module requires incompatible engine",
-				"does not meet required version",
+				"module requires dagger v0.9.0",
+				"support for that version has been removed",
 			},
 		},
 		{
@@ -529,8 +525,7 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 			moduleVersion:    "v2.0.1",
 			moduleMinVersion: "v1.0.0",
 			errs: []string{
-				"module requires incompatible engine",
-				"greater than supported version",
+				"module requires dagger v2.0.1, but you have v2.0.0",
 			},
 		},
 		{
@@ -539,9 +534,8 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 			moduleVersion:    "badbadbad",
 			moduleMinVersion: "v1.0.0",
 			errs: []string{
-				"module requires incompatible engine",
-				"does not meet required version",
-				"v0.11.9", // old-style dev versions are equivalent to v0.11.9
+				"module requires dagger v0.11.9", // old-style dev versions are equivalent to v0.11.9
+				"support for that version has been removed",
 			},
 		},
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -780,11 +780,11 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 	if err != nil {
 		return nil, fmt.Errorf("failed to update dagger.json: %w", err)
 	}
-	if err := engine.CheckVersionCompatibility(modCfg.EngineVersion, engine.MinimumModuleVersion); err != nil {
-		return nil, fmt.Errorf("module requires incompatible engine version: %w", err)
+	if !engine.CheckVersionCompatibility(modCfg.EngineVersion, engine.MinimumModuleVersion) {
+		return nil, fmt.Errorf("module requires dagger %s, but support for that version has been removed", modCfg.EngineVersion)
 	}
-	if err := engine.CheckMaxVersionCompatibility(modCfg.EngineVersion, engine.BaseVersion(engine.Version)); err != nil {
-		return nil, fmt.Errorf("module requires incompatible engine version: %w", err)
+	if !engine.CheckMaxVersionCompatibility(modCfg.EngineVersion, engine.BaseVersion(engine.Version)) {
+		return nil, fmt.Errorf("module requires dagger %s, but you have %s", modCfg.EngineVersion, engine.Version)
 	}
 
 	if err := s.updateDeps(ctx, mod, modCfg, src); err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -205,9 +205,8 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	if err := c.startEngine(connectCtx); err != nil {
 		return nil, nil, fmt.Errorf("start engine: %w", err)
 	}
-	err = engine.CheckVersionCompatibility(engine.NormalizeVersion(c.bkVersion), engine.MinimumEngineVersion)
-	if err != nil {
-		return nil, nil, fmt.Errorf("incompatible engine version: %w", err)
+	if !engine.CheckVersionCompatibility(engine.NormalizeVersion(c.bkVersion), engine.MinimumEngineVersion) {
+		return nil, nil, fmt.Errorf("incompatible engine version %s", engine.NormalizeVersion(c.bkVersion))
 	}
 
 	defer func() {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -841,8 +841,8 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := engine.CheckVersionCompatibility(engine.NormalizeVersion(clientMetadata.ClientVersion), engine.MinimumClientVersion); err != nil {
-		http.Error(w, fmt.Sprintf("incompatible client version: %s", err), http.StatusInternalServerError)
+	if !engine.CheckVersionCompatibility(engine.NormalizeVersion(clientMetadata.ClientVersion), engine.MinimumClientVersion) {
+		http.Error(w, fmt.Sprintf("incompatible client version %s", engine.NormalizeVersion(clientMetadata.ClientVersion)), http.StatusInternalServerError)
 		return
 	}
 

--- a/engine/version.go
+++ b/engine/version.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -80,30 +79,22 @@ func cleanVersion(v string) string {
 	return v
 }
 
-func CheckVersionCompatibility(version string, minVersion string) error {
-	v := version
-	if IsDevVersion(v) && IsDevVersion(Version) {
+func CheckVersionCompatibility(version string, minVersion string) bool {
+	if IsDevVersion(version) && IsDevVersion(Version) {
 		// Both our version and our target version are dev versions - in this
 		// case, strip pre-release info from our target, we should pretend it's
 		// just the real thing here.
-		v = BaseVersion(v)
+		version = BaseVersion(version)
 	}
-	if semver.Compare(v, minVersion) < 0 {
-		return fmt.Errorf("version %s does not meet required version %s", version, minVersion)
-	}
-	return nil
+	return semver.Compare(version, minVersion) >= 0
 }
 
-func CheckMaxVersionCompatibility(version string, maxVersion string) error {
-	v := version
-	if IsDevVersion(v) && IsDevVersion(Version) {
+func CheckMaxVersionCompatibility(version string, maxVersion string) bool {
+	if IsDevVersion(version) && IsDevVersion(Version) {
 		// see CheckVersionCompatibility
-		v = BaseVersion(v)
+		version = BaseVersion(version)
 	}
-	if semver.Compare(v, maxVersion) > 0 {
-		return fmt.Errorf("version %s is greater than supported version %s", version, maxVersion)
-	}
-	return nil
+	return semver.Compare(version, maxVersion) <= 0
 }
 
 func NormalizeVersion(version string) string {

--- a/engine/version_test.go
+++ b/engine/version_test.go
@@ -96,12 +96,7 @@ func TestVersionCompatibility(t *testing.T) {
 				minVersion = currentVersion
 			}
 
-			err := CheckVersionCompatibility(tc.targetVersion, minVersion)
-			if tc.compatible {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-			}
+			require.Equal(t, tc.compatible, CheckVersionCompatibility(tc.targetVersion, minVersion))
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8562.

Previously, these could be a little tricky to read, so we rephrase them to make them a little easier to read.

The new error is something like:

```
Error: input: moduleSource.withContextDirectory.asModule resolve: failed to create module: select: module requires dagger v0.13.8, but you have v0.13.4
```