### PR TITLE
ci: Bump & sha256 pin aquasec/trivy image

### DIFF
--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -393,7 +393,7 @@ func (e *Engine) Scan(ctx context.Context) error {
 	}
 
 	ctr := dag.Container().
-		From("aquasec/trivy:0.53.0").
+		From("aquasec/trivy:0.56.1@sha256:c42bb3221509b0a9fa2291cd79a3a818b30a172ab87e9aac8a43997a5b56f293").
 		WithMountedDirectory("/mnt/ignores", ignoreFiles).
 		WithMountedCache("/root/.cache/", dag.CacheVolume("trivy-cache"))
 

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -395,7 +395,8 @@ func (e *Engine) Scan(ctx context.Context) error {
 	ctr := dag.Container().
 		From("aquasec/trivy:0.56.1@sha256:c42bb3221509b0a9fa2291cd79a3a818b30a172ab87e9aac8a43997a5b56f293").
 		WithMountedDirectory("/mnt/ignores", ignoreFiles).
-		WithMountedCache("/root/.cache/", dag.CacheVolume("trivy-cache"))
+		WithMountedCache("/root/.cache/", dag.CacheVolume("trivy-cache")).
+		With(e.Dagger.withDockerCfg)
 
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -321,3 +321,10 @@ func (dev *DaggerDev) DevExport(
 		WithFile(cliPath, cliBin)
 	return dir, nil
 }
+
+func (dev *DaggerDev) withDockerCfg(ctr *dagger.Container) *dagger.Container {
+	if dev.DockerCfg == nil {
+		return ctr
+	}
+	return ctr.WithMountedSecret("/root/.docker/config.json", dev.DockerCfg)
+}

--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -77,11 +77,8 @@ func (dev *DaggerDev) installer(ctx context.Context, name string) (func(*dagger.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://dagger-engine:1234").
 			WithMountedFile(cliBinaryPath, cliBinary).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinaryPath).
-			WithExec([]string{"ln", "-s", cliBinaryPath, "/usr/local/bin/dagger"})
-		if dev.DockerCfg != nil {
-			// this avoids rate limiting in our ci tests
-			ctr = ctr.WithMountedSecret("/root/.docker/config.json", dev.DockerCfg)
-		}
+			WithExec([]string{"ln", "-s", cliBinaryPath, "/usr/local/bin/dagger"}).
+			With(dev.withDockerCfg) // this avoids rate limiting in our ci tests
 		return ctr
 	}, nil
 }

--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -224,11 +224,8 @@ func (t *Test) testCmd(ctx context.Context) (*dagger.Container, error) {
 	tests = tests.
 		WithMountedFile(cliBinPath, devBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint)
-	if t.Dagger.DockerCfg != nil {
-		// this avoids rate limiting in our ci tests
-		tests = tests.WithMountedSecret("/root/.docker/config.json", t.Dagger.DockerCfg)
-	}
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
+		With(t.Dagger.withDockerCfg) // this avoids rate limiting in our ci tests
 	return tests, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8644

Expecting it to fix the following error:

    Fatal errorinit error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error
    GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 566.363µs, allowed: 44000/minute

---

Follow-up to:
- https://github.com/dagger/dagger/pull/8643