### PR TITLE
ci: Bump CPU for a few jobs which were CPU starved

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
           upload-logs: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
           function: "engine publish --image=dagger-engine.dev --tag=main --dry-run"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-3-8c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I was benchmarking alternative CI runners and noticed that these jobs were being CPU starved. They are 25% - 40% faster when given an adequate number of CPUs.

| Job | Before | After |
| :- | -: | -: |
| engine / lint | `8m 7s` | `4m 8s` |
| engine / test-publish | `6m 44s` | `3m 14s` |
| engine / scan-engine | `3m 37s` | `?` |