### PR TITLE
chore: update telemetry golden tests

### DIFF
--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
@@ -10,10 +10,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -10,10 +10,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
@@ -9,10 +9,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -10,10 +10,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
@@ -5,10 +5,10 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✘ loading module X.Xs
+✘ load module X.Xs
 ! failed to serve module: input: module.withSource.initialize failed to initialize module: failed to call module "broken" to get functions: call constructor: process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 │ ✔ finding module configuration X.Xs
-│ ✘ serving module X.Xs
+│ ✘ initializing module X.Xs
 │ ! input: module.withSource.initialize failed to initialize module: failed to call module "broken" to get functions: call constructor: process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 │ │ $ ModuleSource.resolveFromCaller: ModuleSource! X.Xs CACHED
 │ │ │ ✔ upload /XXX/XXX/XXX from XXXXXXXXXXX (client id: XXXXXXXXXXX, session id: XXXXXXXXXXX) (include: XXXXXXXXXXX) (exclude: XXXXXXXXXXX) X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/custom-span
@@ -10,10 +10,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/pending
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/custom-span
@@ -10,10 +10,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/pending
@@ -5,10 +5,11 @@ Expected stderr:
 │ ✔ connecting to engine X.Xs
 │ ✔ starting session X.Xs
 
-✔ loading module X.Xs
+✔ load module X.Xs
 │ ✔ finding module configuration X.Xs
-│ ✔ serving module X.Xs
-│ ✔ inspecting module X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
 
 ✔ parsing command line arguments X.Xs
 


### PR DESCRIPTION
Should have been included in https://github.com/dagger/dagger/pull/9097.

Will fix the failing `test-everything-else` job on `main`.