### PR TITLE
ci: fix go/php git publishing

### DIFF
--- a/version/main.go
+++ b/version/main.go
@@ -30,7 +30,7 @@ func New(
 	inputs *dagger.Directory,
 	// +optional
 	// +defaultPath="/"
-	// +ignore=["*", "!.git", "!**/.gitignore"]
+	// +ignore=["*", "!.git", "!**/.gitignore", ".git/config"]
 	gitDir *dagger.Directory,
 	// .changes file used to extract version information
 	// +optional


### PR DESCRIPTION
Follow-up from #8749.

Oops, turns out, if there are multiple authorization sections in `.git` then we have issues! We attach multiple authorization headers (https://github.com/git-lfs/git-lfs/issues/4031)

https://github.com/dagger/dagger/actions/runs/11463663592/job/31898032845

The "right" solution for this is to have our versioning module ignore the github-generated `.git/config`.

