### PR TITLE
fix: SSH flake on integration test suite

### DIFF
--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -859,7 +859,6 @@ func (m *Test) ToStatus(status string) Status {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		t.Run("module args", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
-
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			defer cleanup()
 
@@ -2068,7 +2067,6 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		t.Run("git", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
-
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			defer cleanup()
 
@@ -2093,9 +2091,8 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 
 func (CallSuite) TestGitMod(ctx context.Context, t *testctx.T) {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
-		c := connect(ctx, t)
-
 		t.Run("go", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			defer cleanup()
 
@@ -2109,6 +2106,7 @@ func (CallSuite) TestGitMod(ctx context.Context, t *testctx.T) {
 		})
 
 		t.Run("typescript", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			defer cleanup()
 
@@ -2122,6 +2120,7 @@ func (CallSuite) TestGitMod(ctx context.Context, t *testctx.T) {
 		})
 
 		t.Run("python", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			defer cleanup()
 

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -507,7 +507,7 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 		t.Run("fails on git", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-			t.Cleanup(cleanup)
+			defer cleanup()
 
 			_, err := goGitBase(t, c).
 				With(mountedSocket).
@@ -854,7 +854,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 			t.Run("happy", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-				t.Cleanup(cleanup)
+				defer cleanup()
 
 				out, err := goGitBase(t, c).
 					With(mountedSocket).
@@ -881,7 +881,7 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-				t.Cleanup(cleanup)
+				defer cleanup()
 
 				_, err := goGitBase(t, c).
 					With(mountedSocket).
@@ -903,7 +903,7 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 			t.Run("unpinned gets pinned", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-				t.Cleanup(cleanup)
+				defer cleanup()
 
 				out, err := goGitBase(t, c).
 					With(mountedSocket).

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -506,7 +506,6 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		t.Run("fails on git", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
-
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			t.Cleanup(cleanup)
 
@@ -854,7 +853,6 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 		t.Run("git", func(ctx context.Context, t *testctx.T) {
 			t.Run("happy", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
-
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 				t.Cleanup(cleanup)
 
@@ -882,7 +880,6 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
-
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 				t.Cleanup(cleanup)
 
@@ -905,7 +902,6 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 
 			t.Run("unpinned gets pinned", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
-
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 				t.Cleanup(cleanup)
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -70,31 +70,53 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 
 	t.Run("malicious config", func(ctx context.Context, t *testctx.T) {
 		// verify a maliciously/incorrectly constructed dagger.json is still handled correctly
-		c := connect(ctx, t)
+		// c := connect(ctx, t)
 
-		base := goGitBase(t, c).
-			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-			WithWorkdir("/tmp/foo").
-			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
-			WithWorkdir("/work/dep").
-			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
-			WithNewFile("/work/dep/main.go", `package main
+		// base := goGitBase(t, c).
+		// 	WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		// 	WithWorkdir("/tmp/foo").
+		// 	With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+		// 	WithWorkdir("/work/dep").
+		// 	With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+		// 	WithNewFile("/work/dep/main.go", `package main
 
-        import "context"
+		// import "context"
 
-        type Dep struct {}
+		// type Dep struct {}
 
-        func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
-            return dag.CurrentModule().Source()
-        }
-        `,
-			).
-			WithWorkdir("/work").
-			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
+		// func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+		//     return dag.CurrentModule().Source()
+		// }
+		// `,
+		// 	).
+		// 	WithWorkdir("/work").
+		// 	With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
 
 		t.Run("source points out of root", func(ctx context.Context, t *testctx.T) {
 			t.Run("local", func(ctx context.Context, t *testctx.T) {
-				base := base.
+				c := connect(ctx, t)
+
+				base := goGitBase(t, c).
+					WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+					WithWorkdir("/tmp/foo").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithWorkdir("/work/dep").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithNewFile("/work/dep/main.go", `package main
+
+		import "context"
+
+		type Dep struct {}
+
+		func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+		    return dag.CurrentModule().Source()
+		}
+		`,
+					).
+					WithWorkdir("/work").
+					With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
+
+				base = base.
 					With(configFile(".", &modules.ModuleConfig{
 						Name:   "evil",
 						SDK:    "go",
@@ -112,7 +134,29 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 			})
 
 			t.Run("local with absolute path", func(ctx context.Context, t *testctx.T) {
-				base := base.
+				c := connect(ctx, t)
+
+				base := goGitBase(t, c).
+					WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+					WithWorkdir("/tmp/foo").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithWorkdir("/work/dep").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithNewFile("/work/dep/main.go", `package main
+
+		import "context"
+
+		type Dep struct {}
+
+		func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+		    return dag.CurrentModule().Source()
+		}
+		`,
+					).
+					WithWorkdir("/work").
+					With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
+
+				base = base.
 					With(configFile(".", &modules.ModuleConfig{
 						Name:   "evil",
 						SDK:    "go",
@@ -131,8 +175,29 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 
 			testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 				t.Run("git", func(ctx context.Context, t *testctx.T) {
+					c := connect(ctx, t)
 					mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 					t.Cleanup(cleanup)
+
+					base := goGitBase(t, c).
+						WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+						WithWorkdir("/tmp/foo").
+						With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+						WithWorkdir("/work/dep").
+						With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+						WithNewFile("/work/dep/main.go", `package main
+
+					import "context"
+
+					type Dep struct {}
+
+					func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+					    return dag.CurrentModule().Source()
+					}
+					`,
+						).
+						WithWorkdir("/work").
+						With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
 
 					_, err := base.With(mountedSocket).With(daggerCallAt(testGitModuleRef(tc, "invalid/bad-source"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
 					require.ErrorContains(t, err, `source path "../../../" contains parent directory components`)
@@ -142,7 +207,26 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 
 		t.Run("dep points out of root", func(ctx context.Context, t *testctx.T) {
 			t.Run("local", func(ctx context.Context, t *testctx.T) {
-				base := base.
+				c := connect(ctx, t)
+				base := goGitBase(t, c).
+					WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+					WithWorkdir("/tmp/foo").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithWorkdir("/work/dep").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithNewFile("/work/dep/main.go", `package main
+
+					import "context"
+
+					type Dep struct {}
+
+					func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+					    return dag.CurrentModule().Source()
+					}
+					`,
+					).
+					WithWorkdir("/work").
+					With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 					With(configFile(".", &modules.ModuleConfig{
 						Name: "evil",
 						SDK:  "go",
@@ -182,7 +266,29 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 			})
 
 			t.Run("local with absolute path", func(ctx context.Context, t *testctx.T) {
-				base := base.
+				c := connect(ctx, t)
+
+				base := goGitBase(t, c).
+					WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+					WithWorkdir("/tmp/foo").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithWorkdir("/work/dep").
+					With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+					WithNewFile("/work/dep/main.go", `package main
+
+		import "context"
+
+		type Dep struct {}
+
+		func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+		    return dag.CurrentModule().Source()
+		}
+		`,
+					).
+					WithWorkdir("/work").
+					With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
+
+				base = base.
 					With(configFile(".", &modules.ModuleConfig{
 						Name: "evil",
 						SDK:  "go",
@@ -223,8 +329,29 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 
 			testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 				t.Run("git", func(ctx context.Context, t *testctx.T) {
+					c := connect(ctx, t)
 					mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 					t.Cleanup(cleanup)
+
+					base := goGitBase(t, c).
+						WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+						WithWorkdir("/tmp/foo").
+						With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+						WithWorkdir("/work/dep").
+						With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
+						WithNewFile("/work/dep/main.go", `package main
+
+		import "context"
+
+		type Dep struct {}
+
+		func (m *Dep) GetSource(ctx context.Context) *dagger.Directory {
+		    return dag.CurrentModule().Source()
+		}
+		`,
+						).
+						WithWorkdir("/work").
+						With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
 
 					_, err := base.With(mountedSocket).With(daggerCallAt(testGitModuleRef(tc, "invalid/bad-dep"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
 					require.ErrorContains(t, err, `module dep source root path "../../../foo" escapes root`)
@@ -1010,7 +1137,6 @@ func (ConfigSuite) TestDaggerGitWithSources(ctx context.Context, t *testctx.T) {
 			modSubpath := modSubpath
 			t.Run(modSubpath, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
-
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 				t.Cleanup(cleanup)
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -177,7 +177,7 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 				t.Run("git", func(ctx context.Context, t *testctx.T) {
 					c := connect(ctx, t)
 					mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-					t.Cleanup(cleanup)
+					defer cleanup()
 
 					base := goGitBase(t, c).
 						WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -331,7 +331,7 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 				t.Run("git", func(ctx context.Context, t *testctx.T) {
 					c := connect(ctx, t)
 					mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-					t.Cleanup(cleanup)
+					defer cleanup()
 
 					base := goGitBase(t, c).
 						WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1138,7 +1138,7 @@ func (ConfigSuite) TestDaggerGitWithSources(ctx context.Context, t *testctx.T) {
 			t.Run(modSubpath, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-				t.Cleanup(cleanup)
+				defer cleanup()
 
 				ctr := goGitBase(t, c).
 					With(mountedSocket).

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2374,7 +2374,7 @@ func (m *Test) Fn() string {
 		t.Run("git", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
-			t.Cleanup(cleanup)
+			defer cleanup()
 
 			ctr := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2373,7 +2373,6 @@ func (m *Test) Fn() string {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		t.Run("git", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
-
 			mountedSocket, cleanup := mountedPrivateRepoSocket(c, t)
 			t.Cleanup(cleanup)
 


### PR DESCRIPTION
Follow-up of https://github.com/dagger/dagger/issues/8385#issuecomment-2406128224

Attempting the same fix to all the tests: a few were missing + unifying how we cleanup the cancel()