### PR TITLE
core(gitdns-fix): ensure that gitdns support token support works with all Git server providers

### DIFF
--- a/.changes/unreleased/Fixed-20241103-221720.yaml
+++ b/.changes/unreleased/Fixed-20241103-221720.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: ensure that gitdns support token support works with all Git server providers. Bitbucket Cloud requires a specific auth format for Git operations using tokens, where the username must be 'x-token-auth'. This fixes token authentication for Bitbucket while maintaining compatibility with other Git providers like GitHub and GitLab, and Azure.
+time: 2024-11-03T22:17:20.245274684Z
+custom:
+    Author: grouville
+    PR: "8778"

--- a/engine/sources/gitdns/cli.go
+++ b/engine/sources/gitdns/cli.go
@@ -106,6 +106,7 @@ func (cli *gitCLI) run(ctx context.Context, args ...string) (_ *bytes.Buffer, er
 			"GIT_TERMINAL_PROMPT=0",
 			"GIT_SSH_COMMAND=" + GetGitSSHCommand(cli.knownHosts),
 			//	"GIT_TRACE=1",
+			"GIT_ASKPASS=echo",      // ensure git does not ask for a password (avoids cryptic error message)
 			"GIT_CONFIG_NOSYSTEM=1", // Disable reading from system gitconfig.
 			"HOME=/dev/null",        // Disable reading from user gitconfig.
 			"LC_ALL=C",              // Ensure consistent output.


### PR DESCRIPTION
Bitbucket Cloud requires a specific auth format for Git operations using tokens, where the username must be 'x-token-auth'. This fixes token authentication for Bitbucket while maintaining compatibility with other Git providers like GitHub and GitLab, and Azure.

### Context for Bitbucket Token Handling

Our implementation for Bitbucket Cloud authentication is based on the [Repository Access Tokens Documentation](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/), which specifically covers Git operations. While Bitbucket's [HTTP Access Tokens Documentation](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) suggests using Bearer authentication for some cases, this appears to only be working for to REST API calls (upon personal tests).

For Git operations, the documentation recommends using `x-token-auth` as the username, with the token as password, regardless of the token type. After testing both user tokens and repository tokens, I found that Bearer authentication did not work reliably for Git operations, leading my choice to always rely on that for bitbucket auth