### PR TITLE
engine: add support to install certs in amazon linux

### DIFF
--- a/engine/buildkit/cacerts/distros.go
+++ b/engine/buildkit/cacerts/distros.go
@@ -139,6 +139,7 @@ func (d *rhelLike) detect() (bool, error) {
 		"/etc/redhat-release",
 		"/etc/redhat-version",
 		"/etc/centos-release",
+		"/etc/amazon-linux-release",
 	}); err != nil {
 		return false, err
 	} else if exists {


### PR DESCRIPTION
since those are CentOS based, this already works with the current rhel
installer

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
