### PR TITLE
go: trace loadPackages + optimize slightly

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -377,6 +377,10 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 			}
 			return astFile, nil
 		},
+		// Print some debug logs with timing information to stdout
+		Logf: func(format string, args ...interface{}) {
+			fmt.Printf(format+"\n", args...)
+		},
 	}, ".")
 	if err != nil {
 		return nil, nil, err

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"dagger.io/dagger"
+	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/cmd/codegen/generator"
 	"github.com/dagger/dagger/cmd/codegen/introspection"
 )
@@ -56,6 +57,7 @@ func init() {
 
 func ClientGen(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	ctx = telemetry.InitEmbedded(ctx, nil)
 	dag, err := dagger.Connect(ctx)
 	if err != nil {
 		return err

--- a/cmd/codegen/trace/trace.go
+++ b/cmd/codegen/trace/trace.go
@@ -1,0 +1,12 @@
+package trace
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const InstrumentationLibrary = "dagger.io/codegen"
+
+func Tracer() trace.Tracer {
+	return otel.Tracer(InstrumentationLibrary)
+}


### PR DESCRIPTION
context: While working on the otel metrics stuff I saw the codegen steps sometimes writing several hundred MB to disk for seemingly no reason, so went off on a tangent looking into that. Still not sure, but on that tangent followed a subtangent around `packages.Load` taking an absurd amount of time (also seemingly randomly).

---

The call to packages.Load, which does the syntax parsing + type checking needed for go module codegen seems to be a pretty big bottleneck in terms of time. It's often at least half of the time spent in the codegen bin when building modules and I see cases where it's taking more like 18s out of the 20s codegen runs for.
* It's possible that it's downloading deps and thus saving work later, but it's not clear to me that's true yet.

This adds a trace around loadPackages so we can see this more easily.

I also noticed in their docs that you can optimize it by stripping the function bodies if those aren't needed. We don't need those (just the function declarations and other type defs), so I included that here.
* Not 100% clear to me yet how much of a difference this makes, waiting for a full test run in CI. But worst case it appears harmless and may make a difference for modules with lots of code in the function bodies.