### PR TITLE
engine: cache internal sdk constructor calls

### DIFF
--- a/.changes/unreleased/Fixed-20241018-124913.yaml
+++ b/.changes/unreleased/Fixed-20241018-124913.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  Speed up fully cached initialize time by caching more internal SDK operations.
+
+  Dagger wasn't caching as many SDK operations as it could. With this change Dagger's own CI modules initialize ~1s faster when fully cached.
+time: 2024-10-18T12:49:13.053522292-07:00
+custom:
+  Author: sipsma
+  PR: "8735"

--- a/core/object.go
+++ b/core/object.go
@@ -341,6 +341,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 				Inputs:       callInput,
 				ParentTyped:  nil,
 				ParentFields: nil,
+				Cache:        dagql.IsInternal(ctx),
 				Server:       dag,
 			})
 		},

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -204,6 +204,7 @@ func (s *moduleSchema) newModuleSDK(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cache for sdk module %s: %w", sdkModMeta.Self.Name(), err)
 	}
+	dag.Around(core.AroundFunc)
 
 	if err := sdkModMeta.Self.Install(ctx, dag); err != nil {
 		return nil, fmt.Errorf("failed to install sdk module %s: %w", sdkModMeta.Self.Name(), err)


### PR DESCRIPTION
Spending today looking into why `initialize` is so slow. Starting out with why it takes multiple seconds in our CI even when everything is completely cached.

Two quick fixes here:
* We weren't even getting telemetry for SDK module calls, now we do
* We weren't caching SDK constructor calls, now we do

Tested by running `dagger -m 'github.com/dagger/dagger@1adf268ec84693f6543d291083ee8b856a277be5' functions` repeatedly and seeing how long `initialize` took when everything was cached and no local changes were present:
* Before: 2.3s - 2.6s
* After: 1.5s - 1.9s

So an improvement of ~1s. This is obviously not life-changing yet, but these marginal improvements should stack up.
* Next up is to figure out why resolving some images that are cached and pinned by SHA involves network requests and is adding another ~1s of overhead. Will keep that in a separate PR.