### PR TITLE
fix metrics display via tracking by call ID digest

### DIFF
--- a/.changes/unreleased/Fixed-20241211-195735.yaml
+++ b/.changes/unreleased/Fixed-20241211-195735.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Metrics display in the TUI is fixed to display for all executed containers, rather than just services.
+time: 2024-12-11T19:57:35.761154448-08:00
+custom:
+  Author: sipsma
+  PR: "9171"

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -54,6 +54,7 @@ const (
 	ShowEncapsulatedVerbosity = 3
 	ShowSpammyVerbosity       = 4
 	ShowDigestsVerbosity      = 4
+	ShowMetricsVerbosity      = 3
 )
 
 func (opts FrontendOpts) ShouldShow(span *Span) bool {

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -7,7 +7,6 @@ import (
 
 	"dagger.io/dagger/telemetry"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/dagger/dagger/dagql/call/callpbv1"
@@ -32,10 +31,6 @@ type Span struct {
 	// v0.14 and below
 	causesViaAttrs  SpanSet            `json:"-"`
 	effectsViaAttrs map[string]SpanSet `json:"-"`
-
-	// NOTE: this is hard coded for Gauge int64 metricdata essentially right now,
-	// needs generalization as more metric types get added
-	MetricsByName map[string][]metricdata.DataPoint[int64]
 
 	// Indicates that this span was actually exported to the database, and not
 	// just allocated due to a span parent or other relationship.


### PR DESCRIPTION
Some of the recent changes to telemetry span handling resulted in most metrics not showing up in the TUI (other than those for services).

This fixes the display by tracking+displaying metrics based on their associated Call ID digest, which avoids the relative complication of all the various spans we create in different parts of the engine and associated logic on which are actually rendered in the TUI.