### PR TITLE
chore: remove other engine types from codegen

### DIFF
--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -25,7 +25,11 @@ const (
 // the introspection JSON that module SDKs use for codegen.
 var typesHiddenFromModuleSDKs = []dagql.Typed{
 	&Host{},
+
 	&Engine{},
+	&EngineCache{},
+	&EngineCacheEntry{},
+	&EngineCacheEntrySet{},
 }
 
 /*


### PR DESCRIPTION
Saw this while looking into https://github.com/dagger/dagger/pull/8568

These types can't actually be constructed, but we're still putting them in the codegen for modules. We don't need to, so we can just remove these to tidy things up.

When this API was originally added, we missed these types out: https://github.com/dagger/dagger/pull/7767/files#diff-66495f543507cb3a2373d8c23981491184d26ffe1bd45140faab4445bb3a5177R28