### PR TITLE
ci: fix version module when no git metadata is available

### DIFF
--- a/version/git.go
+++ b/version/git.go
@@ -35,12 +35,21 @@ func git(ctx context.Context, gitDir *dagger.Directory, dir *dagger.Directory) (
 			remote := "https://github.com/dagger/dagger.git"
 			maxDepth := "2147483647" // see https://git-scm.com/docs/shallow
 			ctr = ctr.
-				// we need the unshallowed history, so we can determine which tags are in it later
-				WithExec([]string{"git", "fetch", "--no-tags", "--depth=" + maxDepth, remote, "HEAD"}).
-				// we need main, so we can determine the merge base for it later
-				WithExec([]string{"git", "fetch", "--no-tags", "--depth=" + maxDepth, remote, "refs/heads/main:refs/heads/main"}).
-				// we need all the tags, so we can find all the release tags later
-				WithExec([]string{"git", "fetch", "--tags", "--force", remote})
+				WithExec([]string{
+					"git", "fetch",
+					// force so that local tags get overridden if they were wrong
+					"--force",
+					// we need all the tags, so we can find all the release tags later
+					"--tags",
+					// we need the unshallowed history of our branches, so we
+					// can determine which tags are in it later
+					"--depth=" + maxDepth,
+					remote,
+					// update HEAD
+					"HEAD",
+					// update main
+					"refs/heads/main:refs/heads/main",
+				})
 		}
 	}
 


### PR DESCRIPTION
If an empty directory was passed to the version module, then `.git` wouldn't be available, and so all the git operations would fail. The fix is to detect it before running any of the commands.

But to do that, we need a context and an error - so we just move all this operation straight into the constructor, which also avoids a ton of extra calls to the `Git` function anyways.