### PR TITLE
feat(sdk/elixir): implements lint to elixir-sdk-dev 

### DIFF
--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -48,10 +48,9 @@ func (t ElixirSDK) Lint(ctx context.Context) error {
 			return err
 		}
 
-		_, err = t.elixirBase(elixirVersions[elixirLatestVersion]).
-			With(installer).
-			WithExec([]string{"mix", "lint"}).
-			Sync(ctx)
+		sdkDev := dag.ElixirSDKDev()
+		ctr := sdkDev.WithBase(t.Dagger.Source().Directory(elixirSDKPath)).With(installer)
+		_, err = sdkDev.Lint(ctr).Sync(ctx)
 		return err
 	})
 	eg.Go(func() (rerr error) {

--- a/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
@@ -16,6 +16,14 @@ defmodule ElixirSdkDev do
     |> codegen_test()
   end
 
+  @doc """
+  Lint the SDK.
+  """
+  defn lint(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+    |> Dagger.Container.with_exec(~w"mix credo")
+  end
+
   defn sdk_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
     container
     |> Dagger.Container.with_exec(~w"mix test")


### PR DESCRIPTION
~⚠️ Needs #8962~

Implements `lint` function to `elixir-sdk-dev` and uses it in
`ElixirSDK` main module.