### PR TITLE
bump seconv to v1.25.0 to match otel v1.27.0

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	"{{.PackageImport}}/internal/dagger"
 	"{{.PackageImport}}/internal/telemetry"

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/term"
 

--- a/cmd/engine/telemetry.go
+++ b/cmd/engine/telemetry.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/engine"

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"go.opentelemetry.io/otel/trace"
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"

--- a/sdk/go/telemetry/init.go
+++ b/sdk/go/telemetry/init.go
@@ -23,7 +23,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Fixes breakage on `main` in telemetry tests 🙏

Tests failed because now we use the OTel detectors (via #9054), but we haven't actually been using the appropriate version of semconv for the version of OTel we're using, which OTel whines about, even though they're both semantically v1.x.x. This whole thing is pretty annoying for a package that's meant to just be a bunch of canonical names for common attributes. But, that's life.