### PR TITLE
shell: change prompt to '⋈'

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -997,7 +997,12 @@ func loadReadlineConfig() (*readline.Config, error) {
 	}
 
 	return &readline.Config{
-		Prompt:       "> ",
+		// We need a prompt that conveys the unique nature of the Dagger shell. Per gpt4:
+		// The ⋈ symbol, known as the bowtie, has deep roots in relational databases and set theory,
+		// where it denotes a join operation. This makes it especially fitting for a DAG environment,
+		// as it suggests the idea of dependencies, intersections, and points where separate paths
+		// or data sets come together.
+		Prompt:       "⋈ ",
 		HistoryFile:  filepath.Join(dataRoot, "histfile"),
 		HistoryLimit: 1000,
 	}, nil


### PR DESCRIPTION
"The '⋈' symbol, known as the bowtie, has deep roots in relational databases and set theory, where it denotes a join operation. This makes it especially fitting for a DAG environment, as it suggests the idea of dependencies, intersections, and points where separate paths or data sets come together."