### PR TITLE
Fix cgroup error logs + cache volume re-use in go SDK

### DIFF
--- a/engine/buildkit/resources/cpustat.go
+++ b/engine/buildkit/resources/cpustat.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,8 +78,11 @@ func (s *cpuStatSampler) sample(ctx context.Context) error {
 	}
 
 	bs, err := os.ReadFile(s.cpuStatFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read cpu.stat file: %w", err)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.cpuStatFilePath, err)
 	}
 
 	for key, value := range flatKeyValuesInt64(bs) {
@@ -145,8 +149,11 @@ func (s *cpuPressureSampler) sample(ctx context.Context) error {
 	}
 
 	bs, err := os.ReadFile(s.cpuPressureFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read cpu.pressure file: %w", err)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.cpuPressureFilePath, err)
 	}
 
 	p := parsePressure(bs)


### PR DESCRIPTION
I noticed a few easy fix issues while perusing engine logs from a test run earlier today. They technically aren't related but combining them into one PR for convenience.

--- 

[engine: ignore missing cpu.stat/cpu.pressure files](https://github.com/dagger/dagger/commit/cca2f47d4427108494d391bbaef63c51d8822c64)

We already ignored missing cgroup files for io.stat/io.pressure but
missed that for cpu files. These files can be missing if the engine
doesn't support cgroups for execs and result in a ton of useless log
noise in that case.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

[engine: fix cache volume re-use when sourced from builtinContainer](https://github.com/dagger/dagger/commit/adc5b6a5c4facc0e480abf1750086eba62ccd07b)

I noticed that there were a bunch of engine logs about not being able to
re-use cache mount refs due to missing descriptors for lazy blobs.

These is buildkit mumbo jumbo that means it left certain cache refs lazy
but when it needed to unlazy them it didn't find the required metadata
to do so hidden in the context.

This was happening specifically because of the recent change to set go
module building containers to use cache volumes sourced from the base
container. The base container was loaded using OCI LLB which leaves
cache refs lazy.

I am pretty sure this is just a case not handled by buildkit's cache
mount code, but it's easiest to fix in our own code by ensuring these
refs aren't lazy in `builtinContainer`, which this update does by
performing the right magical incantation (solve the ref and call
`.Extract` on it).

Signed-off-by: Erik Sipsma <erik@sipsma.dev>