### PR TITLE
engine: fix excessive cache invalidation for non-function nested execs

### DIFF
--- a/.changes/unreleased/Fixed-20241024-152529.yaml
+++ b/.changes/unreleased/Fixed-20241024-152529.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix excessive cache invalidation of `withExec`s using the `ExperimentalPrivilegedNesting`
+  flag
+time: 2024-10-24T15:25:29.532874059-07:00
+custom:
+  Author: sipsma
+  PR: "8776"

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -224,6 +224,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		CallID:          dagql.CurrentID(ctx),
 		ExecID:          identity.NewID(),
 		CachePerSession: !opts.Cache,
+		CacheByCall:     true, // scope the cache key to the function arguments+receiver values
 		Internal:        true,
 		SpanContext:     propagation.MapCarrier{},
 	}

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -74,7 +74,14 @@ type ExecutionMetadata struct {
 	// object.
 	ParentIDs map[digest.Digest]*resource.ID
 
+	// If true, scope the exec cache key to the current session ID. It will be cached in the context
+	// of the session but invalidated across different sessions.
 	CachePerSession bool
+
+	// If true, scope the exec cache key to the current dagql call digest. This is needed currently
+	// for module function calls specifically so that their cache key is based on their arguments and
+	// receiver object.
+	CacheByCall bool
 
 	// hostname -> list of aliases
 	HostAliases map[string][]string


### PR DESCRIPTION
User reported unexpected cache invalidation here: https://discord.com/channels/707636530424053791/1299094006592049262/1299094006592049262

Funnily enough, I had today ran into the exact same problem but in the context of our Go SDK's internal `codegen` exec, so we also need this fix (among others) to improve module initialization speed 😄

---

Before this, when nesting was enabled for an exec we would always scope the cache key with the dagql call digest for that exec.

This is important for the case of a module function call since it results in the cache key being scoped to that function's args and receiver.

However, this was also happening for non-function nested execs (i.e. use of the ExperimentalPrivilegedNesting flag). For those execs, this was unnecessary. It also resulted in excessive cache invalidation since dagql call digests aren't (yet) smart enough to incorporate content-based cache keys.

Only enabling the cache key scoping for function calls specifically fixes the problem.