### PR TITLE
fix: silence trace setup messages using descriptive env name

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -3,7 +3,6 @@ package idtui
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -49,14 +48,15 @@ func FromCmdContext(ctx context.Context) (*cmdContext, bool) {
 	return nil, false
 }
 
-// having a bit of fun with these. cc @vito @jedevc
-var SkipLoggedOutTraceMsgEnvs = []string{"NOTHANKS", "SHUTUP", "GOAWAY", "STOPIT"}
+var SkipLoggedOutTraceMsgEnvs = []string{
+	"DAGGER_NO_NAG",
 
-// Keep this to one line, and 80 characters max (longest env var name is NOTHANKS)
-//
-//nolint:gosec
-var loggedOutTraceMsg = fmt.Sprintf("Setup tracing at %%s. To hide: export %s=1",
-	SkipLoggedOutTraceMsgEnvs[rand.Intn(len(SkipLoggedOutTraceMsgEnvs))])
+	// old envs kept for backwards compat
+	"NOTHANKS", "SHUTUP", "GOAWAY", "STOPIT",
+}
+
+// NOTE: keep this to one line, and 80 characters max
+var loggedOutTraceMsg = fmt.Sprintf("Setup tracing at %%s. To hide set %s=1", SkipLoggedOutTraceMsgEnvs[0])
 
 type Frontend interface {
 	// Run starts a frontend, and runs the target function.

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -327,7 +327,7 @@ var scrubs = []scrubber{
 	{
 		regexp.MustCompile(`\b` + strings.Join(idtui.SkipLoggedOutTraceMsgEnvs, "|") + `\b`),
 		"SHUTUP",
-		"NOTHANKS",
+		"DAGGER_NO_NAG",
 	},
 	// Uploads
 	{

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -27,4 +27,4 @@ Expected stderr:
 │ ✔ .withExec(args: ["echo", "im busted by that buster"]): Container! X.Xs
 │ ┃ im busted by that buster
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
@@ -28,4 +28,4 @@ Expected stderr:
 │ │ ✔ .stdout: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -36,4 +36,4 @@ Expected stderr:
 ✔ .stdout: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -37,4 +37,4 @@ Error logs:
 im failing
 ! process "/bin/sh -c echo im failing && false" did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
@@ -23,4 +23,4 @@ Expected stderr:
 │ ┃ and then failing
 │ ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
@@ -28,4 +28,4 @@ Error logs:
 this is a failing effect
 ! process "sh -c echo this is a failing effect; exit 1" did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -31,4 +31,4 @@ im doing a lot of work
 and then failing
 ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
@@ -26,4 +26,4 @@ im doing a lot of work
 and then failing
 ! i failed
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
@@ -21,4 +21,4 @@ Expected stderr:
 ✔ .helloWorld: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -24,4 +24,4 @@ Expected stderr:
 │ ! process "false" did not complete successfully: exit code: 1
 │ ○ .withExec(args: ["sleep", "1"]): Container! X.Xs
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -41,4 +41,4 @@ Expected stderr:
 │ ✔ .withExec(args: ["wget", "-q", "-O-", "http://exec-service"]): Container! X.Xs
 │ ┃ <h1>hello, world!</h1>
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
@@ -32,4 +32,4 @@ Expected stderr:
 │ ✔ .withExec(args: ["wget", "-q", "-O-", "http://exec-service"]): Container! X.Xs
 │ ┃ <h1>hello, world!</h1><p>the time is 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X</p>
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -42,4 +42,4 @@ Expected stderr:
 │ ✔ .stdout: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
@@ -34,4 +34,4 @@ Error logs:
 ./main.go:6:6: undefined: ctx
 ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/custom-span
@@ -27,4 +27,4 @@ Expected stderr:
 │ │ ✔ .stdout: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/python/pending
@@ -23,4 +23,4 @@ Expected stderr:
 │ ! process "false" did not complete successfully: exit code: 1
 │ ○ .withExec(args: ["sleep", "1"]): Container! X.Xs
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/custom-span
@@ -27,4 +27,4 @@ Expected stderr:
 │ │ ✔ .stdout: String! X.Xs
 
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/typescript/pending
@@ -30,4 +30,4 @@ Error logs:
 Error: process "false" did not complete successfully: exit code: 1
 ! process "tsx --no-deprecation --tsconfig /src/tsconfig.json /src/src/__dagger.entrypoint.ts" did not complete successfully: exit code: 1
 
-Setup tracing at https://dagger.cloud/traces/setup. To hide: export NOTHANKS=1
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1


### PR DESCRIPTION
Fixes #9242.

We'll now only recommend using the prefixed environment variable `DAGGER_NO_NAG` - no more randomly cycling through. However, we'll keep supporting the old environment variables, in case users are using that to silence this output. We can deprecate those in the future.

Some light rephrasing of the message is required to fit the extra `DAGGER_` characters in - it's important we keep this line under 80 characters, so it fits nicely into standard sized 80x24 terminals.