### PR TITLE
feat(engine): telemetry for netns bytes rx and tx, plus packet drops

### DIFF
--- a/.changes/unreleased/Added-20241114-123823.yaml
+++ b/.changes/unreleased/Added-20241114-123823.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: added network telemetry for execs'
+time: 2024-11-14T12:38:23.340204-08:00
+custom:
+    Author: cwlbraa
+    PR: "8902"

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -342,6 +342,12 @@ var scrubs = []scrubber{
 		" | Disk Read: 9.3 kB",
 		"",
 	},
+	// Network telemetry
+	{
+		regexp.MustCompile(`\s?\| Network (Tx|Rx): \d+(\.\d+)?\s(B|kB|MB|GB|TB)(\s\(\d+(\.\d+)?\% dropped\))?`),
+		" | Network Tx: 3 kB (0.1% dropped)",
+		"",
+	},
 }
 
 func TestScrubbers(t *testing.T) {

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -1221,7 +1221,7 @@ func (w *Worker) runContainer(ctx context.Context, state *execState) (rerr error
 			)
 		}
 
-		cgroupSampler, err := resources.NewSampler(cgroupPath, meter, attribute.NewSet(commonAttrs...))
+		cgroupSampler, err := resources.NewSampler(cgroupPath, state.networkNamespace, meter, attribute.NewSet(commonAttrs...))
 		if err != nil {
 			return fmt.Errorf("create cgroup sampler: %w", err)
 		}

--- a/engine/buildkit/resources/netstat.go
+++ b/engine/buildkit/resources/netstat.go
@@ -1,0 +1,122 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"dagger.io/dagger/telemetry"
+	resourcestypes "github.com/moby/buildkit/executor/resources/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type BKNetworkSampler interface {
+	Sample() (*resourcestypes.NetworkSample, error)
+}
+
+type netNSSampler struct {
+	netNS       BKNetworkSampler
+	meter       metric.Meter
+	commonAttrs attribute.Set
+	rxBytes     metric.Int64Gauge
+	rxPackets   metric.Int64Gauge
+	rxDropped   metric.Int64Gauge
+	txBytes     metric.Int64Gauge
+	txPackets   metric.Int64Gauge
+	txDropped   metric.Int64Gauge
+}
+
+type netNSSample struct {
+	rxBytes   int64GaugeSample
+	rxDropped int64GaugeSample
+	rxPackets int64GaugeSample
+	txBytes   int64GaugeSample
+	txDropped int64GaugeSample
+	txPackets int64GaugeSample
+}
+
+func newNetNSSampler(netNS BKNetworkSampler, meter metric.Meter, commonAttrs attribute.Set) (*netNSSampler, error) {
+	s := &netNSSampler{
+		netNS:       netNS,
+		meter:       meter,
+		commonAttrs: commonAttrs,
+	}
+
+	var err error
+	if s.rxBytes, err = meter.Int64Gauge(
+		telemetry.NetstatRxBytes,
+		metric.WithDescription("Total number of bytes received over the network"),
+		metric.WithUnit("bytes"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create rx bytes gauge: %w", err)
+	}
+	if s.rxDropped, err = meter.Int64Gauge(
+		telemetry.NetstatRxDropped,
+		metric.WithDescription("Total number of received packets dropped"),
+		metric.WithUnit("packets"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create rx dropped gauge: %w", err)
+	}
+	if s.txBytes, err = meter.Int64Gauge(
+		telemetry.NetstatTxBytes,
+		metric.WithDescription("Total number of bytes transmitted over the network"),
+		metric.WithUnit("bytes"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create tx bytes gauge: %w", err)
+	}
+	if s.txDropped, err = meter.Int64Gauge(
+		telemetry.NetstatTxDropped,
+		metric.WithDescription("Total number of transmitted packets dropped"),
+		metric.WithUnit("packets"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create tx dropped gauge: %w", err)
+	}
+	if s.rxPackets, err = meter.Int64Gauge(
+		telemetry.NetstatRxPackets,
+		metric.WithDescription("Total number of packets received over the network"),
+		metric.WithUnit("packets"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create rx packets gauge: %w", err)
+	}
+	if s.txPackets, err = meter.Int64Gauge(
+		telemetry.NetstatTxPackets,
+		metric.WithDescription("Total number of packets transmitted over the network"),
+		metric.WithUnit("packets"),
+	); err != nil {
+		return nil, fmt.Errorf("failed to create tx packets gauge: %w", err)
+	}
+
+	return s, nil
+}
+
+func (s *netNSSampler) sample(ctx context.Context) error {
+	sample := netNSSample{
+		rxBytes:   newInt64GaugeSample(s.rxBytes, s.commonAttrs),
+		rxPackets: newInt64GaugeSample(s.rxPackets, s.commonAttrs),
+		rxDropped: newInt64GaugeSample(s.rxDropped, s.commonAttrs),
+		txBytes:   newInt64GaugeSample(s.txBytes, s.commonAttrs),
+		txPackets: newInt64GaugeSample(s.txPackets, s.commonAttrs),
+		txDropped: newInt64GaugeSample(s.txDropped, s.commonAttrs),
+	}
+
+	bkSample, err := s.netNS.Sample()
+	if err != nil {
+		return fmt.Errorf("failed to sample bk netNS: %w", err)
+	}
+
+	sample.rxBytes.add(bkSample.RxBytes)
+	sample.rxPackets.add(bkSample.RxPackets)
+	sample.rxDropped.add(bkSample.RxDropped)
+	sample.txBytes.add(bkSample.TxBytes)
+	sample.txPackets.add(bkSample.TxPackets)
+	sample.txDropped.add(bkSample.TxDropped)
+
+	sample.rxBytes.record(ctx)
+	sample.rxDropped.record(ctx)
+	sample.txBytes.record(ctx)
+	sample.txDropped.record(ctx)
+	sample.rxPackets.record(ctx)
+	sample.txPackets.record(ctx)
+
+	return nil
+}

--- a/sdk/go/telemetry/metrics.go
+++ b/sdk/go/telemetry/metrics.go
@@ -38,6 +38,24 @@ const (
 	// OTel metric for peak memory bytes consumed by this cgroup and its descendents
 	MemoryPeakBytes = "dagger.io/metrics.memory.peak"
 
+	// OTel metric for number of bytes received by a container, pulled from buildkit's network namespace representation
+	NetstatRxBytes = "dagger.io/metrics.netstat.rx.bytes"
+
+	// OTel metric for number of packets received by a container, pulled from buildkit's network namespace representation
+	NetstatRxPackets = "dagger.io/metrics.netstat.rx.packets"
+
+	// OTel metric for number of received packets dropped by a container, pulled from buildkit's network namespace representation
+	NetstatRxDropped = "dagger.io/metrics.netstat.rx.dropped"
+
+	// OTel metric for number of bytes transmitted by a container, pulled from buildkit's network namespace representation
+	NetstatTxBytes = "dagger.io/metrics.netstat.tx.bytes"
+
+	// OTel metric for number of packets transmitted by a container, pulled from buildkit's network namespace representation
+	NetstatTxPackets = "dagger.io/metrics.netstat.tx.packets"
+
+	// OTel metric for number of transmitted packets dropped by a container, pulled from buildkit's network namespace representation
+	NetstatTxDropped = "dagger.io/metrics.netstat.tx.dropped"
+
 	// OTel metric units should be in UCUM format
 	// https://unitsofmeasure.org/ucum
 


### PR DESCRIPTION
does what it says on the tin, using BK's network namespace "Sample" function.

note this prints % dropped, not % loss. packet loss is harder to instrument, especially on the rx side. if we feel the need, we could probably get stats about tcp retransmissions, but that is out-of-scope here.