### PR TITLE
cli: Alias `fs` to `functions`

### DIFF
--- a/.changes/unreleased/Added-20241113-182715.yaml
+++ b/.changes/unreleased/Added-20241113-182715.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Alias `fs` to `functions` so that pro CLI users can run `d fs` (they all have `d` aliased to `dagger`)
+time: 2024-11-13T18:27:15.063641Z
+custom:
+    Author: gerhard
+    PR: "8945"

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -49,8 +49,9 @@ var callModCmd = &FuncCommand{
 }
 
 var funcListCmd = &cobra.Command{
-	Use:   "functions [options] [function]...",
-	Short: `List available functions`,
+	Use:     "functions [options] [function]...",
+	Aliases: []string{"fs"},
+	Short:   `List available functions`,
 	Long: strings.ReplaceAll(`List available functions in a module.
 
 This is similar to ´dagger call --help´, but only focused on showing the


### PR DESCRIPTION
So that pro CLI users can run:

    d fs

Instead of:

    dagger functions

Because **pro** CLI users already alias `d` to `dagger`

---

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/2b0ef33a-4b5d-4777-b981-8521aa8b94e1">

---

In the absence of this:

```console
which dfs
dfs: aliased to dagger functions
```