### PR TITLE
engine: add cpu stat/pressure metrics

### DIFF
--- a/.changes/unreleased/Added-20241022-224954.yaml
+++ b/.changes/unreleased/Added-20241022-224954.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |
+  Add CPU pressure metrics for execs to TUI output.
+time: 2024-10-22T22:49:54.977668671-07:00
+custom:
+  Author: sipsma
+  PR: "8750"

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -396,10 +396,25 @@ func (r renderer) renderMetrics(out *termenv.Output, span *dagui.Span) {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		if lastPoint.Value != 0 {
 			fmt.Fprint(out, " | ")
-			displayMetric := out.String(fmt.Sprintf("IO Pressure Time: %dµs", lastPoint.Value))
+			displayMetric := out.String(fmt.Sprintf("IO Pressure: %dµs", lastPoint.Value))
 			displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 			fmt.Fprint(out, displayMetric)
 		}
+	}
+
+	if dataPoints := span.MetricsByName[telemetry.CPUStatPressureSomeTotal]; len(dataPoints) > 0 {
+		lastPoint := dataPoints[len(dataPoints)-1]
+		fmt.Fprint(out, " | ")
+		displayMetric := out.String(fmt.Sprintf("CPU Pressure (some): %dµs", lastPoint.Value))
+		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
+		fmt.Fprint(out, displayMetric)
+	}
+	if dataPoints := span.MetricsByName[telemetry.CPUStatPressureFullTotal]; len(dataPoints) > 0 {
+		lastPoint := dataPoints[len(dataPoints)-1]
+		fmt.Fprint(out, " | ")
+		displayMetric := out.String(fmt.Sprintf("CPU Pressure (full): %dµs", lastPoint.Value))
+		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
+		fmt.Fprint(out, displayMetric)
 	}
 }
 

--- a/engine/buildkit/resources/cpustat.go
+++ b/engine/buildkit/resources/cpustat.go
@@ -1,0 +1,145 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	cpuStatFile     = "cpu.stat"
+	cpuPressureFile = "cpu.pressure"
+
+	cpuUsageKey  = "usage_usec"
+	cpuUserKey   = "user_usec"
+	cpuSystemKey = "system_usec"
+)
+
+type cpuStatSampler struct {
+	cpuStatFilePath string
+	commonAttrs     attribute.Set
+
+	cpuUsage  metric.Int64Gauge
+	cpuUser   metric.Int64Gauge
+	cpuSystem metric.Int64Gauge
+}
+
+func newCPUStatSampler(cgroupPath string, meter metric.Meter, commonAttrs attribute.Set) (*cpuStatSampler, error) {
+	s := &cpuStatSampler{
+		cpuStatFilePath: filepath.Join(cgroupPath, cpuStatFile),
+		commonAttrs:     commonAttrs,
+	}
+	var err error
+
+	s.cpuUsage, err = meter.Int64Gauge(telemetry.CPUStatUsage, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cpuUsage metric: %w", err)
+	}
+
+	s.cpuUser, err = meter.Int64Gauge(telemetry.CPUStatUser, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cpuUser metric: %w", err)
+	}
+
+	s.cpuSystem, err = meter.Int64Gauge(telemetry.CPUStatSystem, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cpuSystem metric: %w", err)
+	}
+
+	return s, nil
+}
+
+type cpuStatSample struct {
+	cpuUsage  int64GaugeSample
+	cpuUser   int64GaugeSample
+	cpuSystem int64GaugeSample
+}
+
+func (s *cpuStatSampler) sample(ctx context.Context) error {
+	sample := cpuStatSample{
+		cpuUsage:  newInt64GaugeSample(s.cpuUsage, s.commonAttrs),
+		cpuUser:   newInt64GaugeSample(s.cpuUser, s.commonAttrs),
+		cpuSystem: newInt64GaugeSample(s.cpuSystem, s.commonAttrs),
+	}
+
+	bs, err := os.ReadFile(filepath.Join(s.cpuStatFilePath, cpuStatFile))
+	if err != nil {
+		return fmt.Errorf("failed to read cpu.stat file: %w", err)
+	}
+
+	for key, value := range flatKeyValuesInt64(bs) {
+		switch key {
+		case cpuUsageKey:
+			sample.cpuUsage.add(value)
+		case cpuUserKey:
+			sample.cpuUser.add(value)
+		case cpuSystemKey:
+			sample.cpuSystem.add(value)
+		}
+	}
+
+	sample.cpuUsage.record(ctx)
+	sample.cpuUser.record(ctx)
+	sample.cpuSystem.record(ctx)
+
+	return nil
+}
+
+type cpuPressureSampler struct {
+	cpuPressureFilePath string
+	commonAttrs         attribute.Set
+
+	someTotal metric.Int64Gauge
+	fullTotal metric.Int64Gauge
+}
+
+func newCPUPressureSampler(cgroupPath string, meter metric.Meter, commonAttrs attribute.Set) (*cpuPressureSampler, error) {
+	s := &cpuPressureSampler{
+		cpuPressureFilePath: filepath.Join(cgroupPath, cpuPressureFile),
+		commonAttrs:         commonAttrs,
+	}
+	var err error
+
+	s.someTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureSomeTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create someTotal metric: %w", err)
+	}
+
+	s.fullTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureFullTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fullTotal metric: %w", err)
+	}
+
+	return s, nil
+}
+
+type cpuPressureSample struct {
+	someTotal int64GaugeSample
+	fullTotal int64GaugeSample
+}
+
+func (s *cpuPressureSampler) sample(ctx context.Context) error {
+	sample := cpuPressureSample{
+		someTotal: newInt64GaugeSample(s.someTotal, s.commonAttrs),
+		fullTotal: newInt64GaugeSample(s.fullTotal, s.commonAttrs),
+	}
+
+	bs, err := os.ReadFile(s.cpuPressureFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read cpu.pressure file: %w", err)
+	}
+
+	p := parsePressure(bs)
+	sample.someTotal.add(p.someTotal)
+	sample.fullTotal.add(p.fullTotal)
+
+	sample.someTotal.record(ctx)
+	sample.fullTotal.record(ctx)
+
+	return nil
+}

--- a/engine/buildkit/resources/cpustat.go
+++ b/engine/buildkit/resources/cpustat.go
@@ -36,17 +36,26 @@ func newCPUStatSampler(cgroupPath string, meter metric.Meter, commonAttrs attrib
 	}
 	var err error
 
-	s.cpuUsage, err = meter.Int64Gauge(telemetry.CPUStatUsage, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.cpuUsage, err = meter.Int64Gauge(telemetry.CPUStatUsage,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total CPU time used by all tasks in the container"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cpuUsage metric: %w", err)
 	}
 
-	s.cpuUser, err = meter.Int64Gauge(telemetry.CPUStatUser, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.cpuUser, err = meter.Int64Gauge(telemetry.CPUStatUser,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total CPU time spent in user mode by all tasks in the container"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cpuUser metric: %w", err)
 	}
 
-	s.cpuSystem, err = meter.Int64Gauge(telemetry.CPUStatSystem, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.cpuSystem, err = meter.Int64Gauge(telemetry.CPUStatSystem,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total CPU time spent in kernel mode by all tasks in the container"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cpuSystem metric: %w", err)
 	}
@@ -105,12 +114,18 @@ func newCPUPressureSampler(cgroupPath string, meter metric.Meter, commonAttrs at
 	}
 	var err error
 
-	s.someTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureSomeTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.someTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureSomeTotal,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total time that any task in the container has been throttled due to CPU pressure"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create someTotal metric: %w", err)
 	}
 
-	s.fullTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureFullTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.fullTotal, err = meter.Int64Gauge(telemetry.CPUStatPressureFullTotal,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total time that all tasks in the container have simultaneously been throttled due to CPU pressure"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fullTotal metric: %w", err)
 	}

--- a/engine/buildkit/resources/formats.go
+++ b/engine/buildkit/resources/formats.go
@@ -1,0 +1,150 @@
+package resources
+
+import (
+	"bytes"
+	"iter"
+	"strconv"
+)
+
+// utils for parsing cgroup+pressure files
+// cgroup docs: https://docs.kernel.org/admin-guide/cgroup-v2.html#format
+// pressure docs: https://docs.kernel.org/accounting/psi.html#pressure-interface
+
+type pressure struct {
+	// averages are reported in cgroup file as decimal percentages (e.g. 0.00)
+	// but we convert them to int64 by multiplying by 100 to avoid float plumbing
+	// and float arithmetic nonsense
+	//
+	// total is in units of microseconds
+
+	someAvg10  int64
+	someAvg60  int64
+	someAvg300 int64
+	someTotal  int64
+	fullAvg10  int64
+	fullAvg60  int64
+	fullAvg300 int64
+	fullTotal  int64
+}
+
+func parsePressure(bs []byte) *pressure {
+	var p pressure
+	for key, values := range nestedKeyValuesStr(bs) {
+		switch key {
+		case "some":
+			for key, value := range values {
+				switch key {
+				case "avg10":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.someAvg10 = int64(v * 100)
+					}
+				case "avg60":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.someAvg60 = int64(v * 100)
+					}
+				case "avg300":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.someAvg300 = int64(v * 100)
+					}
+				case "total":
+					p.someTotal, _ = strconv.ParseInt(value, 10, 64)
+				}
+			}
+		case "full":
+			for key, value := range values {
+				switch key {
+				case "avg10":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.fullAvg10 = int64(v * 100)
+					}
+				case "avg60":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.fullAvg60 = int64(v * 100)
+					}
+				case "avg300":
+					v, err := strconv.ParseFloat(value, 64)
+					if err == nil {
+						p.fullAvg300 = int64(v * 100)
+					}
+				case "total":
+					p.fullTotal, _ = strconv.ParseInt(value, 10, 64)
+				}
+			}
+		}
+	}
+	return &p
+}
+
+func nestedKeyValuesStr(bs []byte) iter.Seq2[string, iter.Seq2[string, string]] {
+	return func(yield func(string, iter.Seq2[string, string]) bool) {
+		for line := range lines(bs) {
+			fields := bytes.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			key := string(fields[0])
+			if !yield(key, func(yield func(string, string) bool) {
+				for _, field := range fields[1:] {
+					subkey, subvalue, ok := bytes.Cut(field, []byte("="))
+					if !ok {
+						continue
+					}
+					if !yield(string(subkey), string(subvalue)) {
+						return
+					}
+				}
+			}) {
+				return
+			}
+		}
+	}
+}
+
+func nestedKeyValuesInt64(bs []byte) iter.Seq2[string, iter.Seq2[string, int64]] {
+	return func(yield func(string, iter.Seq2[string, int64]) bool) {
+		for key, subkeyValues := range nestedKeyValuesStr(bs) {
+			if !yield(key, func(yield func(string, int64) bool) {
+				for subkey, subvalueStr := range subkeyValues {
+					subvalue, err := strconv.ParseInt(subvalueStr, 10, 64)
+					if err == nil && !yield(subkey, subvalue) {
+						return
+					}
+				}
+			}) {
+				return
+			}
+		}
+	}
+}
+
+func flatKeyValuesInt64(bs []byte) iter.Seq2[string, int64] {
+	return func(yield func(string, int64) bool) {
+		for line := range lines(bs) {
+			fields := bytes.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			for _, field := range fields[1:] {
+				value, err := strconv.ParseInt(string(field), 10, 64)
+				if err == nil && !yield(string(fields[0]), value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func lines(bs []byte) func(yield func([]byte) bool) {
+	return func(yield func([]byte) bool) {
+		for _, line := range bytes.Split(bs, []byte("\n")) {
+			if !yield(line) {
+				return
+			}
+		}
+	}
+}

--- a/engine/buildkit/resources/iostat.go
+++ b/engine/buildkit/resources/iostat.go
@@ -35,12 +35,18 @@ func newIOStatSampler(cgroupPath string, meter metric.Meter, commonAttrs attribu
 	}
 	var err error
 
-	s.readBytes, err = meter.Int64Gauge(telemetry.IOStatDiskReadBytes, metric.WithUnit(telemetry.ByteUnitName))
+	s.readBytes, err = meter.Int64Gauge(telemetry.IOStatDiskReadBytes,
+		metric.WithUnit(telemetry.ByteUnitName),
+		metric.WithDescription("The total number of bytes read from the disk by all tasks in the container (not including disk read cache)"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create readBytes metric: %w", err)
 	}
 
-	s.writeBytes, err = meter.Int64Gauge(telemetry.IOStatDiskWriteBytes, metric.WithUnit(telemetry.ByteUnitName))
+	s.writeBytes, err = meter.Int64Gauge(telemetry.IOStatDiskWriteBytes,
+		metric.WithUnit(telemetry.ByteUnitName),
+		metric.WithDescription("The total number of bytes written to the disk by all tasks in the container (not including disk write cache)"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create writeBytes metric: %w", err)
 	}
@@ -98,7 +104,10 @@ func newIOPressureSampler(cgroupPath string, meter metric.Meter, commonAttrs att
 	}
 	var err error
 
-	s.someTotal, err = meter.Int64Gauge(telemetry.IOStatPressureSomeTotal, metric.WithUnit(telemetry.MicrosecondUnitName))
+	s.someTotal, err = meter.Int64Gauge(telemetry.IOStatPressureSomeTotal,
+		metric.WithUnit(telemetry.MicrosecondUnitName),
+		metric.WithDescription("The total time in microseconds that tasks in the container were throttled due to I/O pressure"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create some total metric: %w", err)
 	}

--- a/sdk/go/telemetry/metrics.go
+++ b/sdk/go/telemetry/metrics.go
@@ -14,8 +14,23 @@ const (
 	// OTel metric for number of bytes written to disk by a container, as parsed from its cgroup
 	IOStatDiskWriteBytes = "dagger.io/metrics.iostat.disk.writebytes"
 
-	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on IO
+	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on IO due to resource contention
 	IOStatPressureSomeTotal = "dagger.io/metrics.iostat.pressure.some.total"
+
+	// OTel metric for number of microseconds of all CPU usage of a container, as parsed from its cgroup
+	CPUStatUsage = "dagger.io/metrics.cpustat.usage"
+
+	// OTel metric for number of microseconds of CPU time spent in user mode by a container, as parsed from its cgroup
+	CPUStatUser = "dagger.io/metrics.cpustat.user"
+
+	// OTel metric for number of microseconds of CPU time spent in system mode by a container, as parsed from its cgroup
+	CPUStatSystem = "dagger.io/metrics.cpustat.system"
+
+	// OTel metric for number of microseconds SOME tasks in a cgroup were stalled on CPU due to resource contention
+	CPUStatPressureSomeTotal = "dagger.io/metrics.cpustat.pressure.some.total"
+
+	// OTel metric for number of microseconds ALL tasks in a cgroup were stalled on CPU due to resource contention
+	CPUStatPressureFullTotal = "dagger.io/metrics.cpustat.pressure.full.total"
 
 	// OTel metric units should be in UCUM format
 	// https://unitsofmeasure.org/ucum


### PR DESCRIPTION
Only displaying CPU pressure time in TUI right now since that's what I'm most interested in, but other CPU usage is plumbed  now too. Need to rework metrics display before adding more since it's starting to get to be too long a line.

---

Fun fact: when initializing our CI module from empty cache and a go codegen step takes a long time (~30s), up to half the time is spent shows up as full CPU pressure (which means every thread in the container is blocked waiting for a CPU to be available)... This on my 8 core m1 macbook.

Working on some fixes there (go build doesn't de-dupe parallel ongoing work across processes) but these metrics were useful to prove the problem was w/ cpu contention, so spinning out in the meantime.