### PR TITLE
ci: cross-compile dumb-init

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -441,13 +441,14 @@ func (build *Builder) dumbInit() *dagger.File {
 			Packages: []string{
 				"bash",
 				"build-base",
+				"clang",
 			},
-			Arch: build.platformSpec.Architecture,
 		}).
 		Container().
+		WithDirectory("/", dag.Container().From(consts.XxImage).Rootfs()).
 		WithMountedDirectory("/src", dag.Git("github.com/yelp/dumb-init").Ref(consts.DumbInitVersion).Tree()).
 		WithWorkdir("/src").
-		WithExec([]string{"make"}).
+		WithExec([]string{"make", "CC=xx-cc"}).
 		File("dumb-init")
 }
 

--- a/.dagger/consts/versions.go
+++ b/.dagger/consts/versions.go
@@ -13,6 +13,7 @@ const (
 	GolangImage   = distconsts.GolangImage
 
 	AlpineVersion = distconsts.AlpineVersion
+	AlpineImage   = "alpine:" + AlpineVersion
 	UbuntuVersion = "22.04"
 
 	RuncVersion     = "v1.1.14"

--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -31,6 +31,11 @@ func (ProvisionSuite) TestDockerDriver(ctx context.Context, t *testctx.T) {
 		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 
+		// HACK: pre-load the engine image (since trying to pull if from the
+		// registry might not work if it hasn't been built yet)
+		dockerc, err := dockerLoadEngine(ctx, c, dockerc, "registry.dagger.io/engine:"+engine.Tag)
+		require.NoError(t, err)
+
 		out, err := dockerc.
 			WithExec([]string{"dagger", "query"}, dagger.ContainerWithExecOpts{Stdin: "{version}"}).Stdout(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Similar in theme to #9036, but this time to fix this very annoying segfault flake: https://github.com/dagger/dagger/actions/runs/12163689482/job/33923486378

```
cc -std=gnu99 -static -s -Wall -Werror -O3 -o dumb-init dumb-init.c
Stderr:
cc: internal compiler error: Segmentation fault signal terminated program cc1
Please submit a full bug report, with preprocessed source (by using -freport-bug).
See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
make: *** [Makefile:11: build] Error 4
```

If we guess that this is also an annoying QEMU issue, then this can be avoided by just using `xx` here as well. `xx` depends on `clang`, so I install that as well.

I also took size samples before:
``` 
# ls -lh $(which dumb-init)
-rwxr-xr-x    1 root     root       57.7K Dec  2 11:30 /usr/local/bin/dumb-init
```
And after:
```
# ls -lh $(which dumb-init)
-rwxr-xr-x    1 root     root       57.6K Dec  4 16:49 /usr/local/bin/dumb-init
```