### PR TITLE
Shell: "Fix" non-interactive shell stdout

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -1039,13 +1039,13 @@ func (h *shellCallHandler) Result(
 		return nil, nil
 	}
 
-	resp, err := addTypeToResponse(fn.ReturnType, response)
-	if err != nil {
-		return nil, err
-	}
-	response = resp
-
 	if doPrintResponse {
+		resp, err := addTypeToResponse(fn.ReturnType, response)
+		if err != nil {
+			return nil, err
+		}
+		response = resp
+
 		buf := new(bytes.Buffer)
 		frmt := outputFormat(fn.ReturnType)
 		if err := printResponse(buf, response, frmt); err != nil {


### PR DESCRIPTION
## Problem

1. The `shell` and `CLI` behave differently when it comes to `stdout` handling with TTY attached.
2. The response payload does not include the `_type`.

This PR is attempt to produce a pragmatic fix. However, any reviews/pointers are welcome if the code's not up to standard. I found it quicker to fix the issues than to merely describe the problems.

PS: This is required to preserve Runme's existing Notebook UX/UI integration.

## In a nutshell this PR fixes
* Writes payload response to stdout when no TTY is attached to stdout.
* The response payload includes `_type` in response as per `dagger call`.

However, is the stdout fixed in the right place? I see several ways to resolve this issue; however, I am not clear about the side effects. Are there tests to write?

### Shell stdout always goes to stderr

The Dagger shell always writes to stderr, even the response payload. Following command should discard stdout but doesn't.

```sh {"id":"01JFG59MMPCG0DZ95QEVMAH02Z"}
dagger shell -c 'cli | binary' 1> /dev/null

# Ran on 2024-12-19 11:17:59-08:00 for 24.308s exited with 0
 
[...]
{
    "digest": "sha256:ff24da1f384a60498acdbbb9d6203cb19faa607b96d0d22f8d4d0b71fc3f5d93",
    "name": "dagger",
    "size": 29229208
}

 

 
✔ connect 0.2s
✔ load module 7.4s

✔ daggerDev: DaggerDev! 8.6s
✔ .cli: DaggerDevCli! 0.4s
$ .binary: File! 7.1s CACHED

✔ File.digest: String! 0.0s

✔ File.name: String! 0.0s

✔ File.size: Int! 0.0s
```

Unlike the Dagger CLI which does discard stdout correctly.

```sh {"id":"01JFG59MMPCG0DZ95QEX49W09T"}
dagger call cli binary 1> /dev/null

# Ran on 2024-12-19 11:18:01-08:00 for 29.303s exited with 0

[...]

 
✔ connect 0.4s
✔ load module 11.9s

✔ daggerDev: DaggerDev! 6.1s
✔ .cli: DaggerDevCli! 0.5s
$ .binary: File! 9.5s CACHED

✔ File.digest: String! 0.0s

✔ File.name: String! 0.0s

✔ File.size: Int! 0.0s

✔ parsing command line arguments 0.0s
```

## Now with this PR's branch build

It redirects it correctly.

```sh {"id":"01JFG5F182FCSFAHHT7HC79FFY"}
rm -f /tmp/dagger-shell-stdout
./bin/dagger shell -c 'cli | binary' 1> /tmp/dagger-shell-stdout

# Ran on 2024-12-19 11:18:02-08:00 for 27.696s exited with 0
 
✔ connect 0.5s
✔ load module 11.5s

✔ daggerDev: DaggerDev! 7.0s
✔ .cli: DaggerDevCli! 1.0s
✔ .binary: File! 6.7s

✔ File.digest: String! 0.0s

✔ File.name: String! 0.0s

✔ File.size: Int! 0.0s
```

### Redirected stdout works and matches CLI

Here we go! Please note that the response payload now matches the CLI's with the `_type` included. The missing `_type` is a spearate issue.

```sh {"id":"01JFG5MG4ZX4XGJY3YRHNG4NGB","terminalRows":"8"}
cat /tmp/dagger-shell-stdout

# Ran on 2024-12-19 11:18:38-08:00 for 747ms exited with 0
{
    "_type": "File",
    "digest": "sha256:ff24da1f384a60498acdbbb9d6203cb19faa607b96d0d22f8d4d0b71fc3f5d93",
    "name": "dagger",
    "size": 29229208
}
```
