### PR TITLE
docs: bump dagger-for-github to v7

### DIFF
--- a/docs/current_docs/integrations/snippets/github-ghcr.yml
+++ b/docs/current_docs/integrations/snippets/github-ghcr.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Call Dagger Function to build and publish to ghcr.io
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@v7
         with:
           version: "latest"
           verb: call

--- a/docs/current_docs/integrations/snippets/github-hello.yml
+++ b/docs/current_docs/integrations/snippets/github-hello.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@v7
         with:
           version: "latest"
           verb: call

--- a/docs/current_docs/integrations/snippets/github-test-build.yml
+++ b/docs/current_docs/integrations/snippets/github-test-build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@v7
         with:
           version: "latest"
           verb: call
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@v7
         with:
           version: "latest"
           verb: call

--- a/docs/current_docs/integrations/snippets/google-cloud-run/main.yml
+++ b/docs/current_docs/integrations/snippets/google-cloud-run/main.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v6
+        uses: dagger/dagger-for-github@v7
         with:
           version: "0.11.5"
           verb: call


### PR DESCRIPTION
following RELEASING.md, this looks like it might've been skipped previously.