### PR TITLE
chore(tests): archive test results in json format with CI runs

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -27,6 +27,12 @@ type DaggerDev struct {
 	// Can be used by nested clients to forward docker credentials to avoid
 	// rate limits
 	DockerCfg *dagger.Secret // +private
+
+	// github event file
+	GithubEventFile *dagger.File
+
+	// tags to associate the runs
+	Tags []string
 }
 
 func New(
@@ -38,6 +44,12 @@ func New(
 
 	// +optional
 	dockerCfg *dagger.Secret,
+
+	// +optional
+	githubEventFile *dagger.File,
+
+	// +optional
+	tags []string,
 ) (*DaggerDev, error) {
 	v := dag.Version()
 	version, err := v.Version(ctx)
@@ -50,11 +62,13 @@ func New(
 	}
 
 	dev := &DaggerDev{
-		Src:       source,
-		Tag:       tag,
-		Git:       v.Git(),
-		Version:   version,
-		DockerCfg: dockerCfg,
+		Src:             source,
+		Tag:             tag,
+		Git:             v.Git(),
+		Version:         version,
+		DockerCfg:       dockerCfg,
+		GithubEventFile: githubEventFile,
+		Tags:            tags,
 	}
 
 	modules, err := dev.containing(ctx, "dagger.json")

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -116,13 +116,28 @@ runs:
           fi
         }
 
+        ENGINE_VERSION=`dagger core version -q -s | tr -d '\n'`
+        CLI_VERSION=`dagger version | tr -d '\n' | awk -F'(' '{print $1}'`
+
+        echo "$GITHUB_CONTEXT" > github_context.json
+        
         set -x
         if [[ "${{ inputs.module }}" == "." ]]; then
           # set some sane defaults for the current module
           if [[ -f $HOME/.docker/config.json ]]; then
-            redirect_logs dagger -m "${{ inputs.module }}" call --docker-cfg=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+            redirect_logs dagger -m "${{ inputs.module }}" call \
+              --tags "engine_version=$ENGINE_VERSION" \
+              --tags "cli_version=$CLI_VERSION" \
+              --tags "runner=${{ runner.name }}" \
+              --github-event-file="github_context.json" \
+              --docker-cfg=file:"$HOME/.docker/config.json" \
+              ${{ inputs.function }} 
           else
-            redirect_logs dagger -m "${{ inputs.module }}" call ${{ inputs.function }}
+            redirect_logs dagger -m "${{ inputs.module }}" call \
+              --tags "engine_version=$ENGINE_VERSION" \
+              --tags "cli_version=$CLI_VERSION" \
+              --tags "runner=${{ runner.name }}" \
+              --github-event-file="github_context.json" ${{ inputs.function }}            
           fi
         else
           redirect_logs dagger -m "${{ inputs.module }}" call ${{ inputs.function }}

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -81,6 +81,7 @@ func New(
 				// The specific version is dictated by Dagger's own requirement
 				// FIXME: make this optional with overlay support
 				"protoc~3.21.12",
+				"curl",
 			}}).
 			WithEnvVariable("GOLANG_VERSION", version).
 			WithEnvVariable("GOPATH", "/go").
@@ -89,6 +90,7 @@ func New(
 			// Configure caches
 			WithMountedCache("/go/pkg/mod", moduleCache).
 			WithMountedCache("/root/.cache/go-build", buildCache).
+			WithExec([]string{"go", "install", "gotest.tools/gotestsum@v1.12.0"}).
 			WithWorkdir("/app")
 	}
 	return Go{


### PR DESCRIPTION
this is just a poc to try out gotestsum with CI. The benefits includes a little clearer output (more work needs to be done there) and that we can archive results in a json file, which we can then ingest in a tests dashboard to look at the trends over the executions.

happy to discuss if folks have opinions/concerns regarding this. I am just evaluating how this can improve debugging of CI and finding flakes.