### PR TITLE
fix(engine): secrets created inside module constructor fail on repeated accesses

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3007,9 +3007,14 @@ func (m *Mymodule) Issue(ctx context.Context) error {
         return fmt.Errorf("first get: %w", err)
     }
 
+    err = kc.Get(ctx, "a")
+    if err != nil {
+        return fmt.Errorf("second get, same args: %w", err)
+    }
+
     err = kc.Get(ctx, "b")
     if err != nil {
-        return fmt.Errorf("second get: %w", err)
+        return fmt.Errorf("third get: %w", err)
     }
     return nil
 }

--- a/core/object.go
+++ b/core/object.go
@@ -336,13 +336,6 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 
 	spec.Name = gqlFieldName(mod.Name())
 
-	// NB: functions actually _are_ cached per-session, which matches the
-	// lifetime of the server, so we might as well consider them pure.
-	// That way there will be locking around concurrent calls, so the user won't
-	// see multiple in parallel. Reconsider if/when we have a global cache and/or
-	// figure out function caching.
-	spec.ImpurityReason = ""
-
 	spec.Module = obj.Module.IDModule()
 
 	if fn.metadata.SourceMap != nil {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -434,7 +434,7 @@ func (srv *Server) initializeDaggerClient(
 		// of the caller
 		for _, id := range opts.ParentIDs {
 			if err := srv.addClientResourcesFromID(ctx, client, id, opts.CallerClientID, false); err != nil {
-				return fmt.Errorf("failed to add client resources from ID: %w", err)
+				return fmt.Errorf("failed to add parent client resources from ID: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
intended to fix #8935, turns out this was a problem with constructor purity