### PR TITLE
python: replace hatch with uv in tooling

### DIFF
--- a/.dagger/sdk_python.go
+++ b/.dagger/sdk_python.go
@@ -18,23 +18,8 @@ const (
 	pythonGeneratedAPIPath = "sdk/python/src/dagger/client/gen.py"
 )
 
-var pythonVersions = []string{"3.10", "3.11", "3.12"}
-
 type PythonSDK struct {
 	Dagger *DaggerDev // +private
-}
-
-// dev instantiates a PythonSDKDev instance, with source directory
-// from `sdk/python` subdir.
-func (t PythonSDK) dev(opts ...dagger.PythonSDKDevOpts) *dagger.PythonSDKDev {
-	return dag.PythonSDKDev(opts...)
-}
-
-// directory takes a directory returned by PythonSDKDev which is relative
-// to `sdk/python` and returns a new directory relative to the repo's
-// root.
-func (t PythonSDK) directory(dist *dagger.Directory) *dagger.Directory {
-	return dag.Directory().WithDirectory(pythonSubdir, dist)
 }
 
 // Lint the Python SDK
@@ -52,7 +37,7 @@ func (t PythonSDK) Lint(ctx context.Context) (rerr error) {
 			span.End()
 		}()
 		// Preserve same file hierarchy for docs because of extend rules in .ruff.toml
-		_, err := t.dev().
+		_, err := dag.PythonSDKDev().
 			WithDirectory(
 				dag.Directory().
 					WithDirectory(
@@ -110,11 +95,16 @@ func (t PythonSDK) Test(ctx context.Context) (rerr error) {
 		return err
 	}
 
-	base := t.dev().Container().With(installer)
-	dev := t.dev(dagger.PythonSDKDevOpts{Container: base})
+	base := dag.PythonSDKDev().Container().With(installer)
+	dev := dag.PythonSDKDev(dagger.PythonSDKDevOpts{Container: base})
+
+	versions, err := dag.PythonSDKDev().SupportedVersions(ctx)
+	if err != nil {
+		return err
+	}
 
 	eg, ctx := errgroup.WithContext(ctx)
-	for _, version := range pythonVersions {
+	for _, version := range versions {
 		eg.Go(func() error {
 			_, err := dev.
 				Test(dagger.PythonSDKDevTestOpts{Version: version}).
@@ -137,7 +127,10 @@ func (t PythonSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 	if err != nil {
 		return nil, err
 	}
-	return t.directory(t.dev().Generate(introspection)), nil
+	return dag.Directory().WithDirectory(
+		pythonSubdir,
+		dag.PythonSDKDev().Generate(introspection),
+	), nil
 }
 
 // Test the publishing process
@@ -165,26 +158,20 @@ func (t PythonSDK) Publish(
 	githubToken *dagger.Secret,
 ) error {
 	version := strings.TrimPrefix(tag, "sdk/python/")
-	setuptoolsVersion := version
-	if dryRun {
-		setuptoolsVersion = "v0.0.0"
-	}
-	if pypiRepo == "" || pypiRepo == "pypi" {
-		pypiRepo = "main"
-	}
 
-	// TODO: move this to PythonSDKDev
-	result := t.dev().Container().
-		WithEnvVariable("SETUPTOOLS_SCM_PRETEND_VERSION", strings.TrimPrefix(setuptoolsVersion, "v")).
-		WithEnvVariable("HATCH_INDEX_REPO", pypiRepo).
-		WithEnvVariable("HATCH_INDEX_USER", "__token__").
-		WithExec([]string{"uvx", "hatch", "build"})
-	if !dryRun {
-		result = result.
-			WithSecretVariable("HATCH_INDEX_AUTH", pypiToken).
-			WithExec([]string{"uvx", "hatch", "publish"})
+	var ctr *dagger.Container
+	if dryRun {
+		ctr = dag.PythonSDKDev().Build()
+	} else {
+		opts := dagger.PythonSDKDevPublishOpts{
+			Version: strings.TrimPrefix(version, "v"),
+		}
+		if pypiRepo == "test" {
+			opts.URL = "https://test.pypi.org/legacy/"
+		}
+		ctr = dag.PythonSDKDev().Publish(pypiToken, opts)
 	}
-	_, err := result.Sync(ctx)
+	_, err := ctr.Sync(ctx)
 	if err != nil {
 		return err
 	}

--- a/sdk/python/dev/src/main/main.py
+++ b/sdk/python/dev/src/main/main.py
@@ -222,8 +222,14 @@ class PythonSdkDev:
         return [self.test(version) for version in self.supported_versions()]
 
     @function
-    def build(self, version: str = "0.0.0") -> dagger.Container:
-        """Build Python SDK package for distribution."""
+    def build(
+        self,
+        version: Annotated[
+            str,
+            Doc("The version for the distribution package"),
+        ] = "0.0.0",
+    ) -> dagger.Container:
+        """Build the Python SDK client library package for distribution."""
         return (
             self.container.with_env_variable("SETUPTOOLS_SCM_PRETEND_VERSION", version)
             .without_directory("dist")
@@ -233,9 +239,18 @@ class PythonSdkDev:
     @function
     def publish(
         self,
-        token: dagger.Secret,
-        version: str = "0.0.0",
-        url: str = "",
+        token: Annotated[
+            dagger.Secret,
+            Doc("The token for the upload"),
+        ],
+        version: Annotated[
+            str,
+            Doc("The version for the distribution package to publish"),
+        ] = "0.0.0",
+        url: Annotated[
+            str,
+            Doc("The URL of the upload endpoint (empty means PyPI)"),
+        ] = "",
     ) -> dagger.Container:
         """Publish Python SDK client library to PyPI."""
         ctr = self.build(version).with_secret_variable("UV_PUBLISH_TOKEN", token)
@@ -248,9 +263,16 @@ class PythonSdkDev:
     @function
     async def test_publish(
         self,
-        token: dagger.Secret,
-        version: str = "0.0.0",
+        token: Annotated[
+            dagger.Secret,
+            Doc("TestPyPI token"),
+        ],
+        version: Annotated[
+            str,
+            Doc("The version for the distribution package to publish"),
+        ] = "0.0.0",
     ) -> dagger.Container:
+        """Test the publishing of the Python SDK client library to TestPyPI."""
         return self.publish(token, version, url="https://test.pypi.org/legacy/")
 
     @function

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling==1.25.0", "hatch-vcs==0.4.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,10 +7,9 @@ name = "dagger-io"
 dynamic = ["version"]
 description = "A client package for running Dagger pipelines in Python."
 readme = "README.md"
-license = "Apache-2.0"
 authors = [{ name = "Dagger", email = "hello@dagger.io" }]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Framework :: AnyIO",
     "Framework :: Pytest",
@@ -20,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Typing :: Typed",


### PR DESCRIPTION
But also:
- Added tests for Python 3.13
- Offloaded leftovers in `.dagger/sdk_python.go` to `sdk/python/dev`
- Updated library package metadata (license is not necessary since the build backend picks it up automatically from the `sdk/python/LICENSE` file