### PR TITLE
python: remove deprecated index-url in tool.uv

### DIFF
--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -899,49 +899,6 @@ class Test:
 			require.Equal(t, "https://test.pypi.org/simple\nhttps://pypi.org/simple\n", out)
 		})
 
-		t.Run("backwards compat", func(ctx context.Context, t *testctx.T) {
-			c := connect(ctx, t)
-
-			out, err := daggerCliBase(t, c).
-				With(source).
-				With(pyprojectExtra(nil, `
-                    [tool.uv]
-                    index-url = "https://test.pypi.org/simple"
-                    extra-index-url = "https://pypi.org/simple"
-                `)).
-				With(daggerInitPython()).
-				With(daggerCall("urls")).
-				Stdout(ctx)
-
-			require.NoError(t, err)
-			require.Equal(t, "https://test.pypi.org/simple\nhttps://pypi.org/simple\n", out)
-		})
-
-		t.Run("preference", func(ctx context.Context, t *testctx.T) {
-			c := connect(ctx, t)
-
-			out, err := daggerCliBase(t, c).
-				With(source).
-				With(pyprojectExtra(nil, `
-                    [tool.uv]
-                    index-url = "https://test.example.org/simple"
-                    extra-index-url = "https://example.org/simple"
-
-                    [[tool.uv.index]]
-                    url = "https://test.pypi.org/simple"
-                    default = true
-
-                    [[tool.uv.index]]
-                    url = "https://pypi.org/simple"
-                `)).
-				With(daggerInitPython()).
-				With(daggerCall("urls")).
-				Stdout(ctx)
-
-			require.NoError(t, err)
-			require.Equal(t, "https://test.pypi.org/simple\nhttps://pypi.org/simple\n", out)
-		})
-
 		t.Run("without", func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 

--- a/sdk/python/.changes/unreleased/Breaking-20241209-120336.yaml
+++ b/sdk/python/.changes/unreleased/Breaking-20241209-120336.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |
+    Removed the deprecated `index-url` and `index-extral-url` settings under `[tool.uv]`
+
+    These settings were deprecated in Dagger [v0.14.0](https://github.com/dagger/dagger/releases?q=tag%3Asdk%2Fpython%2Fv0) since uv [v0.4.23](https://github.com/astral-sh/uv/releases/tag/0.4.23) replaced them with the `[[tool.uv.index]]` table. See [Package indexes](https://docs.astral.sh/uv/configuration/indexes/) for the full documentation.
+time: 2024-12-09T12:03:36.085711-01:00
+custom:
+    Author: helderco
+    PR: "9127"

--- a/sdk/python/runtime/discovery.go
+++ b/sdk/python/runtime/discovery.go
@@ -29,12 +29,6 @@ type UvConfig struct {
 	// Index is a list of uv index configurations.
 	// Ssee [uv v0.4.23](https://github.com/astral-sh/uv/releases/tag/0.4.23)
 	Index []UvIndexConfig `toml:"index"`
-
-	// Deprecated: use "Index" instead
-	IndexURL string `toml:"index-url"`
-	//
-	// Deprecated: use "Index" instead
-	ExtraIndexURL string `toml:"extra-index-url"`
 }
 
 type UvIndexConfig struct {

--- a/sdk/python/runtime/extension.go
+++ b/sdk/python/runtime/extension.go
@@ -92,10 +92,6 @@ func (m *PythonSdk) IndexURL() string {
 			return cfg.URL
 		}
 	}
-	// deprecated
-	if len(m.Discovery.UvConfig().Index) == 0 {
-		return m.Discovery.UvConfig().IndexURL
-	}
 	return ""
 }
 
@@ -108,9 +104,6 @@ func (m *PythonSdk) ExtraIndexURL() string {
 		if !cfg.Default {
 			return cfg.URL
 		}
-	}
-	if len(m.Discovery.UvConfig().Index) == 0 {
-		return m.Discovery.UvConfig().ExtraIndexURL
 	}
 	return ""
 }


### PR DESCRIPTION
This removes a deprecation from [v0.14.0](https://github.com/dagger/dagger/releases?q=tag%3Asdk%2Fpython%2Fv0):
- https://github.com/dagger/dagger/pull/8772

## Migration



### `UV_INDEX_URL`
```diff
-[tool.uv]
-index-url = "https://pypi.acme.org/simple"
+[[tool.uv.index]]
+url = "https://pypi.acme.org/simple"
+default = true
```

### `UV_EXTRA_INDEX_URL`
```diff
-[tool.uv]
-index-extra-url = "https://pypi.acme.org/simple"
+[[tool.uv.index]]
+url = "https://pypi.acme.org/simple"
```

\ping @ClifHouck