### PR TITLE
Use .dagger-root to improve module load performance on large monorepos (#8496, #8499)

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -518,6 +518,10 @@ func callerHostFindUpContext(
 	if err == nil {
 		return curDirPath, true, nil
 	}
+	_, err = bk.StatCallerHostPath(ctx, filepath.Join(curDirPath, ".dagger-root"), false)
+	if err == nil {
+		return curDirPath, true, nil
+	}
 	// TODO: remove the strings.Contains check here (which aren't cross-platform),
 	// since we now set NotFound (since v0.11.2)
 	if status.Code(err) != codes.NotFound && !strings.Contains(err.Error(), "no such file or directory") {


### PR DESCRIPTION
`dagger` looks for the git repo root when it loads a module.
This has a performance impact, especially on large monorepos.
This change will allow to limit the scope of the module by adding  a `.dagger-root` file.