### PR TITLE
tests: avoid calling cleanup-exec twice

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5333,6 +5333,7 @@ func cleanupExec(t testing.TB, cmd *exec.Cmd) {
 		for {
 			select {
 			case <-done:
+				t.Logf("exited: %v", cmd.Args)
 				return
 			case <-time.After(30 * time.Second):
 				if !t.Failed() {

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -137,7 +137,6 @@ func daggerUpAndGetEndpoint(ctx context.Context, t *testctx.T, modDir string, da
 
 	err := cmd.Start()
 	require.NoError(t, err)
-	cleanupExec(t, cmd)
 
 	return fmt.Sprintf("http://127.0.0.1:%s", trafficPort)
 }
@@ -160,7 +159,6 @@ func daggerUpAndGetEndpointFromLogs(ctx context.Context, t *testctx.T, modDir st
 
 	err = cmd.Start()
 	require.NoError(t, err)
-	cleanupExec(t, cmd)
 
 	_, matches, err := console.MatchLine(ctx, `tunnel started port=(\d+)`)
 	require.NoError(t, err)


### PR DESCRIPTION
Noticed in https://dagger.cloud/dagger/traces/b3d53b83e726ac25892517310b0ee9d2#2e580acd7b4b57ea:L3.

This doesn't help the output for our flakes when this does flake - we see multiple interrupts, which isn't right.

`cleanupExec` is already called as part of `hostDaggerCommand`.