### PR TITLE
chore(go): deprecated unscoped enum values

### DIFF
--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -149,10 +149,14 @@ func formatName(s string) string {
 }
 
 // formatEnum formats a GraphQL Enum value into a Go equivalent
-// Example: `fooId` -> `FooID`
-func (funcs goTemplateFuncs) formatEnum(s string) string {
-	s = strings.ToLower(s)
-	return strcase.ToCamel(s)
+// Example: `FOO_VALUE` -> `FooValue`, `FooValue` -> `FooValue`
+func (funcs goTemplateFuncs) formatEnum(parent string, s string) string {
+	if parent == "" {
+		// legacy path - terrible, removes all the casing :(
+		s = strings.ToLower(s)
+	}
+	s = strcase.ToCamel(s)
+	return parent + s
 }
 
 func (funcs goTemplateFuncs) sortEnumFields(s []introspection.EnumValue) []introspection.EnumValue {

--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -15,7 +15,7 @@ import (
 const errorTypeName = "error"
 
 var voidDef = Qual("dag", "TypeDef").Call().
-	Dot("WithKind").Call(Id("dagger").Dot("VoidKind")).
+	Dot("WithKind").Call(Id("dagger").Dot("TypeDefKindVoidKind")).
 	Dot("WithOptional").Call(Lit(true))
 
 func (ps *parseState) parseGoFunc(parentType *types.Named, fn *types.Func) (*funcTypeSpec, error) {

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -173,15 +173,15 @@ func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
 		// NOTE: this is odd, but it doesn't matter, because the module won't
 		// pass the compilation step if there are invalid types - we just want
 		// to not error out horribly in codegen
-		kind = Id("dagger").Dot("VoidKind")
+		kind = Id("dagger").Dot("TypeDefKindVoidKind")
 	} else {
 		switch spec.goType.Info() {
 		case types.IsString:
-			kind = Id("dagger").Dot("StringKind")
+			kind = Id("dagger").Dot("TypeDefKindStringKind")
 		case types.IsInteger:
-			kind = Id("dagger").Dot("IntegerKind")
+			kind = Id("dagger").Dot("TypeDefKindIntegerKind")
 		case types.IsBoolean:
-			kind = Id("dagger").Dot("BooleanKind")
+			kind = Id("dagger").Dot("TypeDefKindBooleanKind")
 		default:
 			return nil, fmt.Errorf("unsupported basic type: %+v", spec.goType)
 		}

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -59,7 +59,7 @@ type {{ $field | FieldOptionsStructName }} = dagger.{{ $field | FieldOptionsStru
 const (
 	{{- range $index, $field := .EnumValues | SortEnumFields }}
 	{{ $field.Description | Comment }}
-	{{ $field.Name | FormatEnum }} {{ $enumName }} = dagger.{{ $field.Name | FormatEnum }}
+	{{ $field.Name | FormatEnum "" }} {{ $enumName }} = dagger.{{ $field.Name | FormatEnum "" }}
 	{{ end }}
 )
 {{- end }}

--- a/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
@@ -9,8 +9,8 @@ func ({{ $enumName }}) IsEnum() {}
 {{- $needsScopedEnums := CheckVersionCompatibility "v0.14.0" | not }}
 const (
 	{{- range $index, $field := .EnumValues | SortEnumFields }}
-	{{- $fieldName := ($field.Name | FormatEnum) }}
-	{{- $fullFieldName := print $enumName $fieldName }}
+	{{- $fieldName := ($field.Name | FormatEnum "") }}
+	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
 	{{ $field.Description | Comment }}
 	{{ $fullFieldName }} {{ $enumName }} = "{{ $field.Name }}"
 	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}

--- a/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
@@ -6,11 +6,20 @@ type {{ $enumName }} string
 
 func ({{ $enumName }}) IsEnum() {}
 
+{{- $needsScopedEnums := CheckVersionCompatibility "v0.14.0" | not }}
 const (
 	{{- range $index, $field := .EnumValues | SortEnumFields }}
+	{{- $fieldName := ($field.Name | FormatEnum) }}
+	{{- $fullFieldName := print $enumName $fieldName }}
 	{{ $field.Description | Comment }}
-	{{ $field.Name | FormatEnum}} {{ $enumName }} = "{{ $field.Name }}"
+	{{ $fullFieldName }} {{ $enumName }} = "{{ $field.Name }}"
 	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{ if $needsScopedEnums }}
+	{{ $field.Description | Comment }}
+	{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
+	{{ $fieldName }} {{ $enumName }} = {{ $fullFieldName }}
+	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{ end }}
 	{{ end }}
 )
 

--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -444,7 +444,7 @@ func (run configSubcmdRun) runE(localOnly bool) cobraRunE {
 				if err != nil {
 					return fmt.Errorf("failed to get module kind: %w", err)
 				}
-				if kind != dagger.LocalSource {
+				if kind != dagger.ModuleSourceKindLocalSource {
 					return fmt.Errorf("command only valid for local modules")
 				}
 			}

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -594,7 +594,7 @@ func (v *serviceValue) Set(s string) error {
 		v.ports = append(v.ports, dagger.PortForward{
 			Backend:  nPort,
 			Frontend: nPort,
-			Protocol: dagger.Tcp,
+			Protocol: dagger.NetworkProtocolTcp,
 		})
 	case "udp":
 		host, port, err := net.SplitHostPort(u.Host)
@@ -609,7 +609,7 @@ func (v *serviceValue) Set(s string) error {
 		v.ports = append(v.ports, dagger.PortForward{
 			Backend:  nPort,
 			Frontend: nPort,
-			Protocol: dagger.Udp,
+			Protocol: dagger.NetworkProtocolUdp,
 		})
 	default:
 		return fmt.Errorf("unsupported service address. Must be a valid tcp:// or udp:// URL")
@@ -831,22 +831,22 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 	}
 
 	switch r.TypeDef.Kind {
-	case dagger.StringKind:
+	case dagger.TypeDefKindStringKind:
 		val, _ := getDefaultValue[string](r)
 		flags.String(name, val, usage)
 		return nil
 
-	case dagger.IntegerKind:
+	case dagger.TypeDefKindIntegerKind:
 		val, _ := getDefaultValue[int](r)
 		flags.Int(name, val, usage)
 		return nil
 
-	case dagger.BooleanKind:
+	case dagger.TypeDefKindBooleanKind:
 		val, _ := getDefaultValue[bool](r)
 		flags.Bool(name, val, usage)
 		return nil
 
-	case dagger.ScalarKind:
+	case dagger.TypeDefKindScalarKind:
 		scalarName := r.TypeDef.AsScalar.Name
 		defVal, _ := getDefaultValue[string](r)
 
@@ -861,7 +861,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 		flags.String(name, defVal, usage)
 		return nil
 
-	case dagger.EnumKind:
+	case dagger.TypeDefKindEnumKind:
 		enumName := r.TypeDef.AsEnum.Name
 		defVal, _ := getDefaultValue[string](r)
 
@@ -878,7 +878,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 
 		return nil
 
-	case dagger.ObjectKind:
+	case dagger.TypeDefKindObjectKind:
 		objName := r.TypeDef.AsObject.Name
 
 		if name == "id" && r.TypeDef.AsObject.IsCore() {
@@ -902,7 +902,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			Type: fmt.Sprintf("%q object", objName),
 		}
 
-	case dagger.InputKind:
+	case dagger.TypeDefKindInputKind:
 		inputName := r.TypeDef.AsInput.Name
 
 		if val := GetCustomFlagValue(inputName); val != nil {
@@ -916,26 +916,26 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			Type: fmt.Sprintf("%q input", inputName),
 		}
 
-	case dagger.ListKind:
+	case dagger.TypeDefKindListKind:
 		elementType := r.TypeDef.AsList.ElementTypeDef
 
 		switch elementType.Kind {
-		case dagger.StringKind:
+		case dagger.TypeDefKindStringKind:
 			val, _ := getDefaultValue[[]string](r)
 			flags.StringSlice(name, val, usage)
 			return nil
 
-		case dagger.IntegerKind:
+		case dagger.TypeDefKindIntegerKind:
 			val, _ := getDefaultValue[[]int](r)
 			flags.IntSlice(name, val, usage)
 			return nil
 
-		case dagger.BooleanKind:
+		case dagger.TypeDefKindBooleanKind:
 			val, _ := getDefaultValue[[]bool](r)
 			flags.BoolSlice(name, val, usage)
 			return nil
 
-		case dagger.ScalarKind:
+		case dagger.TypeDefKindScalarKind:
 			scalarName := elementType.AsScalar.Name
 			defVal, _ := getDefaultValue[[]string](r)
 
@@ -951,7 +951,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			flags.StringSlice(name, defVal, usage)
 			return nil
 
-		case dagger.EnumKind:
+		case dagger.TypeDefKindEnumKind:
 			enumName := elementType.AsEnum.Name
 			defVal, _ := getDefaultValue[[]string](r)
 
@@ -969,7 +969,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 
 			return nil
 
-		case dagger.ObjectKind:
+		case dagger.TypeDefKindObjectKind:
 			objName := elementType.AsObject.Name
 
 			val, err := GetCustomFlagValueSlice(objName, nil)
@@ -987,7 +987,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 				Type: fmt.Sprintf("list of %q objects", objName),
 			}
 
-		case dagger.InputKind:
+		case dagger.TypeDefKindInputKind:
 			inputName := elementType.AsInput.Name
 
 			val, err := GetCustomFlagValueSlice(inputName, nil)
@@ -1005,7 +1005,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 				Type: fmt.Sprintf("list of %q inputs", inputName),
 			}
 
-		case dagger.ListKind:
+		case dagger.TypeDefKindListKind:
 			return &UnsupportedFlagError{
 				Name: name,
 				Type: "list of lists",

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -668,7 +668,7 @@ func makeRequest(ctx context.Context, q *querybuilder.Selection, response any) e
 }
 
 func handleResponse(returnType *modTypeDef, response any, o, e io.Writer) error {
-	if returnType.Kind == dagger.VoidKind {
+	if returnType.Kind == dagger.TypeDefKindVoidKind {
 		return nil
 	}
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -163,7 +163,7 @@ If --sdk is specified, the given SDK is installed in the module. You can do this
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
 
-			if modConf.SourceKind != dagger.LocalSource {
+			if modConf.SourceKind != dagger.ModuleSourceKindLocalSource {
 				return fmt.Errorf("module must be local")
 			}
 			if modConf.ModuleSourceConfigExists {
@@ -248,7 +248,7 @@ var moduleInstallCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
-			if modConf.SourceKind != dagger.LocalSource {
+			if modConf.SourceKind != dagger.ModuleSourceKindLocalSource {
 				return fmt.Errorf("module must be local")
 			}
 			if !modConf.FullyInitialized() {
@@ -261,7 +261,7 @@ var moduleInstallCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get module ref kind: %w", err)
 			}
-			if depSrcKind == dagger.LocalSource {
+			if depSrcKind == dagger.ModuleSourceKindLocalSource {
 				// need to ensure that local dep paths are relative to the parent root source
 				depAbsPath, err := filepath.Abs(depRefStr)
 				if err != nil {
@@ -305,7 +305,7 @@ var moduleInstallCmd = &cobra.Command{
 				return err
 			}
 
-			if depSrcKind == dagger.GitSource {
+			if depSrcKind == dagger.ModuleSourceKindGitSource {
 				git := depSrc.AsGitSource()
 				gitURL, err := git.CloneRef(ctx)
 				if err != nil {
@@ -331,7 +331,7 @@ var moduleInstallCmd = &cobra.Command{
 					"git_version":   gitVersion,
 					"git_commit":    gitCommit,
 				})
-			} else if depSrcKind == dagger.LocalSource {
+			} else if depSrcKind == dagger.ModuleSourceKindLocalSource {
 				analytics.Ctx(ctx).Capture(ctx, "module_install", map[string]string{
 					"module_name":   name,
 					"install_name":  installName,
@@ -375,7 +375,7 @@ This command is idempotent: you can run it at any time, any number of times. It 
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
-			if modConf.SourceKind != dagger.LocalSource {
+			if modConf.SourceKind != dagger.ModuleSourceKindLocalSource {
 				return fmt.Errorf("module must be local")
 			}
 
@@ -486,7 +486,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
-			if modConf.SourceKind != dagger.LocalSource {
+			if modConf.SourceKind != dagger.ModuleSourceKindLocalSource {
 				return fmt.Errorf("module must be local")
 			}
 			if !modConf.FullyInitialized() {
@@ -661,7 +661,7 @@ func getModuleConfigurationForSourceRef(
 		return nil, fmt.Errorf("failed to get module ref kind: %w", err)
 	}
 
-	if conf.SourceKind == dagger.GitSource {
+	if conf.SourceKind == dagger.ModuleSourceKindGitSource {
 		conf.ModuleSourceConfigExists, err = conf.Source.ConfigExists(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if module config exists: %w", err)
@@ -694,7 +694,7 @@ func getModuleConfigurationForSourceRef(
 					return nil, err
 				}
 				depSrcRef := namedDep.Source
-				if depKind == dagger.LocalSource {
+				if depKind == dagger.ModuleSourceKindLocalSource {
 					depSrcRef = filepath.Join(defaultFindupConfigDir, namedDep.Source)
 				}
 				return getModuleConfigurationForSourceRef(ctx, dag, depSrcRef, false, resolveFromCaller)
@@ -861,7 +861,7 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client) error 
 
 	for _, typeDef := range res.TypeDefs {
 		switch typeDef.Kind {
-		case dagger.ObjectKind:
+		case dagger.TypeDefKindObjectKind:
 			obj := typeDef.AsObject
 			// FIXME: we could get the real constructor's name through the field
 			// in Query which would avoid the need to convert the module name,
@@ -883,11 +883,11 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client) error 
 				}
 			}
 			m.Objects = append(m.Objects, typeDef)
-		case dagger.InterfaceKind:
+		case dagger.TypeDefKindInterfaceKind:
 			m.Interfaces = append(m.Interfaces, typeDef)
-		case dagger.EnumKind:
+		case dagger.TypeDefKindEnumKind:
 			m.Enums = append(m.Enums, typeDef)
-		case dagger.InputKind:
+		case dagger.TypeDefKindInputKind:
 			m.Inputs = append(m.Inputs, typeDef)
 		}
 	}
@@ -1149,13 +1149,13 @@ func GetLeafFunctions(fp functionProvider) []*modFunction {
 
 	for _, fn := range fns {
 		kind := fn.ReturnType.Kind
-		if kind == dagger.ListKind {
+		if kind == dagger.TypeDefKindListKind {
 			kind = fn.ReturnType.AsList.ElementTypeDef.Kind
 		}
 		switch kind {
-		case dagger.ObjectKind, dagger.InterfaceKind, dagger.VoidKind:
+		case dagger.TypeDefKindObjectKind, dagger.TypeDefKindInterfaceKind, dagger.TypeDefKindVoidKind:
 			continue
-		case dagger.ScalarKind:
+		case dagger.TypeDefKindScalarKind:
 			// FIXME: ID types are coming from TypeDef with the wrong case ("Id")
 			if fn.ReturnType.AsScalar.Name == fmt.Sprintf("%sId", fp.ProviderName()) {
 				continue

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3219,7 +3219,7 @@ func (ContainerSuite) TestImport(ctx context.Context, t *testctx.T) {
 	t.Run("Docker", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			Import(c.Container().From(alpineImage).WithEnvVariable("FOO", "bar").AsTarball(dagger.ContainerAsTarballOpts{
-				MediaTypes: dagger.Dockermediatypes,
+				MediaTypes: dagger.ImageMediaTypesDockermediatypes,
 			})).
 			WithExec([]string{"sh", "-c", "echo $FOO"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -3989,19 +3989,19 @@ func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 		expectedOCIMediaType string
 	}{
 		{
-			dagger.Gzip,
+			dagger.ImageLayerCompressionGzip,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.Zstd,
+			dagger.ImageLayerCompressionZstd,
 			"application/vnd.oci.image.layer.v1.tar+zstd",
 		},
 		{
-			dagger.Uncompressed,
+			dagger.ImageLayerCompressionUncompressed,
 			"application/vnd.oci.image.layer.v1.tar",
 		},
 		{
-			dagger.Estargz,
+			dagger.ImageLayerCompressionEstargz,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 	} {
@@ -4069,11 +4069,11 @@ func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.Ocimediatypes,
+			dagger.ImageMediaTypesOcimediatypes,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.Dockermediatypes,
+			dagger.ImageMediaTypesDockermediatypes,
 			"application/vnd.docker.image.rootfs.diff.tar.gzip",
 		},
 	} {
@@ -4296,9 +4296,9 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 		})
 		require.NoError(t, err)
 
-		for _, mediaType := range []dagger.ImageMediaTypes{dagger.Ocimediatypes, dagger.Dockermediatypes} {
+		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediatypes, dagger.ImageMediaTypesDockermediatypes} {
 			mediaType := mediaType
-			for _, compression := range []dagger.ImageLayerCompression{dagger.Gzip, dagger.Zstd, dagger.Uncompressed} {
+			for _, compression := range []dagger.ImageLayerCompression{dagger.ImageLayerCompressionGzip, dagger.ImageLayerCompressionZstd, dagger.ImageLayerCompressionUncompressed} {
 				compression := compression
 				t.Run(fmt.Sprintf("%s-%s-%s-%s", t.Name(), dockerVersion, mediaType, compression), func(ctx context.Context, t *testctx.T) {
 					tmpdir := t.TempDir()
@@ -4321,7 +4321,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 						WithExec([]string{"docker", "load", "-i", "/" + path.Base(tmpfile)})
 
 					output, err := ctr.Stdout(ctx)
-					if dockerVersion == "20.10" && compression == dagger.Zstd {
+					if dockerVersion == "20.10" && compression == dagger.ImageLayerCompressionZstd {
 						// zstd support in docker wasn't added until 23, so sanity check that it fails
 						require.Error(t, err)
 					} else {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3219,7 +3219,7 @@ func (ContainerSuite) TestImport(ctx context.Context, t *testctx.T) {
 	t.Run("Docker", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			Import(c.Container().From(alpineImage).WithEnvVariable("FOO", "bar").AsTarball(dagger.ContainerAsTarballOpts{
-				MediaTypes: dagger.ImageMediaTypesDockermediatypes,
+				MediaTypes: dagger.ImageMediaTypesDockerMediaTypes,
 			})).
 			WithExec([]string{"sh", "-c", "echo $FOO"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -4001,7 +4001,7 @@ func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar",
 		},
 		{
-			dagger.ImageLayerCompressionEstargz,
+			dagger.ImageLayerCompressionEstarGz,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 	} {
@@ -4069,11 +4069,11 @@ func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.ImageMediaTypesOcimediatypes,
+			dagger.ImageMediaTypesOcimediaTypes,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.ImageMediaTypesDockermediatypes,
+			dagger.ImageMediaTypesDockerMediaTypes,
 			"application/vnd.docker.image.rootfs.diff.tar.gzip",
 		},
 	} {
@@ -4296,7 +4296,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 		})
 		require.NoError(t, err)
 
-		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediatypes, dagger.ImageMediaTypesDockermediatypes} {
+		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediaTypes, dagger.ImageMediaTypesDockerMediaTypes} {
 			mediaType := mediaType
 			for _, compression := range []dagger.ImageLayerCompression{dagger.ImageLayerCompressionGzip, dagger.ImageLayerCompressionZstd, dagger.ImageLayerCompressionUncompressed} {
 				compression := compression

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -49,7 +49,7 @@ func devEngineContainer(c *dagger.Client, withs ...func(*dagger.Container) *dagg
 	deviceName, cidr := testutil.GetUniqueNestedEngineNetwork()
 	return ctr.
 		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).
-		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		WithExec([]string{
 			"--addr", "tcp://0.0.0.0:1234",
 			"--addr", "unix:///var/run/buildkit/buildkitd.sock",

--- a/core/integration/future_test.go
+++ b/core/integration/future_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// FutureSuite contains tests for behavior changes that are "scheduled" - that
+// gate functionality behind certain future releases.
+//
+// As those future releases are actually made, tests can be removed from here
+type FutureSuite struct{}
+
+func TestFuture(t *testing.T) {
+	testctx.Run(testCtx, t, FutureSuite{}, Middleware()...)
+}
+
+func futureClient(ctx context.Context, t *testctx.T, futureVersion string) *dagger.Container {
+	c := connect(ctx, t)
+
+	devEngine := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
+		return c.WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", futureVersion)
+	}).AsService()
+	devClient, err := engineClientContainer(ctx, t, c, devEngine)
+	devClient = devClient.WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", futureVersion)
+	require.NoError(t, err)
+
+	return devClient.
+		WithWorkdir("/work")
+}
+
+func (FutureSuite) TestGoScopedEnumValues(ctx context.Context, t *testctx.T) {
+	// Introduced in dagger/dagger#8669
+	//
+	// Ensure that new dagger unscoped enum values are removed.
+
+	c := futureClient(ctx, t, "v0.14.0")
+	c = c.
+		WithExec([]string{"dagger", "init", "--name=test", "--sdk=go", "--source=."}).
+		WithNewFile("dagger.json", `{"name": "test", "sdk": "go", "source": ".", "engineVersion": "v0.14.0"}`).
+		WithNewFile("main.go", `package main
+
+import "dagger/test/internal/dagger"
+
+type Test struct {}
+
+func (m *Test) OldProto(proto dagger.NetworkProtocol) dagger.NetworkProtocol {
+	switch proto {
+	case dagger.Tcp:
+		return dagger.Udp
+	case dagger.Udp:
+		return dagger.Tcp
+	default:
+		panic("nope")
+	}
+}
+
+func (m *Test) NewProto(proto dagger.NetworkProtocol) dagger.NetworkProtocol {
+	switch proto {
+	case dagger.NetworkProtocolTcp:
+		return dagger.NetworkProtocolUdp
+	case dagger.NetworkProtocolUdp:
+		return dagger.NetworkProtocolTcp
+	default:
+		panic("nope")
+	}
+}
+`,
+		)
+
+	out, err := c.
+		WithExec([]string{"sh", "-c", "! dagger call old-proto --proto=TCP"}).
+		Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "undefined: dagger.Tcp")
+	require.Contains(t, out, "undefined: dagger.Udp")
+	require.NotContains(t, out, "undefined: dagger.NetworkProtocolTcp")
+	require.NotContains(t, out, "undefined: dagger.NetworkProtocolUdp")
+}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5268,7 +5268,7 @@ func (m *Dep) Collect(MyEnum, MyInterface) error {
 				// enum
 				`\ntype DepMyEnum string // dep \(../../dep/main.go:16\)\n`,
 				// enum value
-				`\n\s*Myenuma DepMyEnum = "MyEnumA" // dep \(../../dep/main.go:18\)\n`,
+				`\n\s*DepMyEnumMyEnumA DepMyEnum = "MyEnumA" // dep \(../../dep/main.go:18\)\n`,
 
 				// interface
 				`\ntype DepMyInterface struct { // dep \(../../dep/main.go:22\)\n`,

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -40,7 +40,7 @@ func (RemoteCacheSuite) TestRegistry(ctx context.Context, t *testctx.T) {
 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		AsService()
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
@@ -117,7 +117,7 @@ func (RemoteCacheSuite) TestLazyBlobs(ctx context.Context, t *testctx.T) {
 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		AsService()
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
@@ -179,7 +179,7 @@ func (RemoteCacheSuite) TestS3(ctx context.Context, t *testctx.T) {
 
 		s3 := c.Container().From("minio/minio").
 			WithMountedCache("/data", c.CacheVolume("minio-cache")).
-			WithExposedPort(9000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+			WithExposedPort(9000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 			WithExec([]string{"minio", "server", "/data"}).
 			AsService()
 
@@ -259,7 +259,7 @@ func (RemoteCacheSuite) TestRegistryMultipleConfigs(ctx context.Context, t *test
 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		AsService()
 
 	cacheConfigEnv1 := "type=registry,ref=registry:5000/test-cache:latest,mode=max"
@@ -357,7 +357,7 @@ func (RemoteCacheSuite) TestRegistrySeparateImportExport(ctx context.Context, t 
 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		AsService()
 
 	daggerCli := daggerCliFile(t, c)
@@ -485,7 +485,7 @@ func (RemoteCacheSuite) TestRegistryFastCacheBlobSource(ctx context.Context, t *
 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		AsService()
 
 	cacheConfig := "type=registry,ref=registry:5000/test-cache:latest,mode=max"

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -653,7 +653,7 @@ func (ServiceSuite) TestPorts(ctx context.Context, t *testctx.T) {
 		}).
 		WithExposedPort(9000, dagger.ContainerWithExposedPortOpts{
 			Description: "nine thousand",
-			Protocol:    dagger.Udp,
+			Protocol:    dagger.NetworkProtocolUdp,
 		}).
 		WithExec([]string{"python", "-m", "http.server"}).
 		AsService()
@@ -675,11 +675,11 @@ func (ServiceSuite) TestPorts(ctx context.Context, t *testctx.T) {
 		case 0:
 			require.Equal(t, 8000, port)
 			require.Equal(t, "eight thousand", desc)
-			require.Equal(t, dagger.Tcp, proto)
+			require.Equal(t, dagger.NetworkProtocolTcp, proto)
 		case 1:
 			require.Equal(t, 9000, port)
 			require.Equal(t, "nine thousand", desc)
-			require.Equal(t, dagger.Udp, proto)
+			require.Equal(t, dagger.NetworkProtocolUdp, proto)
 		}
 	}
 }
@@ -732,7 +732,7 @@ func (ContainerSuite) TestPortLifecycle(ctx context.Context, t *testctx.T) {
 			Description: "eight thousand tcp",
 		}).
 		WithExposedPort(8000, dagger.ContainerWithExposedPortOpts{
-			Protocol:    dagger.Udp,
+			Protocol:    dagger.NetworkProtocolUdp,
 			Description: "eight thousand udp",
 		}).
 		WithExposedPort(5432)
@@ -813,7 +813,7 @@ func (ContainerSuite) TestPortLifecycle(ctx context.Context, t *testctx.T) {
 	require.Nil(t, desc)
 
 	withoutUDP := withPorts.WithoutExposedPort(8000, dagger.ContainerWithoutExposedPortOpts{
-		Protocol: dagger.Udp,
+		Protocol: dagger.NetworkProtocolUdp,
 	})
 	cid, err = withoutUDP.ID(ctx)
 	require.NoError(t, err)
@@ -850,12 +850,12 @@ func (ContainerSuite) TestPortOCIConfig(ctx context.Context, t *testctx.T) {
 			Description: "eight thousand tcp",
 		}).
 		WithExposedPort(8000, dagger.ContainerWithExposedPortOpts{
-			Protocol:    dagger.Udp,
+			Protocol:    dagger.NetworkProtocolUdp,
 			Description: "eight thousand udp",
 		}).
 		WithExposedPort(5432).
 		WithExposedPort(5432, dagger.ContainerWithExposedPortOpts{
-			Protocol: dagger.Udp,
+			Protocol: dagger.NetworkProtocolUdp,
 		})
 
 	dest := t.TempDir()
@@ -878,7 +878,7 @@ func (ContainerSuite) TestPortOCIConfig(ctx context.Context, t *testctx.T) {
 
 	withoutPorts := withPorts.
 		WithoutExposedPort(8000, dagger.ContainerWithoutExposedPortOpts{
-			Protocol: dagger.Udp,
+			Protocol: dagger.NetworkProtocolUdp,
 		}).
 		WithoutExposedPort(5432)
 
@@ -981,7 +981,7 @@ func (ContainerSuite) TestExecUDPServices(ctx context.Context, t *testctx.T) {
 		WithMountedFile("/src/main.go",
 			c.Directory().WithNewFile("main.go", udpSrc).File("main.go")).
 		WithExposedPort(4321, dagger.ContainerWithExposedPortOpts{
-			Protocol: dagger.Udp,
+			Protocol: dagger.NetworkProtocolUdp,
 		}).
 		// use TCP :4322 for health-check to avoid test flakiness, since UDP dial
 		// health-checks aren't really a thing

--- a/sdk/go/.changes/unreleased/Changed-20241010-122112.yaml
+++ b/sdk/go/.changes/unreleased/Changed-20241010-122112.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |-
+  Deprecated unscoped enum values
+
+  Enum values should now be accessed with the name prefixed by the name of the enum type - for example, "Shared" becomes "CacheSharingModeLocked".
+time: 2024-10-10T12:21:12.088823248+01:00
+custom:
+  Author: jedevc
+  PR: "8669"

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8387,10 +8387,10 @@ type ImageLayerCompression string
 func (ImageLayerCompression) IsEnum() {}
 
 const (
-	ImageLayerCompressionEstargz ImageLayerCompression = "EStarGZ"
+	ImageLayerCompressionEstarGz ImageLayerCompression = "EStarGZ"
 
-	// Deprecated: use ImageLayerCompressionEstargz instead
-	Estargz ImageLayerCompression = ImageLayerCompressionEstargz
+	// Deprecated: use ImageLayerCompressionEstarGz instead
+	Estargz ImageLayerCompression = ImageLayerCompressionEstarGz
 
 	ImageLayerCompressionGzip ImageLayerCompression = "Gzip"
 
@@ -8414,15 +8414,15 @@ type ImageMediaTypes string
 func (ImageMediaTypes) IsEnum() {}
 
 const (
-	ImageMediaTypesDockermediatypes ImageMediaTypes = "DockerMediaTypes"
+	ImageMediaTypesDockerMediaTypes ImageMediaTypes = "DockerMediaTypes"
 
-	// Deprecated: use ImageMediaTypesDockermediatypes instead
-	Dockermediatypes ImageMediaTypes = ImageMediaTypesDockermediatypes
+	// Deprecated: use ImageMediaTypesDockerMediaTypes instead
+	Dockermediatypes ImageMediaTypes = ImageMediaTypesDockerMediaTypes
 
-	ImageMediaTypesOcimediatypes ImageMediaTypes = "OCIMediaTypes"
+	ImageMediaTypesOcimediaTypes ImageMediaTypes = "OCIMediaTypes"
 
-	// Deprecated: use ImageMediaTypesOcimediatypes instead
-	Ocimediatypes ImageMediaTypes = ImageMediaTypesOcimediatypes
+	// Deprecated: use ImageMediaTypesOcimediaTypes instead
+	Ocimediatypes ImageMediaTypes = ImageMediaTypesOcimediaTypes
 )
 
 // The kind of module source.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8360,13 +8360,25 @@ func (CacheSharingMode) IsEnum() {}
 
 const (
 	// Shares the cache volume amongst many build pipelines, but will serialize the writes
-	Locked CacheSharingMode = "LOCKED"
+	CacheSharingModeLocked CacheSharingMode = "LOCKED"
+
+	// Shares the cache volume amongst many build pipelines, but will serialize the writes
+	// Deprecated: use CacheSharingModeLocked instead
+	Locked CacheSharingMode = CacheSharingModeLocked
 
 	// Keeps a cache volume for a single build pipeline
-	Private CacheSharingMode = "PRIVATE"
+	CacheSharingModePrivate CacheSharingMode = "PRIVATE"
+
+	// Keeps a cache volume for a single build pipeline
+	// Deprecated: use CacheSharingModePrivate instead
+	Private CacheSharingMode = CacheSharingModePrivate
 
 	// Shares the cache volume amongst many build pipelines
-	Shared CacheSharingMode = "SHARED"
+	CacheSharingModeShared CacheSharingMode = "SHARED"
+
+	// Shares the cache volume amongst many build pipelines
+	// Deprecated: use CacheSharingModeShared instead
+	Shared CacheSharingMode = CacheSharingModeShared
 )
 
 // Compression algorithm to use for image layers.
@@ -8375,13 +8387,25 @@ type ImageLayerCompression string
 func (ImageLayerCompression) IsEnum() {}
 
 const (
-	Estargz ImageLayerCompression = "EStarGZ"
+	ImageLayerCompressionEstargz ImageLayerCompression = "EStarGZ"
 
-	Gzip ImageLayerCompression = "Gzip"
+	// Deprecated: use ImageLayerCompressionEstargz instead
+	Estargz ImageLayerCompression = ImageLayerCompressionEstargz
 
-	Uncompressed ImageLayerCompression = "Uncompressed"
+	ImageLayerCompressionGzip ImageLayerCompression = "Gzip"
 
-	Zstd ImageLayerCompression = "Zstd"
+	// Deprecated: use ImageLayerCompressionGzip instead
+	Gzip ImageLayerCompression = ImageLayerCompressionGzip
+
+	ImageLayerCompressionUncompressed ImageLayerCompression = "Uncompressed"
+
+	// Deprecated: use ImageLayerCompressionUncompressed instead
+	Uncompressed ImageLayerCompression = ImageLayerCompressionUncompressed
+
+	ImageLayerCompressionZstd ImageLayerCompression = "Zstd"
+
+	// Deprecated: use ImageLayerCompressionZstd instead
+	Zstd ImageLayerCompression = ImageLayerCompressionZstd
 )
 
 // Mediatypes to use in published or exported image metadata.
@@ -8390,9 +8414,15 @@ type ImageMediaTypes string
 func (ImageMediaTypes) IsEnum() {}
 
 const (
-	Dockermediatypes ImageMediaTypes = "DockerMediaTypes"
+	ImageMediaTypesDockermediatypes ImageMediaTypes = "DockerMediaTypes"
 
-	Ocimediatypes ImageMediaTypes = "OCIMediaTypes"
+	// Deprecated: use ImageMediaTypesDockermediatypes instead
+	Dockermediatypes ImageMediaTypes = ImageMediaTypesDockermediatypes
+
+	ImageMediaTypesOcimediatypes ImageMediaTypes = "OCIMediaTypes"
+
+	// Deprecated: use ImageMediaTypesOcimediatypes instead
+	Ocimediatypes ImageMediaTypes = ImageMediaTypesOcimediatypes
 )
 
 // The kind of module source.
@@ -8401,9 +8431,15 @@ type ModuleSourceKind string
 func (ModuleSourceKind) IsEnum() {}
 
 const (
-	GitSource ModuleSourceKind = "GIT_SOURCE"
+	ModuleSourceKindGitSource ModuleSourceKind = "GIT_SOURCE"
 
-	LocalSource ModuleSourceKind = "LOCAL_SOURCE"
+	// Deprecated: use ModuleSourceKindGitSource instead
+	GitSource ModuleSourceKind = ModuleSourceKindGitSource
+
+	ModuleSourceKindLocalSource ModuleSourceKind = "LOCAL_SOURCE"
+
+	// Deprecated: use ModuleSourceKindLocalSource instead
+	LocalSource ModuleSourceKind = ModuleSourceKindLocalSource
 )
 
 // Transport layer network protocol associated to a port.
@@ -8412,9 +8448,15 @@ type NetworkProtocol string
 func (NetworkProtocol) IsEnum() {}
 
 const (
-	Tcp NetworkProtocol = "TCP"
+	NetworkProtocolTcp NetworkProtocol = "TCP"
 
-	Udp NetworkProtocol = "UDP"
+	// Deprecated: use NetworkProtocolTcp instead
+	Tcp NetworkProtocol = NetworkProtocolTcp
+
+	NetworkProtocolUdp NetworkProtocol = "UDP"
+
+	// Deprecated: use NetworkProtocolUdp instead
+	Udp NetworkProtocol = NetworkProtocolUdp
 )
 
 // Distinguishes the different kinds of TypeDefs.
@@ -8424,42 +8466,92 @@ func (TypeDefKind) IsEnum() {}
 
 const (
 	// A boolean value.
-	BooleanKind TypeDefKind = "BOOLEAN_KIND"
+	TypeDefKindBooleanKind TypeDefKind = "BOOLEAN_KIND"
+
+	// A boolean value.
+	// Deprecated: use TypeDefKindBooleanKind instead
+	BooleanKind TypeDefKind = TypeDefKindBooleanKind
 
 	// A GraphQL enum type and its values
 	//
 	// Always paired with an EnumTypeDef.
-	EnumKind TypeDefKind = "ENUM_KIND"
+	TypeDefKindEnumKind TypeDefKind = "ENUM_KIND"
+
+	// A GraphQL enum type and its values
+	//
+	// Always paired with an EnumTypeDef.
+	// Deprecated: use TypeDefKindEnumKind instead
+	EnumKind TypeDefKind = TypeDefKindEnumKind
 
 	// A graphql input type, used only when representing the core API via TypeDefs.
-	InputKind TypeDefKind = "INPUT_KIND"
+	TypeDefKindInputKind TypeDefKind = "INPUT_KIND"
+
+	// A graphql input type, used only when representing the core API via TypeDefs.
+	// Deprecated: use TypeDefKindInputKind instead
+	InputKind TypeDefKind = TypeDefKindInputKind
 
 	// An integer value.
-	IntegerKind TypeDefKind = "INTEGER_KIND"
+	TypeDefKindIntegerKind TypeDefKind = "INTEGER_KIND"
+
+	// An integer value.
+	// Deprecated: use TypeDefKindIntegerKind instead
+	IntegerKind TypeDefKind = TypeDefKindIntegerKind
 
 	// A named type of functions that can be matched+implemented by other objects+interfaces.
 	//
 	// Always paired with an InterfaceTypeDef.
-	InterfaceKind TypeDefKind = "INTERFACE_KIND"
+	TypeDefKindInterfaceKind TypeDefKind = "INTERFACE_KIND"
+
+	// A named type of functions that can be matched+implemented by other objects+interfaces.
+	//
+	// Always paired with an InterfaceTypeDef.
+	// Deprecated: use TypeDefKindInterfaceKind instead
+	InterfaceKind TypeDefKind = TypeDefKindInterfaceKind
 
 	// A list of values all having the same type.
 	//
 	// Always paired with a ListTypeDef.
-	ListKind TypeDefKind = "LIST_KIND"
+	TypeDefKindListKind TypeDefKind = "LIST_KIND"
+
+	// A list of values all having the same type.
+	//
+	// Always paired with a ListTypeDef.
+	// Deprecated: use TypeDefKindListKind instead
+	ListKind TypeDefKind = TypeDefKindListKind
 
 	// A named type defined in the GraphQL schema, with fields and functions.
 	//
 	// Always paired with an ObjectTypeDef.
-	ObjectKind TypeDefKind = "OBJECT_KIND"
+	TypeDefKindObjectKind TypeDefKind = "OBJECT_KIND"
+
+	// A named type defined in the GraphQL schema, with fields and functions.
+	//
+	// Always paired with an ObjectTypeDef.
+	// Deprecated: use TypeDefKindObjectKind instead
+	ObjectKind TypeDefKind = TypeDefKindObjectKind
 
 	// A scalar value of any basic kind.
-	ScalarKind TypeDefKind = "SCALAR_KIND"
+	TypeDefKindScalarKind TypeDefKind = "SCALAR_KIND"
+
+	// A scalar value of any basic kind.
+	// Deprecated: use TypeDefKindScalarKind instead
+	ScalarKind TypeDefKind = TypeDefKindScalarKind
 
 	// A string value.
-	StringKind TypeDefKind = "STRING_KIND"
+	TypeDefKindStringKind TypeDefKind = "STRING_KIND"
+
+	// A string value.
+	// Deprecated: use TypeDefKindStringKind instead
+	StringKind TypeDefKind = TypeDefKindStringKind
 
 	// A special kind used to signify that no value is returned.
 	//
 	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
-	VoidKind TypeDefKind = "VOID_KIND"
+	TypeDefKindVoidKind TypeDefKind = "VOID_KIND"
+
+	// A special kind used to signify that no value is returned.
+	//
+	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
+	// Deprecated: use TypeDefKindVoidKind instead
+	VoidKind TypeDefKind = TypeDefKindVoidKind
 )


### PR DESCRIPTION
In go, enum values are top-level to the package (unlike in typescript/python/etc where they are members of the type itself). Because of this, it's very easily possible to clash - two different enum types might have the same value.

To prevent this clash, we should scope the enum value with the name of the enum it's from - this is pretty standard go practice, and should be familiar.

We keep the old consts around, but alias them to the new consts, and deprecate them (to remove in v0.14.0).