### PR TITLE
engine: split module initialize into more spans

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -841,6 +841,9 @@ func (s *moduleSchema) updateDeps(
 	modCfg *modules.ModuleConfig,
 	src dagql.Instance[*core.ModuleSource],
 ) error {
+	ctx, span := core.Tracer(ctx).Start(ctx, "initialize dependencies")
+	defer span.End()
+
 	var deps []dagql.Instance[*core.ModuleDependency]
 	err := s.dag.Select(ctx, src, &deps, dagql.Selector{Field: "dependencies"})
 	if err != nil {
@@ -959,6 +962,9 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 	mod *core.Module,
 	src dagql.Instance[*core.ModuleSource],
 ) error {
+	ctx, span := core.Tracer(ctx).Start(ctx, "build module")
+	defer span.End()
+
 	if mod.NameField == "" || mod.SDKConfig == "" {
 		// can't codegen yet
 		return nil

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -477,6 +477,26 @@ func (sdk *goSDK) Runtime(
 				},
 			},
 		},
+		// remove shared cache mounts from final container so module code can't
+		// do weird things with them like IPC, etc.
+		dagql.Selector{
+			Field: "withoutMount",
+			Args: []dagql.NamedInput{
+				{
+					Name:  "path",
+					Value: dagql.String("/go/pkg/mod"),
+				},
+			},
+		},
+		dagql.Selector{
+			Field: "withoutMount",
+			Args: []dagql.NamedInput{
+				{
+					Name:  "path",
+					Value: dagql.String("/root/.cache/go-build"),
+				},
+			},
+		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to exec go build in go module sdk container runtime: %w", err)
 	}


### PR DESCRIPTION
Been getting a better understanding of why initialize is slow in the uncached and partially cached cases. The fixes are a bit more involved than the other quick fixes today so still WIP. Just sending out a few easily separable fixes from that effort in the meantime.

Main change to split initialize up into more subspans, which makes it much much easier to tell what the hell is going on in the initialization timing in the trace UIs.

Other one is just a fix for something misc I noticed while working on the go sdk: we have been leaving shared cache mounts in the final runtime container, so all Go functions have been capable of doing IPC with each other across sessions 😄 Super obscure but worth fixing.