### PR TITLE
ci: fix dirty detection by excluding subpaths as well

### DIFF
--- a/version/git.go
+++ b/version/git.go
@@ -310,7 +310,8 @@ func (git *Git) status(ctx context.Context) (string, error) {
 
 	args := []string{"git", "status", "--porcelain", "--"}
 	for _, ignore := range ignores {
-		args = append(args, ":(exclude)"+ignore)
+		pathspec := ":(exclude)" + ignore
+		args = append(args, pathspec, pathspec+"/**")
 	}
 	result, err := git.Container.WithExec(args).Stdout(ctx)
 	if err != nil {


### PR DESCRIPTION
The dirty detection wasn't working with the pattern `:(exclude)**/.dagger` - we need to also exclude all subpaths, i.e. `:(exclude)**/.dagger/**`.`

This appeared when adding a module into `dagger/cmd` in #8870, and the pattern detected that the module file contents were deleted, and so even fresh commits would be marked as dirty.