### PR TITLE
fix include/exclude from dependencies not prefixed correctly

### DIFF
--- a/.changes/unreleased/Fixed-20240926-132311.yaml
+++ b/.changes/unreleased/Fixed-20240926-132311.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix include/exclude patterns from a dependency incorrectly affecting a parent module
+time: 2024-09-26T13:23:11.073823Z
+custom:
+    Author: helderco
+    PR: "8575"

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -837,10 +837,10 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 		}
 
 		// rebase user defined include/exclude relative to context
-		rebaseIncludeExclude := func(path string, set *core.SliceSet[string]) error {
-			isNegation := strings.HasPrefix(path, "!")
-			path = strings.TrimPrefix(path, "!")
-			absPath := filepath.Join(sourceRootAbsPath, path)
+		rebaseIncludeExclude := func(baseAbsPath, pattern string, set *core.SliceSet[string]) error {
+			isNegation := strings.HasPrefix(pattern, "!")
+			pattern = strings.TrimPrefix(pattern, "!")
+			absPath := filepath.Join(baseAbsPath, pattern)
 			relPath, err := filepath.Rel(contextAbsPath, absPath)
 			if err != nil {
 				return fmt.Errorf("failed to get relative path of config include/exclude: %w", err)
@@ -854,13 +854,13 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 			set.Append(relPath)
 			return nil
 		}
-		for _, path := range localDep.modCfg.Include {
-			if err := rebaseIncludeExclude(path, &includeSet); err != nil {
+		for _, pattern := range localDep.modCfg.Include {
+			if err := rebaseIncludeExclude(localDep.sourceRootAbsPath, pattern, &includeSet); err != nil {
 				return inst, err
 			}
 		}
-		for _, path := range localDep.modCfg.Exclude {
-			if err := rebaseIncludeExclude(path, &excludeSet); err != nil {
+		for _, pattern := range localDep.modCfg.Exclude {
+			if err := rebaseIncludeExclude(localDep.sourceRootAbsPath, pattern, &excludeSet); err != nil {
 				return inst, err
 			}
 		}

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -59,13 +59,13 @@ func (c *Client) LocalImport(
 	}
 
 	localName := fmt.Sprintf("upload %s from %s (client id: %s, session id: %s)", srcPath, stableID, clientMetadata.ClientID, clientMetadata.SessionID)
-	if len(excludePatterns) > 0 {
-		localName += fmt.Sprintf(" (exclude: %s)", strings.Join(excludePatterns, ", "))
-		localOpts = append(localOpts, llb.ExcludePatterns(excludePatterns))
-	}
 	if len(includePatterns) > 0 {
 		localName += fmt.Sprintf(" (include: %s)", strings.Join(includePatterns, ", "))
 		localOpts = append(localOpts, llb.IncludePatterns(includePatterns))
+	}
+	if len(excludePatterns) > 0 {
+		localName += fmt.Sprintf(" (exclude: %s)", strings.Join(excludePatterns, ", "))
+		localOpts = append(localOpts, llb.ExcludePatterns(excludePatterns))
 	}
 	localOpts = append(localOpts, llb.WithCustomName(localName))
 	localLLB := llb.Local(srcPath, localOpts...)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8136

Note: I switched the order in the UI to show includes before excludes because that's the order that buildkit applies them.