### PR TITLE
Follow-up from changes to `DAGGER_LEAVE_OLD_ENGINE`

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -113,7 +113,7 @@ jobs:
       - name: "test"
         uses: ./.github/actions/call
         with:
-          function: "test specific --run='TestProvision' --race=true --parallel=16"
+          function: "test specific --run='TestProvision' --race=true --parallel=1"
           upload-logs: true
 
   test-everything-else:

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3632,8 +3632,8 @@ func (ContainerSuite) TestInsecureRootCapabilitesWithService(ctx context.Context
 	// testing it can startup, create containers and bind mount from its filesystem to
 	// them.
 	randID := identity.NewID()
-	dockerd := dockerService(t, c, "23.0.1", middleware)
-	out, err := dockerClient(ctx, t, c, dockerd, "23.0.1", middleware).
+	dockerc := dockerSetup(ctx, t, t.Name(), c, "23.0.1", middleware)
+	out, err := dockerc.
 		WithExec([]string{"sh", "-e", "-c", strings.Join([]string{
 			fmt.Sprintf("echo %s-from-outside > /tmp/from-outside", randID),
 			"docker run --rm -v /tmp:/tmp alpine cat /tmp/from-outside",
@@ -4213,7 +4213,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 	c := connect(ctx, t)
 
 	for _, dockerVersion := range []string{"20.10", "23.0", "24.0"} {
-		dockerd := dockerService(t, c, dockerVersion, nil)
+		dockerc := dockerSetup(ctx, t, t.Name(), c, dockerVersion, nil)
 
 		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediaTypes, dagger.ImageMediaTypesDockerMediaTypes} {
 			mediaType := mediaType
@@ -4231,7 +4231,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 						})
 					require.NoError(t, err)
 
-					ctr := dockerClient(ctx, t, c, dockerd, dockerVersion, nil).
+					ctr := dockerc.
 						WithMountedFile(path.Join("/", path.Base(tmpfile)), c.Host().File(tmpfile)).
 						WithExec([]string{"docker", "load", "-i", "/" + path.Base(tmpfile)})
 

--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -27,8 +27,7 @@ func TestProvision(t *testing.T) {
 func (ProvisionSuite) TestDockerDriver(ctx context.Context, t *testctx.T) {
 	t.Run("default image", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		dockerd := dockerService(t, c, "", nil)
-		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
+		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 
 		out, err := dockerc.
@@ -41,8 +40,7 @@ func (ProvisionSuite) TestDockerDriver(ctx context.Context, t *testctx.T) {
 
 	t.Run("specified image", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		dockerd := dockerService(t, c, "", nil)
-		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
+		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 
 		version := "v0.14.0"
@@ -55,8 +53,7 @@ func (ProvisionSuite) TestDockerDriver(ctx context.Context, t *testctx.T) {
 
 	t.Run("current image", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		dockerd := dockerService(t, c, "", nil)
-		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
+		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 		dockerc, err := dockerLoadEngine(ctx, c, dockerc, "registry.dagger.io/engine:dev")
 		require.NoError(t, err)
@@ -78,8 +75,7 @@ func (ProvisionSuite) TestDockerDriverConfig(ctx context.Context, t *testctx.T) 
 		return ctr.WithNewFile("/root/.config/dagger/engine.json", configContents)
 	}
 
-	dockerd := dockerService(t, c, "", middleware)
-	dockerc := dockerClient(ctx, t, c, dockerd, "", middleware)
+	dockerc := dockerSetup(ctx, t, "provisioner", c, "", middleware)
 	dockerc, err := dockerLoadEngine(ctx, c, dockerc, "registry.dagger.io/engine:dev")
 	require.NoError(t, err)
 	dockerc = dockerc.
@@ -117,8 +113,7 @@ func (ProvisionSuite) TestDockerDriverGarbageCollectEngines(ctx context.Context,
 
 	t.Run("cleanup", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		dockerd := dockerService(t, c, "", nil)
-		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
+		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 
 		require.Len(t, dockerPs(ctx, t, dockerc), 0)
@@ -144,8 +139,7 @@ func (ProvisionSuite) TestDockerDriverGarbageCollectEngines(ctx context.Context,
 
 	t.Run("no cleanup", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		dockerd := dockerService(t, c, "", nil)
-		dockerc := dockerClient(ctx, t, c, dockerd, "", nil)
+		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
 		dockerc = dockerc.WithEnvVariable("DAGGER_LEAVE_OLD_ENGINE", "true")
 
@@ -171,22 +165,24 @@ func (ProvisionSuite) TestDockerDriverGarbageCollectEngines(ctx context.Context,
 	})
 }
 
-func dockerService(t *testctx.T, dag *dagger.Client, dockerVersion string, f func(*dagger.Container) *dagger.Container) *dagger.Service {
-	tag := "dind"
-	if dockerVersion != "" {
-		tag = dockerVersion + "-" + tag
-	}
-
+func dockerSetup(ctx context.Context, t *testctx.T, name string, dag *dagger.Client, dockerVersion string, f func(*dagger.Container) *dagger.Container) *dagger.Container {
 	if f == nil {
 		f = func(ctr *dagger.Container) *dagger.Container {
 			return ctr
 		}
 	}
 
+	dockerdTag := "dind"
+	dockercTag := "cli"
+	if dockerVersion != "" {
+		dockerdTag = dockerVersion + "-" + dockerdTag
+		dockercTag = dockerVersion + "-" + dockercTag
+	}
+
 	port := 4000
-	dockerd := dag.Container().From("docker:"+tag).
+	dockerd := dag.Container().From("docker:"+dockerdTag).
 		With(f).
-		WithMountedCache("/var/lib/docker", dag.CacheVolume(t.Name()+"-"+dockerVersion+"-docker-lib"), dagger.ContainerWithMountedCacheOpts{
+		WithMountedCache("/var/lib/docker", dag.CacheVolume(name+"-"+dockerVersion+"-docker-lib"), dagger.ContainerWithMountedCacheOpts{
 			Sharing: dagger.CacheSharingModePrivate,
 		}).
 		WithExposedPort(port).
@@ -200,35 +196,30 @@ func dockerService(t *testctx.T, dag *dagger.Client, dockerVersion string, f fun
 				InsecureRootCapabilities: true,
 			},
 		)
-
-	return dockerd
-}
-
-func dockerClient(ctx context.Context, t *testctx.T, dag *dagger.Client, dockerd *dagger.Service, dockerVersion string, f func(*dagger.Container) *dagger.Container) *dagger.Container {
-	tag := "cli"
-	if dockerVersion != "" {
-		tag = dockerVersion + "-" + tag
-	}
-
-	if f == nil {
-		f = func(ctr *dagger.Container) *dagger.Container {
-			return ctr
-		}
-	}
+	dockerd, err := dockerd.Start(ctx)
+	require.NoError(t, err)
 
 	dockerHost, err := dockerd.Endpoint(ctx, dagger.ServiceEndpointOpts{
 		Scheme: "tcp",
 	})
 	require.NoError(t, err)
 
-	client := dag.Container().From("docker:"+tag).
+	dockerc := dag.Container().From("docker:"+dockercTag).
 		With(f).
 		With(mountDockerConfig(dag)).
 		WithServiceBinding("docker", dockerd).
 		WithEnvVariable("DOCKER_HOST", dockerHost).
 		WithEnvVariable("CACHEBUSTER", identity.NewID())
 
-	return client
+	t.Cleanup(func() {
+		_, err := dockerc.WithExec([]string{"sh", "-c", "docker rm -f $(docker ps -aq); docker system prune --all --volumes; true"}).Sync(ctx)
+		require.NoError(t, err)
+
+		_, err = dockerd.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	return dockerc
 }
 
 func dockerLoadEngine(ctx context.Context, dag *dagger.Client, ctr *dagger.Container, engineTag string) (*dagger.Container, error) {


### PR DESCRIPTION
Follow-up to #9130.

There's a few issues in the merged PR:
- ~~Committed a built binary~~ (fixed by rewriting git history)
- Hardcoded string in too many places
- Overly complex logic
- Unnecessary logs
- Manual string comparisons instead of `strconv.ParseBool`
- No tests

I've fixed all these, and simplified the code. I've also renamed the variable to `_EXPERIMENTAL_DAGGER_LEAVE_OLD_ENGINE`, since I think this is more inline with other variables that we use in dagger. But happy to leave it as is.