### PR TITLE
chore: add help for install.sh

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,32 @@
 #Requires -Version 7.0
 
+<#
+.Description
+    Download and install dagger.
+.PARAMETER DaggerVersion
+    Semver version of dagger to install.
+.PARAMETER DaggerCommit
+    Commit SHA for a dev build of dagger to install.
+.EXAMPLE
+    .\install.ps1
+    Install with default settings.
+.EXAMPLE
+    .\install.ps1 -InstallPath path\to\dir
+    Install to path/to/dir.
+.EXAMPLE
+    .\install.ps1 -DaggerVersion vX.Y.Z
+    Install specified version vX.Y.Z.
+.EXAMPLE
+    .\install.ps1 -DaggerCommit head
+    Install latest dev build.
+.EXAMPLE
+    .\install.ps1 -DaggerCommit [commit]
+    Install specified dev build [commit].
+#>
+
 Param (
     [Parameter(Mandatory = $false)][System.Management.Automation.SemanticVersion]$DaggerVersion,
-    [Parameter(Mandatory = $false)][string][ValidatePattern("^(?:[0-9a-fA-F]{40})?$")]$DaggerCommit,
+    [Parameter(Mandatory = $false)][string][ValidatePattern("^(?:head|(?:[0-9a-fA-F]{40}))?$")]$DaggerCommit,
     [Parameter(Mandatory = $false)][string]$DownloadPath = [System.IO.Path]::GetTempFileName(),
     [Parameter(Mandatory = $false)][string]$InstallPath = "$env:USERPROFILE\dagger",
     [Parameter(Mandatory = $false)][switch]$AddToPath = $false,
@@ -412,7 +436,7 @@ if ($isInvoked) {
     function Install-Dagger {
         Param (
             [Parameter(Mandatory = $false)][System.Management.Automation.SemanticVersion]$DaggerVersion,
-            [Parameter(Mandatory = $false)][string][ValidatePattern("^(?:[0-9a-fA-F]{40})?$")]$DaggerCommit,
+            [Parameter(Mandatory = $false)][string][ValidatePattern("^(?:head|(?:[0-9a-fA-F]{40}))?$")]$DaggerCommit,
             [Parameter(Mandatory = $false)][string]$DownloadPath = [System.IO.Path]::GetTempFileName(),
             [Parameter(Mandatory = $false)][string]$InstallPath = "$env:USERPROFILE\dagger",
             [Parameter(Mandatory = $false)][switch]$AddToPath = $false,

--- a/install.sh
+++ b/install.sh
@@ -235,6 +235,26 @@ End of functions from https://github.com/client9/shlib
 ------------------------------------------------------------------------
 EOF
 
+help() {
+  cat <<EOF
+Usage: $0
+
+Install:
+  $0
+
+Install to <path/to/dir>:
+  BIN_DIR=<path/to/dir> $0
+
+Install specified version <vX.Y.Z>:
+  DAGGER_VERSION=<vX.Y.Z> $0
+
+Install latest dev build:
+  DAGGER_COMMIT=head $0
+Install specified dev build <commit sha>:
+  DAGGER_COMMIT=<commit sha> $0
+EOF
+}
+
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   case "$os" in
@@ -374,4 +394,9 @@ execute() {
   rm -rf "${tmpdir}"
 }
 
-execute
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  help
+else
+  execute
+fi
+


### PR DESCRIPTION
```
Usage: ./install.sh

Install:
  ./install.sh

Install to <path/to/dir>:
  BIN_DIR=<path/to/dir> ./install.sh

Install specified version <vX.Y.Z>:
  DAGGER_VERSION=<vX.Y.Z> ./install.sh

Install latest nightly build:
  DAGGER_COMMIT=head ./install.sh
Install specified nightly build <commit sha>:
  DAGGER_COMMIT=<commit sha> ./install.sh
```

These options need to be documented - since I keep forgetting what's valid/what's not.