### PR TITLE
ci: manually set remote on git checkout

### DIFF
--- a/.dagger/docs.go
+++ b/.dagger/docs.go
@@ -36,8 +36,10 @@ func (d Docs) Site() *dagger.Directory {
 		Docusaurus(
 			d.Dagger.Source(),
 			dagger.DocusaurusOpts{
-				Dir:             "/src/docs",
-				CacheVolumeName: "dagger-docusaurus-site",
+				Dir: "/src/docs",
+				// HACK: cache seems to cause weird ephemeral errors occasionally -
+				// probably because of cache sharing
+				DisableCache: true,
 			},
 		).
 		Build()

--- a/version/git.go
+++ b/version/git.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"dagger/version/internal/dagger"
 	"errors"
 	"slices"
 	"strings"
 
 	"golang.org/x/mod/semver"
+
+	"github.com/dagger/dagger/version/internal/dagger"
 )
 
 // Git is an opinionated helper for performing various commands on our dagger repo.
@@ -46,10 +47,12 @@ func git(ctx context.Context, gitDir *dagger.Directory, dir *dagger.Directory) (
 		// enter detached head state, then we can rewrite all our refs however we like later
 		ctr = ctr.WithExec([]string{"sh", "-c", "git checkout -q $(git rev-parse HEAD)"})
 
+		// manually add a remote (since .git/config was removed earlier)
+		ctr = ctr.WithExec([]string{"git", "remote", "add", "origin", "https://github.com/dagger/dagger.git"})
+
 		// do various unshallowing operations (only the bare minimum is
 		// provided by the core git functions which are used by our remote git
 		// module sources)
-		remote := "https://github.com/dagger/dagger.git"
 		maxDepth := "2147483647" // see https://git-scm.com/docs/shallow
 		ctr = ctr.
 			WithExec([]string{
@@ -61,7 +64,7 @@ func git(ctx context.Context, gitDir *dagger.Directory, dir *dagger.Directory) (
 				// we need the unshallowed history of our branches, so we
 				// can determine which tags are in it later
 				"--depth=" + maxDepth,
-				remote,
+				"origin",
 				// update HEAD
 				"HEAD",
 				// update main

--- a/version/go.mod
+++ b/version/go.mod
@@ -1,4 +1,4 @@
-module dagger/version
+module github.com/dagger/dagger/version
 
 go 1.23.1
 

--- a/version/main.go
+++ b/version/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"dagger/version/internal/dagger"
 	"fmt"
 	"slices"
 	"strconv"
@@ -14,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+
+	"github.com/dagger/dagger/version/internal/dagger"
 )
 
 func New(
@@ -40,6 +41,9 @@ func New(
 ) (*Version, error) {
 	// NOTE: uploading the whole git dir is inefficient.
 	// we can stop doing it once dagger/dagger#8520 ships
+
+	// NOTE: .git/config is excluded, since *some* tools (GitHub actions)
+	// produce weird configs with custom headers set
 
 	git, err := git(ctx, gitDir, inputs)
 	if err != nil {


### PR DESCRIPTION
More follow-up needed to https://github.com/dagger/dagger/pull/8756:

https://github.com/dagger/dagger/actions/runs/11474521348/job/31930585026

```
error=couldn't get remote URL: fatal: No remote configured to list refs from.
```

Goreleaser really seems to need a remote - not really sure why, but we should be filling in our remote in `version/git.go` anyways.