### PR TITLE
chore(ci): avoid use of dagger.io/dagger dependency

### DIFF
--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/.dagger/internal/dagger"
+	"github.com/dagger/dagger/.dagger/internal/telemetry"
 )
 
 const (


### PR DESCRIPTION
We need to correctly import the *correct* telemetry dependency - then this will work.

This was accidentally introduced in https://github.com/dagger/dagger/pull/8962#discussion_r1844206269.