### PR TITLE
feat(sdk/elixir): move entrypoint invoke task to dagger_sdk

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20241024-153531.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20241024-153531.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: |-
+    Dagger entrypoint invoke is now moved to `dagger_sdk`.
+
+    It's recommended to remove the mix task in `lib/mix/tasks/dagger.invoke.ex`.
+time: 2024-10-24T15:35:31.138498+07:00
+custom:
+    Author: wingyplus
+    PR: "8769"

--- a/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
+++ b/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
@@ -1,0 +1,31 @@
+defmodule Mix.Tasks.Dagger.Entrypoint.Invoke do
+  @shortdoc "Main entrypoint for invoking a Dagger Module."
+
+  @moduledoc """
+  Main entrypoint for invoking a Dagger Module.
+
+  NOTE: This task can run only inside Dagger Elixir runtime.
+
+  ## Arguments
+
+  - `otp_app` - The OTP application to load before invoke.
+  - `module` - A main module to invoke. (e.g. `Potato`)
+  """
+
+  use Mix.Task
+
+  def run([module]) do
+    Mix.Task.run("compile")
+    Mix.Task.reenable("dagger.entrypoint.invoke")
+
+    module =
+      module
+      |> String.split(".")
+      |> Module.concat()
+
+    Code.ensure_loaded?(module) ||
+      Mix.raise("Cannot find module #{module}")
+
+    Dagger.Mod.invoke(module)
+  end
+end

--- a/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
+++ b/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
@@ -8,7 +8,6 @@ defmodule Mix.Tasks.Dagger.Entrypoint.Invoke do
 
   ## Arguments
 
-  - `otp_app` - The OTP application to load before invoke.
   - `module` - A main module to invoke. (e.g. `Potato`)
   """
 

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -58,7 +58,7 @@ func (m *ElixirSdk) ModuleRuntime(
 		return nil, err
 	}
 
-	elixirApplication := normalizeModName(modName)
+	elixirApplication := toElixirApplicationName(modName)
 
 	ctr, err := m.Common(ctx, modSource, introspectionJSON)
 	if err != nil {
@@ -71,7 +71,7 @@ func (m *ElixirSdk) ModuleRuntime(
 		WithEntrypoint([]string{
 			"mix", "cmd",
 			"--cd", path.Join(ModSourceDirPath, subPath, elixirApplication),
-			"mix dagger.invoke",
+			fmt.Sprintf("mix dagger.entrypoint.invoke %s", toElixirModuleName(modName)),
 		}), nil
 }
 
@@ -104,7 +104,7 @@ func (m *ElixirSdk) Common(ctx context.Context,
 	}
 	m = m.Base(modSource, subPath).
 		WithSDK(introspectionJSON).
-		WithNewElixirPackage(ctx, normalizeModName(modName))
+		WithNewElixirPackage(ctx, toElixirApplicationName(modName))
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -196,6 +196,10 @@ func mixProjectCaches(prefix string) (depsCache *dagger.CacheVolume, buildCache 
 	return dag.CacheVolume(prefix + "-deps"), dag.CacheVolume(prefix + "-build")
 }
 
-func normalizeModName(name string) string {
+func toElixirApplicationName(name string) string {
 	return strcase.ToSnake(name)
+}
+
+func toElixirModuleName(name string) string {
+	return strcase.ToCamel(name)
 }

--- a/sdk/elixir/runtime/template.exs
+++ b/sdk/elixir/runtime/template.exs
@@ -17,12 +17,10 @@ defmodule Main do
       )
 
     module = render_module(module: Macro.camelize(mod))
-    mix_task = render_mix_task(module: Macro.camelize(mod))
 
     File.write!(Path.join([mod, ".formatter.exs"]), dot_formatter_exs)
     File.write!(Path.join([mod, "mix.exs"]), mix_exs)
     File.write!(Path.join([mod, "lib", "#{mod_name}.ex"]), module)
-    File.write!(Path.join([mod, "lib", "mix", "tasks", "dagger.invoke.ex"]), mix_task)
   end
 
   defp atom(string), do: ":#{string}"
@@ -112,19 +110,6 @@ defmodule Main do
   """
 
   EEx.function_from_string(:def, :render_module, @module_ex, [:assigns])
-
-  @mix_task_ex """
-  defmodule Mix.Tasks.Dagger.Invoke do
-    use Mix.Task
-
-    def run(_args) do
-      Application.ensure_all_started(:dagger)
-      Dagger.Mod.invoke(<%= @module %>)
-    end
-  end
-  """
-
-  EEx.function_from_string(:def, :render_mix_task, @mix_task_ex, [:assigns])
 end
 
 Main.run(System.argv())


### PR DESCRIPTION
Before this changeset, the invoke task living inside a user defined module. This is confuses for someone who read the module source code.

So, this changeset move the invoke task to the `dagger_sdk` and modify the runtime to use this task instead.

And the runtime is no longer generate mix task anymore.