### PR TITLE
sdk/java: add bump-deps, bump deps to fix engine scan

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -33,6 +33,11 @@
                 <version>${smallrye-graphql.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty-common.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.json</groupId>
                 <artifactId>jakarta.json-api</artifactId>
                 <version>${jakarta.json-api.version}</version>
@@ -158,8 +163,16 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>maven-versions-plugin</artifactId>
-                    <version>${maven-versions-plugin.version}</version>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-maven-plugin.version}</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                        <allowMajorUpdates>false</allowMajorUpdates>
+                        <allowMinorUpdates>true</allowMinorUpdates>
+                        <allowIncrementalUpdates>true</allowIncrementalUpdates>
+                        <allowSnapshots>false</allowSnapshots>
+                        <ignoredVersions type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA)[-_\.]?[0-9]*</ignoredVersions>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -235,33 +248,34 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <daggerengine.version>devel</daggerengine.version>
 
-        <assertj-core.version>3.26.0</assertj-core.version>
-        <commons-compress.version>1.26.2</commons-compress.version>
-        <commons-lang.version>3.14.0</commons-lang.version>
-        <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
+        <assertj-core.version>3.26.3</assertj-core.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
+        <commons-lang.version>3.17.0</commons-lang.version>
+        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
         <fluent-process.version>1.0.1</fluent-process.version>
-        <fmt-maven-plugin.version>2.23</fmt-maven-plugin.version>
+        <fmt-maven-plugin.version>2.25</fmt-maven-plugin.version>
         <inject-maven-plugin.version>1.7</inject-maven-plugin.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <javapoet.version>1.13.0</javapoet.version>
         <json-path.version>2.9.0</json-path.version>
-        <junit.version>5.10.2</junit.version>
-        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
-        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-        <maven-plugin-api.version>3.8.8</maven-plugin-api.version>
-        <maven-plugin-annotations.version>3.8.1</maven-plugin-annotations.version>
+        <junit.version>5.11.3</junit.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
+        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
+        <maven-plugin-api.version>3.9.9</maven-plugin-api.version>
+        <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-project.version>2.2.1</maven-project.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-versions-plugin.version>2.16.0</maven-versions-plugin.version>
-        <mockito-core.version>5.12.0</mockito-core.version>
-        <slf4j-api.version>2.0.13</slf4j-api.version>
-        <slf4j-simple.version>2.0.13</slf4j-simple.version>
-        <smallrye-graphql.version>2.8.4</smallrye-graphql.version>
-        <system-stubs-jupiter.version>2.1.6</system-stubs-jupiter.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+        <mockito-core.version>5.14.2</mockito-core.version>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
+        <slf4j-simple.version>2.0.16</slf4j-simple.version>
+        <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
+        <netty-common.version>4.1.115.Final</netty-common.version>
+        <system-stubs-jupiter.version>2.1.7</system-stubs-jupiter.version>
         <xdg-java.version>0.1.1</xdg-java.version>
         <yasson.version>3.0.4</yasson.version>
     </properties>


### PR DESCRIPTION
`engine-scan` started failing with a transitive dependency, so hopefully this mass bump fixes it