### PR TITLE
feat(engine): make metrics in ui more readable

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -11,6 +11,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
 	"github.com/muesli/termenv"
 	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/log"
@@ -386,14 +387,14 @@ func (r renderer) renderMetrics(out *termenv.Output, span *dagui.Span) {
 	if dataPoints := span.MetricsByName[telemetry.IOStatDiskReadBytes]; len(dataPoints) > 0 {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("Disk Read Bytes: %d", lastPoint.Value))
+		displayMetric := out.String(fmt.Sprintf("Disk Read: %s", humanize.Bytes(uint64(lastPoint.Value))))
 		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 		fmt.Fprint(out, displayMetric)
 	}
 	if dataPoints := span.MetricsByName[telemetry.IOStatDiskWriteBytes]; len(dataPoints) > 0 {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("Disk Write Bytes: %d", lastPoint.Value))
+		displayMetric := out.String(fmt.Sprintf("Disk Write: %s", humanize.Bytes(uint64(lastPoint.Value))))
 		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 		fmt.Fprint(out, displayMetric)
 	}
@@ -401,7 +402,7 @@ func (r renderer) renderMetrics(out *termenv.Output, span *dagui.Span) {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		if lastPoint.Value != 0 {
 			fmt.Fprint(out, " | ")
-			displayMetric := out.String(fmt.Sprintf("IO Pressure: %dµs", lastPoint.Value))
+			displayMetric := out.String(fmt.Sprintf("IO Pressure: %s", durationString(lastPoint.Value)))
 			displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 			fmt.Fprint(out, displayMetric)
 		}
@@ -410,17 +411,22 @@ func (r renderer) renderMetrics(out *termenv.Output, span *dagui.Span) {
 	if dataPoints := span.MetricsByName[telemetry.CPUStatPressureSomeTotal]; len(dataPoints) > 0 {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("CPU Pressure (some): %dµs", lastPoint.Value))
+		displayMetric := out.String(fmt.Sprintf("CPU Pressure (some): %s", durationString(lastPoint.Value)))
 		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 		fmt.Fprint(out, displayMetric)
 	}
 	if dataPoints := span.MetricsByName[telemetry.CPUStatPressureFullTotal]; len(dataPoints) > 0 {
 		lastPoint := dataPoints[len(dataPoints)-1]
 		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("CPU Pressure (full): %dµs", lastPoint.Value))
+		displayMetric := out.String(fmt.Sprintf("CPU Pressure (full): %s", durationString(lastPoint.Value)))
 		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
 		fmt.Fprint(out, displayMetric)
 	}
+}
+
+func durationString(microseconds int64) string {
+	duration := time.Duration(microseconds) * time.Microsecond
+	return duration.String()
 }
 
 // var (

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,6 @@ require (
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
@@ -277,6 +276,7 @@ require (
 require (
 	dagger.io/dagger v0.13.7
 	github.com/dagger/dagger/engine/distconsts v0.13.7
+	github.com/dustin/go-humanize v1.0.1
 )
 
 replace (


### PR DESCRIPTION
this PR makes the tui print human-readable byte and duration values. 

any suggestions on how to manually test the pressure duration printing? I never have these print on `dagger call check`.

bytes, however, are confirmed working and looking good: `exec sh -c git checkout -q $(git rev-parse HEAD) 0.4s | Disk Read Bytes: 45 MB | Disk Write Bytes: 12 kB`