### PR TITLE
engine: fix cache volumes not being mounted into debug containers

### DIFF
--- a/.changes/unreleased/Fixed-20241121-211357.yaml
+++ b/.changes/unreleased/Fixed-20241121-211357.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix cache mounts not being included in interactive debug containers.
+time: 2024-11-21T21:13:57.27419464-08:00
+custom:
+  Author: sipsma
+  PR: "9034"


### PR DESCRIPTION
Reported in discord here: https://discord.com/channels/707636530424053791/1294027305231974480/1309270204806725664

The code for interactive debug containers was skipping over any mounts that weren't "normal layers" (cache mounts, tmpfs, etc.). Now it correctly handles those.