### PR TITLE
Preserve ExecError Stdout/Stderr, just don't show it

### DIFF
--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -176,11 +177,16 @@ func gitPublish(ctx context.Context, git *dagger.VersionGit, opts gitPublishOpts
 			WithExec([]string{"git", "rev-parse", "HEAD"}).
 			Stdout(ctx)
 		if err != nil {
-			if strings.Contains(err.Error(), "invalid reference: "+opts.destTag) {
-				// this is a ref that only exists in the source, and not in the
-				// dest, so no overwriting will occur
-				return nil
+			var execErr *dagger.ExecError
+			if errors.As(err, &execErr) {
+				if strings.Contains(execErr.Stderr, "invalid reference: "+opts.destTag) {
+					// this is a ref that only exists in the source, and not in the
+					// dest, so no overwriting will occur
+					return nil
+				}
+				panic(execErr.Stderr)
 			}
+			panic(err)
 			return err
 		}
 		destCommit = strings.TrimSpace(destCommit)

--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -184,9 +184,7 @@ func gitPublish(ctx context.Context, git *dagger.VersionGit, opts gitPublishOpts
 					// dest, so no overwriting will occur
 					return nil
 				}
-				panic(execErr.Stderr)
 			}
-			panic(err)
 			return err
 		}
 		destCommit = strings.TrimSpace(destCommit)

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -308,18 +308,6 @@ func mainSrc(checkVersionCompatibility func(string) bool) string {
 	}
 }
 
-func unwrapError(rerr error) string {
-	var execErr *dagger.ExecError
-	if errors.As(rerr, &execErr) {
-		return execErr.Message()
-	}
-	var gqlErr *gqlerror.Error
-	if errors.As(rerr, &gqlErr) {
-		return gqlErr.Message
-	}
-	return rerr.Error()
-}
-
 func dispatch(ctx context.Context) (rerr error) {
 	ctx = telemetry.InitEmbedded(ctx, resource.NewWithAttributes(
 		semconv.SchemaURL,
@@ -336,7 +324,7 @@ func dispatch(ctx context.Context) (rerr error) {
 	fnCall := dag.CurrentFunctionCall()
 	defer func() {
 		if rerr != nil {
-			if ` + voidRet + ` := fnCall.ReturnError(ctx, dag.Error(unwrapError(rerr))); err != nil {
+			if ` + voidRet + ` := fnCall.ReturnError(ctx, dag.Error(rerr.Error())); err != nil {
 				fmt.Println("failed to return error:", err)
 			}
 		}

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -308,6 +308,14 @@ func mainSrc(checkVersionCompatibility func(string) bool) string {
 	}
 }
 
+func unwrapError(rerr error) string {
+	var gqlErr *gqlerror.Error
+	if errors.As(rerr, &gqlErr) {
+		return gqlErr.Message
+	}
+	return rerr.Error()
+}
+
 func dispatch(ctx context.Context) (rerr error) {
 	ctx = telemetry.InitEmbedded(ctx, resource.NewWithAttributes(
 		semconv.SchemaURL,
@@ -324,7 +332,7 @@ func dispatch(ctx context.Context) (rerr error) {
 	fnCall := dag.CurrentFunctionCall()
 	defer func() {
 		if rerr != nil {
-			if ` + voidRet + ` := fnCall.ReturnError(ctx, dag.Error(rerr.Error())); err != nil {
+			if ` + voidRet + ` := fnCall.ReturnError(ctx, dag.Error(unwrapError(rerr))); err != nil {
 				fmt.Println("failed to return error:", err)
 			}
 		}

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -105,16 +105,7 @@ type ExecError struct {
 }
 
 func (e *ExecError) Error() string {
-	// As a default when just printing the error, include the stdout
-	// and stderr for visibility
-	msg := e.Message()
-	if strings.TrimSpace(e.Stdout) != "" {
-		msg += "\nStdout:\n"+e.Stdout
-	}
-	if strings.TrimSpace(e.Stderr) != "" {
-		msg += "\nStderr:\n"+e.Stderr
-	}
-	return msg
+	return e.Message()
 }
 
 func (e *ExecError) Message() string {

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -82,9 +82,8 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	return withEngine(ctx, client.Params{
-		SecretToken:     sessionToken.String(),
-		Version:         sessionVersion,
-		ExecErrorOutput: true,
+		SecretToken: sessionToken.String(),
+		Version:     sessionVersion,
 	}, func(ctx context.Context, sess *client.Client) error {
 		// Requests maintain their original trace context from the client, rather
 		// than appearing beneath the dagger session span, so in order to see any

--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -101,7 +101,7 @@ func (ContainerSuite) TestSystemCACerts(ctx context.Context, t *testctx.T) {
 
 			// verify no system CAs are leftover
 			_, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
-			require.ErrorContains(t, err, "no such file or directory")
+			requireErrOut(t, err, "no such file or directory")
 
 			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
 			require.NoError(t, err)
@@ -143,7 +143,7 @@ func (ContainerSuite) TestSystemCACerts(ctx context.Context, t *testctx.T) {
 
 			// verify no system CAs are leftover
 			_, err = ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
-			require.ErrorContains(t, err, "no such file or directory")
+			requireErrOut(t, err, "no such file or directory")
 
 			bundleContents, err = ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
 			require.NoError(t, err)
@@ -268,10 +268,10 @@ func (ContainerSuite) TestSystemCACerts(ctx context.Context, t *testctx.T) {
 
 			// verify no system CAs are leftover
 			_, err = ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
-			require.ErrorContains(t, err, "no such file or directory")
+			requireErrOut(t, err, "no such file or directory")
 
 			_, err = ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
-			require.ErrorContains(t, err, "no such file or directory")
+			requireErrOut(t, err, "no such file or directory")
 		}},
 
 		caCertsTest{"rhel basic", func(t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -417,7 +417,7 @@ func (ContainerSuite) TestExecSync(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}`, nil, nil)
-	require.Contains(t, err.Error(), `process "false" did not complete successfully`)
+	requireErrOut(t, err, `process "false" did not complete successfully`)
 }
 
 func (ContainerSuite) TestExecStdoutStderr(ctx context.Context, t *testctx.T) {
@@ -2231,7 +2231,7 @@ func (ContainerSuite) TestDirectoryErrors(ctx context.Context, t *testctx.T) {
 			"id": id,
 		}})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "path /mnt/dir/some-file is a file, not a directory")
+	requireErrOut(t, err, "path /mnt/dir/some-file is a file, not a directory")
 
 	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
@@ -2248,7 +2248,7 @@ func (ContainerSuite) TestDirectoryErrors(ctx context.Context, t *testctx.T) {
 			"id": id,
 		}})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: no such file or directory")
+	requireErrOut(t, err, "bogus: no such file or directory")
 
 	err = testutil.Query(t,
 		`{
@@ -2263,7 +2263,7 @@ func (ContainerSuite) TestDirectoryErrors(ctx context.Context, t *testctx.T) {
 			}
 		}`, nil, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
+	requireErrOut(t, err, "bogus: cannot retrieve path from tmpfs")
 
 	cacheID := newCache(t)
 	err = testutil.Query(t,
@@ -2281,7 +2281,7 @@ func (ContainerSuite) TestDirectoryErrors(ctx context.Context, t *testctx.T) {
 			"cache": cacheID,
 		}})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
+	requireErrOut(t, err, "bogus: cannot retrieve path from cache")
 }
 
 func (ContainerSuite) TestDirectorySourcePath(ctx context.Context, t *testctx.T) {
@@ -2461,7 +2461,7 @@ func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 				"id": id,
 			}})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "bogus: no such file or directory")
+		requireErrOut(t, err, "bogus: no such file or directory")
 	})
 
 	t.Run("get directory as file", func(ctx context.Context, t *testctx.T) {
@@ -2480,7 +2480,7 @@ func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 				"id": id,
 			}})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "path /mnt/dir is a directory, not a file")
+		requireErrOut(t, err, "path /mnt/dir is a directory, not a file")
 	})
 
 	t.Run("get path under tmpfs", func(ctx context.Context, t *testctx.T) {
@@ -2497,7 +2497,7 @@ func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 			}
 		}`, nil, nil)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
+		requireErrOut(t, err, "bogus: cannot retrieve path from tmpfs")
 	})
 
 	t.Run("get path under cache", func(ctx context.Context, t *testctx.T) {
@@ -2517,7 +2517,7 @@ func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 				"cache": cacheID,
 			}})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
+		requireErrOut(t, err, "bogus: cannot retrieve path from cache")
 	})
 
 	t.Run("get secret mount contents", func(ctx context.Context, t *testctx.T) {
@@ -2536,7 +2536,7 @@ func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 				"secret": "some-secret",
 			}})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "sekret: no such file or directory")
+		requireErrOut(t, err, "sekret: no such file or directory")
 	})
 }
 
@@ -3523,7 +3523,7 @@ func (ContainerSuite) TestImageRef(ctx context.Context, t *testctx.T) {
 				}
 			}`, &res, nil)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
+		requireErrOut(t, err, "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
 	})
 
 	t.Run("should throw error after the container image modification with exec", func(ctx context.Context, t *testctx.T) {
@@ -3546,7 +3546,7 @@ func (ContainerSuite) TestImageRef(ctx context.Context, t *testctx.T) {
 				}
 			}`, &res, nil)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
+		requireErrOut(t, err, "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
 	})
 
 	t.Run("should throw error after the container image modification with directory", func(ctx context.Context, t *testctx.T) {
@@ -3565,7 +3565,7 @@ func (ContainerSuite) TestImageRef(ctx context.Context, t *testctx.T) {
 		_, err := ctr.ImageRef(ctx)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
+		requireErrOut(t, err, "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
 	})
 }
 
@@ -4703,7 +4703,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			Stdout(ctx)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "ls: /mnt/bar: No such file or directory")
+		requireErrOut(t, err, "ls: /mnt/bar: No such file or directory")
 	})
 
 	t.Run("env variable is expanded in WithUnixSocket", func(ctx context.Context, t *testctx.T) {
@@ -4744,7 +4744,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			Stdout(ctx)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "ls: /opt/bar.sock: No such file or directory")
+		requireErrOut(t, err, "ls: /opt/bar.sock: No such file or directory")
 	})
 
 	t.Run("env variable is expanded in WithMountedSecret", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -445,14 +445,14 @@ func (ContainerSuite) TestExecStdoutStderr(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().
 			From(alpineImage).
 			Stdout(ctx)
-		require.ErrorContains(t, err, "no command has been set")
+		requireErrOut(t, err, "no command has been set")
 	})
 
 	t.Run("stderr without exec", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().
 			From(alpineImage).
 			Stderr(ctx)
-		require.ErrorContains(t, err, "no command has been set")
+		requireErrOut(t, err, "no command has been set")
 	})
 }
 
@@ -754,7 +754,7 @@ func (ContainerSuite) TestExecWithEntrypoint(ctx context.Context, t *testctx.T) 
 			UseEntrypoint: true,
 		}).Sync(ctx)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "can't open 'sh'")
+		requireErrOut(t, err, "can't open 'sh'")
 	})
 
 	t.Run("skipped", func(ctx context.Context, t *testctx.T) {
@@ -821,7 +821,7 @@ func (ContainerSuite) TestExecWithoutEntrypoint(ctx context.Context, t *testctx.
 			WithDefaultArgs([]string{"echo", "-n", "foobar"}).
 			WithoutEntrypoint().
 			Stdout(ctx)
-		require.ErrorContains(t, err, "no command has been set")
+		requireErrOut(t, err, "no command has been set")
 		require.Empty(t, res)
 	})
 
@@ -3579,7 +3579,7 @@ func (ContainerSuite) TestBuildNilContextError(ctx context.Context, t *testctx.T
 				}
 			}
 		}`, &map[any]any{}, nil)
-	require.ErrorContains(t, err, "cannot decode empty string as ID")
+	requireErrOut(t, err, "cannot decode empty string as ID")
 }
 
 func (ContainerSuite) TestInsecureRootCapabilites(ctx context.Context, t *testctx.T) {
@@ -4471,7 +4471,7 @@ func (ContainerSuite) TestExecExpect(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}`, &res, nil)
-		require.ErrorContains(t, err, "exit code: 1")
+		requireErrOut(t, err, "exit code: 1")
 	})
 
 	t.Run("failure", func(ctx context.Context, t *testctx.T) {
@@ -4495,7 +4495,7 @@ func (ContainerSuite) TestExecExpect(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}`, &res, nil)
-		require.ErrorContains(t, err, "exit code: 0")
+		requireErrOut(t, err, "exit code: 0")
 
 		err = testutil.Query(t,
 			`{
@@ -4651,7 +4651,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			).
 			WithExec([]string{"ls", "/some-path/bar"}).Stdout(ctx)
 
-		require.ErrorContains(t, err, "ls: /some-path/bar: No such file or directory")
+		requireErrOut(t, err, "ls: /some-path/bar: No such file or directory")
 	})
 
 	t.Run("env variable is expanded in WithoutFile", func(ctx context.Context, t *testctx.T) {
@@ -4665,7 +4665,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			WithoutFile("/some-path/${foo}/some-file.txt", dagger.ContainerWithoutFileOpts{Expand: true}).
 			WithExec([]string{"ls", "/some-path/bar/some-file.txt"}).Stdout(ctx)
 
-		require.ErrorContains(t, err, "ls: /some-path/bar/some-file.txt: No such file or directory")
+		requireErrOut(t, err, "ls: /some-path/bar/some-file.txt: No such file or directory")
 	})
 
 	t.Run("env variable is expanded in WithoutFiles", func(ctx context.Context, t *testctx.T) {
@@ -4679,7 +4679,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			WithoutFiles([]string{"/some-path/${foo}/some-file.txt"}, dagger.ContainerWithoutFilesOpts{Expand: true}).
 			WithExec([]string{"ls", "/some-path/bar/some-file.txt"}).Stdout(ctx)
 
-		require.ErrorContains(t, err, "ls: /some-path/bar/some-file.txt: No such file or directory")
+		requireErrOut(t, err, "ls: /some-path/bar/some-file.txt: No such file or directory")
 	})
 
 	t.Run("env variable is expanded in WithExec", func(ctx context.Context, t *testctx.T) {
@@ -4791,7 +4791,7 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 			WithExec([]string{"sh", "-c", "test ${GITEA_TOKEN} = \"password\""}, dagger.ContainerWithExecOpts{Expand: true}).
 			Sync(ctx)
 
-		require.ErrorContains(t, err, "expand cannot be used with secret env variable \"GITEA_TOKEN\"")
+		requireErrOut(t, err, "expand cannot be used with secret env variable \"GITEA_TOKEN\"")
 	})
 
 	t.Run("env variable is expanded in Export", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1158,7 +1158,7 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 
 	t.Run("directory doesn't exist", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().Directory("foo").Glob(ctx, "**/*")
-		require.ErrorContains(t, err, "no such file or directory")
+		requireErrOut(t, err, "no such file or directory")
 	})
 }
 

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -896,7 +896,7 @@ func (DirectorySuite) TestWithNewFileExceedingLength(ctx context.Context, t *tes
 			}
 		}`, &res, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "File name length exceeds the maximum supported 255 characters")
+	requireErrOut(t, err, "File name length exceeds the maximum supported 255 characters")
 }
 
 func (DirectorySuite) TestWithFileExceedingLength(ctx context.Context, t *testctx.T) {
@@ -921,7 +921,7 @@ func (DirectorySuite) TestWithFileExceedingLength(ctx context.Context, t *testct
 			}
 		}`, &res, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "File name length exceeds the maximum supported 255 characters")
+	requireErrOut(t, err, "File name length exceeds the maximum supported 255 characters")
 }
 
 func (DirectorySuite) TestDirectMerge(ctx context.Context, t *testctx.T) {
@@ -1008,11 +1008,11 @@ func (DirectorySuite) TestSync(ctx context.Context, t *testctx.T) {
 	t.Run("triggers error", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().Directory("/foo").Sync(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such file or directory")
+		requireErrOut(t, err, "no such file or directory")
 
 		_, err = c.Container().From(alpineImage).Directory("/bar").Sync(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such file or directory")
+		requireErrOut(t, err, "no such file or directory")
 	})
 
 	t.Run("allows chaining", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -444,11 +444,11 @@ func (FileSuite) TestSync(ctx context.Context, t *testctx.T) {
 	t.Run("triggers error", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().File("baz").Sync(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such file")
+		requireErrOut(t, err, "no such file")
 
 		_, err = c.Container().From(alpineImage).File("/bar").Sync(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such file")
+		requireErrOut(t, err, "no such file")
 	})
 
 	t.Run("allows chaining", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -295,7 +295,7 @@ func (GitSuite) TestGitTagsSSH(ctx context.Context, t *testctx.T) {
 	t.Run("without SSH auth", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Git(repoURL).Tags(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Permission denied (publickey)")
+		requireErrOut(t, err, "Permission denied (publickey)")
 	})
 }
 

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -374,8 +374,8 @@ func (GitSuite) TestAuthProviders(ctx context.Context, t *testctx.T) {
 			File("README.md").
 			Contents(ctx)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "git error")
-		require.ErrorContains(t, err, "Authentication failed for 'https://github.com/grouville/daggerverse-private.git/'")
+		requireErrOut(t, err, "git error")
+		requireErrOut(t, err, "Authentication failed for 'https://github.com/grouville/daggerverse-private.git/'")
 	})
 }
 
@@ -389,8 +389,8 @@ func (GitSuite) TestAuth(ctx context.Context, t *testctx.T) {
 			Tree().
 			File("README.md").
 			Contents(ctx)
-		require.ErrorContains(t, err, "git error")
-		require.ErrorContains(t, err, "failed to fetch remote")
+		requireErrOut(t, err, "git error")
+		requireErrOut(t, err, "failed to fetch remote")
 	})
 
 	t.Run("incorrect auth", func(ctx context.Context, t *testctx.T) {
@@ -400,8 +400,8 @@ func (GitSuite) TestAuth(ctx context.Context, t *testctx.T) {
 			Tree().
 			File("README.md").
 			Contents(ctx)
-		require.ErrorContains(t, err, "git error")
-		require.ErrorContains(t, err, "failed to fetch remote")
+		requireErrOut(t, err, "git error")
+		requireErrOut(t, err, "failed to fetch remote")
 	})
 
 	t.Run("token auth", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -217,6 +217,6 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory) ([]string, error) 
 
 		_, err = execWithEnv(ctx, t, modDir, nil, "-m", "https://github.com/grouville/daggerverse-private.git/zip", "functions")
 		require.Error(t, err)
-		require.ErrorContains(t, err, "Authentication failed")
+		requireErrOut(t, err, "Authentication failed")
 	})
 }

--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -411,10 +411,10 @@ func (m *Test) NoExec(ctx context.Context) *dagger.Container {
 	require.JSONEq(t, `{"test": {"stdout": "hello\n", "stderr": "goodbye\n"}}`, out)
 
 	_, err = modGen.With(daggerCall("no-exec", "stdout")).Stdout(ctx)
-	require.ErrorContains(t, err, "no command has been set")
+	requireErrOut(t, err, "no command has been set")
 
 	_, err = modGen.With(daggerCall("no-exec", "stderr")).Stdout(ctx)
-	require.ErrorContains(t, err, "no command has been set")
+	requireErrOut(t, err, "no command has been set")
 }
 
 func (LegacySuite) TestReturnVoid(ctx context.Context, t *testctx.T) {
@@ -676,7 +676,7 @@ func (m *Test) GetContents(ctx context.Context, cmtID string) (string, error) {
 		}`, &res, &testutil.QueryOptions{
 			Version: "v0.12.6",
 		})
-	require.ErrorContains(t, err, ".git/HEAD: no such file or directory")
+	requireErrOut(t, err, ".git/HEAD: no such file or directory")
 }
 
 func (LegacySuite) TestGoUnscopedEnumValues(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -505,7 +505,7 @@ func (m *Test) Insecure(ctx context.Context, token *dagger.Secret) (string, erro
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "env:NOWHERETOBEFOUND")).Stdout(ctx)
-				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
+				requireErrOut(t, err, `secret env var not found: "NOW..."`)
 			})
 		})
 
@@ -517,7 +517,7 @@ func (m *Test) Insecure(ctx context.Context, token *dagger.Secret) (string, erro
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "NOWHERETOBEFOUND")).Stdout(ctx)
-				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
+				requireErrOut(t, err, `secret env var not found: "NOW..."`)
 			})
 		})
 
@@ -533,7 +533,7 @@ func (m *Test) Insecure(ctx context.Context, token *dagger.Secret) (string, erro
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "file:/nowheretobefound")).Stdout(ctx)
-				require.ErrorContains(t, err, `failed to read secret file "/nowheretobefound": open /nowheretobefound: no such file or directory`)
+				requireErrOut(t, err, `failed to read secret file "/nowheretobefound": open /nowheretobefound: no such file or directory`)
 			})
 		})
 
@@ -545,13 +545,13 @@ func (m *Test) Insecure(ctx context.Context, token *dagger.Secret) (string, erro
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "cmd:exit 1")).Stdout(ctx)
-				require.ErrorContains(t, err, `failed to run secret command "exit 1": exit status 1`)
+				requireErrOut(t, err, `failed to run secret command "exit 1": exit status 1`)
 			})
 		})
 
 		t.Run("invalid source", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("insecure", "--token", "wtf:HUH")).Stdout(ctx)
-			require.ErrorContains(t, err, `unsupported secret arg source: "wtf"`)
+			requireErrOut(t, err, `unsupported secret arg source: "wtf"`)
 		})
 	})
 
@@ -638,7 +638,7 @@ func (m *Test) ToPlatform(platform string) dagger.Platform {
 
 		t.Run("invalid input", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("from-platform", "--platform", "invalid")).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 		})
 
 		t.Run("valid output", func(ctx context.Context, t *testctx.T) {
@@ -649,7 +649,7 @@ func (m *Test) ToPlatform(platform string) dagger.Platform {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-platform", "--platform", "invalid")).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 		})
 	})
 
@@ -708,7 +708,7 @@ func (m *Test) ToPlatforms(platforms []string) []dagger.Platform {
 
 		t.Run("invalid input", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("from-platforms", "--platforms", "invalid")).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 		})
 
 		t.Run("valid output", func(ctx context.Context, t *testctx.T) {
@@ -719,7 +719,7 @@ func (m *Test) ToPlatforms(platforms []string) []dagger.Platform {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-platforms", "--platforms", "invalid")).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 		})
 	})
 
@@ -757,9 +757,9 @@ func (m *Test) ToProto(proto string) dagger.NetworkProtocol {
 
 		t.Run("invalid input", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("from-proto", "--proto", "INVALID")).Stdout(ctx)
-			require.ErrorContains(t, err, "value should be one of")
-			require.ErrorContains(t, err, "TCP")
-			require.ErrorContains(t, err, "UDP")
+			requireErrOut(t, err, "value should be one of")
+			requireErrOut(t, err, "TCP")
+			requireErrOut(t, err, "UDP")
 		})
 
 		t.Run("default input value", func(ctx context.Context, t *testctx.T) {
@@ -776,7 +776,7 @@ func (m *Test) ToProto(proto string) dagger.NetworkProtocol {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-proto", "--proto", "INVALID")).Stdout(ctx)
-			require.ErrorContains(t, err, "invalid enum value")
+			requireErrOut(t, err, "invalid enum value")
 		})
 
 		t.Run("choices in help", func(ctx context.Context, t *testctx.T) {
@@ -826,9 +826,9 @@ func (m *Test) ToStatus(status string) Status {
 
 		t.Run("invalid input", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("from-status", "--status", "INVALID")).Stdout(ctx)
-			require.ErrorContains(t, err, "value should be one of")
-			require.ErrorContains(t, err, "ACTIVE")
-			require.ErrorContains(t, err, "INACTIVE")
+			requireErrOut(t, err, "value should be one of")
+			requireErrOut(t, err, "ACTIVE")
+			requireErrOut(t, err, "INACTIVE")
 		})
 
 		t.Run("default input value", func(ctx context.Context, t *testctx.T) {
@@ -845,7 +845,7 @@ func (m *Test) ToStatus(status string) Status {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-status", "--status", "INVALID")).Stdout(ctx)
-			require.ErrorContains(t, err, "invalid enum value")
+			requireErrOut(t, err, "invalid enum value")
 		})
 
 		t.Run("choices in help", func(ctx context.Context, t *testctx.T) {
@@ -1410,7 +1410,7 @@ func (m *Test) Fail() *dagger.Container {
 		t.Run("exec", func(ctx context.Context, t *testctx.T) {
 			// Container doesn't show output but executes withExecs
 			out, err := modGen.With(daggerCall("fail")).Stdout(ctx)
-			require.ErrorContains(t, err, "goodbye")
+			requireErrOut(t, err, "goodbye")
 			require.NotContains(t, out, "goodbye")
 		})
 
@@ -1826,7 +1826,7 @@ func (t *Test) File() *dagger.File {
 
 	t.Run("not a file", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerCall("hello", "-o", ".")).Sync(ctx)
-		require.ErrorContains(t, err, "is a directory")
+		requireErrOut(t, err, "is a directory")
 	})
 
 	t.Run("allow dir for file", func(ctx context.Context, t *testctx.T) {
@@ -2038,7 +2038,7 @@ func (CallSuite) TestByName(ctx context.Context, t *testctx.T) {
 		// call main module at /work path
 		_, err := ctr.With(daggerCallAt("foo", "fn")).Stdout(ctx)
 		require.Error(t, err)
-		require.ErrorContains(t, err, `local module dep source path "../outside/mod-a" escapes context "/work"`)
+		requireErrOut(t, err, `local module dep source path "../outside/mod-a" escapes context "/work"`)
 	})
 
 	t.Run("local ref with @", func(ctx context.Context, t *testctx.T) {
@@ -2247,12 +2247,12 @@ func (m *Chain) Echo(msg string) string {
 
 	t.Run("no sub-command", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerCall("fn-a")).Sync(ctx)
-		require.ErrorContains(t, err, `unknown command "fn-a"`)
+		requireErrOut(t, err, `unknown command "fn-a"`)
 	})
 
 	t.Run("no flag", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerCall("fn-b", "--msg", "hello", "--matrix", "")).Sync(ctx)
-		require.ErrorContains(t, err, `unknown flag: --matrix`)
+		requireErrOut(t, err, `unknown flag: --matrix`)
 	})
 }
 
@@ -2282,7 +2282,7 @@ func (m *Test) ToStatus(status string) Status {
 	`)
 
 		_, err := modGen.With(daggerCall("--help")).Stdout(ctx)
-		require.ErrorContains(t, err, `enum value "ACTIVE" is already defined`)
+		requireErrOut(t, err, `enum value "ACTIVE" is already defined`)
 	})
 
 	t.Run("invalid value", func(ctx context.Context, t *testctx.T) {
@@ -2332,7 +2332,7 @@ func (m *Test) FromStatus(status Status) string {
 `, tc.enumValue))
 
 				_, err := modGen.With(daggerCall("--help")).Stdout(ctx)
-				require.ErrorContains(t, err, fmt.Sprintf("enum value %q is not valid", tc.enumValue))
+				requireErrOut(t, err, fmt.Sprintf("enum value %q is not valid", tc.enumValue))
 			})
 		}
 	})
@@ -2356,7 +2356,7 @@ func (m *Test) FromStatus(status Status) string {
 `)
 
 		_, err := modGen.With(daggerCall("--help")).Stdout(ctx)
-		require.ErrorContains(t, err, "enum value must not be empty")
+		requireErrOut(t, err, "enum value must not be empty")
 	})
 }
 
@@ -2478,8 +2478,8 @@ export class Test {
 
 			t.Run("sad input", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("faves", "--langs", "GO,FOO,BAR")).Sync(ctx)
-				require.ErrorContains(t, err, "invalid argument")
-				require.ErrorContains(t, err, "should be one of GO,PYTHON,TYPESCRIPT,PHP,ELIXIR")
+				requireErrOut(t, err, "invalid argument")
+				requireErrOut(t, err, "should be one of GO,PYTHON,TYPESCRIPT,PHP,ELIXIR")
 			})
 
 			t.Run("output", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -149,7 +149,7 @@ func (CLISuite) TestDaggerInit(ctx context.Context, t *testctx.T) {
 
 		_, err := ctr.Stdout(ctx)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "source subdir path \"../..\" escapes context")
+		requireErrOut(t, err, "source subdir path \"../..\" escapes context")
 	})
 }
 
@@ -381,7 +381,7 @@ func (CLISuite) TestDaggerInitGit(ctx context.Context, t *testctx.T) {
 					With(daggerExec("develop", "--sdk=go"))
 
 				_, err = modGen.File(".gitignore").Contents(ctx)
-				require.ErrorContains(t, err, "no such file or directory")
+				requireErrOut(t, err, "no such file or directory")
 			})
 		})
 	}
@@ -449,10 +449,10 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 				// currently, we don't support renaming or re-sdking a module, make sure that errors comprehensibly
 
 				_, err = ctr.With(daggerExec("develop", "--sdk", "python")).Sync(ctx)
-				require.ErrorContains(t, err, `cannot update module SDK that has already been set to "go"`)
+				requireErrOut(t, err, `cannot update module SDK that has already been set to "go"`)
 
 				_, err = ctr.With(daggerExec("develop", "--source", "blahblahblaha/blah")).Sync(ctx)
-				require.ErrorContains(t, err, `cannot update module source path that has already been set to "cool/subdir"`)
+				requireErrOut(t, err, `cannot update module source path that has already been set to "cool/subdir"`)
 			})
 		}
 	})
@@ -514,7 +514,7 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 				With(mountedSocket).
 				With(daggerExec("develop", "-m", testGitModuleRef(tc, "top-level"))).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module must be local`)
+			requireErrOut(t, err, `module must be local`)
 		})
 	})
 
@@ -806,7 +806,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/work/test").
 				With(daggerExec("install", "../../play/dep")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `local module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `local module dep source path "../play/dep" escapes context "/work"`)
 		})
 
 		t.Run("from src dir with absolute path", func(ctx context.Context, t *testctx.T) {
@@ -814,7 +814,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/work/test").
 				With(daggerExec("install", "/play/dep")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `local module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `local module dep source path "../play/dep" escapes context "/work"`)
 		})
 
 		t.Run("from dep dir", func(ctx context.Context, t *testctx.T) {
@@ -822,7 +822,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/play/dep").
 				With(daggerExec("install", "-m=../../work/test", ".")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `module dep source path "../play/dep" escapes context "/work"`)
 		})
 
 		t.Run("from dep dir with absolute path", func(ctx context.Context, t *testctx.T) {
@@ -830,7 +830,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/play/dep").
 				With(daggerExec("install", "-m=/work/test", ".")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `module dep source path "../play/dep" escapes context "/work"`)
 		})
 
 		t.Run("from root", func(ctx context.Context, t *testctx.T) {
@@ -838,7 +838,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/").
 				With(daggerExec("install", "-m=work/test", "play/dep")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `module dep source path "../play/dep" escapes context "/work"`)
 		})
 
 		t.Run("from root with absolute path", func(ctx context.Context, t *testctx.T) {
@@ -846,7 +846,7 @@ func (CLISuite) TestDaggerInstall(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/").
 				With(daggerExec("install", "-m=/work/test", "play/dep")).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module dep source path "../play/dep" escapes context "/work"`)
+			requireErrOut(t, err, `module dep source path "../play/dep" escapes context "/work"`)
 		})
 	})
 
@@ -890,7 +890,7 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 					With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
 					With(daggerExec("install", testGitModuleRef(tc, "../../"))).
 					Sync(ctx)
-				require.ErrorContains(t, err, `git module source subpath points out of root: "../.."`)
+				requireErrOut(t, err, `git module source subpath points out of root: "../.."`)
 
 				_, err = goGitBase(t, c).
 					With(mountedSocket).
@@ -898,7 +898,7 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 					With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
 					With(daggerExec("install", testGitModuleRef(tc, "this/just/does/not/exist"))).
 					Sync(ctx)
-				require.ErrorContains(t, err, `module "test" dependency "" with source root path "this/just/does/not/exist" does not exist or does not have a configuration file`)
+				requireErrOut(t, err, `module "test" dependency "" with source root path "this/just/does/not/exist" does not exist or does not have a configuration file`)
 			})
 
 			t.Run("unpinned gets pinned", func(ctx context.Context, t *testctx.T) {
@@ -1037,7 +1037,7 @@ func (m *OtherObj) FnE() *dagger.Container {
 
 	t.Run("return primitive", func(ctx context.Context, t *testctx.T) {
 		_, err := ctr.With(daggerFunctions("prim")).Stdout(ctx)
-		require.ErrorContains(t, err, `function "prim" returns type "STRING_KIND" with no further functions available`)
+		requireErrOut(t, err, `function "prim" returns type "STRING_KIND" with no further functions available`)
 	})
 
 	t.Run("alt casing", func(ctx context.Context, t *testctx.T) {
@@ -1291,7 +1291,7 @@ func (f *Foo) ContainerEcho(ctx context.Context, input string) (string, error) {
 					File("dagger.json").Contents(ctx)
 
 				if tc.expectedError != "" {
-					require.ErrorContains(t, err, tc.expectedError)
+					requireErrOut(t, err, tc.expectedError)
 				} else {
 					require.NoError(t, err)
 					require.NotContains(t, daggerjson, "hello")

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -105,13 +105,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module source path ".." escapes context "/work"`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module source path ".." escapes context "/work"`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module source path ".." escapes context "/work"`)
 			})
 
 			t.Run("local with absolute path", func(ctx context.Context, t *testctx.T) {
@@ -125,13 +125,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `source path "/tmp" contains parent directory components`)
+				requireErrOut(t, err, `source path "/tmp" contains parent directory components`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `source path "/tmp" contains parent directory components`)
+				requireErrOut(t, err, `source path "/tmp" contains parent directory components`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `source path "/tmp" contains parent directory components`)
+				requireErrOut(t, err, `source path "/tmp" contains parent directory components`)
 			})
 
 			testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
@@ -141,7 +141,7 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					defer cleanup()
 
 					_, err := baseCtr(t, c).With(mountedSocket).With(daggerCallAt(testGitModuleRef(tc, "invalid/bad-source"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
-					require.ErrorContains(t, err, `source path "../../../" contains parent directory components`)
+					requireErrOut(t, err, `source path "../../../" contains parent directory components`)
 				})
 			})
 		})
@@ -160,13 +160,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module dep source path ".." escapes context "/work"`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module dep source path ".." escapes context "/work"`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				requireErrOut(t, err, `local module dep source path ".." escapes context "/work"`)
 
 				base = base.
 					With(configFile(".", &modules.ModuleConfig{
@@ -179,13 +179,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err = base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../work/dep" escapes root`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../work/dep" escapes root`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../work/dep" escapes root`)
 			})
 
 			t.Run("local with absolute path", func(ctx context.Context, t *testctx.T) {
@@ -202,13 +202,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `missing config file /work/tmp/foo/dagger.json`)
+				requireErrOut(t, err, `missing config file /work/tmp/foo/dagger.json`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `missing config file /work/tmp/foo/dagger.json`)
+				requireErrOut(t, err, `missing config file /work/tmp/foo/dagger.json`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `missing config file /work/tmp/foo/dagger.json`)
+				requireErrOut(t, err, `missing config file /work/tmp/foo/dagger.json`)
 
 				base = base.
 					With(configFile(".", &modules.ModuleConfig{
@@ -221,13 +221,13 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					}))
 
 				_, err = base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../dep" escapes root`)
 
 				_, err = base.With(daggerExec("develop")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../dep" escapes root`)
 
 				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-				require.ErrorContains(t, err, `module dep source root path "../dep" escapes root`)
+				requireErrOut(t, err, `module dep source root path "../dep" escapes root`)
 			})
 
 			testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
@@ -237,7 +237,7 @@ func (ConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 					defer cleanup()
 
 					_, err := baseCtr(t, c).With(mountedSocket).With(daggerCallAt(testGitModuleRef(tc, "invalid/bad-dep"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
-					require.ErrorContains(t, err, `module dep source root path "../../../foo" escapes root`)
+					requireErrOut(t, err, `module dep source root path "../../../foo" escapes root`)
 				})
 			})
 		})
@@ -1004,7 +1004,7 @@ func (ConfigSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 			_, err := c.ModuleSource(tc.gitTestRepoRef, dagger.ModuleSourceOpts{
 				Stable: true,
 			}).AsString(ctx)
-			require.ErrorContains(t, err, fmt.Sprintf(`no version provided for stable remote ref: %s`, tc.gitTestRepoRef))
+			requireErrOut(t, err, fmt.Sprintf(`no version provided for stable remote ref: %s`, tc.gitTestRepoRef))
 
 			_, err = c.ModuleSource(testGitModuleRef(tc, "top-level"), dagger.ModuleSourceOpts{
 				Stable: true,
@@ -1249,7 +1249,7 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 	require.Contains(t, strings.TrimSpace(out), `View "mean-view" removed`)
 
 	_, err = ctr.With(daggerExec("config", "views", "-n", "mean-view")).Stdout(ctx)
-	require.ErrorContains(t, err, `view "mean-view" not found`)
+	requireErrOut(t, err, `view "mean-view" not found`)
 
 	out, err = ctr.With(daggerExec("config", "views")).Stdout(ctx)
 	require.NoError(t, err)

--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -116,7 +116,7 @@ func (GoSuite) TestInit(ctx context.Context, t *testctx.T) {
 
 		t.Run("no new go.mod", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.File("dagger/go.mod").Contents(ctx)
-			require.ErrorContains(t, err, "no such file or directory")
+			requireErrOut(t, err, "no such file or directory")
 		})
 	})
 
@@ -1567,7 +1567,7 @@ func (m *Test) Fn() (*dagger.DepObj, error) {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q cannot return external type from dependency module %q",
 				"Test", "Fn", "dep",
 			))
@@ -1589,7 +1589,7 @@ func (m *Test) Fn() ([]*dagger.DepObj, error) {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q cannot return external type from dependency module %q",
 				"Test", "Fn", "dep",
 			))
@@ -1612,7 +1612,7 @@ func (m *Test) Fn(obj *dagger.DepObj) error {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q arg %q cannot reference external type from dependency module %q",
 				"Test", "Fn", "obj", "dep",
 			))
@@ -1633,7 +1633,7 @@ func (m *Test) Fn(obj []*dagger.DepObj) error {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q arg %q cannot reference external type from dependency module %q",
 				"Test", "Fn", "obj", "dep",
 			))
@@ -1661,7 +1661,7 @@ func (m *Test) Fn() (*Obj, error) {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q field %q cannot reference external type from dependency module %q",
 				"Obj", "Foo", "dep",
 			))
@@ -1687,7 +1687,7 @@ func (m *Test) Fn() (*Obj, error) {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q field %q cannot reference external type from dependency module %q",
 				"Obj", "Foo", "dep",
 			))

--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -465,7 +465,7 @@ func main() {
 			With(daggerQuery(`{hasGoMod{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.Error(t, err)
-		require.Regexp(t, "existing go.mod does not", err.Error())
+		requireErrOut(t, err, "existing go.mod does not")
 	})
 
 	t.Run("do not merge go.mod with parent", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -69,7 +69,7 @@ func (PythonSuite) TestInit(ctx context.Context, t *testctx.T) {
 			With(daggerExec("develop", "--sdk=python", "--source=.")).
 			Sync(ctx)
 
-		require.ErrorContains(t, err, "no python files found")
+		requireErrOut(t, err, "no python files found")
 	})
 
 	t.Run("uses expected field casing", func(ctx context.Context, t *testctx.T) {
@@ -114,7 +114,7 @@ func (PythonSuite) TestInit(ctx context.Context, t *testctx.T) {
 			With(daggerQuery(`{helloWorld(myName: "Monde"){message}}`)).
 			Stdout(ctx)
 
-		require.ErrorContains(t, err, "merge is only supported")
+		requireErrOut(t, err, "merge is only supported")
 	})
 
 	t.Run("init module in .dagger if files present in current dir", func(ctx context.Context, t *testctx.T) {
@@ -815,8 +815,8 @@ func (PythonSuite) TestUv(ctx context.Context, t *testctx.T) {
 			Stdout(ctx)
 
 		t.Logf("out: %s", out)
-		require.ErrorContains(t, err, "pip is looking at multiple versions of test")
-		require.ErrorContains(t, err, "requires a different Python")
+		requireErrOut(t, err, "pip is looking at multiple versions of test")
+		requireErrOut(t, err, "requires a different Python")
 	})
 
 	t.Run("pinned version", func(ctx context.Context, t *testctx.T) {
@@ -968,8 +968,9 @@ class Test:
 				With(daggerInitPython()).
 				Sync(ctx)
 
-				// hatchling is a build requirement so it will fail to build if the index is unreachable
-			require.ErrorContains(t, err, "hatchling")
+			// hatchling is a build requirement so it will fail to build if the index
+			// is unreachable
+			requireErrOut(t, err, "hatchling")
 		})
 	})
 }
@@ -1415,7 +1416,7 @@ func (PythonSuite) TestDocs(ctx context.Context, t *testctx.T) {
         `)
 
 		_, err := modGen.With(daggerCall("--help")).Sync(ctx)
-		require.ErrorContains(t, err, "InitVar[typing.Annotated[str, Doc('A URL')]]")
+		requireErrOut(t, err, "InitVar[typing.Annotated[str, Doc('A URL')]]")
 	})
 
 	t.Run("alternative constructor", func(ctx context.Context, t *testctx.T) {
@@ -1647,7 +1648,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q cannot return external type from dependency module %q",
 				"Test", "fn", "dep",
 			))
@@ -1667,7 +1668,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q cannot return external type from dependency module %q",
 				"Test", "fn", "dep",
 			))
@@ -1688,7 +1689,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q arg %q cannot reference external type from dependency module %q",
 				"Test", "fn", "obj", "dep",
 			))
@@ -1707,7 +1708,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q function %q arg %q cannot reference external type from dependency module %q",
 				"Test", "fn", "obj", "dep",
 			))
@@ -1733,7 +1734,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q field %q cannot reference external type from dependency module %q",
 				"Obj", "foo", "dep",
 			))
@@ -1757,7 +1758,7 @@ func (PythonSuite) TestWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
 				With(daggerFunctions()).
 				Sync(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf(
+			requireErrOut(t, err, fmt.Sprintf(
 				"object %q field %q cannot reference external type from dependency module %q",
 				"Obj", "foo", "dep",
 			))

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -82,17 +82,17 @@ func (ShellSuite) TestNoModule(ctx context.Context, t *testctx.T) {
 
 	t.Run("first command no fallback to core", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerShell("container")).Sync(ctx)
-		require.ErrorContains(t, err, "module not loaded")
+		requireErrOut(t, err, "module not loaded")
 	})
 
 	t.Run("module builtin does not work", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerShell(".config")).Sync(ctx)
-		require.ErrorContains(t, err, "module not loaded")
+		requireErrOut(t, err, "module not loaded")
 	})
 
 	t.Run("no main object doc", func(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerShell(".config")).Sync(ctx)
-		require.ErrorContains(t, err, "module not loaded")
+		requireErrOut(t, err, "module not loaded")
 	})
 }
 
@@ -111,7 +111,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 		_, err := modInit(t, c, "go", "").
 			With(daggerShellNoLoad(".config")).
 			Sync(ctx)
-		require.ErrorContains(t, err, "module not loaded")
+		requireErrOut(t, err, "module not loaded")
 	})
 
 	t.Run("dynamically loaded", func(ctx context.Context, t *testctx.T) {
@@ -202,7 +202,7 @@ func (ShellSuite) TestNotExists(ctx context.Context, t *testctx.T) {
 	_, err := modInit(t, c, "go", "").
 		With(daggerShell("container")).
 		Sync(ctx)
-	require.ErrorContains(t, err, "no such function")
+	requireErrOut(t, err, "no such function")
 }
 
 func (ShellSuite) TestIntegerArg(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -393,7 +393,7 @@ export class Test {
 			require.JSONEq(t, `{"test":{"set":{"foo": "abc"}}}`, out)
 
 			_, err = modGen.With(daggerQuery(`{test{set(foo: "abc", bar: "xyz"){bar}}}`)).Stdout(ctx)
-			require.ErrorContains(t, err, `Test has no such field: "bar"`)
+			requireErrOut(t, err, `Test has no such field: "bar"`)
 		})
 	}
 }
@@ -949,7 +949,7 @@ func (ModuleSuite) TestUseLocal(ctx context.Context, t *testctx.T) {
 			// cannot use transitive dependency directly
 			_, err = modGen.With(daggerQuery(`{dep{hello}}`)).Stdout(ctx)
 			require.Error(t, err)
-			require.ErrorContains(t, err, `Query has no such field: "dep"`)
+			requireErrOut(t, err, `Query has no such field: "dep"`)
 		})
 	}
 }
@@ -1955,7 +1955,7 @@ func (ModuleSuite) TestLoops(ctx context.Context, t *testctx.T) {
 		With(daggerExec("install", "-m=depB", "./depA")).
 		With(daggerExec("install", "-m=depA", "./depC")).
 		Sync(ctx)
-	require.ErrorContains(t, err, `local module at "/work/depA" has a circular dependency`)
+	requireErrOut(t, err, `local module at "/work/depA" has a circular dependency`)
 }
 
 //go:embed testdata/modules/go/id/arg/main.go
@@ -2046,7 +2046,7 @@ func (ModuleSuite) TestReservedWords(ctx context.Context, t *testctx.T) {
 						With(daggerQuery(`{test{fn{id}}}`)).
 						Sync(ctx)
 
-					require.ErrorContains(t, err, "cannot define field with reserved name \"id\"")
+					requireErrOut(t, err, "cannot define field with reserved name \"id\"")
 				})
 			}
 		})
@@ -2079,7 +2079,7 @@ func (ModuleSuite) TestReservedWords(ctx context.Context, t *testctx.T) {
 						With(daggerQuery(`{test{id}}`)).
 						Sync(ctx)
 
-					require.ErrorContains(t, err, "cannot define function with reserved name \"id\"")
+					requireErrOut(t, err, "cannot define function with reserved name \"id\"")
 				})
 			}
 		})
@@ -2296,22 +2296,22 @@ func (ModuleSuite) TestCurrentModuleAPI(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(daggerCall("escape-file", "contents")).
 				Stdout(ctx)
-			require.ErrorContains(t, err, `workdir path "../rootfile.txt" escapes workdir`)
+			requireErrOut(t, err, `workdir path "../rootfile.txt" escapes workdir`)
 
 			_, err = ctr.
 				With(daggerCall("escape-file-abs", "contents")).
 				Stdout(ctx)
-			require.ErrorContains(t, err, `workdir path "/rootfile.txt" escapes workdir`)
+			requireErrOut(t, err, `workdir path "/rootfile.txt" escapes workdir`)
 
 			_, err = ctr.
 				With(daggerCall("escape-dir", "entries")).
 				Stdout(ctx)
-			require.ErrorContains(t, err, `workdir path "../foo" escapes workdir`)
+			requireErrOut(t, err, `workdir path "../foo" escapes workdir`)
 
 			_, err = ctr.
 				With(daggerCall("escape-dir-abs", "entries")).
 				Stdout(ctx)
-			require.ErrorContains(t, err, `workdir path "/foo" escapes workdir`)
+			requireErrOut(t, err, `workdir path "/foo" escapes workdir`)
 		})
 	})
 }
@@ -2428,7 +2428,7 @@ func (ModuleSuite) TestHostError(ctx context.Context, t *testctx.T) {
 		).
 		With(daggerCall("fn")).
 		Sync(ctx)
-	require.ErrorContains(t, err, "dag.Host undefined")
+	requireErrOut(t, err, "dag.Host undefined")
 }
 
 // TestModuleEngineError verifies the engine api is not exposed to modules
@@ -2452,7 +2452,7 @@ func (ModuleSuite) TestEngineError(ctx context.Context, t *testctx.T) {
 		).
 		With(daggerCall("fn")).
 		Sync(ctx)
-	require.ErrorContains(t, err, "dag.Engine undefined")
+	requireErrOut(t, err, "dag.Engine undefined")
 }
 
 func (ModuleSuite) TestDaggerListen(ctx context.Context, t *testctx.T) {
@@ -4700,28 +4700,28 @@ export class Test {
 					out, err := modGen.With(daggerCall("too-high-relative-dir-path")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, `path should be relative to the context directory`)
+					requireErrOut(t, err, `path should be relative to the context directory`)
 				})
 
 				t.Run("too high relative context file path", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("too-high-relative-file-path")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, `path should be relative to the context directory`)
+					requireErrOut(t, err, `path should be relative to the context directory`)
 				})
 
 				t.Run("non existing dir path", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("non-existing-path")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, "no such file or directory")
+					requireErrOut(t, err, "no such file or directory")
 				})
 
 				t.Run("non existing file", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("non-existing-file")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, "no such file or directory")
+					requireErrOut(t, err, "no such file or directory")
 				})
 			})
 		}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -56,7 +56,7 @@ func (ModuleSuite) TestInvalidSDK(ctx context.Context, t *testctx.T) {
 			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `The "foo-bar" SDK does not exist.`)
+		requireErrOut(t, err, `The "foo-bar" SDK does not exist.`)
 	})
 
 	t.Run("specifying version with either of go/python/typescript sdk returns error", func(ctx context.Context, t *testctx.T) {
@@ -71,7 +71,7 @@ func (ModuleSuite) TestInvalidSDK(ctx context.Context, t *testctx.T) {
 			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `the go sdk does not currently support selecting a specific version`)
+		requireErrOut(t, err, `the go sdk does not currently support selecting a specific version`)
 	})
 }
 

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -995,27 +995,27 @@ export class Test {
 			require.NoError(t, err)
 			require.Equal(t, "linux/amd64", gjson.Get(out, "test.fromPlatform").String())
 			_, err = modGen.With(daggerQuery(`{test{fromPlatform(platform: "invalid")}}`)).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 
 			out, err = modGen.With(daggerQuery(`{test{toPlatform(platform: "linux/amd64")}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "linux/amd64", gjson.Get(out, "test.toPlatform").String())
 			_, err = modGen.With(daggerQuery(`{test{toPlatform(platform: "invalid")}}`)).Sync(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 
 			out, err = modGen.With(daggerQuery(`{test{fromPlatforms(platform: ["linux/amd64"])}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(gjson.Get(out, "test.fromPlatforms").Array()))
 			require.Equal(t, "linux/amd64", gjson.Get(out, "test.fromPlatforms.0").String())
 			_, err = modGen.With(daggerQuery(`{test{fromPlatforms(platform: ["invalid"])}}`)).Stdout(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 
 			out, err = modGen.With(daggerQuery(`{test{toPlatforms(platform: ["linux/amd64"])}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(gjson.Get(out, "test.toPlatforms.0").Array()))
 			require.Equal(t, "linux/amd64", gjson.Get(out, "test.toPlatforms.0").String())
 			_, err = modGen.With(daggerQuery(`{test{toPlatforms(platform: ["invalid"])}}`)).Sync(ctx)
-			require.ErrorContains(t, err, "unknown operating system or architecture")
+			requireErrOut(t, err, "unknown operating system or architecture")
 		})
 	}
 }
@@ -1097,14 +1097,14 @@ export class Test {
 			require.Equal(t, "TCP", gjson.Get(out, "test.fromProto").String())
 
 			_, err = modGen.With(daggerQuery(`{test{fromProto(proto: "INVALID")}}`)).Stdout(ctx)
-			require.ErrorContains(t, err, "invalid enum value")
+			requireErrOut(t, err, "invalid enum value")
 
 			out, err = modGen.With(daggerQuery(`{test{toProto(proto: "TCP")}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "TCP", gjson.Get(out, "test.toProto").String())
 
 			_, err = modGen.With(daggerQuery(`{test{toProto(proto: "INVALID")}}`)).Sync(ctx)
-			require.ErrorContains(t, err, "invalid enum value")
+			requireErrOut(t, err, "invalid enum value")
 		})
 	}
 }
@@ -1260,7 +1260,7 @@ export class Test {
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.status").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatus(status: "INVALID")}}`)).Stdout(ctx)
-				require.ErrorContains(t, err, "invalid enum value")
+				requireErrOut(t, err, "invalid enum value")
 
 				// fromStatusOpt
 				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt}}`)).Stdout(ctx)
@@ -1272,7 +1272,7 @@ export class Test {
 				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatusOpt").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "INVALID")}}`)).Stdout(ctx)
-				require.ErrorContains(t, err, "invalid enum value")
+				requireErrOut(t, err, "invalid enum value")
 
 				// toStatus
 				out, err = modGen.With(daggerQuery(`{test{toStatus(status: "INACTIVE")}}`)).Stdout(ctx)
@@ -1280,7 +1280,7 @@ export class Test {
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.toStatus").String())
 
 				_, err = modGen.With(daggerQuery(`{test{toStatus(status: "INVALID")}}`)).Sync(ctx)
-				require.ErrorContains(t, err, "invalid enum value")
+				requireErrOut(t, err, "invalid enum value")
 
 				// introspection
 				mod := inspectModule(ctx, t, modGen)

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -227,7 +227,7 @@ func (TypescriptSuite) TestInit(ctx context.Context, t *testctx.T) {
 		_, err := modGen.
 			With(daggerQuery(`{hasPkgJson{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
-		require.ErrorContains(t, err, "merge is only supported")
+		requireErrOut(t, err, "merge is only supported")
 	})
 
 	t.Run("init module in .dagger if files present in current dir", func(ctx context.Context, t *testctx.T) {
@@ -1283,7 +1283,7 @@ export class Test {
 `))
 
 		_, err := modGen.With(daggerQuery(`{test{str("hello")}}`)).Stdout(ctx)
-		require.ErrorContains(t, err, "Use of primitive 'String' type detected, please use 'string' instead.")
+		requireErrOut(t, err, "Use of primitive 'String' type detected, please use 'string' instead.")
 	})
 
 	t.Run("should throw error on Number", func(ctx context.Context, t *testctx.T) {
@@ -1306,7 +1306,7 @@ export class Test {
 `))
 
 		_, err := modGen.With(daggerQuery(`{test{integer(4)}}`)).Stdout(ctx)
-		require.ErrorContains(t, err, "Use of primitive 'Number' type detected, please use 'number' instead.")
+		requireErrOut(t, err, "Use of primitive 'Number' type detected, please use 'number' instead.")
 	})
 
 	t.Run("should throw error on Boolean", func(ctx context.Context, t *testctx.T) {
@@ -1329,7 +1329,7 @@ export class Test {
 `))
 
 		_, err := modGen.With(daggerQuery(`{test{bool(false)}}`)).Stdout(ctx)
-		require.ErrorContains(t, err, "Use of primitive 'Boolean' type detected, please use 'boolean' instead.")
+		requireErrOut(t, err, "Use of primitive 'Boolean' type detected, please use 'boolean' instead.")
 	})
 }
 

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -948,10 +948,10 @@ export class Foo {}
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+function\s+%q\s+cannot\s+return\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Test", "fn", "dep",
-			), err.Error())
+			))
 		})
 
 		t.Run("list", func(ctx context.Context, t *testctx.T) {
@@ -969,10 +969,10 @@ export class Foo {}
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+function\s+%q\s+cannot\s+return\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Test", "fn", "dep",
-			), err.Error())
+			))
 		})
 	})
 
@@ -990,10 +990,10 @@ export class Test {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+function\s+%q\s+arg\s+%q\s+cannot\s+reference\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Test", "fn", "obj", "dep",
-			), err.Error())
+			))
 		})
 
 		t.Run("list", func(ctx context.Context, t *testctx.T) {
@@ -1010,10 +1010,10 @@ export class Test {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+function\s+%q\s+arg\s+%q\s+cannot\s+reference\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Test", "fn", "obj", "dep",
-			), err.Error())
+			))
 		})
 	})
 
@@ -1040,10 +1040,10 @@ export class Obj {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+field\s+%q\s+cannot\s+reference\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Obj", "foo", "dep",
-			), err.Error())
+			))
 		})
 
 		t.Run("list", func(ctx context.Context, t *testctx.T) {
@@ -1068,10 +1068,10 @@ export class Obj {
 				With(daggerFunctions()).
 				Stdout(ctx)
 			require.Error(t, err)
-			require.Regexp(t, fmt.Sprintf(
+			requireErrRegexp(t, err, fmt.Sprintf(
 				`object\s+%q\s+field\s+%q\s+cannot\s+reference\s+external\s+type\s+from\s+dependency\s+module\s+%q`,
 				"Obj", "foo", "dep",
-			), err.Error())
+			))
 		})
 	})
 }

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -194,7 +194,7 @@ func (PlatformSuite) TestInvalid(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	_, err := c.Container(dagger.ContainerOpts{Platform: "windows98"}).ID(ctx)
-	require.ErrorContains(t, err, "unknown operating system or architecture")
+	requireErrOut(t, err, "unknown operating system or architecture")
 }
 
 func (PlatformSuite) TestWindows(ctx context.Context, t *testctx.T) {

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -349,7 +349,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					WithExec([]string{"curl", "-v", f.httpsServerURL.String()}).
 					Stderr(ctx)
 				// curl WON'T exit 0 if it gets a 407 when using TLS, so DO expect an error
-				require.ErrorContains(t, err, "< HTTP/1.1 407 Proxy Authentication Required")
+				requireErrOut(t, err, "< HTTP/1.1 407 Proxy Authentication Required")
 			}},
 		)
 	})

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -944,7 +944,7 @@ func (ContainerSuite) TestExecServicesError(ctx context.Context, t *testctx.T) {
 
 	_, err = client.Sync(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "start "+host+" (aliased as www): exited:")
+	requireErrOut(t, err, "start "+host+" (aliased as www): exited:")
 }
 
 func (ContainerSuite) TestServiceNoExec(ctx context.Context, t *testctx.T) {
@@ -967,7 +967,7 @@ func (ContainerSuite) TestServiceNoExec(ctx context.Context, t *testctx.T) {
 
 	_, err = client.Sync(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "start "+host+" (aliased as www)")
+	requireErrOut(t, err, "start "+host+" (aliased as www)")
 }
 
 //go:embed testdata/udp-service.go
@@ -1557,7 +1557,7 @@ func (FileSuite) TestServiceSync(ctx context.Context, t *testctx.T) {
 		}).Sync(ctx)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "status 404")
+		requireErrOut(t, err, "status 404")
 	})
 
 	t.Run("with chaining", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -329,3 +329,22 @@ func preventCacheMountPrune(ctx context.Context, t *testctx.T, c *dagger.Client,
 		return eg.Wait()
 	}
 }
+
+// requireErrOut is the same as require.ErrorContains, except it also looks in
+// the Stdout/Stderr of a *dagger.ExecErr, since that's something we do a lot
+// in tests.
+//
+// TODO: A better alternative might be to record the log output and assert
+// against what the user sees there, but that's a bigger lift.
+func requireErrOut(t *testctx.T, err error, out string) {
+	var execErr *dagger.ExecError
+	if errors.As(err, &execErr) {
+		require.Contains(
+			t,
+			fmt.Sprintf("%s\nStdout: %s\nStderr: %s", err, execErr.Stdout, execErr.Stderr),
+			out,
+		)
+		return
+	}
+	require.ErrorContains(t, err, out)
+}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -348,3 +348,22 @@ func requireErrOut(t *testctx.T, err error, out string) {
 	}
 	require.ErrorContains(t, err, out)
 }
+
+// requireErrRegexp is the same as require.Regexp against err.Error(), except
+// it also looks in the Stdout/Stderr of a *dagger.ExecErr, since that's
+// something we do a lot in tests.
+//
+// TODO: A better alternative might be to record the log output and assert
+// against what the user sees there, but that's a bigger lift.
+func requireErrRegexp(t *testctx.T, err error, re string) {
+	var execErr *dagger.ExecError
+	if errors.As(err, &execErr) {
+		require.Regexp(
+			t,
+			re,
+			fmt.Sprintf("%s\nStdout: %s\nStderr: %s", err, execErr.Stdout, execErr.Stderr),
+		)
+		return
+	}
+	require.Regexp(t, re, err.Error())
+}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -312,7 +312,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 			return nil, errors.New(errInst.Self.Message)
 		}
 		if fn.metadata.OriginalName == "" {
-			return nil, fmt.Errorf("call constructor: %w", err)
+			return nil, fmt.Errorf("call constructor: %w\n\n%s", err, InspectError(err))
 		} else {
 			return nil, fmt.Errorf("call function %q: %w", fn.metadata.OriginalName, err)
 		}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -312,7 +312,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 			return nil, errors.New(errInst.Self.Message)
 		}
 		if fn.metadata.OriginalName == "" {
-			return nil, fmt.Errorf("call constructor: %w\n\n%s", err, InspectError(err))
+			return nil, fmt.Errorf("call constructor: %w", err)
 		} else {
 			return nil, fmt.Errorf("call function %q: %w", fn.metadata.OriginalName, err)
 		}

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -2,19 +2,23 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"dagger.io/dagger"
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func collectDefs(ctx context.Context, val dagql.Typed) []*pb.Definition {
@@ -30,6 +34,18 @@ func collectDefs(ctx context.Context, val dagql.Typed) []*pb.Definition {
 		}
 	}
 	return nil
+}
+
+func unwrapError(rerr error) string {
+	var execErr *dagger.ExecError
+	if errors.As(rerr, &execErr) {
+		return execErr.Message()
+	}
+	var gqlErr *gqlerror.Error
+	if errors.As(rerr, &gqlErr) {
+		return gqlErr.Message
+	}
+	return rerr.Error()
 }
 
 func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Context, func(res dagql.Typed, cached bool, rerr error)) {
@@ -81,7 +97,12 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 		Start(ctx, spanName, trace.WithAttributes(attrs...))
 
 	return ctx, func(res dagql.Typed, cached bool, err error) {
-		defer telemetry.End(span, func() error { return err })
+		defer telemetry.End(span, func() error {
+			if err != nil {
+				return errors.New(unwrapError(err) + "\n\n" + InspectError(err))
+			}
+			return nil
+		})
 
 		if cached {
 			// NOTE: this is never actually called on cache hits, but might be in the
@@ -179,4 +200,59 @@ func isIntrospection(id *call.ID) bool {
 	} else {
 		return isIntrospection(id.Receiver())
 	}
+}
+
+// InspectError deeply analyzes an error, unwrapping all layers and printing
+// detailed information about each error in the chain. It returns a string
+// containing the full error analysis.
+func InspectError(err error) string {
+	if err == nil {
+		return "nil error"
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Error Chain Analysis:\n")
+
+	// Track depth for indentation
+	depth := 0
+
+	// Examine current error
+	current := err
+	for current != nil {
+		// Create indentation based on depth
+		indent := strings.Repeat("  ", depth)
+
+		// Get error type
+		errType := reflect.TypeOf(current)
+		if errType.Kind() == reflect.Ptr {
+			errType = errType.Elem()
+		}
+
+		// Write error information
+		fmt.Fprintf(&builder, "%s→ Type: %v\n", indent, errType)
+		fmt.Fprintf(&builder, "%s  Message: %v\n", indent, current.Error())
+
+		// Check for additional error details
+		if unwrapped := errors.Unwrap(current); unwrapped != nil {
+			current = unwrapped
+			depth++
+		} else {
+			// Check for multiple wrapped errors using errors.As
+			switch v := current.(type) {
+			case interface{ Unwrap() []error }:
+				if errs := v.Unwrap(); len(errs) > 0 {
+					fmt.Fprintf(&builder, "%s  Multiple wrapped errors found (%d):\n", indent, len(errs))
+					for i, e := range errs {
+						depth++
+						fmt.Fprintf(&builder, "%s  Branch %d:\n", indent, i+1)
+						fmt.Fprintf(&builder, "%s%s", indent, InspectError(e))
+						depth--
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return builder.String()
 }

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -14,7 +14,7 @@ Expected stderr:
 
 ✔ viztest: Viztest! X.Xs
 ✘ .failLog: Void X.Xs
-! input: container.from.withEnvVariable.withExec.sync process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
+! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
 │ ✔ container: Container! X.Xs
 │ $ .from(address: "alpine"): Container! X.Xs CACHED
 │ │ ✔ resolving docker.io/library/alpine:latest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -14,7 +14,7 @@ Expected stderr:
 
 ✔ viztest: Viztest! X.Xs
 ✘ .pending: Void X.Xs
-! input: container.from.withEnvVariable.withExec.withExec.withExec.sync process "false" did not complete successfully: exit code: 1
+! process "false" did not complete successfully: exit code: 1
 │ ✔ container: Container! X.Xs
 │ $ .from(address: "alpine"): Container! X.Xs CACHED
 │ │ ✔ resolving docker.io/library/alpine:latest X.Xs

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/continuity/fs"
 	"github.com/dagger/dagger/dagql/idtui"
-	"github.com/dagger/dagger/engine"
 	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/contenthash"
 	cacheutil "github.com/moby/buildkit/cache/util"
@@ -288,11 +287,6 @@ func ConvertToWorkerCacheResult(ctx context.Context, res *solverresult.Result[*r
 }
 
 func wrapError(ctx context.Context, baseErr error, client *Client) error {
-	clientMeta, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get client metadata: %w", err)
-	}
-
 	var slowCacheErr *bksolver.SlowCacheError
 	if errors.As(baseErr, &slowCacheErr) {
 		if slowCacheErr.Result != nil {
@@ -356,18 +350,14 @@ func wrapError(ctx context.Context, baseErr error, client *Client) error {
 		return errors.Join(err, baseErr)
 	}
 
-	var stdoutBytes, stderrBytes []byte
-	if clientMeta.ExecErrorOutput {
-		stdoutBytes, err = getExecMetaFile(ctx, client, mntable, MetaMountStdoutPath)
-		if err != nil {
-			return errors.Join(err, baseErr)
-		}
-		stderrBytes, err = getExecMetaFile(ctx, client, mntable, MetaMountStderrPath)
-		if err != nil {
-			return errors.Join(err, baseErr)
-		}
+	stdoutBytes, err := getExecMetaFile(ctx, client, mntable, MetaMountStdoutPath)
+	if err != nil {
+		return errors.Join(err, baseErr)
 	}
-
+	stderrBytes, err := getExecMetaFile(ctx, client, mntable, MetaMountStderrPath)
+	if err != nil {
+		return errors.Join(err, baseErr)
+	}
 	exitCodeBytes, err := getExecMetaFile(ctx, client, mntable, MetaMountExitCodePath)
 	if err != nil {
 		return errors.Join(err, baseErr)

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1125,7 +1125,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		Interactive:               c.Interactive,
 		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
-		ExecErrorOutput:           true, //c.ExecErrorOutput,
+		ExecErrorOutput:           c.ExecErrorOutput,
 	}
 }
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1125,7 +1125,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		Interactive:               c.Interactive,
 		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
-		ExecErrorOutput:           c.ExecErrorOutput,
+		ExecErrorOutput:           true, //c.ExecErrorOutput,
 	}
 }
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -72,9 +72,6 @@ type Params struct {
 
 	DisableHostRW bool
 
-	// Enable collecting Stdout and Stderr for failed execs.
-	ExecErrorOutput bool
-
 	EngineCallback   func(context.Context, string, string, string)
 	CloudURLCallback func(context.Context, string, string, bool)
 
@@ -1125,7 +1122,6 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		Interactive:               c.Interactive,
 		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
-		ExecErrorOutput:           c.ExecErrorOutput,
 	}
 }
 

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -82,10 +82,6 @@ type ClientMetadata struct {
 
 	// SSH auth socket path
 	SSHAuthSocketPath string
-
-	// ExecErrorOutput determines whether to collect stdout/stderr for failed
-	// execs.
-	ExecErrorOutput bool
 }
 
 type clientMetadataCtxKey struct{}

--- a/sdk/elixir/.changes/unreleased/Breaking-20241122-121153.yaml
+++ b/sdk/elixir/.changes/unreleased/Breaking-20241122-121153.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |-
+    `ExecErr.message` no longer contains the values of `stdout` or `stderr`.
+
+    When comparing error values for expected output, use the more specific values.
+time: 2024-11-22T12:11:53.934008034Z
+custom:
+    Author: vito
+    PR: "9033"

--- a/sdk/elixir/lib/dagger/core/error.ex
+++ b/sdk/elixir/lib/dagger/core/error.ex
@@ -20,36 +20,6 @@ defmodule Dagger.Core.ExecError do
 
   @impl true
   def message(exception) do
-    stdout =
-      if String.trim(exception.stdout) != "" do
-        [
-          "Stdout:",
-          ?\n,
-          exception.stdout
-        ]
-      else
-        ""
-      end
-
-    stderr =
-      if String.trim(exception.stderr) != "" do
-        [
-          "Stderr:",
-          ?\n,
-          exception.stderr
-        ]
-      else
-        ""
-      end
-
-    [
-      Exception.message(exception.original_error),
-      ?\n,
-      stdout,
-      ?\n,
-      stderr,
-      ?\n
-    ]
-    |> IO.iodata_to_binary()
+    Exception.message(exception.original_error)
   end
 end

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -331,9 +331,7 @@ defmodule Dagger.ClientTest do
              |> Container.with_exec(["foobar"])
              |> Sync.sync()
 
-    assert Exception.message(error) == """
-           input: container.from.withExec.sync process \"foobar\" did not complete successfully: exit code: 2
-           """
+    assert Exception.message(error) == "input: container.from.withExec.sync process \"foobar\" did not complete successfully: exit code: 2"
   end
 
   test "iss 8601 - Dagger.Directory.with_directory/4 should not crash", %{dag: dag} do

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -333,9 +333,6 @@ defmodule Dagger.ClientTest do
 
     assert Exception.message(error) == """
            input: container.from.withExec.sync process \"foobar\" did not complete successfully: exit code: 2
-
-           Stderr:
-           [dumb-init] foobar: No such file or directory
            """
   end
 

--- a/sdk/go/.changes/unreleased/Breaking-20241122-121153.yaml
+++ b/sdk/go/.changes/unreleased/Breaking-20241122-121153.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |-
+    `ExecErr.Error` no longer contains the values of `Stdout` or `Stderr`.
+
+    When comparing error values for expected output, use the more specific values.
+time: 2024-11-22T12:11:53.934008034Z
+custom:
+    Author: vito
+    PR: "9033"

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -240,8 +240,6 @@ func TestExecError(t *testing.T) {
 		require.Equal(t, outMsg, exErr.Stdout)
 		require.Equal(t, errMsg, exErr.Stderr)
 
-		require.Contains(t, exErr.Error(), outMsg)
-		require.Contains(t, exErr.Error(), errMsg)
 		require.NotContains(t, exErr.Message(), outMsg)
 		require.NotContains(t, exErr.Message(), errMsg)
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel"
@@ -89,16 +88,7 @@ type ExecError struct {
 }
 
 func (e *ExecError) Error() string {
-	// As a default when just printing the error, include the stdout
-	// and stderr for visibility
-	msg := e.Message()
-	if strings.TrimSpace(e.Stdout) != "" {
-		msg += "\nStdout:\n" + e.Stdout
-	}
-	if strings.TrimSpace(e.Stderr) != "" {
-		msg += "\nStderr:\n" + e.Stderr
-	}
-	return msg
+	return e.Message()
 }
 
 func (e *ExecError) Message() string {

--- a/sdk/python/.changes/unreleased/Breaking-20241122-121153.yaml
+++ b/sdk/python/.changes/unreleased/Breaking-20241122-121153.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |-
+    `str(ExecErr)` no longer contains the values of `stdout` or `stderr`.
+
+    When comparing error values for expected output, use the more specific values.
+time: 2024-11-22T12:11:53.934008034Z
+custom:
+    Author: vito
+    PR: "9033"

--- a/sdk/python/src/dagger/_exceptions.py
+++ b/sdk/python/src/dagger/_exceptions.py
@@ -178,13 +178,8 @@ class ExecError(QueryError):
         self.stderr = ext["stderr"]
 
     def __str__(self):
-        """Prints the error message with stdout and stderr."""
-        msg = self.message
-        if self.stdout:
-            msg += f"\nStdout:\n{self.stdout}"
-        if self.stderr:
-            msg += f"\nStderr:\n{self.stderr}"
-        return msg
+        """Prints the original error message."""
+        return self.message
 
 
 __all__ = [

--- a/sdk/python/tests/client/test_execute_errors.py
+++ b/sdk/python/tests/client/test_execute_errors.py
@@ -125,4 +125,3 @@ async def test_exec_error(client: dagger.Client, httpx_mock: HTTPXMock):
     assert exc.stdout == ""
 
     assert "command not found" in str(exc)
-    assert "spam: not found" in str(exc)

--- a/sdk/typescript/.changes/unreleased/Breaking-20241122-121153.yaml
+++ b/sdk/typescript/.changes/unreleased/Breaking-20241122-121153.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |-
+    `ExecErr.toString` no longer contains the values of `stdout` or `stderr`.
+
+    When comparing error values for expected output, use the more specific values.
+time: 2024-11-22T12:11:53.934008034Z
+custom:
+    Author: vito
+    PR: "9033"

--- a/sdk/typescript/api/test/api.spec.ts
+++ b/sdk/typescript/api/test/api.spec.ts
@@ -249,8 +249,8 @@ describe("TypeScript SDK api", function () {
           assert.strictEqual(e.exitCode, 127)
           assert.strictEqual(e.stdout, stdout)
           assert.strictEqual(e.stderr, stderr)
-          assert(e.toString().includes(stdout))
-          assert(e.toString().includes(stderr))
+          assert(!e.toString().includes(stdout))
+          assert(!e.toString().includes(stderr))
           assert(!e.message.includes(stdout))
           assert(!e.message.includes(stderr))
         } else {

--- a/sdk/typescript/common/errors/ExecError.ts
+++ b/sdk/typescript/common/errors/ExecError.ts
@@ -45,8 +45,4 @@ export class ExecError extends DaggerSDKError {
     this.stdout = options.stdout
     this.stderr = options.stderr
   }
-
-  toString(): string {
-    return `${super.toString()}\nStdout:\n${this.stdout}\nStderr:\n${this.stderr}`
-  }
 }


### PR DESCRIPTION
Follow-up to #8442 for better backwards compatibility.

We'll still break anyone relying on `.Error()` to contain Stdout/Stderr, but at least now they can check the Stdout/Stderr fields on the error, which is more explicit anyway.

Included some prior attempts at preserving even the `Error()` behavior, but I think it's much too brittle to rely on, so I reverted it and added the alternative (less backwards-compatible) approach on top.

edit: brought back some of that error-unwrapping code, since it was pretty nice that it removed those noisy `input: container.withExec.withExec.withExec...` messages.