### PR TITLE
Fix broken terminal tests and broken Directory.terminal feature

### DIFF
--- a/.changes/unreleased/Fixed-20241113-221407.yaml
+++ b/.changes/unreleased/Fixed-20241113-221407.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Directory.terminal API works now
+time: 2024-11-13T22:14:07.998787448-08:00
+custom:
+  Author: sipsma
+  PR: "8952"

--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -130,16 +130,27 @@ func (t *Test) Debug() *dagger.Terminal {
 		err = cmd.Start()
 		require.NoError(t, err)
 
+		prompt := fmt.Sprintf("/coolworkdir%s $ ", resetSeq)
+
+		_, err = console.ExpectString(prompt)
+		require.NoError(t, err)
+
 		_, err = console.SendLine("pwd")
 		require.NoError(t, err)
 
-		_, err = console.ExpectString("/coolworkdir")
+		_, err = console.ExpectString("/coolworkdir\r\n")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString(prompt)
 		require.NoError(t, err)
 
 		_, err = console.SendLine("echo $COOLENV")
 		require.NoError(t, err)
 
-		err = console.ExpectLineRegex(ctx, "woo")
+		_, err = console.ExpectString("woo\r\n")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString(prompt)
 		require.NoError(t, err)
 
 		_, err = console.SendLine("exit")
@@ -186,16 +197,27 @@ func (t *Test) Debug() *dagger.Terminal {
 		err = cmd.Start()
 		require.NoError(t, err)
 
+		prompt := fmt.Sprintf("/coolworkdir%s $ ", resetSeq)
+
+		_, err = console.ExpectString(prompt)
+		require.NoError(t, err)
+
 		_, err = console.SendLine("pwd")
 		require.NoError(t, err)
 
-		_, err = console.ExpectString("/coolworkdir")
+		_, err = console.ExpectString("/coolworkdir\r\n")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString(prompt)
 		require.NoError(t, err)
 
 		_, err = console.SendLine("echo $COOLENV")
 		require.NoError(t, err)
 
-		err = console.ExpectLineRegex(ctx, "woo")
+		_, err = console.ExpectString("woo\r\n")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString(prompt)
 		require.NoError(t, err)
 
 		_, err = console.SendLine("exit")

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -471,21 +471,31 @@ func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 			return fmt.Errorf("mount %s points to invalid target: %w", mnt.Target, err)
 		}
 
-		// ref: https://github.com/opencontainers/runc/blob/9d02c20df7faf7b356a632e35dfccf332fc7efed/libcontainer/rootfs_linux.go#L1173
 		if _, err := os.Stat(dstPath); err != nil {
 			if !os.IsNotExist(err) {
 				return fmt.Errorf("stat mount target %s: %w", dstPath, err)
 			}
-			srcStat, err := os.Stat(mnt.Source)
-			if err != nil {
-				return fmt.Errorf("stat mount source %s: %w", mnt.Source, err)
+
+			// Need to check if the source is a directory or file so we can create the stub for the mount
+			// with the correct type. Only bind mounts can be files (as far as we are concerned), so look
+			// for that option and otherwise assume it is a directory (i.e. overlay).
+			srcIsDir := true
+			for _, opt := range mnt.Options {
+				if opt == "bind" || opt == "rbind" {
+					srcStat, err := os.Stat(mnt.Source)
+					if err != nil {
+						return fmt.Errorf("stat mount source %s: %w", mnt.Source, err)
+					}
+					srcIsDir = srcStat.IsDir()
+					break
+				}
 			}
-			switch srcStat.Mode() & os.ModeType {
-			case os.ModeDir:
+
+			if srcIsDir {
 				if err := os.MkdirAll(dstPath, 0o755); err != nil {
 					return fmt.Errorf("create mount target dir %s: %w", dstPath, err)
 				}
-			default:
+			} else {
 				if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 					return fmt.Errorf("create mount target parent dir %s: %w", dstPath, err)
 				}


### PR DESCRIPTION
While debugging an unrelated PR I realized that our terminal tests were not working as expected and that the Directory.terminal feature just didn't work at all:

---
[tests: fix terminal tests not asserting as expected](https://github.com/dagger/dagger/commit/a708114f344e0d10e75d600028d6956fa5e7ddf0)

Our terminal tests were not actually working how we thought they were.
Many of them were not waiting for prompts and instead just matching on
strings right away, which ended up including all the progress output
before the terminal was opened.

This broke a few of them since the string they were expecting happened
to also show up in the progress output, which isn't what we actually
wanted to assert on.

This updates the tests to correctly wait for prompts (doing some
terminal escape sequence handling when needed).

This commit leaves the `TestDaggerTerminal/directory` test case failing
because that feature was actually totally broken due to a separate issue
(which went unnoticed until now because the test case was broken).

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---
[engine: fix Directory.terminal and overlay mount handling](https://github.com/dagger/dagger/commit/deb49b901b6cc73ce73fe7229265758180029034)

The previous commit fixed assertions in our terminal test cases, which
revealed that the Directory.terminal feature was totally broken.

The problem was in the executor and it's handling of mounts that were of
type overlay. It was looking at the `Source` field of the mount assuming
it was a bind and that the field pointed to the source of the bind.

However, for non-bind mounts the `Source` is just the type of mount.

The reason this only broke the Directory.terminal case so far was that
Directory.terminal is the only place in our code where we create
read-only mounts. This triggers a different codepath in buildkit's cache
logic that results in actual overlay mounts being provided to the
executor; in other read-write mount cases buildkit has some logic that
creates a "shared" overlay mount which is just bind-mounted to other
places (to avoid conflicts around multiple overlay mounts with the same
upperdir).

This commit just fixes handling of that `Source` field to interpret it
correctly based on whether it's a bind mount or not.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>
