### PR TITLE
docs: add instructions to generate all sdks if you've made GQL schema changes

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -113,6 +113,10 @@ Generate SDK static files (replace `<sdk>` with one of the supported SDKs):
 
     dagger call sdk <sdk> generate export --path=.
 
+If you've made changes to the GraphQL schema, you will need to generate all sdks in one go prior to committing:
+
+    dagger call sdk all generate export --path=.
+
 ### Publish
 
 Dry-run an SDK publishing step (replace `<sdk>` with one of the supported SDKs):


### PR DESCRIPTION
see https://github.com/dagger/dagger/pull/8652#pullrequestreview-2355647374 where @sipsma noticed this documentation gap.