### PR TITLE
fix: allow Container.withExec to intercept exit code 128

### DIFF
--- a/.changes/unreleased/Fixed-20241121-155915.yaml
+++ b/.changes/unreleased/Fixed-20241121-155915.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Allow `Container.withExec` `expect` to catch exit code 128
+time: 2024-11-21T15:59:15.645085385Z
+custom:
+    Author: jedevc
+    PR: "9027"

--- a/core/container.go
+++ b/core/container.go
@@ -1874,21 +1874,21 @@ func (expect ReturnTypes) ToLiteral() call.Literal {
 
 // ReturnCodes gets the valid exit codes allowed for a specific return status
 //
-// NOTE: exit status codes above 127 are likely from exiting via a signal - we
+// NOTE: exit status codes above 128 are likely from exiting via a signal - we
 // shouldn't try and handle these.
 func (expect ReturnTypes) ReturnCodes() []int {
 	switch expect {
 	case ReturnSuccess:
 		return []int{0}
 	case ReturnFailure:
-		codes := make([]int, 0, 127)
-		for i := 1; i <= 127; i++ {
+		codes := make([]int, 0, 128)
+		for i := 1; i <= 128; i++ {
 			codes = append(codes, i)
 		}
 		return codes
 	case ReturnAny:
-		codes := make([]int, 0, 128)
-		for i := 0; i <= 127; i++ {
+		codes := make([]int, 0, 129)
+		for i := 0; i <= 128; i++ {
 			codes = append(codes, i)
 		}
 		return codes


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/8466.

Some tools (like `git checkout`) return valid 128 exit codes.

We only exclude the range 128+<n>, because this is the exit code for a process that was terminated by signal(<n>). 0 isn't a valid signal number (they all start from 1). So there's no reason to not handle 128.