### PR TITLE
`Container.up` consistency with `Container.asService`

### DIFF
--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -63,6 +63,13 @@ func (ModuleSuite) TestDaggerUp(ctx context.Context, t *testctx.T) {
 			cachedModDir: modDirForAsContainerTests,
 		},
 		{
+			name:         "container port map with explicit args",
+			endpointFn:   daggerUpAndGetEndpoint,
+			trafficPort:  "23102",
+			daggerArgs:   []string{"call", "ctr", "without-exposed-port", "--port", defaultTrafficPortForContainerTests, "with-exposed-port", "--port", "23102", "up", "--args", "python,-m,http.server,23102", "--ports", "23102:23102"},
+			cachedModDir: modDirForAsContainerTests,
+		},
+		{
 			name:         "service native",
 			endpointFn:   daggerUpAndGetEndpoint,
 			trafficPort:  "23200",

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -125,6 +125,7 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*cor
 	err := s.srv.Select(ctx, ctr, &svc,
 		dagql.Selector{
 			Field: "asService",
+			View:  s.srv.View,
 		},
 	)
 	if err != nil {

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -52,12 +52,45 @@ func (s *serviceSchema) Install() {
 				pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
 			),
 
-		dagql.NodeFunc("up", s.containerUp).
+		dagql.NodeFunc("up", s.containerUpLegacy).
+			View(BeforeVersion("v0.15.2")).
 			Doc(`Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.`,
 				`Be sure to set any exposed ports before calling this api.`).
 			ArgDoc("random", `Bind each tunnel port to a random port on the host.`).
 			ArgDoc("ports", `List of frontend/backend port mappings to forward.`,
 				`Frontend is the port accepting traffic on the host, backend is the service port.`),
+
+		dagql.NodeFunc("up", s.containerUp).
+			View(AfterVersion("v0.15.2")).
+			Doc(`Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.`,
+				`Be sure to set any exposed ports before calling this api.`).
+			ArgDoc("random", `Bind each tunnel port to a random port on the host.`).
+			ArgDoc("ports", `List of frontend/backend port mappings to forward.`,
+				`Frontend is the port accepting traffic on the host, backend is the service port.`).
+			ArgDoc("args",
+				`Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).`,
+				`If empty, the container's default command is used.`).
+			ArgDoc("useEntrypoint",
+				`If the container has an entrypoint, prepend it to the args.`).
+			ArgDoc("experimentalPrivilegedNesting",
+				`Provides Dagger access to the executed command.`,
+				`Do not use this option unless you trust the command being executed;
+				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
+				FILESYSTEM.`).
+			ArgDoc("insecureRootCapabilities",
+				`Execute the command with all root capabilities. This is similar to
+				running a command with "sudo" or executing "docker run" with the
+				"--privileged" flag. Containerization does not provide any security
+				guarantees when using this option. It should only be used when
+				absolutely necessary and only with trusted commands.`).
+			ArgDoc("expand",
+				`Replace "${VAR}" or "$VAR" in the args according to the current `+
+					`environment variables defined in the container (e.g. "/$VAR/foo").`).
+			ArgDoc("noInit",
+				`If set, skip the automatic init process injected into containers by default.`,
+				`This should only be used if the user requires that their exec process be the
+				pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
+			),
 	}.Install(s.srv)
 
 	dagql.Fields[*core.Service]{
@@ -118,7 +151,66 @@ func (s *serviceSchema) containerAsService(ctx context.Context, parent *core.Con
 	return parent.AsService(ctx, args)
 }
 
-func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*core.Container], args upArgs) (dagql.Nullable[core.Void], error) {
+func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*core.Container], args struct {
+	UpArgs
+	core.ContainerAsServiceArgs
+}) (dagql.Nullable[core.Void], error) {
+	void := dagql.Null[core.Void]()
+
+	var inputs []dagql.NamedInput
+	if args.Args != nil {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "args",
+			Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(args.Args...)),
+		})
+	}
+	if args.UseEntrypoint {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "useEntrypoint",
+			Value: dagql.Boolean(true),
+		})
+	}
+	if args.ExperimentalPrivilegedNesting {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "experimentalPrivilegedNesting",
+			Value: dagql.Boolean(true),
+		})
+	}
+	if args.InsecureRootCapabilities {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "insecureRootCapabilities",
+			Value: dagql.Boolean(true),
+		})
+	}
+	if args.Expand {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "expand",
+			Value: dagql.Boolean(true),
+		})
+	}
+	if args.NoInit {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "noInit",
+			Value: dagql.Boolean(true),
+		})
+	}
+
+	var svc dagql.Instance[*core.Service]
+	err := s.srv.Select(ctx, ctr, &svc,
+		dagql.Selector{
+			Field: "asService",
+			View:  s.srv.View,
+			Args:  inputs,
+		},
+	)
+	if err != nil {
+		return void, err
+	}
+
+	return s.up(ctx, svc, args.UpArgs)
+}
+
+func (s *serviceSchema) containerUpLegacy(ctx context.Context, ctr dagql.Instance[*core.Container], args UpArgs) (dagql.Nullable[core.Void], error) {
 	void := dagql.Null[core.Void]()
 
 	var svc dagql.Instance[*core.Service]
@@ -131,7 +223,6 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*cor
 	if err != nil {
 		return void, err
 	}
-
 	return s.up(ctx, svc, args)
 }
 
@@ -192,14 +283,14 @@ func (s *serviceSchema) stop(ctx context.Context, parent dagql.Instance[*core.Se
 	return dagql.NewID[*core.Service](parent.ID()), nil
 }
 
-type upArgs struct {
+type UpArgs struct {
 	Ports  []dagql.InputObject[core.PortForward] `default:"[]"`
 	Random bool                                  `default:"false"`
 }
 
 const InstrumentationLibrary = "dagger.io/engine.schema"
 
-func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service], args upArgs) (dagql.Nullable[core.Void], error) {
+func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service], args UpArgs) (dagql.Nullable[core.Void], error) {
 	void := dagql.Null[core.Void]()
 
 	useNative := !args.Random && len(args.Ports) == 0

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -430,6 +430,44 @@ type Container {
   """
   up(
     """
+    Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+    
+    If empty, the container's default command is used.
+    """
+    args: [String!] = []
+
+    """
+    Replace "${VAR}" or "$VAR" in the args according to the current environment
+    variables defined in the container (e.g. "/$VAR/foo").
+    """
+    expand: Boolean = false
+
+    """
+    Provides Dagger access to the executed command.
+    
+    Do not use this option unless you trust the command being executed; the
+    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    """
+    experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Execute the command with all root capabilities. This is similar to running a
+    command with "sudo" or executing "docker run" with the "--privileged" flag.
+    Containerization does not provide any security guarantees when using this
+    option. It should only be used when absolutely necessary and only with
+    trusted commands.
+    """
+    insecureRootCapabilities: Boolean = false
+
+    """
+    If set, skip the automatic init process injected into containers by default.
+    
+    This should only be used if the user requires that their exec process be the
+    pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    """
+    noInit: Boolean = false
+
+    """
     List of frontend/backend port mappings to forward.
     
     Frontend is the port accepting traffic on the host, backend is the service port.
@@ -438,6 +476,9 @@ type Container {
 
     """Bind each tunnel port to a random port on the host."""
     random: Boolean = false
+
+    """If the container has an entrypoint, prepend it to the args."""
+    useEntrypoint: Boolean = false
   ): Void
 
   """Retrieves the user to be set for all commands."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4249,6 +4249,29 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>args</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Command to run instead of the container&#39;s default command (e.g., [&quot;go&quot;, &quot;run&quot;, &quot;main.go&quot;]).</p>
+                                <p>If empty, the container&#39;s default command is used.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Replace &quot;${VAR}&quot; or &quot;$VAR&quot; in the args according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Provides Dagger access to the executed command.</p>
+                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Execute the command with all root capabilities. This is similar to running a command with &quot;sudo&quot; or executing &quot;docker run&quot; with the &quot;--privileged&quot; flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noInit</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If set, skip the automatic init process injected into containers by default.</p>
+                                <p>This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>ports</code></span> - <span class="property-type"><a href="#definition-PortForward"><code>[PortForward!]</code></a></span></h6>
                                 <p>List of frontend/backend port mappings to forward.</p>
                                 <p>Frontend is the port accepting traffic on the host, backend is the service port.</p>
@@ -4256,6 +4279,10 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>random</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Bind each tunnel port to a random port on the host.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>useEntrypoint</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If the container has an entrypoint, prepend it to the args.</p>
                               </div>
                             </div>
                           </div>

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -499,14 +499,31 @@ defmodule Dagger.Container do
 
   Be sure to set any exposed ports before calling this api.
   """
-  @spec up(t(), [{:ports, [Dagger.PortForward.t()]}, {:random, boolean() | nil}]) ::
-          :ok | {:error, term()}
+  @spec up(t(), [
+          {:ports, [Dagger.PortForward.t()]},
+          {:random, boolean() | nil},
+          {:args, [String.t()]},
+          {:use_entrypoint, boolean() | nil},
+          {:experimental_privileged_nesting, boolean() | nil},
+          {:insecure_root_capabilities, boolean() | nil},
+          {:expand, boolean() | nil},
+          {:no_init, boolean() | nil}
+        ]) :: :ok | {:error, term()}
   def up(%__MODULE__{} = container, optional_args \\ []) do
     query_builder =
       container.query_builder
       |> QB.select("up")
       |> QB.maybe_put_arg("ports", optional_args[:ports])
       |> QB.maybe_put_arg("random", optional_args[:random])
+      |> QB.maybe_put_arg("args", optional_args[:args])
+      |> QB.maybe_put_arg("useEntrypoint", optional_args[:use_entrypoint])
+      |> QB.maybe_put_arg(
+        "experimentalPrivilegedNesting",
+        optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
+      |> QB.maybe_put_arg("expand", optional_args[:expand])
+      |> QB.maybe_put_arg("noInit", optional_args[:no_init])
 
     case Client.execute(container.client, query_builder) do
       {:ok, _} -> :ok

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1040,6 +1040,24 @@ type ContainerUpOpts struct {
 	Ports []PortForward
 	// Bind each tunnel port to a random port on the host.
 	Random bool
+	// Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+	//
+	// If empty, the container's default command is used.
+	Args []string
+	// If the container has an entrypoint, prepend it to the args.
+	UseEntrypoint bool
+	// Provides Dagger access to the executed command.
+	//
+	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+	ExperimentalPrivilegedNesting bool
+	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+	InsecureRootCapabilities bool
+	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
+	// If set, skip the automatic init process injected into containers by default.
+	//
+	// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+	NoInit bool
 }
 
 // Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.
@@ -1058,6 +1076,30 @@ func (r *Container) Up(ctx context.Context, opts ...ContainerUpOpts) error {
 		// `random` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Random) {
 			q = q.Arg("random", opts[i].Random)
+		}
+		// `args` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Args) {
+			q = q.Arg("args", opts[i].Args)
+		}
+		// `useEntrypoint` optional argument
+		if !querybuilder.IsZeroValue(opts[i].UseEntrypoint) {
+			q = q.Arg("useEntrypoint", opts[i].UseEntrypoint)
+		}
+		// `experimentalPrivilegedNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `insecureRootCapabilities` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
+			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `noInit` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoInit) {
+			q = q.Arg("noInit", opts[i].NoInit)
 		}
 	}
 

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -414,14 +414,40 @@ class Container extends Client\AbstractObject implements Client\IdAble
      *
      * Be sure to set any exposed ports before calling this api.
      */
-    public function up(?array $ports = null, ?bool $random = false): void
-    {
+    public function up(
+        ?array $ports = null,
+        ?bool $random = false,
+        ?array $args = null,
+        ?bool $useEntrypoint = false,
+        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $insecureRootCapabilities = false,
+        ?bool $expand = false,
+        ?bool $noInit = false,
+    ): void {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('up');
         if (null !== $ports) {
         $leafQueryBuilder->setArgument('ports', $ports);
         }
         if (null !== $random) {
         $leafQueryBuilder->setArgument('random', $random);
+        }
+        if (null !== $args) {
+        $leafQueryBuilder->setArgument('args', $args);
+        }
+        if (null !== $useEntrypoint) {
+        $leafQueryBuilder->setArgument('useEntrypoint', $useEntrypoint);
+        }
+        if (null !== $experimentalPrivilegedNesting) {
+        $leafQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $insecureRootCapabilities) {
+        $leafQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
+        }
+        if (null !== $expand) {
+        $leafQueryBuilder->setArgument('expand', $expand);
+        }
+        if (null !== $noInit) {
+        $leafQueryBuilder->setArgument('noInit', $noInit);
         }
         $this->queryLeaf($leafQueryBuilder, 'up');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1200,6 +1200,12 @@ class Container(Type):
         *,
         ports: list[PortForward] | None = None,
         random: bool | None = False,
+        args: list[str] | None = None,
+        use_entrypoint: bool | None = False,
+        experimental_privileged_nesting: bool | None = False,
+        insecure_root_capabilities: bool | None = False,
+        expand: bool | None = False,
+        no_init: bool | None = False,
     ) -> Void | None:
         """Starts a Service and creates a tunnel that forwards traffic from the
         caller's network to that service.
@@ -1214,6 +1220,32 @@ class Container(Type):
             service port.
         random:
             Bind each tunnel port to a random port on the host.
+        args:
+            Command to run instead of the container's default command (e.g.,
+            ["go", "run", "main.go"]).
+            If empty, the container's default command is used.
+        use_entrypoint:
+            If the container has an entrypoint, prepend it to the args.
+        experimental_privileged_nesting:
+            Provides Dagger access to the executed command.
+            Do not use this option unless you trust the command being
+            executed; the command being executed WILL BE GRANTED FULL ACCESS
+            TO YOUR HOST FILESYSTEM.
+        insecure_root_capabilities:
+            Execute the command with all root capabilities. This is similar to
+            running a command with "sudo" or executing "docker run" with the "
+            --privileged" flag. Containerization does not provide any security
+            guarantees when using this option. It should only be used when
+            absolutely necessary and only with trusted commands.
+        expand:
+            Replace "${VAR}" or "$VAR" in the args according to the current
+            environment variables defined in the container (e.g. "/$VAR/foo").
+        no_init:
+            If set, skip the automatic init process injected into containers
+            by default.
+            This should only be used if the user requires that their exec
+            process be the pid 1 process in the container. Otherwise it may
+            result in unexpected behavior.
 
         Returns
         -------
@@ -1231,6 +1263,14 @@ class Container(Type):
         _args = [
             Arg("ports", () if ports is None else ports, ()),
             Arg("random", random, False),
+            Arg("args", () if args is None else args, ()),
+            Arg("useEntrypoint", use_entrypoint, False),
+            Arg(
+                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
+            ),
+            Arg("insecureRootCapabilities", insecure_root_capabilities, False),
+            Arg("expand", expand, False),
+            Arg("noInit", no_init, False),
         ]
         _ctx = self._select("up", _args)
         await _ctx.execute()

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1623,7 +1623,25 @@ pub struct ContainerTerminalOpts<'a> {
     pub insecure_root_capabilities: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct ContainerUpOpts {
+pub struct ContainerUpOpts<'a> {
+    /// Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+    /// If empty, the container's default command is used.
+    #[builder(setter(into, strip_option), default)]
+    pub args: Option<Vec<&'a str>>,
+    /// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+    #[builder(setter(into, strip_option), default)]
+    pub expand: Option<bool>,
+    /// Provides Dagger access to the executed command.
+    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    #[builder(setter(into, strip_option), default)]
+    pub experimental_privileged_nesting: Option<bool>,
+    /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub insecure_root_capabilities: Option<bool>,
+    /// If set, skip the automatic init process injected into containers by default.
+    /// This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+    #[builder(setter(into, strip_option), default)]
+    pub no_init: Option<bool>,
     /// List of frontend/backend port mappings to forward.
     /// Frontend is the port accepting traffic on the host, backend is the service port.
     #[builder(setter(into, strip_option), default)]
@@ -1631,6 +1649,9 @@ pub struct ContainerUpOpts {
     /// Bind each tunnel port to a random port on the host.
     #[builder(setter(into, strip_option), default)]
     pub random: Option<bool>,
+    /// If the container has an entrypoint, prepend it to the args.
+    #[builder(setter(into, strip_option), default)]
+    pub use_entrypoint: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
@@ -2447,13 +2468,34 @@ impl Container {
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn up_opts(&self, opts: ContainerUpOpts) -> Result<Void, DaggerError> {
+    pub async fn up_opts<'a>(&self, opts: ContainerUpOpts<'a>) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("up");
         if let Some(ports) = opts.ports {
             query = query.arg("ports", ports);
         }
         if let Some(random) = opts.random {
             query = query.arg("random", random);
+        }
+        if let Some(args) = opts.args {
+            query = query.arg("args", args);
+        }
+        if let Some(use_entrypoint) = opts.use_entrypoint {
+            query = query.arg("useEntrypoint", use_entrypoint);
+        }
+        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
+            query = query.arg(
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+            );
+        }
+        if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
+            query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
+        }
+        if let Some(expand) = opts.expand {
+            query = query.arg("expand", expand);
+        }
+        if let Some(no_init) = opts.no_init {
+            query = query.arg("noInit", no_init);
         }
         query.execute(self.graphql_client.clone()).await
     }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -238,6 +238,42 @@ export type ContainerUpOpts = {
    * Bind each tunnel port to a random port on the host.
    */
   random?: boolean
+
+  /**
+   * Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+   *
+   * If empty, the container's default command is used.
+   */
+  args?: string[]
+
+  /**
+   * If the container has an entrypoint, prepend it to the args.
+   */
+  useEntrypoint?: boolean
+
+  /**
+   * Provides Dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   */
+  experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+   */
+  insecureRootCapabilities?: boolean
+
+  /**
+   * Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   */
+  expand?: boolean
+
+  /**
+   * If set, skip the automatic init process injected into containers by default.
+   *
+   * This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   */
+  noInit?: boolean
 }
 
 export type ContainerWithDefaultTerminalCmdOpts = {
@@ -1987,6 +2023,18 @@ export class Container extends BaseClient {
    *
    * Frontend is the port accepting traffic on the host, backend is the service port.
    * @param opts.random Bind each tunnel port to a random port on the host.
+   * @param opts.args Command to run instead of the container's default command (e.g., ["go", "run", "main.go"]).
+   *
+   * If empty, the container's default command is used.
+   * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
+   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+   * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   * @param opts.noInit If set, skip the automatic init process injected into containers by default.
+   *
+   * This should only be used if the user requires that their exec process be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
    */
   up = async (opts?: ContainerUpOpts): Promise<void> => {
     if (this._up) {


### PR DESCRIPTION
Follow-up from #8865, and handles part of the issue in https://github.com/dagger/dagger/issues/9190.

This PR makes two distinct changes:
- Fix the `Container.up` to always use the user-expected version of `Container.asService`. This makes sense, since the former is just sugar for the latter. This was pretty hard to run into in-practice, since it requires that you call `Container.up` *inside* a module.
- Add all the args from `Container.asService` to `Container.up` - we should be able to set args like `insecureRootCapabilities` on `Container.up`, otherwise, there's really no other place to put them. I *think* this was just an oversight.