### PR TITLE
tests: reduce excessive verbosity

### DIFF
--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -35,8 +35,10 @@ func (t *Test) All(
 	timeout string,
 	// +optional
 	race bool,
+	// +optional
+	verbose bool,
 ) error {
-	return t.test(ctx, "", "", "./...", failfast, parallel, timeout, race, 1)
+	return t.test(ctx, "", "", "./...", failfast, parallel, timeout, race, 1, verbose)
 }
 
 // List all tests
@@ -77,8 +79,11 @@ func (t *Test) Specific(
 	// +default=1
 	// +optional
 	count int,
+	// Enable verbose output
+	// +optional
+	verbose bool,
 ) error {
-	return t.test(ctx, run, skip, pkg, failfast, parallel, timeout, race, count)
+	return t.test(ctx, run, skip, pkg, failfast, parallel, timeout, race, count, verbose)
 }
 
 func (t *Test) test(
@@ -91,12 +96,17 @@ func (t *Test) test(
 	timeout string,
 	race bool,
 	count int,
+	verbose bool,
 ) error {
 	cgoEnabledEnv := "0"
 	args := []string{
 		"go",
 		"test",
-		"-v",
+	}
+
+	// allow verbose
+	if verbose {
+		args = append(args, "-v")
 	}
 
 	// Add ldflags

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4369,7 +4369,7 @@ func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().From(alpineImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithNewFile("/query.graphql", `{ defaultPlatform }`). // arbitrary valid query
-			WithExec([]string{"dagger", "query", "--debug", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{
+			WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 			}).
 			Sync(ctx)

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -155,7 +155,7 @@ func (ClientSuite) TestWaitsForEngine(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 	_, err = clientCtr.
 		WithNewFile("/query.graphql", `{ version }`). // arbitrary valid query
-		WithExec([]string{"dagger", "query", "--debug", "--doc", "/query.graphql"}).Sync(ctx)
+		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}).Sync(ctx)
 
 	require.NoError(t, err)
 }
@@ -176,7 +176,7 @@ func (EngineSuite) TestSetsNameFromEnv(ctx context.Context, t *testctx.T) {
 
 	clientCtr = clientCtr.
 		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"dagger", "query", "--debug", "--doc", "/query.graphql"})
+		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"})
 	stdout, err := clientCtr.Stdout(ctx)
 	require.NoError(t, err)
 	stderr, err := clientCtr.Stderr(ctx)
@@ -457,11 +457,11 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			if tc.errs == nil {
 				clientCtr = clientCtr.
 					WithNewFile("/query.graphql", `{ version }`).
-					WithExec([]string{"sh", "-c", "dagger version && dagger query --debug --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "dagger version && dagger query --doc /query.graphql"})
 			} else {
 				clientCtr = clientCtr.
 					WithNewFile("/query.graphql", `{ version }`).
-					WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "! dagger query --doc /query.graphql"})
 			}
 
 			if tc.errs == nil {
@@ -575,10 +575,10 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 
 			if tc.errs == nil {
 				clientCtr = clientCtr.
-					WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "dagger query --doc /query.graphql"})
 			} else {
 				clientCtr = clientCtr.
-					WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "! dagger query --doc /query.graphql"})
 			}
 
 			stderr, err := clientCtr.Stderr(ctx)

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -172,7 +172,7 @@ func (m *Dep) ListFiles(ctx context.Context, dir *dagger.Directory) ([]string, e
 		require.NoError(t, err)
 
 		// Initialize the dependent module
-		_, err = hostDaggerExec(ctx, t, depModDir, "--debug", "init", "--source=.", "--name=dep", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, depModDir, "init", "--source=.", "--name=dep", "--sdk=go")
 		require.NoError(t, err)
 
 		// Write the main module's code with matching return type
@@ -192,11 +192,11 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory) ([]string, error) 
 		require.NoError(t, err)
 
 		// Initialize the main module
-		_, err = hostDaggerExec(ctx, t, rootDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, rootDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// Install the dependent module using relative path
-		_, err = hostDaggerExec(ctx, t, rootDir, "--debug", "install", "./dep")
+		_, err = hostDaggerExec(ctx, t, rootDir, "install", "./dep")
 		require.NoError(t, err)
 
 		// Execute the module with a private Git repository directory

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -975,7 +975,7 @@ func (m *Test) Fn(ctx context.Context, sock *dagger.Socket) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		sockPath, cleanup := getHostSocket(t)
@@ -1018,7 +1018,7 @@ func (m *Dep) Fn(ctx context.Context, sock *dagger.Socket) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, depModDir, "--debug", "init", "--source=.", "--name=dep", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, depModDir, "init", "--source=.", "--name=dep", "--sdk=go")
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
@@ -1037,10 +1037,10 @@ func (m *Test) Fn(ctx context.Context, sock *dagger.Socket) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "install", depModDir)
+		_, err = hostDaggerExec(ctx, t, modDir, "install", depModDir)
 		require.NoError(t, err)
 
 		sockPath, cleanup := getHostSocket(t)
@@ -1079,7 +1079,7 @@ func (m *Dep) Fn(ctx context.Context, ctr *dagger.Container) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, depModDir, "--debug", "init", "--source=.", "--name=dep", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, depModDir, "init", "--source=.", "--name=dep", "--sdk=go")
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
@@ -1103,10 +1103,10 @@ func (m *Test) Fn(ctx context.Context, sock *dagger.Socket) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "install", depModDir)
+		_, err = hostDaggerExec(ctx, t, modDir, "install", depModDir)
 		require.NoError(t, err)
 
 		sockPath, cleanup := getHostSocket(t)
@@ -1140,7 +1140,7 @@ func (m *Dep) Fn(ctr *dagger.Container, sock *dagger.Socket) *dagger.Container {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, depModDir, "--debug", "init", "--source=.", "--name=dep", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, depModDir, "init", "--source=.", "--name=dep", "--sdk=go")
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
@@ -1171,10 +1171,10 @@ func (m *Test) Fn(ctx context.Context, sock *dagger.Socket) error {
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "install", depModDir)
+		_, err = hostDaggerExec(ctx, t, modDir, "install", depModDir)
 		require.NoError(t, err)
 
 		sockPath, cleanup := getHostSocket(t)
@@ -1296,7 +1296,7 @@ func (m *Test) Fn(ctx context.Context, sockPath string, runContainerQuery string
 `), 0o644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		sockPath, cleanup := getHostSocket(t)

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -46,11 +46,11 @@ type Test struct {
 `, alpineImage)), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
@@ -120,11 +120,11 @@ type Test struct {
 	`, alpineImage)), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
@@ -201,11 +201,11 @@ type Test struct {
 	`, alpineImage)), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
@@ -278,11 +278,11 @@ type Test struct {
 	`, alpineImage)), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the returned container so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "call", "ctr", "sync")
+		_, err = hostDaggerExec(ctx, t, modDir, "call", "ctr", "sync")
 		require.NoError(t, err)
 
 		console, err := newTUIConsole(t, 60*time.Second)
@@ -348,11 +348,11 @@ type Test struct {
 	 `), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		thisRepoPath, err := filepath.Abs("../..")
@@ -438,11 +438,11 @@ type Test struct {
 `), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
@@ -503,11 +503,11 @@ type Test struct {
 	`, alpineImage)), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -204,11 +204,11 @@ func daggerUpInitModFn(ctx context.Context, t *testctx.T, defaultPort string) st
 	err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(mainGoTmpl, defaultPort)), 0o644)
 	require.NoError(t, err)
 
-	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+	_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
 	require.NoError(t, err)
 
 	// cache the module load itself so there's less to wait for below
-	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+	_, err = hostDaggerExec(ctx, t, modDir, "functions")
 	require.NoError(t, err)
 
 	return modDir


### PR DESCRIPTION
Was getting annoyed with digging through tons of test output today, couple quick improvements here

---

[tests: remove --debug flag from integ test cli invocations](https://github.com/dagger/dagger/commit/7eefd6273fc1f7cd079aae509684aa7440aeb758)

This increases verbosity quite a bit but doesn't really help debug the
vast majority of the time. If ever needed for debugging it's also very
easy to add locally, so makes sense to not do by default.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

[tests: disable go test verbosity by default](https://github.com/dagger/dagger/commit/0d29f6343fd98ad9984edd177a860d763407f955)

the -v flag on go test results in all output being printed, whereas the
default behavior only shows output when a test fails.

The majority of the time we only care about output from failed tests, so
we are usually wasting time processing + uploading tons of output from
tests.

This change disables -v by default but leaves it as an option to enable
when needed.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>
