### PR TITLE
feat: support tmpfs size in withMountedTemp

### DIFF
--- a/.changes/unreleased/Added-20241008-154901.yaml
+++ b/.changes/unreleased/Added-20241008-154901.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: enabled withMountedTemp size configuration
+time: 2024-10-08T15:49:01.009581-07:00
+custom:
+    Author: cwlbraa
+    PR: "8652"

--- a/core/container.go
+++ b/core/container.go
@@ -245,6 +245,9 @@ type ContainerMount struct {
 	// Configure the mount as a tmpfs.
 	Tmpfs bool `json:"tmpfs,omitempty"`
 
+	// Configure the size of the mounted tmpfs in bytes
+	Size int `json:"size,omitempty"`
+
 	// Configure the mount as read-only.
 	Readonly bool `json:"readonly,omitempty"`
 }
@@ -622,7 +625,7 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 	return container, nil
 }
 
-func (container *Container) WithMountedTemp(ctx context.Context, target string) (*Container, error) {
+func (container *Container) WithMountedTemp(ctx context.Context, target string, size int) (*Container, error) {
 	container = container.Clone()
 
 	target = absPath(container.Config.WorkingDir, target)
@@ -630,6 +633,7 @@ func (container *Container) WithMountedTemp(ctx context.Context, target string) 
 	container.Mounts = container.Mounts.With(ContainerMount{
 		Target: target,
 		Tmpfs:  true,
+		Size:   size,
 	})
 
 	// set image ref to empty string

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -262,7 +262,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		}
 
 		if mnt.Tmpfs {
-			mountOpts = append(mountOpts, llb.Tmpfs())
+			mountOpts = append(mountOpts, llb.Tmpfs(llb.TmpfsSize(int64(mnt.Size))))
 		}
 
 		if mnt.Readonly {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1737,6 +1737,35 @@ func (ContainerSuite) TestWithMountedTemp(ctx context.Context, t *testctx.T) {
 		}`, &execRes, nil)
 	require.NoError(t, err)
 	require.Contains(t, execRes.Container.From.WithMountedTemp.WithExec.Stdout, "tmpfs /mnt/tmp tmpfs")
+	require.NotContains(t, execRes.Container.From.WithMountedTemp.WithExec.Stdout, "size=2k")
+}
+
+func (ContainerSuite) TestWithMountedTempSized(ctx context.Context, t *testctx.T) {
+	execRes := struct {
+		Container struct {
+			From struct {
+				WithMountedTemp struct {
+					WithExec struct {
+						Stdout string
+					}
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(t, `{
+			container {
+				from(address: "`+alpineImage+`") {
+					withMountedTemp(path: "/mnt/tmp", size: 4000) {
+						withExec(args: ["grep", "/mnt/tmp", "/proc/mounts"]) {
+							stdout
+						}
+					}
+				}
+			}
+		}`, &execRes, nil)
+	require.NoError(t, err)
+	require.Contains(t, execRes.Container.From.WithMountedTemp.WithExec.Stdout, "size=4k")
 }
 
 func (ContainerSuite) TestWithDirectory(ctx context.Context, t *testctx.T) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -221,6 +221,7 @@ func (s *containerSchema) Install() {
 		dagql.Func("withMountedTemp", s.withMountedTemp).
 			Doc(`Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.`).
 			ArgDoc("path", `Location of the temporary directory (e.g., "/tmp/temp_dir").`).
+			ArgDoc("size", `Size of the temporary directory in bytes.`).
 			ArgDoc("expand",
 				"Replace ${VAR} or $VAR in the value of path according to the current "+
 					`environment variables defined in the container (e.g. "/$VAR/foo").`),
@@ -1308,6 +1309,7 @@ func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Con
 
 type containerWithMountedTempArgs struct {
 	Path   string
+	Size   dagql.Optional[dagql.Int]
 	Expand bool `default:"false"`
 }
 
@@ -1317,7 +1319,8 @@ func (s *containerSchema) withMountedTemp(ctx context.Context, parent *core.Cont
 		return nil, err
 	}
 
-	return parent.WithMountedTemp(ctx, path)
+	// TODO: is the optional safe to dereference?
+	return parent.WithMountedTemp(ctx, path, args.Size.Value.Int())
 }
 
 type containerWithoutMountArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1319,7 +1319,6 @@ func (s *containerSchema) withMountedTemp(ctx context.Context, parent *core.Cont
 		return nil, err
 	}
 
-	// TODO: is the optional safe to dereference?
 	return parent.WithMountedTemp(ctx, path, args.Size.Value.Int())
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -769,6 +769,9 @@ type Container {
 
     """Location of the temporary directory (e.g., "/tmp/temp_dir")."""
     path: String!
+
+    """Size of the temporary directory in bytes."""
+    size: Int
   ): Container!
 
   """Retrieves this container plus a new file written at the given path."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4497,6 +4497,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Location of the temporary directory (e.g., &quot;/tmp/temp_dir&quot;).</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>size</code></span> - <span class="property-type"><a href="#definition-Int"><code>Int</code></a></span></h6>
+                                <p>Size of the temporary directory in bytes.</p>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -821,12 +821,14 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs."
-  @spec with_mounted_temp(t(), String.t(), [{:expand, boolean() | nil}]) :: Dagger.Container.t()
+  @spec with_mounted_temp(t(), String.t(), [{:size, integer() | nil}, {:expand, boolean() | nil}]) ::
+          Dagger.Container.t()
   def with_mounted_temp(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
       container.query_builder
       |> QB.select("withMountedTemp")
       |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("size", optional_args[:size])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
 
     %Dagger.Container{

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1518,6 +1518,8 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 
 // ContainerWithMountedTempOpts contains options for Container.WithMountedTemp
 type ContainerWithMountedTempOpts struct {
+	// Size of the temporary directory in bytes.
+	Size int
 	// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
 }
@@ -1526,6 +1528,10 @@ type ContainerWithMountedTempOpts struct {
 func (r *Container) WithMountedTemp(path string, opts ...ContainerWithMountedTempOpts) *Container {
 	q := r.query.Select("withMountedTemp")
 	for i := len(opts) - 1; i >= 0; i-- {
+		// `size` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Size) {
+			q = q.Arg("size", opts[i].Size)
+		}
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
 			q = q.Arg("expand", opts[i].Expand)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -733,10 +733,13 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
      */
-    public function withMountedTemp(string $path, ?bool $expand = false): Container
+    public function withMountedTemp(string $path, ?int $size = null, ?bool $expand = false): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedTemp');
         $innerQueryBuilder->setArgument('path', $path);
+        if (null !== $size) {
+        $innerQueryBuilder->setArgument('size', $size);
+        }
         if (null !== $expand) {
         $innerQueryBuilder->setArgument('expand', $expand);
         }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1690,6 +1690,7 @@ class Container(Type):
         self,
         path: str,
         *,
+        size: int | None = None,
         expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus a temporary directory mounted at the
@@ -1700,6 +1701,8 @@ class Container(Type):
         ----------
         path:
             Location of the temporary directory (e.g., "/tmp/temp_dir").
+        size:
+            Size of the temporary directory in bytes.
         expand:
             Replace ${VAR} or $VAR in the value of path according to the
             current environment variables defined in the container (e.g.
@@ -1707,6 +1710,7 @@ class Container(Type):
         """
         _args = [
             Arg("path", path),
+            Arg("size", size, None),
             Arg("expand", expand, False),
         ]
         _ctx = self._select("withMountedTemp", _args)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1716,6 +1716,9 @@ pub struct ContainerWithMountedTempOpts {
     /// Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
+    /// Size of the temporary directory in bytes.
+    #[builder(setter(into, strip_option), default)]
+    pub size: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithNewFileOpts<'a> {
@@ -3096,6 +3099,9 @@ impl Container {
     ) -> Container {
         let mut query = self.selection.select("withMountedTemp");
         query = query.arg("path", path.into());
+        if let Some(size) = opts.size {
+            query = query.arg("size", size);
+        }
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
         }

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -474,6 +474,11 @@ export type ContainerWithMountedSecretOpts = {
 
 export type ContainerWithMountedTempOpts = {
   /**
+   * Size of the temporary directory in bytes.
+   */
+  size?: number
+
+  /**
    * Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   expand?: boolean
@@ -2526,6 +2531,7 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
    * @param path Location of the temporary directory (e.g., "/tmp/temp_dir").
+   * @param opts.size Size of the temporary directory in bytes.
    * @param opts.expand Replace ${VAR} or $VAR in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   withMountedTemp = (


### PR DESCRIPTION
fixes #8573, at least partially

this pr adds a size parameter to withMountedTemp and passes that down to buildkit's mount initialization.

I had many questions that @sipsma answered in the comments.
1. I don't particularly like the structure of the test, adding a whole additional test that's 99% repeated code, but it seems hard to parameterize around optional params; putting 2 WithMountedTemps in parallel creates a marshaling-into-struct ambiguity that's unresolvable.... should I be chaining or something? 
2. Is the "size" parameter in the appropriate place in the graphql schema? it can only be supplied for tmpfses, but it lives on the same level. do we want errors if folks try to supply sizes for other mounts? where would one add that logic?
3. corollary question, should we be adding a more open-to-extension TmpfsOptions sort of struct here?
4. In schema/container.go, do I need to expand env vars for size the same way it's done for paths?
5. there's a TODO regarding handling of optionals in dagql -- can I just blindly traverse these structs without worrying about nil deferences? it kinda seems like it from the test results.
6. do the SDKs just work themselves out from API level changes? or am I missing some steps here?
7. I'm sure I have unknown-unknowns, plz look for them :)

