### PR TITLE
fix: insert `Module.withDependencies` in correct order

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1035,14 +1035,8 @@ func (s *moduleSchema) updateDeps(
 			return fmt.Errorf("unsupported dependency source kind: %s", dep.Source.Self.Kind)
 		}
 
-		depName := dep.Name
-		if dep.Name == "" {
-			// fill in default dep names if missing with the name of the module
-			depName = mod.DependenciesField[i].Self.Name()
-		}
-
 		modCfg.Dependencies[i] = &modules.ModuleConfigDependency{
-			Name:   depName,
+			Name:   dep.Name,
 			Source: srcStr,
 			Pin:    pinStr,
 		}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -661,12 +661,20 @@ func (s *moduleSchema) moduleSourceDependencies(
 					return fmt.Errorf("failed to resolve dependency: %w", err)
 				}
 
+				name := depCfg.Name
+				if name == "" {
+					name, err = resolvedDepSrc.Self.ModuleName(ctx)
+					if err != nil {
+						return fmt.Errorf("failed to load module name: %w", err)
+					}
+				}
+
 				err = s.dag.Select(ctx, s.dag.Root(), &existingDeps[i],
 					dagql.Selector{
 						Field: "moduleDependency",
 						Args: []dagql.NamedInput{
 							{Name: "source", Value: dagql.NewID[*core.ModuleSource](resolvedDepSrc.ID())},
-							{Name: "name", Value: dagql.String(depCfg.Name)},
+							{Name: "name", Value: dagql.String(name)},
 						},
 					},
 				)
@@ -698,12 +706,20 @@ func (s *moduleSchema) moduleSourceDependencies(
 				return fmt.Errorf("failed to resolve dependency: %w", err)
 			}
 
+			name := dep.Self.Name
+			if name == "" {
+				name, err = resolvedDepSrc.Self.ModuleName(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to load module name: %w", err)
+				}
+			}
+
 			err = s.dag.Select(ctx, s.dag.Root(), &newDeps[i],
 				dagql.Selector{
 					Field: "moduleDependency",
 					Args: []dagql.NamedInput{
 						{Name: "source", Value: dagql.NewID[*core.ModuleSource](resolvedDepSrc.ID())},
-						{Name: "name", Value: dagql.String(dep.Self.Name)},
+						{Name: "name", Value: dagql.String(name)},
 					},
 				},
 			)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -613,6 +613,44 @@ func (s *moduleSchema) moduleSourceDependencies(
 		return nil, fmt.Errorf("failed to get module config: %w", err)
 	}
 
+	resolveDep := func(ctx context.Context, depName string, depSrc dagql.Instance[*core.ModuleSource]) (inst dagql.Instance[*core.ModuleDependency], err error) {
+		var resolvedDepSrc dagql.Instance[*core.ModuleSource]
+		err = s.dag.Select(ctx, src, &resolvedDepSrc,
+			dagql.Selector{
+				Field: "resolveDependency",
+				Args: []dagql.NamedInput{
+					{Name: "dep", Value: dagql.NewID[*core.ModuleSource](depSrc.ID())},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to resolve dependency: %w", err)
+		}
+
+		if depName == "" {
+			// this happens if installing a new module without an explicit
+			// name or upgrading from an old config that doesn't have a name set
+			depName, err = resolvedDepSrc.Self.ModuleName(ctx)
+			if err != nil {
+				return inst, fmt.Errorf("failed to load module name: %w", err)
+			}
+		}
+
+		err = s.dag.Select(ctx, s.dag.Root(), &inst,
+			dagql.Selector{
+				Field: "moduleDependency",
+				Args: []dagql.NamedInput{
+					{Name: "source", Value: dagql.NewID[*core.ModuleSource](resolvedDepSrc.ID())},
+					{Name: "name", Value: dagql.String(depName)},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to create module dependency: %w", err)
+		}
+		return inst, nil
+	}
+
 	var existingDeps []dagql.Instance[*core.ModuleDependency]
 	if ok {
 		bk, err := src.Self.Query.Buildkit(ctx)
@@ -648,40 +686,8 @@ func (s *moduleSchema) moduleSourceDependencies(
 					return fmt.Errorf("failed to create module source from dependency: %w", err)
 				}
 
-				var resolvedDepSrc dagql.Instance[*core.ModuleSource]
-				err = s.dag.Select(ctx, src, &resolvedDepSrc,
-					dagql.Selector{
-						Field: "resolveDependency",
-						Args: []dagql.NamedInput{
-							{Name: "dep", Value: dagql.NewID[*core.ModuleSource](depSrc.ID())},
-						},
-					},
-				)
-				if err != nil {
-					return fmt.Errorf("failed to resolve dependency: %w", err)
-				}
-
-				name := depCfg.Name
-				if name == "" {
-					name, err = resolvedDepSrc.Self.ModuleName(ctx)
-					if err != nil {
-						return fmt.Errorf("failed to load module name: %w", err)
-					}
-				}
-
-				err = s.dag.Select(ctx, s.dag.Root(), &existingDeps[i],
-					dagql.Selector{
-						Field: "moduleDependency",
-						Args: []dagql.NamedInput{
-							{Name: "source", Value: dagql.NewID[*core.ModuleSource](resolvedDepSrc.ID())},
-							{Name: "name", Value: dagql.String(name)},
-						},
-					},
-				)
-				if err != nil {
-					return fmt.Errorf("failed to create module dependency: %w", err)
-				}
-				return nil
+				existingDeps[i], err = resolveDep(ctx, depCfg.Name, depSrc)
+				return err
 			})
 		}
 		if err := eg.Wait(); err != nil {
@@ -693,40 +699,8 @@ func (s *moduleSchema) moduleSourceDependencies(
 	var eg errgroup.Group
 	for i, dep := range src.Self.WithDependencies {
 		eg.Go(func() error {
-			var resolvedDepSrc dagql.Instance[*core.ModuleSource]
-			err := s.dag.Select(ctx, src, &resolvedDepSrc,
-				dagql.Selector{
-					Field: "resolveDependency",
-					Args: []dagql.NamedInput{
-						{Name: "dep", Value: dagql.NewID[*core.ModuleSource](dep.Self.Source.ID())},
-					},
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to resolve dependency: %w", err)
-			}
-
-			name := dep.Self.Name
-			if name == "" {
-				name, err = resolvedDepSrc.Self.ModuleName(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to load module name: %w", err)
-				}
-			}
-
-			err = s.dag.Select(ctx, s.dag.Root(), &newDeps[i],
-				dagql.Selector{
-					Field: "moduleDependency",
-					Args: []dagql.NamedInput{
-						{Name: "source", Value: dagql.NewID[*core.ModuleSource](resolvedDepSrc.ID())},
-						{Name: "name", Value: dagql.String(name)},
-					},
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create module dependency: %w", err)
-			}
-			return nil
+			newDeps[i], err = resolveDep(ctx, dep.Self.Name, dep.Self.Source)
+			return err
 		})
 	}
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
Previously, calling `dagger install` with no name would bizarrely insert it into the beginning of the `dagger.json` `dependencies` field. Then calling `dagger develop` would fix it.

This was an absurd little pet-peeve, so took some time to fix it - it will be nice when we can clean up `ModuleSource.resolveFromCaller`, since trying to understand that for this bug was by far the trickiest bit to actually understand and track.

This is what was happening:
- We call `updateDeps` to update our dependencies.
- We were calling `ModuleSource.dependencies` (which merges `withDependencies` nicely) and getting all ordered dependencies.
- However, no name was specified in the `withDependencies` call, so the name was actually the empty string - so was appearing first in the lexigraphic sort.
- Then, later in `updateDeps`, we fill in the missing name - this is correct, but is now too late for the sort, so we have the wrong order.

The solution is fairly simply - `dependencies` should fill in missing names if possible.

We *could* have added `updateDeps` as an alternative, but this is actually not great, since this means that `dependencies` would still be returning `dependencies` that have no name - which is a potential footgun for the next person coming along.