### PR TITLE
chore: remove `withFocus`/`withoutFocus`

### DIFF
--- a/.changes/unreleased/Breaking-20241008-181543.yaml
+++ b/.changes/unreleased/Breaking-20241008-181543.yaml
@@ -1,0 +1,7 @@
+kind: Breaking
+body: |
+  Remove deprecated `Container.withFocus` and `Container.withoutFocus`
+time: 2024-10-08T18:15:43.775091231+01:00
+custom:
+  Author: jedevc
+  PR: "8647"

--- a/core/container.go
+++ b/core/container.go
@@ -92,10 +92,6 @@ type Container struct {
 	// Services to start before running the container.
 	Services ServiceBindings `json:"services,omitempty"`
 
-	// Focused indicates whether subsequent operations will be
-	// focused, i.e. shown more prominently in the UI.
-	Focused bool `json:"focused"`
-
 	// The args to invoke when using the terminal api on this container.
 	DefaultTerminalCmd DefaultTerminalCmdOpts `json:"defaultTerminalCmd,omitempty"`
 

--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -709,3 +709,28 @@ func (m *Test) NewProto(proto dagger.NetworkProtocol) dagger.NetworkProtocol {
 	require.NoError(t, err)
 	require.Contains(t, out, "UDP")
 }
+
+func (LegacySuite) TestContainerWithFocus(ctx context.Context, t *testctx.T) {
+	// Changed in dagger/dagger#8647
+	//
+	// Ensure that the old schemas still have withFocus/withoutFocus.
+
+	var res any
+	err := testutil.Query(t,
+		`{
+			container {
+				from(address: "alpine") {
+					withFocus {
+						withoutFocus {
+							withExec(args: ["echo", "hello world"]) {
+								sync
+							}
+						}
+					}
+				}
+			}
+		}`, &res, &testutil.QueryOptions{
+			Version: "v0.13.3",
+		})
+	require.NoError(t, err)
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -631,9 +631,11 @@ func (s *containerSchema) Install() {
 			ArgDoc("service", `Identifier of the service container`),
 
 		dagql.Func("withFocus", s.withFocus).
+			View(BeforeVersion("v0.13.4")).
 			Doc(`Indicate that subsequent operations should be featured more prominently in the UI.`),
 
 		dagql.Func("withoutFocus", s.withoutFocus).
+			View(BeforeVersion("v0.13.4")).
 			Doc(`Indicate that subsequent operations should not be featured more prominently in the UI.`,
 				`This is the initial state of all containers.`),
 
@@ -1952,15 +1954,11 @@ func (s *containerSchema) exposedPorts(ctx context.Context, parent *core.Contain
 }
 
 func (s *containerSchema) withFocus(ctx context.Context, parent *core.Container, args struct{}) (*core.Container, error) {
-	child := parent.Clone()
-	child.Focused = true
-	return child, nil
+	return parent, nil
 }
 
 func (s *containerSchema) withoutFocus(ctx context.Context, parent *core.Container, args struct{}) (*core.Container, error) {
-	child := parent.Clone()
-	child.Focused = false
-	return child, nil
+	return parent, nil
 }
 
 type containerWithDefaultTerminalCmdArgs struct {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -645,11 +645,6 @@ type Container {
     sources: [FileID!]!
   ): Container!
 
-  """
-  Indicate that subsequent operations should be featured more prominently in the UI.
-  """
-  withFocus: Container!
-
   """Retrieves this container plus the given label."""
   withLabel(
     """The name of the label (e.g., "org.opencontainers.artifact.created")."""
@@ -889,13 +884,6 @@ type Container {
     """Location of the files to remove (e.g., ["/file.txt"])."""
     paths: [String!]!
   ): Container!
-
-  """
-  Indicate that subsequent operations should not be featured more prominently in the UI.
-  
-  This is the initial state of all containers.
-  """
-  withoutFocus: Container!
 
   """Retrieves this container minus the given environment label."""
   withoutLabel(

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4453,10 +4453,6 @@
                           </div>
                         </td>
                       </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="Container-withFocus" href="#Container-withFocus"><code>withFocus</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td> Indicate that subsequent operations should be featured more prominently in the UI. </td>
-                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-withLabel" href="#Container-withLabel"><code>withLabel</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
                         <td> Retrieves this container plus the given label. </td>
@@ -4813,13 +4809,6 @@
                               </div>
                             </div>
                           </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="Container-withoutFocus" href="#Container-withoutFocus"><code>withoutFocus</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td>
-                          <p>Indicate that subsequent operations should not be featured more prominently in the UI.</p>
-                          <p>This is the initial state of all containers.</p>
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -724,18 +724,6 @@ defmodule Dagger.Container do
     }
   end
 
-  @doc "Indicate that subsequent operations should be featured more prominently in the UI."
-  @spec with_focus(t()) :: Dagger.Container.t()
-  def with_focus(%__MODULE__{} = container) do
-    query_builder =
-      container.query_builder |> QB.select("withFocus")
-
-    %Dagger.Container{
-      query_builder: query_builder,
-      client: container.client
-    }
-  end
-
   @doc "Retrieves this container plus the given label."
   @spec with_label(t(), String.t(), String.t()) :: Dagger.Container.t()
   def with_label(%__MODULE__{} = container, name, value) do
@@ -1095,22 +1083,6 @@ defmodule Dagger.Container do
       |> QB.select("withoutFiles")
       |> QB.put_arg("paths", paths)
       |> QB.maybe_put_arg("expand", optional_args[:expand])
-
-    %Dagger.Container{
-      query_builder: query_builder,
-      client: container.client
-    }
-  end
-
-  @doc """
-  Indicate that subsequent operations should not be featured more prominently in the UI.
-
-  This is the initial state of all containers.
-  """
-  @spec without_focus(t()) :: Dagger.Container.t()
-  def without_focus(%__MODULE__{} = container) do
-    query_builder =
-      container.query_builder |> QB.select("withoutFocus")
 
     %Dagger.Container{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1371,15 +1371,6 @@ func (r *Container) WithFiles(path string, sources []*File, opts ...ContainerWit
 	}
 }
 
-// Indicate that subsequent operations should be featured more prominently in the UI.
-func (r *Container) WithFocus() *Container {
-	q := r.query.Select("withFocus")
-
-	return &Container{
-		query: q,
-	}
-}
-
 // Retrieves this container plus the given label.
 func (r *Container) WithLabel(name string, value string) *Container {
 	q := r.query.Select("withLabel")
@@ -1868,17 +1859,6 @@ func (r *Container) WithoutFiles(paths []string, opts ...ContainerWithoutFilesOp
 		}
 	}
 	q = q.Arg("paths", paths)
-
-	return &Container{
-		query: q,
-	}
-}
-
-// Indicate that subsequent operations should not be featured more prominently in the UI.
-//
-// This is the initial state of all containers.
-func (r *Container) WithoutFocus() *Container {
-	q := r.query.Select("withoutFocus")
 
 	return &Container{
 		query: q,

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -634,15 +634,6 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Indicate that subsequent operations should be featured more prominently in the UI.
-     */
-    public function withFocus(): Container
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFocus');
-        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * Retrieves this container plus the given label.
      */
     public function withLabel(string $name, string $value): Container
@@ -974,17 +965,6 @@ class Container extends Client\AbstractObject implements Client\IdAble
         if (null !== $expand) {
         $innerQueryBuilder->setArgument('expand', $expand);
         }
-        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
-     * Indicate that subsequent operations should not be featured more prominently in the UI.
-     *
-     * This is the initial state of all containers.
-     */
-    public function withoutFocus(): Container
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutFocus');
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1556,14 +1556,6 @@ class Container(Type):
         _ctx = self._select("withFiles", _args)
         return Container(_ctx)
 
-    def with_focus(self) -> Self:
-        """Indicate that subsequent operations should be featured more
-        prominently in the UI.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("withFocus", _args)
-        return Container(_ctx)
-
     def with_label(self, name: str, value: str) -> Self:
         """Retrieves this container plus the given label.
 
@@ -2116,16 +2108,6 @@ class Container(Type):
             Arg("expand", expand, False),
         ]
         _ctx = self._select("withoutFiles", _args)
-        return Container(_ctx)
-
-    def without_focus(self) -> Self:
-        """Indicate that subsequent operations should not be featured more
-        prominently in the UI.
-
-        This is the initial state of all containers.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("withoutFocus", _args)
         return Container(_ctx)
 
     def without_label(self, name: str) -> Self:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2847,15 +2847,6 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// Indicate that subsequent operations should be featured more prominently in the UI.
-    pub fn with_focus(&self) -> Container {
-        let query = self.selection.select("withFocus");
-        Container {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
     /// Retrieves this container plus the given label.
     ///
     /// # Arguments
@@ -3645,16 +3636,6 @@ impl Container {
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
         }
-        Container {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Indicate that subsequent operations should not be featured more prominently in the UI.
-    /// This is the initial state of all containers.
-    pub fn without_focus(&self) -> Container {
-        let query = self.selection.select("withoutFocus");
         Container {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -2466,21 +2466,6 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Indicate that subsequent operations should be featured more prominently in the UI.
-   */
-  withFocus = (): Container => {
-    return new Container({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "withFocus",
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
    * Retrieves this container plus the given label.
    * @param name The name of the label (e.g., "org.opencontainers.artifact.created").
    * @param value The value of the label (e.g., "2023-01-01T00:00:00Z").
@@ -2964,23 +2949,6 @@ export class Container extends BaseClient {
         {
           operation: "withoutFiles",
           args: { paths, ...opts },
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
-   * Indicate that subsequent operations should not be featured more prominently in the UI.
-   *
-   * This is the initial state of all containers.
-   */
-  withoutFocus = (): Container => {
-    return new Container({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "withoutFocus",
         },
       ],
       ctx: this._ctx,


### PR DESCRIPTION
> [!WARNING]
>
> Only merge for v0.14.0!

I have no idea why we didn't remove these before - they've been deprecated since https://github.com/dagger/dagger/pull/6835. They should've gone when we got rid of `pipeline` as well, but looks like it got missed.

This is *technically* a breaking change, so maybe needs to wait till v0.14.0.