### PR TITLE
fix(core): drop leading slash from paths for gitignore

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1175,6 +1175,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 			if bytes.Contains(gitIgnoreContents, []byte(fileName)) {
 				continue
 			}
+			fileName := strings.TrimPrefix(fileName, "/")
 			gitIgnoreContents = append(gitIgnoreContents,
 				[]byte(fmt.Sprintf("/%s\n", fileName))...,
 			)


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/8221.

We've got some very similar code below, we should probably handle it for `gitignore` as well :thinking: 