### PR TITLE
shell: support state result

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -476,6 +476,14 @@ func (h *shellCallHandler) Exec(next interp.ExecHandlerFunc) interp.ExecHandlerF
 			args = args[1:]
 		}
 
+		// If argument is a state value, just pass it on to stdout.
+		// Example: `$FOO` or `$FOO | bar`
+		if strings.HasPrefix(args[0], shellStatePrefix) {
+			hctx := interp.HandlerCtx(ctx)
+			fmt.Fprint(hctx.Stdout, args[0])
+			return nil
+		}
+
 		st, err := h.cmd(ctx, args)
 		if err == nil && st != nil {
 			if h.debug {

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -578,6 +578,28 @@ func (m *Test) DirectoryID(ctx context.Context) (string, error) {
 	require.Equal(t, "bar", out)
 }
 
+func (ShellSuite) TestStateCommand(ctx context.Context, t *testctx.T) {
+	setup := "FOO=$(directory | with-new-file foo bar); "
+
+	t.Run("state result", func(ctx context.Context, t *testctx.T) {
+		script := setup + "$FOO"
+
+		c := connect(ctx, t)
+		out, err := daggerCliBase(t, c).With(daggerShell(script)).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "foo")
+	})
+
+	t.Run("pipeline from state value", func(ctx context.Context, t *testctx.T) {
+		script := setup + "$FOO | file foo | contents"
+
+		c := connect(ctx, t)
+		out, err := daggerCliBase(t, c).With(daggerShell(script)).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "bar", out)
+	})
+}
+
 func (ShellSuite) TestArgsSpread(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen := daggerCliBase(t, c)


### PR DESCRIPTION
This allows saving a pipeline in a variable and reuse it later:

```console
⋈ CTR=$(container | from alpine)
⋈ $CTR | with-exec echo foobar | stdout
foobar
```

## Before

Previously you had to echo the output yourself (with the added caveat that interpreter builtins like `echo`  are prefixed with `..` to avoid a conflict with function names):
```console
⋈ CTR=$(container | from alpine)
⋈ ..echo $CTR | with-exec echo foobar | stdout
foobar
```
Or you can define a function for a more natural usage:
```console
⋈ ctr() { container | from alpine; }
⋈ ctr | with-exec echo foobar | stdout
foobar
```