### PR TITLE
ci: Generate nightly workflows for alternative runners

### DIFF
--- a/.github/dagger_runner.go
+++ b/.github/dagger_runner.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	generation = 2
+
+	smallRunner    = 2
+	mediumRunner   = 4
+	largeRunner    = 8
+	xlargeRunner   = 16
+	xxlargeRunner  = 32
+	xxxlargeRunner = 64
+)
+
+type Runner interface {
+	Small() Runner
+	Medium() Runner
+	Large() Runner
+	XLarge() Runner
+	XXLarge() Runner
+	XXXLarge() Runner
+
+	SingleTenant() Runner
+	DaggerInDocker() Runner
+	Cached() Runner
+
+	Size() string
+	AddLabel(string) Runner
+	Labels() []string
+
+	Pipeline(string) string
+	RunsOn() []string
+}
+
+type DaggerRunner struct {
+	cores          int
+	daggerVersion  string
+	daggerInDocker bool
+	generation     int
+	labels         []string
+	singleTenant   bool
+	withCaching    bool
+}
+
+func NewDaggerRunner(
+	daggerVersion string,
+) DaggerRunner {
+	return DaggerRunner{
+		generation:    generation,
+		daggerVersion: daggerVersion,
+		labels:        []string{},
+		withCaching:   false,
+	}
+}
+
+func (r DaggerRunner) RunsOn() []string {
+	// We add size last in case the runner was customised
+	return r.AddLabel(r.Size()).Labels()
+}
+
+func (r DaggerRunner) AddLabel(label string) Runner {
+	r.labels = append(r.labels, label)
+
+	return r
+}
+
+func (r DaggerRunner) Labels() []string {
+	return r.labels
+}
+
+func (r DaggerRunner) Size() string {
+	size := fmt.Sprintf("dagger-g%d-%s-%dc",
+		r.generation,
+		strings.ReplaceAll(r.daggerVersion, ".", "-"),
+		r.cores)
+	if r.daggerInDocker {
+		size += "-dind"
+	}
+	if r.singleTenant {
+		size += "-st"
+	}
+
+	return fmt.Sprintf(
+		"${{ github.repository == '%s' && '%s' || '%s' }}",
+		upstreamRepository,
+		size,
+		defaultRunner)
+}
+
+func (r DaggerRunner) Pipeline(name string) string {
+	return name
+}
+
+func (r DaggerRunner) Small() Runner {
+	r.cores = smallRunner
+	return r
+}
+
+func (r DaggerRunner) Medium() Runner {
+	r.cores = mediumRunner
+	return r
+}
+
+func (r DaggerRunner) Large() Runner {
+	r.cores = largeRunner
+	return r
+}
+
+func (r DaggerRunner) XLarge() Runner {
+	r.cores = xlargeRunner
+	return r
+}
+
+func (r DaggerRunner) XXLarge() Runner {
+	r.cores = xxlargeRunner
+	return r
+}
+
+func (r DaggerRunner) XXXLarge() Runner {
+	// Infrastructure constraint - EC2 instance sizing
+	r.cores = xxlargeRunner
+	return r
+}
+
+func (r DaggerRunner) SingleTenant() Runner {
+	r.singleTenant = true
+	return r
+}
+
+func (r DaggerRunner) DaggerInDocker() Runner {
+	r.daggerInDocker = true
+	return r
+}
+
+func (r DaggerRunner) Cached() Runner {
+	// There is no option to enable caching in the current generation
+	return r
+}

--- a/.github/depot_runner.go
+++ b/.github/depot_runner.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DepotRunner struct {
+	cores         int
+	daggerVersion string
+	labels        []string
+	ubuntuVersion string
+	withCaching   bool
+}
+
+func NewDepotRunner(
+	daggerVersion string,
+) DepotRunner {
+	return DepotRunner{
+		daggerVersion: daggerVersion,
+		ubuntuVersion: "22.04",
+		withCaching:   false,
+	}
+}
+
+func (r DepotRunner) RunsOn() []string {
+	// We add size last in case the runner was customised
+	return r.AddLabel(r.Size()).Labels()
+}
+
+func (r DepotRunner) AddLabel(label string) Runner {
+	r.labels = append(r.labels, label)
+
+	return r
+}
+
+func (r DepotRunner) Labels() []string {
+	return r.labels
+}
+
+func (r DepotRunner) Size() string {
+	// Enabling caching in this context implies pre-provisioned Dagger
+	// And no size for the CI runner itself (Dagger Engine is the right size)
+	if r.withCaching {
+		return fmt.Sprintf(
+			"depot-ubuntu-%s,dagger=%s",
+			r.ubuntuVersion,
+			strings.ReplaceAll(r.daggerVersion, "v", ""))
+	}
+
+	return fmt.Sprintf(
+		"depot-ubuntu-%s-%d",
+		r.ubuntuVersion,
+		r.cores)
+}
+
+func (r DepotRunner) Pipeline(name string) string {
+	return fmt.Sprintf("%s-on-depot", name)
+}
+
+func (r DepotRunner) Small() Runner {
+	r.cores = smallRunner
+	return r
+}
+
+func (r DepotRunner) Medium() Runner {
+	r.cores = mediumRunner
+	return r
+}
+
+func (r DepotRunner) Large() Runner {
+	r.cores = largeRunner
+	return r
+}
+
+func (r DepotRunner) XLarge() Runner {
+	r.cores = xlargeRunner
+	return r
+}
+
+func (r DepotRunner) XXLarge() Runner {
+	r.cores = xxlargeRunner
+	return r
+}
+
+func (r DepotRunner) XXXLarge() Runner {
+	r.cores = xxxlargeRunner
+	return r
+}
+
+func (r DepotRunner) SingleTenant() Runner {
+	return r
+}
+
+func (r DepotRunner) DaggerInDocker() Runner {
+	return r
+}
+
+func (r DepotRunner) Cached() Runner {
+	r.withCaching = true
+	return r
+}

--- a/.github/namespace_runner.go
+++ b/.github/namespace_runner.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+)
+
+type NamespaceRunner struct {
+	cores         int
+	memory        int
+	daggerVersion string
+	ubuntuVersion string
+	labels        []string
+	withCaching   bool
+}
+
+func NewNamespaceRunner(
+	daggerVersion string,
+) NamespaceRunner {
+	return NamespaceRunner{
+		daggerVersion: daggerVersion,
+		ubuntuVersion: "22.04",
+		cores:         smallRunner,
+		memory:        smallRunner * 2,
+		withCaching:   false,
+	}
+}
+
+func (r NamespaceRunner) RunsOn() []string {
+	// We add size last in case the runner was customised
+	return r.AddLabel(r.Size()).Labels()
+}
+
+func (r NamespaceRunner) AddLabel(label string) Runner {
+	r.labels = append(r.labels, label)
+
+	return r
+}
+
+func (r NamespaceRunner) Labels() []string {
+	return r.labels
+}
+
+func (r NamespaceRunner) Size() string {
+	var cached string
+	if r.withCaching {
+		cached = "-with-cache"
+	}
+
+	return fmt.Sprintf(
+		"nscloud-ubuntu-%s-amd64-%dx%d%s",
+		r.ubuntuVersion,
+		r.cores,
+		r.memory,
+		cached)
+}
+
+func (r NamespaceRunner) Pipeline(name string) string {
+	return fmt.Sprintf("%s-on-namespace", name)
+}
+
+func (r NamespaceRunner) Small() Runner {
+	r.cores = smallRunner
+	r.memory = smallRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) Medium() Runner {
+	r.cores = mediumRunner
+	r.memory = mediumRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) Large() Runner {
+	r.cores = largeRunner
+	r.memory = largeRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) XLarge() Runner {
+	r.cores = xlargeRunner
+	r.memory = xlargeRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) XXLarge() Runner {
+	r.cores = xxlargeRunner
+	r.memory = xxlargeRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) XXXLarge() Runner {
+	// Infrastructure constraint - high-frequency cores
+	r.cores = xxlargeRunner
+	r.memory = xxlargeRunner * 2
+	return r
+}
+
+func (r NamespaceRunner) SingleTenant() Runner {
+	return r
+}
+
+func (r NamespaceRunner) DaggerInDocker() Runner {
+	return r
+}
+
+func (r NamespaceRunner) Cached() Runner {
+	r.withCaching = true
+	return r
+}

--- a/.github/workflows/sdks-on-depot.gen.yml
+++ b/.github/workflows/sdks-on-depot.gen.yml
@@ -1,15 +1,8 @@
 # This file was generated. See https://daggerverse.dev/mod/github.com/dagger/dagger/modules/gha
-name: SDKs
+name: SDKs-on-depot
 "on":
-    push:
-        branches:
-            - main
-    pull_request:
-        types:
-            - opened
-            - reopened
-            - synchronize
-            - ready_for_review
+    schedule:
+        - cron: 6 0 * * *
     workflow_dispatch: {}
 permissions:
     contents: read
@@ -19,7 +12,7 @@ concurrency:
 jobs:
     elixir:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: elixir
         steps:
             - name: Checkout
@@ -205,7 +198,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-16
         name: elixir-dev
         steps:
             - name: Checkout
@@ -434,7 +427,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: go
         steps:
             - name: Checkout
@@ -620,7 +613,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-8
         name: go-dev
         steps:
             - name: Checkout
@@ -849,7 +842,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: java
         steps:
             - name: Checkout
@@ -1035,7 +1028,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-8
         name: java-dev
         steps:
             - name: Checkout
@@ -1264,7 +1257,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: php
         steps:
             - name: Checkout
@@ -1450,7 +1443,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-8
         name: php-dev
         steps:
             - name: Checkout
@@ -1679,7 +1672,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: python
         steps:
             - name: Checkout
@@ -1865,7 +1858,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-8
         name: python-dev
         steps:
             - name: Checkout
@@ -2094,7 +2087,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: rust
         steps:
             - name: Checkout
@@ -2280,7 +2273,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-16
         name: rust-dev
         steps:
             - name: Checkout
@@ -2509,7 +2502,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04,dagger=0.13.7
         name: typescript
         steps:
             - name: Checkout
@@ -2695,7 +2688,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - depot-ubuntu-22.04-8
         name: typescript-dev
         steps:
             - name: Checkout

--- a/.github/workflows/sdks-on-namespace.gen.yml
+++ b/.github/workflows/sdks-on-namespace.gen.yml
@@ -1,15 +1,8 @@
 # This file was generated. See https://daggerverse.dev/mod/github.com/dagger/dagger/modules/gha
-name: SDKs
+name: SDKs-on-namespace
 "on":
-    push:
-        branches:
-            - main
-    pull_request:
-        types:
-            - opened
-            - reopened
-            - synchronize
-            - ready_for_review
+    schedule:
+        - cron: 6 0 * * *
     workflow_dispatch: {}
 permissions:
     contents: read
@@ -19,7 +12,9 @@ concurrency:
 jobs:
     elixir:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-16x32-with-cache
         name: elixir
         steps:
             - name: Checkout
@@ -205,7 +200,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-16x32
         name: elixir-dev
         steps:
             - name: Checkout
@@ -434,7 +431,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-4x8-with-cache
         name: go
         steps:
             - name: Checkout
@@ -620,7 +619,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-8x16
         name: go-dev
         steps:
             - name: Checkout
@@ -849,7 +850,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-4x8-with-cache
         name: java
         steps:
             - name: Checkout
@@ -1035,7 +1038,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-8x16
         name: java-dev
         steps:
             - name: Checkout
@@ -1264,7 +1269,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-4x8-with-cache
         name: php
         steps:
             - name: Checkout
@@ -1450,7 +1457,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-8x16
         name: php-dev
         steps:
             - name: Checkout
@@ -1679,7 +1688,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-4x8-with-cache
         name: python
         steps:
             - name: Checkout
@@ -1865,7 +1876,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-8x16
         name: python-dev
         steps:
             - name: Checkout
@@ -2094,7 +2107,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-16x32-with-cache
         name: rust
         steps:
             - name: Checkout
@@ -2280,7 +2295,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-16x32
         name: rust-dev
         steps:
             - name: Checkout
@@ -2509,7 +2526,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-4x8-with-cache
         name: typescript
         steps:
             - name: Checkout
@@ -2695,7 +2714,9 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - nscloud-cache-size-100gb
+            - nscloud-exp-container-image-cache
+            - nscloud-ubuntu-22.04-amd64-8x16
         name: typescript-dev
         steps:
             - name: Checkout

--- a/modules/gha/api/workflow.go
+++ b/modules/gha/api/workflow.go
@@ -62,6 +62,7 @@ type Job struct {
 	Strategy       *Strategy         `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 	TimeoutMinutes int               `json:"timeout-minutes,omitempty" yaml:"timeout-minutes,omitempty"`
 	Outputs        map[string]string `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	RunIf          string            `json:"if,omitempty" yaml:"if,omitempty"`
 }
 
 type JobStep struct {

--- a/modules/gha/dagger.json
+++ b/modules/gha/dagger.json
@@ -1,12 +1,13 @@
 {
   "name": "gha",
+  "engineVersion": "v0.13.7",
   "sdk": "go",
   "dependencies": [
     {
       "name": "wolfi",
-      "source": "../wolfi"
+      "source": "../wolfi",
+      "pin": ""
     }
   ],
-  "source": ".",
-  "engineVersion": "v0.13.6"
+  "source": "."
 }

--- a/modules/gha/job.go
+++ b/modules/gha/job.go
@@ -38,6 +38,8 @@ type Job struct {
 	PublicToken string
 	// Explicitly stop the dagger engine after completing the workflow.
 	StopEngine bool
+	// Determines when this workflow should run.
+	RunIf string
 }
 
 func (gha *Gha) Job(
@@ -80,6 +82,9 @@ func (gha *Gha) Job(
 	// Dagger version to run this workflow
 	// +optional
 	daggerVersion string,
+	// Determines when this workflow should run
+	// +optional
+	runIf string,
 ) *Job {
 	j := &Job{
 		Name:           name,
@@ -94,6 +99,7 @@ func (gha *Gha) Job(
 		Runner:         runner,
 		Module:         module,
 		DaggerVersion:  daggerVersion,
+		RunIf:          runIf,
 	}
 	j.applyDefaults(gha.JobDefaults)
 	return j
@@ -140,6 +146,7 @@ func (j *Job) applyDefaults(other *Job) *Job {
 	setDefault(&j.TimeoutMinutes, other.TimeoutMinutes)
 	setDefault(&j.Debug, other.Debug)
 	mergeDefault(&j.Runner, other.Runner)
+	setDefault(&j.RunIf, other.RunIf)
 	setDefault(&j.Module, other.Module)
 	setDefault(&j.DaggerVersion, other.DaggerVersion)
 	return j

--- a/modules/gha/workflow.go
+++ b/modules/gha/workflow.go
@@ -396,6 +396,7 @@ func (w *Workflow) asWorkflow() api.Workflow {
 			// The job name is used by the "required checks feature" in branch protection rules
 			Name:           job.Name,
 			RunsOn:         job.Runner,
+			RunIf:          job.RunIf,
 			Steps:          steps,
 			TimeoutMinutes: job.TimeoutMinutes,
 			Outputs: map[string]string{


### PR DESCRIPTION
They were generated in the root of the repo using the following command:

    dagger call -m .github workflows generate export --path .

The new workflows are only configured to run in the context of `dagger/dagger` repository. These runners will not be available in forks & running the same job with the `ubuntu-latest` runner doesn't make sense.

The new workflows start with `sdk-` so that it's easier to group them when looking at metrics. Before this, a special `OR` filter had to created which was making additional filtering impossible.