### PR TITLE
chore: omit empty dependency pin in dagger.json

### DIFF
--- a/.changes/unreleased/Added-20241207-013627.yaml
+++ b/.changes/unreleased/Added-20241207-013627.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added DAGGER_LEAVE_OLD_ENGINE environment variable to optionally prevent removal of old engine containers during upgrades
+time: 2024-12-07T01:36:27.59938702Z
+custom:
+    Author: devin
+    PR: "8195"

--- a/.dagger/docker.go
+++ b/.dagger/docker.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dagger/dagger/.dagger/internal/dagger"
+	"github.com/dagger/dagger/engine/distconsts"
+	"github.com/moby/buildkit/identity"
+)
+
+// LoadToDocker loads the engine container into docker
+func (e *DaggerEngine) LoadToDocker(
+	ctx context.Context,
+
+	docker *dagger.Socket,
+	name string,
+
+	// +optional
+	platform dagger.Platform,
+
+	// Set target distro
+	// +optional
+	image *Distro,
+	// Enable experimental GPU support
+	// +optional
+	gpuSupport bool,
+) (*LoadedEngine, error) {
+	ctr, err := e.Container(ctx, platform, image, gpuSupport)
+	if err != nil {
+		return nil, err
+	}
+	tar := ctr.AsTarball(dagger.ContainerAsTarballOpts{
+		// use gzip to avoid incompatibility w/ older docker versions
+		ForcedCompression: dagger.ImageLayerCompressionGzip,
+	})
+
+	loader := dag.Container().
+		From("docker:cli").
+		WithUnixSocket("/var/run/docker.sock", docker).
+		WithMountedFile("/image.tar.gz", tar).
+		WithEnvVariable("CACHEBUSTER", identity.NewID())
+
+	stdout, err := loader.
+		WithExec([]string{"docker", "load", "-i", "/image.tar.gz"}).
+		Stdout(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("docker load failed: %w", err)
+	}
+
+	_, imageID, ok := strings.Cut(stdout, "Loaded image ID: sha256:")
+	if !ok {
+		_, imageID, ok = strings.Cut(stdout, "Loaded image: sha256:") // podman
+		if !ok {
+			return nil, fmt.Errorf("unexpected output from docker load")
+		}
+	}
+	imageID = strings.TrimSpace(imageID)
+
+	_, err = loader.
+		WithExec([]string{"docker", "tag", imageID, name}).
+		Sync(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("docker tag failed: %w", err)
+	}
+
+	return &LoadedEngine{
+		Loader:     loader,
+		Image:      name,
+		GPUSupport: gpuSupport,
+	}, nil
+}
+
+type LoadedEngine struct {
+	Loader *dagger.Container // +private
+	Image  string
+
+	GPUSupport bool // +private
+}
+
+// Start the loaded engine container
+func (e LoadedEngine) Start(
+	ctx context.Context,
+
+	// +optional
+	// +default="dagger-engine.dev"
+	name string,
+	// +optional
+	cloudToken *dagger.Secret,
+) error {
+	loader := e.Loader
+
+	_, err := loader.WithExec([]string{"docker", "rm", "-fv", name}).Sync(ctx)
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"docker",
+		"run",
+		"-d",
+	}
+	if e.GPUSupport {
+		args = append(args, "--gpus", "all")
+		loader = loader.WithEnvVariable("_EXPERIMENTAL_DAGGER_GPU_SUPPORT", "true")
+	}
+	if cloudToken != nil {
+		// NOTE: this is only for connecting to dagger cloud's cache service
+		args = append(args, "-e", "DAGGER_CLOUD_TOKEN")
+		loader = loader.WithSecretVariable("DAGGER_CLOUD_TOKEN", cloudToken)
+	}
+	args = append(args, []string{
+		"-v", name + ":" + distconsts.EngineDefaultStateDir,
+		"--name", name,
+		"--privileged",
+	}...)
+	args = append(args, e.Image, "--extra-debug", "--debugaddr=0.0.0.0:6060")
+
+	_, err = loader.WithExec(args).Sync(ctx)
+	return err
+}

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -84,7 +84,7 @@ type ModuleConfigDependency struct {
 	Source string `json:"source"`
 
 	// The pinned version of the module dependency.
-	Pin string `json:"pin"`
+	Pin string `json:"pin,omitempty"`
 }
 
 func (depCfg *ModuleConfigDependency) UnmarshalJSON(data []byte) error {

--- a/docs/static/reference/dagger.schema.json
+++ b/docs/static/reference/dagger.schema.json
@@ -91,8 +91,7 @@
       "type": "object",
       "required": [
         "name",
-        "source",
-        "pin"
+        "source"
       ]
     },
     "ModuleConfigView": {

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -34,6 +34,12 @@ func init() {
 	register("docker-image", &dockerDriver{})
 }
 
+// shouldCleanupEngines returns true if old engines should be cleaned up
+func shouldCleanupEngines() bool {
+	val := os.Getenv("DAGGER_LEAVE_OLD_ENGINE")
+	return val == "" || val == "0" || strings.ToLower(val) == "false"
+}
+
 // dockerDriver creates and manages a container, then connects to it
 type dockerDriver struct{}
 
@@ -72,6 +78,11 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *Driver
 	defer telemetry.End(span, func() error { return rerr })
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
+	// Log environment variable state at creation
+	slog.Info("checking engine environment",
+		"DAGGER_LEAVE_OLD_ENGINE", os.Getenv("DAGGER_LEAVE_OLD_ENGINE"),
+		"shouldCleanup", shouldCleanupEngines())
+
 	id, err := resolveImageID(imageRef)
 	if err != nil {
 		return nil, err
@@ -92,11 +103,17 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *Driver
 	for i, leftoverEngine := range leftoverEngines {
 		// if we already have a container with that name, attempt to start it
 		if leftoverEngine == containerName {
+			slog.Info("found existing container", "name", containerName)
 			cmd := exec.CommandContext(ctx, "docker", "start", leftoverEngine)
 			if output, err := traceExec(ctx, cmd); err != nil {
 				return nil, errors.Wrapf(err, "failed to start container: %s", output)
 			}
-			garbageCollectEngines(ctx, slog, append(leftoverEngines[:i], leftoverEngines[i+1:]...))
+			slog.Info("cleaning up other engines after starting existing container",
+				"current", containerName,
+				"leftover_count", len(leftoverEngines)-1)
+			if shouldCleanupEngines() {
+				garbageCollectEngines(ctx, slog, append(leftoverEngines[:i], leftoverEngines[i+1:]...))
+			}
 			return connhDocker.Helper(&url.URL{
 				Scheme: "docker-container",
 				Host:   containerName,
@@ -134,6 +151,7 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *Driver
 	// explicitly pass current env vars; if we append more below existing ones like DOCKER_HOST
 	// won't be passed to the cmd
 	cmd.Env = os.Environ()
+
 	if opts.DaggerCloudToken != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", EnvDaggerCloudToken, opts.DaggerCloudToken))
 		cmd.Args = append(cmd.Args, "-e", EnvDaggerCloudToken)
@@ -151,10 +169,12 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *Driver
 		}
 	}
 
-	// garbage collect any other containers with the same name pattern, which
-	// we assume to be leftover from previous runs of the engine using an older
-	// version
-	garbageCollectEngines(ctx, slog, leftoverEngines)
+	if shouldCleanupEngines() {
+		slog.Info("cleaning up old engines after creating new container",
+			"current", containerName,
+			"leftover_count", len(leftoverEngines))
+		garbageCollectEngines(ctx, slog, leftoverEngines)
+	}
 
 	return connhDocker.Helper(&url.URL{
 		Scheme: "docker-container",
@@ -185,19 +205,35 @@ func resolveImageID(imageRef string) (string, error) {
 }
 
 func garbageCollectEngines(ctx context.Context, log *slog.Logger, engines []string) {
+	val := os.Getenv("DAGGER_LEAVE_OLD_ENGINE")
+
+	// Enhanced logging for debugging
+	log.Info("evaluating engine cleanup",
+		"raw_env_value", val,
+		"engineCount", len(engines))
+
+	// Log each engine being considered
+	for i, engine := range engines {
+		log.Info("found engine",
+			"index", i,
+			"name", engine)
+	}
+
 	for _, engine := range engines {
 		if engine == "" {
 			continue
 		}
+		log.Info("removing engine",
+			"name", engine,
+			"env_value", val)
+
 		if output, err := traceExec(ctx, exec.CommandContext(ctx,
 			"docker", "rm", "-fv", engine,
 		)); err != nil {
-			if errors.Is(err, context.Canceled) {
-				return
-			}
-			if !strings.Contains(output, "already in progress") {
-				log.Warn("failed to remove old container", "container", engine, "error", err)
-			}
+			log.Warn("failed to remove container",
+				"name", engine,
+				"error", err,
+				"output", output)
 		}
 	}
 }
@@ -217,6 +253,10 @@ func traceExec(ctx context.Context, cmd *exec.Cmd, opts ...trace.SpanStartOption
 }
 
 func collectLeftoverEngines(ctx context.Context) ([]string, error) {
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
+	slog.Info("collecting leftover engines",
+		"DAGGER_LEAVE_OLD_ENGINE", os.Getenv("DAGGER_LEAVE_OLD_ENGINE"))
+
 	cmd := exec.CommandContext(ctx,
 		"docker", "ps",
 		"-a",
@@ -226,11 +266,19 @@ func collectLeftoverEngines(ctx context.Context) ([]string, error) {
 	)
 	output, err := traceExec(ctx, cmd)
 	if err != nil {
+		slog.Error("failed to list containers",
+			"error", err,
+			"output", output)
 		return nil, errors.Wrapf(err, "failed to list containers: %s", output)
 	}
 
 	output = strings.TrimSpace(output)
 	engineNames := strings.Split(output, "\n")
+
+	slog.Info("found engines",
+		"count", len(engineNames),
+		"names", engineNames)
+
 	return engineNames, err
 }
 


### PR DESCRIPTION
Made a mistake in #8801. While `pin` is required on git sources, it's not on local sources.

So we end up with https://github.com/dagger/dagger/blob/e6bbc047dd19692eb9d6d65cb20d2c53853078b2/dagger.json#L5-L10

with an empty `pin` field, which is kinda meh.

So we should relax the `pin` output, and omit it if it's empty.