### PR TITLE
python: fix failing test from dependabot update

### DIFF
--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -776,7 +776,7 @@ class Test:
 				With(daggerInitPython()).
 				Sync(ctx)
 
-			require.ErrorContains(t, err, "Failed to fetch wheel")
+			require.ErrorContains(t, err, "Failed to prepare distributions")
 		})
 	})
 }

--- a/sdk/python/runtime/Dockerfile
+++ b/sdk/python/runtime/Dockerfile
@@ -1,3 +1,3 @@
 # Images defined here for Dependabot.
 FROM python:3.12-slim@sha256:032c52613401895aa3d418a4c563d2d05f993bc3ecc065c8f4e2280978acd249 AS base
-FROM ghcr.io/astral-sh/uv:0.4.25@sha256:75ea96bbba2e43a11c90173f1b963eb2354a18e7673d2b0ee8e9428fa4afec7a AS uv
+FROM ghcr.io/astral-sh/uv:0.4.26@sha256:7775c60dca9cc5827c36757c32c75985244d8f31447565fa8147e2b2e11ad280 AS uv


### PR DESCRIPTION
Follow up to https://github.com/dagger/dagger/pull/8744 which was merged prematurely.