### PR TITLE
fix: allow cloning commit shas not referenced by branch/tag

### DIFF
--- a/.changes/unreleased/Fixed-20241021-150717.yaml
+++ b/.changes/unreleased/Fixed-20241021-150717.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+    Allow cloning hidden commits that are not part of a normal clone
+
+    For example, `refs/pull/<pr>/head`, or `refs/pull/<pr>/merge`.
+time: 2024-10-21T15:07:17.272068377+01:00
+custom:
+    Author: jedevc
+    PR: "8747"

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -39,11 +39,12 @@ func (GitSuite) TestGit(ctx context.Context, t *testctx.T) {
 
 	res := struct {
 		Git struct {
-			Head   result
-			Ref    result
-			Commit result
-			Branch result
-			Tag    result
+			Head         result
+			Ref          result
+			Commit       result
+			Branch       result
+			Tag          result
+			HiddenCommit result
 		}
 	}{}
 
@@ -90,6 +91,14 @@ func (GitSuite) TestGit(ctx context.Context, t *testctx.T) {
 						}
 					}
 				}
+				hiddenCommit: commit(id: "318970484f692d7a76cfa533c5d47458631c9654") {
+					commit
+					tree {
+						file(path: "README.md") {
+							contents
+						}
+					}
+				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
@@ -114,6 +123,11 @@ func (GitSuite) TestGit(ctx context.Context, t *testctx.T) {
 	// v0.9.5
 	require.Equal(t, res.Git.Tag.Commit, "9ea5ea7c848fef2a2c47cce0716d5fcb8d6bedeb")
 	require.Contains(t, res.Git.Tag.Tree.File.Contents, "Dagger")
+
+	// $ git ls-remote https://github.com/dagger/dagger.git | grep pull/8735
+	// 318970484f692d7a76cfa533c5d47458631c9654	refs/pull/8735/head
+	require.Equal(t, res.Git.HiddenCommit.Commit, "318970484f692d7a76cfa533c5d47458631c9654")
+	require.Contains(t, res.Git.HiddenCommit.Tree.File.Contents, "Dagger")
 }
 
 func (GitSuite) TestDiscardGitDir(ctx context.Context, t *testctx.T) {

--- a/engine/sources/gitdns/cli.go
+++ b/engine/sources/gitdns/cli.go
@@ -132,6 +132,14 @@ func (cli *gitCLI) run(ctx context.Context, args ...string) (_ *bytes.Buffer, er
 					continue
 				}
 			}
+			if strings.Contains(errbuf.String(), "not our ref") || strings.Contains(errbuf.String(), "unadvertised object") {
+				// server-side error: https://github.com/git/git/blob/34b6ce9b30747131b6e781ff718a45328aa887d0/upload-pack.c#L811-L812
+				// client-side error: https://github.com/git/git/blob/34b6ce9b30747131b6e781ff718a45328aa887d0/fetch-pack.c#L2250-L2253
+				if newArgs := argsNoCommitRefspec(args); len(args) > len(newArgs) {
+					args = newArgs
+					continue
+				}
+			}
 			return buf, errors.Errorf("git error: %s\nstderr:\n%s", err, errbuf.String())
 		}
 		return buf, nil
@@ -156,4 +164,20 @@ func argsNoDepth(args []string) []string {
 		}
 	}
 	return out
+}
+
+func argsNoCommitRefspec(args []string) []string {
+	if len(args) <= 2 {
+		return args
+	}
+	if args[0] != "fetch" {
+		return args
+	}
+
+	// assume the refspec is the last arg
+	if isCommitSHA(args[len(args)-1]) {
+		return args[:len(args)-1]
+	}
+
+	return args
 }

--- a/engine/sources/gitdns/source.go
+++ b/engine/sources/gitdns/source.go
@@ -516,16 +516,19 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		if !isCommitSHA(ref) { // TODO: find a branch from ls-remote?
 			args = append(args, "--depth=1", "--no-tags")
 		} else {
+			args = append(args, "--tags")
 			if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
 				args = append(args, "--unshallow")
 			}
 		}
 		args = append(args, "origin")
-		if !isCommitSHA(ref) {
-			args = append(args, "--force", ref+":tags/"+ref)
+		if isCommitSHA(ref) {
+			args = append(args, ref)
+		} else {
 			// local refs are needed so they would be advertised on next fetches. Force is used
 			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?
+			args = append(args, "--force", ref+":tags/"+ref)
 		}
 		if _, err := git.run(ctx, args...); err != nil {
 			return nil, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(gs.src.Remote))


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8584 (upstream fix in https://github.com/moby/buildkit/pull/5441, but we have a vendored copy of the relevant files to handle our custom DNS for services).