### PR TITLE
engine: return error if services don't have a command set

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1727,7 +1727,9 @@ func (container *Container) AsService(ctx context.Context, args ContainerAsServi
 	var cmdargs = container.Config.Cmd
 	if len(args.Args) > 0 {
 		cmdargs = args.Args
-		useEntrypoint = false
+		if !args.UseEntrypoint {
+			useEntrypoint = false
+		}
 	}
 
 	container, err := container.WithExec(ctx, ContainerExecOpts{

--- a/core/container.go
+++ b/core/container.go
@@ -1710,14 +1710,26 @@ func (container *Container) AsServiceLegacy(ctx context.Context) (*Service, erro
 }
 
 func (container *Container) AsService(ctx context.Context, args ContainerAsServiceArgs) (*Service, error) {
+	if len(args.Args) == 0 &&
+		len(container.Config.Cmd) == 0 &&
+		len(container.Config.Entrypoint) == 0 {
+		return nil, ErrNoSvcCommand
+	}
+
+	useEntrypoint := args.UseEntrypoint
+	if len(container.Config.Entrypoint) > 0 {
+		useEntrypoint = true
+	}
+
 	var cmdargs = container.Config.Cmd
 	if len(args.Args) > 0 {
 		cmdargs = args.Args
+		useEntrypoint = false
 	}
 
 	container, err := container.WithExec(ctx, ContainerExecOpts{
 		Args:                          cmdargs,
-		UseEntrypoint:                 args.UseEntrypoint,
+		UseEntrypoint:                 useEntrypoint,
 		ExperimentalPrivilegedNesting: args.ExperimentalPrivilegedNesting,
 		InsecureRootCapabilities:      args.InsecureRootCapabilities,
 		Expand:                        args.Expand,

--- a/core/container.go
+++ b/core/container.go
@@ -100,6 +100,9 @@ type Container struct {
 	// (Internal-only for now) Environment variables from the engine container, prefixed
 	// with a special value, that will be inherited by this container if set.
 	SystemEnvNames []string `json:"system_envs,omitempty"`
+
+	// DefaultArgs have been explicitly set by the user
+	DefaultArgs bool `json:"defaultArgs,omitempty"`
 }
 
 func (*Container) Type() *ast.Type {
@@ -1717,7 +1720,7 @@ func (container *Container) AsService(ctx context.Context, args ContainerAsServi
 	}
 
 	useEntrypoint := args.UseEntrypoint
-	if len(container.Config.Entrypoint) > 0 {
+	if len(container.Config.Entrypoint) > 0 && !container.DefaultArgs {
 		useEntrypoint = true
 	}
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -19,6 +19,7 @@ import (
 )
 
 var ErrNoCommand = errors.New("no command has been set")
+var ErrNoSvcCommand = errors.New("no service command has been set")
 
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4855,6 +4855,21 @@ func main() {
 		require.Equal(t, "args: /bin/app,via-entrypoint,/bin/app,via-default-args", output)
 	})
 
+	t.Run("use both args and entrypoint", func(ctx context.Context, t *testctx.T) {
+		withargsOverwritten := binctr.
+			AsService(dagger.ContainerAsServiceOpts{
+				UseEntrypoint: true,
+				Args:          []string{"/bin/app via-service-override"},
+			})
+
+		output, err := curlctr.
+			WithServiceBinding("myapp", withargsOverwritten).
+			WithExec([]string{"sh", "-c", "curl -vXGET 'http://myapp:8080/hello'"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "args: /bin/app,via-entrypoint,/bin/app via-service-override", output)
+	})
+
 	t.Run("error when no cmd and entrypoint is set", func(ctx context.Context, t *testctx.T) {
 		withargsOverwritten := binctr.
 			WithoutEntrypoint().

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -438,6 +438,7 @@ func (GitSuite) TestServiceStableDigest(ctx context.Context, t *testctx.T) {
 			WithMountedDirectory("/repo", c.Git(url, dagger.GitOpts{
 				ExperimentalServiceHost: svc,
 			}).Branch("main").Tree()).
+			WithDefaultArgs([]string{"sleep"}).
 			AsService().
 			Hostname(ctx)
 		require.NoError(t, err)

--- a/core/integration/http_test.go
+++ b/core/integration/http_test.go
@@ -54,6 +54,7 @@ func (HTTPSuite) TestHTTPServiceStableDigest(ctx context.Context, t *testctx.T) 
 			WithMountedFile("/index.html", c.HTTP(url, dagger.HTTPOpts{
 				ExperimentalServiceHost: svc,
 			})).
+			WithDefaultArgs([]string{"sleep"}).
 			AsService().
 			Hostname(ctx)
 		require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3677,7 +3677,8 @@ func (m *Test) Fn(ctx context.Context) *dagger.Container {
 	redis := dag.Container().
 		From("redis").
 		WithExposedPort(6379).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
+
 	cli := dag.Container().
 		From("redis").
 		WithoutEntrypoint().

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -226,7 +226,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService()
-	
+
 	hn, err := srv.Hostname(ctx)
 	if err != nil {
 		return err
@@ -401,7 +401,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup0")
-	
+
 	_, err := srv.Start(ctx)
 	if err != nil {
 		return err
@@ -462,7 +462,7 @@ func (m *Caller) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
-	
+
 	_, err = srv.Start(ctx)
 	if err != nil {
 		return err
@@ -505,7 +505,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
-	
+
 	_, err := srv.Start(ctx)
 	if err != nil {
 		return err

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1011,7 +1011,9 @@ type containerWithDefaultArgs struct {
 }
 
 func (s *containerSchema) withDefaultArgs(ctx context.Context, parent *core.Container, args containerWithDefaultArgs) (*core.Container, error) {
-	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
+	c := parent.Clone()
+	c.DefaultArgs = true
+	return c.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
 		if args.Args == nil {
 			cfg.Cmd = []string{}
 			return cfg
@@ -1023,7 +1025,9 @@ func (s *containerSchema) withDefaultArgs(ctx context.Context, parent *core.Cont
 }
 
 func (s *containerSchema) withoutDefaultArgs(ctx context.Context, parent *core.Container, _ struct{}) (*core.Container, error) {
-	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
+	c := parent.Clone()
+	c.DefaultArgs = false
+	return c.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
 		cfg.Cmd = nil
 		return cfg
 	})

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -283,7 +283,7 @@ defmodule Dagger.ClientTest do
       |> Client.container()
       |> Container.from("nginx:1.25-alpine3.18")
       |> Container.with_exposed_port(80)
-      |> Container.as_service()
+      |> Container.as_service(use_entrypoint: true)
 
     assert {:ok, out} =
              dag


### PR DESCRIPTION
this addresses the issue introduced in v0.15.0 where services will hang
to start if neither CMD or ENTRYPOINT is used.

fixes #9190

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
