### PR TITLE
fix: flake on TestSSHAuthSockPathHandling test

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5527,11 +5527,10 @@ func (ModuleSuite) TestSSHAgentConnection(ctx context.Context, t *testctx.T) {
 }
 
 func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-
 	repoURL := "git@gitlab.com:dagger-modules/private/test/more/dagger-test-modules-private.git"
 
 	t.Run("SSH auth with home expansion and symlink", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 		defer cleanup()
 
@@ -5555,6 +5554,7 @@ func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T
 	})
 
 	t.Run("SSH auth from different relative paths", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 		defer cleanup()
 


### PR DESCRIPTION
Closes #8571

When testing the TestSSHAuthSockPathHandling, Alex encountered rightfully a flake on this test, leading to this error:

```
Error: module at source dir "" doesn't exist or is invalid
```

It turns out that the error comes from the tests being run in parallel whilst relying on the same client

More context [here](https://github.com/dagger/dagger/issues/8571#issuecomment-2375333486). After the change, no flake after 30 runs on my side

> Still a bit surprised that in a nested environment, when interacting with the host, the same client cannot be used in parallel. Is it my test / setup that is wrong or is it by-design / expected ? 

The very reason that it sometimes work would be that one of the test sets the nested SESSION's env vars prior the second one's erasing the HOME var, or before ?