### PR TITLE
ci: install colima for docker step

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -126,6 +126,8 @@ jobs:
         shell: bash
       - name: "Install Docker"
         run: |
+          echo "Install colima..."
+          brew install colima
           echo "Install docker CLI..."
           brew install docker
           echo "Start Docker daemon via Colima..."


### PR DESCRIPTION
Colima doesn't appear to be installed by default on the new macos-15 runners.