### PR TITLE
add wallclock profiling & graphviz disk util

### DIFF
--- a/.dagger/mage/engine.go
+++ b/.dagger/mage/engine.go
@@ -116,7 +116,7 @@ func (t Engine) Dev(ctx context.Context) error {
 		"-e", "DAGGER_CLOUD_URL",
 		"-e", util.GPUSupportEnvName,
 		"-v", volumeName + ":" + distconsts.EngineDefaultStateDir,
-		// "-p", "6060:6060",
+		"-p", "6060:6060",
 		"--name", containerName,
 		"--privileged",
 	}...)

--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/felixge/fgprof"
 	"github.com/mackerelio/go-osstat/cpu"
 	"github.com/mackerelio/go-osstat/loadavg"
 	"github.com/mackerelio/go-osstat/memory"
@@ -35,6 +36,7 @@ func setupDebugHandlers(addr string) error {
 	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	m.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 	m.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	m.Handle("/debug/fgprof", fgprof.Handler())
 	m.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
 	m.Handle("/debug/events", http.HandlerFunc(trace.Events))
 	// m.Handle("/debug/fgtrace", fgtrace.Config{})

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/google/uuid"
 	"github.com/iancoleman/strcase"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
@@ -1739,6 +1740,7 @@ func (ModuleSuite) TestLotsOfFunctions(ctx context.Context, t *testctx.T) {
 			}
 			eg.Go(func() error {
 				_, err := modGen.
+					WithEnvVariable("CACHE_BUST", uuid.NewString()).
 					With(daggerCall(fmt.Sprintf("potato-%d", i))).
 					Sync(ctx)
 				return err
@@ -1780,6 +1782,7 @@ class PotatoSack:
 			}
 			eg.Go(func() error {
 				_, err := modGen.
+					WithEnvVariable("CACHE_BUST", uuid.NewString()).
 					With(daggerCall(fmt.Sprintf("potato-%d", i))).
 					Sync(ctx)
 				return err
@@ -1826,6 +1829,7 @@ export class PotatoSack {
 			}
 			eg.Go(func() error {
 				_, err := modGen.
+					WithEnvVariable("CACHE_BUST", uuid.NewString()).
 					With(daggerCall(fmt.Sprintf("potato-%d", i))).
 					Sync(ctx)
 				return err
@@ -1887,6 +1891,7 @@ func (ModuleSuite) TestLotsOfDeps(ctx context.Context, t *testctx.T) {
 			newModNames = append(newModNames, name)
 			modGen = modGen.
 				WithWorkdir("/work/"+name).
+				WithEnvVariable("CACHE_BUST", uuid.NewString()).
 				WithNewFile("./main.go", getModMainSrc(name, depNames))
 
 			var depCfgs []*modules.ModuleConfigDependency

--- a/dagql/dagui/dot.go
+++ b/dagql/dagui/dot.go
@@ -239,14 +239,20 @@ func (dag *dotDag) writeTo(out io.Writer) {
 			color = "red"
 		}
 
-		if readBytes := vtx.span.MetricsByName[telemetry.IOStatDiskReadBytes]; len(readBytes) > 0 {
-			lastPoint := readBytes[len(readBytes)-1]
-			label += fmt.Sprintf("\nRead: %s", humanize.Bytes(uint64(lastPoint.Value)))
-		}
+		// if vtx.span.db.MetricsByCall == nil {
+		// 	vtx.span.db.MetricsByCall = make(map[string]map[string][]metricdata.DataPoint[int64])
+		// }
+		metricsByName, ok := vtx.span.db.MetricsByCall[vtxDgst]
+		if ok {
+			if readBytes := metricsByName[telemetry.IOStatDiskReadBytes]; len(readBytes) > 0 {
+				lastPoint := readBytes[len(readBytes)-1]
+				label += fmt.Sprintf("\nRead: %s", humanize.Bytes(uint64(lastPoint.Value)))
+			}
 
-		if writeBytes := vtx.span.MetricsByName[telemetry.IOStatDiskWriteBytes]; len(writeBytes) > 0 {
-			lastPoint := writeBytes[len(writeBytes)-1]
-			label += fmt.Sprintf("\nWrite: %s", humanize.Bytes(uint64(lastPoint.Value)))
+			if writeBytes := metricsByName[telemetry.IOStatDiskWriteBytes]; len(writeBytes) > 0 {
+				lastPoint := writeBytes[len(writeBytes)-1]
+				label += fmt.Sprintf("\nWrite: %s", humanize.Bytes(uint64(lastPoint.Value)))
+			}
 		}
 
 		fmt.Fprintf(out, "  %q [label=%q shape=ellipse penwidth=%f color=%s];\n", vtxDgst, label, border, color)

--- a/dagql/dagui/dot.go
+++ b/dagql/dagui/dot.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"time"
 
+	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
+	"github.com/dustin/go-humanize"
 )
 
 func (db *DB) WriteDot(
@@ -235,6 +237,16 @@ func (dag *dotDag) writeTo(out io.Writer) {
 		if thicc {
 			border = 10.0
 			color = "red"
+		}
+
+		if readBytes := vtx.span.MetricsByName[telemetry.IOStatDiskReadBytes]; len(readBytes) > 0 {
+			lastPoint := readBytes[len(readBytes)-1]
+			label += fmt.Sprintf("\nRead: %s", humanize.Bytes(uint64(lastPoint.Value)))
+		}
+
+		if writeBytes := vtx.span.MetricsByName[telemetry.IOStatDiskWriteBytes]; len(writeBytes) > 0 {
+			lastPoint := writeBytes[len(writeBytes)-1]
+			label += fmt.Sprintf("\nWrite: %s", humanize.Bytes(uint64(lastPoint.Value)))
 		}
 
 		fmt.Fprintf(out, "  %q [label=%q shape=ellipse penwidth=%f color=%s];\n", vtxDgst, label, border, color)

--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/felixge/fgprof v0.9.3 // indirect
+	github.com/felixge/fgprof v0.9.5
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,9 @@ github.com/charmbracelet/x/ansi v0.4.5 h1:LqK4vwBNaXw2AyGIICa5/29Sbdq58GbGdFngSe
 github.com/charmbracelet/x/ansi v0.4.5/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
+github.com/chromedp/chromedp v0.9.2/go.mod h1:LkSXJKONWTCHAfQasKFUZI+mxqS4tZqhmtGzzhLsnLs=
+github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
@@ -233,8 +236,9 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
 github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
+github.com/felixge/fgprof v0.9.5 h1:8+vR6yu2vvSKn08urWyEuxx75NWPEvybbkBirEpsbVY=
+github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -264,6 +268,9 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
@@ -312,6 +319,7 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
+github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQNvHSdIE7iqsQxK1P41mySCvssg=
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
@@ -350,6 +358,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
+github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF/XEFBbY=
 github.com/in-toto/in-toto-golang v0.5.0/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -393,6 +402,7 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/lmittmann/tint v1.0.5 h1:NQclAutOfYsqs2F1Lenue6OoWCajs5wJcP3DfWVpePw=
 github.com/lmittmann/tint v1.0.5/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -478,6 +488,7 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
+github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 h1:DiLBVp4DAcZlBVBEtJpNWZpZVq0AEeCY7Hqk8URVs4o=
 github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
wip, needs cleanup, but adds fgprof to do wall-clock profiling (looking for time spent waiting on disk– this doesn't show with cpu profiling offered by pprof) as well as wiring through disk utilization to @sipsma's graphviz visualizations