### PR TITLE
use default cmd args when starting service

### DIFF
--- a/.changes/unreleased/Breaking-20241111-195013.yaml
+++ b/.changes/unreleased/Breaking-20241111-195013.yaml
@@ -1,0 +1,11 @@
+kind: Breaking
+body: |-
+    AsService now runs "DefaultCmd" by default instead of last "Exec" command.
+
+    User can override the args by providing "ContainerAsServiceOpts.Args" option. They can also configure the container to use Entrypoint by using "ContainerAsServiceOpts.UseEntrypoint" option.
+
+    See sdk documentation for additional options.
+time: 2024-12-06T08:20:21.242739+05:30
+custom:
+    Author: rajatjindal
+    PR: "8865"

--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -358,9 +358,6 @@ func registry() *dagger.Service {
 	return dag.Container().
 		From("registry:2").
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		WithExec(nil, dagger.ContainerWithExecOpts{
-			UseEntrypoint: true,
-		}).
 		AsService()
 }
 
@@ -373,8 +370,5 @@ func privateRegistry() *dagger.Service {
 		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_REALM", "Registry Realm").
 		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_PATH", "/auth/htpasswd").
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		WithExec(nil, dagger.ContainerWithExecOpts{
-			UseEntrypoint: true,
-		}).
 		AsService()
 }

--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -546,9 +546,9 @@ func customCACertTests(
 			WithMountedFile("/usr/local/share/ca-certificates/dagger-test-custom-ca.crt", certGen.caRootCert).
 			WithServiceBinding("server", serverCtr.AsService())
 	})
-	engineSvc, err := c.Host().Tunnel(devEngine.AsService()).Start(ctx)
+	engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(devEngine)).Start(ctx)
 	require.NoError(t, err)
-	t.Cleanup(func() { engineSvc.Stop(ctx) })
+	t.Cleanup(func() { _, _ = engineSvc.Stop(ctx) })
 	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
 	require.NoError(t, err)
 	c2, err := dagger.Connect(ctx, dagger.WithRunnerHost(endpoint), dagger.WithLogOutput(testutil.NewTWriter(t)))
@@ -756,5 +756,5 @@ ssl_dhparam /etc/ssl/certs/dhparam.pem;
 		WithExec([]string{"nginx", "-t"}).
 		WithExposedPort(80).
 		WithExposedPort(443).
-		WithExec([]string{"nginx", "-g", "daemon off;"})
+		WithDefaultArgs([]string{"nginx", "-g", "daemon off;"})
 }

--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -128,7 +128,7 @@ func (ClientSuite) TestMultiSameTrace(ctx context.Context, t *testctx.T) {
 func (ClientSuite) TestClientStableID(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	devEngine := devEngineContainer(c)
-	clientCtr := engineClientContainer(ctx, t, c, devEngine.AsService())
+	clientCtr := engineClientContainer(ctx, t, c, devEngineContainerAsService(devEngine))
 
 	// just run any dagger cli command that connects to the engine
 	stableID, err := clientCtr.

--- a/core/integration/future_test.go
+++ b/core/integration/future_test.go
@@ -25,8 +25,8 @@ func futureClient(ctx context.Context, t *testctx.T, futureVersion string) *dagg
 
 	devEngine := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
 		return c.WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", futureVersion)
-	}).AsService()
-	devClient := engineClientContainer(ctx, t, c, devEngine)
+	})
+	devClient := engineClientContainer(ctx, t, c, devEngineContainerAsService(devEngine))
 	devClient = devClient.WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", futureVersion)
 
 	return devClient.

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -254,7 +254,7 @@ sleep infinity
 	sshSvc := hostKeyGen.
 		WithMountedFile("/root/start.sh", setupScript).
 		WithExposedPort(sshPort).
-		WithExec([]string{"sh", "/root/start.sh"}).
+		WithDefaultArgs([]string{"sh", "/root/start.sh"}).
 		AsService()
 
 	sshHost, err := sshSvc.Hostname(ctx)

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -51,7 +51,7 @@ func (EngineSuite) TestLocalCacheGCKeepBytesConfig(ctx context.Context, t *testc
 		},
 	} {
 		f := func(ctx context.Context, t *testctx.T, engine *dagger.Container) {
-			engineSvc, err := c.Host().Tunnel(engine.AsService()).Start(ctx)
+			engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(engine)).Start(ctx)
 			require.NoError(t, err)
 			t.Cleanup(func() { engineSvc.Stop(ctx) })
 
@@ -148,7 +148,7 @@ func (EngineSuite) TestLocalCacheAutomaticGC(ctx context.Context, t *testctx.T) 
 		},
 	} {
 		f := func(ctx context.Context, t *testctx.T, engine *dagger.Container) {
-			engineSvc, err := c.Host().Tunnel(engine.AsService()).Start(ctx)
+			engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(engine)).Start(ctx)
 			require.NoError(t, err)
 			t.Cleanup(func() { engineSvc.Stop(ctx) })
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3621,7 +3621,7 @@ func (ModuleSuite) TestStartServices(ctx context.Context, t *testctx.T) {
 			).
 			WithWorkdir("/srv/www").
 			WithExposedPort(23457).
-			WithExec([]string{"python", "-m", "http.server", "23457"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server", "23457"}).
 			AsService()
 
 		ctr := dag.Container().

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -191,7 +191,7 @@ func daggerUpInitModFn(ctx context.Context, t *testctx.T, defaultPort string) st
 				).
 				WithWorkdir("/srv/www").
 				WithExposedPort(port).
-				WithExec([]string{"python", "-m", "http.server", strconv.Itoa(port)}),
+				WithDefaultArgs([]string{"python", "-m", "http.server", strconv.Itoa(port)}),
 		}
 	}
 	

--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -120,14 +120,16 @@ func dockerService(t *testctx.T, dag *dagger.Client, dockerVersion string, f fun
 			Sharing: dagger.CacheSharingModePrivate,
 		}).
 		WithExposedPort(port).
-		WithExec([]string{
-			"dockerd",
-			"--host=tcp://0.0.0.0:" + strconv.Itoa(port),
-			"--tls=false",
-		}, dagger.ContainerWithExecOpts{
-			InsecureRootCapabilities: true,
-		}).
-		AsService()
+		AsService(
+			dagger.ContainerAsServiceOpts{
+				Args: []string{
+					"dockerd",
+					"--host=tcp://0.0.0.0:" + strconv.Itoa(port),
+					"--tls=false",
+				},
+				InsecureRootCapabilities: true,
+			},
+		)
 
 	return dockerd
 }

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -175,7 +175,7 @@ http_access allow localhost
 		WithNewFile("/etc/squid/squid.conf", squidConf).
 		WithServiceBinding(httpServerAlias, httpServer.AsService()).
 		WithServiceBinding(noproxyHTTPServerAlias, noproxyHTTPServer.AsService()).
-		WithExec([]string{"sh", "-c", "chmod -R a+rw /var/log/squidaccess && exec squid --foreground"}).
+		WithDefaultArgs([]string{"sh", "-c", "chmod -R a+rw /var/log/squidaccess && exec squid --foreground"}).
 		AsService()
 
 	if os.Getenv(executeTestEnvName) == "" {
@@ -208,7 +208,7 @@ http_access allow localhost
 			WithMountedDirectory("/src", thisRepo).
 			WithWorkdir("/src").
 			WithMountedFile("/ca.pem", certGen.caRootCert).
-			WithServiceBinding("engine", devEngine.AsService()).
+			WithServiceBinding("engine", devEngineContainerAsService(devEngine)).
 			WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://engine:1234").
@@ -458,7 +458,7 @@ func (ContainerSuite) TestSystemGoProxy(ctx context.Context, t *testctx.T) {
 						With(goCache(c)).
 						WithMountedDirectory("/src", thisRepo).
 						WithWorkdir("/src").
-						WithServiceBinding("engine", devEngine.AsService()).
+						WithServiceBinding("engine", devEngineContainerAsService(devEngine)).
 						WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 						WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
 						WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://engine:1234").

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -17,10 +17,11 @@ import (
 const cliBinPath = "/.dagger-cli"
 
 func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *dagger.Service, cacheName string) (devEngineSvc *dagger.Service, endpoint string, err error) {
-	devEngineSvc = devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
+	devEngine := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
 		return c.WithServiceBinding(cacheName, cache)
-	}).AsService()
+	})
 
+	devEngineSvc = devEngineContainerAsService(devEngine)
 	endpoint, err = devEngineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{
 		Port:   1234,
 		Scheme: "tcp",
@@ -41,7 +42,7 @@ func (RemoteCacheSuite) TestRegistry(ctx context.Context, t *testctx.T) {
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
 
@@ -118,7 +119,7 @@ func (RemoteCacheSuite) TestLazyBlobs(ctx context.Context, t *testctx.T) {
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
 
@@ -180,7 +181,7 @@ func (RemoteCacheSuite) TestS3(ctx context.Context, t *testctx.T) {
 		s3 := c.Container().From("minio/minio").
 			WithMountedCache("/data", c.CacheVolume("minio-cache")).
 			WithExposedPort(9000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-			WithExec([]string{"minio", "server", "/data"}).
+			WithDefaultArgs([]string{"minio", "server", "/data"}).
 			AsService()
 
 		s3Endpoint, err := s3.Endpoint(ctx, dagger.ServiceEndpointOpts{Port: 9000, Scheme: "http"})
@@ -260,7 +261,7 @@ func (RemoteCacheSuite) TestRegistryMultipleConfigs(ctx context.Context, t *test
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	cacheConfigEnv1 := "type=registry,ref=registry:5000/test-cache:latest,mode=max"
 	cacheConfigEnv2 := "type=registry,ref=registry:5000/test-cache-b:latest,mode=max"
@@ -358,7 +359,7 @@ func (RemoteCacheSuite) TestRegistrySeparateImportExport(ctx context.Context, t 
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	daggerCli := daggerCliFile(t, c)
 
@@ -486,7 +487,7 @@ func (RemoteCacheSuite) TestRegistryFastCacheBlobSource(ctx context.Context, t *
 	registry := c.Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
 		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	cacheConfig := "type=registry,ref=registry:5000/test-cache:latest,mode=max"
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -64,7 +64,7 @@ func (ServiceSuite) TestHostnamesAreStable(ctx context.Context, t *testctx.T) {
 			WithEnvVariable("FOO", "123").
 			WithEnvVariable("BAR", "456").
 			WithExposedPort(8000).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		hostname, err := srv.Hostname(ctx)
@@ -79,13 +79,13 @@ func (ServiceSuite) TestHostnamesAreStable(ctx context.Context, t *testctx.T) {
 		srv1 := c.Container().
 			From("python").
 			WithExposedPort(8000).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		srv2 := c.Container().
 			From("python").
 			WithExposedPort(8001).
-			WithExec([]string{"python", "-m", "http.server", "8081"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server", "8081"}).
 			AsService()
 
 		hn1, err := srv1.Hostname(ctx)
@@ -126,7 +126,7 @@ func (ServiceSuite) TestHostnameEndpoint(ctx context.Context, t *testctx.T) {
 		srv := c.Container().
 			From("python").
 			WithExposedPort(8000).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		hn, err := srv.Hostname(ctx)
@@ -141,7 +141,7 @@ func (ServiceSuite) TestHostnameEndpoint(ctx context.Context, t *testctx.T) {
 	t.Run("endpoint can specify arbitrary port", func(ctx context.Context, t *testctx.T) {
 		srv := c.Container().
 			From("python").
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		hn, err := srv.Hostname(ctx)
@@ -158,7 +158,7 @@ func (ServiceSuite) TestHostnameEndpoint(ctx context.Context, t *testctx.T) {
 	t.Run("endpoint with no port errors if no exposed port", func(ctx context.Context, t *testctx.T) {
 		srv := c.Container().
 			From("python").
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		_, err := srv.Endpoint(ctx)
@@ -173,7 +173,7 @@ func (ServiceSuite) TestWithHostname(ctx context.Context, t *testctx.T) {
 		From(busyboxImage).
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "Hello, world!").
-		WithExec([]string{"httpd", "-v", "-f"}).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup")
@@ -223,7 +223,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		From("`+busyboxImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "I am the one who hosts.").
-		WithExec([]string{"httpd", "-v", "-f"}).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService()
 	
@@ -319,7 +319,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		From("`+golangImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("main.go", counterMain).
-		WithExec([]string{"go", "run", "main.go"}).
+		WithDefaultArgs([]string{"go", "run", "main.go"}).
 		WithExposedPort(80).
 		AsService()
 
@@ -397,7 +397,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		From("`+busyboxImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "I am the one who hosts.").
-		WithExec([]string{"httpd", "-v", "-f"}).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup0")
@@ -458,7 +458,7 @@ func (m *Caller) Run(ctx context.Context) error {
 		From("`+busyboxImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "I am within the called module.").
-		WithExec([]string{"httpd", "-v", "-f"}).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
@@ -501,7 +501,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		From("`+busyboxImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "I am the one who hosts.").
-		WithExec([]string{"httpd", "-v", "-f"}).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
@@ -567,7 +567,7 @@ func (m *Relayer) Service() *dagger.Service {
 		From("`+golangImage+`").
 		WithWorkdir("/srv").
 		WithNewFile("main.go", relayMain).
-		WithExec([]string{"go", "run", "main.go"}).
+		WithDefaultArgs([]string{"go", "run", "main.go"}).
 		WithExposedPort(80).
 		AsService()
 }
@@ -655,7 +655,7 @@ func (ServiceSuite) TestPorts(ctx context.Context, t *testctx.T) {
 			Description: "nine thousand",
 			Protocol:    dagger.NetworkProtocolUdp,
 		}).
-		WithExec([]string{"python", "-m", "http.server"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server"}).
 		AsService()
 
 	portCfgs, err := srv.Ports(ctx)
@@ -696,7 +696,7 @@ func (ServiceSuite) TestPortsSkipHealthCheck(ctx context.Context, t *testctx.T) 
 			WithExposedPort(6215, dagger.ContainerWithExposedPortOpts{
 				ExperimentalSkipHealthcheck: true,
 			}).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		_, err := srv.Start(ctx)
@@ -715,7 +715,7 @@ func (ServiceSuite) TestPortsSkipHealthCheck(ctx context.Context, t *testctx.T) 
 			WithExposedPort(6215, dagger.ContainerWithExposedPortOpts{
 				ExperimentalSkipHealthcheck: true,
 			}).
-			WithExec([]string{"python", "-m", "http.server", "8000"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server", "8000"}).
 			AsService()
 
 		_, err := srv.Start(ctx)
@@ -931,7 +931,7 @@ func (ContainerSuite) TestExecServicesError(ctx context.Context, t *testctx.T) {
 	srv := c.Container().
 		From(alpineImage).
 		WithExposedPort(8080).
-		WithExec([]string{"sh", "-c", "echo nope; exit 42"}).
+		WithDefaultArgs([]string{"sh", "-c", "echo nope; exit 42"}).
 		AsService()
 
 	host, err := srv.Hostname(ctx)
@@ -986,7 +986,7 @@ func (ContainerSuite) TestExecUDPServices(ctx context.Context, t *testctx.T) {
 		// use TCP :4322 for health-check to avoid test flakiness, since UDP dial
 		// health-checks aren't really a thing
 		WithExposedPort(4322).
-		WithExec([]string{"go", "run", "/src/main.go"}).
+		WithDefaultArgs([]string{"go", "run", "/src/main.go"}).
 		AsService()
 
 	client := c.Container().
@@ -1039,7 +1039,7 @@ func (ContainerSuite) TestExecServicesDeduping(ctx context.Context, t *testctx.T
 		WithMountedFile("/src/main.go",
 			c.Directory().WithNewFile("main.go", pipeSrc).File("main.go")).
 		WithExposedPort(8080).
-		WithExec([]string{"go", "run", "/src/main.go"}).
+		WithDefaultArgs([]string{"go", "run", "/src/main.go"}).
 		AsService()
 
 	client := c.Container().
@@ -1087,7 +1087,7 @@ func (ContainerSuite) TestExecServicesChained(ctx context.Context, t *testctx.T)
 			WithExec([]string{"sh", "-c", "echo $0 >> /srv/www/index.html", strconv.Itoa(i)}).
 			WithWorkdir("/srv/www").
 			WithExposedPort(8000).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 	}
 
@@ -1761,7 +1761,7 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 			).
 			WithWorkdir("/srv/www").
 			WithExposedPort(8000).
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		tunnel, err := c.Host().Tunnel(srv).Start(ctx)
@@ -1794,7 +1794,7 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 				c.Directory().WithNewFile("index.html", content+"-1")).
 			WithMountedDirectory("/srv/www2",
 				c.Directory().WithNewFile("index.html", content+"-2")).
-			WithExec([]string{
+			WithDefaultArgs([]string{
 				"sh", "-c",
 				`( cd /srv/www1 && python -m http.server 8000 ) &
 				 ( cd /srv/www2 && python -m http.server 9000 ) &
@@ -1840,7 +1840,7 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 				c.Directory().WithNewFile("index.html", content+"-1")).
 			WithMountedDirectory("/srv/www2",
 				c.Directory().WithNewFile("index.html", content+"-2")).
-			WithExec([]string{
+			WithDefaultArgs([]string{
 				"sh", "-c",
 				`( cd /srv/www1 && python -m http.server 32767 ) &
 				 ( cd /srv/www2 && python -m http.server 32766 ) &
@@ -1890,7 +1890,7 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 				c.Directory().WithNewFile("index.html", content+"-1")).
 			WithMountedDirectory("/srv/www2",
 				c.Directory().WithNewFile("index.html", content+"-2")).
-			WithExec([]string{
+			WithDefaultArgs([]string{
 				"sh", "-c",
 				`( cd /srv/www1 && python -m http.server 32765 ) &
 				 ( cd /srv/www2 && python -m http.server 32764 ) &
@@ -1944,7 +1944,7 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 			).
 			WithWorkdir("/srv/www").
 			// WithExposedPort(8000). // INTENTIONAL
-			WithExec([]string{"python", "-m", "http.server"}).
+			WithDefaultArgs([]string{"python", "-m", "http.server"}).
 			AsService()
 
 		_, err := c.Host().Tunnel(srv).ID(ctx)
@@ -2087,12 +2087,13 @@ func (ServiceSuite) TestSearchDomainAlwaysSet(ctx context.Context, t *testctx.T)
 
 	devEngine := devEngineContainer(c, func(ctr *dagger.Container) *dagger.Container {
 		return ctr.WithMountedFile("/etc/resolv.conf", newResolvConf)
-	}).AsService()
+	})
+	devEngineSvc := devEngineContainerAsService(devEngine)
 	t.Cleanup(func() {
-		devEngine.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+		devEngineSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
 	})
 
-	hostSvc, err := c.Host().Tunnel(devEngine, dagger.HostTunnelOpts{
+	hostSvc, err := c.Host().Tunnel(devEngineSvc, dagger.HostTunnelOpts{
 		Ports: []dagger.PortForward{{
 			Backend:  1234,
 			Frontend: 32132,
@@ -2134,7 +2135,7 @@ func httpService(ctx context.Context, t *testctx.T, c *dagger.Client, content st
 		).
 		WithWorkdir("/srv/www").
 		WithExposedPort(8000).
-		WithExec([]string{"python", "-m", "http.server"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server"}).
 		AsService()
 
 	httpURL, err := srv.Endpoint(ctx, dagger.ServiceEndpointOpts{
@@ -2159,7 +2160,7 @@ func gitServiceWithBranch(ctx context.Context, t *testctx.T, c *dagger.Client, c
 		WithExec([]string{"apk", "add", "git", "git-daemon"}).
 		WithDirectory("/root/srv", makeGitDir(c, content, branchName)).
 		WithExposedPort(gitPort).
-		WithExec([]string{"sh", "-c", "git daemon --verbose --export-all --base-path=/root/srv"}).
+		WithDefaultArgs([]string{"sh", "-c", "git daemon --verbose --export-all --base-path=/root/srv"}).
 		AsService()
 
 	gitHost, err := gitDaemon.Hostname(ctx)
@@ -2214,7 +2215,7 @@ server {
 			Owner: "nginx",
 		}).
 		WithExposedPort(80).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
 	gitHost, err := gitDaemon.Hostname(ctx)
 	require.NoError(t, err)
@@ -2286,7 +2287,7 @@ with socketserver.TCPServer(("", 8000), http.server.SimpleHTTPRequestHandler) as
 		WithWorkdir("/srv/www").
 		WithNewFile("signals.txt", "").
 		WithExposedPort(8000).
-		WithExec([]string{"python", "/signals.py"}).
+		WithDefaultArgs([]string{"python", "/signals.py"}).
 		AsService()
 
 	httpURL, err := srv.Endpoint(ctx, dagger.ServiceEndpointOpts{

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -155,7 +155,7 @@ func httpService(ctx context.Context, c *dagger.Client, dir *dagger.Directory) (
 		WithMountedDirectory("/srv/www", dir).
 		WithWorkdir("/srv/www").
 		WithExposedPort(8000).
-		WithExec([]string{"python", "-m", "http.server"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server"}).
 		AsService()
 
 	httpURL, err := srv.Endpoint(ctx, dagger.ServiceEndpointOpts{
@@ -202,7 +202,7 @@ git daemon --verbose --export-all --base-path=/root/srv
 `).
 				File("start.sh")).
 		WithExposedPort(gitPort).
-		WithExec([]string{"sh", "/root/start.sh"}).
+		WithDefaultArgs([]string{"sh", "/root/start.sh"}).
 		AsService()
 
 	gitHost, err := gitDaemon.Hostname(ctx)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -376,7 +376,7 @@ func (s *containerSchema) Install() {
 			View(AllVersion).
 			Doc(`Retrieves this container after executing the specified command inside it.`).
 			ArgDoc("args",
-				`Command to run instead of the container's default command (e.g., ["run", "main.go"]).`,
+				`Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).`,
 				`If empty, the container's default command is used.`).
 			ArgDoc("useEntrypoint",
 				`If the container has an entrypoint, prepend it to the args.`).

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -18,9 +18,40 @@ var _ SchemaResolvers = &serviceSchema{}
 
 func (s *serviceSchema) Install() {
 	dagql.Fields[*core.Container]{
-		dagql.Func("asService", s.containerAsService).
+		dagql.Func("asService", s.containerAsServiceLegacy).
+			View(BeforeVersion("v0.15.0")).
 			Doc(`Turn the container into a Service.`,
 				`Be sure to set any exposed ports before this conversion.`),
+
+		dagql.Func("asService", s.containerAsService).
+			View(AfterVersion("v0.15.0")).
+			Doc(`Turn the container into a Service.`,
+				`Be sure to set any exposed ports before this conversion.`).
+			ArgDoc("args",
+				`Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).`,
+				`If empty, the container's default command is used.`).
+			ArgDoc("useEntrypoint",
+				`If the container has an entrypoint, prepend it to the args.`).
+			ArgDoc("experimentalPrivilegedNesting",
+				`Provides Dagger access to the executed command.`,
+				`Do not use this option unless you trust the command being executed;
+				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
+				FILESYSTEM.`).
+			ArgDoc("insecureRootCapabilities",
+				`Execute the command with all root capabilities. This is similar to
+				running a command with "sudo" or executing "docker run" with the
+				"--privileged" flag. Containerization does not provide any security
+				guarantees when using this option. It should only be used when
+				absolutely necessary and only with trusted commands.`).
+			ArgDoc("expand",
+				`Replace "${VAR}" or "$VAR" in the args according to the current `+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`).
+			ArgDoc("noInit",
+				`If set, skip the automatic init process injected into containers by default.`,
+				`This should only be used if the user requires that their exec process be the
+				pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
+			),
+
 		dagql.NodeFunc("up", s.containerUp).
 			Doc(`Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.`,
 				`Be sure to set any exposed ports before calling this api.`).
@@ -68,8 +99,23 @@ func (s *serviceSchema) Install() {
 	}.Install(s.srv)
 }
 
-func (s *serviceSchema) containerAsService(ctx context.Context, parent *core.Container, args struct{}) (*core.Service, error) {
-	return parent.AsService(ctx)
+func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent *core.Container, args struct{}) (*core.Service, error) {
+	return parent.AsServiceLegacy(ctx)
+}
+
+func (s *serviceSchema) containerAsService(ctx context.Context, parent *core.Container, args core.ContainerAsServiceArgs) (*core.Service, error) {
+	expandedArgs := make([]string, len(args.Args))
+	for i, arg := range args.Args {
+		expandedArg, err := expandEnvVar(ctx, parent, arg, args.Expand)
+		if err != nil {
+			return nil, err
+		}
+
+		expandedArgs[i] = expandedArg
+	}
+	args.Args = expandedArgs
+
+	return parent.AsService(ctx, args)
 }
 
 func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*core.Container], args upArgs) (dagql.Nullable[core.Void], error) {

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -68,15 +68,12 @@ func (container *Container) Terminal(
 		output.String("dagger").Foreground(termenv.ANSIYellow).String(),
 		output.String(`$(pwd | sed "s|^$HOME|~|")`).Faint().String(),
 	))
-	container, err = container.WithExec(ctx, ContainerExecOpts{
+
+	svc, err := container.AsService(ctx, ContainerAsServiceArgs{
 		Args:                          args.Cmd,
 		ExperimentalPrivilegedNesting: args.ExperimentalPrivilegedNesting.Value.Bool(),
 		InsecureRootCapabilities:      args.InsecureRootCapabilities.Value.Bool(),
 	})
-	if err != nil {
-		return fmt.Errorf("failed to create container for interactive terminal: %w", err)
-	}
-	svc, err := container.AsService(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create service for interactive terminal: %w", err)
 	}

--- a/docs/current_docs/api/snippets/services/bind-services/go/main.go
+++ b/docs/current_docs/api/snippets/services/bind-services/go/main.go
@@ -13,7 +13,7 @@ func (m *MyModule) HttpService() *dagger.Service {
 		From("python").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "Hello, world!").
-		WithExec([]string{"python", "-m", "http.server", "8080"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server", "8080"}).
 		WithExposedPort(8080).
 		AsService()
 }

--- a/docs/current_docs/api/snippets/services/expose-dagger-services-to-host/go/main.go
+++ b/docs/current_docs/api/snippets/services/expose-dagger-services-to-host/go/main.go
@@ -10,7 +10,7 @@ func (m *MyModule) HttpService() *dagger.Service {
 		From("python").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "Hello, world!").
-		WithExec([]string{"python", "-m", "http.server", "8080"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server", "8080"}).
 		WithExposedPort(8080).
 		AsService()
 }

--- a/docs/current_docs/features/snippets/services-1/go/main.go
+++ b/docs/current_docs/features/snippets/services-1/go/main.go
@@ -13,7 +13,7 @@ func (m *MyModule) HttpService() *dagger.Service {
 		From("python").
 		WithWorkdir("/srv").
 		WithNewFile("index.html", "Hello, world!").
-		WithExec([]string{"python", "-m", "http.server", "8080"}).
+		WithDefaultArgs([]string{"python", "-m", "http.server", "8080"}).
 		WithExposedPort(8080).
 		AsService()
 }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -60,7 +60,48 @@ type Container {
   
   Be sure to set any exposed ports before this conversion.
   """
-  asService: Service!
+  asService(
+    """
+    Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+    
+    If empty, the container's default command is used.
+    """
+    args: [String!] = []
+
+    """
+    Replace "${VAR}" or "$VAR" in the args according to the current environment
+    variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
+    Provides Dagger access to the executed command.
+    
+    Do not use this option unless you trust the command being executed; the
+    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    """
+    experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Execute the command with all root capabilities. This is similar to running a
+    command with "sudo" or executing "docker run" with the "--privileged" flag.
+    Containerization does not provide any security guarantees when using this
+    option. It should only be used when absolutely necessary and only with
+    trusted commands.
+    """
+    insecureRootCapabilities: Boolean = false
+
+    """
+    If set, skip the automatic init process injected into containers by default.
+    
+    This should only be used if the user requires that their exec process be the
+    pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    """
+    noInit: Boolean = false
+
+    """If the container has an entrypoint, prepend it to the args."""
+    useEntrypoint: Boolean = false
+  ): Service!
 
   """Returns a File representing the container serialized to a tarball."""
   asTarball(
@@ -505,7 +546,7 @@ type Container {
   """
   withExec(
     """
-    Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
     
     If empty, the container's default command is used.
     """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -3806,11 +3806,47 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-asService" href="#Container-asService"><code>asService</code></a> - <span class="property-type"><a href="#definition-Service"><code>Service!</code></a></span> </td>
                         <td>
                           <p>Turn the container into a Service.</p>
                           <p>Be sure to set any exposed ports before this conversion.</p>
+                        </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>args</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Command to run instead of the container&#39;s default command (e.g., [&quot;go&quot;, &quot;run&quot;, &quot;main.go&quot;]).</p>
+                                <p>If empty, the container&#39;s default command is used.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace &quot;${VAR}&quot; or &quot;$VAR&quot; in the args according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Provides Dagger access to the executed command.</p>
+                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Execute the command with all root capabilities. This is similar to running a command with &quot;sudo&quot; or executing &quot;docker run&quot; with the &quot;--privileged&quot; flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noInit</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If set, skip the automatic init process injected into containers by default.</p>
+                                <p>This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>useEntrypoint</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If the container has an entrypoint, prepend it to the args.</p>
+                              </div>
+                            </div>
+                          </div>
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
@@ -4389,7 +4425,7 @@
                             <div class="field-argument-list">
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>args</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
-                                <p>Command to run instead of the container&#39;s default command (e.g., [&quot;run&quot;, &quot;main.go&quot;]).</p>
+                                <p>Command to run instead of the container&#39;s default command (e.g., [&quot;go&quot;, &quot;run&quot;, &quot;main.go&quot;]).</p>
                                 <p>If empty, the container&#39;s default command is used.</p>
                               </div>
                               <div class="field-argument">

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -16,10 +16,27 @@ defmodule Dagger.Container do
 
   Be sure to set any exposed ports before this conversion.
   """
-  @spec as_service(t()) :: Dagger.Service.t()
-  def as_service(%__MODULE__{} = container) do
+  @spec as_service(t(), [
+          {:args, [String.t()]},
+          {:use_entrypoint, boolean() | nil},
+          {:experimental_privileged_nesting, boolean() | nil},
+          {:insecure_root_capabilities, boolean() | nil},
+          {:expand, boolean() | nil},
+          {:no_init, boolean() | nil}
+        ]) :: Dagger.Service.t()
+  def as_service(%__MODULE__{} = container, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("asService")
+      container.query_builder
+      |> QB.select("asService")
+      |> QB.maybe_put_arg("args", optional_args[:args])
+      |> QB.maybe_put_arg("useEntrypoint", optional_args[:use_entrypoint])
+      |> QB.maybe_put_arg(
+        "experimentalPrivilegedNesting",
+        optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
+      |> QB.maybe_put_arg("noInit", optional_args[:no_init])
 
     %Dagger.Service{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -352,11 +352,59 @@ func (r *Container) WithGraphQLQuery(q *querybuilder.Selection) *Container {
 	}
 }
 
+// ContainerAsServiceOpts contains options for Container.AsService
+type ContainerAsServiceOpts struct {
+	// Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+	//
+	// If empty, the container's default command is used.
+	Args []string
+	// If the container has an entrypoint, prepend it to the args.
+	UseEntrypoint bool
+	// Provides Dagger access to the executed command.
+	//
+	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+	ExperimentalPrivilegedNesting bool
+	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+	InsecureRootCapabilities bool
+	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+	// If set, skip the automatic init process injected into containers by default.
+	//
+	// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+	NoInit bool
+}
+
 // Turn the container into a Service.
 //
 // Be sure to set any exposed ports before this conversion.
-func (r *Container) AsService() *Service {
+func (r *Container) AsService(opts ...ContainerAsServiceOpts) *Service {
 	q := r.query.Select("asService")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `args` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Args) {
+			q = q.Arg("args", opts[i].Args)
+		}
+		// `useEntrypoint` optional argument
+		if !querybuilder.IsZeroValue(opts[i].UseEntrypoint) {
+			q = q.Arg("useEntrypoint", opts[i].UseEntrypoint)
+		}
+		// `experimentalPrivilegedNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `insecureRootCapabilities` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
+			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `noInit` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoInit) {
+			q = q.Arg("noInit", opts[i].NoInit)
+		}
+	}
 
 	return &Service{
 		query: q,

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -18,9 +18,33 @@ class Container extends Client\AbstractObject implements Client\IdAble
      *
      * Be sure to set any exposed ports before this conversion.
      */
-    public function asService(): Service
-    {
+    public function asService(
+        ?array $args = null,
+        ?bool $useEntrypoint = false,
+        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $insecureRootCapabilities = false,
+        ?bool $expand = false,
+        ?bool $noInit = false,
+    ): Service {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asService');
+        if (null !== $args) {
+        $innerQueryBuilder->setArgument('args', $args);
+        }
+        if (null !== $useEntrypoint) {
+        $innerQueryBuilder->setArgument('useEntrypoint', $useEntrypoint);
+        }
+        if (null !== $experimentalPrivilegedNesting) {
+        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $insecureRootCapabilities) {
+        $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
+        }
+        if (null !== $expand) {
+        $innerQueryBuilder->setArgument('expand', $expand);
+        }
+        if (null !== $noInit) {
+        $innerQueryBuilder->setArgument('noInit', $noInit);
+        }
         return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1503,6 +1503,30 @@ pub struct Container {
     pub graphql_client: DynGraphQLClient,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ContainerAsServiceOpts<'a> {
+    /// Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+    /// If empty, the container's default command is used.
+    #[builder(setter(into, strip_option), default)]
+    pub args: Option<Vec<&'a str>>,
+    /// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+    /// Provides Dagger access to the executed command.
+    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    #[builder(setter(into, strip_option), default)]
+    pub experimental_privileged_nesting: Option<bool>,
+    /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub insecure_root_capabilities: Option<bool>,
+    /// If set, skip the automatic init process injected into containers by default.
+    /// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    #[builder(setter(into, strip_option), default)]
+    pub no_init: Option<bool>,
+    /// If the container has an entrypoint, prepend it to the args.
+    #[builder(setter(into, strip_option), default)]
+    pub use_entrypoint: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerAsTarballOpts {
     /// Force each layer of the image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
@@ -1859,8 +1883,47 @@ pub struct ContainerWithoutUnixSocketOpts {
 impl Container {
     /// Turn the container into a Service.
     /// Be sure to set any exposed ports before this conversion.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_service(&self) -> Service {
         let query = self.selection.select("asService");
+        Service {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Turn the container into a Service.
+    /// Be sure to set any exposed ports before this conversion.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn as_service_opts<'a>(&self, opts: ContainerAsServiceOpts<'a>) -> Service {
+        let mut query = self.selection.select("asService");
+        if let Some(args) = opts.args {
+            query = query.arg("args", args);
+        }
+        if let Some(use_entrypoint) = opts.use_entrypoint {
+            query = query.arg("useEntrypoint", use_entrypoint);
+        }
+        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
+            query = query.arg(
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+            );
+        }
+        if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
+            query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
+        }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
+        if let Some(no_init) = opts.no_init {
+            query = query.arg("noInit", no_init);
+        }
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -2641,7 +2704,7 @@ impl Container {
     ///
     /// # Arguments
     ///
-    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    /// * `args` - Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2661,7 +2724,7 @@ impl Container {
     ///
     /// # Arguments
     ///
-    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    /// * `args` - Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use


### PR DESCRIPTION
Following changes are being done to the `AsService` API:

- Runs the `DefaultCmd` by default. This can be overwritten by passing optional `Args` option to the `AsService` API.
- Entrypoint is disabled by default. This can be enabled using the option `UseEntrypoint` option to the `AsService` API. If this is enabled, then we prepend the "Entrypoint" to the default args.

fixes #8140 