### PR TITLE
feat: shell autocomplete

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -2100,6 +2100,12 @@ to the currently loaded module.
 				}
 				return cmd.Send(h.newDepsState())
 			},
+			Complete: func(ctx *CompletionContext, _ []string) *CompletionContext {
+				return &CompletionContext{
+					Completer: ctx.Completer,
+					CmdRoot:   shellDepsCmdName,
+				}
+			},
 		},
 		&ShellCommand{
 			Use:         shellStdlibCmdName,
@@ -2109,6 +2115,12 @@ to the currently loaded module.
 			Run: func(cmd *ShellCommand, _ []string, _ *ShellState) error {
 				return cmd.Send(h.newStdlibState())
 			},
+			Complete: func(ctx *CompletionContext, _ []string) *CompletionContext {
+				return &CompletionContext{
+					Completer: ctx.Completer,
+					CmdRoot:   shellStdlibCmdName,
+				}
+			},
 		},
 		&ShellCommand{
 			Use:         ".core [function]",
@@ -2116,6 +2128,12 @@ to the currently loaded module.
 			State:       NoState,
 			Run: func(cmd *ShellCommand, args []string, _ *ShellState) error {
 				return cmd.Send(h.newCoreState())
+			},
+			Complete: func(ctx *CompletionContext, _ []string) *CompletionContext {
+				return &CompletionContext{
+					Completer: ctx.Completer,
+					CmdRoot:   shellCoreCmdName,
+				}
 			},
 		},
 		cobraToShellCommand(loginCmd),

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -2104,6 +2104,7 @@ to the currently loaded module.
 				return &CompletionContext{
 					Completer: ctx.Completer,
 					CmdRoot:   shellDepsCmdName,
+					root:      true,
 				}
 			},
 		},
@@ -2119,6 +2120,7 @@ to the currently loaded module.
 				return &CompletionContext{
 					Completer: ctx.Completer,
 					CmdRoot:   shellStdlibCmdName,
+					root:      true,
 				}
 			},
 		},
@@ -2133,6 +2135,7 @@ to the currently loaded module.
 				return &CompletionContext{
 					Completer: ctx.Completer,
 					CmdRoot:   shellCoreCmdName,
+					root:      true,
 				}
 			},
 		},
@@ -2187,6 +2190,7 @@ to the currently loaded module.
 					return &CompletionContext{
 						Completer:   ctx.Completer,
 						ModFunction: fn,
+						root:        true,
 					}
 				},
 			},

--- a/cmd/dagger/shell_completion.go
+++ b/cmd/dagger/shell_completion.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/chzyer/readline"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// shellAutoComplete is a wrapper for the shell call handler
+type shellAutoComplete struct {
+	// This is separated out, since we don't want to have to attach all these
+	// methods to the shellCallHandler directly
+	*shellCallHandler
+}
+
+var _ readline.AutoCompleter = (*shellAutoComplete)(nil)
+
+func (h *shellAutoComplete) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	file, err := parseShell(strings.NewReader(string(line)), "")
+	if err != nil {
+		return nil, 0
+	}
+
+	// find the smallest stmt next to the cursor - this allows accurate
+	// completion inside subshells, for example
+	var stmt *syntax.Stmt
+	excluded := map[*syntax.Stmt]struct{}{}
+	syntax.Walk(file, func(node syntax.Node) bool {
+		switch node := node.(type) {
+		case *syntax.BinaryCmd:
+			if node.Op == syntax.Pipe {
+				// pipes are special, and those statements aren't atomic
+				// because they're chained off of the previous ones - so avoid
+				// isolating them
+				excluded[node.X] = struct{}{}
+				excluded[node.Y] = struct{}{}
+			}
+		case *syntax.Stmt:
+			if stmt == nil {
+				stmt = node
+				break
+			}
+			if pos < int(node.Pos().Offset()) || pos > int(node.End().Offset()) {
+				return false
+			}
+			if _, ok := excluded[node]; !ok {
+				stmt = node
+			}
+		}
+		return true
+	})
+
+	var inprogressWord *syntax.Word
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if node, ok := node.(*syntax.Word); ok {
+			if node.End().Offset() == uint(pos) {
+				inprogressWord = node
+				return false
+			}
+		}
+		return true
+	})
+	var inprogressPrefix string
+	if inprogressWord != nil {
+		inprogressPrefix = inprogressWord.Lit()
+	}
+
+	// discard the in-progress word for the process of determining the
+	// auto-completion context (since it's likely to be invalid)
+	var cursor uint
+	if inprogressWord == nil {
+		cursor = uint(pos)
+	} else {
+		cursor = inprogressWord.Pos().Offset()
+	}
+
+	shctx := h.root()
+	if stmt != nil {
+		shctx = h.dispatch(shctx, stmt, cursor)
+	}
+	if shctx == nil {
+		return nil, 0
+	}
+
+	var results [][]rune
+	for _, result := range shctx.completions(inprogressPrefix) {
+		if result, ok := strings.CutPrefix(result, inprogressPrefix); ok {
+			results = append(results, []rune(result))
+		}
+	}
+	return results, len(inprogressPrefix)
+}
+
+func (h *shellAutoComplete) dispatch(previous *CompletionContext, stmt *syntax.Stmt, cursor uint) *CompletionContext {
+	if stmt == nil {
+		return previous
+	}
+	switch cmd := stmt.Cmd.(type) {
+	case *syntax.CallExpr:
+		return h.dispatchCall(previous, cmd, cursor)
+	case *syntax.BinaryCmd:
+		return h.dispatchPipe(previous, cmd, cursor)
+	}
+	return nil
+}
+
+func (h *shellAutoComplete) dispatchCall(previous *CompletionContext, call *syntax.CallExpr, cursor uint) *CompletionContext {
+	if call.Pos().Offset() >= cursor {
+		// short-circuit calls once we get past the current cursor context
+		return previous
+	}
+
+	args := make([]string, 0, len(call.Args))
+	for _, arg := range call.Args {
+		args = append(args, arg.Lit())
+	}
+	return previous.lookupField(args[0], args[1:])
+}
+
+func (h *shellAutoComplete) dispatchPipe(previous *CompletionContext, pipe *syntax.BinaryCmd, cursor uint) *CompletionContext {
+	if pipe.Op != syntax.Pipe {
+		return nil
+	}
+
+	previous = h.dispatch(previous, pipe.X, cursor)
+	if previous == nil {
+		return nil
+	}
+
+	if pipe.OpPos.Offset() >= cursor {
+		// short-circuit pipes once we get past the current cursor context
+		return previous
+	}
+	previous = previous.lookupType()
+	if previous == nil {
+		return nil
+	}
+
+	previous = h.dispatch(previous, pipe.Y, cursor)
+	return previous
+}
+
+func (h *shellAutoComplete) root() *CompletionContext {
+	def := h.modDef(nil)
+	return &CompletionContext{
+		Completer: h,
+		ModType:   def.MainObject.AsFunctionProvider(),
+		root:      true,
+	}
+}
+
+// CompletionContext provides completions for a specific point in a command
+// chain. Each point is represented by one of `Mod` prefixed fields being set
+// at a time.
+type CompletionContext struct {
+	Completer *shellAutoComplete
+
+	// ModType indicates the completions should be performed on an
+	// object/interface/etc.
+	ModType functionProvider
+	// ModFunc indicates the completions should be performed on the arguments
+	// for a function call.
+	ModFunction *modFunction
+
+	root bool
+}
+
+func (ctx *CompletionContext) completions(prefix string) []string {
+	var results []string
+	if ctx.ModFunction != nil {
+		// TODO: also complete required args sometimes (depending on type)
+
+		// complete optional args
+		if strings.HasPrefix(prefix, "-") {
+			for _, arg := range ctx.ModFunction.OptionalArgs() {
+				flag := "--" + arg.FlagName() + " "
+				results = append(results, flag)
+			}
+		}
+	} else if ctx.ModType != nil {
+		// complete possible functions for this type
+		for _, f := range ctx.ModType.GetFunctions() {
+			cmd := f.CmdName() + " "
+			results = append(results, cmd)
+		}
+		// complete potentially chainable builtins
+		for _, builtin := range ctx.builtins() {
+			cmd := builtin.Name() + " "
+			results = append(results, cmd)
+		}
+	}
+
+	return results
+}
+
+func (ctx *CompletionContext) lookupField(field string, args []string) *CompletionContext {
+	if builtin, _ := ctx.Completer.BuiltinCommand(field); builtin != nil {
+		if builtin.Complete == nil {
+			return nil
+		}
+		return builtin.Complete(ctx, args)
+	}
+
+	previous := ctx.ModType
+	if previous == nil {
+		previous = ctx.ModFunction.ReturnType.AsFunctionProvider()
+	}
+	if previous == nil {
+		return nil
+	}
+
+	def := ctx.Completer.modDef(nil)
+	next, err := def.GetObjectFunction(previous.ProviderName(), field)
+	if err != nil {
+		return nil
+	}
+	return &CompletionContext{
+		Completer:   ctx.Completer,
+		ModFunction: next,
+	}
+}
+
+func (ctx *CompletionContext) lookupType() *CompletionContext {
+	if ctx.ModType != nil {
+		return ctx
+	} else if ctx.ModFunction != nil {
+		def := ctx.Completer.modDef(nil)
+		next := def.GetFunctionProvider(ctx.ModFunction.ReturnType.Name())
+		return &CompletionContext{
+			Completer: ctx.Completer,
+			ModType:   next,
+		}
+	} else {
+		return nil
+	}
+}
+
+func (ctx *CompletionContext) builtins() []*ShellCommand {
+	if ctx.ModType == nil {
+		return nil
+	}
+	var builtins []*ShellCommand
+	for _, builtin := range ctx.Completer.Builtins() {
+		if ctx.root && builtin.State == RequiredState {
+			continue
+		} else if !ctx.root && builtin.State == NoState {
+			continue
+		}
+		builtins = append(builtins, builtin)
+	}
+	return builtins
+}

--- a/cmd/dagger/shell_completion_test.go
+++ b/cmd/dagger/shell_completion_test.go
@@ -20,12 +20,19 @@ func TestShellAutocomplete(t *testing.T) {
 	// options should include the contents after the $
 
 	cmdlines := []string{
-		// top-level
+		// top-level function
 		`<con$tainer >`,
 		`<$container >`,
 		`  <$container >`,
 		`<con$tainer > "alpine:latest"`,
 		`<con$tainer >| directory`,
+
+		// top-level deps
+		`<a$lpine >`,
+
+		// stdlib fallback
+		`<dir$ectory >`,
+		`directory | <with$-new-file >`,
 
 		// chaining
 		`container | <dir$ectory >`,
@@ -44,18 +51,24 @@ func TestShellAutocomplete(t *testing.T) {
 		`container <--$packages > | directory`,
 		`container | directory <--$expand >`,
 
-		// .container builtin
-		`<.con$tainer >`,
-		`<$.container >`,
-		`.container <--$platform >`,
-		`.container | <dir$ectory >`,
+		// .deps builtin
+		`<.dep$s >`,
+		`<$.deps >`,
+		`.deps | <a$lpine >`,
+
+		// .stdlib builtin
+		`<.std$lib >`,
+		`<$.stdlib >`,
+		`.stdlib | <con$tainer >`,
+		`.stdlib | container <--$platform >`,
+		`.stdlib | container | <dir$ectory >`,
 
 		// .core builtin
 		`<.co$re >`,
 		`<$.core >`,
-		`.core <con$tainer >`,
-		`.core container <--$platform >`,
-		`.core container | <dir$ectory >`,
+		`.core | <con$tainer >`,
+		`.core | container <--$platform >`,
+		`.core | container | <dir$ectory >`,
 
 		// FIXME: avoid inserting extra spaces
 		// `<contain$er> `,

--- a/cmd/dagger/shell_completion_test.go
+++ b/cmd/dagger/shell_completion_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellAutocomplete(t *testing.T) {
+	// each cmdline is a prompt input
+	// the contents of the angle brackets are the word we want to complete -
+	// everything before the $ sign is already written, and one of the response
+	// options should include the contents after the $
+
+	cmdlines := []string{
+		// top-level
+		`<con$tainer >`,
+		`<$container >`,
+		`  <$container >`,
+		`<con$tainer > "alpine:latest"`,
+		`<con$tainer >| directory`,
+
+		// chaining
+		`container | <dir$ectory >`,
+		`container | directory "./path" | <f$ile >`,
+		// NOTE: this requires parsing partial parse trees
+		// "container | <$directory >",
+
+		// subshells
+		// FIXME: this edge case should probably still work
+		// `container | with-directory $(<$container >)`,
+		`container | with-directory $(<con$tainer >)`,
+		`container | with-directory $(container | <dir$ectory >)`,
+
+		// args
+		`container <--$packages >`,
+		`container <--$packages > | directory`,
+		`container | directory <--$expand >`,
+
+		// .container builtin
+		`<.con$tainer >`,
+		`<$.container >`,
+		`.container <--$platform >`,
+		`.container | <dir$ectory >`,
+
+		// .core builtin
+		`<.co$re >`,
+		`<$.core >`,
+		`.core <con$tainer >`,
+		`.core container <--$platform >`,
+		`.core container | <dir$ectory >`,
+
+		// FIXME: avoid inserting extra spaces
+		// `<contain$er> `,
+	}
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.CopyFS(dir, os.DirFS(filepath.Join(wd, "../../modules"))))
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+
+	os.Chdir(dir)
+	t.Cleanup(func() {
+		os.Chdir(wd)
+	})
+	t.Setenv("DAGGER_MODULE", "./wolfi")
+
+	ctx := context.TODO()
+
+	client, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	handler := &shellCallHandler{
+		dag:    client,
+		stdin:  nil,
+		stdout: io.Discard,
+		stderr: io.Discard,
+		debug:  debug,
+	}
+	require.NoError(t, handler.RunAll(ctx, nil))
+	autoComplete := shellAutoComplete{handler}
+
+	for _, cmdline := range cmdlines {
+		t.Run(cmdline, func(t *testing.T) {
+			start := strings.IndexRune(cmdline, '<')
+			end := strings.IndexRune(cmdline, '>')
+			if start == -1 || end == -1 || !(start < end) {
+				require.FailNow(t, "invalid cmdline: could not find <expr>")
+			}
+			inprogress, expected, ok := strings.Cut(cmdline[start+1:end], "$")
+			if !ok {
+				require.FailNow(t, "invalid cmdline: no token '$' in <expr>")
+			}
+
+			cmdline := cmdline[:start] + inprogress + cmdline[end+1:]
+			cursor := start + len(inprogress)
+
+			results, length := autoComplete.Do([]rune(cmdline), cursor)
+			sresults := make([]string, 0, len(results))
+			for _, result := range results {
+				sresults = append(sresults, string(result))
+			}
+			require.Contains(t, sresults, expected)
+			require.Equal(t, len(inprogress), length)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces support for shell autocompletion. We allow auto-completing module commands, chained commands, builtins, arg flags, etc.

<a href="https://asciinema.org/a/WYvfoe6VCH66c8Nlb3YHzuuZ6" target="_blank"><img src="https://asciinema.org/a/WYvfoe6VCH66c8Nlb3YHzuuZ6.svg" /></a>

There's still some important functionality missing, but this is a good first pass. Some things we should maybe come back and do:
- We should allow autocompletion of args, such as `File`s and `Directory`s to paths on the host, and autocompletion of enums to their list of allowed values
- We should allow partial parse tree - so that we can handle cases like `.container | \t` to auto-complete functions on the container type. Currently, we need to have at least one character inserted.

---

TODO:
- [x] Determine "code completion context" at cursor
- [x] Autocomplete flags from context
- [ ] Autocomplete args of certain types from context (e.g. `dagger.File`/`dagger.Directory`)
  - This probably requires some way of parsing flags during auto-completion :cry: 
- [x] Autocomplete command names from context
- [x] Autocomplete builtins
- [ ] Support partial parse trees
  - Sort of working, but relies on a temporary fork: https://github.com/mvdan/sh/compare/master...jedevc:mvdan-sh:allow-partial-parse-tree
  - Moving this to a follow-up! https://github.com/jedevc/dagger/compare/jedevc:dagger:shell-autocomplete...shell-autocomplete-partial-parse-tree
- [x] Add tests!
  - Very important, this logic is very fragile!
- [x] Cleanup
