### PR TITLE
dev: add blurb for necessary steps following GraphQL schema changes

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -70,9 +70,9 @@ Connect to it from a dagger cli:
     dagger call -m github.com/shykes/daggerverse/hello@main hello
     # hello, world!
 
-## Generation
+## Code Generation
 
-In core/schema, changes utilizing the dagql package modify the engine's GraphQL API. API documentation and SDK bindings must be generated and committed when modifying the schema. See "Docs" and "SDKs" below for more granular generation functionality.
+In core/schema, changes utilizing the dagql package modify the engine's GraphQL API. API documentation and SDK bindings must be generated and committed when modifying the schema. See "Docs" and "SDKs" below for more granular generation functionality. This command also runs go generate for engine code.
 
     dagger call generate export --path=.
 

--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -18,7 +18,7 @@ For example `dagger call foo bar baz` will call 3 functions (`foo`, `bar` and
 this case, `baz`) will be printed to the terminal.
 
 A module is a collection of functions (and types) which can be used by `dagger
-call`. By default, the current module will be infered from your working
+call`. By default, the current module will be inferred from your working
 directory, but you can override this with `-m`.
 
 To discover available functions in a given module: `dagger functions`.
@@ -70,6 +70,18 @@ Connect to it from a dagger cli:
     dagger call -m github.com/shykes/daggerverse/hello@main hello
     # hello, world!
 
+## Generation
+
+In core/schema, changes utilizing the dagql package modify the engine's GraphQL API. API documentation and SDK bindings must be generated and committed when modifying the schema. See "Docs" and "SDKs" below for more granular generation functionality.
+
+    dagger call generate export --path=.
+
+> [!NOTE]
+>
+> For `PHP` and `Elixir` SDKs it's important to manually delete the generated folder before running
+> this command
+
+
 ## Docs
 
 Lint the docs:
@@ -79,6 +91,8 @@ Lint the docs:
 Auto-generate docs components:
 
     dagger call docs generate -o .
+
+    
 
 ## SDKs
 
@@ -109,7 +123,7 @@ Run SDK tests (replace `<sdk>` with one of the supported SDKs):
 
 ### Generate
 
-Generate SDK static files (replace `<sdk>` with one of the supported SDKs):
+Generate SDK static files (replace `<sdk>` with one of the supported SDKs, or "all" for all of them):
 
     dagger call sdk <sdk> generate export --path=.
 

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -164,6 +164,20 @@ func (dev *DaggerDev) Test() *Test {
 	return &Test{Dagger: dev}
 }
 
+// Run all code generation - SDKs, docs, etc
+func (dev *DaggerDev) Generate(ctx context.Context) (*dagger.Directory, error) {
+	docs, error := dev.Docs().Generate(ctx)
+	if error != nil {
+		return nil, error
+	}
+	sdks, error := dev.SDK().All().Generate(ctx)
+	if error != nil {
+		return nil, error
+	}
+
+	return docs.WithDirectory(".", sdks), nil
+}
+
 // Develop Dagger SDKs
 func (dev *DaggerDev) SDK() *SDK {
 	return &SDK{


### PR DESCRIPTION
steps I missed in #8652, bundled all together.

added a top level dev function "generate" intended to all code generation in one go. 

as an aside: writing this with the heading "GraphQL schema changes" immediately gave me the urge to write the typical warnings regarding backwards-incompatible changes to graphql schemas that you've got to drumbeat in a more typical SaaS graphql deployment (nullables can't be made non-nullable, renames must be duplicated and deprecated, etc) but it occurs to me that maybe our release structure is less sensitive to backwards incompatibility? how concerned are we with breaking clients via engine api changes?