### PR TITLE
fix(engine): don't configure metrics export timeout

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -627,14 +627,12 @@ func (srv *Server) initializeDaggerClient(
 	}
 
 	const metricReaderInterval = 1 * time.Second
-	const metricReaderTimeout = 1 * time.Second
 
 	meterOpts := []sdkmetric.Option{
 		sdkmetric.WithResource(telemetry.Resource),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(
 			srv.telemetryPubSub.Metrics(client),
 			sdkmetric.WithInterval(metricReaderInterval),
-			sdkmetric.WithTimeout(metricReaderTimeout),
 		)),
 	}
 
@@ -655,7 +653,6 @@ func (srv *Server) initializeDaggerClient(
 			sdkmetric.NewPeriodicReader(
 				srv.telemetryPubSub.Metrics(parent),
 				sdkmetric.WithInterval(metricReaderInterval),
-				sdkmetric.WithTimeout(metricReaderTimeout),
 			),
 		))
 	}

--- a/sdk/go/telemetry/init.go
+++ b/sdk/go/telemetry/init.go
@@ -442,13 +442,10 @@ func Init(ctx context.Context, cfg Config) context.Context {
 			sdkmetric.WithResource(cfg.Resource),
 		}
 		const metricsExportInterval = 1 * time.Second
-		const metricsExportTimeout = 1 * time.Second
 		for _, exp := range cfg.LiveMetricExporters {
 			MetricExporters = append(MetricExporters, exp)
 			reader := sdkmetric.NewPeriodicReader(exp,
-				sdkmetric.WithInterval(metricsExportInterval),
-				sdkmetric.WithTimeout(metricsExportTimeout),
-			)
+				sdkmetric.WithInterval(metricsExportInterval))
 			meterOpts = append(meterOpts, sdkmetric.WithReader(reader))
 		}
 		ctx = WithMeterProvider(ctx, sdkmetric.NewMeterProvider(meterOpts...))


### PR DESCRIPTION
1 second is a bit too low, and it seems like we hit it in some deployment environments. Asked @sipsma and it sounds like there wasn't a major reason to set it, likely just a placeholder. Let's just ride with the default (currently 30s) until it's proven that we need to set something different.

cc @gerhard 