### PR TITLE
fix(install.sh): remove duplicate functions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -255,31 +255,6 @@ Install specified dev build <commit sha>:
 EOF
 }
 
-uname_os() {
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  case "$os" in
-    cygwin_nt*) os="windows" ;;
-    mingw*) os="windows" ;;
-    msys_nt*) os="windows" ;;
-  esac
-  echo "$os"
-}
-
-uname_arch() {
-  arch=$(uname -m)
-  case $arch in
-    x86_64) arch="amd64" ;;
-    x86) arch="386" ;;
-    i686) arch="386" ;;
-    i386) arch="386" ;;
-    aarch64) arch="arm64" ;;
-    armv5*) arch="armv5" ;;
-    armv6*) arch="armv6" ;;
-    armv7*) arch="armv7" ;;
-  esac
-  echo "$arch"
-}
-
 latest_version() {
   curl -sfL "${base}/${name}/latest_version"
 }


### PR DESCRIPTION
Remove the duplicate functions `os_uname` and `os_arch` on lines 258 and 268, which are duplicated with lines 65 and 74.

Fixes #9077 