### PR TITLE
feat: use lts-alpine as the default node tag

### DIFF
--- a/.dagger/sdk_typescript.go
+++ b/.dagger/sdk_typescript.go
@@ -21,10 +21,10 @@ const (
 	typescriptRuntimeSubdir    = "sdk/typescript/runtime"
 	typescriptGeneratedAPIPath = "sdk/typescript/api/client.gen.ts"
 
-	nodeVersionMaintenance = "18"
-	nodeVersionLTS         = "20"
+	nodeVersionMaintenance = "20.18.1"
+	nodeVersionLTS         = "22.11.0"
 
-	bunVersion = "1.1.26"
+	bunVersion = "1.1.38"
 )
 
 type TypescriptSDK struct {

--- a/.dagger/sdk_typescript.go
+++ b/.dagger/sdk_typescript.go
@@ -21,8 +21,8 @@ const (
 	typescriptRuntimeSubdir    = "sdk/typescript/runtime"
 	typescriptGeneratedAPIPath = "sdk/typescript/api/client.gen.ts"
 
-	nodeVersionMaintenance = "20.18.1"
-	nodeVersionLTS         = "22.11.0"
+	nodePreviousLTS = "20.18.1"
+	nodeCurrentLTS  = "22.11.0"
 
 	bunVersion = "1.1.38"
 )
@@ -122,7 +122,7 @@ func (t TypescriptSDK) Test(ctx context.Context) (rerr error) {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// Loop over the LTS and Maintenance versions and test them
-	for _, version := range []string{nodeVersionLTS, nodeVersionMaintenance} {
+	for _, version := range []string{nodeCurrentLTS, nodePreviousLTS} {
 		base := t.nodeJsBaseFromVersion(version).With(installer)
 
 		eg.Go(func() error {
@@ -251,7 +251,7 @@ func (t TypescriptSDK) Bump(ctx context.Context, version string) (*dagger.Direct
 
 func (t TypescriptSDK) nodeJsBase() *dagger.Container {
 	// Use the LTS version by default
-	return t.nodeJsBaseFromVersion(nodeVersionMaintenance)
+	return t.nodeJsBaseFromVersion(nodePreviousLTS)
 }
 
 func (t TypescriptSDK) nodeJsBaseFromVersion(nodeVersion string) *dagger.Container {

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -788,7 +788,7 @@ func (TypescriptSuite) TestCustomBaseImage(ctx context.Context, t *testctx.T) {
 			WithWorkdir("/work").
 			WithNewFile("package.json", `{
       "dagger": {
-        "baseImage": "oven/bun:1.1.25-alpine@sha256:2d9027f7dd57d5343d787eae23d5bfa80cc8480154893e156d39ccc86df05cb4",
+        "baseImage": "oven/bun:1.1.37-alpine@sha256:aa3c07503fe8097fd185aa1fa7a55ec99c1d9041586b0efb1ed6fc0bd6923803",
         "runtime": "bun"
       }
     }`).
@@ -797,7 +797,7 @@ func (TypescriptSuite) TestCustomBaseImage(ctx context.Context, t *testctx.T) {
 
 		out, err := modGen.With(daggerCall("runtime")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "bun@1.1.25", out)
+		require.Equal(t, "bun@1.1.37", out)
 	})
 
 	t.Run("should use custom base image if base image is set - node", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -808,7 +808,7 @@ func (TypescriptSuite) TestCustomBaseImage(ctx context.Context, t *testctx.T) {
 			WithWorkdir("/work").
 			WithNewFile("package.json", `{
       "dagger": {
-        "baseImage": "node:20.18.0-alpine@sha256:b1e0880c3af955867bc2f1944b49d20187beb7afa3f30173e15a97149ab7f5f1",
+        "baseImage": "node:22.10.0-alpine@sha256:fc95a044b87e95507c60c1f8c829e5d98ddf46401034932499db370c494ef0ff",
         "runtime": "node"
       }
     }`).
@@ -817,7 +817,7 @@ func (TypescriptSuite) TestCustomBaseImage(ctx context.Context, t *testctx.T) {
 
 		out, err := modGen.With(daggerCall("runtime")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "node@20.18.0", out)
+		require.Equal(t, "node@22.10.0", out)
 	})
 }
 

--- a/sdk/typescript/.changes/unreleased/Changed-20241129-174122.yaml
+++ b/sdk/typescript/.changes/unreleased/Changed-20241129-174122.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: |-
+  Bump runtime Node version's to new LTS (22.11.0) (JOD: https://nodejs.org/en/about/previous-releases)
+  Bump runtime Bun version's to 1.1.38
+time: 2024-11-29T17:41:22.881989+01:00
+custom:
+  Author: TomChv
+  PR: "8823"

--- a/sdk/typescript/dev/node/src/index.ts
+++ b/sdk/typescript/dev/node/src/index.ts
@@ -12,7 +12,7 @@ import { Commands } from "./commands"
 @object()
 class Node {
   @func()
-  version = "lts-alpine"
+  version = "22.11.0-alpine@sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
 
   @func()
   container: Container

--- a/sdk/typescript/dev/node/src/index.ts
+++ b/sdk/typescript/dev/node/src/index.ts
@@ -12,7 +12,7 @@ import { Commands } from "./commands"
 @object()
 class Node {
   @func()
-  version = "18-alpine"
+  version = "lts-alpine"
 
   @func()
   container: Container

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	bunVersion  = "1.1.26"
-	nodeVersion = "20.18.1" // LTS version, IRON (https://nodejs.org/en/about/previous-releases)
+	bunVersion  = "1.1.38"
+	nodeVersion = "22.11.0" // LTS version, JOD (https://nodejs.org/en/about/previous-releases)
 
-	nodeImageDigest = "sha256:b5b9467fe7b33aad47f1ec3f6e0646a658f85f05c18d4243024212a91f3b7554"
-	bunImageDigest  = "sha256:f344713375598be5f0b40e478cdb70578cc255135a37f9c98179edb1ceb3b4f0"
+	nodeImageDigest = "sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
+	bunImageDigest  = "sha256:5148f6742ac31fac28e6eab391ab1f11f6dfc0c8512c7a3679b374ec470f5982"
 
 	nodeImageRef = "node:" + nodeVersion + "-alpine@" + nodeImageDigest
 	bunImageRef  = "oven/bun:" + bunVersion + "-alpine@" + bunImageDigest


### PR DESCRIPTION
Node.js 18 is in maintenance mode, Node.js 22 is the current LTS. Updating the default version to `lts-alpine` ensures that the current (active) LTS is used by default.