### PR TITLE
ci: allow to share engine cache across dev calls

### DIFF
--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -130,19 +130,23 @@ func (e *Engine) Service(
 	image *Distro,
 	// +optional
 	gpuSupport bool,
+	// +optional
+	sharedCache bool,
 ) (*dagger.Service, error) {
-	version, err := dag.Version().Version(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var cacheVolumeName string
-	if version != "" {
-		cacheVolumeName = "dagger-dev-engine-state-" + version
-	} else {
-		cacheVolumeName = "dagger-dev-engine-state-" + identity.NewID()
-	}
-	if name != "" {
-		cacheVolumeName += "-" + name
+	cacheVolumeName := "dagger-dev-engine-state"
+	if !sharedCache {
+		version, err := dag.Version().Version(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if version != "" {
+			cacheVolumeName = "dagger-dev-engine-state-" + version
+		} else {
+			cacheVolumeName = "dagger-dev-engine-state-" + identity.NewID()
+		}
+		if name != "" {
+			cacheVolumeName += "-" + name
+		}
 	}
 
 	e = e.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -236,12 +236,15 @@ func (dev *DaggerDev) Dev(
 	// Enable experimental GPU support
 	// +optional
 	gpuSupport bool,
+	// Share cache globally
+	// +optional
+	sharedCache bool,
 ) (*dagger.Container, error) {
 	if target == nil {
 		target = dag.Directory()
 	}
 
-	svc, err := dev.Engine().Service(ctx, "", image, gpuSupport)
+	svc, err := dev.Engine().Service(ctx, "", image, gpuSupport, sharedCache)
 	if err != nil {
 		return nil, err
 	}

--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -60,7 +60,7 @@ func (sdk *SDK) allSDKs() []sdkBase {
 }
 
 func (dev *DaggerDev) installer(ctx context.Context, name string) (func(*dagger.Container) *dagger.Container, error) {
-	engineSvc, err := dev.Engine().Service(ctx, name, nil, false)
+	engineSvc, err := dev.Engine().Service(ctx, name, nil, false, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows sharing the engine cache locally across `dagger call dev`
calls which results quite convenient when testing different engine
versions

i.e `dagger -m github.com/dagger/dagger@pull/8728/head call dev --shared-cache terminal`

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
