### PR TITLE
feat: use context directory and ignore in TypeScript runtime

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -48,11 +48,14 @@ const (
 )
 
 func New(
+	// Directory with the TypeScript SDK source code.
+	// +defaultPath=".."
+	// +ignore=["**", "!package.json", "!yarn.lock", "!tsconfig.json", "!LICENSE", "!README.md", "!**/*.ts", "**/test/", "node_modules/"]
 	// +optional
 	sdkSourceDir *dagger.Directory,
 ) *TypescriptSdk {
 	return &TypescriptSdk{
-		SDKSourceDir: sdkSourceDir,
+		SDKSourceDir: sdkSourceDir.WithoutDirectory("runtime"),
 		moduleConfig: &moduleConfig{},
 	}
 }


### PR DESCRIPTION
⚠️ Currently broken, I need to find a way to fetch the go codegen binary from Git

```
invoke: failed to create codegen base: failed to add template: could not list module source entries: input: directory.withDirectory.withoutDirectory.file resolve: lstat /codegen: no such file or directory
```