### PR TITLE
shell: add `.doc` builtin command

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -115,13 +115,9 @@ func functionListRun(o functionProvider, writer io.Writer, skipUnsupported bool)
 			skipped = append(skipped, fn.CmdName())
 			continue
 		}
-		desc := strings.SplitN(fn.Description, "\n", 2)[0]
-		if desc == "" {
-			desc = "-"
-		}
 		fmt.Fprintf(tw, "%s\t%s\n",
-			cliName(fn.Name),
-			desc,
+			fn.CmdName(),
+			fn.Short(),
 		)
 	}
 	if len(skipped) > 0 {

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -70,7 +70,7 @@ available functions.
 			// Walk the hypothetical function pipeline specified by the args
 			for _, field := range cmd.Flags().Args() {
 				// Lookup the next function in the specified pipeline
-				nextFunc, err := GetFunction(o, field)
+				nextFunc, err := mod.GetFunction(o, field)
 				if err != nil {
 					return err
 				}

--- a/cmd/dagger/cloud.go
+++ b/cmd/dagger/cloud.go
@@ -14,30 +14,30 @@ import (
 	"github.com/dagger/dagger/internal/cloud/auth"
 )
 
+var cloudGroup = &cobra.Group{
+	ID:    "cloud",
+	Title: "Dagger Cloud Commands",
+}
+
+var cloudCLI = &CloudCLI{}
+
+var loginCmd = &cobra.Command{
+	Use:     "login [options] [org]",
+	Short:   "Log in to Dagger Cloud",
+	GroupID: cloudGroup.ID,
+	RunE:    cloudCLI.Login,
+}
+
+var logoutCmd = &cobra.Command{
+	Use:     "logout",
+	Short:   "Log out from Dagger Cloud",
+	GroupID: cloudGroup.ID,
+	RunE:    cloudCLI.Logout,
+}
+
 func init() {
-	cloud := &CloudCLI{}
-
-	group := &cobra.Group{
-		ID:    "cloud",
-		Title: "Dagger Cloud Commands",
-	}
-	rootCmd.AddGroup(group)
-
-	loginCmd := &cobra.Command{
-		Use:     "login [options] [org]",
-		Short:   "Log in to Dagger Cloud",
-		GroupID: group.ID,
-		RunE:    cloud.Login,
-	}
-	rootCmd.AddCommand(loginCmd)
-
-	logoutCmd := &cobra.Command{
-		Use:     "logout",
-		Short:   "Log out from Dagger Cloud",
-		GroupID: group.ID,
-		RunE:    cloud.Logout,
-	}
-	rootCmd.AddCommand(logoutCmd)
+	rootCmd.AddGroup(cloudGroup)
+	rootCmd.AddCommand(loginCmd, logoutCmd)
 }
 
 type CloudCLI struct{}

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -504,7 +504,7 @@ func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, t
 func (fc *FuncCommand) makeSubCmd(ctx context.Context, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:                   cliName(fn.Name),
-		Short:                 strings.SplitN(fn.Description, "\n", 2)[0],
+		Short:                 fn.Short(),
 		Long:                  fn.Description,
 		GroupID:               funcGroup.ID,
 		DisableFlagsInUseLine: true,

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -439,23 +439,54 @@ func flagUsagesWrapped(flags *pflag.FlagSet) string {
 //
 // Ideally `c.Short` fields should be as short as possible.
 func cmdShortWrapped(c *cobra.Command) string {
+	return wrapCmdDescription(c.Name(), c.Short, c.NamePadding())
+}
+
+func wrapCmdDescription(name, short string, padding int) string {
 	width := getViewWidth()
 
 	// Produce the same string length for all sibling commands by padding to
 	// the right based on the longest name. Add two extra spaces to the left
 	// of the screen, and three extra spaces before the description.
-	nameFormat := fmt.Sprintf("  %%-%ds   ", c.NamePadding())
-	name := fmt.Sprintf(nameFormat, c.Name())
-
-	description := c.Short
-	if len(name)+len(description) >= width {
-		wrapped := wordwrap.String(c.Short, width-len(name))
+	nameFormat := fmt.Sprintf("  %%-%ds   ", padding)
+	name = fmt.Sprintf(nameFormat, name)
+	if len(name)+len(short) >= width {
+		wrapped := wordwrap.String(short, width-len(name))
 		indented := indent.String(wrapped, uint(len(name)))
 		// first line shouldn't be indented since we're going to prepend the name
-		description = strings.TrimLeftFunc(indented, unicode.IsSpace)
+		short = strings.TrimLeftFunc(indented, unicode.IsSpace)
+	}
+	return name + short
+}
+
+func nameShortWrapped[S ~[]E, E any](s S, f func(e E) (string, string)) string {
+	minPadding := 11
+	maxLen := 0
+	lines := []string{}
+
+	for _, e := range s {
+		name, short := f(e)
+		nameLen := len(name)
+		if nameLen > maxLen {
+			maxLen = nameLen
+		}
+		// This special character will be replaced with spacing once the
+		// correct alignment is calculated
+		lines = append(lines, fmt.Sprintf("%s\x00%s", name, short))
 	}
 
-	return name + description
+	padding := maxLen
+	if minPadding > maxLen {
+		padding = minPadding
+	}
+
+	sb := new(strings.Builder)
+	for _, line := range lines {
+		s := strings.SplitN(line, "\x00", 2)
+		sb.WriteString(wrapCmdDescription(s[0], s[1], padding))
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 // toUpperBold returns the given string in uppercase and bold.

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -892,6 +892,8 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client) error 
 		}
 	}
 
+	m.LoadFunctionTypeDefs(m.MainObject.AsObject.Constructor)
+
 	return nil
 }
 
@@ -963,17 +965,17 @@ func (m *moduleDef) GetObjectFunction(objectName, functionName string) (*modFunc
 	if fp == nil {
 		return nil, fmt.Errorf("module %q does not have a %q object or interface", m.Name, objectName)
 	}
-	fn, err := GetFunction(fp, functionName)
-	if err != nil {
-		return nil, err
+	return m.GetFunction(fp, functionName)
+}
+
+func (m *moduleDef) GetFunction(fp functionProvider, functionName string) (*modFunction, error) {
+	for _, fn := range fp.GetFunctions() {
+		if fn.Name == functionName || fn.CmdName() == functionName {
+			m.LoadFunctionTypeDefs(fn)
+			return fn, nil
+		}
 	}
-	// We need to load references to types with their type definitions because
-	// the introspection doesn't recursively add them, just their names.
-	m.LoadTypeDef(fn.ReturnType)
-	for _, arg := range fn.Args {
-		m.LoadTypeDef(arg.TypeDef)
-	}
-	return fn, nil
+	return nil, fmt.Errorf("no function %q in type %q", functionName, fp.ProviderName())
 }
 
 // GetInterface retrieves a saved interface type definition from the module.
@@ -1022,16 +1024,21 @@ func (m *moduleDef) GetInput(name string) *modInput {
 
 // HasCoreFunction checks if there's a core function (under Query) with the given name.
 func (m *moduleDef) HasCoreFunction(name string) bool {
-	o := m.GetFunctionProvider("Query")
-	if o == nil || !o.IsCore() {
-		return false
-	}
-	return HasFunction(o, name)
+	fp := m.GetFunctionProvider("Query")
+	return m.HasFunction(fp, name)
 }
 
-// HasFunction checks if the module has a top level function with the given name.
-func (m *moduleDef) HasFunction(name string) bool {
-	return HasFunction(m.MainObject.AsFunctionProvider(), name)
+// HasFunction checks if an object has a function with the given name.
+func (m *moduleDef) HasFunction(fp functionProvider, name string) bool {
+	if fp == nil {
+		return false
+	}
+	fn, _ := m.GetFunction(fp, name)
+	return fn != nil
+}
+
+func (m *moduleDef) IsConstructor(name string) bool {
+	return m.HasCoreFunction(name) || m.MainObject.AsObject.Constructor.CmdName() == name
 }
 
 // LoadTypeDef attempts to replace a function's return object type or argument's
@@ -1067,6 +1074,15 @@ func (m *moduleDef) LoadTypeDef(typeDef *modTypeDef) {
 	}
 }
 
+func (m *moduleDef) LoadFunctionTypeDefs(fn *modFunction) {
+	// We need to load references to types with their type definitions because
+	// the introspection doesn't recursively add them, just their names.
+	m.LoadTypeDef(fn.ReturnType)
+	for _, arg := range fn.Args {
+		m.LoadTypeDef(arg.TypeDef)
+	}
+}
+
 // modTypeDef is a representation of dagger.TypeDef.
 type modTypeDef struct {
 	Kind        dagger.TypeDefKind
@@ -1087,6 +1103,8 @@ func (t *modTypeDef) String() string {
 		return "int"
 	case dagger.TypeDefKindBooleanKind:
 		return "bool"
+	case dagger.TypeDefKindVoidKind:
+		return "void"
 	case dagger.TypeDefKindScalarKind:
 		return t.AsScalar.Name
 	case dagger.TypeDefKindEnumKind:
@@ -1099,12 +1117,78 @@ func (t *modTypeDef) String() string {
 		return t.AsInterface.Name
 	case dagger.TypeDefKindListKind:
 		return "[]" + t.AsList.ElementTypeDef.String()
-	case dagger.TypeDefKindVoidKind:
+	default:
+		// this should never happen because all values for kind are covered,
+		// unless a new one is added and this code isn't updated
 		return ""
 	}
-	// this should never happen because all values for kind are covered,
-	// unless a new one is added and this code isn't updated
-	return "<unknown>"
+}
+
+func (t *modTypeDef) KindDisplay() string {
+	switch t.Kind {
+	case dagger.TypeDefKindStringKind,
+		dagger.TypeDefKindIntegerKind,
+		dagger.TypeDefKindBooleanKind:
+		return "Scalar"
+	case dagger.TypeDefKindScalarKind,
+		dagger.TypeDefKindVoidKind:
+		return "Custom scalar"
+	case dagger.TypeDefKindEnumKind:
+		return "Enum"
+	case dagger.TypeDefKindInputKind:
+		return "Input"
+	case dagger.TypeDefKindObjectKind:
+		return "Object"
+	case dagger.TypeDefKindInterfaceKind:
+		return "Interface"
+	case dagger.TypeDefKindListKind:
+		return "List of " + strings.ToLower(t.AsList.ElementTypeDef.KindDisplay()) + "s"
+	default:
+		return ""
+	}
+}
+
+func (t *modTypeDef) Description() string {
+	switch t.Kind {
+	case dagger.TypeDefKindStringKind,
+		dagger.TypeDefKindIntegerKind,
+		dagger.TypeDefKindBooleanKind:
+		return "Primitive type."
+	case dagger.TypeDefKindVoidKind:
+		return ""
+	case dagger.TypeDefKindScalarKind:
+		return t.AsScalar.Description
+	case dagger.TypeDefKindEnumKind:
+		return t.AsEnum.Description
+	case dagger.TypeDefKindInputKind:
+		return t.AsInput.Description
+	case dagger.TypeDefKindObjectKind:
+		return t.AsObject.Description
+	case dagger.TypeDefKindInterfaceKind:
+		return t.AsInterface.Description
+	case dagger.TypeDefKindListKind:
+		return t.AsList.ElementTypeDef.Description()
+	default:
+		// this should never happen because all values for kind are covered,
+		// unless a new one is added and this code isn't updated
+		return ""
+	}
+}
+
+func (t *modTypeDef) Short() string {
+	s := t.String()
+	if d := t.Description(); d != "" {
+		s = fmt.Sprintf("%s - %s", s, strings.SplitN(d, "\n", 2)[0])
+	}
+	return s
+}
+
+func (t *modTypeDef) Long() string {
+	s := t.String()
+	if d := t.Description(); d != "" {
+		s = fmt.Sprintf("%s - %s", s, d)
+	}
+	return s
 }
 
 type functionProvider interface {
@@ -1123,15 +1207,6 @@ func HasAvailableFunctions(o functionProvider) bool {
 		}
 	}
 	return false
-}
-
-// HasFunction checks if an object has a function with the given name.
-func HasFunction(o functionProvider, name string) bool {
-	if o == nil {
-		return false
-	}
-	fn, _ := GetFunction(o, name)
-	return fn != nil
 }
 
 // skipLeaves is a map of provider names to function names that should be skipped
@@ -1202,15 +1277,6 @@ func GetLeafFunctions(fp functionProvider) []*modFunction {
 	return r
 }
 
-func GetFunction(o functionProvider, name string) (*modFunction, error) {
-	for _, fn := range o.GetFunctions() {
-		if fn.Name == name || fn.CmdName() == name {
-			return fn, nil
-		}
-	}
-	return nil, fmt.Errorf("no function %q in type %q", name, o.ProviderName())
-}
-
 func (t *modTypeDef) Name() string {
 	if fp := t.AsFunctionProvider(); fp != nil {
 		return fp.ProviderName()
@@ -1234,6 +1300,7 @@ func (t *modTypeDef) AsFunctionProvider() functionProvider {
 // modObject is a representation of dagger.ObjectTypeDef.
 type modObject struct {
 	Name             string
+	Description      string
 	Functions        []*modFunction
 	Fields           []*modField
 	Constructor      *modFunction
@@ -1300,6 +1367,7 @@ func (o *modObject) GetFieldFunctions() []*modFunction {
 
 type modInterface struct {
 	Name             string
+	Description      string
 	Functions        []*modFunction
 	SourceModuleName string
 }
@@ -1325,12 +1393,14 @@ func (o *modInterface) GetFunctions() []*modFunction {
 }
 
 type modScalar struct {
-	Name string
+	Name        string
+	Description string
 }
 
 type modEnum struct {
-	Name   string
-	Values []*modEnumValue
+	Name        string
+	Description string
+	Values      []*modEnumValue
 }
 
 func (e *modEnum) ValueNames() []string {
@@ -1342,12 +1412,14 @@ func (e *modEnum) ValueNames() []string {
 }
 
 type modEnumValue struct {
-	Name string
+	Name        string
+	Description string
 }
 
 type modInput struct {
-	Name   string
-	Fields []*modField
+	Name        string
+	Description string
+	Fields      []*modField
 }
 
 // modList is a representation of dagger.ListTypeDef.

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -48,6 +48,7 @@ fragment FunctionParts on Function {
 		name
 		description
 		defaultValue
+        defaultPath
 		ignore
 		typeDef {
 			...TypeDefRefParts

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -70,6 +70,7 @@ query TypeDefs {
 		optional
 		asObject {
 			name
+			description
 			sourceModuleName
 			constructor {
 				...FunctionParts
@@ -83,15 +84,19 @@ query TypeDefs {
 		}
 		asScalar {
 			name
+			description
 		}
 		asEnum {
 			name
+			description
 			values {
 				name
+			    description
 			}
 		}
 		asInterface {
 			name
+			description
 			sourceModuleName
 			functions {
 				...FunctionParts

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -82,7 +82,7 @@ func (m *Test) Container() *dagger.Container {
 func (ShellSuite) TestBasicGit(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	script := ".git https://github.com/dagger/dagger.git | file README.md | contents"
+	script := ".git https://github.com/dagger/dagger | head | tree | file README.md | contents"
 	out, err := daggerCliBase(t, c).
 		With(withModInit("go", "")).
 		With(daggerShell(script)).


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/8831

## Basic usage

**Main object + Constructor**
```console
> .doc
```

**Return type of a function**
```console
> test | .doc
```

**More details on a function, if return type is an object**
```console
> test | .doc unit
```

**Same with core functions, this documents `Container`**
```console
> .container | .doc
```

**For the arguments to `Query.container`, use `.help`**
```console
> .help .container
```


## Examples

### Main object + Constructor + Available functions

```console
> .doc
TYPE: OBJECT
  DaggerDev - A dev environment for the DaggerDev Engine

CONSTRUCTOR
  .config [options]

OPTIONAL ARGUMENTS
  --source Directory    (default: "/")
  --docker-cfg Secret

AVAILABLE FUNCTIONS
  version               -
  tag                   -
  mod-codegen           When set, module codegen is automatically applied when retrieving the Dagger source code
  mod-codegen-targets   -
  check                 Check that everything works. Use this as CI entrypoint.
  with-mod-codegen      Enable module auto-codegen when retrieving the dagger source code
  cli                   Develop the Dagger CLI
  source                Return the Dagger source code
  go                    Dagger's Go toolchain
  engine                Develop the Dagger engine container
  docs                  Develop the Dagger documentation
  scripts               Run Dagger scripts
  test                  Run all tests
  sdk                   Develop Dagger SDKs
  helm                  Develop the Dagger helm chart
  release               Run Dagger release-related tasks
  dev                   Creates a dev container that has a running CLI connected to a dagger engine
  dev-export            Creates an static dev build

Use ".doc <function>" for more information on a function.
```

### Object + Available functions

```console
> cli | .doc
TYPE: OBJECT
  DaggerDevCli

AVAILABLE FUNCTIONS
  binary         Build the CLI binary
  publish        Publish the CLI using GoReleaser
  test-publish   Verify that the CLI builds without actually publishing anything

Use ".doc <function>" for more information on a function.
```

### Function details

```console
> cli | .doc binary
Build the CLI binary

USAGE
  binary [options]

OPTIONAL ARGUMENTS
  --platform Platform

RETURNS
  File - A file.

Use "binary | .doc" for available functions.
```

### Function that returns a string

```console
> .doc version
USAGE
  version

RETURNS
  string - Primitive type.
```

### Function that returns nothing

```console
> .doc check
Check that everything works. Use this as CI entrypoint.

USAGE
  check [options]

OPTIONAL ARGUMENTS
  --targets []string   Directories to check

RETURNS
  void
```

### Function with required arguments

```console
> go | .doc lint
USAGE
  lint <packages>

REQUIRED ARGUMENTS
  packages []string

RETURNS
  void
```

### List of builtin commands

```console
> .help
DAGGER MODULE COMMANDS
  .config       Set module constructor options
  .deps         List module dependencies
  .install      Install a dependency

DAGGER CORE COMMANDS
  .blob                Retrieves a content-addressed blob.
  .container           Creates a scratch container.
  .current-type-defs   The TypeDef representations of the objects currently being served in the session.
  .dagger-engine       The Dagger engine container configuration and state
  .default-platform    The default platform of the engine.
  .directory           Creates an empty directory.
  .git                 Queries a Git repository.
  .host                Queries the host environment.
  .http                Returns a file containing an http remote url content.
  .version             Get the current Dagger Engine version.

DAGGER CLOUD COMMANDS
  .login        Log in to Dagger Cloud
  .logout       Log out from Dagger Cloud

ADDITIONAL COMMANDS
  .core         Load a core Dagger type
  .doc          Show documentation for a type, or a function
  .help         Print this help message

Use ".help <command>" for more information.
```

### More details on a core function

```console
> .help .git
Queries a Git repository.

USAGE
  .git <url> [options]

REQUIRED ARGUMENTS
  url string    URL of the git repository.

                Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.

                Suffix ".git" is optional.

OPTIONAL ARGUMENTS
  --keep-git-dir bool                   DEPRECATED: Set to true to keep .git directory. (default: true)
  --experimental-service-host Service   A service which must be started before the repo is fetched.
  --ssh-known-hosts string              Set SSH known hosts (default: "")
  --ssh-auth-socket Socket              Set SSH auth socket

RETURNS
  GitRepository

Use ".git <url> | .doc" for available functions.
```

