### PR TITLE
docs: add cli instructions to cache documentation

### DIFF
--- a/docs/current_docs/configuration/cache.mdx
+++ b/docs/current_docs/configuration/cache.mdx
@@ -16,6 +16,13 @@ Dagger caches two types of data:
 
 - Show all the cache entry metadata:
 
+<Tabs groupId="api">
+<TabItem value="CLI">
+```shell
+dagger core engine local-cache entry-set entries
+```
+</TabItem>
+<TabItem value="GraphQL">
     ```shell
     dagger query <<EOF
     {
@@ -32,9 +39,18 @@ Dagger caches two types of data:
     }
     EOF
     ```
+</TabItem>
+</Tabs>
 
 - Show high level summaries of cache usage:
 
+<Tabs groupId="api">
+<TabItem value="CLI">
+```shell
+dagger core engine local-cache entry-set
+```
+</TabItem>
+<TabItem value="GraphQL">
     ```shell
     dagger query <<EOF
     {
@@ -49,6 +65,8 @@ Dagger caches two types of data:
     }
     EOF
     ```
+</TabItem>
+</Tabs>
 
 ## Garbage collection
 
@@ -66,6 +84,13 @@ The cache policy can be manually configured using the [engine config](./engine.m
 
 To manually free up disk space used by the cache, use the following command:
 
+<Tabs groupId="api">
+<TabItem value="CLI">
+```shell
+dagger core engine local-cache prune
+```
+</TabItem>
+<TabItem value="GraphQL">
 ```shell
 dagger query <<EOF
 {
@@ -77,3 +102,5 @@ dagger query <<EOF
 }
 EOF
 ```
+</TabItem>
+</Tabs>

--- a/docs/current_docs/configuration/cache.mdx
+++ b/docs/current_docs/configuration/cache.mdx
@@ -16,57 +16,15 @@ Dagger caches two types of data:
 
 - Show all the cache entry metadata:
 
-<Tabs groupId="api">
-<TabItem value="CLI">
 ```shell
 dagger core engine local-cache entry-set entries
 ```
-</TabItem>
-<TabItem value="GraphQL">
-    ```shell
-    dagger query <<EOF
-    {
-      engine {
-        localCache {
-          entrySet {
-            entries {
-              description
-              diskSpaceBytes
-            }
-          }
-        }
-      }
-    }
-    EOF
-    ```
-</TabItem>
-</Tabs>
 
 - Show high level summaries of cache usage:
 
-<Tabs groupId="api">
-<TabItem value="CLI">
 ```shell
 dagger core engine local-cache entry-set
 ```
-</TabItem>
-<TabItem value="GraphQL">
-    ```shell
-    dagger query <<EOF
-    {
-      engine {
-        localCache {
-          entrySet {
-            entryCount
-            diskSpaceBytes
-          }
-        }
-      }
-    }
-    EOF
-    ```
-</TabItem>
-</Tabs>
 
 ## Garbage collection
 
@@ -84,23 +42,6 @@ The cache policy can be manually configured using the [engine config](./engine.m
 
 To manually free up disk space used by the cache, use the following command:
 
-<Tabs groupId="api">
-<TabItem value="CLI">
 ```shell
 dagger core engine local-cache prune
 ```
-</TabItem>
-<TabItem value="GraphQL">
-```shell
-dagger query <<EOF
-{
-  engine {
-    localCache {
-      prune
-    }
-  }
-}
-EOF
-```
-</TabItem>
-</Tabs>


### PR DESCRIPTION
[discussed in discord](https://discord.com/channels/707636530424053791/1003718839739105300/1316174724744871977), these commands are otherwise undocumented and `dagger core engine local-cache prune` can be useful for performance testing.