### PR TITLE
docs: remove confusing inline docs in python examples

### DIFF
--- a/docs/current_docs/manuals/developer/snippets/documentation/python/main.py
+++ b/docs/current_docs/manuals/developer/snippets/documentation/python/main.py
@@ -12,8 +12,6 @@ from dagger import Doc, function, object_type
 class MyModule:
     """Simple hello functions."""
 
-    """A function to say hello."""
-
     @function
     def hello(
         self,
@@ -22,8 +20,6 @@ class MyModule:
     ) -> str:
         """Return a greeting."""
         return f"{greeting}, {name}!"
-
-    """A function to say a loud hello."""
 
     @function
     def loud_hello(


### PR DESCRIPTION
As discovered by @kpenfound during friday demos