### PR TITLE
More fixups from `version` split fallout

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -27,24 +27,10 @@ jobs:
         with:
           go-version: "1.23"
           cache-dependency-path: ".dagger/go.sum"
-      - name: "Determine tag"
-        run: |
-          mkdir -p /tmp/publish
-          echo "${{ github.ref_name == 'main' && github.sha || github.ref_name }}" > /tmp/publish/tag
-      - name: "Determine version"
-        uses: ./.github/actions/call
-        with:
-          # determine the version before releasing any components - this keeps
-          # it consistent across all components (since pre-releases might have
-          # timestamps)
-          function: --version="$(cat /tmp/publish/tag)" version string
-          redirect: "/tmp/publish/version"
       - name: "Publish Engine"
         uses: ./.github/actions/call
         with:
           function: |-
-            --version="$(cat /tmp/publish/version)" \
-            --tag="$(cat /tmp/publish/tag)" \
             engine \
             publish \
             --image="$DAGGER_ENGINE_IMAGE" \
@@ -61,8 +47,6 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: |-
-            --version="$(cat /tmp/publish/version)" \
-            --tag="$(cat /tmp/publish/tag)" \
             cli \
             publish \
             --git-dir=./.git \

--- a/version/git.go
+++ b/version/git.go
@@ -26,12 +26,14 @@ func (v *Version) Git() *Git {
 		// provided by the core git functions which are used by our remote git
 		// module sources)
 		remote := "https://github.com/dagger/dagger.git"
+		maxDepth := "2147483647" // see https://git-scm.com/docs/shallow
 		ctr = ctr.
-			// we need all the tags and the unshallowed repo, so we can
-			// determine which tags are in HEAD's history later
-			WithExec([]string{"git", "fetch", "--tags", "--unshallow", remote}).
+			// we need the unshallowed history, so we can determine which tags are in it later
+			WithExec([]string{"git", "fetch", "--no-tags", "--depth=" + maxDepth, remote, "HEAD"}).
 			// we need main, so we can determine the merge base for it later
-			WithExec([]string{"git", "fetch", "--no-tags", remote, "refs/heads/main:refs/heads/main"})
+			WithExec([]string{"git", "fetch", "--no-tags", "--depth=" + maxDepth, remote, "refs/heads/main:refs/heads/main"}).
+			// we need all the tags, so we can find all the release tags later
+			WithExec([]string{"git", "fetch", "--tags", "--force", remote})
 	}
 	return &Git{ctr}
 }


### PR DESCRIPTION
See #8564.

Engine publish is failing - https://github.com/dagger/dagger/actions/runs/11058428600/job/30724413276. We can remove those extra steps though, since now the version module handles this (the commit timestamp is used, so we get the right results here).

Also, I can't run `dagger call` locally - this is because, my repo is already unshallowed, so calling `unshallow` causes a failure. There's a neat way to do this though - we just set the `--depth` to the max int32 value, as specified in the git docs here: https://git-scm.com/docs/shallow

> The special depth 2147483647 (or 0x7fffffff, the largest positive number a signed 32-bit integer can contain) means infinite depth.

This should only deeper the current branch, instead of unshallowing *everything*.