### PR TITLE
shell: reimplement module loading and execution according to new model

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -62,7 +62,7 @@ available functions.
 	GroupID: moduleGroup.ID,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) (rerr error) {
-			mod, err := initializeModule(ctx, engineClient.Dagger())
+			mod, err := initializeDefaultModule(ctx, engineClient.Dagger())
 			if err != nil {
 				return err
 			}

--- a/cmd/dagger/modconf.graphql
+++ b/cmd/dagger/modconf.graphql
@@ -11,6 +11,7 @@ query ModuleConfig($source: ModuleSourceID!) {
         description
         source {
           asString
+          pin
         }
       }
     }

--- a/cmd/dagger/modconf.graphql
+++ b/cmd/dagger/modconf.graphql
@@ -3,7 +3,9 @@ query ModuleConfig($source: ModuleSourceID!) {
     asString
     module: asModule {
       name
-      description
+      initialize {
+        description
+      }
       dependencies {
         name
         description

--- a/cmd/dagger/modconf.graphql
+++ b/cmd/dagger/modconf.graphql
@@ -1,0 +1,16 @@
+query ModuleConfig($source: ModuleSourceID!) {
+  source: loadModuleSourceFromID(id: $source) {
+    asString
+    module: asModule {
+      name
+      description
+      dependencies {
+        name
+        description
+        source {
+          asString
+        }
+      }
+    }
+  }
+}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1205,6 +1205,10 @@ func (m *moduleDef) GetObjectFunction(objectName, functionName string) (*modFunc
 }
 
 func (m *moduleDef) GetFunction(fp functionProvider, functionName string) (*modFunction, error) {
+	// This avoids an issue with module constructors overriding core functions
+	if m.HasModule() && fp.ProviderName() == "Query" && m.MainObject.AsObject.Constructor.CmdName() == functionName {
+		return m.MainObject.AsObject.Constructor, nil
+	}
 	for _, fn := range fp.GetFunctions() {
 		if fn.Name == functionName || fn.CmdName() == functionName {
 			m.LoadFunctionTypeDefs(fn)
@@ -1313,11 +1317,6 @@ func (m *moduleDef) HasFunction(fp functionProvider, name string) bool {
 	}
 	fn, _ := m.GetFunction(fp, name)
 	return fn != nil
-}
-
-func (m *moduleDef) IsModuleConstructor(fn *modFunction) bool {
-	fp := fn.ReturnType.AsFunctionProvider()
-	return fp != nil && !fp.IsCore()
 }
 
 // LoadTypeDef attempts to replace a function's return object type or argument's

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1277,7 +1277,7 @@ func (m *moduleDef) GetCoreFunctions() []*modFunction {
 	fns := make([]*modFunction, 0, len(all))
 
 	for _, fn := range all {
-		if fn.ReturnType.AsObject != nil && !fn.ReturnType.AsObject.IsCore() {
+		if fn.ReturnType.AsObject != nil && !fn.ReturnType.AsObject.IsCore() || fn.Name == "" {
 			continue
 		}
 		fns = append(fns, fn)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1286,14 +1286,20 @@ func (m *moduleDef) GetCoreFunctions() []*modFunction {
 	return fns
 }
 
-// HasCoreFunction checks if there's a core function with the given name.
-func (m *moduleDef) HasCoreFunction(name string) bool {
+// GetCoreFunction returns a core function with the given name.
+func (m *moduleDef) GetCoreFunction(name string) *modFunction {
 	for _, fn := range m.GetCoreFunctions() {
 		if fn.Name == name || fn.CmdName() == name {
-			return true
+			return fn
 		}
 	}
-	return false
+	return nil
+}
+
+// HasCoreFunction checks if there's a core function with the given name.
+func (m *moduleDef) HasCoreFunction(name string) bool {
+	fn := m.GetCoreFunction(name)
+	return fn != nil
 }
 
 func (m *moduleDef) HasMainFunction(name string) bool {

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -961,6 +961,7 @@ type moduleDef struct {
 	// the ModuleSource definition for the module, needed by some arg types
 	// applying module-specific configs to the arg value.
 	Source *dagger.ModuleSource
+
 	ModRef string
 
 	Dependencies []*moduleDependency

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1001,8 +1001,10 @@ func inspectModule(ctx context.Context, dag *dagger.Client, source *dagger.Modul
 		Source struct {
 			AsString string
 			Module   struct {
-				Name         string
-				Description  string
+				Name       string
+				Initialize struct {
+					Description string
+				}
 				Dependencies []struct {
 					Name        string
 					Description string
@@ -1044,7 +1046,7 @@ func inspectModule(ctx context.Context, dag *dagger.Client, source *dagger.Modul
 		Source:       source,
 		ModRef:       res.Source.AsString,
 		Name:         res.Source.Module.Name,
-		Description:  res.Source.Module.Description,
+		Description:  res.Source.Module.Initialize.Description,
 		Dependencies: deps,
 	}
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -906,7 +906,7 @@ func initializeModule(ctx context.Context, dag *dagger.Client, srcRef string) (r
 }
 
 // maybeInitializeModule optionally loads the module's type definitions.
-func maybeInitializeModule(ctx context.Context, dag *dagger.Client, srcRef string) (rdef *moduleDef, modRef string, rerr error) {
+func maybeInitializeModule(ctx context.Context, dag *dagger.Client, srcRef string) (*moduleDef, string, error) {
 	if def, err := tryInitializeModule(ctx, dag, srcRef); def != nil || err != nil {
 		return def, srcRef, err
 	}

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -676,14 +676,10 @@ func (h *shellCallHandler) getOrInitDefState(ref string, fn func() (*moduleDef, 
 
 func (h *shellCallHandler) constructorCall(ctx context.Context, md *moduleDef, st *ShellState, args []string) (*ShellState, error) {
 	fn := md.MainObject.AsObject.Constructor
-	if err := ExactArgs(len(fn.RequiredArgs()))(args); err != nil {
-		usage := shellFunctionUseLine(md, fn)
-		return nil, fmt.Errorf("constructor: %w\nusage: %s", err, usage)
-	}
 
 	values, err := h.parseArgumentValues(ctx, md, fn, args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("constructor: %w", err)
 	}
 
 	return st.WithCall(fn, values), nil
@@ -2007,7 +2003,6 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 			&ShellCommand{
 				Use:         shellFunctionUseLine(def, fn),
 				Description: fn.Description,
-				Args:        ExactArgs(len(fn.RequiredArgs())),
 				HelpFunc: func(cmd *ShellCommand) string {
 					return shellFunctionDoc(def, fn)
 				},

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -426,8 +426,8 @@ func (h *shellCallHandler) loadReadlineConfig(prompt string) (*readline.Config, 
 func (h *shellCallHandler) Prompt(out *termenv.Output, fg termenv.Color) string {
 	sb := new(strings.Builder)
 
-	if md := h.modDef(nil); md.ModRef != "" {
-		sb.WriteString(out.String(md.ModRef).Bold().Foreground(termenv.ANSICyan).String())
+	if h.modRef != "" {
+		sb.WriteString(out.String(h.modRef).Bold().Foreground(termenv.ANSICyan).String())
 		sb.WriteString(" ")
 	}
 

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1808,7 +1808,7 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 					doc.Add(
 						group.Title,
 						nameShortWrapped(cmds, func(c *ShellCommand) (string, string) {
-							return c.Name(), c.Description
+							return c.Name(), c.Short()
 						}),
 					)
 				}
@@ -1819,7 +1819,7 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 			},
 		},
 		&ShellCommand{
-			Use:         ".doc [function]",
+			Use:         ".doc [module]\n<function> | .doc [function]",
 			Description: "Show documentation for a module, a type, or a function",
 			Args:        MaximumArgs(1),
 			RunState: func(cmd *ShellCommand, args []string, st *ShellState) error {
@@ -1892,9 +1892,12 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 						}
 						return cmd.Println(shellFunctionDoc(def, fn))
 
-					case len(args) == 0 && def.HasModule():
+					case len(args) == 0:
+						if !def.HasModule() {
+							return fmt.Errorf("module not loaded.\nUse %q to see what's available", shellStdlibCmdName)
+						}
 						// Document module
-						// Example: `.doc [module | dependency]`
+						// Example: `.doc [module]`
 						return cmd.Println(shellModuleDoc(def))
 					}
 				}

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -73,8 +73,9 @@ var (
 )
 
 func init() {
-	shellCmd.Flags().StringVarP(&shellCode, "code", "c", "", "command to be executed")
-	shellCmd.Flags().BoolVar(&shellNoLoadModule, "no-load", false, "don't load module during shell startup")
+	shellCmd.Flags().StringVarP(&shellCode, "code", "c", "", "Command to be executed")
+	shellCmd.Flags().BoolVar(&shellNoLoadModule, "no-mod", false, "Don't load module during shell startup (mutually exclusive with --mod)")
+	shellCmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
 }
 
 var shellCmd = &cobra.Command{

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1617,7 +1617,7 @@ func shellModuleDoc(m *moduleDef) string {
 	return doc.String()
 }
 
-func shellTypeDoc(m *moduleDef, t *modTypeDef) string {
+func shellTypeDoc(t *modTypeDef) string {
 	var doc ShellDoc
 
 	fp := t.AsFunctionProvider()
@@ -1907,7 +1907,7 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 				// Document type
 				// Example: `container | .doc`
 				if len(args) == 0 {
-					return cmd.Println(shellTypeDoc(def, t))
+					return cmd.Println(shellTypeDoc(t))
 				}
 
 				fp := t.AsFunctionProvider()

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -88,7 +88,7 @@ var shellCmd = &cobra.Command{
 				stdin:  cmd.InOrStdin(),
 				stdout: cmd.OutOrStdout(),
 				stderr: cmd.ErrOrStderr(),
-				debug:  true,
+				debug:  debug,
 			}
 			return handler.RunAll(ctx, args)
 		})
@@ -1440,8 +1440,6 @@ func shellModuleDoc(m *moduleDef) string {
 		doc.Add("Module", meta.String())
 	}
 
-	doc.Add("Reference", m.ModRef)
-
 	fn := m.MainObject.AsObject.Constructor
 	if len(fn.Args) > 0 {
 		constructor := new(strings.Builder)
@@ -1557,7 +1555,7 @@ func shellFunctionDoc(md *moduleDef, fn *modFunction) string {
 }
 
 func (h *shellCallHandler) isDefaultState(st ShellState) bool {
-	return st.Cmd == "" && (st.ModRef == "" || st.ModRef == h.modRef)
+	return st.ModRef == "" || st.ModRef == h.modRef
 }
 
 func (h *shellCallHandler) newModState(ref string) *ShellState {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -109,10 +109,12 @@ type shellCallHandler struct {
 	stdout io.Writer
 	stderr io.Writer
 
-	// modRef is the module reference for the default module to use
+	// modRef is a key from modDefs, to set the corresponding module as the default
+	// when no state is present, or when the state's ModRef is empty
 	modRef string
 
-	// modDefs has the module type definitions from introspection, keyed by module ref
+	// modDefs has the cached module definitions, after loading, and keyed by
+	// module reference as inputed by the user
 	modDefs map[string]*moduleDef
 
 	// switch to Frontend.Background for rendering output while the TUI is
@@ -995,6 +997,8 @@ type ShellState struct {
 	// ModRef is the module reference for the current state
 	//
 	// If empty, it must fall back to the default context.
+	// It matches a key in the modDefs map in the handler, which comes from
+	// user input, not from the API.
 	ModRef string `json:"modRef"`
 
 	// Cmd is non-empty if next command comes from a builtin instead of an API object

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1980,8 +1980,10 @@ to the currently loaded module.
 		},
 		cobraToShellCommand(loginCmd),
 		cobraToShellCommand(logoutCmd),
-		// TODO: Add uninstall command when available.
 		cobraToShellCommand(moduleInstallCmd),
+		cobraToShellCommand(moduleUnInstallCmd),
+		// TODO: Add update command when available:
+		// - https://github.com/dagger/dagger/pull/8839
 	)
 
 	def := h.modDef(nil)

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1760,13 +1760,16 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 			},
 		},
 		&ShellCommand{
-			Use:         ".use",
-			Description: "Set a loaded module as the default for the session",
+			Use:         ".use <module>",
+			Description: "Set a module as the default for the session",
 			GroupID:     moduleGroup.ID,
-			Args:        NoArgs,
-			RunState: func(cmd *ShellCommand, _ []string, st *ShellState) error {
-				if st == nil {
-					return fmt.Errorf("usage: <module> | .use")
+			Args:        ExactArgs(1),
+			Run: func(cmd *ShellCommand, args []string) error {
+				st, err := h.getOrInitDefState(args[0], func() (*moduleDef, error) {
+					return initializeModule(cmd.Context(), h.dag, args[0])
+				})
+				if err != nil {
+					return err
 				}
 
 				if st.ModRef != h.modRef {

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -24,9 +24,9 @@ func daggerShell(script string) dagger.WithContainerFunc {
 	}
 }
 
-func daggerShellNoLoad(script string) dagger.WithContainerFunc {
+func daggerShellNoMod(script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec([]string{"dagger", "shell", "--no-load", "-c", script}, dagger.ContainerWithExecOpts{
+		return c.WithExec([]string{"dagger", "shell", "--no-mod", "-c", script}, dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		})
 	}
@@ -104,7 +104,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("forced no load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		_, err := modInit(t, c, "go", "").
-			With(daggerShellNoLoad(".deps")).
+			With(daggerShellNoMod(".deps")).
 			Sync(ctx)
 		requireErrOut(t, err, "module not loaded")
 	})
@@ -112,7 +112,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("dynamically loaded", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoLoad(".use .; .doc")).
+			With(daggerShellNoMod(".use .; .doc")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-echo")
@@ -121,7 +121,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("stateless load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoLoad(". | .doc container-echo")).
+			With(daggerShellNoMod(". | .doc container-echo")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "echoes whatever string argument")
@@ -130,7 +130,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("stateless .doc load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoLoad(".doc .")).
+			With(daggerShellNoMod(".doc .")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-echo")

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -270,7 +270,7 @@ func (m *Test) DirectoryID(ctx context.Context) (string, error) {
 	return string(id), err
 }
 `
-	script := ".core load-directory-from-id $(directory-id) | file foo | contents"
+	script := ".core | load-directory-from-id $(directory-id) | file foo | contents"
 
 	out, err := modInit(t, c, "go", source).
 		With(daggerShell(script)).

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -148,7 +148,7 @@ func (Other) Version() string {
 		require.Contains(t, out, "MODULE")
 		require.Contains(t, out, "Main module")
 		require.Contains(t, out, "ENTRYPOINT")
-		require.Contains(t, out, "Usage: ./. [options]")
+		require.Contains(t, out, "Usage: . [options]")
 		require.Contains(t, out, "AVAILABLE FUNCTIONS")
 		require.Contains(t, out, "Encouragement")
 	})

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -157,6 +157,9 @@ func (s *moduleSchema) Install() {
 		dagql.Func("asString", s.moduleSourceAsString).
 			Doc(`A human readable ref string representation of this module source.`),
 
+		dagql.Func("pin", s.moduleSourcePin).
+			Doc(`The pinned version of this module source.`),
+
 		dagql.NodeFunc("asModule", s.moduleSourceAsModule).
 			Doc(`Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation`).
 			ArgDoc("engineVersion", `The engine version to upgrade to.`),

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -377,6 +377,10 @@ func (s *moduleSchema) moduleSourceAsString(ctx context.Context, src *core.Modul
 	return src.RefString()
 }
 
+func (s *moduleSchema) moduleSourcePin(ctx context.Context, src *core.ModuleSource, args struct{}) (string, error) {
+	return src.Pin()
+}
+
 func (s *moduleSchema) gitModuleSourceHTMLURL(
 	ctx context.Context,
 	ref *core.GitModuleSource,
@@ -897,7 +901,9 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 	// ensure sourceRootRelPath has a local path structure
 	// even when subdir relative to git source has ref structure
 	// (cf. test TestRefFormat)
-	sourceRootRelPath = "./" + sourceRootRelPath
+	if sourceRootRelPath != "." {
+		sourceRootRelPath = "./" + sourceRootRelPath
+	}
 
 	collectedDeps := dagql.NewCacheMap[string, *callerLocalDep]()
 	if err := s.collectCallerLocalDeps(ctx, src.Query, contextAbsPath, sourceRootAbsPath, true, src, collectedDeps); err != nil {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2361,6 +2361,9 @@ type ModuleSource {
   """
   moduleOriginalName: String!
 
+  """The pinned version of this module source."""
+  pin: String!
+
   """
   The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
   """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8142,6 +8142,10 @@
                         <td> The original name of the module this source references, as defined in the module configuration. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-pin" href="#ModuleSource-pin"><code>pin</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The pinned version of this module source. </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-resolveContextPathFromCaller" href="#ModuleSource-resolveContextPathFromCaller"><code>resolveContextPathFromCaller</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The path to the module source's context directory on the caller's filesystem. Only valid for local sources. </td>
                       </tr>

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -159,6 +159,15 @@ defmodule Dagger.ModuleSource do
     Client.execute(module_source.client, query_builder)
   end
 
+  @doc "The pinned version of this module source."
+  @spec pin(t()) :: {:ok, String.t()} | {:error, term()}
+  def pin(%__MODULE__{} = module_source) do
+    query_builder =
+      module_source.query_builder |> QB.select("pin")
+
+    Client.execute(module_source.client, query_builder)
+  end
+
   @doc "The path to the module source's context directory on the caller's filesystem. Only valid for local sources."
   @spec resolve_context_path_from_caller(t()) :: {:ok, String.t()} | {:error, term()}
   def resolve_context_path_from_caller(%__MODULE__{} = module_source) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5916,6 +5916,7 @@ type ModuleSource struct {
 	kind                         *ModuleSourceKind
 	moduleName                   *string
 	moduleOriginalName           *string
+	pin                          *string
 	resolveContextPathFromCaller *string
 	sourceRootSubpath            *string
 	sourceSubpath                *string
@@ -6137,6 +6138,19 @@ func (r *ModuleSource) ModuleOriginalName(ctx context.Context) (string, error) {
 		return *r.moduleOriginalName, nil
 	}
 	q := r.query.Select("moduleOriginalName")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The pinned version of this module source.
+func (r *ModuleSource) Pin(ctx context.Context) (string, error) {
+	if r.pin != nil {
+		return *r.pin, nil
+	}
+	q := r.query.Select("pin")
 
 	var response string
 

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -135,6 +135,15 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The pinned version of this module source.
+     */
+    public function pin(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('pin');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'pin');
+    }
+
+    /**
      * The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
      */
     public function resolveContextPathFromCaller(): string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6210,6 +6210,27 @@ class ModuleSource(Type):
         _ctx = self._select("moduleOriginalName", _args)
         return await _ctx.execute(str)
 
+    async def pin(self) -> str:
+        """The pinned version of this module source.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("pin", _args)
+        return await _ctx.execute(str)
+
     async def resolve_context_path_from_caller(self) -> str:
         """The path to the module source's context directory on the caller's
         filesystem. Only valid for local sources.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6444,6 +6444,11 @@ impl ModuleSource {
         let query = self.selection.select("moduleOriginalName");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The pinned version of this module source.
+    pub async fn pin(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("pin");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
     pub async fn resolve_context_path_from_caller(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("resolveContextPathFromCaller");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -5845,6 +5845,7 @@ export class ModuleSource extends BaseClient {
   private readonly _kind?: ModuleSourceKind = undefined
   private readonly _moduleName?: string = undefined
   private readonly _moduleOriginalName?: string = undefined
+  private readonly _pin?: string = undefined
   private readonly _resolveContextPathFromCaller?: string = undefined
   private readonly _sourceRootSubpath?: string = undefined
   private readonly _sourceSubpath?: string = undefined
@@ -5861,6 +5862,7 @@ export class ModuleSource extends BaseClient {
     _kind?: ModuleSourceKind,
     _moduleName?: string,
     _moduleOriginalName?: string,
+    _pin?: string,
     _resolveContextPathFromCaller?: string,
     _sourceRootSubpath?: string,
     _sourceSubpath?: string,
@@ -5874,6 +5876,7 @@ export class ModuleSource extends BaseClient {
     this._kind = _kind
     this._moduleName = _moduleName
     this._moduleOriginalName = _moduleOriginalName
+    this._pin = _pin
     this._resolveContextPathFromCaller = _resolveContextPathFromCaller
     this._sourceRootSubpath = _sourceRootSubpath
     this._sourceSubpath = _sourceSubpath
@@ -6051,6 +6054,27 @@ export class ModuleSource extends BaseClient {
     const ctx = this._ctx.select("moduleOriginalName")
 
     const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The pinned version of this module source.
+   */
+  pin = async (): Promise<string> => {
+    if (this._pin) {
+      return this._pin
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "pin",
+        },
+      ],
+      await this._ctx.connection(),
+    )
 
     return response
   }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6066,15 +6066,9 @@ export class ModuleSource extends BaseClient {
       return this._pin
     }
 
-    const response: Awaited<string> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "pin",
-        },
-      ],
-      await this._ctx.connection(),
-    )
+    const ctx = this._ctx.select("pin")
+
+    const response: Awaited<string> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
Implements first part of https://github.com/dagger/dagger/issues/9035
Fixes https://github.com/dagger/dagger/issues/9129

## Notes

- documentation for a module and its constructor/entrypoint:
```diff
-.load <module> | .doc
+.doc <module>
```
- documentation for a module’s main object:
```diff
-.load <module> | .config <required arguments>... | .doc
+<module> <required arguments>... | .doc
```
- set a module as the default for current session:
```diff
-.load <module> | .use
+.use <module>
```
- execute a stdlib function (disambiguated)
```diff
-.version
+.stdlib | version
```
- execute any core function
```diff
-.default-platform
-.core default-platform
+.core | default-platform
```

## Todo

- [x] Command execution lookup
- [x] Dynamic module loading through `.doc`
- [x] Document a module, separately from its main object
- [x] Migrate core API builtins to `.stdlib`
- [x] Command disambiguation with `.deps`, `.stdlib`, and `.core`
- [x] More tests
- [x] Use pinned versions for dependencies

## Bikeshedding

- [ ] Rename `.core` to something else?

## Next

- https://github.com/dagger/dagger/issues/8969
- https://github.com/dagger/dagger/issues/9019
- https://github.com/dagger/dagger/issues/8990
- Filesystem navigation (from [proposal](https://github.com/dagger/dagger/issues/9035))