### PR TITLE
core(git): ensure socket is passed to functions + update socket implementation following Alex's purity PR

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -362,9 +362,9 @@ func makeGitDirectory(gitURL *gitutil.GitURL, dag *dagger.Client) *dagger.Direct
 	gitOpts := dagger.GitOpts{
 		KeepGitDir: true,
 	}
-	if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
-		gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
-	}
+	// if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
+	// 	gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
+	// }
 	git := dag.Git(gitURL.Remote, gitOpts)
 	var gitRef *dagger.GitRef
 	if gitURL.Fragment.Ref == "" {
@@ -425,9 +425,9 @@ func (v *fileValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleS
 		gitOpts := dagger.GitOpts{
 			KeepGitDir: true,
 		}
-		if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
-			gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
-		}
+		// if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
+		// 	gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
+		// }
 		git := dag.Git(parsedGit.Remote, gitOpts)
 		var gitRef *dagger.GitRef
 		if parsedGit.Fragment.Ref == "" {

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -362,9 +362,6 @@ func makeGitDirectory(gitURL *gitutil.GitURL, dag *dagger.Client) *dagger.Direct
 	gitOpts := dagger.GitOpts{
 		KeepGitDir: true,
 	}
-	// if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
-	// 	gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
-	// }
 	git := dag.Git(gitURL.Remote, gitOpts)
 	var gitRef *dagger.GitRef
 	if gitURL.Fragment.Ref == "" {
@@ -425,9 +422,6 @@ func (v *fileValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleS
 		gitOpts := dagger.GitOpts{
 			KeepGitDir: true,
 		}
-		// if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
-		// 	gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
-		// }
 		git := dag.Git(parsedGit.Remote, gitOpts)
 		var gitRef *dagger.GitRef
 		if parsedGit.Fragment.Ref == "" {

--- a/core/host.go
+++ b/core/host.go
@@ -153,6 +153,7 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 				Value: dagql.Opt(dagql.NewString(accessor)),
 			},
 		},
+		Pure: true,
 	})
 	if err != nil {
 		return i, fmt.Errorf("failed to select secret: %w", err)

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -273,8 +273,8 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.Instance[*core.Query],
 		inst = instWithToken
 	}
 
-	// set the auth socket by selecting withAuthToken so that it shows up in the dagql call
-	// as a secret and can thus be passed to functions
+	// set the auth socket by selecting __internalwithSSHSocket so that it shows up in the dagql call
+	// as a socket and can thus be passed to functions
 	if authSock.Self != nil {
 		var instWithSocket dagql.Instance[*core.GitRepository]
 		err := s.srv.Select(ctx, inst, &instWithSocket,


### PR DESCRIPTION
This PR originates from a follow-up of: https://github.com/dagger/dagger/pull/8805/commits/e86d0d4c88981532bd0840ebd809e7b2d18fc2dd

The same issue existed for the SSH ref:
> In order for a function to be granted selective access to a socket, the socket needs to appear in the dagql call. Previously the socket was just set on a field in the returned struct, now it is in the returned dagql.Instance and thus passes to function clients through args.

### What does that mean ?

Concretely, it means that the `core/schema/git()` implementation needs to make sure that, when returning its `core.GitRepository` object, and in order for other functions using that object (a version requiring auth [via socket or secret]), those fields have to also be part of the dagql ID.

We had no test for this edge case. It turns out that we were not encountering this subtle bug because the CLI had until now the responsibility of mounting the SSH socket.

However, with the progressive move from CLI -> SHELL + more and more implementation in which it is the engine requesting the host for credentials, this responsibility seems redundant.

### How ?

In order to fix, I implemented an `__internalWithSSHSocket` whose aim is just to ensure that the dagql ID does have the socket in its ID so that external functions are able to access the socket

### Related

Now, in the meantime, Alex also added the [selective purity feature](https://github.com/dagger/dagger/pull/8971) to dagql, meaning that we could refactor the `unixSocket` and implement the`ipSocket` API (extracted from a closed PR):
1. remove the `__internalSocket`
2. Define the `unixSocket` and `ipSocket` as impure API calls that return pure values (due to the accessor, ensuring that its ID is pure at runtime)

### Test
A test case towards this edge case has also been added