### PR TITLE
feat(helm): add imagePullSecrets

### DIFF
--- a/helm/dagger/.changes/unreleased/Added-20241025-152517.yaml
+++ b/helm/dagger/.changes/unreleased/Added-20241025-152517.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add imagePullSecrets to allow pulling from private registry.
+time: 2024-10-25T15:25:17.272304+02:00
+custom:
+    Author: Jacob Lorenzen
+    PR: "8785"

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -25,6 +25,10 @@ spec:
         name: {{ include "dagger.fullname" . }}-engine
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.engine.imagePullSecrets }}
+      imagesPullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.engine.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -30,6 +30,10 @@ engine:
     #    cpu: "1"
     #    memory: 1Gi
 
+  ### Set a an imagePullSecrets if you need to pull from a private registry
+  imagePullSecrets: []
+  # - name: regcred
+
   image:
     ### Set a ref if you want to use a custom Dagger image
     #   NOTE: you will need to ensure that a compatible dagger CLI is embedded in the image, otherwise readiness probes will fail


### PR DESCRIPTION
This PR add imagePullSecrets to the helm chart to allow pulling the docker image from a private registry.