### PR TITLE
fix(engine): isolate netnses so insecure-root-added iptables rules dont leak through the bk cni pool [DEV-4584]

### DIFF
--- a/core/integration/sequential_test.go
+++ b/core/integration/sequential_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/testctx"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// This suite contains tests that must run on their own. This comes with a heavy time penalty.
+// Add additional tests here only if strictly necessary, typical if verifying some type of isolation.
+type SequentialSuite struct{}
+
+func TestSequential(t *testing.T) {
+	testctx.Run(
+		testCtx,
+		t,
+		SequentialSuite{},
+		// omitting testctx.WithParallel middleware to get the desired sequential behavior
+		testctx.WithOTelLogging(Logger()),
+		testctx.WithOTelTracing(Tracer()),
+	)
+}
+
+func (SequentialSuite) TestInsecureRootNetNSIsolation(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	opts := dagger.ContainerWithExecOpts{InsecureRootCapabilities: true}
+	baseContainer := c.Container().
+		From("alpine:latest").
+		WithExec([]string{"apk", "add", "iputils", "iptables"}).
+		WithEnvVariable("CACHE_BUST", uuid.NewString())
+
+	listNATRules := func(ctr *dagger.Container) (string, error) {
+		return ctr.
+			WithExec([]string{"sh", "-c", "iptables -t nat -L -v -n"}, opts).
+			Stdout(ctx)
+	}
+
+	withoutRules, err := listNATRules(baseContainer)
+	require.NoError(t, err)
+	require.NotContains(t, withoutRules, "DNAT")
+	require.NotContains(t, withoutRules, "to:127.0.0.1")
+
+	// iptables rules should not persist to "child" contains - ideally we could clone+CoW, but buildkit makes this difficult.
+	withoutClonedRules, err := listNATRules(baseContainer.WithExec([]string{
+		"sh", "-c", "iptables -t nat -A PREROUTING -p tcp -j DNAT --to-destination 127.0.0.1",
+	}, opts))
+	require.NoError(t, err)
+	require.NotContains(t, withoutClonedRules, "DNAT")
+	require.NotContains(t, withoutClonedRules, "to:127.0.0.1")
+
+	withRules, err := baseContainer.WithExec([]string{
+		"sh", "-c", "iptables -t nat -A PREROUTING -p tcp -j DNAT --to-destination 127.0.0.1 > /dev/null && iptables -t nat -L -v -n",
+	}, opts).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, withRules, "DNAT")
+	require.Contains(t, withRules, "to:127.0.0.1")
+}

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -400,7 +400,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExec([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
-		WithHostname("wwwhatsup")
+		WithHostname("wwwhatsup0")
 	
 	_, err := srv.Start(ctx)
 	if err != nil {
@@ -409,7 +409,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 
 	resp, err := dag.Container().
 		From("`+busyboxImage+`").
-		WithExec([]string{"wget", "-O-", "http://wwwhatsup"}).
+		WithExec([]string{"wget", "-O-", "http://wwwhatsup0"}).
 		Stdout(ctx)
 	if err != nil {
 		return err
@@ -448,7 +448,7 @@ func (m *Caller) Run(ctx context.Context) error {
 	resp, err := dag.Container().
 		From("`+busyboxImage+`").
 		WithEnvVariable("NOW", time.Now().String()).
-		WithExec([]string{"wget", "-O-", "http://wwwhatsup"}).
+		WithExec([]string{"wget", "-O-", "http://wwwhatsup1"}).
 		Stdout(ctx)
 	if err == nil {
 		return fmt.Errorf("should not have been able to reach service")
@@ -461,7 +461,7 @@ func (m *Caller) Run(ctx context.Context) error {
 		WithExec([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
-		WithHostname("wwwhatsup")
+		WithHostname("wwwhatsup1")
 	
 	_, err = srv.Start(ctx)
 	if err != nil {
@@ -471,7 +471,7 @@ func (m *Caller) Run(ctx context.Context) error {
 	resp, err = dag.Container().
 		From("`+busyboxImage+`").
 		WithEnvVariable("NOW", time.Now().String()).
-		WithExec([]string{"wget", "-O-", "http://wwwhatsup"}).
+		WithExec([]string{"wget", "-O-", "http://wwwhatsup1"}).
 		Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to reach service: %w", err)
@@ -504,7 +504,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExec([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
-		WithHostname("wwwhatsup")
+		WithHostname("wwwhatsup1")
 	
 	_, err := srv.Start(ctx)
 	if err != nil {
@@ -519,7 +519,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 	resp, err := dag.Container().
 		From("`+busyboxImage+`").
 		WithEnvVariable("NOW", time.Now().String()).
-		WithExec([]string{"wget", "-O-", "http://wwwhatsup"}).
+		WithExec([]string{"wget", "-O-", "http://wwwhatsup1"}).
 		Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to reach service: %w", err)


### PR DESCRIPTION
attempt at fixing #8585. 

This PR sets a host name for every netns to avoid buildkits netns pooling, which leaks changes to netnses across the pool. This is only relevant to insecure privileged containers, but can lead to very unpredictable network behavior when users modify the network namespace. 

This fix does come with a perf hit, at least on macos. See below for benchmarks. The perf hit has been mitigated by only avoiding pooling for privileged containers.