### PR TITLE
chore: upgrade go to 1.23.2

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -34,9 +34,7 @@ func (cli *CLI) Binary(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v2.2.0"
-	// TODO: remove go1_23_1 👇 after upgrading to v2.3.0
-	// https://github.com/goreleaser/goreleaser/pull/5126#issuecomment-2338622698
+	goReleaserVersion = "v2.3.2"
 )
 
 // Publish the CLI using GoReleaser
@@ -162,13 +160,12 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 }
 
 func publishEnv(ctx context.Context) (*dagger.Container, error) {
-	// TODO: remove after upgrading to GoReleaser Pro v2.3.0
-	// https://github.com/goreleaser/goreleaser/pull/5126#issuecomment-2338622698
-	go1_23_1 := dag.Container().From("golang:1.23.1-alpine@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06").Directory("/usr/local/go")
+	// TODO: remove after upgrading to GoReleaser Pro has go 1.23.2 (it currently only has go 1.23.1)
+	go1_23_2 := dag.Container().From("golang:1.23.2-alpine@sha256:9dd2625a1ff2859b8d8b01d8f7822c0f528942fe56cfe7a1e7c38d3b8d72d679").Directory("/usr/local/go")
 
 	ctr := dag.Container().
 		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s-pro", goReleaserVersion)).
-		WithDirectory("/usr/local/go", go1_23_1).
+		WithDirectory("/usr/local/go", go1_23_2).
 		WithEntrypoint([]string{}).
 		WithExec([]string{"apk", "add", "aws-cli"})
 

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.23.1-alpine").
+		From("golang:1.23.2-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/dagger.json
+++ b/dagger.json
@@ -3,10 +3,6 @@
   "sdk": "go",
   "dependencies": [
     {
-      "name": "version",
-      "source": "version"
-    },
-    {
       "name": "alpine",
       "source": "modules/alpine"
     },
@@ -49,6 +45,10 @@
     {
       "name": "shellcheck",
       "source": "modules/shellcheck"
+    },
+    {
+      "name": "version",
+      "source": "version"
     },
     {
       "name": "wolfi",

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -25,7 +25,7 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.23.1"
+	GolangVersion = "1.23.2"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -15,7 +15,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.23.1"
+	// +default="1.23.2"
 	version string,
 ) *Go {
 	if source == nil {


### PR DESCRIPTION
I was getting ephemeral panics from the Go runtime on my OTEL metrics PR that (seemingly?) disappeared when I upgraded to the new version of Go. Not sure precisely which change fixed it (they were "invalid pointer found in heap" errors) but there were a few fixes to the runtime and open issues that seemed possibly related, so worth an upgrade.