### PR TITLE
fix: handle explicit `null`s, and stop allowing weird overlapped enums

### DIFF
--- a/core/json.go
+++ b/core/json.go
@@ -73,8 +73,6 @@ var _ dagql.ScalarType = JSON{}
 
 func (JSON) DecodeInput(val any) (res dagql.Input, err error) {
 	switch x := val.(type) {
-	case nil:
-		return nil, nil
 	case string:
 		if x == "" {
 			return nil, nil

--- a/core/modtypes.go
+++ b/core/modtypes.go
@@ -40,7 +40,11 @@ type PrimitiveType struct {
 
 func (t *PrimitiveType) ConvertFromSDKResult(ctx context.Context, value any) (dagql.Typed, error) {
 	// NB: we lean on the fact that all primitive types are also dagql.Inputs
-	return t.Def.ToInput().Decoder().DecodeInput(value)
+	input := t.Def.ToInput()
+	if value == nil {
+		return input, nil
+	}
+	return input.Decoder().DecodeInput(value)
 }
 
 func (t *PrimitiveType) ConvertToSDKInput(ctx context.Context, value dagql.Typed) (any, error) {

--- a/core/platform.go
+++ b/core/platform.go
@@ -54,9 +54,6 @@ func (p Platform) ToLiteral() call.Literal {
 var _ dagql.ScalarType = Platform{}
 
 func (Platform) DecodeInput(val any) (dagql.Input, error) {
-	if val == nil {
-		val = ""
-	}
 	switch x := val.(type) {
 	case string:
 		plat, err := platforms.Parse(x)

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -259,9 +259,6 @@ func (d DynamicID) TypeName() string {
 var _ dagql.InputDecoder = DynamicID{}
 
 func (d DynamicID) DecodeInput(val any) (dagql.Input, error) {
-	if val == nil {
-		val = ""
-	}
 	switch x := val.(type) {
 	case string:
 		var idp call.ID

--- a/core/void.go
+++ b/core/void.go
@@ -43,10 +43,6 @@ func (p Void) ToLiteral() call.Literal {
 var _ dagql.ScalarType = Void{}
 
 func (Void) DecodeInput(val any) (dagql.Input, error) {
-	switch val.(type) {
-	case nil:
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("cannot convert %T to Void", val)
-	}
+	// void types cannot be constructed - they have no corresponding valid values
+	return nil, fmt.Errorf("cannot convert %T to Void", val)
 }

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -173,9 +173,6 @@ type DynamicArrayInput struct {
 var _ InputDecoder = DynamicArrayInput{}
 
 func (d DynamicArrayInput) DecodeInput(val any) (Input, error) {
-	if val == nil {
-		val = []any{}
-	}
 	switch x := val.(type) {
 	case []any:
 		arr := DynamicArrayInput{

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -197,25 +197,10 @@ func (cls Class[T]) ParseField(ctx context.Context, view string, astField *ast.F
 			return Selector{}, nil, fmt.Errorf("%s.%s has no such argument: %q", cls.TypeName(), field.Spec.Name, arg.Name)
 		}
 
-		if argDef, ok := argSpec.Type.(Definitive); ok {
-			def := argDef.TypeDefinition(view)
-			if def.Kind == ast.Enum && (arg.Value.Kind == ast.BooleanValue || arg.Value.Kind == ast.NullValue) {
-				// enum values can sometimes be mis-parsed as true/false/null
-				// https://github.com/vektah/gqlparser/blob/v2.5.16/parser/query.go#L271-L279
-				argClone := *arg
-				arg = &argClone
-				arg.Value.Kind = ast.EnumValue
-			}
-		}
-
 		val, err := arg.Value.Value(vars)
 		if err != nil {
 			return Selector{}, nil, err
 		}
-		if val == nil {
-			continue
-		}
-
 		input, err := argSpec.Type.Decoder().DecodeInput(val)
 		if err != nil {
 			return Selector{}, nil, fmt.Errorf("init arg %q value as %T (%s) using %T: %w", arg.Name, argSpec.Type, argSpec.Type.Type(), argSpec.Type.Decoder(), err)

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -142,8 +142,6 @@ func (i Int) TypeDefinition(views ...string) *ast.Definition {
 
 func (Int) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
-	case nil:
-		return NewInt(0), nil
 	case int:
 		return NewInt(x), nil
 	case int32:
@@ -241,8 +239,6 @@ func (f Float) TypeDefinition(views ...string) *ast.Definition {
 
 func (Float) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
-	case nil:
-		return NewFloat(float64(0)), nil
 	case float32:
 		return NewFloat(float64(x)), nil
 	case float64:
@@ -344,8 +340,6 @@ func (b Boolean) TypeDefinition(views ...string) *ast.Definition {
 
 func (Boolean) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
-	case nil:
-		return NewBoolean(false), nil
 	case bool:
 		return NewBoolean(x), nil
 	case string: // from default
@@ -431,8 +425,6 @@ func (s String) TypeDefinition(views ...string) *ast.Definition {
 
 func (String) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
-	case nil:
-		return NewString(""), nil
 	case string:
 		return NewString(x), nil
 	default:
@@ -766,14 +758,11 @@ func (a ArrayInput[S]) Decoder() InputDecoder {
 var _ InputDecoder = ArrayInput[Input]{}
 
 func (a ArrayInput[I]) DecodeInput(val any) (Input, error) {
-	var zero I
-	decoder := zero.Decoder()
-
-	if val == nil {
-		val = []any{}
-	}
 	switch x := val.(type) {
 	case []any:
+		var zero I
+		decoder := zero.Decoder()
+
 		arr := make(ArrayInput[I], len(x))
 		for i, val := range x {
 			elem, err := decoder.DecodeInput(val)
@@ -996,6 +985,10 @@ func (e *EnumValueName) DecodeInput(val any) (Input, error) {
 		return &EnumValueName{Enum: e.Enum, Value: x.Value}, nil
 	case string:
 		return &EnumValueName{Enum: e.Enum, Value: x}, nil
+	case bool:
+		return nil, fmt.Errorf("invalid enum value %t", x)
+	case nil:
+		return nil, fmt.Errorf("invalid enum value null")
 	default:
 		return nil, fmt.Errorf("cannot create enum name from %T", x)
 	}


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/8682, and starts to do some of #6749.

`null` should be allowed as an argument to optional args - but nowhere else. When it is provided, it should indicate that the default value **should not be used**.

Also, `null` (and `true` and `false`) are now never valid values for enums - we never allow decoding these.