### PR TITLE
ci: bump dagger runners generation to g3

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -227,7 +227,7 @@ func BronzeRunner(
 	// +optional
 	dind bool,
 ) string {
-	return Runner(2, daggerVersion, 4, false, dind)
+	return Runner(3, daggerVersion, 4, false, dind)
 }
 
 // Silver runner: Multi-tenant instance, 8 cpu
@@ -236,7 +236,7 @@ func SilverRunner(
 	// +optional
 	dind bool,
 ) string {
-	return Runner(2, daggerVersion, 8, false, dind)
+	return Runner(3, daggerVersion, 8, false, dind)
 }
 
 // Gold runner: Single-tenant instance, 16 cpu
@@ -245,7 +245,7 @@ func GoldRunner(
 	// +optional
 	dind bool,
 ) string {
-	return Runner(2, daggerVersion, 16, true, dind)
+	return Runner(3, daggerVersion, 16, true, dind)
 }
 
 // Platinum runner: Single-tenant instance, 32 cpu
@@ -254,5 +254,5 @@ func PlatinumRunner(
 	// +optional
 	dind bool,
 ) string {
-	return Runner(2, daggerVersion, 32, true, dind)
+	return Runner(3, daggerVersion, 32, true, dind)
 }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   benchmark-go:
     name: Benchmark (Go)
-    runs-on: "dagger-g2-main-4c"
+    runs-on: "dagger-g3-main-4c"
     if: ${{ github.repository == 'dagger/dagger' }}
     timeout-minutes: 10
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   benchmark-python:
     name: Benchmark (Python)
-    runs-on: "dagger-g2-main-4c"
+    runs-on: "dagger-g3-main-4c"
     if: ${{ github.repository == 'dagger/dagger' }}
     timeout-minutes: 10    
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   benchmark-typescript:
     name: Benchmark (TypeScript::${{ matrix.package-manager }})
-    runs-on: "dagger-g2-main-4c"
+    runs-on: "dagger-g3-main-4c"
     if: ${{ github.repository == 'dagger/dagger' }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
     deploy:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: deploy
         steps:
             - name: Checkout

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     docs:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: Docs
         steps:
             - name: Checkout

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           function: "engine publish --image=dagger-engine.dev --tag=main --dry-run"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
   # TEMPORARILY DISABLED. Context: https://github.com/dagger/dagger/pull/8998#issuecomment-2491426455
   # test:
-  #   runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+  #   runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   #         function: "test all --race=true --parallel=16"
   #         upload-logs: true
   test-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
           upload-logs: true
 
   test-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
           upload-logs: true
 
   test-cli-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
 
   test-provision:
     # HACK: this is split out, since these tests require cgroupsv2
-    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    # runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
@@ -117,7 +117,7 @@ jobs:
           upload-logs: true
 
   test-everything-else:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
   #
   # TEMPORARILY DISABLED. Context: https://github.com/dagger/dagger/pull/8998#issuecomment-2491426455
   # testdev:
-  #   runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
+  #   runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
   #         upload-logs: true
 
   testdev-modules:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
           upload-logs: true
 
   testdev-module-runtimes:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
           upload-logs: true
 
   testdev-container:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-32c-dind-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     github:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: Github
         steps:
             - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g2-v0-15-1-16c
+    runs-on: dagger-g3-v0-15-1-16c
     steps:
       - uses: actions/checkout@v4
       - name: "Publish Engine"
@@ -99,7 +99,7 @@ jobs:
 
   publish-sdk-go:
     needs: publish
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"
@@ -112,7 +112,7 @@ jobs:
 
   publish-sdk-php:
     needs: publish
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"
@@ -126,7 +126,7 @@ jobs:
   publish-sdk-python:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"
@@ -142,7 +142,7 @@ jobs:
   publish-sdk-typescript:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"
@@ -157,7 +157,7 @@ jobs:
   publish-sdk-elixir:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"
@@ -172,7 +172,7 @@ jobs:
   publish-helm:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"
@@ -187,7 +187,7 @@ jobs:
   daggerverse-bump-dagger:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g2-v0-15-1-4c
+    runs-on: dagger-g3-v0-15-1-4c
     steps:
       - uses: actions/checkout@v4
       - name: "Bump Dagger version in Daggerverse"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     elixir:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: elixir
         steps:
             - name: Checkout
@@ -190,7 +190,7 @@ jobs:
         timeout-minutes: 10
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: elixir-dev
         steps:
             - name: Checkout
@@ -404,7 +404,7 @@ jobs:
         timeout-minutes: 10
     go:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: go
         steps:
             - name: Checkout
@@ -575,7 +575,7 @@ jobs:
         timeout-minutes: 10
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: go-dev
         steps:
             - name: Checkout
@@ -789,7 +789,7 @@ jobs:
         timeout-minutes: 10
     java:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: java
         steps:
             - name: Checkout
@@ -960,7 +960,7 @@ jobs:
         timeout-minutes: 10
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: java-dev
         steps:
             - name: Checkout
@@ -1174,7 +1174,7 @@ jobs:
         timeout-minutes: 10
     php:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: php
         steps:
             - name: Checkout
@@ -1345,7 +1345,7 @@ jobs:
         timeout-minutes: 10
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: php-dev
         steps:
             - name: Checkout
@@ -1559,7 +1559,7 @@ jobs:
         timeout-minutes: 10
     python:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: python
         steps:
             - name: Checkout
@@ -1730,7 +1730,7 @@ jobs:
         timeout-minutes: 10
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: python-dev
         steps:
             - name: Checkout
@@ -1944,7 +1944,7 @@ jobs:
         timeout-minutes: 10
     rust:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: rust
         steps:
             - name: Checkout
@@ -2115,7 +2115,7 @@ jobs:
         timeout-minutes: 10
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: rust-dev
         steps:
             - name: Checkout
@@ -2329,7 +2329,7 @@ jobs:
         timeout-minutes: 10
     typescript:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
         name: typescript
         steps:
             - name: Checkout
@@ -2500,7 +2500,7 @@ jobs:
         timeout-minutes: 10
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-15-1-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-8c-dind' || 'ubuntu-latest' }}
         name: typescript-dev
         steps:
             - name: Checkout


### PR DESCRIPTION
# Description
`dagger-g2-*` runners are often over-provisioned, primarily due to how we request resources internally and how Karpenter allocates instances (full deep-dive of our setup can be seen [here](https://dagger.io/blog/argo-cd-kubernetes)) . Each instance type has a defined set of resources, however, not all of those resources are considered allocatable by Karpenter. An instance with 8 cores and 32Gi of RAM might only have 7 cores and 28Gi of RAM available for use. When we requested resources, we were requesting the exact number. If a new runner showed up and request 8 cores, instead of allocating an 8 core machine we would double and go for 16 cores. This, multiplied by the amount of PRs are created in dagger/dagger and the size of our runners, lead to a not so cost-effective CI.

In `g3` we introduce one major change: we change resource allocation to be more conservative. Now, if a `dagger-g3-v0-15-1-st-16c` is requested, we will allocate an instance that has 16 cores, instead of 32 cores like we did previously. We introduce this change as a new generation because it can have a performance impact. Jobs that were assuming to have 16 cores were actually operating with 32, so performance might defer.

---

Internal PR: https://github.com/dagger/dagger.io/pull/4128