### PR TITLE
chore(engine): adjust log levels for telemetry logs

### DIFF
--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -85,7 +85,7 @@ func (db *DB) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) er
 		}
 
 		if span.StartTime().Before(traceData.Epoch) {
-			slog.Debug("new epoch", "old", traceData.Epoch, "new", span.StartTime())
+			slog.ExtraDebug("new epoch", "old", traceData.Epoch, "new", span.StartTime())
 			traceData.Epoch = span.StartTime()
 		}
 
@@ -94,7 +94,7 @@ func (db *DB) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) er
 		}
 
 		if span.EndTime().After(traceData.End) {
-			slog.Debug("new end", "old", traceData.End, "new", span.EndTime())
+			slog.ExtraDebug("new end", "old", traceData.End, "new", span.EndTime())
 			traceData.End = span.EndTime()
 		}
 
@@ -229,14 +229,14 @@ func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) { //
 	spanData.ReadOnlySpan = span
 	spanData.IsSelfRunning = span.EndTime().Before(span.StartTime())
 
-	slog.Debug("recording span", "span", span.Name(), "id", spanID)
+	slog.ExtraDebug("recording span", "span", span.Name(), "id", spanID)
 
 	// track parent/child relationships
 	if parent := span.Parent(); parent.IsValid() {
 		if db.Children[parent.SpanID()] == nil {
 			db.Children[parent.SpanID()] = make(map[trace.SpanID]struct{})
 		}
-		slog.Debug("recording span child", "span", span.Name(), "parent", parent.SpanID(), "child", spanID)
+		slog.ExtraDebug("recording span child", "span", span.Name(), "parent", parent.SpanID(), "child", spanID)
 		if _, found := db.Children[parent.SpanID()][spanID]; !found {
 			db.Children[parent.SpanID()][spanID] = struct{}{}
 			db.ChildrenOrder[parent.SpanID()] = append(db.ChildrenOrder[parent.SpanID()], spanID)

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -255,7 +255,7 @@ func (fe plainSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.Re
 		for i, span := range spans {
 			spanIDs[i] = span.SpanContext().SpanID().String()
 		}
-		slog.Debug("frontend exporting spans", "spans", len(spanIDs))
+		slog.ExtraDebug("frontend exporting spans", "spans", len(spanIDs))
 	}
 
 	for _, span := range spans {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -257,7 +257,7 @@ func (fe FrontendSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
 	defer fe.recalculateViewLocked() // recalculate view *after* updating the db
-	slog.Debug("frontend exporting spans", "spans", len(spans))
+	slog.ExtraDebug("frontend exporting spans", "spans", len(spans))
 	return fe.db.ExportSpans(ctx, spans)
 }
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -304,7 +304,7 @@ func (c *Client) subscribeTelemetry(ctx context.Context) (rerr error) {
 
 	slog := slog.With("client", c.ID)
 
-	slog.Debug("subscribing to telemetry", "remote", c.RunnerHost)
+	slog.ExtraDebug("subscribing to telemetry", "remote", c.RunnerHost)
 
 	c.telemetry = new(errgroup.Group)
 	httpClient := c.newTelemetryHTTPClient()


### PR DESCRIPTION
I feel these logs can be moved to ExtraDebug level as it makes the traces more readable. Please let me know if you think that is not a good idea. thanks