### PR TITLE
docs: Add instructions and assets for rebuilding the 0.9 docs archive without embeds

### DIFF
--- a/docs/ARCHIVING.md
+++ b/docs/ARCHIVING.md
@@ -136,6 +136,9 @@ NOTE: At the time of writing, this is a completely manual process. This is becau
 
 ## Build 0.9 sub-site
 
+- Copy the following to a temporary location (`temp`) from the `main` branch before beginning
+  - `docs\archived_docs\assets`
+  - `docs\src\scripts\replace-embeds.go`
 - Clone branch `v0.9.x` at last commit 77a53a8
 - Delete `docs/versioned_docs/version-zenith` sub-directory
 - Delete `docs/versioned_sidebars/version-zenith-sidebars.json` file
@@ -238,6 +241,14 @@ NOTE: At the time of writing, this is a completely manual process. This is becau
   - Replace `(../sdk/python/)` URL links with `(/0.9/sdk/python/)` URL links
   - Replace `(../sdk/go/)` URL links with `(/0.9/sdk/go/)` URL links
   - Replace `(../api/)` URL links with `(/0.9/api/)` URL links
+- Replace embedded snippets with file references
+  - Remove `import QuickstartDoc from '@site/src/components/quickstartDoc.js'` in all pages
+  - Remove `<QuickstartDoc embeds={ids}>` in all pages
+  - Remove `</QuickstartDoc>` in all pages
+  - Move `temp/assets/0.9/api/snippets/*` to `docs/current_docs/api/snippets` (snippets which previously existed only as embeds, not files)
+  - Move `temp/assets/0.9/quickstart/snippets/*` to `docs/current_docs/quickstart/snippets` (snippets which previously existed only as embeds, not files)
+  - From the `docs` directory, run the command `go run src/scripts/replace-embeds.go` to replace all embedded snippets with file references
+  - Perform a search over the `docs` directory tree to confirm that there are no orphaned `<Embed` directives
 - Run `npm run build` and store the `build/` directory as `site/0.9`
 
 ## Build top-level site (archive.docs.dagger.io)

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query1.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query1.gql
@@ -1,0 +1,9 @@
+query {
+  container {
+    from(address: "alpine:latest") {
+      withExec(args: ["apk", "info"]) {
+        stdout
+      }
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query2.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query2.gql
@@ -1,0 +1,7 @@
+query {
+  host {
+    directory(path: ".") {
+      id
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query3.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query3.gql
@@ -1,0 +1,9 @@
+query {
+  container {
+    from(address: "alpine:latest") {
+      withExec(args: ["touch", "/tmp/myfile"]) {
+        id
+      }
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query4.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query4.gql
@@ -1,0 +1,7 @@
+query {
+  container(id: "YOUR-ID-HERE") {
+    withExec(args: ["ls", "/tmp"]) {
+      stdout
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query5.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query5.gql
@@ -1,0 +1,11 @@
+query {
+  container {
+    from(address: "alpine:latest") {
+      withExec(args: ["apk", "add", "curl"]) {
+        withExec(args: ["curl", "YOUR-WEBHOOK-URL"]) {
+          id
+        }
+      }
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/api/snippets/concepts/query6.gql
+++ b/docs/archived_docs/assets/0.9/api/snippets/concepts/query6.gql
@@ -1,0 +1,11 @@
+query {
+  container {
+    from(address: "alpine:latest") {
+      withExec(args: ["apk", "add", "curl"]) {
+        withExec(args: ["curl", "YOUR-WEBHOOK-URL-HERE"]) {
+          stdout
+        }
+      }
+    }
+  }
+}

--- a/docs/archived_docs/assets/0.9/quickstart/snippets/build/index.mjs
+++ b/docs/archived_docs/assets/0.9/quickstart/snippets/build/index.mjs
@@ -1,0 +1,34 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(
+  async (client) => {
+    // use a node:16-slim container
+    // mount the source code directory on the host
+    // at /src in the container
+    const source = client
+      .container()
+      .from("node:16-slim")
+      .withDirectory(
+        "/src",
+        client.host().directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
+      )
+
+    // set the working directory in the container
+    // install application dependencies
+    const runner = source.withWorkdir("/src").withExec(["npm", "install"])
+
+    // run application tests
+    const test = runner.withExec(["npm", "test", "--", "--watchAll=false"])
+
+    // build application
+    // write the build output to the host
+    const buildDir = test.withExec(["npm", "run", "build"]).directory("./build")
+
+    await buildDir.export("./build")
+
+    const e = await buildDir.entries()
+
+    console.log("build dir contents:\n", e)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/archived_docs/assets/0.9/quickstart/snippets/build/main.go
+++ b/docs/archived_docs/assets/0.9/quickstart/snippets/build/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// use a node:16-slim container
+	// mount the source code directory on the host
+	// at /src in the container
+	source := client.Container().
+		From("node:16-slim").
+		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"node_modules/", "ci/"},
+		})
+
+		// set the working directory in the container
+		// install application dependencies
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+		// run application tests
+	test := runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"})
+
+	// build application
+	// write the build output to the host
+	buildDir := test.WithExec([]string{"npm", "run", "build"}).
+		Directory("./build")
+
+	_, err = buildDir.Export(ctx, "./build")
+	if err != nil {
+		panic(err)
+	}
+
+	e, err := buildDir.Entries(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("build dir contents:\n %s\n", e)
+}

--- a/docs/archived_docs/assets/0.9/quickstart/snippets/build/main.py
+++ b/docs/archived_docs/assets/0.9/quickstart/snippets/build/main.py
@@ -1,0 +1,45 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_directory(
+                "/src",
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]),
+            )
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
+
+        # build application
+        # write the build output to the host
+        build_dir = (
+            test.with_exec(["npm", "run", "build"])
+            .directory("./build")
+        )
+
+        await build_dir.export("./build")
+
+        e = await build_dir.entries()
+
+        print(f"build dir contents:\n{e}")
+
+anyio.run(main)

--- a/docs/current_docs/api/playground.mdx
+++ b/docs/current_docs/api/playground.mdx
@@ -1,0 +1,11 @@
+---
+slug: /api/playground
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# API Playground
+
+The API Playground was an in-browser tool for testing, running and sharing Dagger API queries. It has since been decommissioned.
+
+The recommended approach is to use the [`dagger query`](./clients-http.mdx#dagger-cli) sub-command, which provides an easy way to send raw GraphQL queries to the Dagger API from the command line.

--- a/docs/src/scripts/replace-embeds.go
+++ b/docs/src/scripts/replace-embeds.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Define the struct to hold the data
+type FileEntry struct {
+	SourceFilename string
+	Language       string
+	EmbedID        string
+	ScriptFilename string
+}
+
+// Function to process each file entry
+func processFile(entry FileEntry) error {
+	// Read the contents of the source file
+	content, err := ioutil.ReadFile(entry.SourceFilename)
+	if err != nil {
+		return fmt.Errorf("error reading file %s: %w", entry.SourceFilename, err)
+	}
+
+	// Replace occurrences of ID with script filename
+	// HACK: do this twice because some <Embed tags have whitespace before closing and some don't
+	// handle <Embed .. /> (with spaces)
+	modifiedContent := strings.ReplaceAll(string(content), "<Embed id=\""+entry.EmbedID+"\" />", "```"+entry.Language+" file="+entry.ScriptFilename+"\r```")
+	// handle <Embed ../> (without spaces)
+	modifiedContent = strings.ReplaceAll(string(modifiedContent), "<Embed id=\""+entry.EmbedID+"\"/>", "```"+entry.Language+" file="+entry.ScriptFilename+"\r```")
+
+	// Write the modified content back to the source file
+	err = ioutil.WriteFile(entry.SourceFilename, []byte(modifiedContent), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing to file %s: %w", entry.SourceFilename, err)
+	}
+
+	fmt.Printf("Processed file: %s (Replaced '%s' with '%s')\n", entry.SourceFilename, entry.EmbedID, entry.ScriptFilename)
+	return nil
+}
+
+func main() {
+	// Define multiple file entries
+	entries := []FileEntry{
+		{
+			SourceFilename: "current_docs/quickstart/593914-hello.mdx",
+			Language:       "go",
+			EmbedID:        "AqF1QrJBh1L",
+			ScriptFilename: "./snippets/hello/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/593914-hello.mdx",
+			Language:       "javascript",
+			EmbedID:        "ANSxtgC136o",
+			ScriptFilename: "./snippets/hello/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/593914-hello.mdx",
+			Language:       "python",
+			EmbedID:        "sLUm92wLwtw",
+			ScriptFilename: "./snippets/hello/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/947391-test.mdx",
+			Language:       "go",
+			EmbedID:        "v676qm2pxae",
+			ScriptFilename: "./snippets/test/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/947391-test.mdx",
+			Language:       "javascript",
+			EmbedID:        "Wb_vszr9Ule",
+			ScriptFilename: "./snippets/test/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/947391-test.mdx",
+			Language:       "python",
+			EmbedID:        "yZj9P2N03-D",
+			ScriptFilename: "./snippets/test/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/349011-build.mdx",
+			Language:       "go",
+			EmbedID:        "smjo0gkeiFz",
+			ScriptFilename: "./snippets/build/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/349011-build.mdx",
+			Language:       "javascript",
+			EmbedID:        "5i8mcHTVJ-x",
+			ScriptFilename: "./snippets/build/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/349011-build.mdx",
+			Language:       "python",
+			EmbedID:        "E8rjb5DFd2m",
+			ScriptFilename: "./snippets/build/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/730264-publish.mdx",
+			Language:       "go",
+			EmbedID:        "PgPJUlg4Aq8",
+			ScriptFilename: "./snippets/publish/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/730264-publish.mdx",
+			Language:       "javascript",
+			EmbedID:        "1P5-90wivSP",
+			ScriptFilename: "./snippets/publish/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/730264-publish.mdx",
+			Language:       "python",
+			EmbedID:        "8vUQnWJ6mxe",
+			ScriptFilename: "./snippets/publish/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/472910-build-multi.mdx",
+			Language:       "go",
+			EmbedID:        "NJF-IQ7XzG-",
+			ScriptFilename: "./snippets/build-multi/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/472910-build-multi.mdx",
+			Language:       "javascript",
+			EmbedID:        "loDAHfMcysK",
+			ScriptFilename: "./snippets/build-multi/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/472910-build-multi.mdx",
+			Language:       "python",
+			EmbedID:        "3xJIBUQdEkp",
+			ScriptFilename: "./snippets/build-multi/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/429462-build-dockerfile.mdx",
+			Language:       "go",
+			EmbedID:        "gFFeUi06wW3",
+			ScriptFilename: "./snippets/build-dockerfile/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/429462-build-dockerfile.mdx",
+			Language:       "javascript",
+			EmbedID:        "AnwtJTV9Xj3",
+			ScriptFilename: "./snippets/build-dockerfile/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/429462-build-dockerfile.mdx",
+			Language:       "python",
+			EmbedID:        "EaSvAH9iPiG",
+			ScriptFilename: "./snippets/build-dockerfile/main.py",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/635927-caching.mdx",
+			Language:       "go",
+			EmbedID:        "1J5Fs4NoQcW",
+			ScriptFilename: "./snippets/caching/main.go",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/635927-caching.mdx",
+			Language:       "javascript",
+			EmbedID:        "HjFX8td15TX",
+			ScriptFilename: "./snippets/caching/index.mjs",
+		},
+		{
+			SourceFilename: "current_docs/quickstart/635927-caching.mdx",
+			Language:       "python",
+			EmbedID:        "TCdOYrKMfV_d",
+			ScriptFilename: "./snippets/caching/main.py",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "9SB8ePzCltX",
+			ScriptFilename: "./snippets/concepts/query1.gql",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "8I0c_SMKQbj",
+			ScriptFilename: "./snippets/concepts/query2.gql",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "PE1GJrfZODq",
+			ScriptFilename: "./snippets/concepts/query3.gql",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "DKUH7PI5Yt0",
+			ScriptFilename: "./snippets/concepts/query4.gql",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "NuLZcSHaNno",
+			ScriptFilename: "./snippets/concepts/query5.gql",
+		},
+		{
+			SourceFilename: "current_docs/api/975146-concepts.mdx",
+			Language:       "graphql",
+			EmbedID:        "SLtXQ4lvqNS",
+			ScriptFilename: "./snippets/concepts/query6.gql",
+		},
+	}
+
+	// Iterate over the entries and process each file
+	for _, entry := range entries {
+		err := processFile(entry)
+		if err != nil {
+			fmt.Println("Error:", err)
+		}
+	}
+}


### PR DESCRIPTION
The 0.9.x docs archive includes "live" code snippets which rely on the API Playground. Once the Playground is decommissioned, those snippets will neither display nor execute in the 0.9.x docs archive. 

The solution we have agreed on is to replace the "live" code snippets with static code snippets in the 0.9.x docs archive, so that users browsing the docs archive are not impacted by this change. This PR provides the instructions, scripts and assets needed to reliably rebuild the 0.9 docs archive with the above change. Refer to ARCHIVING.md for full details.

This PR also includes a static information page noting the decommissioning and providing alternative resources. All future API Playground requests may be redirected to this page. The URL of this static information page will be docs.dagger.io/api/playground.

