### PR TITLE
engine: optimize+stabilize container.From with digests

### DIFF
--- a/.changes/unreleased/Fixed-20241018-153744.yaml
+++ b/.changes/unreleased/Fixed-20241018-153744.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: |-
+  Optimize container.From for image refs with digests.
+
+  Previously, if container.From was given an image ref with a digest and that image already existed in the local cache, the engine would still waste time resolving metadata over the network from the registry.
+
+  Now, if a digested image ref already exists locally, the network requests are skipped entirely.
+time: 2024-10-18T15:37:44.578042988-07:00
+custom:
+  Author: sipsma
+  PR: "8736"

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -50,7 +53,7 @@ func (s *containerSchema) Install() {
 			ArgDoc("description", "Description of the sub-pipeline.").
 			ArgDoc("labels", "Labels to apply to the sub-pipeline."),
 
-		dagql.Func("from", s.from).
+		dagql.NodeFunc("from", s.from).
 			Doc(`Initializes this container from a pulled base image.`).
 			ArgDoc("address",
 				`Image's address from its registry.`,
@@ -715,8 +718,64 @@ type containerFromArgs struct {
 	Address string
 }
 
-func (s *containerSchema) from(ctx context.Context, parent *core.Container, args containerFromArgs) (*core.Container, error) {
-	return parent.From(ctx, args.Address)
+func (s *containerSchema) from(ctx context.Context, parent dagql.Instance[*core.Container], args containerFromArgs) (inst dagql.Instance[*core.Container], _ error) {
+	bk, err := parent.Self.Query.Buildkit(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	platform := parent.Self.Platform
+
+	refName, err := reference.ParseNormalizedNamed(args.Address)
+	if err != nil {
+		return inst, fmt.Errorf("failed to parse image address %s: %w", args.Address, err)
+	}
+	// add a default :latest if no tag or digest, otherwise this is a no-op
+	refName = reference.TagNameOnly(refName)
+
+	if refName, isCanonical := refName.(reference.Canonical); isCanonical {
+		ctr, err := parent.Self.FromCanonical(ctx, refName)
+		if err != nil {
+			return inst, err
+		}
+
+		return dagql.Instance[*core.Container]{
+			Constructor: dagql.CurrentID(ctx),
+			Self:        ctr,
+			Class:       parent.Class,
+			Module:      parent.Module,
+		}, nil
+	}
+
+	// Doesn't have a digest, resolve that now and re-call this field using the canonical
+	// digested ref instead. This ensures the ID returned here is always stable w/ the
+	// digested image ref.
+	_, digest, _, err := bk.ResolveImageConfig(ctx, refName.String(), sourceresolver.Opt{
+		Platform: ptr(platform.Spec()),
+		ImageOpt: &sourceresolver.ResolveImageOpt{
+			ResolveMode: llb.ResolveModeDefault.String(),
+		},
+	})
+	if err != nil {
+		return inst, fmt.Errorf("failed to resolve image %s: %w", refName.String(), err)
+	}
+	refName, err = reference.WithDigest(refName, digest)
+	if err != nil {
+		return inst, fmt.Errorf("failed to set digest on image %s: %w", refName.String(), err)
+	}
+
+	err = s.srv.Select(ctx, parent, &inst,
+		dagql.Selector{
+			Field: "from",
+			Args: []dagql.NamedInput{
+				{Name: "address", Value: dagql.String(refName.String())},
+			},
+		},
+	)
+	if err != nil {
+		return inst, err
+	}
+
+	return inst, nil
 }
 
 type containerBuildArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -733,17 +733,12 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.Instance[*core.
 	refName = reference.TagNameOnly(refName)
 
 	if refName, isCanonical := refName.(reference.Canonical); isCanonical {
-		ctr, err := parent.Self.FromCanonical(ctx, refName)
+		ctr, err := parent.Self.FromCanonicalRef(ctx, refName, nil)
 		if err != nil {
 			return inst, err
 		}
 
-		return dagql.Instance[*core.Container]{
-			Constructor: dagql.CurrentID(ctx),
-			Self:        ctr,
-			Class:       parent.Class,
-			Module:      parent.Module,
-		}, nil
+		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, ctr)
 	}
 
 	// Doesn't have a digest, resolve that now and re-call this field using the canonical

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -102,3 +102,7 @@ func (maxVersion BeforeVersion) Contains(version string) bool {
 	}
 	return semver.Compare(version, string(maxVersion)) < 0
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -176,7 +176,7 @@ func (dir *Directory) Terminal(
 		if err != nil {
 			return fmt.Errorf("failed to create terminal container: %w", err)
 		}
-		ctr, err = ctr.From(ctx, defaultTerminalImage)
+		ctr, err = ctr.FromRefString(ctx, defaultTerminalImage)
 		if err != nil {
 			return fmt.Errorf("failed to create terminal container: %w", err)
 		}


### PR DESCRIPTION
There's two interrelated improvements here.

---

First, before this change we were always making network requests for image metadata even in the case where the image ref had a digest (and was thus immutable) *and* the image was already cached locally.

That was wasteful since there's no need to query registries for metadata on immutable images we already have locally.

That's fixed by using the "PreferLocal" resolve mode on images with a digest, which tells buildkit to check the local cache before checking a registry.

---

Second, before this change even though we always resolved image ref digests (if they didn't already have one), the actual ID for container.From still included the unresolved image ref the user provided. That had some subtle but significant side effects.

For example, while running the `initialize` step of our CI module repeatedly, you'd often see a few hundred milliseconds spent repeatedly resolving a `uv` image (used by the python sdk module), especially if you waited a little bit between runs.

The reason was that the Python SDK didn't provide a digest for that image ref, so after the cached resolve timed out we'd resend requests for its metadata. This was especially unfortunate+unnecessary since the SDK functions are all cached. Even though the function never ran, the engine still found the unresolved image ref in the returned IDs and thus triggered network requests to resolve the image ref's digest.

The change here modifies container.From to still resolve image ref digests *but* now the returned ID includes that resolved ref rather than the unresolved one the user provided.

This results in the cached results of the Python SDK including that digest in the ID and thus saving us from having to re-resolve it when that SDK call was cached.

More generally, I think this behavior makes us more reproducible. E.g. when we enable general function caching we'll avoid this problem and ensure that cached return values of functions always point to the precise same image as when the value was originally cached.

---

Overall, when testing locally I can see in traces that this trims a few 100ms from spans, but the overall runtime is about the same since those resolves currently happen in parallel with other steps.

However, any future tweaks to our CI module could shuffle steps around such that this resolution actually would have extended the runtime of initialize, so we are now protected against that.

Additionally, I'm on gigabit connection at home. Anyone with more network latency (especially the "airplane wifi" type cases) will likely benefit from this quite a bit more noticeably.