### PR TITLE
config: Allow $schema in dagger.json

### DIFF
--- a/.changes/unreleased/Added-20241127-183919.yaml
+++ b/.changes/unreleased/Added-20241127-183919.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'config: allow $schema in dagger.json'
+time: 2024-11-27T18:39:19.703543-06:00
+custom:
+    Author: JacobLey
+    PR: "9069"

--- a/cmd/json-schema/main.go
+++ b/cmd/json-schema/main.go
@@ -55,7 +55,7 @@ var targets = []target{
 	{
 		id:    "dagger.json",
 		path:  "./core/modules",
-		value: &modules.ModuleConfig{},
+		value: &modules.ModuleConfigWithUserFields{},
 	},
 	{
 		id:    "engine.json",

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -892,7 +892,7 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 	}
 	// write dagger.json last so SDKs can't intentionally or unintentionally
 	// modify it during codegen in ways that would be hard to deal with
-	if err := s.writeDaggerConfig(ctx, mod, modCfg, modCfgPath); err != nil {
+	if err := s.writeDaggerConfig(ctx, mod, modCfg, modCfgPath, src); err != nil {
 		return nil, fmt.Errorf("failed to update dagger.json: %w", err)
 	}
 
@@ -1212,19 +1212,33 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 	return nil
 }
 
+func (s *moduleSchema) readDaggerConfig(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+) (*modules.ModuleConfigWithUserFields, error) {
+	modCfg, exists, err := src.Self.ModuleConfigWithUserFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get module config: %w", err)
+	}
+	if !exists {
+		return &modules.ModuleConfigWithUserFields{
+			ModuleConfig: modules.ModuleConfig{EngineVersion: engine.Version},
+		}, nil
+	}
+	return modCfg, nil
+}
+
 func (s *moduleSchema) updateDaggerConfig(
 	ctx context.Context,
 	engineVersion string,
 	mod *core.Module,
 	src dagql.Instance[*core.ModuleSource],
 ) (*modules.ModuleConfig, string, error) {
-	modCfg, ok, err := src.Self.ModuleConfig(ctx)
+	modCfgWithUserFields, err := s.readDaggerConfig(ctx, src)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get module config: %w", err)
+		return nil, "", err
 	}
-	if !ok {
-		modCfg = &modules.ModuleConfig{EngineVersion: engine.Version}
-	}
+	modCfg := &modCfgWithUserFields.ModuleConfig
 
 	modCfg.Name = mod.OriginalName
 	modCfg.SDK = mod.SDKConfig
@@ -1284,8 +1298,16 @@ func (s *moduleSchema) writeDaggerConfig(
 	mod *core.Module,
 	modCfg *modules.ModuleConfig,
 	modCfgPath string,
+	src dagql.Instance[*core.ModuleSource],
 ) error {
-	updatedModCfgBytes, err := json.MarshalIndent(modCfg, "", "  ")
+	modCfgWithUserFields, err := s.readDaggerConfig(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	modCfgWithUserFields.ModuleConfig = *modCfg
+
+	updatedModCfgBytes, err := json.MarshalIndent(modCfgWithUserFields, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to encode module config: %w", err)
 	}

--- a/docs/static/reference/dagger.schema.json
+++ b/docs/static/reference/dagger.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/dagger/dagger/core/modules/module-config",
-  "$ref": "#/$defs/ModuleConfig",
+  "$id": "https://github.com/dagger/dagger/core/modules/module-config-with-user-fields",
+  "$ref": "#/$defs/ModuleConfigWithUserFields",
   "$defs": {
     "ModuleCodegenConfig": {
       "properties": {
@@ -13,8 +13,52 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "ModuleConfig": {
+    "ModuleConfigDependency": {
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name to use for this dependency. By default, the same as the dependency module's name, but can also be overridden to use a different name."
+        },
+        "source": {
+          "type": "string",
+          "description": "The source ref of the module dependency."
+        },
+        "pin": {
+          "type": "string",
+          "description": "The pinned version of the module dependency."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "source"
+      ]
+    },
+    "ModuleConfigView": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "patterns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "ModuleConfigWithUserFields": {
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "The self-describing json $schema"
+        },
         "name": {
           "type": "string",
           "description": "The name of the module."
@@ -70,47 +114,7 @@
         "name",
         "engineVersion"
       ],
-      "description": "ModuleConfig is the config for a single module as loaded from a dagger.json file."
-    },
-    "ModuleConfigDependency": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name to use for this dependency. By default, the same as the dependency module's name, but can also be overridden to use a different name."
-        },
-        "source": {
-          "type": "string",
-          "description": "The source ref of the module dependency."
-        },
-        "pin": {
-          "type": "string",
-          "description": "The pinned version of the module dependency."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name",
-        "source"
-      ]
-    },
-    "ModuleConfigView": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "patterns": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ]
+      "description": "ModuleConfigWithUserFields is the config for a single module as loaded from a dagger.json file."
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/8967

Took a first swing at allowing $schema in the parsed config, and writing it back _if_ it exists.

It does not write a value by default, nor does it actually enforce that the json file abides by the schema (technically the URI could point to a completely random schema, or not resolve in the first place).

Primarily for the benefit of local development, because IDEs can help with descriptions and autocompletion if a $schema property is available