### PR TITLE
docs: Update dagger version in Argo Workflows snippet

### DIFF
--- a/docs/current_docs/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/integrations/snippets/argo-workflow.yaml
@@ -14,7 +14,7 @@ spec:
       sidecars:
         - name: dagger-engine
           # replace with the latest available version of Dagger for your platform
-          image: registry.dagger.io/engine:v0.12.7
+          image: registry.dagger.io/engine:v0.15.1
           securityContext:
             privileged: true
             capabilities:
@@ -41,7 +41,7 @@ spec:
             mode: 0755
             http:
               # replace with the latest available version of Dagger for your platform
-              url: https://github.com/dagger/dagger/releases/download/v0.12.7/dagger_v0.12.7_linux_amd64.tar.gz
+              url: https://github.com/dagger/dagger/releases/download/v0.15.1/dagger_v0.15.1_linux_amd64.tar.gz
       container:
         image: alpine:latest
         command: ["sh", "-c"]


### PR DESCRIPTION
`dagger call` works as expected with 0.15.1.

Closes https://linear.app/dagger/issue/DOCS-388/argo-workflows-integration-page-update

![image](https://github.com/user-attachments/assets/e7dcbb41-6a05-47fb-a010-29956bcdc086)
