### PR TITLE
fix: use ignore pattern when pulling dir from git

### DIFF
--- a/.changes/unreleased/Fixed-20241112-151649.yaml
+++ b/.changes/unreleased/Fixed-20241112-151649.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correctly apply ignore pattern when pulling a directory from git
+time: 2024-11-12T15:16:49.67229+01:00
+custom:
+  Author: TomChv
+  PR: "8931"

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -332,7 +332,6 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 
 	// The core module doesn't have a ModuleSource.
 	if modSrc == nil {
-		// TODO: use modArg.Ignore if not empty
 		return dag.Host().Directory(path), nil
 	}
 


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/8782#discussion_r1828846725 spotted an issue where ignore patterns where not applied when pulling a directory from git.

This PR fixes that issue.

Results now:

```shell
dagger call copy-directory-with-exclusions --source=https://github.com/dagger/dagger#main directory --path=/src entries

.changes
.dagger
CHANGELOG.md
CODE_OF_CONDUCT.md
CONTRIBUTING.md
README.md
RELEASING.md
core
dagql
docs
hack
helm
modules
sdk
```