### PR TITLE
Add experimental Deno support

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -344,7 +344,7 @@ func (t *TypescriptSdk) configureModule(ctr *dagger.Container) *dagger.Container
 
 	// If there's a package.json, run the tsconfig updator script and install the genDir.
 	// else, copy the template config files.
-	if t.moduleConfig.packageJSONConfig != nil || t.moduleConfig.hasFile("deno.json"){
+	if t.moduleConfig.packageJSONConfig != nil || t.moduleConfig.hasFile("deno.json") {
 		switch runtime {
 		case Bun:
 			return ctr.
@@ -363,7 +363,7 @@ func (t *TypescriptSdk) configureModule(ctr *dagger.Container) *dagger.Container
 				ctr = ctr.WithFile("deno.json", ctr.File("/opt/module/template/deno.json"))
 			}
 
-			return ctr 
+			return ctr
 		}
 
 	}

--- a/sdk/typescript/runtime/template/deno.json
+++ b/sdk/typescript/runtime/template/deno.json
@@ -1,0 +1,35 @@
+{
+  "nodeModulesDir": "auto",
+  "unstable": [
+    "bare-node-builtins",
+    "byonm",
+    "sloppy-imports",
+    "node-globals"
+  ],
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "imports": {
+    "@dagger.io/dagger": "./sdk/src",
+    "@dagger.io/dagger/telemetry": "./sdk/src/telemetry",
+    "@std/random": "jsr:@std/random@^0.1.0",
+    "graphql-request": "npm:graphql-request@7.1.0",
+    "graphql-tag": "npm:graphql-tag@^2.12.6",
+    "@grpc/grpc-js": "npm:@grpc/grpc-js@^1.11.1",
+    "@lifeomic/axios-fetch": "npm:@lifeomic/axios-fetch@^3.1.0",
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.5.0",
+    "@opentelemetry/core": "npm:@opentelemetry/core@^1.25.1",
+    "@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@^0.53.0",
+    "@opentelemetry/sdk-metrics": "npm:@opentelemetry/sdk-metrics@^1.25.1",
+    "@opentelemetry/sdk-node": "npm:@opentelemetry/sdk-node@^0.52.1",
+    "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.25.1",
+    "adm-zip": "npm:adm-zip@^0.5.15",
+    "env-paths": "npm:env-paths@^3.0.0",
+    "graphql": "npm:graphql@^16.9.0",
+    "node-color-log": "npm:node-color-log@^12.0.1",
+    "node-fetch": "npm:node-fetch@^3.3.2",
+    "reflect-metadata": "npm:reflect-metadata@^0.2.2",
+    "tar": "npm:tar@^7.4.2"
+  }
+}

--- a/sdk/typescript/runtime/template/deno.json
+++ b/sdk/typescript/runtime/template/deno.json
@@ -30,6 +30,7 @@
     "node-color-log": "npm:node-color-log@^12.0.1",
     "node-fetch": "npm:node-fetch@^3.3.2",
     "reflect-metadata": "npm:reflect-metadata@^0.2.2",
-    "tar": "npm:tar@^7.4.2"
+    "tar": "npm:tar@^7.4.2",
+    "typescript": "npm:typescript@^5.5.4"
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,5 +1,4 @@
-export { gql } from "graphql-tag"
-export { GraphQLClient } from "graphql-request"
+export { GraphQLClient, gql } from "graphql-request"
 
 // Default client bindings
 export * from "./api/client.gen.js"


### PR DESCRIPTION
### ✨ Deno support steps

- [x] Add Deno runtime container inside TS runtime
- [x] Add `deno.json` generation
- [ ] Run unit tests with Deno ⚠️ 
- [ ] Run integration tests with Deno ⚠️ 
- [ ] Run Dagger tests inside Deno container ⚠️ 

### :warning: Merge blockers

There are 2 problems that currently block the merge of that PR:
1. [Deno doesn't support local dependency installation](https://github.com/denoland/deno/issues/18474), meaning that we need to add all the SDK dependencies at the root `deno.json`, it's not ideal but that's the only way I could make it work.
2. I cannot run tests with `deno run -A npm:mocha` because  the `--loader` option cannot be passed, it throws an error. Theses issues https://github.com/mochajs/mocha/issues/5108 and https://github.com/mochajs/mocha-examples/issues/99 tracks progress but not much activities happens.

The PR is usable, but we cannot merge it until these 2 blockers are solved since it creates too much problem for long term supports.

### 🔎 Example of usage

```shell
# Init a Dagger project
$ dagger init --sdk=typescript --name=test-deno

# Set runtime to deno in `package.json`
npm pkg set "dagger.runtime=deno" 

# Rerun codegen to update module and generate a `deno.json`
$ dagger develop

# The module will now run inside a deno runtime
dagger call container-echo --string-arg foo
```

Signed-off-by: Tom Chauveau <tom@epitech.eu>