### PR TITLE
ci: fix distro to be a real enum

### DIFF
--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -19,9 +19,9 @@ import (
 type Distro string
 
 const (
-	DistroAlpine = "alpine"
-	DistroWolfi  = "wolfi"
-	DistroUbuntu = "ubuntu"
+	DistroAlpine Distro = "alpine"
+	DistroWolfi  Distro = "wolfi"
+	DistroUbuntu Distro = "ubuntu"
 )
 
 type DaggerEngine struct {


### PR DESCRIPTION
`Distro` wasn't a proper enum type :( I got the syntax wrong when adding it.

The enum members need to be *explicitly* declared to be of the distro type to apply.