### PR TITLE
fix: explicitly handle null dir panic

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -174,7 +174,10 @@ func (dir *Directory) Evaluate(ctx context.Context) (*buildkit.Result, error) {
 func (dir *Directory) Digest(ctx context.Context) (string, error) {
 	result, err := dir.Evaluate(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to evaluate file: %w", err)
+		return "", fmt.Errorf("failed to evaluate directory: %w", err)
+	}
+	if result == nil {
+		return "", fmt.Errorf("failed to evaluate null directory")
 	}
 
 	digest, err := result.Ref.Digest(ctx, dir.Dir)


### PR DESCRIPTION
Cheers to @shykes for finding this one :clinking_glasses: 

```
❯ dagger core container rootfs digest
goroutine 5186939 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:26 +0x5e
github.com/dagger/dagger/dagql.(*Server).resolvePath.func1()
        /app/dagql/server.go:697 +0x77
panic({0x20e3240?, 0x3af1f80?})
        /usr/lib/go/src/runtime/panic.go:785 +0x132
github.com/dagger/dagger/core.(*Directory).Digest(0xc04f4426c0, {0x28a5830, 0xc04c3f50e0})
	/app/core/directory.go:180 +0x6f
github.com/dagger/dagger/core/schema.(*directorySchema).digest(0x6?, {0x28a5830?, 0xc04c3f50e0?}, 0x3b77880?, {})
	/app/core/schema/directory.go:206 +0x25
github.com/dagger/dagger/dagql.Func[...].func1({0xc0429b2fc0?, 0xc04f4426c0?, {0x0, 0x1, 0xc02ec27920, 0xc04c7035d8}, 0x0}, {})
	/app/dagql/objects.go:402 +0x49
github.com/dagger/dagger/dagql.NodeFunc[...].func1({0xc0429b2fc0, 0xc04f4426c0, {0x0, 0x1, 0xc02ec27920, 0xc04c7035d8}, 0x0}, 0xc04c3f5170)
	/app/dagql/objects.go:439 +0xfc
github.com/dagger/dagger/dagql.Class[...].Call(0x28dd100?, {0x28a5830?, 0xc04c3f50e0?}, {0xc0429b2fc0, 0xc04f4426c0, {0x0, 0x1, 0xc02ec27920, 0xc04c7035d8}, 0x0}, ...)
	/app/dagql/objects.go:260 +0x19d
github.com/dagger/dagger/dagql.Instance[...].Select(0x28c8700, {0x28a5830, 0xc04c3f50e0}, {{0xc039a70317, 0x6}, {0x3b77880, 0x0, 0x0}, 0x0, {0x0, ...}})
	/app/dagql/objects.go:326 +0x358
github.com/dagger/dagger/dagql.(*Server).cachedSelect.func1({0x28a5830?, 0xc04c3f4ff0?})
	/app/dagql/server.go:642 +0x132
github.com/dagger/dagger/dagql.(*cacheMap[...]).GetOrInitializeOnHit(0x28d5fc0, {0x28a5830, 0xc04c3f4f90}, {0xc06055aa08, 0x15}, 0xc0503b3b90, 0xc045901ac8)
	/app/dagql/cachemap.go:85 +0x262
github.com/dagger/dagger/dagql.(*cacheMap[...]).GetOrInitialize(0xc045901b08?, {0x28a5830?, 0xc04c3f4f90?}, {0xc06055aa08?, 0xf236aa?}, 0x3b77801?)
	/app/dagql/cachemap.go:60 +0x3e
github.com/dagger/dagger/dagql.(*Server).cachedSelect(0xc0147cd740, {0x28a5830, 0xc04c3f4990}, {0x28aa440, 0xc0429b3680}, {{0xc039a70317, 0x6}, {0x3b77880, 0x0, 0x0}, ...})
	/app/dagql/server.go:647 +0x216
github.com/dagger/dagger/dagql.(*Server).resolvePath(0xc0147cd740, {0x28a5830, 0xc04c3f4990}, {0x28aa440?, 0xc0429b3680?}, {{0xc039a70317, 0x6}, {{0xc039a70317, 0x6}, {0x3b77880, ...}, ...}, ...})
	/app/dagql/server.go:706 +0x14b
github.com/dagger/dagger/dagql.(*Server).Resolve.func1()
	/app/dagql/server.go:438 +0x7f
github.com/dagger/dagger/dagql.(*Server).Resolve.(*ErrorPool).Go.func3()
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/error_pool.go:30 +0x23
github.com/sourcegraph/conc/pool.(*Pool).worker(0x1f5be80?)
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/pool.go:154 +0x69
github.com/sourcegraph/conc/panics.(*Catcher).Try(0xc03de2f7d0?, 0x99aaec?)
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/panics/panics.go:23 +0x42
github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:32 +0x4d
created by github.com/sourcegraph/conc.(*WaitGroup).Go in goroutine 5186938
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:30 +0x73
```

We need to explicitly handle `result == nil`, since `dir.Evaluate` can clearly return `nil` if there is no previous LLB - which makes sense.

We can just return an error here.