### PR TITLE
Mention container runtime should be running in quickstart

### DIFF
--- a/docs/current_docs/quickstart/index.mdx
+++ b/docs/current_docs/quickstart/index.mdx
@@ -37,5 +37,5 @@ This quickstart will take you approximately 25 minutes to complete. You should b
 
 Before beginning, ensure that:
 - you know [what Dagger is](../index.mdx).
-- you have [Git](https://git-scm.com/downloads) and a container runtime installed on your system. This can be [Docker](https://docs.docker.com/engine/install/), but you can also use Podman, nerdctl, or other Docker-like systems.
+- you have [Git](https://git-scm.com/downloads) and a container runtime installed on your system and running. This can be [Docker](https://docs.docker.com/engine/install/), but you can also use Podman, nerdctl, or other Docker-like systems.
 - you have a GitHub account (optional, only if configuring Dagger Cloud)


### PR DESCRIPTION
Maybe this is obvious, but the prerequisites don't actually mention that the container runtime should also be running.