### PR TITLE
ci: invalidate install scripts cache after publishing

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -39,9 +39,10 @@ func (cli *CLI) Publish(
 
 	awsAccessKeyID *dagger.Secret,
 	awsSecretAccessKey *dagger.Secret,
-	awsRegion *dagger.Secret,
-	awsBucket *dagger.Secret,
 
+	awsRegion string,
+	awsBucket string,
+	awsCloudfrontDistribution string,
 	artefactsFQDN string,
 ) error {
 	ctr, err := publishEnv(ctx)
@@ -84,8 +85,9 @@ func (cli *CLI) Publish(
 		WithSecretVariable("GORELEASER_KEY", goreleaserKey).
 		WithSecretVariable("AWS_ACCESS_KEY_ID", awsAccessKeyID).
 		WithSecretVariable("AWS_SECRET_ACCESS_KEY", awsSecretAccessKey).
-		WithSecretVariable("AWS_REGION", awsRegion).
-		WithSecretVariable("AWS_BUCKET", awsBucket).
+		WithEnvVariable("AWS_REGION", awsRegion).
+		WithEnvVariable("AWS_BUCKET", awsBucket).
+		WithEnvVariable("AWS_CLOUDFRONT_DISTRIBUTION_ID", awsCloudfrontDistribution).
 		WithEnvVariable("ARTEFACTS_FQDN", artefactsFQDN).
 		WithEnvVariable("ENGINE_VERSION", cli.Dagger.Version).
 		WithEnvVariable("ENGINE_TAG", cli.Dagger.Tag).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,16 +49,18 @@ jobs:
             --goreleaser-key=env:GORELEASER_KEY \
             --aws-access-key-id=env:AWS_ACCESS_KEY_ID \
             --aws-secret-access-key=env:AWS_SECRET_ACCESS_KEY \
-            --aws-region=env:AWS_REGION \
-            --aws-bucket=env:AWS_BUCKET \
+            --aws-region="$AWS_REGION" \
+            --aws-bucket="$AWS_BUCKET" \
+            --aws-cloudfront-distribution="$AWS_CLOUDFRONT_DISTRIBUTION" \
             --artefacts-fqdn="$ARTEFACTS_FQDN"
         env:
           GH_ORG_NAME: ${{ vars.GH_ORG_NAME }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
-          AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
+          AWS_REGION: ${{ vars.RELEASE_AWS_REGION }}
+          AWS_BUCKET: ${{ vars.RELEASE_AWS_BUCKET }}
+          AWS_CLOUDFRONT_DISTRIBUTION: ${{ vars.RELEASE_AWS_CLOUDFRONT_DISTRIBUTION }}
           ARTEFACTS_FQDN: ${{ vars.RELEASE_FQDN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_LICENSE_KEY }}
       - name: "Notify"

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -56,3 +56,12 @@ publishers:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-install-ps1
+    cmd: sh -c "aws cloudfront create-invalidation --distribution-id {{ .Env.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths /dagger/install.sh /dagger/install.ps1"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_CLOUDFRONT_DISTRIBUTION_ID={{ .Env.AWS_CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
This invalidates the cloudfront cache for `install.sh` and `install.ps1` after publishing.

Also, we change some secrets to vars, while we're here.