### PR TITLE
fix: allow decoding enums that overlap with bool types

### DIFF
--- a/.changes/unreleased/Fixed-20241014-161755.yaml
+++ b/.changes/unreleased/Fixed-20241014-161755.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+    Allow custom enums that include ambiguous names (such as "true"/"false")
+time: 2024-10-14T16:17:55.998067541+01:00
+custom:
+    Author: jedevc
+    PR: "8682"

--- a/core/module.go
+++ b/core/module.go
@@ -613,11 +613,13 @@ func (mod *Module) namespaceTypeDef(ctx context.Context, typeDef *TypeDef) error
 		enum := typeDef.AsEnum.Value
 
 		// only namespace enums defined in this module
-		_, ok, err := mod.Deps.ModTypeFor(ctx, typeDef)
+		mtype, ok, err := mod.Deps.ModTypeFor(ctx, typeDef)
 		if err != nil {
 			return fmt.Errorf("failed to get mod type for type def: %w", err)
 		}
-
+		if ok {
+			enum.Values = mtype.TypeDef().AsEnum.Value.Values
+		}
 		if !ok {
 			enum.Name = namespaceObject(enum.OriginalName, mod.Name(), mod.OriginalName)
 		}

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -376,7 +376,7 @@ func (typeDef *TypeDef) ToInput() dagql.Input {
 	case TypeDefKindScalar:
 		typed = dagql.NewScalar[dagql.String](typeDef.AsScalar.Value.Name, dagql.String(""))
 	case TypeDefKindEnum:
-		typed = dagql.NewScalar[dagql.String](typeDef.AsEnum.Value.Name, dagql.String(""))
+		typed = &dagql.EnumValueName{Enum: typeDef.AsEnum.Value.Name}
 	case TypeDefKindList:
 		typed = dagql.DynamicArrayInput{
 			Elem: typeDef.AsList.Value.ElementTypeDef.ToInput(),

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -196,6 +196,18 @@ func (cls Class[T]) ParseField(ctx context.Context, view string, astField *ast.F
 		if !ok {
 			return Selector{}, nil, fmt.Errorf("%s.%s has no such argument: %q", cls.TypeName(), field.Spec.Name, arg.Name)
 		}
+
+		if argDef, ok := argSpec.Type.(Definitive); ok {
+			def := argDef.TypeDefinition(view)
+			if def.Kind == ast.Enum && (arg.Value.Kind == ast.BooleanValue || arg.Value.Kind == ast.NullValue) {
+				// enum values can sometimes be mis-parsed as true/false/null
+				// https://github.com/vektah/gqlparser/blob/v2.5.16/parser/query.go#L271-L279
+				argClone := *arg
+				arg = &argClone
+				arg.Value.Kind = ast.EnumValue
+			}
+		}
+
 		val, err := arg.Value.Value(vars)
 		if err != nil {
 			return Selector{}, nil, err


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/pull/8673#issuecomment-2407223417

`false` and `true` values are always decoded by gqlparser as booleans - however, this might not always be the case: a standalone value *might* potentially be decodable as an enum instead.
    
The solution for this is to just add another case for decoding booleans in enums.
    
> [!NOTE]
>
> There's really no way to avoid this hack from what I can tell - you can put a `false`/`true` value as an enum value, but when you come to parse it, the parse tree you *should* construct is dependent on the types that you declare inside the parse tree :cry: Not actually sure if there exists a general class of parser that can correctly parse these :laughing: 