### PR TITLE
fix(test): make go test work on macOS

### DIFF
--- a/engine/buildkit/linux_namespace.go
+++ b/engine/buildkit/linux_namespace.go
@@ -1,3 +1,5 @@
+//go:build !darwin && !windows
+
 package buildkit
 
 import (

--- a/engine/buildkit/unimplemented_namespace.go
+++ b/engine/buildkit/unimplemented_namespace.go
@@ -1,0 +1,53 @@
+//go:build darwin || windows
+
+package buildkit
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+const (
+	idleTimeout    = 1 * time.Second
+	workerPoolSize = 5
+)
+
+func runInNetNS[T any](
+	ctx context.Context,
+	state *execState,
+	fn func() (T, error),
+) (T, error) {
+	panic("implemented only on linux")
+}
+
+func (w *Worker) runNetNSWorkers(ctx context.Context, state *execState) error {
+	panic("implemented only on linux")
+}
+
+type namespaceWorker struct {
+	namespaces []*namespaceFiles
+
+	inContainer   bool
+	idleTimerCh   <-chan time.Time
+	stopIdleTimer func() bool
+}
+
+type namespaceFiles struct {
+	hostFile *os.File
+	ctrFile  *os.File
+
+	setNSArg int
+}
+
+func (nsw *namespaceWorker) enterContainer() error {
+	panic("implemented only on linux")
+}
+
+func (nsw *namespaceWorker) leaveContainer() error {
+	panic("implemented only on linux")
+}
+
+func (nsw *namespaceWorker) run(ctx context.Context, jobQueue <-chan func()) error {
+	panic("implemented only on linux")
+}

--- a/engine/sources/gitdns/source_linux.go
+++ b/engine/sources/gitdns/source_linux.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !darwin
 
 package gitdns
 
@@ -20,6 +19,14 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
+
+func (cli *gitCLI) initConfig(dnsConf *oci.DNSConfig) error {
+	if dnsConf == nil {
+		return nil
+	}
+
+	return cli.generateResolv(dnsConf)
+}
 
 func runWithStandardUmaskAndNetOverride(ctx context.Context, cmd *exec.Cmd, hosts, resolv string) error {
 	errCh := make(chan error)
@@ -90,14 +97,6 @@ func overrideNetworkConfig(hostsOverride, resolvOverride string) error {
 	}
 
 	return nil
-}
-
-func (cli *gitCLI) initConfig(dnsConf *oci.DNSConfig) error {
-	if dnsConf == nil {
-		return nil
-	}
-
-	return cli.generateResolv(dnsConf)
 }
 
 func (cli *gitCLI) generateResolv(dns *oci.DNSConfig) error {

--- a/engine/sources/gitdns/source_unimplemented.go
+++ b/engine/sources/gitdns/source_unimplemented.go
@@ -1,0 +1,18 @@
+//go:build windows || darwin
+
+package gitdns
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/moby/buildkit/executor/oci"
+)
+
+func runWithStandardUmaskAndNetOverride(ctx context.Context, cmd *exec.Cmd, hosts, resolv string) error {
+	panic("only implemented on linux")
+}
+
+func (cli *gitCLI) initConfig(dnsConf *oci.DNSConfig) error {
+	panic("only implemented on linux")
+}


### PR DESCRIPTION
see https://github.com/dagger/dagger/issues/8956 for error logs. this PR makes it so we can build our test packages (at least tui and core/integration) on macOS, by adding panic(unimplemented) impls hidden behind conditional build directives. 