### PR TITLE
feat: directories in entries and glob have trailing slash

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -275,7 +276,11 @@ func (dir *Directory) Entries(ctx context.Context, src string) ([]string, error)
 
 	paths := []string{}
 	for _, entry := range entries {
-		paths = append(paths, entry.GetPath())
+		path := entry.Path
+		if os.FileMode(entry.Mode).IsDir() {
+			path += "/"
+		}
+		paths = append(paths, path)
 	}
 
 	return paths, nil
@@ -325,7 +330,7 @@ func (dir *Directory) Glob(ctx context.Context, pattern string) ([]string, error
 	err = ref.WalkDir(ctx, buildkit.WalkDirRequest{
 		IncludePattern: pattern,
 		Path:           dir.Dir,
-		Callback: func(path string, info *fstypes.Stat) error {
+		Callback: func(path string, info os.FileInfo) error {
 			// HACK: ideally, we'd have something like MatchesExact, which
 			// would skip the parent behavior that we don't really want here -
 			// oh well, let's just fake it with false
@@ -333,6 +338,10 @@ func (dir *Directory) Glob(ctx context.Context, pattern string) ([]string, error
 			match, err := pm.MatchesUsingParentResult(filepath.Clean(path), false)
 			if err != nil {
 				return err
+			}
+
+			if info.Mode().IsDir() {
+				path += "/"
 			}
 			if match {
 				paths = append(paths, path)

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -95,7 +95,7 @@ func (DirectorySuite) TestEntries(ctx context.Context, t *testctx.T) {
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"some-file", "some-dir"}, res.Directory.WithNewFile.WithNewFile.Entries)
+	require.ElementsMatch(t, []string{"some-file", "some-dir/"}, res.Directory.WithNewFile.WithNewFile.Entries)
 }
 
 func (DirectorySuite) TestEntriesOfPath(ctx context.Context, t *testctx.T) {
@@ -258,7 +258,7 @@ func (DirectorySuite) TestWithDirectoryIncludeExclude(ctx context.Context, t *te
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
 		require.NoError(t, err)
-		require.Equal(t, []string{"a.txt", "b.txt", "subdir"}, entries)
+		require.Equal(t, []string{"a.txt", "b.txt", "subdir/"}, entries)
 	})
 
 	t.Run("include", func(ctx context.Context, t *testctx.T) {
@@ -315,13 +315,13 @@ func (DirectorySuite) TestWithNewDirectory(ctx context.Context, t *testctx.T) {
 
 	entries, err := dir.Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b"}, entries)
+	require.Equal(t, []string{"a/", "b/"}, entries)
 
 	entries, err = dir.Entries(ctx, dagger.DirectoryEntriesOpts{
 		Path: "b",
 	})
 	require.NoError(t, err)
-	require.Equal(t, []string{"c"}, entries)
+	require.Equal(t, []string{"c/"}, entries)
 
 	t.Run("does not permit creating directory outside of root", func(ctx context.Context, t *testctx.T) {
 		_, err := dir.Directory("b").WithNewDirectory("../c").ID(ctx)
@@ -504,7 +504,7 @@ func (DirectorySuite) TestWithoutPaths(ctx context.Context, t *testctx.T) {
 		Entries(ctx)
 
 	require.NoError(t, err)
-	require.Equal(t, []string{"some-dir", "some-file"}, entries)
+	require.Equal(t, []string{"some-dir/", "some-file"}, entries)
 
 	dir := c.Directory().
 		WithNewFile("foo.txt", "foo").
@@ -520,13 +520,13 @@ func (DirectorySuite) TestWithoutPaths(ctx context.Context, t *testctx.T) {
 
 	entries, err = dir.Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b", "c", "foo.txt"}, entries)
+	require.Equal(t, []string{"a/", "b/", "c/", "foo.txt"}, entries)
 
 	entries, err = dir.
 		WithoutDirectory("a").
 		Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"b", "c", "foo.txt"}, entries)
+	require.Equal(t, []string{"b/", "c/", "foo.txt"}, entries)
 
 	entries, err = dir.
 		WithoutFile("b/*.txt").
@@ -550,7 +550,7 @@ func (DirectorySuite) TestWithoutPaths(ctx context.Context, t *testctx.T) {
 
 	entries, err = dirDir.WithoutDirectory("a*").Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"b1", "foo.txt"}, entries)
+	require.Equal(t, []string{"b1/", "foo.txt"}, entries)
 
 	// Test WithoutFile
 	filesDir := c.Directory().
@@ -560,7 +560,7 @@ func (DirectorySuite) TestWithoutPaths(ctx context.Context, t *testctx.T) {
 
 	entries, err = filesDir.Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"some-dir"}, entries)
+	require.Equal(t, []string{"some-dir/"}, entries)
 
 	// Test WithoutFiles
 	filesDir = c.Directory().
@@ -571,7 +571,7 @@ func (DirectorySuite) TestWithoutPaths(ctx context.Context, t *testctx.T) {
 
 	entries, err = filesDir.Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"some-dir"}, entries)
+	require.Equal(t, []string{"some-dir/"}, entries)
 
 	// verify WithoutFile works when dir has be selected to a subdir
 	subdirWithout := c.Directory().
@@ -1088,9 +1088,9 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 				require.NoError(t, err)
 				require.ElementsMatch(t, entries, []string{
 					"func.go", "main.go", "test.md", "foo.txt", "README.txt",
-					"subdir", "subdir/foo.txt", "subdir/README.md",
-					"subdir2", "subdir2/subsubdir", "subdir2/baz.txt", "subdir2/TESTING.md",
-					"subdir/subsubdir", "subdir/subsubdir/package.json",
+					"subdir/", "subdir/foo.txt", "subdir/README.md",
+					"subdir2/", "subdir2/subsubdir/", "subdir2/baz.txt", "subdir2/TESTING.md",
+					"subdir/subsubdir/", "subdir/subsubdir/package.json",
 					"subdir/subsubdir/index.mts", "subdir/subsubdir/JS.md",
 				})
 			})
@@ -1127,7 +1127,7 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 
 		require.NoError(t, err)
 		require.ElementsMatch(t, entries, []string{
-			"foo/bar.md",
+			"foo/bar.md/",
 			"foo/bar.md/w.md",
 			"foo/baz.go/y.md",
 		})

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -137,14 +137,14 @@ func (GitSuite) TestDiscardGitDir(ctx context.Context, t *testctx.T) {
 		dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree()
 		ent, err := dir.Entries(ctx)
 		require.NoError(t, err)
-		require.Contains(t, ent, ".git")
+		require.Contains(t, ent, ".git/")
 	})
 
 	t.Run("git dir is not present", func(ctx context.Context, t *testctx.T) {
 		dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{DiscardGitDir: true})
 		ent, err := dir.Entries(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, ent, ".git")
+		require.NotContains(t, ent, ".git/")
 	})
 }
 
@@ -155,14 +155,14 @@ func (GitSuite) TestKeepGitDir(ctx context.Context, t *testctx.T) {
 		dir := c.Git("https://github.com/dagger/dagger", dagger.GitOpts{KeepGitDir: true}).Branch("main").Tree()
 		ent, err := dir.Entries(ctx)
 		require.NoError(t, err)
-		require.Contains(t, ent, ".git")
+		require.Contains(t, ent, ".git/")
 	})
 
 	t.Run("git dir is not present", func(ctx context.Context, t *testctx.T) {
 		dir := c.Git("https://github.com/dagger/dagger", dagger.GitOpts{KeepGitDir: true}).Branch("main").Tree(dagger.GitRefTreeOpts{DiscardGitDir: true})
 		ent, err := dir.Entries(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, ent, ".git")
+		require.NotContains(t, ent, ".git/")
 	})
 }
 

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -250,7 +250,7 @@ func (HostSuite) TestDirectoryExcludeInclude(ctx context.Context, t *testctx.T) 
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
 		require.NoError(t, err)
-		require.Equal(t, []string{"a.txt", "b.txt", "subdir"}, entries)
+		require.Equal(t, []string{"a.txt", "b.txt", "subdir/"}, entries)
 	})
 
 	t.Run("include", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -264,7 +264,7 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 				out, err := modGen.With(daggerCall("fn", "--dir", "~", "entries")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "foo.txt\nsubdir\n", out)
+				require.Equal(t, "foo.txt\nsubdir/\n", out)
 
 				out, err = modGen.With(daggerCall("fn", "--dir", "~/subdir", "entries")).Stdout(ctx)
 				require.NoError(t, err)
@@ -889,11 +889,11 @@ func (m *Test) Mod(ctx context.Context, module *dagger.Module) *dagger.Module {
 
 			out, err := modGen.With(daggerCall("mod-src", "--mod-src", ".", "directory", "--path", ".", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 
 			out, err = modGen.With(daggerCall("mod", "--module", ".", "source", "directory", "--path", ".", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 
 			out, err = modGen.With(daggerCall("mod-src", "--mod-src", testGitModuleRef(tc, "top-level"), "as-string")).Stdout(ctx)
 			require.NoError(t, err)

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -60,11 +60,11 @@ func (CLISuite) TestDaggerInit(ctx context.Context, t *testctx.T) {
 			},
 			{
 				sdk:          "python",
-				sourceDirEnt: "src",
+				sourceDirEnt: "src/",
 			},
 			{
 				sdk:          "typescript",
-				sourceDirEnt: "src",
+				sourceDirEnt: "src/",
 			},
 		} {
 			tc := tc

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -613,7 +613,7 @@ func (m *Coolsdk) RequiredPaths() []string {
 				With(daggerCall("fn", "directory", "--path", "subdir", "entries")).
 				Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "keepdir", strings.TrimSpace(out))
+			require.Equal(t, "keepdir/", strings.TrimSpace(out))
 
 			out, err = ctr.
 				With(daggerCall("fn", "directory", "--path", "subdir/keepdir", "entries")).
@@ -627,7 +627,7 @@ func (m *Coolsdk) RequiredPaths() []string {
 				With(daggerCallAt("../work", "fn", "directory", "--path", "subdir", "entries")).
 				Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "keepdir", strings.TrimSpace(out))
+			require.Equal(t, "keepdir/", strings.TrimSpace(out))
 
 			// call should still work after develop
 			ctr = ctr.With(daggerExec("develop"))
@@ -636,7 +636,7 @@ func (m *Coolsdk) RequiredPaths() []string {
 				With(daggerCall("fn", "directory", "--path", "subdir", "entries")).
 				Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "keepdir", strings.TrimSpace(out))
+			require.Equal(t, "keepdir/", strings.TrimSpace(out))
 			out, err = ctr.
 				With(daggerCall("fn", "directory", "--path", "subdir/keepdir", "entries")).
 				Stdout(ctx)
@@ -1104,7 +1104,7 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:nice-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "nice-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "nice-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:nice-view", "directory", "--path=subdir", "entries")).Stdout(ctx)
 	require.NoError(t, err)
@@ -1129,11 +1129,11 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:nice-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "nice-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "nice-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:mean-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "mean-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "mean-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:mean-view", "directory", "--path=subdir", "entries")).Stdout(ctx)
 	require.NoError(t, err)
@@ -1157,15 +1157,15 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:nice-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "nice-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "nice-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:mean-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "mean-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "mean-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:txt-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "foo.txt\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "foo.txt\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:txt-view", "directory", "--path=subdir", "entries")).Stdout(ctx)
 	require.NoError(t, err)
@@ -1196,15 +1196,15 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:nice-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "nice-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "nice-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:mean-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "mean-file\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "mean-file\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:txt-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "foo.txt\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "foo.txt\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:no-subdir-txt-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
@@ -1236,7 +1236,7 @@ func (m *Test) Fn(dir *dagger.Directory) *dagger.Directory {
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:no-subdir-txt-view", "entries")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "foo.txt\nsubdir", strings.TrimSpace(out))
+	require.Equal(t, "foo.txt\nsubdir/", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("fn", "--dir", "stuff:no-subdir-txt-view", "directory", "--path=subdir", "entries")).Stdout(ctx)
 	require.NoError(t, err)

--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -232,7 +232,7 @@ func (GoSuite) TestInit(ctx context.Context, t *testctx.T) {
 
 		parentEntries, err := generated.Entries(ctx)
 		require.NoError(t, err)
-		require.Equal(t, []string{".git", "child", "foo.go", "go.mod", "go.sum"}, parentEntries)
+		require.Equal(t, []string{".git/", "child/", "foo.go", "go.mod", "go.sum"}, parentEntries)
 
 		childEntries, err := generated.Directory("child").Entries(ctx)
 		require.NoError(t, err)
@@ -266,7 +266,7 @@ func (GoSuite) TestInit(ctx context.Context, t *testctx.T) {
 		parentEntries, err := generated.Entries(ctx)
 		require.NoError(t, err)
 		// no go.sum
-		require.Equal(t, []string{".git", "child", "foo.go", "go.mod"}, parentEntries)
+		require.Equal(t, []string{".git/", "child/", "foo.go", "go.mod"}, parentEntries)
 
 		childEntries, err := generated.Directory("child").Entries(ctx)
 		require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4359,13 +4359,13 @@ export class Test {
 				t.Run("absolute and relative root context dir", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCallAt("ci", "dirs")).Stdout(ctx)
 					require.NoError(t, err)
-					require.Equal(t, ".git\nbackend\nci\nfrontend\nLICENSE\ndagger\ndagger.json\n", out)
+					require.Equal(t, ".git/\nbackend/\nci/\nfrontend/\nLICENSE\ndagger/\ndagger.json\n", out)
 				})
 
 				t.Run("dir ignore", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCallAt("ci", "dirs-ignore")).Stdout(ctx)
 					require.NoError(t, err)
-					require.Equal(t, "backend\nfrontend\ndagger\n", out)
+					require.Equal(t, "backend/\nfrontend/\ndagger/\n", out)
 				})
 
 				t.Run("absolute context dir subpath", func(ctx context.Context, t *testctx.T) {
@@ -4623,7 +4623,7 @@ export class Test {
 				t.Run("absolute and relative root context dir", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("dirs")).Stdout(ctx)
 					require.NoError(t, err)
-					require.Equal(t, ".git\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n.git\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n", out)
+					require.Equal(t, ".git/\nLICENSE\nbackend/\ndagger/\ndagger.json\nfrontend/\n.git/\nLICENSE\nbackend/\ndagger/\ndagger.json\nfrontend/\n", out)
 				})
 
 				t.Run("absolute context dir subpath", func(ctx context.Context, t *testctx.T) {
@@ -5110,19 +5110,19 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 		t.Run("ignore all then reverse ignore all", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-reverse-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore all then reverse ignore then exclude files", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-reverse-ignore-then-exclude-git-files", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "dagger.gen.go\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, "dagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore all then exclude files then reverse ignore", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-exclude-files-then-reverse-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore dir", func(ctx context.Context, t *testctx.T) {
@@ -5140,18 +5140,18 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 		t.Run("no ignore", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("no-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore every go files except main.go", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-every-go-file-except-main-go", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 
 			// Verify the directories exist but files are correctlyignored
 			out, err = modGen.With(daggerCall("ignore-every-go-file-except-main-go", "directory", "--path", "internal", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "dagger\nquerybuilder\ntelemetry\n", out)
+			require.Equal(t, "dagger/\nquerybuilder/\ntelemetry/\n", out)
 
 			out, err = modGen.With(daggerCall("ignore-every-go-file-except-main-go", "directory", "--path", "internal/telemetry", "entries")).Stdout(ctx)
 			require.NoError(t, err)
@@ -5177,7 +5177,7 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 		t.Run("ignore all then reverse ignore all with different dir than the one set in context", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-reverse-ignore", "--dir", "/work", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".git\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n", out)
+			require.Equal(t, ".git/\nLICENSE\nbackend/\ndagger/\ndagger.json\nfrontend/\n", out)
 		})
 	})
 }

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -173,11 +173,11 @@ func (TypescriptSuite) TestInit(ctx context.Context, t *testctx.T) {
 
 		sourceSubdirEnts, err := modGen.Directory("/work/some/subdir").Entries(ctx)
 		require.NoError(t, err)
-		require.Contains(t, sourceSubdirEnts, "src")
+		require.Contains(t, sourceSubdirEnts, "src/")
 
 		sourceRootEnts, err := modGen.Directory("/work").Entries(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, sourceRootEnts, "src")
+		require.NotContains(t, sourceRootEnts, "src/")
 	})
 
 	t.Run("ignore parent directory package manager", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -206,5 +206,5 @@ func (PlatformSuite) TestWindows(ctx context.Context, t *testctx.T) {
 		Rootfs().
 		Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"License.txt", "ProgramData", "Users", "Windows"}, ents)
+	require.Equal(t, []string{"License.txt", "ProgramData/", "Users/", "Windows/"}, ents)
 }

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -1433,7 +1433,7 @@ func (ServiceSuite) TestDirectoryEntries(ctx context.Context, t *testctx.T) {
 		Tree().
 		Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{".git", "README.md"}, entries)
+	require.Equal(t, []string{".git/", "README.md"}, entries)
 }
 
 func (ServiceSuite) TestDirectorySync(ctx context.Context, t *testctx.T) {
@@ -1462,7 +1462,7 @@ func (ServiceSuite) TestDirectorySync(ctx context.Context, t *testctx.T) {
 
 		entries, err := repo.Entries(ctx)
 		require.NoError(t, err)
-		require.Equal(t, []string{".git", "README.md"}, entries)
+		require.Equal(t, []string{".git/", "README.md"}, entries)
 	})
 }
 
@@ -1501,7 +1501,7 @@ func (ServiceSuite) TestWithDirectoryFileServices(ctx context.Context, t *testct
 
 	entries, err := useBoth.Directory("/repo").Entries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{".git", "README.md"}, entries)
+	require.Equal(t, []string{".git/", "README.md"}, entries)
 
 	fileContent, err := useBoth.File("/index.html").Contents(ctx)
 	require.NoError(t, err)

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -581,7 +581,7 @@ func ReadSnapshotPath(ctx context.Context, c *Client, mntable snapshot.Mountable
 type WalkDirRequest struct {
 	Path           string
 	IncludePattern string
-	Callback       func(path string, info *fstypes.Stat) error
+	Callback       func(path string, info os.FileInfo) error
 }
 
 // walkDir is inspired by cacheutil.ReadDir, but instead executes a callback on
@@ -605,12 +605,7 @@ func walkDir(ctx context.Context, mount snapshot.Mountable, req WalkDirRequest) 
 			if err != nil {
 				return fmt.Errorf("walking %q: %w", root, err)
 			}
-			stat, ok := info.Sys().(*fstypes.Stat)
-			if !ok {
-				// This "can't happen(tm)".
-				return fmt.Errorf("expected a *fsutil.Stat but got %T", info.Sys())
-			}
-			return req.Callback(path, stat)
+			return req.Callback(path, info)
 		})
 	})
 }

--- a/modules/alpine/main.go
+++ b/modules/alpine/main.go
@@ -224,10 +224,12 @@ func (m *Alpine) withPkgs(
 			// - ld-linux installs to /lib64
 			// TODO: this should *probably* apply to /usr/lib64/ and
 			// /usr/local/lib64/ as well
-			if m.Distro == DistroWolfi && pkg.PackageName() != "wolfi-baselayout" && slices.Contains(entries, "lib64") {
-				alpinePkg.dir = alpinePkg.dir.
-					WithDirectory("/lib", alpinePkg.dir.Directory("/lib64")).
-					WithoutDirectory("/lib64")
+			if m.Distro == DistroWolfi && pkg.PackageName() != "wolfi-baselayout" {
+				if slices.Contains(entries, "lib64/") || slices.Contains(entries, "lib64") {
+					alpinePkg.dir = alpinePkg.dir.
+						WithDirectory("/lib", alpinePkg.dir.Directory("/lib64")).
+						WithoutDirectory("/lib64")
+				}
 			}
 
 			for _, entry := range entries {

--- a/version/git.go
+++ b/version/git.go
@@ -39,7 +39,7 @@ func git(ctx context.Context, gitDir *dagger.Directory, dir *dagger.Directory) (
 	if err != nil {
 		return nil, err
 	}
-	if slices.Contains(entries, ".git") {
+	if slices.Contains(entries, ".git/") || slices.Contains(entries, ".git") {
 		valid = true
 	}
 


### PR DESCRIPTION
> [!NOTE]
>
> This is a proposal! Thoughts wanted :thinking: 
>
> We *might* consider this a breaking change, so should probably put it behind our module compat if we choose to take it.

This is fairly useful, and matches the output of GNU's `tar xvf` - it makes it a lot easier to inspect and traverse a filesystem using this.

This came up while working with a filesystem, and wanting to filter out the results of `Glob` to *only* the directories, or to *only* the leaf-level files.