### PR TITLE
fix "return nil on err" cases and enable related linter

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -135,7 +135,7 @@ func (dir *Directory) SetState(ctx context.Context, st llb.State) error {
 		buildkit.WithPassthrough(), // these spans aren't particularly interesting
 	)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	dir.LLB = def.ToPB()

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -572,7 +572,7 @@ func (src *ModuleSource) ModuleConfig(ctx context.Context) (*modules.ModuleConfi
 	configFile, err := contextDir.Self.File(ctx, filepath.Join(rootSubpath, modules.Filename))
 	if err != nil {
 		// no configuration for this module yet, so no name
-		return nil, false, nil
+		return nil, false, nil //nolint:nilerr
 	}
 	configBytes, err := configFile.Contents(ctx)
 	if err != nil {

--- a/engine/sources/httpdns/source.go
+++ b/engine/sources/httpdns/source.go
@@ -162,7 +162,7 @@ func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, inde
 
 	uh, err := hs.urlHash()
 	if err != nil {
-		return "", "", nil, false, nil
+		return "", "", nil, false, err
 	}
 
 	// look up metadata(previously stored headers) for that URL

--- a/modules/golangci/lint-config.yml
+++ b/modules/golangci/lint-config.yml
@@ -27,6 +27,7 @@ linters:
     - unparam
     - whitespace
     - gomodguard
+    - nilerr
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Happened across an instance of incorrectly returning nil when err was set while working on stuff. This fixes that and enables the nilerr linter for catching these things, which revealed another occurence.

As far as I can tell these haven't been actively hurting us most likely (the error cases are extremely unlikely to happen) but worth preventing these spooky typos from happening again going forward.