### PR TITLE
hack(ci): use enum values that don't clash with booleans

### DIFF
--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -251,7 +251,7 @@ func githubRelease(ctx context.Context, opts githubReleaseOpts) error {
 		dagger.GhReleaseCreateOpts{
 			VerifyTag: true,
 			NotesFile: opts.notes,
-			Latest:    dagger.False,
+			Latest:    dagger.LatestFalse,
 		},
 	)
 }

--- a/dagger.json
+++ b/dagger.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "gh",
-      "source": "github.com/sagikazarmark/daggerverse/gh@7adfe94b980c6f54d46b3cef495475a9cd81058d"
+      "source": "github.com/jedevc/daggerverse-sagikazarmark/gh@a104424df38ca8b0b758f699dcfeeb0c2210cc2e"
     },
     {
       "name": "go",


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/8673 - this wasn't *quite* right, since `true`/`false`/`null` are "special" words.

We need https://github.com/dagger/dagger/pull/8682 to be released in v0.13.6 before the original works *properly*.