### PR TITLE
fix: use latest go release version 1.23.2 in .dagger

### DIFF
--- a/.dagger/go.mod
+++ b/.dagger/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/.dagger
 
-go 1.23
+go 1.23.2
 
 require github.com/dagger/dagger/engine/distconsts v0.13.5
 


### PR DESCRIPTION
During the CI / release improvements, go version in .dagger/go.mod was bumped to 1.23 which has no release for ARM, leading to this error:

.dagger git:(fix-go-version-daggerci) go env GOPROXY go: downloading go1.23 (linux/arm64)
go: download go1.23 for linux/arm64: toolchain not available

As per https://go.dev/dl/, the latest official version is 1.23.2