### PR TITLE
engine: account for oci index in TestFromImagePlatform

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -305,7 +305,7 @@ func (container *Container) FromRefString(ctx context.Context, addr string) (*Co
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve image %s: %w", refName.String(), err)
+		return nil, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refName.String(), platform.Format(), err)
 	}
 	canonRefName, err := reference.WithDigest(refName, digest)
 	if err != nil {
@@ -343,7 +343,7 @@ func (container *Container) FromCanonicalRef(
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve image %s: %w", refStr, err)
+			return nil, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refStr, platform.Format(), err)
 		}
 	}
 

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -9,6 +9,7 @@ const (
 	debianImage  = "debian:bookworm"
 	rhelImage    = "registry.access.redhat.com/ubi9/ubi"
 	alpineArm    = "arm64v8/alpine"
+	alpineAmd    = "amd64/alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -761,7 +761,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.Instance[*core.
 		},
 	})
 	if err != nil {
-		return inst, fmt.Errorf("failed to resolve image %s: %w", refName.String(), err)
+		return inst, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refName.String(), platform.Format(), err)
 	}
 	refName, err = reference.WithDigest(refName, digest)
 	if err != nil {


### PR DESCRIPTION
This test started failing out of band in our CI on amd64 hosts.

Justin noticed that the published arm64v8/alpine image had changed from a single manifest to a multiplatform oci index w/ a single platform-specific manifest.

This broke the test because previously in the "single manifest" case the platform we tried to resolve the image with was completely ignored. After switching to the oci index, the platform actually mattered.

We were defaulting the platform to the host's platform when resolving the image, but this test purposely attempts to pull an image for a different platform.

After some discussion we decided erroring in the case is expected and the simplest behavior. If users want to pull images that don't match their host's platform, they need to explicitly request that platform in the Container opts.

This thus updates the test case to explicitly ask for the desired platform.

I also included a small improvement to the error messages when hitting this case, which would have sped up debugging this a bit.