### PR TITLE
enable more integration tests to run on raw macOS

### DIFF
--- a/.dagger/mage/engine.go
+++ b/.dagger/mage/engine.go
@@ -126,6 +126,12 @@ func (t Engine) Dev(ctx context.Context) error {
 	}
 
 	fmt.Println("export _EXPERIMENTAL_DAGGER_CLI_BIN=" + binDest)
+
+	if runtime.GOOS != "linux" {
+		linuxBinDest := filepath.Join(binDir, "dagger-linux")
+		fmt.Println("export _TEST_DAGGER_CLI_LINUX_BIN=" + linuxBinDest)
+	}
+
 	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + containerName)
 	fmt.Println("export _DAGGER_TESTS_ENGINE_TAR=" + filepath.Join(binDir, "engine.tar"))
 	fmt.Println("export PATH=" + binDir + ":$PATH")
@@ -146,6 +152,12 @@ func (t Engine) DevEnv(ctx context.Context) {
 	}
 
 	fmt.Println("export _EXPERIMENTAL_DAGGER_CLI_BIN=" + binDest)
+
+	if runtime.GOOS != "linux" {
+		linuxBinDest := filepath.Join(binDir, "dagger-linux")
+		fmt.Println("export _TEST_DAGGER_CLI_LINUX_BIN=" + linuxBinDest)
+	}
+
 	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + EngineContainerName)
 	fmt.Println("export _DAGGER_TESTS_ENGINE_TAR=" + filepath.Join(binDir, "engine.tar"))
 	fmt.Println("export PATH=" + binDir + ":$PATH")

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -300,13 +300,19 @@ func (dev *DaggerDev) DevExport(
 	})
 
 	// FIXME: get path from the cli file (windows is already handled)
-	cliPath := "dagger"
+	hostCliPath := "dagger"
 	if platformSpec.OS == "windows" {
-		cliPath += ".exe"
+		hostCliPath += ".exe"
 	}
 	dir := dag.Directory().
 		WithFile("engine.tar", engineTar).
-		WithFile(cliPath, dag.DaggerCli().Binary(dagger.DaggerCliBinaryOpts{Platform: platform}))
+		WithFile(hostCliPath, dag.DaggerCli().Binary(dagger.DaggerCliBinaryOpts{Platform: platform}))
+
+	// this allows our integration tests to plumb built cli binaries into containers when the host OS doesn't match
+	if platformSpec.OS != "linux" {
+		linuxCliPath := "dagger-linux"
+		dir = dir.WithFile(linuxCliPath, engineCtr.File(cliPath))
+	}
 	return dir, nil
 }
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -244,12 +245,24 @@ func daggerCliPath(t testing.TB) string {
 	return cliPath
 }
 
+func daggerLinuxCliPath(t testing.TB) string {
+	if runtime.GOOS == "linux" {
+		return daggerCliPath(t)
+	}
+	cliPath := os.Getenv("_TEST_DAGGER_CLI_LINUX_BIN")
+	if cliPath == "" {
+		t.Log("missing _TEST_DAGGER_CLI_LINUX_BIN")
+		t.FailNow()
+	}
+	return cliPath
+}
+
 func daggerCliFile(t testing.TB, c *dagger.Client) *dagger.File {
 	// This loads the dagger-cli binary from the host into the container, that
 	// was set up by the test caller. This is used to communicate with the dev
 	// engine.
 	t.Helper()
-	return c.Host().File(daggerCliPath(t))
+	return c.Host().File(daggerLinuxCliPath(t))
 }
 
 func daggerCliBase(t testing.TB, c *dagger.Client) *dagger.Container {


### PR DESCRIPTION
for profiling and fast dev loops, it's often useful to run tests on your host machine aimed at a `./hack/dev`-built engine. 

```
./hack/dev go test -count=1 -v -run TestModule/TestLots ./core/integration
```

on MacOS, many tests won't run locally because we often upload a local dagger CLI binary as part of the test. 

this PR teaches dev-export to copy the engine container's linux binary to ./bin/dagger-linux, then wires that path out through mage/engine.go so it can be consumed by ./core/integration/suite_test.go as the desired binary to upload to test-created containers.

this _does not_ make all or nearly all the tests pass successfully when running on macOS. many tests still rely on running inside of dagger, as @vito noted in `./hack/most-tests`. re-cataloguing which tests those are seems host-machine-dependent, so I don't bother here.

some of those tests are fairly obvious, like when the tests attempt to push or pull from registry:5000. others are far less obvious.