### PR TITLE
feat(cli): add dagger uninstall command

### DIFF
--- a/.changes/unreleased/Added-20241026-123323.yaml
+++ b/.changes/unreleased/Added-20241026-123323.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: added dagger uninstall command to remove a dependency
+time: 2024-10-26T12:33:23.212344+05:30
+custom:
+    Author: rajatjindal
+    PR: "8745"

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -87,6 +87,7 @@ func init() {
 		configCmd,
 		moduleInitCmd,
 		moduleInstallCmd,
+		moduleUnInstallCmd,
 		moduleDevelopCmd,
 		modulePublishCmd,
 		funcListCmd,

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -65,12 +65,13 @@ type ModuleSource struct {
 	AsGitSource dagql.Nullable[*GitModuleSource] `field:"true" doc:"If the source is a of kind git, the git source representation of it."`
 
 	// Settings that can be used to initialize or override the source's configuration
-	WithName          string
-	WithDependencies  []dagql.Instance[*ModuleDependency]
-	WithSDK           string
-	WithInitConfig    *ModuleInitConfig
-	WithSourceSubpath string
-	WithViews         []*ModuleSourceView
+	WithName            string
+	WithDependencies    []dagql.Instance[*ModuleDependency]
+	WithoutDependencies []string
+	WithSDK             string
+	WithInitConfig      *ModuleInitConfig
+	WithSourceSubpath   string
+	WithViews           []*ModuleSourceView
 }
 
 func (src *ModuleSource) Type() *ast.Type {

--- a/core/schema/git_test.go
+++ b/core/schema/git_test.go
@@ -23,6 +23,9 @@ func TestMatchVersion(t *testing.T) {
 
 	_, err = matchVersion(vers, "v2.0.1", "/")
 	require.Error(t, err)
+
+	_, err = matchVersion([]string{"hello/v0.3.0"}, "v0.3.0", "/hello")
+	require.NoError(t, err)
 }
 
 func TestIsSemver(t *testing.T) {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -129,11 +129,15 @@ func (s *moduleSchema) Install() {
 			ArgDoc("name", `The name to set.`),
 
 		dagql.NodeFunc("dependencies", s.moduleSourceDependencies).
-			Doc(`The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.`),
+			Doc(`The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.`),
 
 		dagql.Func("withDependencies", s.moduleSourceWithDependencies).
 			Doc(`Append the provided dependencies to the module source's dependency list.`).
 			ArgDoc("dependencies", `The dependencies to append.`),
+
+		dagql.Func("withoutDependencies", s.moduleSourceWithoutDependencies).
+			Doc(`Remove the provided dependencies from the module source's dependency list.`).
+			ArgDoc("dependencies", `The dependencies to remove.`),
 
 		dagql.Func("withSDK", s.moduleSourceWithSDK).
 			Doc(`Update the module source with a new SDK.`).
@@ -931,6 +935,7 @@ func (s *moduleSchema) updateDeps(
 	if err != nil {
 		return fmt.Errorf("failed to load module dependencies: %w", err)
 	}
+
 	mod.DependencyConfig = make([]*core.ModuleDependency, len(deps))
 	for i, dep := range deps {
 		// verify that the dependency config actually exists

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -36,6 +36,7 @@ A tool to run CI/CD pipelines in containers, anywhere
 * [dagger logout](#dagger-logout)	 - Log out from Dagger Cloud
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
 * [dagger run](#dagger-run)	 - Run a command in a Dagger session
+* [dagger uninstall](#dagger-uninstall)	 - Uninstall a dependency
 * [dagger version](#dagger-version)	 - Print dagger version
 
 ## dagger call
@@ -491,6 +492,42 @@ dagger run python main.py
 ```
       --cleanup-timeout duration   max duration to wait between SIGTERM and SIGKILL on interrupt (default 10s)
       --focus                      Only show output for focused commands.
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+  -E, --no-exit                      Leave the TUI running after completion
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+
+## dagger uninstall
+
+Uninstall a dependency
+
+### Synopsis
+
+Uninstall module as a dependency from the current module. The target module must be local.
+
+```
+dagger uninstall [options] <module>
+```
+
+### Examples
+
+```
+dagger uninstall hello
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2287,8 +2287,7 @@ type ModuleSource {
   contextDirectory: Directory!
 
   """
-  The dependencies of the module source. Includes dependencies from the
-  configuration and any extras from withDependencies calls.
+  The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.
   """
   dependencies: [ModuleDependency!]!
 
@@ -2402,6 +2401,14 @@ type ModuleSource {
   withName(
     """The name to set."""
     name: String!
+  ): ModuleSource!
+
+  """
+  Remove the provided dependencies from the module source's dependency list.
+  """
+  withoutDependencies(
+    """The dependencies to remove."""
+    dependencies: [String!]!
   ): ModuleSource!
 
   """Update the module source with a new SDK."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8072,7 +8072,7 @@
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-dependencies" href="#ModuleSource-dependencies"><code>dependencies</code></a> - <span class="property-type"><a href="#definition-ModuleDependency"><code>[ModuleDependency!]!</code></a></span> </td>
-                        <td> The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls. </td>
+                        <td> The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies. </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-digest" href="#ModuleSource-digest"><code>digest</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
@@ -8253,6 +8253,23 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>The name to set.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-withoutDependencies" href="#ModuleSource-withoutDependencies"><code>withoutDependencies</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Remove the provided dependencies from the module source's dependency list. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>dependencies</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
+                                <p>The dependencies to remove.</p>
                               </div>
                             </div>
                           </div>

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -79,7 +79,7 @@ defmodule Dagger.ModuleSource do
     }
   end
 
-  @doc "The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls."
+  @doc "The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies."
   @spec dependencies(t()) :: {:ok, [Dagger.ModuleDependency.t()]} | {:error, term()}
   def dependencies(%__MODULE__{} = module_source) do
     query_builder =
@@ -349,6 +349,20 @@ defmodule Dagger.ModuleSource do
       |> QB.select("withView")
       |> QB.put_arg("name", name)
       |> QB.put_arg("patterns", patterns)
+
+    %Dagger.ModuleSource{
+      query_builder: query_builder,
+      client: module_source.client
+    }
+  end
+
+  @doc "Remove the provided dependencies from the module source's dependency list."
+  @spec without_dependencies(t(), [String.t()]) :: Dagger.ModuleSource.t()
+  def without_dependencies(%__MODULE__{} = module_source, dependencies) do
+    query_builder =
+      module_source.query_builder
+      |> QB.select("withoutDependencies")
+      |> QB.put_arg("dependencies", dependencies)
 
     %Dagger.ModuleSource{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5960,7 +5960,7 @@ func (r *ModuleSource) ContextDirectory() *Directory {
 	}
 }
 
-// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+// The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.
 func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, error) {
 	q := r.query.Select("dependencies")
 
@@ -6302,6 +6302,16 @@ func (r *ModuleSource) WithView(name string, patterns []string) *ModuleSource {
 	q := r.query.Select("withView")
 	q = q.Arg("name", name)
 	q = q.Arg("patterns", patterns)
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
+// Remove the provided dependencies from the module source's dependency list.
+func (r *ModuleSource) WithoutDependencies(dependencies []string) *ModuleSource {
+	q := r.query.Select("withoutDependencies")
+	q = q.Arg("dependencies", dependencies)
 
 	return &ModuleSource{
 		query: q,

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -71,7 +71,7 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+     * The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.
      */
     public function dependencies(): array
     {
@@ -288,6 +288,16 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withView');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('patterns', $patterns);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Remove the provided dependencies from the module source's dependency list.
+     */
+    public function withoutDependencies(array $dependencies): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutDependencies');
+        $innerQueryBuilder->setArgument('dependencies', $dependencies);
         return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6016,8 +6016,8 @@ class ModuleSource(Type):
         return Directory(_ctx)
 
     async def dependencies(self) -> list[ModuleDependency]:
-        """The dependencies of the module source. Includes dependencies from the
-        configuration and any extras from withDependencies calls.
+        """The effective module source dependencies from the configuration, and
+        calls to withDependencies and withoutDependencies.
         """
         _args: list[Arg] = []
         _ctx = self._select("dependencies", _args)
@@ -6421,6 +6421,21 @@ class ModuleSource(Type):
             Arg("patterns", patterns),
         ]
         _ctx = self._select("withView", _args)
+        return ModuleSource(_ctx)
+
+    def without_dependencies(self, dependencies: list[str]) -> Self:
+        """Remove the provided dependencies from the module source's dependency
+        list.
+
+        Parameters
+        ----------
+        dependencies:
+            The dependencies to remove.
+        """
+        _args = [
+            Arg("dependencies", dependencies),
+        ]
+        _ctx = self._select("withoutDependencies", _args)
         return ModuleSource(_ctx)
 
     def with_(self, cb: Callable[["ModuleSource"], "ModuleSource"]) -> "ModuleSource":

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6308,7 +6308,7 @@ impl ModuleSource {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+    /// The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.
     pub fn dependencies(&self) -> Vec<ModuleDependency> {
         let query = self.selection.select("dependencies");
         vec![ModuleDependency {
@@ -6584,6 +6584,26 @@ impl ModuleSource {
         query = query.arg(
             "patterns",
             patterns
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
+        ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Remove the provided dependencies from the module source's dependency list.
+    ///
+    /// # Arguments
+    ///
+    /// * `dependencies` - The dependencies to remove.
+    pub fn without_dependencies(&self, dependencies: Vec<impl Into<String>>) -> ModuleSource {
+        let mut query = self.selection.select("withoutDependencies");
+        query = query.arg(
+            "dependencies",
+            dependencies
                 .into_iter()
                 .map(|i| i.into())
                 .collect::<Vec<String>>(),

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -7728,7 +7728,7 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
-   * The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+   * The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.
    */
   dependencies = async (): Promise<ModuleDependency[]> => {
     type dependencies = {
@@ -8152,6 +8152,23 @@ export class ModuleSource extends BaseClient {
         {
           operation: "withView",
           args: { name, patterns },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Remove the provided dependencies from the module source's dependency list.
+   * @param dependencies The dependencies to remove.
+   */
+  withoutDependencies = (dependencies: string[]): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withoutDependencies",
+          args: { dependencies },
         },
       ],
       ctx: this._ctx,


### PR DESCRIPTION
add a `dagger uninstall` command. Following test scenarios are covered:

-  ✅  if local dependency is not available in dagger.json. it should error out. works
-  ✅  local dependency is not used - works.
-  ⚠️ local dependency is used - (The code gives compile error as the dependency usage is still there in module).
-  ✅ git dependency is not used - it should error out. works
-  ⚠️ git dependency is used - (The code gives compile error as the dependency usage is still there in module)
-  ✅ git dependency uninstall by git repo url + version - works
-  ✅ git dependency uninstall by git repo url only - works
-  ✅  git dependency uninstall by name - works
-  ✅ dependency source does not exist (git or local) e.g. folder removed or git repo deleted - What should be the expected behavior here?