### PR TITLE
feat(cli): add dagger update command

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -88,6 +88,7 @@ func init() {
 		moduleInitCmd,
 		moduleInstallCmd,
 		moduleUnInstallCmd,
+		moduleUpdateCmd,
 		moduleDevelopCmd,
 		modulePublishCmd,
 		funcListCmd,

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -695,7 +694,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 			With(daggerExec("install", "github.com/shykes/daggerverse/wolfi@v0.1.4", "--name=docker")).
 			Sync(ctx)
 
-		require.ErrorContains(t, err, "two or more dependencies are trying to use the same name")
+		requireErrOut(t, err, "two or more dependencies are trying to use the same name")
 	})
 
 	t.Run("install dep from various places", func(ctx context.Context, t *testctx.T) {
@@ -1538,12 +1537,7 @@ func (CLISuite) TestDaggerUpdate(ctx context.Context, t *testctx.T) {
 				Contents(ctx)
 
 			if tc.expectedError != "" {
-				var execErr *dagger.ExecError
-				if errors.As(err, &execErr) {
-					require.Contains(t, execErr.Stderr, tc.expectedError)
-				} else {
-					require.ErrorContains(t, err, tc.expectedError)
-				}
+				requireErrOut(t, err, tc.expectedError)
 			} else {
 				require.NoError(t, err)
 				for _, s := range tc.contains {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -65,13 +65,15 @@ type ModuleSource struct {
 	AsGitSource dagql.Nullable[*GitModuleSource] `field:"true" doc:"If the source is a of kind git, the git source representation of it."`
 
 	// Settings that can be used to initialize or override the source's configuration
-	WithName            string
-	WithDependencies    []dagql.Instance[*ModuleDependency]
-	WithoutDependencies []string
-	WithSDK             string
-	WithInitConfig      *ModuleInitConfig
-	WithSourceSubpath   string
-	WithViews           []*ModuleSourceView
+	WithName                  string
+	WithDependencies          []dagql.Instance[*ModuleDependency]
+	WithoutDependencies       []string
+	WithUpdateDependencies    []string
+	WithUpdateAllDependencies bool
+	WithSDK                   string
+	WithInitConfig            *ModuleInitConfig
+	WithSourceSubpath         string
+	WithViews                 []*ModuleSourceView
 }
 
 func (src *ModuleSource) Type() *ast.Type {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -131,6 +131,10 @@ func (s *moduleSchema) Install() {
 		dagql.NodeFunc("dependencies", s.moduleSourceDependencies).
 			Doc(`The effective module source dependencies from the configuration, and calls to withDependencies and withoutDependencies.`),
 
+		dagql.Func("withUpdateDependencies", s.moduleSourceWithUpdateDependencies).
+			Doc(`Update one or more module dependencies.`).
+			ArgDoc("dependencies", `The dependencies to update.`),
+
 		dagql.Func("withDependencies", s.moduleSourceWithDependencies).
 			Doc(`Append the provided dependencies to the module source's dependency list.`).
 			ArgDoc("dependencies", `The dependencies to append.`),

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -37,6 +37,7 @@ A tool to run CI/CD pipelines in containers, anywhere
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
 * [dagger run](#dagger-run)	 - Run a command in a Dagger session
 * [dagger uninstall](#dagger-uninstall)	 - Uninstall a dependency
+* [dagger update](#dagger-update)	 - Update a dependency
 * [dagger version](#dagger-version)	 - Print dagger version
 
 ## dagger call
@@ -528,6 +529,42 @@ dagger uninstall [options] <module>
 
 ```
 dagger uninstall hello
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+  -E, --no-exit                      Leave the TUI running after completion
+      --progress string              Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+
+## dagger update
+
+Update a dependency
+
+### Synopsis
+
+Update a dependency to the latest version (or the version specified). The target module must be local.
+
+```
+dagger update [options] <module>
+```
+
+### Examples
+
+```
+"dagger update github.com/shykes/daggerverse/hello@v0.3.0" or "dagger update hello"
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2465,6 +2465,12 @@ type ModuleSource {
     path: String!
   ): ModuleSource!
 
+  """Update one or more module dependencies."""
+  withUpdateDependencies(
+    """The dependencies to update."""
+    dependencies: [String!]!
+  ): ModuleSource!
+
   """Update the module source with a new named view."""
   withView(
     """The name of the view to set."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8344,6 +8344,23 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-withUpdateDependencies" href="#ModuleSource-withUpdateDependencies"><code>withUpdateDependencies</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Update one or more module dependencies. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>dependencies</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
+                                <p>The dependencies to update.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="ModuleSource-withView" href="#ModuleSource-withView"><code>withView</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
                         <td> Update the module source with a new named view. </td>
                       </tr>

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -350,6 +350,20 @@ defmodule Dagger.ModuleSource do
     }
   end
 
+  @doc "Update one or more module dependencies."
+  @spec with_update_dependencies(t(), [String.t()]) :: Dagger.ModuleSource.t()
+  def with_update_dependencies(%__MODULE__{} = module_source, dependencies) do
+    query_builder =
+      module_source.query_builder
+      |> QB.select("withUpdateDependencies")
+      |> QB.put_arg("dependencies", dependencies)
+
+    %Dagger.ModuleSource{
+      query_builder: query_builder,
+      client: module_source.client
+    }
+  end
+
   @doc "Update the module source with a new named view."
   @spec with_view(t(), String.t(), [String.t()]) :: Dagger.ModuleSource.t()
   def with_view(%__MODULE__{} = module_source, name, patterns) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6360,6 +6360,16 @@ func (r *ModuleSource) WithSourceSubpath(path string) *ModuleSource {
 	}
 }
 
+// Update one or more module dependencies.
+func (r *ModuleSource) WithUpdateDependencies(dependencies []string) *ModuleSource {
+	q := r.query.Select("withUpdateDependencies")
+	q = q.Arg("dependencies", dependencies)
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
 // Update the module source with a new named view.
 func (r *ModuleSource) WithView(name string, patterns []string) *ModuleSource {
 	q := r.query.Select("withView")

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -290,6 +290,16 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Update one or more module dependencies.
+     */
+    public function withUpdateDependencies(array $dependencies): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withUpdateDependencies');
+        $innerQueryBuilder->setArgument('dependencies', $dependencies);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Update the module source with a new named view.
      */
     public function withView(string $name, array $patterns): ModuleSource

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6474,6 +6474,20 @@ class ModuleSource(Type):
         _ctx = self._select("withSourceSubpath", _args)
         return ModuleSource(_ctx)
 
+    def with_update_dependencies(self, dependencies: list[str]) -> Self:
+        """Update one or more module dependencies.
+
+        Parameters
+        ----------
+        dependencies:
+            The dependencies to update.
+        """
+        _args = [
+            Arg("dependencies", dependencies),
+        ]
+        _ctx = self._select("withUpdateDependencies", _args)
+        return ModuleSource(_ctx)
+
     def with_view(self, name: str, patterns: list[str]) -> Self:
         """Update the module source with a new named view.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6661,6 +6661,26 @@ impl ModuleSource {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Update one or more module dependencies.
+    ///
+    /// # Arguments
+    ///
+    /// * `dependencies` - The dependencies to update.
+    pub fn with_update_dependencies(&self, dependencies: Vec<impl Into<String>>) -> ModuleSource {
+        let mut query = self.selection.select("withUpdateDependencies");
+        query = query.arg(
+            "dependencies",
+            dependencies
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
+        ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Update the module source with a new named view.
     ///
     /// # Arguments

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6245,6 +6245,15 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
+   * Update one or more module dependencies.
+   * @param dependencies The dependencies to update.
+   */
+  withUpdateDependencies = (dependencies: string[]): ModuleSource => {
+    const ctx = this._ctx.select("withUpdateDependencies", { dependencies })
+    return new ModuleSource(ctx)
+  }
+
+  /**
    * Update the module source with a new named view.
    * @param name The name of the view to set.
    * @param patterns The patterns to set as the view filters.


### PR DESCRIPTION
This PR adds the `dagger update` command. Based on discussion in this ticket, we have decided not to update the version of the dependency (unless explicitly asked) but instead move the pin to the latest commit of the current version.

e.g. 

given current dependency of `<github.com/path/name>@<branch/tag>`:

- if the update command is `dagger update github.com/path/name`, it will update the `pin` to latest commit of the branch/tag. 
- however, if the update command is `dagger update github.com/path/name@<diff-version>`, it will update the `pin` to the latest commit for `<diff-version>` branch/tag.

potentially also fixes #8821