### PR TITLE
feat(shell): load module dynamically

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -362,6 +362,12 @@ func maybeInitializeModule(ctx context.Context, dag *dagger.Client, srcRef strin
 	}
 	def.Name = name
 
+	desc, err := mod.Description(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get module name: %w", err)
+	}
+	def.Description = desc
+
 	if err := def.loadTypeDefs(ctx, dag); err != nil {
 		return nil, err
 	}
@@ -513,13 +519,9 @@ func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, t
 
 	cmd.AddGroup(funcGroup)
 
-	skipped := make([]string, 0)
+	fns, skipped := GetSupportedFunctions(fnProvider)
 
-	for _, fn := range fnProvider.GetFunctions() {
-		if fn.IsUnsupported() {
-			skipped = append(skipped, fn.CmdName())
-			continue
-		}
+	for _, fn := range fns {
 		subCmd := fc.makeSubCmd(ctx, fn)
 		cmd.AddCommand(subCmd)
 	}

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -145,7 +145,7 @@ func (h *shellCallHandler) RunAll(ctx context.Context, args []string) error {
 
 	r, err := interp.New(
 		interp.StdIO(nil, h.stdoutBuf, h.stderrBuf),
-		// interp.Params("-e", "-u", "-o", "pipefail"),
+		interp.Params("-e", "-u", "-o", "pipefail"),
 
 		// The "Interactive" option is useful even when not running dagger shell
 		// in interactive mode. It expands aliases and maybe more in the future.
@@ -761,6 +761,13 @@ func (h *shellCallHandler) parseStateArgument(ctx context.Context, arg *modFunct
 
 // Result handles making the final request and printing the response
 func (h *shellCallHandler) Result(ctx context.Context, st *ShellState) error {
+	if h.debug {
+		withTerminal(func(_ io.Reader, _, stderr io.Writer) error {
+			fmt.Fprintf(stderr, "[DBG] Result state: %+v\n", st)
+			return nil
+		})
+	}
+
 	def := h.modDef(st)
 
 	if def.HasModule() && st.ModRef != nil && len(st.Calls) == 0 {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -544,22 +544,20 @@ func (h *shellCallHandler) entrypointCall(ctx context.Context, args []string) (*
 		shellLogf(ctx, "[DBG] └ Entrypoint(%v)\n", args)
 	}
 
-	def := h.modDef(nil)
+	def, err := h.GetModuleDef(nil)
+	if err != nil {
+		return nil, err
+	}
 	st := h.newState()
 
-	// 1. Same-module call (eg. 'build')
+	// Same-module call (eg. 'build')
 	if def.HasModule() && def.HasFunction(def.MainObject.AsFunctionProvider(), args[0]) {
 		return h.constructorCall(def, st)
 	}
 
-	// 2. Core function call (eg. 'git')
-	if def.HasCoreFunction(args[0]) {
-		return st, nil
-	}
+	// TODO: Dependency short name (eg. 'wolfi container')
 
-	// TODO: 3. Dependency short name (eg. 'wolfi container')
-
-	return nil, fmt.Errorf("no such module or core function: %q", args[0])
+	return nil, fmt.Errorf("no such function: %q", args[0])
 }
 
 func (h *shellCallHandler) constructorCall(md *moduleDef, st *ShellState) (*ShellState, error) {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1369,7 +1369,7 @@ func shellTypeDoc(m *moduleDef, t *modTypeDef) string {
 				}),
 			)
 		}
-	} else {
+	} else if fp.ProviderName() != "Query" {
 		doc.Add(t.KindDisplay(), t.Long())
 	}
 
@@ -1469,10 +1469,7 @@ func (h *shellCallHandler) registerBuiltins() { //nolint:gocyclo
 			Short: "Show documentation for a type, or a function",
 			Args:  MaximumArgs(1),
 			RunState: func(cmd *ShellCommand, args []string, st *ShellState) error {
-				def, err := h.GetModuleDef(st)
-				if err != nil {
-					return err
-				}
+				def := h.modDef(st)
 
 				t, err := st.GetTypeDef(def)
 				if err != nil {

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -90,10 +90,9 @@ func (ShellSuite) TestNoModule(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "Container", gjson.Get(out, "_type").String())
 	})
 
-	t.Run("no module commands", func(ctx context.Context, t *testctx.T) {
-		out, err := modGen.With(daggerShell(".help")).Stdout(ctx)
-		require.NoError(t, err)
-		require.NotContains(t, out, ".install")
+	t.Run("module builtin does not work", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.With(daggerShell(".config")).Sync(ctx)
+		require.ErrorContains(t, err, "module not loaded")
 	})
 
 	t.Run("no main object doc", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -25,6 +25,14 @@ func daggerShell(script string) dagger.WithContainerFunc {
 	}
 }
 
+func daggerShellNoLoad(script string) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		return c.WithExec([]string{"dagger", "shell", "--no-load", "-c", script}, dagger.ContainerWithExecOpts{
+			ExperimentalPrivilegedNesting: true,
+		})
+	}
+}
+
 func (ShellSuite) TestFallbackToCore(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -48,7 +56,7 @@ import (
 type Test struct{}
 
 func (m *Test) Container() *dagger.Container {
-    return dag.Container(). From("`+alpineImage+`")
+	return dag.Container(). From("`+alpineImage+`")
 }
 `,
 	).
@@ -70,7 +78,7 @@ import (
 type Test struct{}
 
 func (m *Test) Container() *dagger.Container {
-    return dag.Container().From("`+golangImage+`")
+	return dag.Container().From("`+golangImage+`")
 }
 `,
 	).
@@ -96,31 +104,109 @@ func (ShellSuite) TestNoModule(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("no main object doc", func(ctx context.Context, t *testctx.T) {
-		_, err := modGen.With(daggerShell(".doc")).Sync(ctx)
+		_, err := modGen.With(daggerShell(".config")).Sync(ctx)
 		require.ErrorContains(t, err, "module not loaded")
 	})
 }
 
 func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	modGen := modInit(t, c, "go", "")
-
 	t.Run("sanity check", func(ctx context.Context, t *testctx.T) {
-		out, err := modGen.With(daggerShell(".doc")).Stdout(ctx)
+		c := connect(ctx, t)
+		out, err := modInit(t, c, "go", "").
+			With(daggerShell(".doc")).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-echo")
 	})
 
 	t.Run("forced no load", func(ctx context.Context, t *testctx.T) {
-		_, err := modGen.
-			WithExec(
-				[]string{"dagger", "shell", "--no-load", "-c", ".doc"},
-				dagger.ContainerWithExecOpts{
-					ExperimentalPrivilegedNesting: true,
-				},
-			).
+		c := connect(ctx, t)
+		_, err := modInit(t, c, "go", "").
+			With(daggerShellNoLoad(".config")).
 			Sync(ctx)
 		require.ErrorContains(t, err, "module not loaded")
+	})
+
+	t.Run("dynamically loaded", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := modInit(t, c, "go", "").
+			With(daggerShellNoLoad(".load | .use; .doc")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container-echo")
+	})
+
+	t.Run("stateless load", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := modInit(t, c, "go", "").
+			With(daggerShellNoLoad(".load | .doc")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container-echo")
+	})
+}
+
+func (ShellSuite) TestLoadAnotherModule(ctx context.Context, t *testctx.T) {
+	test := `package main
+
+type Test struct{}
+
+func (m *Test) Bar() string {
+	return "testbar"
+}
+`
+
+	foo := `package main
+
+func New() *Foo {
+	return &Foo{
+		Bar: "foobar",
+	}
+}
+
+type Foo struct{
+	Bar string
+}
+`
+	t.Run("main object", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := modInit(t, c, "go", test).
+			With(daggerExec("init", "--sdk=go", "--source=foo", "foo")).
+			With(sdkSourceAt("foo", "go", foo)).
+			With(daggerShell(".load foo")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"_type": "Foo", "bar": "foobar"}`, out)
+	})
+
+	t.Run("stateful", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := modInit(t, c, "go", test).
+			With(daggerExec("init", "--sdk=go", "--source=foo", "foo")).
+			With(sdkSourceAt("foo", "go", foo)).
+			With(daggerShell(".load foo | .use; bar")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "foobar")
+	})
+
+	t.Run("stateless", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		modGen := modInit(t, c, "go", test).
+			With(daggerExec("init", "--sdk=go", "--source=foo", "foo")).
+			With(sdkSourceAt("foo", "go", foo))
+
+		out, err := modGen.
+			With(daggerShell(".load foo | bar")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "foobar", out)
+
+		out, err = modGen.
+			With(daggerShell("bar")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "testbar", out)
 	})
 }
 
@@ -182,4 +268,38 @@ func (m *Test) DirectoryID(ctx context.Context) (string, error) {
 
 	require.NoError(t, err)
 	require.Equal(t, "bar", out)
+}
+
+func (ShellSuite) TestModuleDoc(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	source := `// This is a test module
+
+package main
+
+// The entrypoint for the module
+func New(foo string, bar string) *Test {
+	return &Test{
+		Foo: foo,
+		Bar: bar,
+	}
+}
+
+type Test struct{
+	Foo string 
+	Bar string
+}
+
+// Some function
+func (m *Test) FooBar() string {
+	return m.Foo+m.Bar
+}
+`
+	out, err := modInit(t, c, "go", source).
+		With(daggerShell(".doc")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "\n  test\n  \n  This is a test module")
+	require.Contains(t, out, "Usage: .config <foo> <bar>\n  \n  The entrypoint for the module")
+	require.Regexp(t, "foo-bar +Some function", out)
 }


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/8932

## Prompt

Since we can now load different modules within the same session, the prompt now shows the default module (global), if loaded:

<img width="900" alt="Screenshot 2024-11-15 at 21 33 00" src="https://github.com/user-attachments/assets/2fb1f66a-75d0-4258-8543-45abafafe171">

## Colors

In order to be easier to spot, errors are now shown in red:

<img width="1000" alt="Screenshot 2024-11-15 at 21 36 31" src="https://github.com/user-attachments/assets/6d9d22e5-1d4e-41ec-bda4-1031b4479ee2">

Thanks to @cwlbraa for this idea, the prompt symbol (⋈) is also turned red if the last command errored. It's green otherwise.

## Fixes

- A few core functions like `.cache-volume` weren't showing, that's now fixed
- Module description is now shown when using `.doc` on the main object, and constructor output improved
- A non existing function won't fallback to core anymore since core functions are readily available with the `.` prefix

## Todo

- [x] Add `.load` builtin to load module when `--no-load` was used
- [x] Add `.use` builtin and pass introspection through state
- [x] Load any module
- [x] Tests