### PR TITLE
feat(cli): detect OTel resource attributes

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -68,7 +68,7 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 	// Setup telemetry config
 	telemetryCfg := telemetry.Config{
 		Detect:   true,
-		Resource: Resource(),
+		Resource: Resource(ctx),
 
 		LiveTraceExporters:  []sdktrace.SpanExporter{Frontend.SpanExporter()},
 		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},


### PR DESCRIPTION
This allows an operator to set arbitrary resource attributes for annotating traces, using the standard [`OTEL_RESOURCE_ATTRIBUTES`](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_resource_attributes) env.