### PR TITLE
feat(cli): enable metrics forwarding to dagger cloud

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -74,10 +74,10 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},
 		LiveMetricExporters: []sdkmetric.Exporter{Frontend.MetricExporter()},
 	}
-	if spans, logs, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
+	if spans, logs, metrics, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
 		telemetryCfg.LiveTraceExporters = append(telemetryCfg.LiveTraceExporters, spans)
 		telemetryCfg.LiveLogExporters = append(telemetryCfg.LiveLogExporters, logs)
-		// TODO: metrics to cloud
+		telemetryCfg.LiveMetricExporters = append(telemetryCfg.LiveMetricExporters, metrics)
 	}
 	ctx = telemetry.Init(ctx, telemetryCfg)
 

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.52.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
working now with https://github.com/dagger/dagger.io/pull/4071 merged!

I did also drive through a refactor to extract a refreshingSpanExporter generic base struct, but it's honestly worse than the existing copy-pasta implementation because of the way token auth configuration leverages composition, so it's not included here.