### PR TITLE
ci(alt runners): Use common terminology

### DIFF
--- a/.github/workflows/_dagger_on_depot_local_engine.yml
+++ b/.github/workflows/_dagger_on_depot_local_engine.yml
@@ -1,4 +1,4 @@
-name: Dagger on Depot - CLI provisioned
+name: Dagger on Depot - Local Engine
 
 on:
   workflow_call:
@@ -28,7 +28,7 @@ on:
         required: false
 
 jobs:
-  cli-provisioned-dagger-no-cache:
+  local-dagger-engine:
     if: ${{ github.repository == 'dagger/dagger' }}
     runs-on: depot-ubuntu-${{ inputs.ubuntu }}-${{ inputs.size }}
     timeout-minutes: ${{ inputs.timeout }}
@@ -39,5 +39,9 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: ${{ inputs.function }}
-          version: v${{ inputs.dagger }}
+          dev-engine: ${{ inputs.dev }}
+      - name: ${{ inputs.function }} (CACHE TEST)
+        uses: ./.github/actions/call
+        with:
+          function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -1,4 +1,4 @@
-name: Dagger on Depot - Pre-provisioned with Cache
+name: Dagger on Depot - Remote Engine
 
 on:
   workflow_call:
@@ -24,7 +24,7 @@ on:
         required: false
 
 jobs:
-  pre-provisioned-dagger-with-cache:
+  remote-dagger-engine:
     if: ${{ github.repository == 'dagger/dagger' }}
     runs-on: depot-ubuntu-${{ inputs.ubuntu }},dagger=${{ inputs.dagger }}
     timeout-minutes: ${{ inputs.timeout }}
@@ -32,6 +32,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: ${{ inputs.function }}
+        uses: ./.github/actions/call
+        with:
+          function: ${{ inputs.function }}
+          version: v${{ inputs.dagger }}
+          dev-engine: ${{ inputs.dev }}
+      - name: ${{ inputs.function }} (CACHE TEST)
         uses: ./.github/actions/call
         with:
           function: ${{ inputs.function }}

--- a/.github/workflows/alternative-ci-runners.yml
+++ b/.github/workflows/alternative-ci-runners.yml
@@ -3,9 +3,9 @@ name: Alternative CI Runners
 on:
   # Run the workflow every day TWICE:
   # 1. 9:06AM UTC (low activity)
-  # 2. 9:16AM UTC (cache test - high chance of no code changes)
+  # 2. 9:26AM UTC (cache test - high chance of no code changes)
   schedule:
-    - cron: "0 6,16 9 * *"
+    - cron: "6,26 9 * * *"
   # Enable manual trigger for on-demand runs - helps when debugging
   workflow_dispatch:
 
@@ -13,114 +13,50 @@ permissions:
   contents: read
 
 jobs:
-  # engine-lint-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: engine lint
-  # engine-test-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: test all --race=true --parallel=16
-  #     timeout: 30
-  # engine-testdev-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
-  #   with:
-  #     function: test specific --run='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestContainer' --skip='TestDev' --race=true --parallel=16
-  #     size: 32
-  #     timeout: 60
-
-  scripts-lint-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-    with:
-      function: scripts lint
-
-  docs-lint-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+  docs-lint-on-depot-remote-engine:
+    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
     with:
       function: docs lint
 
-  helm-lint-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+  test-cli-engine-on-depot-remote-engine:
+    needs: docs-lint-on-depot-remote-engine
+    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
     with:
-      function: helm lint
-  helm-test-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-    with:
-      function: helm publish --dry-run=true --tag=main
+      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
+      timeout: 20
 
-  # sdk-elixir-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: check --targets=sdk/elixir
-  # sdk-elixir-dev-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
-  #   with:
-  #     function: check --targets=sdk/elixir
-  #     size: 16
-  #     dev: true
-
-  sdk-go-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+  sdk-go-on-depot-remote-engine:
+    needs: docs-lint-on-depot-remote-engine
+    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
     with:
       function: check --targets=sdk/go
-  sdk-go-dev-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+  sdk-go-dev-on-depot-local-engine:
+    uses: ./.github/workflows/_dagger_on_depot_local_engine.yml
     with:
       function: check --targets=sdk/go
       size: 4
       dev: true
 
-  # sdk-java-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: check --targets=sdk/java
-  # sdk-java-dev-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
-  #   with:
-  #     function: check --targets=sdk/java
-  #     size: 8
-  #     dev: true
-
-  # sdk-php-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: check --targets=sdk/php
-  # sdk-php-dev-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
-  #   with:
-  #     function: check --targets=sdk/php
-  #     size: 4
-  #     dev: true
-
-  sdk-python-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+  sdk-python-on-depot-remote-engine:
+    needs: docs-lint-on-depot-remote-engine
+    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
     with:
       function: check --targets=sdk/python
-  sdk-python-dev-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+  sdk-python-dev-on-depot-local-engine:
+    uses: ./.github/workflows/_dagger_on_depot_local_engine.yml
     with:
       function: check --targets=sdk/python
-      size: 4
+      size: 8
       dev: true
 
-  # sdk-rust-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
-  #   with:
-  #     function: check --targets=sdk/rust
-  # sdk-rust-dev-on-depot:
-  #   uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
-  #   with:
-  #     function: check --targets=sdk/rust
-  #     size: 16
-  #     dev: true
-
-  sdk-typescript-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_pre-provisioned_with_cache.yml
+  sdk-typescript-on-depot-remote-engine:
+    needs: docs-lint-on-depot-remote-engine
+    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
     with:
       function: check --targets=sdk/typescript
-  sdk-typescript-dev-on-depot:
-    uses: ./.github/workflows/_dagger_on_depot_cli_provisioned.yml
+  sdk-typescript-dev-on-depot-local-engine:
+    uses: ./.github/workflows/_dagger_on_depot_local_engine.yml
     with:
       function: check --targets=sdk/typescript
-      size: 4
+      size: 8
       dev: true


### PR DESCRIPTION
Also:
- fix schedule syntax (it did not trigger as expected)
- remove all jobs which are unlikely to run on a regular basis
- increase runner size for jobs which timed out in the last run

Outcome:
<img width="1555" alt="image" src="https://github.com/user-attachments/assets/c4c8be5a-0fde-4901-9e3b-36e62fe20730">

The failing test was captured in:
- https://github.com/dagger/dagger/issues/9023

---
Follow-up to the session with @jacobwgillespie