### PR TITLE
chore: bump internal tooling to v0.14.0

### DIFF
--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -24,7 +24,7 @@ const (
 	DistroUbuntu = "ubuntu"
 )
 
-type DEngine struct {
+type DaggerEngine struct {
 	Dagger *DaggerDev // +private
 
 	Args   []string // +private
@@ -35,28 +35,28 @@ type DEngine struct {
 	Race bool // +private
 }
 
-func (e *DEngine) WithConfig(key, value string) *DEngine {
+func (e *DaggerEngine) WithConfig(key, value string) *DaggerEngine {
 	e.Config = append(e.Config, key+"="+value)
 	return e
 }
 
-func (e *DEngine) WithArg(key, value string) *DEngine {
+func (e *DaggerEngine) WithArg(key, value string) *DaggerEngine {
 	e.Args = append(e.Args, key+"="+value)
 	return e
 }
 
-func (e *DEngine) WithRace() *DEngine {
+func (e *DaggerEngine) WithRace() *DaggerEngine {
 	e.Race = true
 	return e
 }
 
-func (e *DEngine) WithTrace() *DEngine {
+func (e *DaggerEngine) WithTrace() *DaggerEngine {
 	e.Trace = true
 	return e
 }
 
 // Build the engine container
-func (e *DEngine) Container(
+func (e *DaggerEngine) Container(
 	ctx context.Context,
 
 	// +optional
@@ -123,7 +123,7 @@ func (e *DEngine) Container(
 }
 
 // Create a test engine service
-func (e *DEngine) Service(
+func (e *DaggerEngine) Service(
 	ctx context.Context,
 	name string,
 	// +optional
@@ -174,7 +174,7 @@ func (e *DEngine) Service(
 }
 
 // Lint the engine
-func (e *DEngine) Lint(
+func (e *DaggerEngine) Lint(
 	ctx context.Context,
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
@@ -208,7 +208,7 @@ func (e *DEngine) Lint(
 
 // Generate any engine-related files
 // Note: this is codegen of the 'go generate' variety, not 'dagger develop'
-func (e *DEngine) Generate() *dagger.Directory {
+func (e *DaggerEngine) Generate() *dagger.Directory {
 	generated := e.Dagger.Go().Env().
 		WithoutDirectory("sdk") // sdk generation happens separately
 
@@ -225,7 +225,7 @@ func (e *DEngine) Generate() *dagger.Directory {
 }
 
 // Lint any generated engine-related files
-func (e *DEngine) LintGenerate(ctx context.Context) error {
+func (e *DaggerEngine) LintGenerate(ctx context.Context) error {
 	before := e.Dagger.Go().Env().WithoutDirectory("sdk").Directory(".")
 	after := e.Generate()
 	return dag.Dirdiff().AssertEqual(ctx, before, after, []string{"."})
@@ -267,7 +267,7 @@ var targets = []struct {
 }
 
 // Publish all engine images to a registry
-func (e *DEngine) Publish(
+func (e *DaggerEngine) Publish(
 	ctx context.Context,
 
 	// Image target to push to
@@ -375,7 +375,7 @@ func (e *DEngine) Publish(
 	return nil
 }
 
-func (e *DEngine) Scan(ctx context.Context) error {
+func (e *DaggerEngine) Scan(ctx context.Context) error {
 	ignoreFiles := dag.Directory().WithDirectory("/", e.Dagger.Source(), dagger.DirectoryWithDirectoryOpts{
 		Include: []string{
 			".trivyignore",

--- a/.dagger/go.mod
+++ b/.dagger/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/.dagger
 
 go 1.23.2
 
-require github.com/dagger/dagger/engine/distconsts v0.13.7
+require github.com/dagger/dagger/engine/distconsts v0.14.0
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -147,8 +147,8 @@ func (gtc *GoToolchain) Lint(
 }
 
 // Develop the Dagger engine container
-func (dev *DaggerDev) Engine() *DEngine {
-	return &DEngine{Dagger: dev}
+func (dev *DaggerDev) Engine() *DaggerEngine {
+	return &DaggerEngine{Dagger: dev}
 }
 
 // Develop the Dagger documentation

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.13.7"
+    default: "v0.14.0"
     required: false
 
   dev-engine:

--- a/.github/dagger.json
+++ b/.github/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ci",
-  "engineVersion": "v0.13.7",
+  "engineVersion": "v0.14.0",
   "sdk": "go",
   "dependencies": [
     {

--- a/.github/main.go
+++ b/.github/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	daggerVersion      = "v0.13.7"
+	daggerVersion      = "v0.14.0"
 	upstreamRepository = "dagger/dagger"
 	defaultRunner      = "ubuntu-latest"
 	publicToken        = "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/main.go
+++ b/.github/main.go
@@ -153,7 +153,7 @@ func (ci *CI) withPrepareReleaseWorkflow() *CI {
 			PullRequestConcurrency: "queue",
 			Permissions:            []dagger.GhaPermission{dagger.GhaPermissionReadContents},
 			OnPullRequestOpened:    true,
-			OnPullRequestPaths:     []string{"/CHANGELOG.md", "/.changes"},
+			OnPullRequestPaths:     []string{".changes/.next"},
 		}),
 	})
 	w := gha.

--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
     deploy:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: deploy
         steps:
             - name: Checkout
@@ -46,7 +46,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine

--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -6,8 +6,7 @@ name: daggerverse-preview
             - paths
             - opened
         paths:
-            - /CHANGELOG.md
-            - /.changes
+            - .changes/.next
     workflow_dispatch: {}
 permissions:
     contents: read

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     docs:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: Docs
         steps:
             - name: Checkout
@@ -49,7 +49,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine

--- a/.github/workflows/engine-and-cli-split.yml
+++ b/.github/workflows/engine-and-cli-split.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
           upload-logs: true
 
   test-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           upload-logs: true
 
   test-cli-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           upload-logs: true
 
   test-everything-else:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
           upload-logs: true
 
   testdev-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           upload-logs: true
 
   testdev-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
           upload-logs: true
 
   testdev-container:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
           upload-logs: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-16c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
           function: "engine publish --image=dagger-engine.dev --tag=main --dry-run"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     github:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: Github
         steps:
             - name: Checkout
@@ -49,7 +49,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g2-v0-13-7-16c
+    runs-on: dagger-g2-v0-14-0-16c
     steps:
       - uses: actions/checkout@v4
       - name: "Publish Engine"
@@ -70,7 +70,7 @@ jobs:
 
   publish-sdk-go:
     needs: publish
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"
@@ -88,7 +88,7 @@ jobs:
 
   publish-sdk-php:
     needs: publish
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"
@@ -107,7 +107,7 @@ jobs:
   publish-sdk-python:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"
@@ -127,7 +127,7 @@ jobs:
   publish-sdk-typescript:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"
@@ -147,7 +147,7 @@ jobs:
   publish-sdk-elixir:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"
@@ -166,7 +166,7 @@ jobs:
   publish-helm:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     elixir:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: elixir
         steps:
             - name: Checkout
@@ -49,7 +49,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -205,7 +205,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: elixir-dev
         steps:
             - name: Checkout
@@ -434,7 +434,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: go
         steps:
             - name: Checkout
@@ -464,7 +464,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -620,7 +620,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: go-dev
         steps:
             - name: Checkout
@@ -849,7 +849,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: java
         steps:
             - name: Checkout
@@ -879,7 +879,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -1035,7 +1035,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: java-dev
         steps:
             - name: Checkout
@@ -1264,7 +1264,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: php
         steps:
             - name: Checkout
@@ -1294,7 +1294,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -1450,7 +1450,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: php-dev
         steps:
             - name: Checkout
@@ -1679,7 +1679,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: python
         steps:
             - name: Checkout
@@ -1709,7 +1709,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -1865,7 +1865,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: python-dev
         steps:
             - name: Checkout
@@ -2094,7 +2094,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: rust
         steps:
             - name: Checkout
@@ -2124,7 +2124,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -2280,7 +2280,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: rust-dev
         steps:
             - name: Checkout
@@ -2509,7 +2509,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}
         name: typescript
         steps:
             - name: Checkout
@@ -2539,7 +2539,7 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
               env:
-                DAGGER_VERSION: v0.13.7
+                DAGGER_VERSION: v0.14.0
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -2695,7 +2695,7 @@ jobs:
             stdout: ${{ steps.exec.outputs.stdout }}
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-13-7-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-8c-dind' || 'ubuntu-latest' }}
         name: typescript-dev
         steps:
             - name: Checkout

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -217,7 +217,7 @@ git add docs sdk helm
 git commit -s -m "chore: bump dependencies to $ENGINE_VERSION"
 ```
 
-- [ ] Push and open the PR as a draft, and capture the PR number:
+- [ ] Push to `dagger/dagger` - we need access to secrets that PRs coming from forks will not have. Open the PR as a draft and capture the PR number:
 
 ```console
 gh pr create --draft --title "chore: prep for v0.13.7" --body "" | tee /tmp/prep-pr.txt

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2452,7 +2452,7 @@ func (ModuleSuite) TestEngineError(ctx context.Context, t *testctx.T) {
 		).
 		With(daggerCall("fn")).
 		Sync(ctx)
-	require.ErrorContains(t, err, "dag.DaggerEngine undefined")
+	require.ErrorContains(t, err, "dag.Engine undefined")
 }
 
 func (ModuleSuite) TestDaggerListen(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2445,7 +2445,7 @@ func (ModuleSuite) TestEngineError(ctx context.Context, t *testctx.T) {
  			)
  			type Test struct {}
  			func (m *Test) Fn(ctx context.Context) error {
- 				_, _ = dag.DaggerEngine().LocalCache().EntrySet().Entries(ctx)
+ 				_, _ = dag.Engine().LocalCache().EntrySet().Entries(ctx)
 				return nil
  			}
  			`,

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "dagger-dev",
-  "engineVersion": "v0.13.7",
+  "engineVersion": "v0.14.0",
   "sdk": "go",
   "dependencies": [
     {

--- a/go.mod
+++ b/go.mod
@@ -274,8 +274,8 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.13.7
-	github.com/dagger/dagger/engine/distconsts v0.13.7
+	dagger.io/dagger v0.14.0
+	github.com/dagger/dagger/engine/distconsts v0.14.0
 	github.com/dustin/go-humanize v1.0.1
 )
 


### PR DESCRIPTION
Just autogenerated stuff here. 

FTR, hit lots of things big and small but will split them out to follow ups so this isn't blocked too long:
- daggerverse preview never ran 
- this link is broken in ts autogenerated release notes https://docs.dagger.io/reference/typescript/modules/api_client_gen
- https://github.com/dagger/dagger/pull/8901
- Fix dynamic optional error hit during SDK publishes
- Fix python publish error (being handled by Helder)
- Updates to RELEASING.md needed
   - updating `.changes/.next` is in wrong order (shouldbe included in a commit that's pushed)
   - "Open a PR with the title Improve Releasing during $ENGINE_VERSION" is a duplicate of previous instruction, seems like a typo