### PR TITLE
feat(sdk/php): support TRACEPARENT

### DIFF
--- a/sdk/php/.changes/unreleased/Added-20241109-103911.yaml
+++ b/sdk/php/.changes/unreleased/Added-20241109-103911.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add support for TRACEPARENT. The user will see what's function doing in the TUI.
+time: 2024-11-09T10:39:11.945216+07:00
+custom:
+    Author: wingyplus
+    PR: "8896"

--- a/sdk/php/src/Connection.php
+++ b/sdk/php/src/Connection.php
@@ -55,10 +55,16 @@ abstract class Connection
     protected static function createGraphQlClient(int $port, string $token): Client
     {
         $encodedToken = base64_encode("{$token}:");
-
-        return new Client("http://127.0.0.1:{$port}/query", [
+        $headers = [
             'Authorization' => "Basic {$encodedToken}",
-        ]);
+        ];
+
+        $traceparent = getenv('TRACEPARENT');
+        if ($traceparent) {
+            $headers = array_merge($headers, ['Traceparent' => $traceparent]);
+        }
+
+        return new Client("http://127.0.0.1:{$port}/query", $headers);
     }
 
     abstract public function connect(): Client;


### PR DESCRIPTION
Inject `Traceparent` headers into client when `TRACEPARENT` env variable is presents.

Before:

```
✔ Potato.containerEcho(stringArg: "hello"): Container! 1.2s
  ✔ exec /src/sdk/php/potato/entrypoint.php 1.1s | CPU Pressure (some): 163µs | CPU Pressure (full): 148µs
✔ Void.stdout: String! 0.0s
  ✔ cache request: pull docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
  ✔ load cache: exec echo hello 0.0s
```

After:

```
✔ Potato.containerEcho(stringArg: "hello"): Container! 2.3s
  ✔ exec /src/sdk/php/potato/entrypoint.php 2.2s | CPU Pressure (some): 210µs | CPU Pressure (full): 209µs
  ✔ Container.from(address: "alpine:latest"): Container! 2.0s
    ✔ resolving docker.io/library/alpine:latest 2.0s
      ✘ remotes.docker.resolver.HTTPRequest 0.8s
        ✘ HTTP HEAD 0.8s
      ✔ HTTP GET 0.9s
      ✔ remotes.docker.resolver.HTTPRequest 0.3s
        ✔ HTTP HEAD 0.3s
    ✔ Container.from(address: "docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"): Container! 0.0s
      ✔ resolving docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
  ✔ Container.withExec(args: ["echo", "hello"], expand: false, experimentalPrivilegedNesting: false, insecureRootCapabilities: false, noInit: false, redirectStderr: "", redirectStdout: "", stdin: "", useEntrypoint: false): Container! 0.0s
    ✔ cache request: pull docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d 0.0s
    ✔ load cache: exec echo hello 0.0s
✔ Container.stdout: String! 0.0s
```