### PR TITLE
docs: add mention about dagger login on cloud-get-started documentation

### DIFF
--- a/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
+++ b/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
@@ -76,7 +76,7 @@ Once you have your token, you can now use it to connect Dagger Cloud with your C
 
 You can visualize and debug your local Dagger pipeline runs with Dagger Cloud to identify issues before pushing them to CI.
 
-To configure for local development, run `dagger login` command.
+To configure for local development, run the `dagger login` command.
 
 The Dagger CLI will invite you to authenticate your device by displaying a link containing a unique key. Click the link in your browser, and verify that you see the same key in the Dagger Cloud Web interface.
 

--- a/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
+++ b/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
@@ -83,7 +83,7 @@ The Dagger CLI will invite you to authenticate your device by displaying a link 
 ```shell
 $ dagger login
 Browser opened to: https://auth.dagger.cloud/activate?user_code=XXXX-YYYY
-Confirmation code: FQNJ-BANG
+Confirmation code: XXXX-YYYY
 ```
 
 Once you confirm your authentication code, your Dagger CLI will be authenticated and you can now visualize and debug your local Dagger pipeline runs.

--- a/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
+++ b/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
@@ -76,11 +76,25 @@ Once you have your token, you can now use it to connect Dagger Cloud with your C
 
 You can visualize and debug your local Dagger pipeline runs with Dagger Cloud to identify issues before pushing them to CI.
 
-To configure for local development, set your Dagger Cloud token as an environment variable. For example:
+To configure for local development, run `dagger login` command.
+
+The Dagger CLI will invite you to authenticate your device by displaying a link containing a unique key. Click the link in your browser, and verify that you see the same key in the Dagger Cloud Web interface.
 
 ```shell
-export DAGGER_CLOUD_TOKEN={your token}
+$ dagger login
+Browser opened to: https://auth.dagger.cloud/activate?user_code=FQNJ-BANG
+Confirmation code: FQNJ-BANG
 ```
+
+Once you confirm your authentication code, your Dagger CLI will be authenticated and you can now visualize and debug your local Dagger pipeline runs.
+
+  :::info
+  If you do not want to use `dagger login`, set your Dagger Cloud token as an environment variable. For example:
+  ```shell
+  export DAGGER_CLOUD_TOKEN={your token}
+  ```
+  :::
+
 
 ### Connect from your CI engine
 

--- a/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
+++ b/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
@@ -82,7 +82,7 @@ The Dagger CLI will invite you to authenticate your device by displaying a link 
 
 ```shell
 $ dagger login
-Browser opened to: https://auth.dagger.cloud/activate?user_code=FQNJ-BANG
+Browser opened to: https://auth.dagger.cloud/activate?user_code=XXXX-YYYY
 Confirmation code: FQNJ-BANG
 ```
 


### PR DESCRIPTION
## What?

This pull request aims to mention `dagger login` at [Dagger Cloud Introduction](https://docs.dagger.io/manuals/user/cloud-get-started/#connect-from-your-local-development-host) documentation.

## Why?

After the `dagger login` there was no mentions about `dagger login` on Dagger Cloud Introduction documentation.

The idea is to add it (`dagger login`) as a new way to connect to Dagger Cloud.

Closes #7734 