### PR TITLE
PHP SDK: Extract logic from entrypoint to test in isolation

### DIFF
--- a/sdk/php/src/Service/DecodesValue.php
+++ b/sdk/php/src/Service/DecodesValue.php
@@ -70,7 +70,7 @@ final readonly class DecodesValue
                 ));
             case TypeDefKind::OBJECT_KIND:
                 if ($type->isIdable()) {
-                    $method = sprintf('load%sFromId', $type->getShortName());
+                    $method = sprintf('load%sFromId', NormalizesClassName::shorten($type->name));
                     $id = sprintf('%sId', $type->name);
 
                     return $this->client->$method(new $id(json_decode($value)));

--- a/sdk/php/src/Service/NormalizesClassName.php
+++ b/sdk/php/src/Service/NormalizesClassName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service;
+
+final readonly class NormalizesClassName
+{
+    public static function trimLeadingNamespace(string $name): string
+    {
+        return preg_replace('#^\\\\?[^\\\\]+\\\\#', '', $name, 1);
+    }
+
+    public static function shorten(string $name): string
+    {
+        return preg_replace('#[^\\\\]+\\\\#', '', $name);
+    }
+}

--- a/sdk/php/src/ValueObject/Type.php
+++ b/sdk/php/src/ValueObject/Type.php
@@ -48,20 +48,6 @@ final readonly class Type
         return $class->implementsInterface(IdAble::class);
     }
 
-    public function getShortName(): string
-    {
-        if (!class_exists($this->name)) {
-            throw new RuntimeException(sprintf(
-                'cannot get short class name from type: %s',
-                $this->name,
-            ));
-        }
-
-        $class = new ReflectionClass($this->name);
-
-        return $class->getShortName();
-    }
-
     private function getTypeDefKind(string $nameOfType): TypeDefKind
     {
         switch ($nameOfType) {

--- a/sdk/php/tests/Unit/Service/NormalizesClassNameTest.php
+++ b/sdk/php/tests/Unit/Service/NormalizesClassNameTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Dagger\Tests\Unit\Service;
+
+use Dagger\ValueObject\Type;
+use Generator;
+use Dagger\Service\NormalizesClassName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+#[CoversClass(NormalizesClassName::class)]
+final class NormalizesClassNameTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('provideNamesToTrim')]
+    public function itTrimsLeadingNamespace(
+        string $expected,
+        string $name,
+    ): void {
+        self::assertSame(
+            $expected,
+            NormalizesClassName::trimLeadingNamespace($name),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('provideNamesToShorten')]
+    public function itShortensNames(
+        string $expected,
+        string $name,
+    ): void {
+        self::assertSame(
+            $expected,
+            NormalizesClassName::shorten($name),
+        );
+    }
+
+    /** @return \Generator<array{ 1:string, 2:string }> */
+    public static function provideNamesToTrim(): Generator
+    {
+        $cases = [
+            'Dagger' => 'Dagger',
+            'Class' => 'Class',
+            'Dagger\\Class' => 'Class',
+            'DaggerModule\\Class' => 'Class',
+            'MyModule\\Class' => 'Class',
+            'Dagger\\Tests\\Unit' => 'Tests\\Unit',
+            'DaggerModule\\Tests\\Unit' => 'Tests\\Unit',
+            'MyModule\\Tests\\Unit\\MyTest' => 'Tests\\Unit\\MyTest',
+        ];
+
+        foreach ($cases as $name => $trimmedName) {
+            yield $name => [$trimmedName, $name];
+        }
+    }
+
+    /** @return \Generator<array{ 1:string, 2:string }> */
+    public static function provideNamesToShorten(): Generator
+    {
+        $cases = [
+            'Dagger' => 'Dagger',
+            'Class' => 'Class',
+            'Dagger\\Class' => 'Class',
+            'DaggerModule\\Class' => 'Class',
+            'MyModule\\Class' => 'Class',
+            'Dagger\\Tests\\Unit' => 'Unit',
+            'DaggerModule\\Tests\\Unit' => 'Unit',
+            'MyModule\\Tests\\Unit\\MyTest' => 'MyTest',
+        ];
+
+        foreach ($cases as $name => $shortenedName) {
+            yield $name => [$shortenedName, $name];
+        }
+    }
+}

--- a/sdk/php/tests/Unit/ValueObject/TypeTest.php
+++ b/sdk/php/tests/Unit/ValueObject/TypeTest.php
@@ -73,13 +73,6 @@ class TypeTest extends TestCase
         self::assertEquals($expected, (new Type($type))->typeDefKind);
     }
 
-    #[Test]
-    #[DataProvider('provideShortNames')]
-    public function itGetsShortClassNames(string $expected, string $type): void
-    {
-        self::assertEquals($expected, (new Type($type))->getShortName());
-    }
-
     /** @return Generator<array{0:ReflectionType}> */
     public static function provideUnsupportedReflectionTypes(): Generator
     {
@@ -223,22 +216,6 @@ class TypeTest extends TestCase
             yield $scalar => [
                 Dagger\TypeDefKind::SCALAR_KIND,
                 $scalar,
-            ];
-        }
-    }
-
-    /** @return Generator<array{ 0: string, 1:class-string}> */
-    public static function provideShortNames(): Generator
-    {
-        $classes = array_merge(
-            self::provideIdAbleClasses(),
-            self::provideAbstractScalars(),
-        );
-
-        foreach ($classes as $class) {
-            yield $class => [
-                (new ReflectionClass($class))->getShortName(),
-                $class,
             ];
         }
     }


### PR DESCRIPTION
### What?

- Extracts logic for normalizing class names before registering them with Dagger.
- Adds tests for the extracted logic.

### Why?

[sdk/php/src/Command/EntrypointCommand.php](https://github.com/dagger/dagger/compare/main...charjr:add-normalize-classname?expand=1#diff-9a9bae0159266493bd51c77501f9e9bfa8e1ef6d4ae998719e760c57cada1e58) is tied heavily to the dagger engine and cannot easily be tested in isolation. [This service](https://github.com/dagger/dagger/pull/8607/files#diff-55deae05ce0b3d6698fb01c4636faf6ca1f4e203ac81f53f9f28310a7a1e4d78) extracts logic from the EntrypointCommand [to make it testable](https://github.com/dagger/dagger/pull/8607/files#diff-c2bf4fe664d08669a2dee5d8de256c7a37326eea951b68dc95943358030479df) in isolation.

It also reduces the repetition of classes that require duplicate methods. Which is something I'm encountering working on a separate PR to add more testing to enums.