### PR TITLE
ci: Add nightly workflow on Depot runners

### DIFF
--- a/_dagger_on_depot_cli_provisioned.yml
+++ b/_dagger_on_depot_cli_provisioned.yml
@@ -1,0 +1,43 @@
+name: Dagger on Depot - CLI provisioned
+
+on:
+  workflow_call:
+    inputs:
+      function:
+        description: "Dagger function"
+        type: string
+        required: true
+      size:
+        description: "Runner size"
+        type: number
+        required: true
+      timeout:
+        description: "Timeout if not finished after this many minutes"
+        type: number
+        default: 10
+        required: false
+      dev:
+        description: "Use a development version of Dagger"
+        type: string
+        default: "false"
+        required: false
+      ubuntu:
+        description: "Ubuntu version"
+        type: string
+        default: "24.04"
+        required: false
+
+jobs:
+  cli-provisioned-dagger-no-cache:
+    if: ${{ github.repository == 'dagger/on-depot' }}
+    runs-on: depot-ubuntu-${{ inputs.ubuntu }}-${{ inputs.size }}
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: ${{ inputs.function }}
+        uses: ./.github/actions/call
+        with:
+          function: ${{ inputs.function }}
+          version: v${{ inputs.dagger }}
+          dev-engine: ${{ inputs.dev }}

--- a/_dagger_on_depot_pre-provisioned_with_cache.yml
+++ b/_dagger_on_depot_pre-provisioned_with_cache.yml
@@ -1,0 +1,39 @@
+name: Dagger on Depot - Pre-provisioned with Cache
+
+on:
+  workflow_call:
+    inputs:
+      function:
+        description: "Dagger function"
+        type: string
+        required: true
+      timeout:
+        description: "Timeout if not finished after this many minutes"
+        type: number
+        default: 10
+        required: false
+      dagger:
+        description: "Dagger version"
+        type: string
+        default: "0.14.0"
+        required: false
+      ubuntu:
+        description: "Ubuntu version"
+        type: string
+        default: "24.04"
+        required: false
+
+jobs:
+  pre-provisioned-dagger-with-cache:
+    if: ${{ github.repository == 'dagger/on-depot' }}
+    runs-on: depot-ubuntu-${{ inputs.ubuntu }},dagger=${{ inputs.dagger }}
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: ${{ inputs.function }}
+        uses: ./.github/actions/call
+        with:
+          function: ${{ inputs.function }}
+          version: v${{ inputs.dagger }}
+          dev-engine: ${{ inputs.dev }}

--- a/alternative-ci-runners.yml
+++ b/alternative-ci-runners.yml
@@ -1,0 +1,125 @@
+name: Alternative CI Runners
+
+on:
+  # Run the workflow every day at 1AM UTC
+  # That's 2AM CET, 8PM EST & 5PM PST
+  schedule:
+    - cron: "0 1 * * *"
+  # Enable manual trigger for on-demand runs - helps when debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  engine-lint-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: engine lint
+  engine-test-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: test all --race=true --parallel=16
+      timeout: 30
+  engine-testdev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: test specific --run='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestContainer' --skip='TestDev' --race=true --parallel=16
+      size: 32
+      timeout: 30
+
+  scripts-lint-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: scripts lint
+
+  docs-lint-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: docs lint
+
+  helm-lint-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: helm lint
+  helm-test-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: helm publish --dry-run=true --tag=main
+
+  sdk-elixir-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/elixir
+  sdk-elixir-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/elixir
+      size: 16
+      dev: true
+
+  sdk-go-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/go
+  sdk-go-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/go
+      size: 4
+      dev: true
+
+  sdk-java-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/java
+  sdk-java-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/java
+      size: 8
+      dev: true
+
+  sdk-php-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/php
+  sdk-php-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/php
+      size: 4
+      dev: true
+
+  sdk-python-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/python
+  sdk-python-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/python
+      size: 4
+      dev: true
+
+  sdk-rust-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/rust
+  sdk-rust-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/rust
+      size: 16
+      dev: true
+
+  sdk-typescript-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+    with:
+      function: check --targets=sdk/typescript
+  sdk-typescript-dev-on-depot:
+    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+    with:
+      function: check --targets=sdk/typescript
+      size: 4
+      dev: true


### PR DESCRIPTION
The workflow runs a good mix of jobs, including jobs that:
- take more than 20 minutes to run
- finish in a few minutes and cache well
- don't cache at all
- require a handful of vCPUs
- require 32 vCPUs
- put a lot of disk I/O pressure

Tests were performed on a temporary repo since new workflows cannot run until they exist on the `main` branch. More details in the PR.

This change is an alternative to:
- https://github.com/dagger/dagger/pull/8792

---

![Screenshot 2024-11-13 at 17 47 04](https://github.com/user-attachments/assets/e622c83e-0d7e-43ee-81e5-cc88140ecdb0)