### PR TITLE
don't bother with transactions for client DB

### DIFF
--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -321,14 +321,6 @@ func (ps *PubSub) Spans(client *daggerClient) sdktrace.SpanExporter {
 	}
 }
 
-func spanNames(spans []sdktrace.ReadOnlySpan) []string {
-	names := make([]string, len(spans))
-	for i, span := range spans {
-		names[i] = span.Name()
-	}
-	return names
-}
-
 func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	slog.ExtraDebug("pubsub exporting spans", "client", ps.client.clientID, "count", len(spans))
 


### PR DESCRIPTION
Some users are still hitting 'database is locked' errors despite SQLite being tuned properly as far as I can tell. We really don't need transactions for this, so just remove them.