### PR TITLE
cli: internal tooling for graphviz output

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -60,6 +60,10 @@ var (
 	web                      bool
 	noExit                   bool
 
+	dotOutputFilePath string
+	dotFocusField     string
+	dotShowInternal   bool
+
 	stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())
 	stderrIsTTY = isatty.IsTerminal(os.Stderr.Fd())
 
@@ -222,7 +226,16 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")
 	flags.BoolVarP(&noExit, "no-exit", "E", false, "Leave the TUI running after completion")
 
-	for _, fl := range []string{"workdir"} {
+	flags.StringVar(&dotOutputFilePath, "dot-output", "", "If set, write the calls made during execution to a dot file at the given path before exiting")
+	flags.StringVar(&dotFocusField, "dot-focus-field", "", "In dot output, filter out vertices that aren't this field or descendents of this field")
+	flags.BoolVar(&dotShowInternal, "dot-show-internal", false, "In dot output, if true then include calls and spans marked as internal")
+
+	for _, fl := range []string{
+		"workdir",
+		"dot-output",
+		"dot-focus-field",
+		"dot-show-internal",
+	} {
 		if err := flags.MarkHidden(fl); err != nil {
 			fmt.Println("Error hiding flag: "+fl, err)
 			os.Exit(1)
@@ -296,6 +309,9 @@ func main() {
 	opts.Debug = debug                             // show everything
 	opts.OpenWeb = web
 	opts.NoExit = noExit
+	opts.DotOutputFilePath = dotOutputFilePath
+	opts.DotFocusField = dotFocusField
+	opts.DotShowInternal = dotShowInternal
 	if progress == "auto" {
 		if hasTTY {
 			progress = "tty"

--- a/dagql/dagui/dot.go
+++ b/dagql/dagui/dot.go
@@ -1,0 +1,328 @@
+package dagui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/dagger/dagger/dagql/call/callpbv1"
+)
+
+func (db *DB) WriteDot(
+	outputFilePath string,
+	focusField string,
+	showInternal bool,
+) {
+	if outputFilePath == "" {
+		return
+	}
+	out, err := os.Create(outputFilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	dag := db.getDotDag(focusField, showInternal)
+	dag.writeTo(out)
+}
+
+type dotDag struct {
+	vtxByCallDgst map[string]*dotVtx
+}
+
+type dotVtx struct {
+	dgst string
+	call *callpbv1.Call
+	span *Span
+
+	children map[string]*dotEdge
+	parents  map[string]*dotEdge
+
+	// whether to include in dot output
+	show bool
+}
+
+type dotEdge struct {
+	kind edgeKind
+	// only for kind arg
+	argName string
+}
+
+func (db *DB) getDotDag(focusField string, showInternal bool) *dotDag {
+	dag := &dotDag{
+		vtxByCallDgst: make(map[string]*dotVtx),
+	}
+
+	for _, span := range db.Spans {
+		call := span.Call
+		if call == nil {
+			continue
+		}
+		callDgst := call.Digest
+
+		vtx, ok := dag.getOrInitVtx(callDgst)
+		if ok && vtx.call != nil {
+			// already handled
+			continue
+		}
+		vtx.call = call
+		vtx.span = span
+
+		if vtx.call.ReceiverDigest != "" {
+			parentVtx, _ := dag.getOrInitVtx(vtx.call.ReceiverDigest)
+			edge := dag.getOrInitEdge(parentVtx, vtx)
+			edge.kind = edgeKindReceiver
+		} else if parentSpan := findParentSpanWithCall(vtx.span); parentSpan != nil {
+			// see if we can connect to a parent span (i.e. one module calling to another or to core, etc.)
+			parentVtx, _ := dag.getOrInitVtx(parentSpan.Call.Digest)
+			edge := dag.getOrInitEdge(parentVtx, vtx)
+			if edge.kind == edgeKindUnset {
+				edge.kind = edgeKindSpan
+			}
+		}
+
+		for _, arg := range vtx.call.Args {
+			argCallDgstLit, ok := arg.Value.Value.(*callpbv1.Literal_CallDigest)
+			if !ok || argCallDgstLit == nil {
+				continue
+			}
+			argCallDgst := argCallDgstLit.CallDigest
+
+			parentVtx, _ := dag.getOrInitVtx(argCallDgst)
+			edge := dag.getOrInitEdge(parentVtx, vtx)
+			if edge.kind == edgeKindUnset {
+				edge.kind = edgeKindArg
+				edge.argName = arg.Name
+			}
+		}
+	}
+
+	focusedVtxs := make(map[*dotVtx]struct{})
+	for _, vtx := range dag.vtxByCallDgst {
+		// if asked to focus on vertexes with a given field name, find those
+		if focusField != "" {
+			if vtx.call == nil {
+				continue
+			}
+			if vtx.call.Field == focusField {
+				focusedVtxs[vtx] = struct{}{}
+			}
+			continue
+		}
+
+		// otherwise, "focus" on the roots (vtxs with no parents) so we show everything
+		if len(vtx.parents) == 0 {
+			focusedVtxs[vtx] = struct{}{}
+		}
+	}
+
+	visited := make(map[*dotVtx]struct{})
+	for vtx := range focusedVtxs {
+		dag.setShow(vtx, visited, showInternal)
+	}
+
+	return dag
+}
+
+func (dag *dotDag) getOrInitVtx(callDgst string) (*dotVtx, bool) {
+	vtx, ok := dag.vtxByCallDgst[callDgst]
+	if !ok {
+		vtx = &dotVtx{
+			dgst:     callDgst,
+			children: make(map[string]*dotEdge),
+			parents:  make(map[string]*dotEdge),
+		}
+		dag.vtxByCallDgst[callDgst] = vtx
+	}
+	return vtx, ok
+}
+
+func (dag *dotDag) getOrInitEdge(parent, child *dotVtx) *dotEdge {
+	_, parentToChildOk := parent.children[child.dgst]
+	edge, childToParentOk := child.parents[parent.dgst]
+	switch {
+	case parentToChildOk && childToParentOk:
+		return edge
+	case parentToChildOk:
+		panic(fmt.Sprintf(
+			"parent-to-child edge exists, but child-to-parent does not: child (%q) -> parent (%q)",
+			child.dgst,
+			parent.dgst,
+		))
+	case childToParentOk:
+		panic(fmt.Sprintf(
+			"child-to-parent edge exists, but parent-to-child does not: parent (%q) -> child (%q)",
+			parent.dgst,
+			child.dgst,
+		))
+	}
+
+	edge = &dotEdge{}
+	parent.children[child.dgst] = edge
+	child.parents[parent.dgst] = edge
+	return edge
+}
+
+func (dag *dotDag) setShow(vtx *dotVtx, visited map[*dotVtx]struct{}, showInternal bool) {
+	if _, ok := visited[vtx]; ok {
+		return
+	}
+	visited[vtx] = struct{}{}
+
+	// don't show things we never found call data for
+	if vtx.call == nil {
+		return
+	}
+
+	// don't show internal unless asked to
+	if !showInternal && vtx.span.Internal {
+		return
+	}
+
+	// hide noisy "id" unless internal requested (even though id is not technically marked as internal)
+	if !showInternal && vtx.call.Field == "id" {
+		return
+	}
+
+	// show it and check its children
+	vtx.show = true
+	for childVtxDgst := range vtx.children {
+		childVtx, ok := dag.vtxByCallDgst[childVtxDgst]
+		if !ok {
+			panic(fmt.Sprintf("child vtx %q not found", childVtxDgst))
+		}
+		dag.setShow(childVtx, visited, showInternal)
+	}
+}
+
+func (dag *dotDag) writeTo(out io.Writer) {
+	fmt.Fprintln(out, "digraph {")
+	defer fmt.Fprintln(out, "}")
+
+	for vtxDgst, vtx := range dag.vtxByCallDgst {
+		if !vtx.show {
+			continue
+		}
+
+		buf := new(bytes.Buffer)
+		fmt.Fprintf(buf, "%s", vtx.call.Field)
+		for ai, arg := range vtx.call.Args {
+			if ai == 0 {
+				fmt.Fprintf(buf, "(")
+			} else {
+				fmt.Fprintf(buf, ", ")
+			}
+			fmt.Fprintf(buf, "%s: %s", arg.Name, displayLit(arg.Value))
+			if ai == len(vtx.call.Args)-1 {
+				fmt.Fprintf(buf, ")")
+			}
+		}
+		if vtx.call.Nth != 0 {
+			fmt.Fprintf(buf, "#%d", vtx.call.Nth)
+		}
+		label := buf.String()
+
+		duration := vtx.span.ActiveDuration(time.Now())
+		label += fmt.Sprintf("\n%s", duration)
+
+		thicc := false
+		if s := duration.Seconds(); s > 1.0 {
+			thicc = true
+		}
+		border := 1.0
+		color := "black"
+		if thicc {
+			border = 10.0
+			color = "red"
+		}
+
+		fmt.Fprintf(out, "  %q [label=%q shape=ellipse penwidth=%f color=%s];\n", vtxDgst, label, border, color)
+
+		for childVtxDgst, edge := range vtx.children {
+			childVtx, ok := dag.vtxByCallDgst[childVtxDgst]
+			if !ok {
+				panic(fmt.Sprintf("child vtx %q not found", childVtxDgst))
+			}
+			if !childVtx.show {
+				continue
+			}
+
+			switch edge.kind {
+			case edgeKindReceiver:
+				fmt.Fprintf(out, "  %q -> %q [color=black];\n", vtx.dgst, childVtx.dgst)
+			case edgeKindArg:
+				fmt.Fprintf(out, "  %q -> %q [color=blue label=%q];\n",
+					vtx.dgst,
+					childVtx.dgst,
+					edge.argName,
+				)
+			case edgeKindSpan:
+				fmt.Fprintf(out, "  %q -> %q [color=green];\n", vtx.dgst, childVtx.dgst)
+			}
+		}
+	}
+}
+
+type edgeKind int
+
+const (
+	edgeKindUnset edgeKind = iota
+	edgeKindReceiver
+	edgeKindArg
+	edgeKindSpan
+)
+
+func findParentSpanWithCall(span *Span) *Span {
+	if span.ParentSpan == nil {
+		return nil
+	}
+	if span.ParentSpan.Call != nil {
+		return span.ParentSpan
+	}
+	return findParentSpanWithCall(span.ParentSpan)
+}
+
+func displayLit(lit *callpbv1.Literal) string {
+	switch val := lit.GetValue().(type) {
+	case *callpbv1.Literal_Bool:
+		return fmt.Sprintf("%v", val.Bool)
+	case *callpbv1.Literal_Int:
+		return fmt.Sprintf("%d", val.Int)
+	case *callpbv1.Literal_Float:
+		return fmt.Sprintf("%f", val.Float)
+	case *callpbv1.Literal_String_:
+		if len(val.String_) > 256 {
+			return "ETOOBIG"
+		}
+		return fmt.Sprintf("%q", val.String_)
+	case *callpbv1.Literal_CallDigest:
+		return "<input>"
+	case *callpbv1.Literal_Enum:
+		return val.Enum
+	case *callpbv1.Literal_Null:
+		return "null"
+	case *callpbv1.Literal_List:
+		s := "["
+		for i, item := range val.List.GetValues() {
+			if i > 0 {
+				s += ", "
+			}
+			s += displayLit(item)
+		}
+		s += "]"
+		return s
+	case *callpbv1.Literal_Object:
+		s := "{"
+		for i, item := range val.Object.GetValues() {
+			if i > 0 {
+				s += ", "
+			}
+			s += fmt.Sprintf("%s: %s", item.GetName(), displayLit(item.GetValue()))
+		}
+		s += "}"
+		return s
+	default:
+		panic(fmt.Sprintf("unknown literal type %T", val))
+	}
+}

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -27,6 +27,15 @@ type FrontendOpts struct {
 
 	// Leave the TUI running instead of exiting after completion.
 	NoExit bool
+
+	// DotOutputFilePath is the path to write the DOT output to after execution, if any
+	DotOutputFilePath string
+
+	// DotFocusField is the field name to focus on in the DOT output, if any
+	DotFocusField string
+
+	// DotShowInternal indicates whether to include internal steps in the DOT output
+	DotShowInternal bool
 }
 
 const (

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -198,6 +198,9 @@ func (fe *frontendPlain) Run(ctx context.Context, opts dagui.FrontendOpts, run f
 
 	runErr := run(ctx)
 	fe.finalRender()
+
+	fe.db.WriteDot(opts.DotOutputFilePath, opts.DotFocusField, opts.DotShowInternal)
+
 	return runErr
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -157,6 +157,8 @@ func (fe *frontendPretty) Run(ctx context.Context, opts dagui.FrontendOpts, run 
 		return renderErr
 	}
 
+	fe.db.WriteDot(opts.DotOutputFilePath, opts.DotFocusField, opts.DotShowInternal)
+
 	// return original err
 	return runErr
 }


### PR DESCRIPTION
This is a slightly cleaned up version of what I did at Dagger's recent team hackathon, differences being:
1. Code is *slightly* improved from hackathon-quality (just so it can be easier to build off of and not complete throwaway)
2. No exec metrics yet (like disk usage) since that PR is still pending merge
3. It's controlled via hidden top-level dagger CLI flags now (instead of inlined consts):
   * `--dot-output=<path>` will trigger writing a `.dot` formatted file to the given path
   * `--dot-focus-field=<gql field name>` gives some very crude filtering ability by resulting in only calls for the given field name and their descendents being shown
   * `--dot-show-internal` results in calls under internal spans showing up too (they are hidden by default).

E.g. to look at the DAG for running a set of integ tests you could run:
```
dagger --dot-output /home/sipsma/dag.dot call test specific --pkg=./core/integration --run=TestCall/TestSocketArg

dot -Tsvg -x -o dag.svg dag.dot # can open dag.svg in most web browsers
```

The above command requires `dot` to be installed, which is typically available in system packages named something like `graphviz`.

It should work on any command that has progress output, not just `dagger call`.

This is still very barebones, but just useful enough to be worth merging especially since it's controlled with hidden flags and otherwise unintrusive to our code (just reuses existing telemetry the cli already collects).

The idea is to merge the basic thing now and then use+improve it while debugging/bottleneck-hunting.

Some low-hanging fruit improvements possible as we iterate:
* Make the "highlight bottlenecks in red" more configurable (just colors a vertex red if it takes longer than a second right now). Can also make degree of highlighting proportional rather than off/on
* Make it work off OTEL data persisted somewhere (i.e. cloud, a json dump of all OTEL data received by the CLI, etc.) so that you can change filters/configuration without having to actually run `dagger call` again
* Make use of clustering in graphviz (by span?)
* Make use of other graphviz layout engines that might have nicer output for complex cases
* Add a dagger module for going from `.dot`->`.svg` (and more)