### PR TITLE
docs: Update dagger version in Jenkins snippet

### DIFF
--- a/docs/current_docs/integrations/snippets/Jenkinsfile
+++ b/docs/current_docs/integrations/snippets/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   // assumes that the Dagger Cloud token
   // is in a Jenkins credential named DAGGER_CLOUD_TOKEN
   environment {
-    DAGGER_VERSION = "0.12.7"
+    DAGGER_VERSION = "0.15.1"
     PATH = "/tmp/dagger/bin:$PATH"
     DAGGER_CLOUD_TOKEN =  credentials('DAGGER_CLOUD_TOKEN')
   }


### PR DESCRIPTION
`dagger call` works as expected with 0.15.1.

closes https://linear.app/dagger/issue/DOCS-387/jenkins-integration-page-update

![image](https://github.com/user-attachments/assets/a344ef59-1142-41e5-9de3-fd4a174227de)
