### PR TITLE
fix(engine): correct cpu.stat path

### DIFF
--- a/engine/buildkit/resources/cpustat.go
+++ b/engine/buildkit/resources/cpustat.go
@@ -76,7 +76,7 @@ func (s *cpuStatSampler) sample(ctx context.Context) error {
 		cpuSystem: newInt64GaugeSample(s.cpuSystem, s.commonAttrs),
 	}
 
-	bs, err := os.ReadFile(filepath.Join(s.cpuStatFilePath, cpuStatFile))
+	bs, err := os.ReadFile(s.cpuStatFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read cpu.stat file: %w", err)
 	}


### PR DESCRIPTION
fixes #8806 

tested locally by looking for the error message in the logs