### PR TITLE
wip: see if keeping APIs lazier speeds anything up

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -391,55 +391,15 @@ func (dir *Directory) WithNewFile(ctx context.Context, dest string, content []by
 func (dir *Directory) Directory(ctx context.Context, subdir string) (*Directory, error) {
 	dir = dir.Clone()
 
-	svcs, err := dir.Query.Services(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get services: %w", err)
-	}
-	bk, err := dir.Query.Buildkit(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
-	}
-
 	dir.Dir = path.Join(dir.Dir, subdir)
-
-	// check that the directory actually exists so the user gets an error earlier
-	// rather than when the dir is used
-	info, err := dir.Stat(ctx, bk, svcs, ".")
-	if err != nil {
-		return nil, err
-	}
-
-	if !info.IsDir() {
-		return nil, fmt.Errorf("path %s is a file, not a directory", subdir)
-	}
 
 	return dir, nil
 }
 
 func (dir *Directory) File(ctx context.Context, file string) (*File, error) {
-	svcs, err := dir.Query.Services(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get services: %w", err)
-	}
-	bk, err := dir.Query.Buildkit(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
-	}
-
-	err = validateFileName(file)
+	err := validateFileName(file)
 	if err != nil {
 		return nil, err
-	}
-
-	// check that the file actually exists so the user gets an error earlier
-	// rather than when the file is used
-	info, err := dir.Stat(ctx, bk, svcs, file)
-	if err != nil {
-		return nil, err
-	}
-
-	if info.IsDir() {
-		return nil, fmt.Errorf("path %s is a directory, not a file", file)
 	}
 
 	return &File{

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -571,12 +571,12 @@ func (src *ModuleSource) ModuleConfig(ctx context.Context) (*modules.ModuleConfi
 	var modCfg modules.ModuleConfig
 	configFile, err := contextDir.Self.File(ctx, filepath.Join(rootSubpath, modules.Filename))
 	if err != nil {
-		// no configuration for this module yet, so no name
-		return nil, false, nil //nolint:nilerr
+		return nil, false, fmt.Errorf("failed to get module config file: %w", err)
 	}
 	configBytes, err := configFile.Contents(ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to read module config file: %w", err)
+		// no configuration for this module yet, so no name
+		return nil, false, nil //nolint:nilerr
 	}
 
 	if err := json.Unmarshal(configBytes, &modCfg); err != nil {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1120,11 +1120,11 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 		gitAttrsPath := filepath.Join(sourceSubpath, ".gitattributes")
 		var gitAttrsContents []byte
 		gitAttrsFile, err := baseContext.Self.File(ctx, gitAttrsPath)
+		if err != nil {
+			return fmt.Errorf("failed to get git attributes file: %w", err)
+		}
+		gitAttrsContents, err = gitAttrsFile.Contents(ctx)
 		if err == nil {
-			gitAttrsContents, err = gitAttrsFile.Contents(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to get git attributes file contents: %w", err)
-			}
 			if !bytes.HasSuffix(gitAttrsContents, []byte("\n")) {
 				gitAttrsContents = append(gitAttrsContents, []byte("\n")...)
 			}
@@ -1170,8 +1170,11 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 		gitIgnorePath := filepath.Join(sourceSubpath, ".gitignore")
 		var gitIgnoreContents []byte
 		gitIgnoreFile, err := baseContext.Self.File(ctx, gitIgnorePath)
+		if err != nil {
+			return fmt.Errorf("failed to get .gitignore file: %w", err)
+		}
+		gitIgnoreContents, err = gitIgnoreFile.Contents(ctx)
 		if err == nil {
-			gitIgnoreContents, err = gitIgnoreFile.Contents(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get .gitignore file contents: %w", err)
 			}


### PR DESCRIPTION
Noticed some ops on Directory/File were unlazying results when it wasn't really necessary to.

I'm pretty sure there are cases where this will for sure hurt parallelism quite a bit, but want to see a full CI run to get an idea on whether there's much of a practical impact right now for us.

If there is, we should consider doing this. If not, I'll probably just close and leave for now since it's *technically* a breaking change and subtle enough that we'd need to carefully think through the implications + impact on progress in the TUI/cloud.