### PR TITLE
docs: Move content on rootless mode from operator manual

### DIFF
--- a/docs/current_docs/configuration/custom-runner.mdx
+++ b/docs/current_docs/configuration/custom-runner.mdx
@@ -75,4 +75,3 @@ are using a connection type that does not provide encryption, then all queries
 and responses will be sent in plaintext over the wire from the Dagger CLI to
 the runner.
 :::
-

--- a/docs/current_docs/configuration/engine.mdx
+++ b/docs/current_docs/configuration/engine.mdx
@@ -190,6 +190,27 @@ insecure-entitlements = []
 </TabItem>
 </Tabs>
 
+#### Rootless mode
+
+"Rootless mode" means running the Dagger Engine as a container without the `--privileged` flag. In this case, the container would not run as the `root` user of the system.
+
+Currently, the Dagger Engine cannot be run as a rootless container; network and filesystem constraints related to rootless usage would currently significantly limit its capabilities and performance.
+
+##### Filesystem constraints
+
+The Dagger Engine relies on the `overlayfs` snapshotter for efficient construction of container filesystems. However, only relatively recent Linux kernel versions fully support `overlayfs` inside of rootless user namespaces. On older kernels, there are fallback options such as [`fuse-overlayfs`](https://github.com/containers/fuse-overlayfs), but they come with their own complications in terms of degraded performance and host-specific setup.
+
+We've not yet invested in the significant work it would take to support+document running optimally on each kernel version, hence the limitation at this time.
+
+##### Network constraints
+
+Running the Dagger Engine in rootless mode constrains network management due to the fact that it's not possible for a rootless container to move a network device from the host network namespace to its own network namespace.
+
+It is possible to use userspace TCP/IP implementations such as [slirp](https://github.com/rootless-containers/slirp4netns) as a workaround, but they often significantly decrease network performance. This [comparison table of network drivers](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md#network-drivers) shows that `slirp` is at least five times slower than a root-privileged network driver.
+
+Newer options for more performant userspace network stacks have arisen in recent years, but they are generally either reliant on relatively recent kernel versions or in a nascent stage that would require significant validation around robustness+security.
+
+
 ### Garbage collection
 
 The Dagger Engine [caches various operations](./cache.mdx) to improve speed on

--- a/docs/current_docs/configuration/engine.mdx
+++ b/docs/current_docs/configuration/engine.mdx
@@ -60,10 +60,6 @@ at `/etc/dagger/engine.json`. For example:
 
 </TabItem>
 <TabItem value="engine.toml">
-<<<<<<< HEAD
-=======
-
->>>>>>> 184cbbd9b (chore: apply suggestions from code review)
 To configure `engine.toml`, a [custom runner](./custom-runner.mdx) is required -
 unlike with `engine.json`, the configuration is not automatically mounted to the
 engine.

--- a/docs/current_docs/configuration/engine.mdx
+++ b/docs/current_docs/configuration/engine.mdx
@@ -60,6 +60,10 @@ at `/etc/dagger/engine.json`. For example:
 
 </TabItem>
 <TabItem value="engine.toml">
+<<<<<<< HEAD
+=======
+
+>>>>>>> 184cbbd9b (chore: apply suggestions from code review)
 To configure `engine.toml`, a [custom runner](./custom-runner.mdx) is required -
 unlike with `engine.json`, the configuration is not automatically mounted to the
 engine.

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -39,10 +39,6 @@ We use telemetry for aggregate analysis, and do not tie telemetry events to a sp
 
 Dagger implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/). As a result, you can disable the telemetry by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI.
 
-### Can I run the Dagger Engine as a "rootless" container?
-
-No. "Rootless mode" means running the Dagger Engine as a container without the `--privileged` flag. In this case, the container would not run as the "root" user of the system. Currently, the Dagger Engine cannot be run as a rootless container; network and filesystem constraints related to rootless usage would significantly limit its capabilities and performance. This also means that Dagger is not compatible with platforms which do not support privileged containers, such as AWS Fargate and GKE Autopilot. [Read more about these constraints](https://github.com/dagger/dagger/blob/main/core/docs/d7yxc-operator_manual.md).
-
 ### Can I configure the Dagger Engine?
 
 Yes. [Read more about Dagger Engine configuration](https://github.com/dagger/dagger/blob/main/core/docs/d7yxc-operator_manual.md).

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1209,6 +1209,12 @@
   to = "/api/engine#caching"
   status = 301
 
+[[redirects]]
+  # redirect
+  from = "/configuration/cache"
+  to = "/api/engine#caching"
+  status = 301
+
 ###### end: redirects for specific v0.9 pages ######
 
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1200,7 +1200,7 @@
 [[redirects]]
   # redirect
   from = "/configuration/custom-registry"
-  to = "/configuration/engine#configuring-custom-registries"
+  to = "/configuration/engine#custom-registries"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
This is branched off https://github.com/dagger/dagger/pull/9022 so should be merged after.