### PR TITLE
add Service.WithHostname

### DIFF
--- a/.changes/unreleased/Added-20241008-125457.yaml
+++ b/.changes/unreleased/Added-20241008-125457.yaml
@@ -1,0 +1,13 @@
+kind: Added
+body: |
+  Services can now be given an explicit hostname via `Service.withHostname`.
+
+  Previously, you could only express a DAG of services, because each service hostname was derived from the service's configuration, and changing a service to point to another service would inherently change that service's configuration.
+
+  Now you can set your own hostnames ahead of time, tell your services about each other's hostnames, and start they manually.
+
+  Services with custom hostnames are namespaced to the module that starts them, to prevent conflicts.
+time: 2024-10-08T12:54:57.125973062-04:00
+custom:
+    Author: vito
+    PR: "8641"

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -88,6 +88,11 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	execMD.SystemEnvNames = container.SystemEnvNames
 	execMD.EnabledGPUs = container.EnabledGPUs
 
+	mod, err := container.Query.CurrentModule(ctx)
+	if err == nil {
+		execMD.ServiceModuleScope = mod.InstanceID
+	}
+
 	// if GPU parameters are set for this container pass them over:
 	if len(execMD.EnabledGPUs) > 0 {
 		if gpuSupportEnabled := os.Getenv("_EXPERIMENTAL_DAGGER_GPU_SUPPORT"); gpuSupportEnabled == "" {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/network"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/identity"
 	"github.com/pkg/errors"
@@ -90,7 +91,10 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	mod, err := container.Query.CurrentModule(ctx)
 	if err == nil {
-		execMD.ServiceModuleScope = mod.InstanceID
+		// allow the exec to reach services scoped to the module that
+		// installed it
+		execMD.ExtraSearchDomains = append(execMD.ExtraSearchDomains,
+			network.ModuleDomain(mod.InstanceID, clientMetadata.SessionID))
 	}
 
 	// if GPU parameters are set for this container pass them over:

--- a/core/healthcheck.go
+++ b/core/healthcheck.go
@@ -47,7 +47,7 @@ func (d *portHealthChecker) Check(ctx context.Context) (rerr error) {
 	ctx, span := Tracer(ctx).Start(ctx, strings.Join(portStrs, " "))
 	defer telemetry.End(span, func() error { return rerr })
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary).With("host", d.host)
 
 	dialer := net.Dialer{
 		Timeout: time.Second,

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -3,11 +3,12 @@ package core
 import "github.com/dagger/dagger/engine/distconsts"
 
 const (
-	alpineImage = distconsts.AlpineImage
-	golangImage = distconsts.GolangImage
-	debianImage = "debian:bookworm"
-	rhelImage   = "registry.access.redhat.com/ubi9/ubi"
-	alpineArm   = "arm64v8/alpine"
+	alpineImage  = distconsts.AlpineImage
+	busyboxImage = distconsts.BusyboxImage
+	golangImage  = distconsts.GolangImage
+	debianImage  = "debian:bookworm"
+	rhelImage    = "registry.access.redhat.com/ubi9/ubi"
+	alpineArm    = "arm64v8/alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"

--- a/core/integration/testdata/counter/main.go
+++ b/core/integration/testdata/counter/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+)
+
+func main() {
+	var count int32
+	http.ListenAndServe(":80", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint: gosec
+		res := atomic.AddInt32(&count, 1)
+		log.Println("count:", res)
+		fmt.Fprint(w, res)
+	}))
+}

--- a/core/integration/testdata/relay/main.go
+++ b/core/integration/testdata/relay/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	http.ListenAndServe(":80", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint: gosec
+		log.Printf("HANDLE: %+v", r.URL)
+
+		q, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		relay := q["relay"]
+		end := q.Get("end")
+		if len(relay) == 0 {
+			log.Println("reached end:", end)
+			fmt.Fprint(w, end)
+			return
+		}
+
+		first, rest := relay[0], relay[1:]
+
+		next, err := url.Parse(first)
+		if err != nil {
+			log.Println("PARSE ERROR:", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		next.RawQuery = url.Values{
+			"relay": rest,
+			"end":   {end},
+		}.Encode()
+
+		log.Println("relaying:", next)
+
+		cat := exec.Command("cat", "/etc/resolv.conf")
+		cat.Stdout = os.Stdout
+		cat.Stderr = os.Stderr
+		cat.Run()
+
+		res, err := http.Get(next.String())
+		if err != nil {
+			log.Println("GET ERROR:", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer res.Body.Close()
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			log.Println("READ ERROR:", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, "%s: %s", first, string(body))
+	}))
+}

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -33,6 +33,10 @@ func (s *serviceSchema) Install() {
 		dagql.NodeFunc("hostname", s.hostname).
 			Doc(`Retrieves a hostname which can be used by clients to reach this container.`),
 
+		dagql.NodeFunc("withHostname", s.withHostname).
+			Doc(`Configures a hostname which can be used by clients within the session to reach this container.`).
+			ArgDoc("hostname", `The hostname to use.`),
+
 		dagql.NodeFunc("ports", s.ports).
 			Impure("A tunnel service's ports can change each time it is restarted.").
 			Doc(`Retrieves the list of ports provided by the service.`),
@@ -90,6 +94,12 @@ func (s *serviceSchema) hostname(ctx context.Context, parent dagql.Instance[*cor
 		return "", err
 	}
 	return dagql.NewString(hn), nil
+}
+
+func (s *serviceSchema) withHostname(ctx context.Context, parent dagql.Instance[*core.Service], args struct {
+	Hostname string
+}) (*core.Service, error) {
+	return parent.Self.WithHostname(args.Hostname), nil
 }
 
 func (s *serviceSchema) ports(ctx context.Context, parent dagql.Instance[*core.Service], args struct{}) (dagql.Array[core.Port], error) {

--- a/core/service.go
+++ b/core/service.go
@@ -313,7 +313,7 @@ func (svc *Service) startContainer(
 	}()
 
 	var domain string
-	if mod, err := svc.Query.CurrentModule(ctx); err == nil {
+	if mod, err := svc.Query.CurrentModule(ctx); err == nil && svc.CustomHostname != "" {
 		domain = network.ModuleDomain(mod.InstanceID, clientMetadata.SessionID)
 		if !slices.Contains(execMD.ExtraSearchDomains, domain) {
 			// ensure a service can reach other services in the module that started

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2744,6 +2744,14 @@ type Service {
     """Bind each tunnel port to a random port on the host."""
     random: Boolean = false
   ): Void
+
+  """
+  Configures a hostname which can be used by clients within the session to reach this container.
+  """
+  withHostname(
+    """The hostname to use."""
+    hostname: String!
+  ): Service!
 }
 
 """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8520,6 +8520,23 @@
                           </div>
                         </td>
                       </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Service-withHostname" href="#Service-withHostname"><code>withHostname</code></a> - <span class="property-type"><a href="#definition-Service"><code>Service!</code></a></span> </td>
+                        <td> Configures a hostname which can be used by clients within the session to reach this container. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>hostname</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The hostname to use.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -79,6 +79,8 @@ type ExecutionMetadata struct {
 
 	// hostname -> list of aliases
 	HostAliases map[string][]string
+	// search domains to install prior to the session's domain
+	ExtraSearchDomains []string
 
 	RedirectStdoutPath string
 	RedirectStderrPath string
@@ -94,8 +96,6 @@ type ExecutionMetadata struct {
 
 	// Path to the SSH auth socket. Used for Dagger-in-Dagger support.
 	SSHAuthSocketPath string
-
-	ServiceModuleScope *call.ID
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -94,6 +94,8 @@ type ExecutionMetadata struct {
 
 	// Path to the SSH auth socket. Used for Dagger-in-Dagger support.
 	SSHAuthSocketPath string
+
+	ServiceModuleScope *call.ID
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -166,16 +166,9 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 		return nil
 	}
 
-	extraSearchDomains := []string{
-		network.ClientDomain(w.execMD.SessionID),
-	}
-
-	if w.execMD.ServiceModuleScope != nil {
-		extraSearchDomains = append([]string{
-			network.HostHash(w.execMD.ServiceModuleScope.Digest()) + "." +
-				network.ClientDomain(w.execMD.SessionID),
-		}, extraSearchDomains...)
-	}
+	extraSearchDomains := []string{}
+	extraSearchDomains = append(extraSearchDomains, w.execMD.ExtraSearchDomains...)
+	extraSearchDomains = append(extraSearchDomains, network.SessionDomain(w.execMD.SessionID))
 
 	baseResolvFile, err := os.Open(state.resolvConfPath)
 	if err != nil {
@@ -950,7 +943,7 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 				}
 				var resolvedHost string
 				var errs error
-				for _, searchDomain := range []string{"", network.ClientDomain(w.execMD.SessionID)} {
+				for _, searchDomain := range []string{"", network.SessionDomain(w.execMD.SessionID)} {
 					qualified := hostName
 					if searchDomain != "" {
 						qualified += "." + searchDomain

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -166,7 +166,16 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 		return nil
 	}
 
-	extraSearchDomain := network.ClientDomain(w.execMD.SessionID)
+	extraSearchDomains := []string{
+		network.ClientDomain(w.execMD.SessionID),
+	}
+
+	if w.execMD.ServiceModuleScope != nil {
+		extraSearchDomains = append([]string{
+			network.HostHash(w.execMD.ServiceModuleScope.Digest()) + "." +
+				network.ClientDomain(w.execMD.SessionID),
+		}, extraSearchDomains...)
+	}
 
 	baseResolvFile, err := os.Open(state.resolvConfPath)
 	if err != nil {
@@ -205,7 +214,7 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 		}
 
 		domains := strings.Fields(line)[1:]
-		domains = append(domains, extraSearchDomain)
+		domains = append(domains, extraSearchDomains...)
 		if _, err := fmt.Fprintln(ctrResolvFile, "search", strings.Join(domains, " ")); err != nil {
 			return fmt.Errorf("write resolv.conf: %w", err)
 		}
@@ -215,7 +224,7 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 		return fmt.Errorf("read resolv.conf: %w", err)
 	}
 	if !replaced {
-		if _, err := fmt.Fprintln(ctrResolvFile, "search", extraSearchDomain); err != nil {
+		if _, err := fmt.Fprintln(ctrResolvFile, "search", strings.Join(extraSearchDomains, " ")); err != nil {
 			return fmt.Errorf("write resolv.conf: %w", err)
 		}
 	}
@@ -256,7 +265,7 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 	for target, aliases := range w.execMD.HostAliases {
 		var ips []net.IP
 		var errs error
-		for _, domain := range []string{"", extraSearchDomain} {
+		for _, domain := range append([]string{""}, extraSearchDomains...) {
 			qualified := target
 			if domain != "" {
 				qualified += "." + domain

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -27,6 +27,9 @@ const (
 
 	GolangVersion = "1.23.1"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
+
+	BusyboxVersion = "1.37.0"
+	BusyboxImage   = "busybox:" + BusyboxVersion
 )
 
 const (

--- a/engine/sources/gitdns/source.go
+++ b/engine/sources/gitdns/source.go
@@ -323,7 +323,7 @@ func (gs *gitSourceHandler) mountKnownHosts() (string, func() error, error) {
 func (gs *gitSourceHandler) dnsConfig() *oci.DNSConfig {
 	clientDomains := []string{}
 	if gs.src.Namespace != "" {
-		clientDomains = append(clientDomains, network.ClientDomain(gs.src.Namespace))
+		clientDomains = append(clientDomains, network.SessionDomain(gs.src.Namespace))
 	}
 	dns := *gs.dns
 	dns.SearchDomains = append(clientDomains, dns.SearchDomains...)

--- a/engine/sources/httpdns/source.go
+++ b/engine/sources/httpdns/source.go
@@ -107,7 +107,7 @@ type httpSourceHandler struct {
 func (hs *httpSourceHandler) client(g session.Group) *http.Client {
 	clientDomains := []string{}
 	if ns := hs.src.Namespace; ns != "" {
-		clientDomains = append(clientDomains, network.ClientDomain(ns))
+		clientDomains = append(clientDomains, network.SessionDomain(ns))
 	}
 
 	dns := *hs.dns

--- a/network/hosts.go
+++ b/network/hosts.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base32"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/opencontainers/go-digest"
 	"github.com/zeebo/xxh3"
 )
@@ -23,14 +25,19 @@ func HostHashStr(val string) string {
 	return strings.ToLower(b32(xxh3.HashString(val)))
 }
 
-// ClientDomain is a session-global domain suffix appended to every service's
-// hostname. It is randomly generated on the first call.
-//
-// Ideally we would base this on the Buildkit gateway session ID instead of
-// using global state, but for exporting we actually establish multiple gateway
-// sessions.
-func ClientDomain(sid string) string {
+// SessionDomain is a session-wide domain suffix for a given session ID.
+func SessionDomain(sid string) string {
 	return HostHashStr(sid) + DomainSuffix
+}
+
+// SessionDomain is a session-wide domain suffix for a given session ID.
+func ModuleDomain(modID *call.ID, sid string) string {
+	return fmt.Sprintf(
+		"%s.%s%s",
+		HostHash(modID.Digest()),
+		HostHashStr(sid),
+		DomainSuffix,
+	)
 }
 
 func b32(n uint64) string {

--- a/sdk/elixir/lib/dagger/gen/service.ex
+++ b/sdk/elixir/lib/dagger/gen/service.ex
@@ -123,4 +123,16 @@ defmodule Dagger.Service do
       error -> error
     end
   end
+
+  @doc "Configures a hostname which can be used by clients within the session to reach this container."
+  @spec with_hostname(t(), String.t()) :: Dagger.Service.t()
+  def with_hostname(%__MODULE__{} = service, hostname) do
+    query_builder =
+      service.query_builder |> QB.select("withHostname") |> QB.put_arg("hostname", hostname)
+
+    %Dagger.Service{
+      query_builder: query_builder,
+      client: service.client
+    }
+  end
 end

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -7203,6 +7203,14 @@ type Service struct {
 	stop     *ServiceID
 	up       *Void
 }
+type WithServiceFunc func(r *Service) *Service
+
+// With calls the provided function with current Service.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Service) With(f WithServiceFunc) *Service {
+	return f(r)
+}
 
 func (r *Service) WithGraphQLQuery(q *querybuilder.Selection) *Service {
 	return &Service{
@@ -7399,6 +7407,16 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) error {
 	}
 
 	return q.Execute(ctx)
+}
+
+// Configures a hostname which can be used by clients within the session to reach this container.
+func (r *Service) WithHostname(hostname string) *Service {
+	q := r.query.Select("withHostname")
+	q = q.Arg("hostname", hostname)
+
+	return &Service{
+		query: q,
+	}
 }
 
 // A Unix or TCP/IP socket that can be mounted into a container.

--- a/sdk/php/generated/Service.php
+++ b/sdk/php/generated/Service.php
@@ -96,4 +96,14 @@ class Service extends Client\AbstractObject implements Client\IdAble
         }
         $this->queryLeaf($leafQueryBuilder, 'up');
     }
+
+    /**
+     * Configures a hostname which can be used by clients within the session to reach this container.
+     */
+    public function withHostname(string $hostname): Service
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withHostname');
+        $innerQueryBuilder->setArgument('hostname', $hostname);
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -7412,6 +7412,28 @@ class Service(Type):
         _ctx = self._select("up", _args)
         await _ctx.execute()
 
+    def with_hostname(self, hostname: str) -> Self:
+        """Configures a hostname which can be used by clients within the session
+        to reach this container.
+
+        Parameters
+        ----------
+        hostname:
+            The hostname to use.
+        """
+        _args = [
+            Arg("hostname", hostname),
+        ]
+        _ctx = self._select("withHostname", _args)
+        return Service(_ctx)
+
+    def with_(self, cb: Callable[["Service"], "Service"]) -> "Service":
+        """Call the provided callable with current Service.
+
+        This is useful for reusability and readability by not breaking the calling chain.
+        """
+        return cb(self)
+
 
 @typecheck
 class Socket(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7512,6 +7512,20 @@ impl Service {
         }
         query.execute(self.graphql_client.clone()).await
     }
+    /// Configures a hostname which can be used by clients within the session to reach this container.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The hostname to use.
+    pub fn with_hostname(&self, hostname: impl Into<String>) -> Service {
+        let mut query = self.selection.select("withHostname");
+        query = query.arg("hostname", hostname.into());
+        Service {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
 }
 #[derive(Clone)]
 pub struct Socket {

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -9600,6 +9600,32 @@ export class Service extends BaseClient {
       await this._ctx.connection(),
     )
   }
+
+  /**
+   * Configures a hostname which can be used by clients within the session to reach this container.
+   * @param hostname The hostname to use.
+   */
+  withHostname = (hostname: string): Service => {
+    return new Service({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withHostname",
+          args: { hostname },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Call the provided function with current Service.
+   *
+   * This is useful for reusability and readability by not breaking the calling chain.
+   */
+  with = (arg: (param: Service) => Service) => {
+    return arg(this)
+  }
 }
 
 /**


### PR DESCRIPTION
Allows you to manually configure a hostname for a service, which will be automatically namespaced within the module. This ability allows you to express circular service dependencies, which was previously impossible with content-addressed hostnames.

Implementation notes:

* New API: `Service { withHostname(hostname: String!): Service! }`
  * Sets a custom hostname to be used instead of the regular content-addressed (query ID -derived) hostname
* When a service has a custom hostname its FQDN will be `<host>.<module id>.<session id>.dagger.local`
  * The `<module id>` is a new component to ensure two modules setting the same hostname don't conflict
* A `withExec` always installs its calling `<module id>.<session id>.dagger.local` to its list of search domains
  * In other words, it will always be able to reach service hostnames run by the module that _installed_ the withExec
* A container service always installs its _starting_ `<module id>.<session id>.dagger.local` to its list of search domains
  * This allows a service returned by a module to reach services with custom hostnames running via the _using_ module
  * This is in addition to the search domain installed by the original `withExec`