### PR TITLE
feat(sdk/elixir): bump dev & runtime image

### DIFF
--- a/sdk/elixir/dev/dagger.json
+++ b/sdk/elixir/dev/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "elixir-sdk-dev",
+  "engineVersion": "v0.15.1",
   "sdk": "elixir@v0.14.0",
-  "engineVersion": "v0.14.0"
+  "source": "."
 }

--- a/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/elixir_sdk_dev/lib/elixir_sdk_dev.ex
@@ -5,7 +5,7 @@ defmodule ElixirSdkDev do
 
   use Dagger.Mod.Object, name: "ElixirSdkDev"
 
-  @base_image "hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.20.2@sha256:7c8a13cbff321b7d6f54b4c9a21a10fc8b987974171231eaa77532b8e638b645"
+  @base_image "hexpm/elixir:1.17.3-erlang-27.2-alpine-3.20.3@sha256:557156f12d23b0d2aa12d8955668cc3b9a981563690bb9ecabd7a5a951702afe"
 
   @doc """
   Test the SDK.
@@ -44,15 +44,46 @@ defmodule ElixirSdkDev do
     |> Dagger.Directory.with_directory("sdk/elixir/lib/dagger/gen", gen)
   end
 
+  @doc """
+  Run the SDK tests.
+  """
   defn sdk_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
     container
     |> Dagger.Container.with_exec(~w"mix test")
   end
 
+  @doc """
+  Run dagger_codegen tests.
+  """
   defn codegen_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
     container
     |> with_codegen()
     |> Dagger.Container.with_exec(~w"mix test")
+  end
+
+  @doc """
+  Sync Elixir image to keep both dev and runtime modules consistent.
+  """
+  defn sync_image(
+         source: {Dagger.Directory.t(), doc: "The Elixir SDK source", default_path: ".."}
+       ) :: Dagger.File.t() do
+    path = "runtime/main.go"
+
+    {:ok, runtime_main_go} =
+      source
+      |> with_base()
+      |> Dagger.Container.file(path)
+      |> Dagger.File.contents()
+
+    new_runtime_main_go =
+      Regex.replace(~r/elixirImage\s*=.*\n/, runtime_main_go, "elixirImage = \"#{@base_image}\"\n")
+
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("golang:1.23-alpine")
+    |> Dagger.Container.with_new_file(path, new_runtime_main_go)
+    |> Dagger.Container.with_exec(["go", "fmt", path])
+    |> Dagger.Container.file(path)
   end
 
   defn with_base(source: {Dagger.Directory.t(), doc: "The Elixir SDK source"}) ::

--- a/sdk/elixir/dev/elixir_sdk_dev/mix.exs
+++ b/sdk/elixir/dev/elixir_sdk_dev/mix.exs
@@ -13,7 +13,7 @@ defmodule ElixirSdkDev.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger]
     ]
   end
 

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -15,7 +15,7 @@ const (
 	sdkSrc           = "/sdk"
 	genDir           = "dagger_sdk"
 	schemaPath       = "/schema.json"
-	elixirImage      = "hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.20.2@sha256:7c8a13cbff321b7d6f54b4c9a21a10fc8b987974171231eaa77532b8e638b645"
+	elixirImage      = "hexpm/elixir:1.17.3-erlang-27.2-alpine-3.20.3@sha256:557156f12d23b0d2aa12d8955668cc3b9a981563690bb9ecabd7a5a951702afe"
 )
 
 func New(


### PR DESCRIPTION
This is follow-ups changeset comment in https://github.com/dagger/dagger/pull/8962

Changes to `dev` module:

* Bump image to Elixir 1.17.2 with OTP 27.2.
* Add a function named `sync-image` to sync between dev and runtime so we can change image only in dev module then it'll modify automatically after calling this function.
* Bump engineVersion to the latest version (0.15.1).
* Run mix format.

Changes to `runtime` modules:

* Bump image to Elixir 1.17.2 with OTP 27.2 by using `sync-image` from `dev` module.