### PR TITLE
feat(engine): ensure cache volumes are namespaced

### DIFF
--- a/.changes/unreleased/Changed-20250106-153156.yaml
+++ b/.changes/unreleased/Changed-20250106-153156.yaml
@@ -1,0 +1,7 @@
+kind: Changed
+body: |
+    CacheVolumes are now namespaced between different modules.
+time: 2025-01-06T15:31:56.693249098Z
+custom:
+    Author: rajatjindal
+    PR: "8724"

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -107,3 +107,226 @@ func (CacheSuite) TestLocalImportCacheReuse(ctx context.Context, t *testctx.T) {
 
 	require.Equal(t, out1, out2)
 }
+
+func (CacheSuite) TestCacheIsNamespaced(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	fooTmpl := `package main
+
+import (
+	"context"
+)
+
+type Foo struct{}
+
+func (f *Foo) GetCacheVolumeId(ctx context.Context) (string, error) {
+	id, err := dag.CacheVolume("volume-name").ID(ctx)
+	return string(id), err
+}
+`
+	barTmpl := `package main
+
+import (
+	"context"
+)
+
+type Bar struct{}
+
+func (b *Bar) GetCacheVolumeId(ctx context.Context) (string, error) {
+	id, err := dag.CacheVolume("volume-name").ID(ctx)
+	return string(id), err
+}
+`
+	ctr := c.Container().
+		From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work/bar").
+		With(daggerExec("init", "--name=bar", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", barTmpl).
+		WithWorkdir("/work/foo").
+		With(daggerExec("init", "--name=foo", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", fooTmpl)
+
+	fooID, err := ctr.
+		WithWorkdir("/work/foo").
+		With(daggerExec("call", "get-cache-volume-id")).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	barID, err := ctr.
+		WithWorkdir("/work/bar").
+		With(daggerExec("call", "get-cache-volume-id")).
+		Stdout(ctx)
+
+	require.NoError(t, err)
+	require.NotEqual(t, fooID, barID)
+}
+
+func (CacheSuite) TestCacheIdSameAcrossSession(ctx context.Context, t *testctx.T) {
+	session1 := connect(ctx, t)
+
+	fooTmpl := `package main
+	import (
+		"context"
+	)
+
+	type Foo struct {}
+	func (f *Foo) GetCacheVolumeId(ctx context.Context) (string, error) {
+		id, err := dag.CacheVolume("volume-name").ID(ctx)
+		return string(id), err
+	}
+	`
+
+	ctr1 := session1.Container().
+		From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, session1)).
+		WithWorkdir("/work/foo").
+		With(daggerExec("init", "--name=foo", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", fooTmpl)
+
+	fooID, err := ctr1.
+		WithWorkdir("/work/foo").
+		With(daggerExec("call", "get-cache-volume-id")).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	session2 := connect(ctx, t)
+	ctr2 := session2.Container().
+		From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, session2)).
+		WithWorkdir("/work/foo").
+		With(daggerExec("init", "--name=foo", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", fooTmpl)
+
+	fooID2, err := ctr2.
+		WithWorkdir("/work/foo").
+		With(daggerExec("call", "get-cache-volume-id")).
+		Stdout(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, fooID, fooID2)
+}
+
+func (CacheSuite) TestCacheVolumePassedAcrossModules(ctx context.Context, t *testctx.T) {
+	session := connect(ctx, t)
+
+	fooTmpl := `package main
+
+import (
+	"context"
+	"dagger/foo/internal/dagger"
+	"fmt"
+)
+
+type Foo struct{}
+
+func (f *Foo) Populate(ctx context.Context, input string) (*dagger.Container, error) {
+	return dag.Container().
+		From("alpine").
+		WithMountedCache("/tmp-cache-mount", dag.CacheVolume("cache-name")).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("echo '%s' > /tmp-cache-mount/input.txt", input)}).
+		Sync(ctx)
+}
+
+func (f *Foo) Fetch(ctx context.Context) (string, error) {
+	cache := dag.CacheVolume("cache-name")
+	return dag.Bar().Fetch(ctx, cache)
+}
+`
+
+	barTmpl := `package main
+
+import (
+	"context"
+	"dagger/bar/internal/dagger"
+)
+
+type Bar struct{}
+
+func (f *Bar) Fetch(ctx context.Context, vol *dagger.CacheVolume) (string, error) {
+	return dag.Container().
+		From("alpine").
+		WithMountedCache("/tmp-cache-mount-bar", vol).
+		WithExec([]string{"sh", "-c", "cat /tmp-cache-mount-bar/input.txt"}).
+		Stdout(ctx)
+}
+`
+
+	ctr := session.Container().
+		From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, session)).
+		WithWorkdir("/work/bar").
+		With(daggerExec("init", "--name=bar", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", barTmpl).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=foo", "--source=.", "--sdk=go")).
+		WithNewFile("main.go", fooTmpl).
+		With(daggerExec("use", "./bar"))
+
+	inpContent := "some-foo-bar-content"
+	_, err := ctr.
+		WithWorkdir("/work").
+		With(daggerExec("call", "populate", "--input", inpContent)).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	fetchedFromCache, err := ctr.
+		WithWorkdir("/work").
+		With(daggerExec("call", "fetch")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, inpContent, strings.TrimSpace(fetchedFromCache))
+}
+
+func (CacheSuite) TestCacheNotImpactedByChangeInModuleSource(ctx context.Context, t *testctx.T) {
+	session := connect(ctx, t)
+
+	fooTmpl := `package main
+	import (
+		"context"
+	)
+
+	type Foo struct {}
+	func (f *Foo) UseCacheVolume(ctx context.Context) (string, error) {
+		id, err := dag.CacheVolume("cache-name").ID(ctx)
+		return string(id), err
+	}
+	`
+
+	barTmpl := `package main
+	import (
+		"context"
+	)
+
+	type Foo struct {}
+	func (f *Foo) UseCacheVolume(ctx context.Context) (string, error) {
+		id, err := dag.CacheVolume("cache-name").ID(ctx)
+		return string(id), err
+	}
+
+	func (f *Foo) PassCacheVolume(ctx context.Context) (string, error) {
+		return f.UseCacheVolume(ctx)
+	}
+	`
+
+	ctr := session.Container().
+		From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, session)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=foo", "--source=.", "--sdk=go"))
+
+	fooID, err := ctr.
+		WithWorkdir("/work").
+		WithNewFile("main.go", fooTmpl).
+		With(daggerExec("call", "use-cache-volume")).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	fooID2, err := ctr.WithWorkdir("/work").
+		WithNewFile("main.go", barTmpl).
+		With(daggerExec("call", "use-cache-volume")).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, fooID, fooID2)
+}

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
@@ -19,8 +20,9 @@ func (s *cacheSchema) Name() string {
 
 func (s *cacheSchema) Install() {
 	dagql.Fields[*core.Query]{
-		dagql.Func("cacheVolume", s.cacheVolume).
+		dagql.NodeFunc("cacheVolume", s.cacheVolume).
 			Doc("Constructs a cache volume for a given cache key.").
+			Impure("cache volume should be namespaced").
 			ArgDoc("key", `A string identifier to target this cache volume (e.g., "modules-cache").`),
 	}.Install(s.srv)
 
@@ -32,13 +34,59 @@ func (s *cacheSchema) Dependencies() []SchemaResolvers {
 }
 
 type cacheArgs struct {
-	Key string
+	Key       string
+	Namespace string `default:""`
 }
 
-func (s *cacheSchema) cacheVolume(ctx context.Context, parent *core.Query, args cacheArgs) (*core.CacheVolume, error) {
-	// TODO(vito): inject some sort of scope/session/project/user derived value
-	// here instead of a static value
-	//
-	// we have to inject something so we can tell it's a valid ID
-	return core.NewCache(args.Key), nil
+func (s *cacheSchema) cacheVolume(ctx context.Context, parent dagql.Instance[*core.Query], args cacheArgs) (dagql.Instance[*core.CacheVolume], error) {
+	var inst dagql.Instance[*core.CacheVolume]
+
+	if args.Namespace != "" {
+		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, core.NewCache(args.Namespace+":"+args.Key))
+	}
+
+	m, err := parent.Self.Server.CurrentModule(ctx)
+	if err != nil && !errors.Is(err, core.ErrNoCurrentModule) {
+		return inst, err
+	}
+
+	namespaceKey := ""
+	if m != nil {
+		name, err := m.Source.Self.ModuleName(ctx)
+		if err != nil {
+			return inst, err
+		}
+
+		symbolic, err := m.Source.Self.Symbolic()
+		if err != nil {
+			return inst, err
+		}
+
+		namespaceKey = name + symbolic
+	}
+
+	// if no namespace key, just return the NewCache based on key
+	if namespaceKey == "" {
+		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, core.NewCache(args.Key))
+	}
+
+	err = s.srv.Select(ctx, s.srv.Root(), &inst, dagql.Selector{
+		Field: "cacheVolume",
+		Pure:  true,
+		Args: []dagql.NamedInput{
+			{
+				Name:  "namespace",
+				Value: dagql.NewString(namespaceKey),
+			},
+			{
+				Name:  "key",
+				Value: dagql.NewString(args.Key),
+			},
+		},
+	})
+	if err != nil {
+		return inst, err
+	}
+
+	return inst, nil
 }

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -901,7 +901,8 @@ func (sel Selector) AppendTo(id *call.ID, spec FieldSpec) *call.ID {
 	if sel.Nth != 0 {
 		astType = astType.Elem
 	}
-	return id.Append(
+
+	idx := id.Append(
 		astType,
 		sel.Field,
 		sel.View,
@@ -910,6 +911,8 @@ func (sel Selector) AppendTo(id *call.ID, spec FieldSpec) *call.ID {
 		sel.Nth,
 		idArgs...,
 	)
+
+	return idx
 }
 
 type Inputs []NamedInput

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2622,6 +2622,7 @@ type Query {
     A string identifier to target this cache volume (e.g., "modules-cache").
     """
     key: String!
+    namespace: String = ""
   ): CacheVolume!
 
   """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -352,6 +352,12 @@
                         </td>
                         <td> A string identifier to target this cache volume (e.g., "modules-cache"). </td>
                       </tr>
+                      <tr>
+                        <td>
+                          <span class="property-name"><code>namespace</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                        </td>
+                        <td> Default = <code>""</code> </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -34,10 +34,13 @@ defmodule Dagger.Client do
   end
 
   @doc "Constructs a cache volume for a given cache key."
-  @spec cache_volume(t(), String.t()) :: Dagger.CacheVolume.t()
-  def cache_volume(%__MODULE__{} = client, key) do
+  @spec cache_volume(t(), String.t(), [{:namespace, String.t() | nil}]) :: Dagger.CacheVolume.t()
+  def cache_volume(%__MODULE__{} = client, key, optional_args \\ []) do
     query_builder =
-      client.query_builder |> QB.select("cacheVolume") |> QB.put_arg("key", key)
+      client.query_builder
+      |> QB.select("cacheVolume")
+      |> QB.put_arg("key", key)
+      |> QB.maybe_put_arg("namespace", optional_args[:namespace])
 
     %Dagger.CacheVolume{
       query_builder: query_builder,

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -53,9 +53,9 @@ func BuiltinContainer(digest string) *dagger.Container {
 }
 
 // Constructs a cache volume for a given cache key.
-func CacheVolume(key string) *dagger.CacheVolume {
+func CacheVolume(key string, opts ...dagger.CacheVolumeOpts) *dagger.CacheVolume {
 	client := initClient()
-	return client.CacheVolume(key)
+	return client.CacheVolume(key, opts...)
 }
 
 // Creates a scratch container.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6783,9 +6783,20 @@ func (r *Client) BuiltinContainer(digest string) *Container {
 	}
 }
 
+// CacheVolumeOpts contains options for Client.CacheVolume
+type CacheVolumeOpts struct {
+	Namespace string
+}
+
 // Constructs a cache volume for a given cache key.
-func (r *Client) CacheVolume(key string) *CacheVolume {
+func (r *Client) CacheVolume(key string, opts ...CacheVolumeOpts) *CacheVolume {
 	q := r.query.Select("cacheVolume")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `namespace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Namespace) {
+			q = q.Arg("namespace", opts[i].Namespace)
+		}
+	}
 	q = q.Arg("key", key)
 
 	return &CacheVolume{

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -36,10 +36,13 @@ class Client extends Client\AbstractClient
     /**
      * Constructs a cache volume for a given cache key.
      */
-    public function cacheVolume(string $key): CacheVolume
+    public function cacheVolume(string $key, ?string $namespace = ''): CacheVolume
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('cacheVolume');
         $innerQueryBuilder->setArgument('key', $key);
+        if (null !== $namespace) {
+        $innerQueryBuilder->setArgument('namespace', $namespace);
+        }
         return new \Dagger\CacheVolume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6888,7 +6888,12 @@ class Client(Root):
         _ctx = self._select("builtinContainer", _args)
         return Container(_ctx)
 
-    def cache_volume(self, key: str) -> CacheVolume:
+    def cache_volume(
+        self,
+        key: str,
+        *,
+        namespace: str | None = "",
+    ) -> CacheVolume:
         """Constructs a cache volume for a given cache key.
 
         Parameters
@@ -6896,9 +6901,11 @@ class Client(Root):
         key:
             A string identifier to target this cache volume (e.g., "modules-
             cache").
+        namespace:
         """
         _args = [
             Arg("key", key),
+            Arg("namespace", namespace, ""),
         ]
         _ctx = self._select("cacheVolume", _args)
         return CacheVolume(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6855,6 +6855,11 @@ pub struct Query {
     pub graphql_client: DynGraphQLClient,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct QueryCacheVolumeOpts<'a> {
+    #[builder(setter(into, strip_option), default)]
+    pub namespace: Option<&'a str>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct QueryContainerOpts {
     /// Platform to initialize the container with.
     #[builder(setter(into, strip_option), default)]
@@ -6938,9 +6943,32 @@ impl Query {
     /// # Arguments
     ///
     /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
         query = query.arg("key", key.into());
+        CacheVolume {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Constructs a cache volume for a given cache key.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn cache_volume_opts<'a>(
+        &self,
+        key: impl Into<String>,
+        opts: QueryCacheVolumeOpts<'a>,
+    ) -> CacheVolume {
+        let mut query = self.selection.select("cacheVolume");
+        query = query.arg("key", key.into());
+        if let Some(namespace) = opts.namespace {
+            query = query.arg("namespace", namespace);
+        }
         CacheVolume {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1101,6 +1101,10 @@ export type PortForward = {
  */
 export type PortID = string & { __PortID: never }
 
+export type ClientCacheVolumeOpts = {
+  namespace?: string
+}
+
 export type ClientContainerOpts = {
   /**
    * Platform to initialize the container with.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6659,8 +6659,8 @@ export class Client extends BaseClient {
    * Constructs a cache volume for a given cache key.
    * @param key A string identifier to target this cache volume (e.g., "modules-cache").
    */
-  cacheVolume = (key: string): CacheVolume => {
-    const ctx = this._ctx.select("cacheVolume", { key })
+  cacheVolume = (key: string, opts?: ClientCacheVolumeOpts): CacheVolume => {
+    const ctx = this._ctx.select("cacheVolume", { key, ...opts })
     return new CacheVolume(ctx)
   }
 


### PR DESCRIPTION
fixes #7211 

This PR namespaces the cache volumes so that across the modules they have different keys. 