### PR TITLE
engine: make otel proxy shutdown error non-fatal

### DIFF
--- a/engine/buildkit/cleanup.go
+++ b/engine/buildkit/cleanup.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ func (c *Cleanups) Add(msg string, f func() error) CleanupFunc {
 		err := f()
 		if err != nil {
 			slog.Error("cleanup failed", "msg", msg, "err", err, "duration", time.Since(start))
+			err = fmt.Errorf("cleanup failed: %q: %w", msg, err)
 		} else {
 			slog.ExtraDebug("cleanup succeeded", "msg", msg, "duration", time.Since(start))
 		}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8934

I haven't tracked down why, but it appears that sometimes in our test
workflows the "shutdown otel proxy" cleanup step takes over 10s, hits
its timeout and then causes the exec to fail.

It shouldn't take that long, but in the meantime there's no reason for
this to be fatal to the exec. The error is now just logged.

---

@vito let me know what you think of this workaround. I'm a bit mystified and concerned why shutting down the otel proxy server is taking >10s sometimes. The only recent change I can think of that's plausibly related is getting rid of the transactions, which I suppose could *somehow* be causing the http handlers take longer? Maybe? Pretty shot in the dark guess.

But for now it at least stops this from breaking user execs.