### PR TITLE
core: support disabling automatic init in withExec

### DIFF
--- a/.changes/unreleased/Added-20241008-171908.yaml
+++ b/.changes/unreleased/Added-20241008-171908.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: |-
+  Add `noInit` option to `withExec` to support disabling automatic init process.
+
+  Use cases that strictly require the user exec is PID 1 of the container are now supported by setting `noInit` to true.
+time: 2024-10-08T17:19:08.364837213-07:00
+custom:
+  Author: sipsma
+  PR: "8656"

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4680,3 +4680,25 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 		require.Contains(t, entries, "manifest.json")
 	})
 }
+
+func (ContainerSuite) TestExecInit(ctx context.Context, t *testctx.T) {
+	t.Run("automatic init", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := c.Container().From(alpineImage).
+			WithExec([]string{"ps", "-o", "pid,comm"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "1 .init")
+	})
+
+	t.Run("disable automatic init", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := c.Container().From(alpineImage).
+			WithExec([]string{"ps", "-o", "pid,comm"}, dagger.ContainerWithExecOpts{
+				NoInit: true,
+			}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "1 ps")
+	})
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -398,7 +398,12 @@ func (s *containerSchema) Install() {
 				absolutely necessary and only with trusted commands.`).
 			ArgDoc("expand",
 				"Replace ${VAR} or $VAR in the args according to the current "+
-					`environment variables defined in the container (e.g. "/$VAR/foo").`),
+					`environment variables defined in the container (e.g. "/$VAR/foo").`).
+			ArgDoc("noInit",
+				"If set, skip the automatic init process injected into containers by default.",
+				"This should only be used if the user requires that their exec process be the",
+				"pid 1 process in the container. Otherwise it may result in unexpected behavior.",
+			),
 
 		dagql.Func("withExec", s.withExec).
 			View(BeforeVersion("v0.13.0")).

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -400,9 +400,9 @@ func (s *containerSchema) Install() {
 				"Replace ${VAR} or $VAR in the args according to the current "+
 					`environment variables defined in the container (e.g. "/$VAR/foo").`).
 			ArgDoc("noInit",
-				"If set, skip the automatic init process injected into containers by default.",
-				"This should only be used if the user requires that their exec process be the",
-				"pid 1 process in the container. Otherwise it may result in unexpected behavior.",
+				`If set, skip the automatic init process injected into containers by default.`,
+				`This should only be used if the user requires that their exec process be the
+				pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
 			),
 
 		dagql.Func("withExec", s.withExec).

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -525,6 +525,15 @@ type Container {
     insecureRootCapabilities: Boolean = false
 
     """
+    If set, skip the automatic init process injected into containers by default.
+    
+    This should only be used if the user requires that their exec process be the
+    
+    pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    """
+    noInit: Boolean = false
+
+    """
     Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").
     """
     redirectStderr: String = ""

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -528,7 +528,6 @@ type Container {
     If set, skip the automatic init process injected into containers by default.
     
     This should only be used if the user requires that their exec process be the
-    
     pid 1 process in the container. Otherwise it may result in unexpected behavior.
     """
     noInit: Boolean = false

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4188,6 +4188,12 @@
                                 <p>Execute the command with all root capabilities. This is similar to running a command with &quot;sudo&quot; or executing &quot;docker run&quot; with the &quot;--privileged&quot; flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.</p>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noInit</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If set, skip the automatic init process injected into containers by default.</p>
+                                <p>This should only be used if the user requires that their exec process be the</p>
+                                <p>pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>redirectStderr</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>Redirect the command&#39;s standard error to a file in the container (e.g., &quot;/tmp/stderr&quot;).</p>
                               </div>

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4190,8 +4190,7 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>noInit</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>If set, skip the automatic init process injected into containers by default.</p>
-                                <p>This should only be used if the user requires that their exec process be the</p>
-                                <p>pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
+                                <p>This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>redirectStderr</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -96,6 +96,9 @@ type ExecutionMetadata struct {
 
 	// Path to the SSH auth socket. Used for Dagger-in-Dagger support.
 	SSHAuthSocketPath string
+
+	// If true, skip injecting dumb-init into the container.
+	NoInit bool
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -52,6 +52,7 @@ const (
 	DaggerRedirectStdoutEnv  = "_DAGGER_REDIRECT_STDOUT"
 	DaggerRedirectStderrEnv  = "_DAGGER_REDIRECT_STDERR"
 	DaggerHostnameAliasesEnv = "_DAGGER_HOSTNAME_ALIASES"
+	DaggerNoInitEnv          = "_DAGGER_NOINIT"
 
 	DaggerSessionPortEnv  = "DAGGER_SESSION_PORT"
 	DaggerSessionTokenEnv = "DAGGER_SESSION_TOKEN"
@@ -80,6 +81,7 @@ var removeEnvs = map[string]struct{}{
 	DaggerRedirectStdoutEnv:  {},
 	DaggerRedirectStderrEnv:  {},
 	DaggerHostnameAliasesEnv: {},
+	DaggerNoInitEnv:          {},
 }
 
 type execState struct {
@@ -319,6 +321,10 @@ func (m hostBindMountRef) IdentityMapping() *idtools.IdentityMapping {
 }
 
 func (w *Worker) injectDumbInit(_ context.Context, state *execState) error {
+	if w.execMD != nil && w.execMD.NoInit {
+		return nil
+	}
+
 	dumbInitPath := "/.init"
 	state.mounts = append(state.mounts, executor.Mount{
 		Src:      hostBindMount{srcPath: distconsts.DumbInitPath},

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -607,7 +607,8 @@ defmodule Dagger.Container do
           {:redirect_stderr, String.t() | nil},
           {:experimental_privileged_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil},
-          {:expand, boolean() | nil}
+          {:expand, boolean() | nil},
+          {:no_init, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_exec(%__MODULE__{} = container, args, optional_args \\ []) do
     query_builder =
@@ -624,6 +625,7 @@ defmodule Dagger.Container do
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
+      |> QB.maybe_put_arg("noInit", optional_args[:no_init])
 
     %Dagger.Container{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1179,9 +1179,7 @@ type ContainerWithExecOpts struct {
 	Expand bool
 	// If set, skip the automatic init process injected into containers by default.
 	//
-	// This should only be used if the user requires that their exec process be the
-	//
-	// pid 1 process in the container. Otherwise it may result in unexpected behavior.
+	// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
 	NoInit bool
 }
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1177,6 +1177,12 @@ type ContainerWithExecOpts struct {
 	InsecureRootCapabilities bool
 	// Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
+	// If set, skip the automatic init process injected into containers by default.
+	//
+	// This should only be used if the user requires that their exec process be the
+	//
+	// pid 1 process in the container. Otherwise it may result in unexpected behavior.
+	NoInit bool
 }
 
 // Retrieves this container after executing the specified command inside it.
@@ -1210,6 +1216,10 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
 			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `noInit` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoInit) {
+			q = q.Arg("noInit", opts[i].NoInit)
 		}
 	}
 	q = q.Arg("args", args)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -508,6 +508,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?bool $experimentalPrivilegedNesting = false,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
+        ?bool $noInit = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withExec');
         $innerQueryBuilder->setArgument('args', $args);
@@ -531,6 +532,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $expand) {
         $innerQueryBuilder->setArgument('expand', $expand);
+        }
+        if (null !== $noInit) {
+        $innerQueryBuilder->setArgument('noInit', $noInit);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1375,9 +1375,8 @@ class Container(Type):
             If set, skip the automatic init process injected into containers
             by default.
             This should only be used if the user requires that their exec
-            process be the
-            pid 1 process in the container. Otherwise it may result in
-            unexpected behavior.
+            process be the pid 1 process in the container. Otherwise it may
+            result in unexpected behavior.
         """
         _args = [
             Arg("args", args),

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1335,6 +1335,7 @@ class Container(Type):
         experimental_privileged_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
+        no_init: bool | None = False,
     ) -> Self:
         """Retrieves this container after executing the specified command inside
         it.
@@ -1370,6 +1371,13 @@ class Container(Type):
         expand:
             Replace ${VAR} or $VAR in the args according to the current
             environment variables defined in the container (e.g. "/$VAR/foo").
+        no_init:
+            If set, skip the automatic init process injected into containers
+            by default.
+            This should only be used if the user requires that their exec
+            process be the
+            pid 1 process in the container. Otherwise it may result in
+            unexpected behavior.
         """
         _args = [
             Arg("args", args),
@@ -1382,6 +1390,7 @@ class Container(Type):
             ),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
+            Arg("noInit", no_init, False),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1603,6 +1603,11 @@ pub struct ContainerWithExecOpts<'a> {
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
+    /// If set, skip the automatic init process injected into containers by default.
+    /// This should only be used if the user requires that their exec process be the
+    /// pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    #[builder(setter(into, strip_option), default)]
+    pub no_init: Option<bool>,
     /// Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").
     #[builder(setter(into, strip_option), default)]
     pub redirect_stderr: Option<&'a str>,
@@ -2626,6 +2631,9 @@ impl Container {
         }
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
+        }
+        if let Some(no_init) = opts.no_init {
+            query = query.arg("noInit", no_init);
         }
         Container {
             proc: self.proc.clone(),

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1604,8 +1604,7 @@ pub struct ContainerWithExecOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
     /// If set, skip the automatic init process injected into containers by default.
-    /// This should only be used if the user requires that their exec process be the
-    /// pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    /// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
     #[builder(setter(into, strip_option), default)]
     pub no_init: Option<bool>,
     /// Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -328,6 +328,15 @@ export type ContainerWithExecOpts = {
    * Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   expand?: boolean
+
+  /**
+   * If set, skip the automatic init process injected into containers by default.
+   *
+   * This should only be used if the user requires that their exec process be the
+   *
+   * pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   */
+  noInit?: boolean
 }
 
 export type ContainerWithExposedPortOpts = {
@@ -2262,6 +2271,11 @@ export class Container extends BaseClient {
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   * @param opts.noInit If set, skip the automatic init process injected into containers by default.
+   *
+   * This should only be used if the user requires that their exec process be the
+   *
+   * pid 1 process in the container. Otherwise it may result in unexpected behavior.
    */
   withExec = (args: string[], opts?: ContainerWithExecOpts): Container => {
     return new Container({

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -332,9 +332,7 @@ export type ContainerWithExecOpts = {
   /**
    * If set, skip the automatic init process injected into containers by default.
    *
-   * This should only be used if the user requires that their exec process be the
-   *
-   * pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   * This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
    */
   noInit?: boolean
 }
@@ -2273,9 +2271,7 @@ export class Container extends BaseClient {
    * @param opts.expand Replace ${VAR} or $VAR in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
    *
-   * This should only be used if the user requires that their exec process be the
-   *
-   * pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   * This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
    */
   withExec = (args: string[], opts?: ContainerWithExecOpts): Container => {
     return new Container({


### PR DESCRIPTION
Dagger automatically injects an init process in withExecs in order to avoid surprising behavior around processes being PID 1. I have generally gathered that this is the right default behavior, to the point that I've seen some docker maintainers say that they wish docker had defaulted to this same behavior.

However, there are less common use cases that do call for user processes being PID 1, such as when they want very custom init behavior or are testing init systems (i.e. testing systemd in a container).

For a long time this was impossible because of the shim but after we moved to the executor, which operates entirely in the engine process, it became technically optional to have an init process injected into the container (even if the right default).

This change adds an option to `withExec` for disabling the automatic init process, `noInit` so we can support those use cases. The default behavior is left alone.

---

Fixes https://github.com/dagger/dagger/issues/8513