### PR TITLE
fix replace-embeds golangci-lint issues

### DIFF
--- a/docs/src/scripts/replace-embeds.go
+++ b/docs/src/scripts/replace-embeds.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
+
 	"strings"
 )
 
@@ -17,7 +18,7 @@ type FileEntry struct {
 // Function to process each file entry
 func processFile(entry FileEntry) error {
 	// Read the contents of the source file
-	content, err := ioutil.ReadFile(entry.SourceFilename)
+	content, err := os.ReadFile(entry.SourceFilename)
 	if err != nil {
 		return fmt.Errorf("error reading file %s: %w", entry.SourceFilename, err)
 	}
@@ -27,10 +28,10 @@ func processFile(entry FileEntry) error {
 	// handle <Embed .. /> (with spaces)
 	modifiedContent := strings.ReplaceAll(string(content), "<Embed id=\""+entry.EmbedID+"\" />", "```"+entry.Language+" file="+entry.ScriptFilename+"\r```")
 	// handle <Embed ../> (without spaces)
-	modifiedContent = strings.ReplaceAll(string(modifiedContent), "<Embed id=\""+entry.EmbedID+"\"/>", "```"+entry.Language+" file="+entry.ScriptFilename+"\r```")
+	modifiedContent = strings.ReplaceAll(modifiedContent, "<Embed id=\""+entry.EmbedID+"\"/>", "```"+entry.Language+" file="+entry.ScriptFilename+"\r```")
 
 	// Write the modified content back to the source file
-	err = ioutil.WriteFile(entry.SourceFilename, []byte(modifiedContent), 0644)
+	err = os.WriteFile(entry.SourceFilename, []byte(modifiedContent), 0644)
 	if err != nil {
 		return fmt.Errorf("error writing to file %s: %w", entry.SourceFilename, err)
 	}


### PR DESCRIPTION
@marcosnils [noticed this and fixed in a separate PR](https://github.com/dagger/dagger/pull/8568/commits/31a0f52fadda73feb139aa38b32da158ef7f0343), but want it sooner than we are merging that one so splitting out to its own PR