### PR TITLE
fix: allow using old dockerfile pragmas

### DIFF
--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -279,7 +279,9 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		runOpts = append(runOpts, llb.AddMount(mnt.Target, srcSt, mountOpts...))
 	}
 
-	runOpts = append(runOpts, llb.ValidExitCodes(opts.Expect.ReturnCodes()...))
+	if opts.Expect != ReturnSuccess {
+		runOpts = append(runOpts, llb.ValidExitCodes(opts.Expect.ReturnCodes()...))
+	}
 
 	if opts.InsecureRootCapabilities {
 		runOpts = append(runOpts, llb.Security(llb.SecurityModeInsecure))


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9095.

This fixes a bug where if the directory passed as a context directory had an exec *anywhere* in its history, it could not be built with an old syntax pragma (including docker/dockerfile:1.10 and before).

This is because a new `exec.validexitcode` capability was added when using `llb.ValidExitCodes` - which we were unconditionally using in every `WithExec` regardless of whether we actually need it or not. When passing this result to an old dockerfile frontend, it would not recognize this capability and fail out.

The solution here is to avoid unnecessarily attaching this capability - we only need to use `llb.ValidExitCodes` when actually working with values of `Expect` that are not `Success`. Now, this issue will only appear when using an old dockerfile frontend, *and* creating a build context that contains a non-default `Expect` value.