### PR TITLE
chore: avoid direct use of `trace.SpanKindInternal`

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"go.opentelemetry.io/otel/trace"
+	"dagger.io/dagger/telemetry"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -238,7 +238,7 @@ type buildkitClient interface {
 // - if not, try to isolate root of git repo from the ref
 // - if nothing worked, fallback as local ref, as before
 func parseRefString(ctx context.Context, bk buildkitClient, refString string) parsedRefString {
-	ctx, span := core.Tracer(ctx).Start(ctx, fmt.Sprintf("parseRefString: %s", refString), trace.WithSpanKind(trace.SpanKindInternal))
+	ctx, span := core.Tracer(ctx).Start(ctx, fmt.Sprintf("parseRefString: %s", refString), telemetry.Internal())
 	defer span.End()
 	localParsed := parsedRefString{
 		modPath: refString,


### PR DESCRIPTION
Instead, use `telemetry.Internal`.

See @vito's comment here: https://github.com/dagger/dagger/pull/8818#discussion_r1861051922

`parseRefString` is indeed showing up in weird places, and is noisy :cry: 