### PR TITLE
helm: Enable deploying multiple Engines per node

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -117,7 +117,7 @@ jobs:
           upload-logs: true
 
   test-everything-else:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-16c-st' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-32c-st' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/helm/dagger.json
+++ b/helm/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "helm",
-  "engineVersion": "v0.15.0",
+  "engineVersion": "v0.15.1",
   "sdk": "go",
   "dependencies": [
     {

--- a/helm/dagger/.changes/unreleased/Added-20241220-193552.yaml
+++ b/helm/dagger/.changes/unreleased/Added-20241220-193552.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Enable deploying multiples Dagger Engines on a single K8s nodes
+time: 2024-12-20T19:35:52.957849Z
+custom:
+    Author: gerhard
+    PR: "9249"

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "dagger.labels" . | nindent 4 }}
 spec:
+  # DO NOT RUN MORE THAN 1 REPLICA.
+  # Only one (1) Engine is able to hold the lock, other replicas will not be able to start.
+  replicas: 1
   selector:
     matchLabels:
       name: {{ include "dagger.fullname" . }}-engine
@@ -53,15 +56,15 @@ spec:
           {{- end }}
           {{- if .Values.magicache.enabled }}
           env:
-          - name: _EXPERIMENTAL_DAGGER_CACHESERVICE_URL
-            value: {{ required "A magicache url is required" .Values.magicache.url }}
+            - name: _EXPERIMENTAL_DAGGER_CACHESERVICE_URL
+              value: {{ required "A magicache url is required" .Values.magicache.url }}
           envFrom:
-          - secretRef:
-              {{- if .Values.magicache.secretName }}
-              name: {{ .Values.magicache.secretName }}
-              {{- else }}
-              name: {{ include "dagger.fullname" . }}-magicache-token
-              {{- end }}
+            - secretRef:
+                {{- if .Values.magicache.secretName }}
+                name: {{ .Values.magicache.secretName }}
+                {{- else }}
+                name: {{ include "dagger.fullname" . }}-magicache-token
+                {{- end }}
           {{- end }}
           securityContext:
             privileged: true

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -1,7 +1,7 @@
-{{- if eq .Values.engine.kind "DaemonSet" -}}
+{{- if eq .Values.engine.kind "StatefulSet" -}}
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   name: {{ include "dagger.fullname" . }}-engine
   namespace: {{ .Release.Namespace }}
@@ -80,25 +80,25 @@ spec:
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}
           volumeMounts:
-            - name: varlibdagger
+            - name: data
               mountPath: /var/lib/dagger
-            - name: varrundagger
+            - name: run
               mountPath: /var/run/buildkit
             {{- if .Values.engine.config }}
-            - name: dagger-engine-config
+            - name: config
               mountPath: /etc/dagger/engine.toml
               subPath: engine.toml
             {{- end }}
       terminationGracePeriodSeconds: {{ .Values.engine.terminationGracePeriodSeconds }}
       volumes:
-        - name: varlibdagger
+        - name: data
           hostPath:
-            path: /var/lib/dagger
-        - name: varrundagger
+            path: /var/lib/dagger-{{ include "dagger.fullname" . }}
+        - name: run
           hostPath:
-            path: /var/run/dagger
+            path: /var/run/dagger-{{ include "dagger.fullname" . }}
         {{- if .Values.engine.config }}
-        - name: dagger-engine-config
+        - name: config
           configMap:
             name: {{ include "dagger.fullname" . }}-engine-config
             items:

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -16,6 +16,11 @@ engine:
   #     format = "json"
   labels: {}
 
+  ### `DaemonSet` guarantees a single Engine per K8s node (default behaviour)
+  #
+  # Set to `StatefulSet` for running multiple Engines per K8s node
+  kind: DaemonSet
+
   ### Customize Dagger Engine start args
   #
   args: []


### PR DESCRIPTION
This adds a new property - `kind` - which defaults to `DaemonSet`. It means that nothing will change for existing users: one Engine per K8s node.

For users that want to deploy **multiple** Engines per K8s node, set `kind: StatefulSet`, and the chart will take care of the rest.

This opens the door to experimenting with runtimes such as firecracker-containerd, gVisor, etc. for putting a sandbox around the Engine - should help address some of the `CAP_SYS_ADMIN` concerns.

Paired with @ioboi @chrira from [puzzle.ch](https://puzzle.ch)

## TODO

- [x] Tests
- [x] Changelog
- [ ] Add to next milestone after merging