### PR TITLE
ci: merge several dependabot configs into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,17 +15,17 @@ updates:
       - "area/engine"
       - "area/cli"
       - "area/sdk/go"
+    ignore:
+        # these are fiddly, we want to do them manually
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/moby/buildkit"
+      - dependency-name: "github.com/tonistiigi/fsutil"
+      - dependency-name: "github.com/vito/midterm"
     groups:
       engine:
         applies-to: version-updates
         patterns:
           - "*"
-        exclude-patterns:
-          # these are fiddly, we want to do them manually
-          - "go.opentelemetry.io/*"
-          - "github.com/moby/buildkit"
-          - "github.com/tonistiigi/fsutil"
-          - "github.com/vito/midterm"
 
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/sdk/go"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -11,6 +14,7 @@ updates:
       - "kind/dependencies"
       - "area/engine"
       - "area/cli"
+      - "area/sdk/go"
     groups:
       engine:
         applies-to: version-updates
@@ -55,25 +59,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "gomod"
-    directory: "/sdk/go"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "07:00"
-      timezone: "UTC"
-    labels:
-      - "kind/dependencies"
-      - "area/sdk/go"
-    groups:
-      sdk-go:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          # these are fiddly, we want to do them manually
-          - "go.opentelemetry.io/*"
-
   - package-ecosystem: "pip"
     directory: "/sdk/python"
     schedule:
@@ -91,7 +76,9 @@ updates:
           - "*"
 
   - package-ecosystem: "docker"
-    directory: "/sdk/python/runtime"
+    directories:
+      - "/sdk/python/runtime"
+      - "/modules/ruff/build"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -101,23 +88,7 @@ updates:
       - "kind/dependencies"
       - "area/sdk/python"
     groups:
-      sdk-python:
-        applies-to: version-updates
-        patterns:
-          - "*"
-
-  - package-ecosystem: "docker"
-    directory: "/modules/ruff/build"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "07:00"
-      timezone: "UTC"
-    labels:
-      - "kind/dependencies"
-      - "area/sdk/python"
-    groups:
-      sdk-python:
+      sdk-python-docker:
         applies-to: version-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,10 @@ updates:
     labels:
       - "kind/dependencies"
       - "area/sdk/python"
+    ignore:
+      # python needs to be manually bumped
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
       sdk-python-docker:
         applies-to: version-updates


### PR DESCRIPTION
This is pretty useful - I think maybe the `directories` option is new? Otherwise, I feel like I would have caught it before when doing all this. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
 
Anyways, this will let us bump the sdk/go and the top-level directory go.mods together, so we won't need to do horrendous dependency resolution ourselves hopefully (like in https://github.com/dagger/dagger/pull/9187#issuecomment-2548200615).

While in the area, we can bump the docker update together as well.