### PR TITLE
fix: fix slice init length

### DIFF
--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -149,7 +149,7 @@ func logValue(v any) log.Value {
 		}
 		return log.MapValue(kvs...)
 	case []any:
-		vals := make([]log.Value, len(x))
+		vals := make([]log.Value, 0, len(x))
 		for _, v := range x {
 			vals = append(vals, logValue(v))
 		}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(x) rather than initializing the length of this slice.