### PR TITLE
chore(refactor): make engine set optional on defaultPath so SDKs don't have to

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -518,7 +518,14 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 		return nil, fmt.Errorf("can only set ignore for Directory type, not %s", argType.Self.AsObject.Value.Name)
 	}
 
-	return fn.WithArg(args.Name, argType.Self, args.Description, args.DefaultValue, args.DefaultPath, args.Ignore), nil
+	// When using a default path SDKs can't set a default value and the argument
+	// may be non-nullable, so we need to enforce it as optional.
+	td := argType.Self
+	if args.DefaultPath != "" {
+		td = td.WithOptional(true)
+	}
+
+	return fn.WithArg(args.Name, td, args.Description, args.DefaultValue, args.DefaultPath, args.Ignore), nil
 }
 
 func (s *moduleSchema) moduleDependency(

--- a/sdk/php/src/Command/EntrypointCommand.php
+++ b/sdk/php/src/Command/EntrypointCommand.php
@@ -76,10 +76,7 @@ class EntrypointCommand extends Command
                         name: $argument->name,
                         typeDef: $this
                             ->getTypeDef($argument->type)
-                            ->withOptional(
-                                $argument->type->nullable ||
-                                $argument->defaultPath !== null /// @TODO Remove this once engine handles it.
-                            ),
+                            ->withOptional($argument->type->nullable),
                         description: $argument->description,
                         defaultValue: $argument->default,
                         defaultPath: $argument->defaultPath,

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -159,9 +159,6 @@ class FunctionResolver(Generic[P, R]):
                 default = None
                 arg_type = arg_type.with_optional(True)
 
-            if param.default_path:
-                arg_type = arg_type.with_optional(True)
-
             fn = fn.with_arg(
                 param.name,
                 arg_type,
@@ -308,6 +305,8 @@ class FunctionResolver(Generic[P, R]):
             default_path=get_meta(param.annotation, DefaultPath),
         )
 
+        # These validations are already done by the engine, just repeating them
+        # here for better error messages.
         if not p.is_nullable and p.has_default and p.signature.default is None:
             msg = (
                 "Can't use a default value of None on a non-nullable type for "

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -142,7 +142,6 @@ function addArg(args: Arguments): (fct: Function_) => Function_ {
       // If the argument is a contextual argument, it becomes optional.
       if (arg.defaultPath) {
         opts.defaultPath = arg.defaultPath
-        typeDef = typeDef.withOptional(true)
       }
 
       if (arg.ignore) {


### PR DESCRIPTION
This refactor makes the engine enforce `withOptional(true)` on function arguments that use `defaultPath`. Otherwise it's a footgun for the SDKs to ensure, especially since `withOptional` is incorrectly named.

Context:
- https://github.com/dagger/dagger/pull/8411#discussion_r1775675521
- https://github.com/dagger/dagger/issues/6749