### PR TITLE
ci: Bump Dagger version in Daggerverse after publishing a new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
       # run tests in a PR when an SDK is modified...
       - ./sdk
       # ...or when we are
-      - ./.github/workflows/engine-and-cli-publish.yml
+      - ./.github/workflows/publish.yml
 
 jobs:
   publish:
@@ -72,7 +72,7 @@ jobs:
 
   publish-sdk-go:
     needs: publish
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"
@@ -90,7 +90,7 @@ jobs:
 
   publish-sdk-php:
     needs: publish
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"
@@ -109,7 +109,7 @@ jobs:
   publish-sdk-python:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"
@@ -129,7 +129,7 @@ jobs:
   publish-sdk-typescript:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"
@@ -148,7 +148,7 @@ jobs:
   publish-sdk-elixir:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"
@@ -167,7 +167,7 @@ jobs:
   publish-helm:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-14-0-4c' || 'ubuntu-latest' }}"
+    runs-on: dagger-g2-v0-14-0-4c
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"
@@ -182,6 +182,20 @@ jobs:
         with:
           message: "☸️ Helm Chart: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
           discord-webhook: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
+
+  daggerverse-bump-dagger:
+    needs: publish
+    if: github.ref_name != 'main'
+    runs-on: dagger-g2-v0-14-0-4c
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Bump Dagger version in Daggerverse"
+        uses: ./.github/actions/call
+        env:
+          DAGGER_CI_GITHUB_TOKEN: ${{ secrets.DAGGER_CI_GITHUB_TOKEN }}
+        with:
+          function: --github-token=env:DAGGER_CI_GITHUB_TOKEN bump-dagger-version --to=${{ github.ref_name }} 
+          module: ./modules/daggerverse
 
   # TODO: daggerize provisioning tests
   test-provision-macos:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -437,8 +437,9 @@ production deployment via Netlify as follows:
 
 ## 🌌 Daggerverse ⏱ `2mins`
 
-- [ ] Mention in the release thread on Discord that Daggerverse can be updated
-      to the just-released version. cc @marcosnils @matipan @grouville
+- [ ] Merge the newly opened PR in the dagger.io repository (this is created by
+      the publish workflow). If anything fails, cc the following in the release thread
+      on Discord: cc @jpadams @kpenfound @matipan @gerhard
 
 ## 🌥️ Dagger Cloud ⏱ `2mins`
 

--- a/modules/daggerverse/dagger.json
+++ b/modules/daggerverse/dagger.json
@@ -1,13 +1,18 @@
 {
   "name": "daggerverse",
+  "engineVersion": "v0.14.0",
   "sdk": "go",
   "dependencies": [
     {
       "name": "gh",
       "source": "github.com/sagikazarmark/daggerverse/gh",
       "pin": "68e9daa611183f5334b4059bac6f4aad62da7a37"
+    },
+    {
+      "name": "go",
+      "source": "../go",
+      "pin": ""
     }
   ],
-  "source": ".",
-  "engineVersion": "v0.13.6"
+  "source": "."
 }

--- a/modules/daggerverse/main.go
+++ b/modules/daggerverse/main.go
@@ -4,71 +4,86 @@ import (
 	"context"
 	"dagger/daggerverse/internal/dagger"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v66/github"
 )
 
-type Daggerverse struct{}
+type Daggerverse struct {
+	// +private
+	Gh *dagger.Gh
+	// +private
+	GitHubUser string
+	// +private
+	GitHubUsername string
+	// +private
+	GitHubUserEmail string
+	// +private
+	Repo string
+}
 
-// Deploy preview environment running Dagger main: dagger call deploy-preview-with-dagger-main --github-token=env:GITHUB_PAT
-func (h *Daggerverse) DeployPreviewWithDaggerMain(
+func New(
 	ctx context.Context,
+	// GitHub Personal Access Token which access to dagger/dagger.io repo
 	githubToken *dagger.Secret,
-) error {
+) (*Daggerverse, error) {
 	token, err := githubToken.Plaintext(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// get user config from githubToken
 	ghc := github.NewClient(nil).WithAuthToken(token)
 	user, _, err := ghc.Users.Get(ctx, "")
 	if err != nil {
-		return err
+		return nil, err
+	}
+	repo := "github.com/dagger/dagger.io"
+	dgvs := &Daggerverse{
+		GitHubUsername: *user.Login,
+		GitHubUser:     *user.Name,
+		Repo:           repo,
+		Gh: dag.Gh(dagger.GhOpts{
+			Token: githubToken,
+			Repo:  repo,
+		}),
 	}
 
 	emails, _, err := ghc.Users.ListEmails(ctx, &github.ListOptions{})
 	if err != nil {
-		return err
+		return nil, err
 	}
+	dgvs.GitHubUserEmail = *emails[0].Email
 
-	today := time.Now()
-	date := today.Format("2006-01-02")
+	return dgvs, nil
+}
 
-	// clone dagger.io - private repository, requires a github token
-	repo := "github.com/dagger/dagger.io"
-	// clone dagger.io - private repository, requires a github token
-	gh := dag.Gh(dagger.GhOpts{
-		Token: githubToken,
-		Repo:  repo,
-	})
-
+// Deploy preview environment running Dagger main: dagger call --github-token=env:GITHUB_PAT deploy-preview-with-dagger-main
+func (h *Daggerverse) DeployPreviewWithDaggerMain(
+	ctx context.Context,
+) error {
 	// make a change so that a new Daggerverse deployment will be created
-	daggerio := gh.Repo().Clone(
-		repo,
-		dagger.GhRepoCloneOpts{
-			Args: []string{"--depth=1"},
-		}).
-		WithNewFile("daggerverse/CREATE_PREVIEW_ENVIRONMENT", today.String())
+	daggerio := h.clone().
+		WithNewFile("daggerverse/CREATE_PREVIEW_ENVIRONMENT", time.Now().String())
 
-	branch := fmt.Sprintf("dgvs-test-with-dagger-main-%s", date)
+	branch := fmt.Sprintf("dgvs-test-with-dagger-main-%s", h.date())
 	commitMsg := fmt.Sprintf(`dgvs: Test Dagger Engine main @ %s
 
-daggerverse-checks in GitHub Actions ensures that module crawling works as expected. Should complete within 5 mins.`, date)
+daggerverse-checks in GitHub Actions ensures that module crawling works as expected. Should complete within 5 mins.`, h.date())
 
 	// open a PR so that it creates a new Daggerverse preview environment running Dagger main
-	err = gh.WithSource(daggerio).
+	err := h.Gh.WithSource(daggerio).
 		WithGitExec([]string{"checkout", "-b", branch}).
 		WithGitExec([]string{"add", "daggerverse/CREATE_PREVIEW_ENVIRONMENT"}).
-		WithGitExec([]string{"config", "user.email", *emails[0].Email}).
-		WithGitExec([]string{"config", "user.name", *user.Name}).
+		WithGitExec([]string{"config", "user.email", h.GitHubUserEmail}).
+		WithGitExec([]string{"config", "user.name", h.GitHubUser}).
 		WithGitExec([]string{"commit", "-am", commitMsg}).
-		WithGitExec([]string{"push", "--force", "origin", branch}).
+		WithGitExec([]string{"push", "origin", branch}).
 		PullRequest().Create(
 		ctx,
 		dagger.GhPullRequestCreateOpts{
-			Assignees: []string{*user.Login},
+			Assignees: []string{h.GitHubUsername},
 			Fill:      true,
 			Labels:    []string{"preview", "area/daggerverse"},
 			Head:      branch,
@@ -76,4 +91,118 @@ daggerverse-checks in GitHub Actions ensures that module crawling works as expec
 	)
 
 	return err
+}
+
+// Bump Dagger version: dagger call --github-token=env:GITHUB_PAT bump-dagger-version --from=0.13.7 --to=0.14.0
+func (h *Daggerverse) BumpDaggerVersion(
+	ctx context.Context,
+	// +defaultPath="../../.changes"
+	releases *dagger.Directory,
+	// Which version of Dagger are we bumping from - defaults to version n-1
+	// +optional
+	from string,
+	// Which version of Dagger are we bumping to
+	to string,
+) (err error) {
+	if from == "" {
+		from, err = dag.Container().From("alpine").
+			WithDirectory("/releases", releases).
+			WithWorkdir("/releases").
+			WithExec([]string{"sh", "-c", "ls v* | awk -F'[v.]' '{ print $2\".\"$3.\".\"$4 }' | sort -V | tail -n 2 | head -n 1"}).
+			Stdout(ctx)
+		if err != nil {
+			return err
+		}
+		from = strings.TrimSpace(from)
+	}
+
+	fromDashed := strings.ReplaceAll(from, ".", "-")
+	toDashed := strings.ReplaceAll(to, ".", "-")
+	engineImage := fmt.Sprintf("registry.dagger.io/engine:v%s", to)
+
+	engine := dag.Container().From(engineImage).
+		WithExposedPort(1234).
+		WithExec([]string{
+			"--addr", "tcp://0.0.0.0:1234",
+			"--addr", "unix:///var/run/buildkit/buildkitd.sock",
+			"--network-cidr", "10.12.34.0/24",
+		}, dagger.ContainerWithExecOpts{
+			UseEntrypoint:            true,
+			InsecureRootCapabilities: true,
+		}).AsService()
+
+	daggerio, err := dag.Container().From(engineImage).
+		WithDirectory("/dagger.io", h.clone()).
+		WithWorkdir("/dagger.io").
+		WithExec([]string{"sh", "-c",
+			fmt.Sprintf("find .github/workflows -name '*daggerverse*' -exec sed -i 's/%s/%s/g' {} +", fromDashed, toDashed),
+		}).
+		WithExec([]string{"sh", "-c",
+			fmt.Sprintf("sed -i 's/\\(DaggerVersion\\s*=\\s*\"\\)%s\"/\\1%s\"/' daggerverse/dag/main.go", from, to),
+		}).
+		WithServiceBinding("daggerverse-engine", engine).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://daggerverse-engine:1234").
+		WithExec([]string{"nc", "-vzw", "1", "daggerverse-engine", "1234"}).
+		WithExec([]string{"dagger", "version"}).
+		WithExec([]string{"dagger", "core", "version"}).
+		WithExec([]string{"dagger", "--mod=daggerverse/dag", "develop"}).
+		WithExec([]string{"dagger", "--mod=daggerverse", "develop"}).
+		WithExec([]string{"sh", "-c",
+			fmt.Sprintf("sed -i 's/v[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v%s/' infra/ci/*/argocd/daggerverse-preview/appset.yaml", to),
+		}).
+		WithExec([]string{"sh", "-c",
+			fmt.Sprintf("sed -i 's/registry\\.dagger\\.io\\/engine:v[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/registry\\.dagger\\.io\\/engine:v%s/' infra/ci/*/argocd/daggerverse-preview/manifests/deployment.base.yaml", to),
+		}).
+		WithExec([]string{"sh", "-c",
+			fmt.Sprintf("sed -i 's/registry\\.dagger\\.io\\/engine:v[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/registry\\.dagger\\.io\\/engine:v%s/' infra/prod/*/argocd/daggerverse/deployment.yaml", to),
+		}).
+		Sync(ctx)
+	if err != nil {
+		return err
+	}
+
+	daggerverse, err := dag.Go(daggerio.Directory("daggerverse")).Env().
+		WithExec([]string{"go", "get", fmt.Sprintf("dagger.io/dagger@v%s", to)}).
+		Sync(ctx)
+	if err != nil {
+		return err
+	}
+
+	updated := daggerio.
+		WithDirectory("/dagger.io/daggerverse", daggerverse.Directory(".")).
+		Directory("/dagger.io")
+
+	branch := fmt.Sprintf("dgvs-bump-dagger-from-%s-to-%s-with-dagger-main", from, to)
+	commitMsg := fmt.Sprintf("dgvs: Bump Dagger from %s to %s", from, to)
+
+	err = h.Gh.WithSource(updated).
+		WithGitExec([]string{"checkout", "-b", branch}).
+		WithGitExec([]string{"add", ".github", "daggerverse", "infra"}).
+		WithGitExec([]string{"config", "user.email", h.GitHubUserEmail}).
+		WithGitExec([]string{"config", "user.name", h.GitHubUser}).
+		WithGitExec([]string{"commit", "-am", commitMsg}).
+		WithGitExec([]string{"push", "origin", branch}).
+		PullRequest().Create(
+		ctx,
+		dagger.GhPullRequestCreateOpts{
+			Assignees: []string{h.GitHubUsername},
+			Fill:      true,
+			Labels:    []string{"preview", "area/daggerverse"},
+			Head:      branch,
+		},
+	)
+
+	return err
+}
+
+func (h *Daggerverse) date() string {
+	return time.Now().Format("2006-01-02")
+}
+
+func (h *Daggerverse) clone() *dagger.Directory {
+	return h.Gh.Repo().Clone(
+		h.Repo,
+		dagger.GhRepoCloneOpts{
+			Args: []string{"--depth=1"},
+		})
 }


### PR DESCRIPTION
Upgrades Dagger version for Daggerverse in:
- GitHub workflows
- Daggerverse modules
- Daggerverse app
- Infra config

It also deploys a Daggerverse preview environment with a development version of Dagger (this implies the version that we are upgrading to).

This now runs automatically part of the publish workflow. When no `--from` is specified, it looks inside the `.changes` directory and picks the one but last version (n-1).

Updated the publish workflow runs-on to only use our own runners. This workflow is never meant to run in forks.

## How does it work locally?

https://github.com/user-attachments/assets/615b688c-65b9-4eb2-91f1-eb4d74a84e48