### PR TITLE
ci: Match any workflows which start with Alternative CI Runners

### DIFF
--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -3,7 +3,7 @@ name: Trace GitHub Actions Workflows
 on:
   workflow_run:
     workflows:
-      - "Alternative CI Runners"
+      - "Alternative CI Runners**"
       - "Benchmark"
       - "daggerverse-preview"
       - "Docs"


### PR DESCRIPTION
Not 100% sure whether this will work, but it should based on all the other resources which can be pattern-matched.

The other alternative is to list these explicitly.

Follow-up to:
- https://github.com/dagger/dagger/pull/9182