### PR TITLE
fix: git schema issues

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -602,8 +602,11 @@ func (LegacySuite) TestGitWithKeepDir(ctx context.Context, t *testctx.T) {
 		}
 	}{}
 
-	err := testutil.Query(t,
-		`{
+	// v0.9.9 is a very old version that ensures we call treeLegacy+gitLegacy
+	// v0.12.6 is a more recent version that ensures we call gitLegacy
+	for _, version := range []string{"v0.9.9", "0.12.6"} {
+		err := testutil.Query(t,
+			`{
 			git(url: "github.com/dagger/dagger", keepGitDir: true) {
 				commit(id: "c80ac2c13df7d573a069938e01ca13f7a81f0345") {
 					commit
@@ -615,14 +618,14 @@ func (LegacySuite) TestGitWithKeepDir(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}`, &res, &testutil.QueryOptions{
-			Version: "v0.12.6",
-		})
-	require.NoError(t, err)
-	require.Equal(t, "c80ac2c13df7d573a069938e01ca13f7a81f0345", res.Git.Commit.Commit)
-	require.Equal(t, "c80ac2c13df7d573a069938e01ca13f7a81f0345\n", res.Git.Commit.Tree.File.Contents)
+				Version: version,
+			})
+		require.NoError(t, err)
+		require.Equal(t, "c80ac2c13df7d573a069938e01ca13f7a81f0345", res.Git.Commit.Commit)
+		require.Equal(t, "c80ac2c13df7d573a069938e01ca13f7a81f0345\n", res.Git.Commit.Tree.File.Contents)
 
-	err = testutil.Query(t,
-		`{
+		err = testutil.Query(t,
+			`{
 			git(url: "github.com/dagger/dagger") {
 				commit(id: "c80ac2c13df7d573a069938e01ca13f7a81f0345") {
 					commit
@@ -634,7 +637,8 @@ func (LegacySuite) TestGitWithKeepDir(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}`, &res, &testutil.QueryOptions{
-			Version: "v0.12.6",
-		})
-	require.ErrorContains(t, err, ".git/HEAD: no such file or directory")
+				Version: "v0.12.6",
+			})
+		require.ErrorContains(t, err, ".git/HEAD: no such file or directory")
+	}
 }

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -412,7 +412,8 @@ func (s *gitSchema) tree(ctx context.Context, parent *core.GitRef, args treeArgs
 }
 
 type treeArgsLegacy struct {
-	treeArgs
+	DiscardGitDir bool `default:"false"`
+
 	SSHKnownHosts dagql.Optional[dagql.String]  `name:"sshKnownHosts"`
 	SSHAuthSocket dagql.Optional[core.SocketID] `name:"sshAuthSocket"`
 }

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -39,7 +39,7 @@ func (s *gitSchema) Install() {
 			ArgDoc("sshAuthSocket", `Set SSH auth socket`).
 			ArgDoc("experimentalServiceHost", `A service which must be started before the repo is fetched.`),
 		dagql.Func("git", s.gitLegacy).
-			View(BeforeVersion("v0.13.0")).
+			View(BeforeVersion("v0.13.4")).
 			Doc(`Queries a Git repository.`).
 			ArgDoc("url",
 				`URL of the git repository.`,


### PR DESCRIPTION
Follow-up for https://github.com/dagger/dagger/pull/8318.

A few issues:
- Accidentally, support was enabled for `keepGitDir` as the default on v0.13.0+ (due to merge timing issues) - this should only have been enabled for versions v0.13.4+.
- As reported by @sagikazarmark [here](https://discord.com/channels/707636530424053791/1120503349599543376/1293606367692849202), when calling `treeLegacy`, then we would attempt to unmarshal into a private field (which is invalid). This wasn't tested by our tests.

This fixes the original issue, but ideally we can add some better tests to ensure that all the schema is actually unmarshalable - this shouldn't be possible to hit.