### PR TITLE
chore(python): remove deprecations

### DIFF
--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -369,11 +369,14 @@ func (m *Test) GetHttp(ctx context.Context) (string, error) {
 				With(daggerExec("init", "--name=test", "--sdk=python")).
 				With(sdkSource("python", `
 import urllib.request
-from dagger import function
 
-@function
-def get_http() -> str:
-		return urllib.request.urlopen("https://server").read().decode("utf-8")
+import dagger
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def get_http(self) -> str:
+            return urllib.request.urlopen("https://server").read().decode("utf-8")
 `)).
 				With(daggerCall("get-http")).
 				Stdout(ctx)

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -1373,14 +1373,14 @@ func (PythonSuite) TestNameOverrides(ctx context.Context, t *testctx.T) {
 	modGen := pythonModInit(t, c, `
         from typing import Annotated
 
-        from dagger import Arg, field, function, object_type
+        from dagger import Name, field, function, object_type
 
         @object_type
         class Test:
             field_: str = field(name="field")
 
             @function(name="func")
-            def func_(self, arg_: Annotated[str, Arg(name="arg")] = "") -> str:
+            def func_(self, arg_: Annotated[str, Name(name="arg")] = "") -> str:
                 return ""
         `)
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -893,11 +893,13 @@ func (m *Use) UseHello(ctx context.Context) (string, error) {
 }
 `
 
-var usePythonOuter = `from dagger import dag, function
+var usePythonOuter = `import dagger
 
-@function
-def use_hello() -> str:
-    return dag.dep().hello()
+@dagger.object_type
+class Use:
+    @dagger.function
+    def use_hello(self) -> str:
+        return dag.dep().hello()
 `
 
 var useTSOuter = `
@@ -1113,14 +1115,16 @@ func (m *Use) Names(ctx context.Context) ([]string, error) {
 		},
 		{
 			sdk: "python",
-			source: `from dagger import dag, function
+			source: `import dagger
 
-@function
-async def names() -> list[str]:
-    return [
-        await dag.foo().name(),
-        await dag.bar().name(),
-    ]
+@dagger.object_type
+class Use:
+    @dagger.function
+    async def names(self) -> list[str]:
+        return [
+            await dag.foo().name(),
+            await dag.bar().name(),
+        ]
 `,
 		},
 		{
@@ -1754,14 +1758,17 @@ func (ModuleSuite) TestLotsOfFunctions(ctx context.Context, t *testctx.T) {
 	t.Run("python sdk", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
-		mainSrc := `from dagger import function
-		`
+		mainSrc := `import dagger
+
+@dagger.object_type
+class PotatoStack:
+`
 
 		for i := 0; i < funcCount; i++ {
 			mainSrc += fmt.Sprintf(`
-@function
-def potato_%d() -> str:
-    return "potato #%d"
+    @dagger.function
+    def potato_%d(self) -> str:
+        return "potato #%d"
 `, i, i)
 		}
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -894,6 +894,7 @@ func (m *Use) UseHello(ctx context.Context) (string, error) {
 `
 
 var usePythonOuter = `import dagger
+from dagger import dag
 
 @dagger.object_type
 class Use:
@@ -1116,6 +1117,7 @@ func (m *Use) Names(ctx context.Context) ([]string, error) {
 		{
 			sdk: "python",
 			source: `import dagger
+from dagger import dag
 
 @dagger.object_type
 class Use:
@@ -1761,7 +1763,7 @@ func (ModuleSuite) TestLotsOfFunctions(ctx context.Context, t *testctx.T) {
 		mainSrc := `import dagger
 
 @dagger.object_type
-class PotatoStack:
+class PotatoSack:
 `
 
 		for i := 0; i < funcCount; i++ {
@@ -1772,7 +1774,12 @@ class PotatoStack:
 `, i, i)
 		}
 
-		modGen := pythonModInit(t, c, mainSrc)
+		modGen := c.Container().
+			From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(sdkSource("python", mainSrc)).
+			With(daggerExec("init", "--source=.", "--name=potatoSack", "--sdk=python"))
 
 		var eg errgroup.Group
 		for i := 0; i < funcCount; i++ {

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -51,20 +51,23 @@ func (t *Repeater) Render() string {
 		},
 		{
 			sdk: "python",
-			source: `from dagger import field, function, object_type
+			source: `import dagger
 
-@object_type
+@dagger.object_type
 class Repeater:
     message: str = field(default="")
     times: int = field(default=0)
 
-    @function
+    @dagger.function
     def render(self) -> str:
         return self.message * self.times
 
-@function
-def repeater(msg: str, times: int) -> Repeater:
-    return Repeater(message=msg, times=times)
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def repeater(self, msg: str, times: int) -> Repeater:
+        return Repeater(message=msg, times=times)
 `,
 		},
 		{
@@ -140,15 +143,16 @@ func (m *Foo) MyFunction() X {
 		},
 		{
 			sdk: "python",
-			source: `from dagger import field, function, object_type
+			source: `import dagger
 
-@object_type
+@dagger.object_type
 class X:
     message: str = field(default="")
 
-@function
-def my_function() -> X:
-    return X(message="foo")
+class Test:
+    @dagger.function
+    def my_function(self) -> X:
+        return X(message="foo")
 `,
 		},
 		{

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -55,8 +55,8 @@ func (t *Repeater) Render() string {
 
 @dagger.object_type
 class Repeater:
-    message: str = field(default="")
-    times: int = field(default=0)
+    message: str = dagger.field(default="")
+    times: int = dagger.field(default=0)
 
     @dagger.function
     def render(self) -> str:
@@ -147,9 +147,10 @@ func (m *Foo) MyFunction() X {
 
 @dagger.object_type
 class X:
-    message: str = field(default="")
+    message: str = dagger.field(default="")
 
-class Test:
+@dagger.object_type
+class Foo:
     @dagger.function
     def my_function(self) -> X:
         return X(message="foo")

--- a/core/integration/testdata/modules/python/id/arg/main.py
+++ b/core/integration/testdata/modules/python/id/arg/main.py
@@ -1,8 +1,8 @@
-from typing import Annotated
-
-from dagger import Arg, function
+import dagger
 
 
-@function
-def fn(id_: Annotated[str, Arg("id")]) -> str:
-    return id_
+@dagger.object_type
+class Test:
+    @dagger.function
+    def fn(self, id_: str) -> str:
+        return id_

--- a/core/integration/testdata/modules/python/id/fn/main.py
+++ b/core/integration/testdata/modules/python/id/fn/main.py
@@ -1,6 +1,8 @@
-from dagger import function
+import dagger
 
 
-@function(name="id")
-def id_() -> str:
-    return "NOOOO!!!!"
+@dagger.object_type
+class Test:
+    @dagger.function
+    def id_(self) -> str:
+        return "NOOOO!!!!"

--- a/sdk/python/.changes/unreleased/Removed-20241014-154722.yaml
+++ b/sdk/python/.changes/unreleased/Removed-20241014-154722.yaml
@@ -1,0 +1,9 @@
+kind: Removed
+body: |-
+    Removed deprecated `Arg` and top-level functions
+
+    Use `Name` and object methods instead.
+time: 2024-10-14T15:47:22.763283Z
+custom:
+    Author: helderco
+    PR: "8708"

--- a/sdk/python/src/dagger/__init__.py
+++ b/sdk/python/src/dagger/__init__.py
@@ -26,7 +26,6 @@ from dagger._connection import connect as connect
 from dagger._connection import close as close
 
 # Modules.
-from dagger.mod import Arg as Arg
 from dagger.mod import DefaultPath as DefaultPath
 from dagger.mod import Doc as Doc
 from dagger.mod import Ignore as Ignore

--- a/sdk/python/src/dagger/mod/__init__.py
+++ b/sdk/python/src/dagger/mod/__init__.py
@@ -1,6 +1,5 @@
 from typing_extensions import Doc
 
-from dagger.mod._arguments import Arg
 from dagger.mod._arguments import DefaultPath
 from dagger.mod._arguments import Ignore
 from dagger.mod._arguments import Name
@@ -22,7 +21,6 @@ def default_module() -> Module:
 
 
 __all__ = [
-    "Arg",
     "DefaultPath",
     "Doc",  # Only re-exported because it's in `typing_extensions`.
     "Ignore",

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -1,8 +1,6 @@
 import dataclasses
 import inspect
 
-from typing_extensions import deprecated
-
 from dagger.mod._types import APIName, ContextPath
 
 
@@ -22,15 +20,6 @@ class Name:
 
     def __str__(self) -> str:
         return self.name
-
-
-@deprecated("Arg is deprecated, use Name instead.")
-class Arg(Name):
-    """An alternative name when exposing a function argument to the API.
-
-    .. deprecated::
-        Use :py:class:`Name` instead.
-    """
 
 
 @dataclasses.dataclass(slots=True, frozen=True)

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -15,7 +15,7 @@ class Name:
     Example usage::
 
         @function
-        def pull(from_: Annotated[str, Name("from")]): ...
+        def pull(self, from_: Annotated[str, Name("from")]): ...
     """
 
     name: APIName
@@ -46,7 +46,7 @@ class DefaultPath:
     Example usage::
 
         @function
-        def build(src: Annotated[dagger.Directory, DefaultPath("..")]): ...
+        def build(self, src: Annotated[dagger.Directory, DefaultPath("..")]): ...
     """
 
     from_context: ContextPath
@@ -68,7 +68,7 @@ class Ignore:
     Example usage::
 
         @function
-        def build(src: Annotated[dagger.Directory, Ignore([".venv"])]): ...
+        def build(self, src: Annotated[dagger.Directory, Ignore([".venv"])]): ...
     """
 
     patterns: list[str]

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -431,17 +431,19 @@ class Module:
 
         Example usage::
 
-            @function
-            def foo() -> str:
-                return "bar"
+            @object_type
+            class Foo:
+                @function
+                def bar(self) -> str:
+                    return "foobar"
 
 
         Parameters
         ----------
         func:
-            Should be a top-level function or instance method in a class
-            decorated with :py:meth:`object_type`. Can be an async function
-            or a class, to use it's constructor.
+            Should be an instance method in a class decorated with
+            :py:meth:`object_type`. Can be an async function or a class,
+            to use it's constructor.
         name:
             An alternative name for the API. Useful to avoid conflicts with
             reserved words.

--- a/sdk/python/tests/modules/test_registration.py
+++ b/sdk/python/tests/modules/test_registration.py
@@ -1,9 +1,6 @@
 from typing import cast
 
-import pytest
-
 from dagger.mod import Module
-from dagger.mod._exceptions import NameConflictError, UserError
 from dagger.mod._resolver import FunctionResolver
 
 
@@ -45,72 +42,14 @@ def test_object_type_resolvers():
     ]
 
 
-def test_no_main_object():
-    mod = Module()
-
-    @mod.object_type
-    class Bar:
-        @mod.function
-        def method(self): ...
-
-    with pytest.raises(UserError, match="doesn't define"):
-        mod.get_resolvers("foo")
-
-
-def test_toplevel_and_class_conflict():
+def test_func_doc():
     mod = Module()
 
     @mod.object_type
     class Foo:
         @mod.function
-        def method(self): ...
-
-    @mod.function
-    def func(): ...
-
-    with pytest.raises(NameConflictError, match="not both"):
-        mod.get_resolvers("foo")
-
-
-def test_resolver_name_conflict():
-    mod = Module()
-
-    @mod.function
-    def foo(): ...
-
-    @mod.function(name="foo")
-    def foo_(): ...
-
-    with pytest.raises(NameConflictError, match="“Foo.foo” is defined 2 times"):
-        mod.get_resolvers("foo")
-
-
-@pytest.mark.parametrize(
-    ("mod_name", "class_name"),
-    [
-        ("foo", "Foo"),
-        ("foo-bar", "FooBar"),
-        ("foo_bar", "FooBar"),
-        ("fooBar", "FooBar"),
-        ("FooBar", "FooBar"),
-    ],
-)
-def test_main_object_name(mod_name, class_name):
-    mod = Module()
-
-    @mod.function
-    def func(): ...
-
-    resolvers = mod.get_resolvers(mod_name)
-    assert next(iter(resolvers.keys())).name == class_name
-
-
-def test_func_doc():
-    mod = Module()
-
-    @mod.function
-    def fn_with_doc():
-        """Foo."""
+        def fn_with_doc(self):
+            """Foo."""
 
     r = get_resolver(mod, "Foo", "fn_with_doc")
 

--- a/sdk/python/tests/modules/test_results.py
+++ b/sdk/python/tests/modules/test_results.py
@@ -6,7 +6,7 @@ import pytest
 from typing_extensions import Self
 
 import dagger
-from dagger import Arg, Doc, dag
+from dagger import Doc, Name, dag
 from dagger.mod import Module
 from dagger.mod._exceptions import FatalError
 from dagger.mod._resolver import FunctionResolver
@@ -51,9 +51,11 @@ async def test_unstructure_structure():
         async def bar(self) -> str:
             return await self.ctr.with_exec(["echo", "-n", self.msg]).stdout()
 
-    @mod.function
-    def foo() -> Bar:
-        return Bar(ctr=dag.container().from_("alpine"))
+    @mod.object_type
+    class Foo:
+        @mod.function
+        def foo(self) -> Bar:
+            return Bar(ctr=dag.container().from_("alpine"))
 
     async with dagger.connection():
         resolver = mod.get_resolver(mod.get_resolvers("foo"), "Foo", "foo")
@@ -74,26 +76,41 @@ class TestNameOverrides:
 
         @_mod.object_type
         class Bar:
-            with_: str = _mod.field(name="with")
+            with_: str = _mod.field()
+            with_x: str = _mod.field(name="withx")
 
-        @_mod.function
-        def bar() -> Bar:
-            return Bar(with_="bar")
+        @_mod.object_type
+        class Foo:
+            @_mod.function
+            def bar(self) -> Bar:
+                return Bar(with_="bar", with_x="bax")
 
-        @_mod.function(name="import")
-        def import_(from_: Annotated[str, Arg("from")]) -> str:
-            return from_
+            @_mod.function
+            def import_(self, from_: str) -> str:
+                return from_
+
+            @_mod.function(name="importx")
+            def import_x(self, from_x: Annotated[str, Name("fromx")]) -> str:
+                return from_x
 
         return _mod
 
-    async def test_function_and_arg_name(self, mod: Module):
+    async def test_function_and_arg_name_default(self, mod: Module):
         assert await get_result(mod, "Foo", {}, "import", {"from": "egg"}) == "egg"
 
+    async def test_function_and_arg_name_custom(self, mod: Module):
+        assert await get_result(mod, "Foo", {}, "importx", {"fromx": "egg"}) == "egg"
+
     async def test_field_unstructure(self, mod: Module):
-        assert await get_result(mod, "Foo", {}, "bar", {}) == {"with": "bar"}
+        assert await get_result(mod, "Foo", {}, "bar", {}) == {
+            "with": "bar",
+            "withx": "bax",
+        }
 
     async def test_field_structure(self, mod: Module):
-        assert await get_result(mod, "Bar", {"with": "baz"}, "with", {}) == "baz"
+        state = {"with": "baz", "withx": "bat"}
+        assert await get_result(mod, "Bar", state, "with", {}) == "baz"
+        assert await get_result(mod, "Bar", state, "withx", {}) == "bat"
 
 
 async def test_method_returns_self():
@@ -288,7 +305,7 @@ class TestFunctionFromExternalConstructor:
             baz: int = _mod.field(default=144)
 
         @_mod.object_type
-        class Test:
+        class Foo:
             egg: str = _mod.field(default="chick")
 
             # TODO: Written as `function()(Bar)` to avoid Pyright false negative
@@ -300,19 +317,12 @@ class TestFunctionFromExternalConstructor:
             # create a `Test.bat() -> Bar` constructor function
             bat = _mod.function(name="bat")(Bar)
 
-        # create a `Foo.test() -> Test` constructor function
-        _mod.function(Test)
-
-        # creates a `Foo.tset() -> Test` constructor function
-        _mod.function(Test, name="tset")
-
         return _mod
 
     async def test_chain(self, mod: Module):
-        # Assert Foo.test().bar() -> Bar
+        # Assert Foo.bar() -> Bar
         chains = [
-            ("Foo", "test", {"egg": "chick"}),
-            ("Test", "bas", {"baz": 144}),
+            ("Foo", "bas", {"baz": 144}),
             ("Bar", "baz", 144),
         ]
         result = {}
@@ -321,10 +331,9 @@ class TestFunctionFromExternalConstructor:
             assert result == expected
 
     async def test_name_overrides_and_inputs(self, mod: Module):
-        # Assert Foo.tset(egg="hen").bat(baz=33) -> Bar
+        # Assert Foo.bat(baz=33) -> Bar
         chains = [
-            ("Foo", "tset", {"egg": "hen"}),
-            ("Test", "bat", {"baz": 33}),
+            ("Foo", "bat", {"baz": 33}),
             ("Bar", "baz", {}),
         ]
         result = {}
@@ -395,35 +404,6 @@ async def test_constructor_with_init_var():
     }
     with pytest.raises(FatalError):
         await get_result(mod, "Foo", {}, "bar", {})
-
-
-async def test_can_call_top_level_function():
-    mod = Module()
-
-    @mod.function
-    def foo(msg: str) -> str:
-        return bar(msg)
-
-    @mod.function
-    def bar(msg: str) -> str:
-        return msg
-
-    assert await get_result(mod, "Foo", {}, "foo", {"msg": "foobar"}) == "foobar"
-
-
-async def test_can_call_top_level_async_function():
-    mod = Module()
-
-    @mod.function
-    async def foo(msg: str) -> str:
-        return await bar(msg)
-
-    @mod.function
-    async def bar(msg: str) -> str:
-        return msg
-
-    assert await bar("rab") == "rab"
-    assert await get_result(mod, "Foo", {}, "foo", {"msg": "foobar"}) == "foobar"
 
 
 def test_exposed_field_not_in_constructor():


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8394

These were deprecated before v0.13, but haven't been removed yet:
- `Arg` was deprecated in [v0.12.5](https://github.com/dagger/dagger/releases/tag/sdk%2Fpython%2Fv0.12.5)
- Top-level functions were deprecated in [v0.12.4](https://github.com/dagger/dagger/releases/tag/sdk%2Fpython%2Fv0.12.4)

Besides, these features exist for a very long time but undocumented, so no user impact is expected.