### PR TITLE
go: strip runtime binaries to save disk space

### DIFF
--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -450,6 +450,7 @@ func (sdk *goSDK) Runtime(
 					Name: "args",
 					Value: dagql.ArrayInput[dagql.String]{
 						"go", "build",
+						"-ldflags", "-s -w", // strip DWARF debug symbols to save a few MBs of space
 						"-o", goSDKRuntimePath,
 						".",
 					},


### PR DESCRIPTION
While working on metrics stuff I realized the go build step was writing 19MB for trivial modules, thanks to Go's well known large binary size.

I tried stripping DWARF debug symbols with -ldflags='-s -w' and found it saved about 6MB.

This is not the biggest disk space hog in CI by any means, but saving 6MB per module across the 100+ we build for test runs seems like an easy marginal win given there's no real downside to dropping these debug symbols at this time (right? I can't think of any).