### PR TITLE
Uncached module initialization time improvements

### DIFF
--- a/.changes/unreleased/Fixed-20241023-130813.yaml
+++ b/.changes/unreleased/Fixed-20241023-130813.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: |-
+  Speed up initialization of modules with lots of dependencies using the Go SDK in engines with no cache.
+
+  Various dependencies of Go SDK modules are now pre-cached in the engine image, which avoids significant CPU pressure when building Go SDK modules in parallel with no cache.
+
+  The engine image size increase is expected to be offset by these improvements.
+time: 2024-10-23T13:08:13.514095498-07:00
+custom:
+  Author: sipsma
+  PR: "8761"

--- a/.dagger/build/sdk.go
+++ b/.dagger/build/sdk.go
@@ -135,6 +135,19 @@ func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
 	sdkCtrTarball := base.
 		WithEnvVariable("GOTOOLCHAIN", "auto").
 		WithFile("/usr/local/bin/codegen", build.CodegenBinary()).
+		// pre-cache stdlib
+		WithExec([]string{"go", "build", "std"}).
+		// pre-cache common deps
+		WithDirectory("/sdk", build.source.Directory("sdk/go")).
+		WithExec([]string{"go", "list",
+			"-C", "/sdk",
+			"-e",
+			"-export=true",
+			"-compiled=true",
+			"-deps=true",
+			"-test=false",
+			".",
+		}).
 		AsTarball(dagger.ContainerAsTarballOpts{
 			ForcedCompression: dagger.Uncompressed,
 		})

--- a/.dagger/build/sdk.go
+++ b/.dagger/build/sdk.go
@@ -47,7 +47,7 @@ func (build *Builder) pythonSDKContent(ctx context.Context) (*sdkContent, error)
 	sdkCtrTarball := dag.Container().
 		WithRootfs(rootfs).
 		AsTarball(dagger.ContainerAsTarballOpts{
-			ForcedCompression: dagger.Uncompressed,
+			ForcedCompression: dagger.Zstd,
 		})
 
 	sdkDir := dag.
@@ -98,7 +98,7 @@ func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, er
 		WithRootfs(rootfs).
 		WithFile("/codegen", build.CodegenBinary()).
 		AsTarball(dagger.ContainerAsTarballOpts{
-			ForcedCompression: dagger.Uncompressed,
+			ForcedCompression: dagger.Zstd,
 		})
 
 	sdkDir := dag.
@@ -149,7 +149,7 @@ func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
 			".",
 		}).
 		AsTarball(dagger.ContainerAsTarballOpts{
-			ForcedCompression: dagger.Uncompressed,
+			ForcedCompression: dagger.Zstd,
 		})
 
 	sdkDir := base.

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -393,13 +393,16 @@ func (ContainerSuite) TestSystemGoProxy(ctx context.Context, t *testctx.T) {
 			t.Run("system HTTP go proxy", func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
-				// just a subset of modules we expect to be downloaded since trying to go one to one would
-				// be too fragile whenever the SDK changes
+				// Just a subset of modules we expect to be downloaded since trying to go one to one would
+				// be too fragile whenever the SDK changes.
+				// NOTE: this is also impacted by engine pre-caching of SDK deps, so what shows up here are
+				// deps in testGitModuleRef that aren't pre-cached.
+				// If updating this test becomes a nuisance, we might want to use a custom test git module ref
+				// that specifically has some extra deps not in the Go SDK.
 				expectedGoModDownloads := []string{
-					"github.com/99designs/gqlgen",
-					"github.com/Khan/genqlient",
-					"go.opentelemetry.io/otel/exporters/otlp/otlptrace",
-					"golang.org/x/sync",
+					"github.com/andreyvit/diff",
+					"github.com/davecgh/go-spew",
+					"github.com/go-logr/logr",
 				}
 
 				executeTestEnvName := fmt.Sprintf("DAGGER_TEST_%s", strings.ToUpper(t.Name()))


### PR DESCRIPTION
Spent today working on fixing the bottleneck in uncached Go module initialization time, which turns out to be due largely to CPU contention between go list/build processes (go does not de-dupe concurrent builds/module downloads across processes; dedupe only happens after builds/downloads finish and are written to cache).
* See description on [PR that added cpu pressure metrics](https://github.com/dagger/dagger/pull/8750)

I went all the way to "daggerizing" go build by turning each individual go package build that makes up a single `go build` call into separate dagger `withExec`s. While viable in the long term, it turns out that the engine itself becomes a bottleneck in that case since it doesn't appear to handle *huge* DAGs (i.e. 300+ vertexes and thousands of edges) well at all for various reasons.
* Have some fixes for a few silly problems there, will send out in separate PR. Other problems are deeper, will open issues for those.

At the end of the day I ended up with the simpler improvements in the commits here.

They together reduce engine initialization time in the completely-uncached case:
* For our entire CI module: ~1m25s -> 57s (-28s)
* For `modules/alpine` individually (chosen because it has no dagger deps but lots of go ones): ~25s -> ~21s (-4s)

So not quite as dramatic as I was hoping but progress nonetheless.

There is an increase in engine image size from 165MB -> 265MB. The time it takes to pull the extra bits should be amortized by the decrease in module initialization time for the ephemeral engine + no-cache case. [See this rant](https://github.com/dagger/dagger/pull/8761#discussion_r1813444386).

The commit messages have more details on the individual fixes.