### PR TITLE
feat(sdk/elixir): introduce elixir dev module

### DIFF
--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"dagger.io/dagger/telemetry"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
@@ -80,42 +79,10 @@ func (t ElixirSDK) Test(ctx context.Context) error {
 		return err
 	}
 
-	allGroup, ctx := errgroup.WithContext(ctx)
-
-	for elixirVersion, baseImage := range elixirVersions {
-		ctr := t.elixirBase(baseImage).With(installer)
-
-		allGroup.Go(func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, "test - elixir/"+elixirVersion)
-			defer telemetry.End(span, func() error { return rerr })
-
-			eg, ctx := errgroup.WithContext(ctx)
-			eg.Go(func() (rerr error) {
-				ctx, span := Tracer().Start(ctx, "dagger")
-				defer telemetry.End(span, func() error { return rerr })
-				_, err := ctr.
-					WithExec([]string{"mix", "test"}).
-					Sync(ctx)
-				return err
-			})
-
-			if elixirVersion == elixirLatestVersion {
-				eg.Go(func() (rerr error) {
-					ctx, span := Tracer().Start(ctx, "dagger_codegen")
-					defer telemetry.End(span, func() error { return rerr })
-					_, err := ctr.
-						WithWorkdir("dagger_codegen").
-						WithExec([]string{"mix", "deps.get"}).
-						WithExec([]string{"mix", "test"}).
-						Sync(ctx)
-					return err
-				})
-			}
-			return eg.Wait()
-		})
-	}
-
-	return allGroup.Wait()
+	sdkDev := dag.ElixirSDKDev()
+	ctr := sdkDev.WithBase(t.Dagger.Source().Directory(elixirSDKPath)).With(installer)
+	_, err = sdkDev.Test(ctr).Sync(ctx)
+	return err
 }
 
 // Regenerate the Elixir SDK API

--- a/dagger.json
+++ b/dagger.json
@@ -19,6 +19,11 @@
       "pin": "e494cec1aa8f9faab1e0f12b2e5eea4a2321f2de"
     },
     {
+      "name": "elixir-sdk-dev",
+      "source": "sdk/elixir/dev",
+      "pin": ""
+    },
+    {
       "name": "gh",
       "source": "github.com/sagikazarmark/daggerverse/gh",
       "pin": "68e9daa611183f5334b4059bac6f4aad62da7a37"

--- a/sdk/elixir/dev/.gitattributes
+++ b/sdk/elixir/dev/.gitattributes
@@ -1,0 +1,1 @@
+/dagger_sdk/** linguist-generated

--- a/sdk/elixir/dev/.gitignore
+++ b/sdk/elixir/dev/.gitignore
@@ -1,0 +1,1 @@
+/dagger_sdk

--- a/sdk/elixir/dev/dagger.json
+++ b/sdk/elixir/dev/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "elixir-sdk-dev",
+  "sdk": "elixir@v0.14.0",
+  "engineVersion": "v0.14.0"
+}

--- a/sdk/elixir/dev/elixir_sdk_dev/.formatter.exs
+++ b/sdk/elixir/dev/elixir_sdk_dev/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  import_deps: [:dagger],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/sdk/elixir/dev/elixir_sdk_dev/.gitignore
+++ b/sdk/elixir/dev/elixir_sdk_dev/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+elixir_sdk_dev-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/sdk/elixir/dev/elixir_sdk_dev/README.md
+++ b/sdk/elixir/dev/elixir_sdk_dev/README.md
@@ -1,0 +1,3 @@
+# ElixirSdkDev
+
+A module for help developing Elixir SDK.

--- a/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
@@ -1,0 +1,42 @@
+defmodule ElixirSdkDev do
+  @moduledoc """
+  A module for help developing Elixir SDK.
+  """
+
+  use Dagger.Mod.Object, name: "ElixirSdkDev"
+
+  @base_image "hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.20.2@sha256:7c8a13cbff321b7d6f54b4c9a21a10fc8b987974171231eaa77532b8e638b645"
+
+  @doc """
+  Test the SDK.
+  """
+  defn test(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+    |> sdk_test()
+    |> codegen_test()
+  end
+
+  defn sdk_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+    |> Dagger.Container.with_exec(~w"mix test")
+  end
+
+  defn codegen_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+    |> Dagger.Container.with_workdir("dagger_codegen")
+    |> Dagger.Container.with_exec(~w"mix deps.get")
+    |> Dagger.Container.with_exec(~w"mix test")
+  end
+
+  defn with_base(source: {Dagger.Directory.t(), doc: "The Elixir SDK source"}) ::
+         Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from(@base_image)
+    |> Dagger.Container.with_workdir("/sdk")
+    |> Dagger.Container.with_directory(".", source)
+    |> Dagger.Container.with_exec(~w"mix local.hex --force")
+    |> Dagger.Container.with_exec(~w"mix local.rebar --force")
+    |> Dagger.Container.with_exec(~w"mix deps.get")
+  end
+end

--- a/sdk/elixir/dev/elixir_sdk_dev/mix.exs
+++ b/sdk/elixir/dev/elixir_sdk_dev/mix.exs
@@ -1,0 +1,25 @@
+defmodule ElixirSdkDev.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elixir_sdk_dev,
+      version: "0.1.0",
+      elixir: "~> 1.16",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+    ]
+  end
+
+  defp deps do
+    [
+      {:dagger, path: "../dagger_sdk"}
+    ]
+  end
+end

--- a/sdk/elixir/dev/elixir_sdk_dev/mix.lock
+++ b/sdk/elixir/dev/elixir_sdk_dev/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}

--- a/sdk/elixir/dev/elixir_sdk_dev/test/elixir_sdk_dev_test.exs
+++ b/sdk/elixir/dev/elixir_sdk_dev/test/elixir_sdk_dev_test.exs
@@ -1,0 +1,3 @@
+defmodule ElixirSdkDevTest do
+  use ExUnit.Case
+end

--- a/sdk/elixir/dev/elixir_sdk_dev/test/test_helper.exs
+++ b/sdk/elixir/dev/elixir_sdk_dev/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Add a dev module to dogfood the Elixir SDK by implements `test` function and convert `ElixirSDK` to `test` function instead.

The `test` function also reduce complexity by removing test matrix and use same image as runtime uses.