### PR TITLE
docs: swizzle 404 page

### DIFF
--- a/docs/src/theme/NotFound/Content/index.tsx
+++ b/docs/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme/NotFound/Content';
+import Heading from '@theme/Heading';
+import Head from '@docusaurus/Head';
+
+export default function NotFoundContent({ className }: Props): JSX.Element {
+  return (
+    <>
+      <Head titleTemplate="%s | NotFound" >
+        {false}
+      </Head>
+      <main className={clsx('container margin-vert--xl', className)}>
+        <div className="row">
+          <div className="col col--6 col--offset-3">
+            <Heading as="h1" className="hero__title">
+              <Translate
+                id="theme.NotFound.title"
+                description="The title of the 404 page">
+                Page Not Found
+              </Translate>
+            </Heading>
+            <p>
+              <Translate
+                id="theme.NotFound.p1"
+                description="The first paragraph of the 404 page">
+                We could not find what you were looking for.
+              </Translate>
+            </p>
+            <p>
+              <Translate
+                id="theme.NotFound.p2"
+                description="The 2nd paragraph of the 404 page">
+                Please contact the owner of the site that linked you to the
+                original URL and let them know their link is broken.
+              </Translate>
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/docs/src/theme/NotFound/index.tsx
+++ b/docs/src/theme/NotFound/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { translate } from '@docusaurus/Translate';
+import { PageMetadata } from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+import Head from '@docusaurus/Head';
+
+export default function Index(): JSX.Element {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
swizzle docusaurus NotFound component so we can add a custom header for
better tracking users that land in a 404 page

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
