### PR TITLE
docs: use npm cache instead of node_modules for cache volumes

### DIFF
--- a/docs/current_docs/cookbook/snippets/cache-dependencies/typescript/index.ts
+++ b/docs/current_docs/cookbook/snippets/cache-dependencies/typescript/index.ts
@@ -17,10 +17,6 @@ class MyModule {
       .from("node:21")
       .withDirectory("/src", source)
       .withWorkdir("/src")
-      .withMountedCache(
-        "/src/node_modules",
-        dag.cacheVolume("node-21-myapp-myenv"),
-      )
       .withMountedCache("/root/.npm", dag.cacheVolume("node-21"))
       .withExec(["npm", "install"])
   }

--- a/docs/current_docs/quickstart/snippets/daggerize/go/main.go
+++ b/docs/current_docs/quickstart/snippets/daggerize/go/main.go
@@ -44,7 +44,7 @@ func (m *HelloDagger) BuildEnv(source *dagger.Directory) *dagger.Container {
 	return dag.Container().
 		From("node:21-slim").
 		WithDirectory("/src", source).
-		WithMountedCache("/src/node_modules", nodeCache).
+		WithMountedCache("/root/.npm", nodeCache).
 		WithWorkdir("/src").
 		WithExec([]string{"npm", "install"})
 }

--- a/docs/current_docs/quickstart/snippets/daggerize/python/__init__.py
+++ b/docs/current_docs/quickstart/snippets/daggerize/python/__init__.py
@@ -46,7 +46,7 @@ class HelloDagger:
             dag.container()
             .from_("node:21-slim")
             .with_directory("/src", source)
-            .with_mounted_cache("/src/node_modules", node_cache)
+            .with_mounted_cache("/root/.npm", node_cache)
             .with_workdir("/src")
             .with_exec(["npm", "install"])
         )

--- a/docs/current_docs/quickstart/snippets/daggerize/typescript/index.ts
+++ b/docs/current_docs/quickstart/snippets/daggerize/typescript/index.ts
@@ -48,7 +48,7 @@ class HelloDagger {
       .container()
       .from("node:21-slim")
       .withDirectory("/src", source)
-      .withMountedCache("/src/node_modules", nodeCache)
+      .withMountedCache("/root/.npm", nodeCache)
       .withWorkdir("/src")
       .withExec(["npm", "install"])
   }

--- a/docs/current_docs/quickstart/snippets/env/go/main.go
+++ b/docs/current_docs/quickstart/snippets/env/go/main.go
@@ -13,8 +13,8 @@ func (m *HelloDagger) BuildEnv(source *dagger.Directory) *dagger.Container {
 		From("node:21-slim").
 		// add the source code at /src
 		WithDirectory("/src", source).
-		// mount the cache volume at /src/node_modules
-		WithMountedCache("/src/node_modules", nodeCache).
+		// mount the cache volume at /root/.npm
+		WithMountedCache("/root/.npm", nodeCache).
 		// change the working directory to /src
 		WithWorkdir("/src").
 		// run npm install to install dependencies

--- a/docs/current_docs/quickstart/snippets/env/python/__init__.py
+++ b/docs/current_docs/quickstart/snippets/env/python/__init__.py
@@ -15,8 +15,8 @@ class HelloDagger:
             .from_("node:21-slim")
             # add the source code at /src
             .with_directory("/src", source)
-            # mount the cache volume at /src/node_modules
-            .with_mounted_cache("/src/node_modules", node_cache)
+            # mount the cache volume at /root/.npm
+            .with_mounted_cache("/root/.npm", node_cache)
             # change the working directory to /src
             .with_workdir("/src")
             # run npm install to install dependencies

--- a/docs/current_docs/quickstart/snippets/env/typescript/index.ts
+++ b/docs/current_docs/quickstart/snippets/env/typescript/index.ts
@@ -16,8 +16,8 @@ class HelloDagger {
         .from("node:21-slim")
         // add the source code at /src
         .withDirectory("/src", source)
-        // mount the cache volume at /src/node_modules
-        .withMountedCache("/src/node_modules", nodeCache)
+        // mount the cache volume at /root/.npm
+        .withMountedCache("/root/.npm", nodeCache)
         // change the working directory to /src
         .withWorkdir("/src")
         // run npm install to install dependencies

--- a/sdk/rust/crates/dagger-sdk/examples/caching/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/caching/main.rs
@@ -16,7 +16,7 @@ async fn main() -> eyre::Result<()> {
             .container()
             .from("node:16")
             .with_mounted_directory("/src", host_source_dir)
-            .with_mounted_cache("/src/node_modules", node_cache);
+            .with_mounted_cache("/root/.npm", node_cache);
 
         let runner = source
             .with_workdir("/src")


### PR DESCRIPTION
Mounting a cache volume at `node_modules` within the workdir can cause major issues for a lot of npm apps, especially if the volume is used for multiple projects or multiple sessions.  Because of this, its better to mount the volume to npm's cache directory and let npm pull from the cache itself.

This best practice applies to all usage of cache volumes, however the examples we have for Go and Python already work this way.