### PR TITLE
docs: remove redundant default pragma from Go struct

### DIFF
--- a/docs/current_docs/manuals/developer/snippets/state-functions/go/main.go
+++ b/docs/current_docs/manuals/developer/snippets/state-functions/go/main.go
@@ -4,11 +4,9 @@ import "fmt"
 
 type MyModule struct {
 	// The greeting to use
-	// +default="Hello"
 	Greeting string
 	// Who to greet
 	// +private
-	// +default="World"
 	Name string
 }
 


### PR DESCRIPTION
Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
