### PR TITLE
python: update uv index url config

### DIFF
--- a/sdk/python/.changes/unreleased/Deprecated-20241103-124649.yaml
+++ b/sdk/python/.changes/unreleased/Deprecated-20241103-124649.yaml
@@ -1,0 +1,8 @@
+kind: Deprecated
+body: |+
+    In modules, the `index-url` and `index-extra-url` settings in `[tool.uv]` are now deprecated in favor of the new `[[tool.uv.index]]` setting
+
+time: 2024-11-03T12:46:49.422162-01:00
+custom:
+    Author: helderco
+    PR: "8772"

--- a/sdk/python/runtime/discovery.go
+++ b/sdk/python/runtime/discovery.go
@@ -26,8 +26,21 @@ var FileContents = []string{"pyproject.toml", ".python-version"}
 
 // Uv config bits we'd like to consume.
 type UvConfig struct {
-	IndexURL      string `toml:"index-url"`
+	// Index is a list of uv index configurations.
+	// Ssee [uv v0.4.23](https://github.com/astral-sh/uv/releases/tag/0.4.23)
+	Index []UvIndexConfig `toml:"index"`
+
+	// Deprecated: use "Index" instead
+	IndexURL string `toml:"index-url"`
+	//
+	// Deprecated: use "Index" instead
 	ExtraIndexURL string `toml:"extra-index-url"`
+}
+
+type UvIndexConfig struct {
+	Name    string `toml:"name"`
+	URL     string `toml:"url"`
+	Default bool   `toml:"default"`
 }
 
 // PyProject is the parsed pyproject.toml file.
@@ -37,8 +50,8 @@ type PyProject struct {
 		RequiresPython string `toml:"requires-python"`
 	}
 	Tool struct {
-		Dagger UserConfig
 		Uv     UvConfig
+		Dagger UserConfig
 	}
 }
 

--- a/sdk/python/runtime/extension.go
+++ b/sdk/python/runtime/extension.go
@@ -82,14 +82,37 @@ func (m *PythonSdk) UvVersion() string {
 	return m.Discovery.UserConfig().UvVersion
 }
 
-// Uv's "index-url" setting
+// Uv's default index URL setting
 func (m *PythonSdk) IndexURL() string {
-	return m.Discovery.UvConfig().IndexURL
+	for _, cfg := range m.Discovery.UvConfig().Index {
+		if cfg.Name != "" {
+			continue
+		}
+		if cfg.Default {
+			return cfg.URL
+		}
+	}
+	// deprecated
+	if len(m.Discovery.UvConfig().Index) == 0 {
+		return m.Discovery.UvConfig().IndexURL
+	}
+	return ""
 }
 
 // Uv's "extra-index-url" setting
 func (m *PythonSdk) ExtraIndexURL() string {
-	return m.Discovery.UvConfig().ExtraIndexURL
+	for _, cfg := range m.Discovery.UvConfig().Index {
+		if cfg.Name != "" {
+			continue
+		}
+		if !cfg.Default {
+			return cfg.URL
+		}
+	}
+	if len(m.Discovery.UvConfig().Index) == 0 {
+		return m.Discovery.UvConfig().ExtraIndexURL
+	}
+	return ""
 }
 
 // Override the uv version


### PR DESCRIPTION
[uv v0.4.23](https://github.com/astral-sh/uv/releases/tag/0.4.23) changed the settings for index urls:

## `UV_INDEX_URL`
```diff
-[tool.uv]
-index-url = "https://pypi.acme.org/simple"
+[[tool.uv.index]]
+url = "https://pypi.acme.org/simple"
+default = true
```

## `UV_EXTRA_INDEX_URL`
```diff
-[tool.uv]
-index-extra-url = "https://pypi.acme.org/simple"
+[[tool.uv.index]]
+url = "https://pypi.acme.org/simple"
```

\ping @ClifHouck