### PR TITLE
engine: fix goroutine leaks + deadlock in terminal

### DIFF
--- a/.changes/unreleased/Fixed-20241120-160241.yaml
+++ b/.changes/unreleased/Fixed-20241120-160241.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix resource leaks in the engine that occurred after each debug terminal was opened.
+time: 2024-11-20T16:02:41.381210606-08:00
+custom:
+  Author: sipsma
+  PR: "9013"

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -42,10 +42,14 @@ func (container *Container) Terminal(
 	if err != nil {
 		return fmt.Errorf("failed to get buildkit client: %w", err)
 	}
+
 	term, err := bk.OpenTerminal(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open terminal: %w", err)
 	}
+	// always close term; it's wrapped in a once so it won't be called multiple times
+	defer term.Close(bkgwpb.UnknownExitStatus)
+
 	output := idtui.NewOutput(term.Stderr)
 	fmt.Fprint(
 		term.Stderr,

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -681,8 +681,8 @@ func (c *Client) OpenTerminal(
 	)
 
 	forwardFD := func(r io.Reader, fn func([]byte) *session.SessionRequest) error {
+		b := make([]byte, 2048)
 		for {
-			b := make([]byte, 2048)
 			n, err := r.Read(b)
 			if err != nil {
 				if err == io.EOF || err == io.ErrClosedPipe {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -680,12 +680,13 @@ func (c *Client) OpenTerminal(
 		stdinR, stdinW   = io.Pipe()
 	)
 
-	forwardFD := func(r io.Reader, fn func([]byte) *session.SessionRequest) error {
+	forwardFD := func(r io.ReadCloser, fn func([]byte) *session.SessionRequest) error {
+		defer r.Close()
 		b := make([]byte, 2048)
 		for {
 			n, err := r.Read(b)
 			if err != nil {
-				if err == io.EOF || err == io.ErrClosedPipe {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
 					return nil
 				}
 				return fmt.Errorf("error reading fd: %w", err)
@@ -709,9 +710,10 @@ func (c *Client) OpenTerminal(
 		}
 	})
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	resizeCh := make(chan bkgw.WinSize)
 	go func() {
+		defer stdinW.Close()
 		defer close(errCh)
 		defer close(resizeCh)
 		for {
@@ -746,8 +748,10 @@ func (c *Client) OpenTerminal(
 		Stderr:   stderrW,
 		ErrCh:    errCh,
 		ResizeCh: resizeCh,
-		Close: func(exitCode int) error {
-			defer stdinW.Close()
+		Close: onceValueWithArg(func(exitCode int) error {
+			defer stdinR.Close()
+			defer stdoutW.Close()
+			defer stderrW.Close()
 			defer term.CloseSend()
 
 			err := term.Send(&session.SessionRequest{
@@ -757,8 +761,37 @@ func (c *Client) OpenTerminal(
 				return fmt.Errorf("failed to close terminal: %w", err)
 			}
 			return nil
-		},
+		}),
 	}, nil
+}
+
+// like sync.OnceValue but accepts an arg
+func onceValueWithArg[A any, R any](f func(A) R) func(A) R {
+	var (
+		once   sync.Once
+		valid  bool
+		p      any
+		result R
+	)
+	g := func(a A) {
+		defer func() {
+			p = recover()
+			if !valid {
+				panic(p)
+			}
+		}()
+		result = f(a)
+		valid = true
+	}
+	return func(a A) R {
+		once.Do(func() {
+			g(a)
+		})
+		if !valid {
+			panic(p)
+		}
+		return result
+	}
 }
 
 func withOutgoingContext(c *Client, ctx context.Context) context.Context {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8554

While running some tests locally for the (unrelated) filesync PR I accidentally stumbled on a set of tests to run that coincidentally repro'd the flake in #8554 pretty consistently locally:
```
./hack/with-dev go test -v -run='TestModule/TestDaggerTerminal|TestModule/TestDaggerUp' -count=10 -parallel=8 ./core/integration/
```

I would hit the flake where the `on_failure` test hung after 3-4 counts pretty consistently. The set of tests most likely just happens to tweak timing on my machine in just the right way that the race conditions it was caused by would get triggered more often.

There were multiple problems from the test case down through the engine, described in the commit below.

With this fix in place I can't repro the flake locally anymore. Additionally, after running the terminal tests and sending SIGQUIT to the engine I previously saw a ton of leaked goroutines; now after this change they are all gone.

I also included a small one-line performance fix that I noticed while going through the code here.

---

[engine: fix goroutine leaks + deadlock in terminal](https://github.com/dagger/dagger/commit/2d49491b70f58ff67b8924e2a1efd35483034f1e)

Before this, every interactive debug terminal container would leak
multiple goroutines due to various io pipes not getting closed. In one
particular codepath, the read-side of the stdout io.Pipe would be left
open while the other side was in the middle of a write, which caused the
executor code to block forever and never return. This manifested as an
occasional flake in the TestModule/TestDaggerTerminal/on_failure test
case.

Additionally, the part of that test case which meant to assert on
handling of --interactive-command values which didn't exist was not
checking error values. It was hitting an error due to the fact that it
didn't have a TTY setup rather than the error around the command not
existing. That test case is fixed now to setup a TTY and verify the
error message is the expected one.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

[engine: slightly optimize terminal reading by reusing buffers](https://github.com/dagger/dagger/commit/6f149d02eb694bb365c025b434ea7dcaa916e502)

Rather than allocating a new byte slice for every read from
stdout/stderr sent to clients, we can re-use the same byte slice.

This reduces the amount of allocations the engine does. Not a
world-changing optimization but I have seen similar fixes in other
contexts make a noticeable difference in CPU usage since the Go runtime
has a lot less work to do.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>