### PR TITLE
fix(engine+cli): silence cgroup sampling logs and fix double-printing tui memstats

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -410,6 +410,10 @@ func (r renderer) renderMetrics(out *termenv.Output, span *dagui.Span) {
 	r.renderMetricIfNonzero(out, span, telemetry.CPUStatPressureSomeTotal, "CPU Pressure (some)", durationString)
 	r.renderMetricIfNonzero(out, span, telemetry.CPUStatPressureFullTotal, "CPU Pressure (full)", durationString)
 
+	// Memory Stats
+	r.renderMetric(out, span, telemetry.MemoryCurrentBytes, "Memory Bytes (current)", humanizeBytes)
+	r.renderMetric(out, span, telemetry.MemoryPeakBytes, "Memory Bytes (peak)", humanizeBytes)
+
 	// Network Stats
 	r.renderNetworkMetric(out, span, telemetry.NetstatRxBytes, telemetry.NetstatRxDropped, telemetry.NetstatRxPackets, "Network Rx")
 	r.renderNetworkMetric(out, span, telemetry.NetstatTxBytes, telemetry.NetstatTxDropped, telemetry.NetstatTxPackets, "Network Tx")
@@ -456,22 +460,6 @@ func renderPacketLoss(out *termenv.Output, span *dagui.Span, droppedMetric, pack
 				}
 			}
 		}
-	}
-
-	if dataPoints := span.MetricsByName[telemetry.MemoryCurrentBytes]; len(dataPoints) > 0 {
-		lastPoint := dataPoints[len(dataPoints)-1]
-		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("Memory Bytes (current): %s", humanize.Bytes(uint64(lastPoint.Value))))
-		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
-		fmt.Fprint(out, displayMetric)
-	}
-
-	if dataPoints := span.MetricsByName[telemetry.MemoryPeakBytes]; len(dataPoints) > 0 {
-		lastPoint := dataPoints[len(dataPoints)-1]
-		fmt.Fprint(out, " | ")
-		displayMetric := out.String(fmt.Sprintf("Memory Bytes (peak): %s", humanize.Bytes(uint64(lastPoint.Value))))
-		displayMetric = displayMetric.Foreground(termenv.ANSIGreen)
-		fmt.Fprint(out, displayMetric)
 	}
 }
 

--- a/engine/buildkit/resources/memorystat.go
+++ b/engine/buildkit/resources/memorystat.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,8 +44,11 @@ func newMemoryCurrentSampler(cgroupPath string, meter metric.Meter, commonAttrs 
 func (s *memoryCurrentSampler) sample(ctx context.Context) error {
 	sample := newInt64GaugeSample(s.memoryCurrent, s.commonAttrs)
 	bs, err := os.ReadFile(s.memoryCurrentFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read memory.current file: %w", err)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.memoryCurrentFilePath, err)
 	}
 
 	value, err := singleValue(bs)
@@ -85,8 +89,11 @@ func newMemoryPeakSampler(cgroupPath string, meter metric.Meter, commonAttrs att
 func (s *memoryPeakSampler) sample(ctx context.Context) error {
 	sample := newInt64GaugeSample(s.memoryPeak, s.commonAttrs)
 	bs, err := os.ReadFile(s.memoryPeakFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read memory.Peak file: %w", err)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read %s: %w", s.memoryPeakFilePath, err)
 	}
 
 	value, err := singleValue(bs)


### PR DESCRIPTION
does what it says on the tin, the memstat double-print is an ugly consequence of a merge conflict resolution gone poorly.

fixes #9012