### PR TITLE
feat(sdk/elixir): support TRACEPARENT

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20241109-103555.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20241109-103555.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add support for TRACEPARENT. The user will see what's function doing in the TUI.
+time: 2024-11-09T10:35:55.353113+07:00
+custom:
+    Author: wingyplus
+    PR: "8859"

--- a/sdk/elixir/lib/dagger/core/graphql_client/httpc.ex
+++ b/sdk/elixir/lib/dagger/core/graphql_client/httpc.ex
@@ -3,13 +3,8 @@ defmodule Dagger.Core.GraphQLClient.Httpc do
   `:httpc` HTTP adapter for GraphQL client.
   """
 
-  def request(url, session_token, request_body, http_opts) do
-    token = [session_token, ":"] |> IO.iodata_to_binary() |> Base.encode64()
-
-    headers = [
-      {~c"authorization", ["Basic ", token]}
-    ]
-
+  def request(url, request_body, headers, http_opts) do
+    headers = Enum.map(headers, fn {k, v} -> {String.to_charlist(k), v} end)
     content_type = ~c"application/json"
     request = {url, headers, content_type, request_body}
     options = []


### PR DESCRIPTION
This revive #6962 

In this changeset, add opentelemetry to setup `TRACEPARENT` from env variable to the current context and injecting it HTTP headers once request starting.

Since this support, it change the TUI from returning `Void` to correct type and can show step details inside a function correctly.

Before: the output from release 0.13.7:

```
✔ Potato.containerEcho(stringArg: "hello"): Container! 3.9s
┃ ==> nimble_options
┃ Compiling 3 files (.ex)
┃ Generated nimble_options app
┃ ==> jason
┃ Compiling 10 files (.ex)
┃ Generated jason app
┃ ==> dagger
┃ Compiling 106 files (.ex)
┃ Generated dagger app
┃ ==> potato
┃ Compiling 1 file (.ex)
┃ Generated potato app
  ✔ exec mix cmd --cd /src/sdk/elixir/potato/potato mix dagger.entrypoint.invoke Potato 3.9s | CPU Pressure (some): 128886µs | CPU Pressure (full): 27650µs
✔ Void.stdout: String! 0.1s
  ✔ cache request: pull docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
  ✔ load cache: pull docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
  ✔ exec echo hello 0.1s
  ┃ hello
```

After: this PR:

```
✔ Potato.containerEcho(stringArg: "hello"): Container! 11.4s
┃ ==> nimble_options
┃ Compiling 3 files (.ex)
┃ Generated nimble_options app
┃ ===> Analyzing applications...
┃ ===> Compiling gproc
┃ ==> jason
┃ Compiling 10 files (.ex)
┃ Generated jason app
┃ ===> Analyzing applications...
┃ ===> Compiling acceptor_pool
┃ src/acceptor_pool.erl:56:2: Warning: the callback gen_server:format_status(_,_) is deprecated; use format_status/1 instead
┃
┃ ===> Analyzing applications...
┃ ===> Compiling hpack
┃ ==> ssl_verify_fun
┃ Compiling 7 files (.erl)
┃ Generated ssl_verify_fun app
┃ ===> Analyzing applications...
┃ ===> Compiling tls_certificate_check
┃ ===> Analyzing applications...
┃ ===> Compiling ctx
┃ ===> Analyzing applications...
┃ ===> Compiling chatterbox
┃ ===> Analyzing applications...
┃ ===> Compiling grpcbox
┃ ==> opentelemetry_api
┃ Compiling 19 files (.erl)
┃ Compiling 5 files (.ex)
┃ Generated opentelemetry_api app
┃ ===> Analyzing applications...
┃ ===> Compiling opentelemetry
┃ ===> Analyzing applications...
┃ ===> Compiling opentelemetry_exporter
┃ ==> dagger
┃ Compiling 107 files (.ex)
┃ Generated dagger app
┃ ==> potato
┃ Compiling 1 file (.ex)
┃ Generated potato app
┃
┃ 08:36:03.917 [debug] OTLP exporter failed to initialize: exception error: bad key: exporter_otlp_traces_protocol
┃   in function  otel_configuration:update_config_map/5 (/src/sdk/elixir/potato/potato/deps/opentelemetry/src/otel_configuration.erl, line 280)
┃   in call from lists:foldl_1/3 (lists.erl, line 2151)
┃   in call from otel_exporter_otlp:merge_with_environment/8 (/src/sdk/elixir/potato/potato/deps/opentelemetry_exporter/src/otel_exporter_otlp.erl, line 363)
┃   in call from otel_exporter_traces
┃   in call from otel_exporter:init/1 (/src/sdk/elixir/potato/potato/deps/opentelemetry/src/otel_exporter.erl, line 48)
┃   in call from otel_batch_processor:init_exporter/2 (/src/sdk/elixir/potato/potato/deps/opentelemetry/src/otel_batch_processor.erl, line 327)
┃   in call from otel_batch_processor:idle/3 (/src/sdk/elixir/potato/potato/deps/opentelemetry/src/otel_batch_processor.erl, line 200)
┃   in call from gen_statem:loop_state_callback/11 (gen_statem.erl, line 3113)
┃
┃ 08:36:03.921 [warning] OTLP exporter failed to initialize with exception :error:{:badkey, :exporter_otlp_traces_protocol}
  ✔ exec mix cmd --cd /src/sdk/elixir/potato/potato mix dagger.entrypoint.invoke Potato 11.4s | Disk Read Bytes: 0 | Disk Write Bytes: 1871872 | IO Pressure: 1µs | CPU Pressure (some): 377624µs | CPU Pressure (full): 91220µs
  ✔ Container.from(address: "alpine:latest"): Container! 0.9s
    ✔ resolving docker.io/library/alpine:latest 0.9s
      ✔ remotes.docker.resolver.HTTPRequest 0.9s
        ✔ HTTP HEAD 0.9s
    ✔ Container.from(address: "docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"): Container! 0.0s
      ✔ resolving docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
  ✔ Container.withExec(args: ["echo", "hello"]): Container! 0.0s
    ✔ cache request: pull docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
    ✔ load cache: exec echo hello 0.0s
✔ Container.stdout: String! 0.0s
```

Currently, the OTel will warning that we didn't configure the exporter correctly. But we can leave it for now since what we focus on this PR is to make TUI trace show correctly

