### PR TITLE
php: update symfony/process to avoid CVE

### DIFF
--- a/sdk/php/composer.lock
+++ b/sdk/php/composer.lock
@@ -1710,16 +1710,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.1.3",
+            "version": "v7.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca"
+                "reference": "9b8a40b7289767aa7117e957573c2a535efe6585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7f2f542c668ad6c313dc4a5e9c3321f733197eca",
-                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca",
+                "url": "https://api.github.com/repos/symfony/process/zipball/9b8a40b7289767aa7117e957573c2a535efe6585",
+                "reference": "9b8a40b7289767aa7117e957573c2a535efe6585",
                 "shasum": ""
             },
             "require": {
@@ -1751,7 +1751,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.1.3"
+                "source": "https://github.com/symfony/process/tree/v7.1.7"
             },
             "funding": [
                 {
@@ -1767,7 +1767,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-26T12:44:47+00:00"
+            "time": "2024-11-06T09:25:12+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3878,12 +3878,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/sdk/php/dev/composer.lock
+++ b/sdk/php/dev/composer.lock
@@ -1760,16 +1760,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.1.3",
+            "version": "v7.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca"
+                "reference": "9b8a40b7289767aa7117e957573c2a535efe6585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7f2f542c668ad6c313dc4a5e9c3321f733197eca",
-                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca",
+                "url": "https://api.github.com/repos/symfony/process/zipball/9b8a40b7289767aa7117e957573c2a535efe6585",
+                "reference": "9b8a40b7289767aa7117e957573c2a535efe6585",
                 "shasum": ""
             },
             "require": {
@@ -1801,7 +1801,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.1.3"
+                "source": "https://github.com/symfony/process/tree/v7.1.7"
             },
             "funding": [
                 {
@@ -1817,7 +1817,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-26T12:44:47+00:00"
+            "time": "2024-11-06T09:25:12+00:00"
         },
         {
             "name": "symfony/service-contracts",


### PR DESCRIPTION
Our engine image scans started failing with:
```
    {
      "Target": "sdk/php/composer.lock",
      "Class": "lang-pkgs",
      "Type": "composer",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2024-51736",
          "PkgID": "symfony/process@v7.1.3",
          "PkgName": "symfony/process",
          "PkgIdentifier": {
            "PURL": "pkg:composer/symfony/process@v7.1.3",
            "UID": "b6476f8141579de1"
          },
          "InstalledVersion": "v7.1.3",
          "FixedVersion": "5.3.0, 6.1.0, 5.0.0, 5.2.0, 5.4.46, 6.2.0, 6.3.0, 4.0.0, 5.1.0, 6.4.0, 7.1.0, 7.1.7, 3.0.0, 5.4.0, 6.4.14",
          "Status": "fixed",
          "Layer": {},
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-51736",
          "DataSource": {
            "ID": "php-security-advisories",
            "Name": "PHP Security Advisories Database",
            "URL": "https://github.com/FriendsOfPHP/security-advisories"
          },
          "Title": "CVE-2024-51736: Command execution hijack on Windows with Process class",
          "Description": "Symphony process is a module for the Symphony PHP framework which executes commands in sub-processes. On Windows, when an executable file named `cmd.exe` is located in the current working directory it will be called by the `Process` class when preparing command arguments, leading to possible hijacking. This issue has been addressed in release versions 5.4.46, 6.4.14, and 7.1.7. Users are advised to upgrade. There are no known workarounds for this vulnerability.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-77"
          ],
          "VendorSeverity": {
            "ghsa": 3
          },
          "CVSS": {
            "ghsa": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 8.4
            }
          },
          "References": [
            "https://github.com/FriendsOfPHP/security-advisories/blob/master/symfony/process/CVE-2024-51736.yaml",
            "https://github.com/FriendsOfPHP/security-advisories/blob/master/symfony/symfony/CVE-2024-51736.yaml",
            "https://github.com/symfony/symfony",
            "https://github.com/symfony/symfony/commit/18ecd03eda3917fdf901a48e72518f911c64a1c9",
            "https://github.com/symfony/symfony/security/advisories/GHSA-qq5c-677p-737q",
            "https://nvd.nist.gov/vuln/detail/CVE-2024-51736",
            "https://symfony.com/cve-2024-51736"
          ],
          "PublishedDate": "2024-11-06T21:15:06.6Z",
          "LastModifiedDate": "2024-11-06T21:15:06.6Z"
        }
      ]
    },
    {
      "Target": "sdk/php/dev/composer.lock",
      "Class": "lang-pkgs",
      "Type": "composer",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2024-51736",
          "PkgID": "symfony/process@v7.1.3",
          "PkgName": "symfony/process",
          "PkgIdentifier": {
            "PURL": "pkg:composer/symfony/process@v7.1.3",
            "UID": "ffa18638686d7b9f"
          },
          "InstalledVersion": "v7.1.3",
          "FixedVersion": "5.3.0, 6.1.0, 5.0.0, 5.2.0, 5.4.46, 6.2.0, 6.3.0, 4.0.0, 5.1.0, 6.4.0, 7.1.0, 7.1.7, 3.0.0, 5.4.0, 6.4.14",
          "Status": "fixed",
          "Layer": {},
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-51736",
          "DataSource": {
            "ID": "php-security-advisories",
            "Name": "PHP Security Advisories Database",
            "URL": "https://github.com/FriendsOfPHP/security-advisories"
          },
          "Title": "CVE-2024-51736: Command execution hijack on Windows with Process class",
          "Description": "Symphony process is a module for the Symphony PHP framework which executes commands in sub-processes. On Windows, when an executable file named `cmd.exe` is located in the current working directory it will be called by the `Process` class when preparing command arguments, leading to possible hijacking. This issue has been addressed in release versions 5.4.46, 6.4.14, and 7.1.7. Users are advised to upgrade. There are no known workarounds for this vulnerability.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-77"
          ],
          "VendorSeverity": {
            "ghsa": 3
          },
          "CVSS": {
            "ghsa": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 8.4
            }
          },
          "References": [
            "https://github.com/FriendsOfPHP/security-advisories/blob/master/symfony/process/CVE-2024-51736.yaml",
            "https://github.com/FriendsOfPHP/security-advisories/blob/master/symfony/symfony/CVE-2024-51736.yaml",
            "https://github.com/symfony/symfony",
            "https://github.com/symfony/symfony/commit/18ecd03eda3917fdf901a48e72518f911c64a1c9",
            "https://github.com/symfony/symfony/security/advisories/GHSA-qq5c-677p-737q",
            "https://nvd.nist.gov/vuln/detail/CVE-2024-51736",
            "https://symfony.com/cve-2024-51736"
          ],
          "PublishedDate": "2024-11-06T21:15:06.6Z",
          "LastModifiedDate": "2024-11-06T21:15:06.6Z"
        }
      ]
    },
```

Doesn't look relevant to us but only requires a patch update.