### PR TITLE
docs: improve GitHub Integration PR section

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -3,6 +3,10 @@
   "sdk": "go",
   "dependencies": [
     {
+      "name": "gha",
+      "source": "github.com/shykes/gha@bf36a0b37a75882e4a985179f090d86d2ad1dfb4"
+    },
+    {
       "name": "alpine",
       "source": "modules/alpine"
     },

--- a/docs/current_docs/integrations/github.mdx
+++ b/docs/current_docs/integrations/github.mdx
@@ -87,7 +87,7 @@ Given a Dagger Function called `foo` that accepts a `Directory` as argument, you
 
 #### Pull requests as modules
 
-If your GitHub repository contains a Dagger module, you can test the functionality of a specific branch by calling the Dagger module with the corresponding pull request URL.
+If your GitHub repository contains a Dagger module, you can test the functionality of a specific branch by calling the Dagger module with the corresponding pull request URL. Two options are available:
 
 * You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
   ```shell

--- a/docs/current_docs/integrations/github.mdx
+++ b/docs/current_docs/integrations/github.mdx
@@ -72,18 +72,34 @@ Replace `${{ secrets.SSH_PRIVATE_KEY }}` with your provider secret containing th
 
 By default, the Dagger `Directory` type works with both local directories and [remote Git repositories](../../cookbook#copy-a-directory-or-remote-repository-to-a-container). This makes it easy to work with the directory tree at the root of a Git repository or a given branch.
 
-Given a Dagger Function called `foo` that accepts a `Directory` as argument, you can pass it a GitHub pull request URL as argument like this:
+Given a Dagger Function called `foo` that accepts a `Directory` as argument. You can pass it a GitHub pull request URL.
+
+You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
 
 ```shell
 dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/merge
 ```
 
-#### Pull requests as modules
-
-If your GitHub repository contains a Dagger module, you can test the functionality of a specific branch by calling the Dagger module with the corresponding pull request URL, as shown below:
+Or you can pass it the `/head` ref to use the branch from the PR like this:
 
 ```shell
+dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/head
+```
+
+
+#### Pull requests as modules
+
+If your GitHub repository contains a Dagger module, you can test the functionality of a specific branch by calling the Dagger module with the corresponding pull request URL.
+
+You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
+```shell
 dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/merge --help
+```
+
+Or you can pass it the `/head` ref to use the branch from the PR like this:
+
+```shell
+dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/head --help
 ```
 
 ## Resources

--- a/docs/current_docs/integrations/github.mdx
+++ b/docs/current_docs/integrations/github.mdx
@@ -72,7 +72,7 @@ Replace `${{ secrets.SSH_PRIVATE_KEY }}` with your provider secret containing th
 
 By default, the Dagger `Directory` type works with both local directories and [remote Git repositories](../../cookbook#copy-a-directory-or-remote-repository-to-a-container). This makes it easy to work with the directory tree at the root of a Git repository or a given branch.
 
-Given a Dagger Function called `foo` that accepts a `Directory` as argument. You can pass it a GitHub pull request URL.
+Given a Dagger Function called `foo` that accepts a `Directory` as argument, you can pass it a GitHub pull request URL. Two options are available:
 
 * You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
   ```shell

--- a/docs/current_docs/integrations/github.mdx
+++ b/docs/current_docs/integrations/github.mdx
@@ -74,33 +74,30 @@ By default, the Dagger `Directory` type works with both local directories and [r
 
 Given a Dagger Function called `foo` that accepts a `Directory` as argument. You can pass it a GitHub pull request URL.
 
-You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
+* You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
+  ```shell
+  dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/merge
+  ```
 
-```shell
-dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/merge
-```
-
-Or you can pass it the `/head` ref to use the branch from the PR like this:
-
-```shell
-dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/head
-```
+* Or you can pass it the `/head` ref to use the branch from the PR like this:
+  ```shell
+  dagger call foo --directory=https://github.com/ORGANIZATION/REPOSITORY#pull/NUMBER/head
+  ```
 
 
 #### Pull requests as modules
 
 If your GitHub repository contains a Dagger module, you can test the functionality of a specific branch by calling the Dagger module with the corresponding pull request URL.
 
-You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
-```shell
-dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/merge --help
-```
+* You can use the `/merge` ref to pass a directory that has the head branch merged into the base branch like this:
+  ```shell
+  dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/merge --help
+  ```
 
-Or you can pass it the `/head` ref to use the branch from the PR like this:
-
-```shell
-dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/head --help
-```
+* Or you can pass it the `/head` ref to use the branch from the PR like this:
+  ```shell
+  dagger call -m github.com/ORGANIZATION/REPOSITORY@pull/NUMBER/head --help
+  ```
 
 ## Resources
 


### PR DESCRIPTION
This commit shows an example and clarifies the disctinction between using the `/merge` ref and the `/head` ref. This is based on the feedback we got from Mark here: https://github.com/dagger/dagger/pull/8194#discussion_r1724578389