### PR TITLE
switch to custom init that also handles nested exec sessions

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -246,7 +246,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		{path: "/usr/bin/dial-stdio", file: build.dialstdioBinary()},
 		{path: "/opt/cni/bin/dnsname", file: build.dnsnameBinary()},
 		{path: consts.RuncPath, file: build.runcBin()},
-		{path: consts.DumbInitPath, file: build.dumbInit()},
+		{path: consts.DaggerInitPath, file: build.daggerInit()},
 	}
 	for _, bin := range build.qemuBins(ctx) {
 		name, err := bin.Name(ctx)
@@ -433,22 +433,8 @@ func (build *Builder) cniPlugins() []*dagger.File {
 	return bins
 }
 
-func (build *Builder) dumbInit() *dagger.File {
-	// dumb init is static, so we can use it on any base image
-	return dag.
-		Alpine(dagger.AlpineOpts{
-			Branch: consts.AlpineVersion,
-			Packages: []string{
-				"bash",
-				"build-base",
-			},
-			Arch: build.platformSpec.Architecture,
-		}).
-		Container().
-		WithMountedDirectory("/src", dag.Git("github.com/yelp/dumb-init").Ref(consts.DumbInitVersion).Tree()).
-		WithWorkdir("/src").
-		WithExec([]string{"make"}).
-		File("dumb-init")
+func (build *Builder) daggerInit() *dagger.File {
+	return build.binary("./cmd/init", false, false)
 }
 
 func (build *Builder) goPlatformEnv(ctr *dagger.Container) *dagger.Container {

--- a/.dagger/consts/versions.go
+++ b/.dagger/consts/versions.go
@@ -5,7 +5,7 @@ import "github.com/dagger/dagger/engine/distconsts"
 const (
 	EngineServerPath = "/usr/local/bin/dagger-engine"
 	RuncPath         = distconsts.RuncPath
-	DumbInitPath     = distconsts.DumbInitPath
+	DaggerInitPath   = distconsts.DaggerInitPath
 )
 
 const (
@@ -15,10 +15,9 @@ const (
 	AlpineVersion = distconsts.AlpineVersion
 	UbuntuVersion = "22.04"
 
-	RuncVersion     = "v1.1.15"
-	CniVersion      = "v1.5.0"
-	QemuBinImage    = "tonistiigi/binfmt@sha256:e06789462ac7e2e096b53bfd9e607412426850227afeb1d0f5dfa48a731e0ba5"
-	DumbInitVersion = "v1.2.5"
+	RuncVersion  = "v1.1.15"
+	CniVersion   = "v1.5.0"
+	QemuBinImage = "tonistiigi/binfmt@sha256:e06789462ac7e2e096b53bfd9e607412426850227afeb1d0f5dfa48a731e0ba5"
 
 	XxImage = "tonistiigi/xx:1.2.1"
 )

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -1,0 +1,204 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	bksession "github.com/moby/buildkit/session"
+	"golang.org/x/sys/unix"
+
+	"github.com/dagger/dagger/engine/client"
+	"github.com/dagger/dagger/engine/session"
+)
+
+func main() {
+	sigCh := make(chan os.Signal, 16)
+	// Handle every signal other than a few exceptions noted at the end.
+	// Importantly, by handling all these signals, the child process will start with
+	// the default signal disposition for them after the exec, which is what we want.
+	// https://man7.org/linux/man-pages/man7/signal.7.html
+	signal.Notify(sigCh,
+		syscall.SIGABRT,
+		syscall.SIGALRM,
+		syscall.SIGBUS,
+		syscall.SIGCHLD,
+		syscall.SIGCLD,
+		syscall.SIGCONT,
+		syscall.SIGFPE,
+		syscall.SIGHUP,
+		syscall.SIGILL,
+		syscall.SIGINT,
+		syscall.SIGIO,
+		syscall.SIGIOT,
+		syscall.SIGPIPE,
+		syscall.SIGPOLL,
+		syscall.SIGPROF,
+		syscall.SIGPWR,
+		syscall.SIGQUIT,
+		syscall.SIGSEGV,
+		syscall.SIGSTKFLT,
+		syscall.SIGSYS,
+		syscall.SIGTERM,
+		syscall.SIGTRAP,
+		syscall.SIGTSTP,
+		syscall.SIGTTIN,
+		syscall.SIGTTOU,
+		syscall.SIGUNUSED,
+		syscall.SIGUSR1,
+		syscall.SIGUSR2,
+		syscall.SIGVTALRM,
+		syscall.SIGWINCH,
+		syscall.SIGXCPU,
+		syscall.SIGXFSZ,
+		// explicitly not caught
+		// syscall.SIGKILL, // cannot be caught
+		// syscall.SIGSTOP, // cannot be caught
+		// syscall.SIGURG, // go runtime uses this internally
+	)
+
+	// try to detach from the terminal, if there is one
+	// if detach successful, remember to ignore first SIGHUP/SIGCONT later (they might not be sent immediately and shouldn't be forwarded to the child)
+
+	_, err := unix.IoctlGetTermios(0, unix.TCGETS)
+	haveTTY := err == nil
+
+	sid, err := unix.Getsid(0)
+	if err != nil {
+		panic(err)
+	}
+	pid := unix.Getpid()
+	weAreSessionLeader := sid == pid
+
+	var ignoreFirstHUP bool
+	var ignoreFirstCONT bool
+	if haveTTY && weAreSessionLeader {
+		ignoreFirstHUP = true
+		ignoreFirstCONT = true
+		_, err = unix.IoctlRetInt(0, unix.TIOCNOTTY)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if _, ok := os.LookupEnv("DAGGER_SESSION_TOKEN"); ok {
+		go serveSession()
+	}
+
+	// run the child in a new session
+	sysProcAttr := syscall.SysProcAttr{
+		Setsid: true,
+	}
+	if haveTTY {
+		sysProcAttr.Setctty = true
+		sysProcAttr.Ctty = 0
+	}
+
+	// start the child process
+	fullPath := os.Args[1]
+	if filepath.Base(fullPath) == fullPath {
+		// search for the executable in $PATH
+		fullPath, err = exec.LookPath(fullPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+	child, err := os.StartProcess(fullPath, os.Args[1:], &os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+
+		Sys: &sysProcAttr,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// handle signals until our child exits
+	for sig := range sigCh {
+		sigNum := sig.(syscall.Signal)
+
+		var goToBed bool
+		switch sigNum {
+		case syscall.SIGHUP:
+			if ignoreFirstHUP {
+				ignoreFirstHUP = false
+				continue
+			}
+		case syscall.SIGCONT:
+			if ignoreFirstCONT {
+				ignoreFirstCONT = false
+				continue
+			}
+
+		case syscall.SIGTSTP, syscall.SIGTTIN, syscall.SIGTTOU:
+			sigNum = syscall.SIGSTOP
+			goToBed = true
+
+		case syscall.SIGCHLD:
+			// reap what we have sown (aka various zombie children)
+			for {
+				var ws syscall.WaitStatus
+				deadPid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, nil)
+				if err != nil || deadPid == 0 {
+					break
+				}
+				if deadPid == child.Pid {
+					// our child died, so we should too
+					exitStatus := ws.ExitStatus()
+					if exitStatus == -1 {
+						exitStatus = 128 + int(ws.Signal())
+					}
+
+					// send SIGTERM to anyone left
+					unix.Kill(-child.Pid, syscall.SIGTERM)
+
+					// goodbye
+					os.Exit(exitStatus)
+				}
+			}
+
+			continue
+		}
+
+		// forward the signal to the child's process group
+		unix.Kill(-child.Pid, sigNum) // ignore error, best effort
+
+		if goToBed {
+			unix.Kill(pid, syscall.SIGSTOP)
+		}
+	}
+}
+
+func serveSession() {
+	ctx := context.Background()
+
+	attachables := []bksession.Attachable{
+		// sockets
+		client.SocketProvider{EnableHostNetworkAccess: true},
+		// host=>container networking
+		session.NewTunnelListenerAttachable(ctx),
+		// Git credentials
+		session.NewGitCredentialAttachable(ctx),
+	}
+	// filesync
+	filesyncer, err := client.NewFilesyncer()
+	if err != nil {
+		panic(err)
+	}
+	attachables = append(attachables, filesyncer.AsSource(), filesyncer.AsTarget())
+
+	connF := os.NewFile(3, "session-conn")
+	conn, err := net.FileConn(connF)
+	if err != nil {
+		panic(err)
+	}
+
+	sessionSrv := client.NewBuildkitSessionServer(ctx, conn, attachables...)
+	defer sessionSrv.Stop()
+	sessionSrv.Run(ctx)
+}

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -681,7 +681,7 @@ type Test struct {
 		err = cmd.Start()
 		require.NoError(t, err)
 
-		_, err = console.ExpectString("/bin/noexist: No such file or directory")
+		_, err = console.ExpectString("/bin/noexist: no such file or directory")
 		require.NoError(t, err)
 
 		err = cmd.Wait()

--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -212,7 +212,7 @@ func dockerSetup(ctx context.Context, t *testctx.T, name string, dag *dagger.Cli
 		WithEnvVariable("CACHEBUSTER", identity.NewID())
 
 	t.Cleanup(func() {
-		_, err := dockerc.WithExec([]string{"sh", "-c", "docker rm -f $(docker ps -aq); docker system prune --all --volumes; true"}).Sync(ctx)
+		_, err := dockerc.WithExec([]string{"sh", "-c", "docker rm -f $(docker ps -aq); docker system prune --force --all --volumes; true"}).Sync(ctx)
 		require.NoError(t, err)
 
 		_, err = dockerd.Stop(ctx)

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -100,7 +100,7 @@ type ExecutionMetadata struct {
 	// Path to the SSH auth socket. Used for Dagger-in-Dagger support.
 	SSHAuthSocketPath string
 
-	// If true, skip injecting dumb-init into the container.
+	// If true, skip injecting dagger-init into the container.
 	NoInit bool
 }
 
@@ -159,7 +159,7 @@ func (w *Worker) Run(
 	state := newExecState(id, &procInfo, rootMount, mounts, started)
 	return nil, w.run(ctx, state,
 		w.setupNetwork,
-		w.injectDumbInit,
+		w.injectInit,
 		w.generateBaseSpec,
 		w.filterEnvs,
 		w.setupRootfs,

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -10,8 +10,8 @@ const (
 )
 
 const (
-	RuncPath     = "/usr/local/bin/runc"
-	DumbInitPath = "/usr/local/bin/dumb-init"
+	RuncPath       = "/usr/local/bin/runc"
+	DaggerInitPath = "/usr/local/bin/dagger-init"
 
 	EngineDefaultStateDir = "/var/lib/dagger"
 

--- a/engine/server/bk_session.go
+++ b/engine/server/bk_session.go
@@ -41,7 +41,7 @@ func (srv *Server) newBuildkitSession(ctx context.Context, c *daggerClient) (*bk
 		"oci:" + buildkit.BuiltinContentOCIStoreName: builtinStore,
 	}))
 
-	filesyncer, err := client.NewFilesyncer("", "", nil, nil)
+	filesyncer, err := client.NewFilesyncer()
 	if err != nil {
 		return nil, fmt.Errorf("new filesyncer: %w", err)
 	}

--- a/engine/session/h2c.go
+++ b/engine/session/h2c.go
@@ -14,23 +14,14 @@ import (
 )
 
 type TunnelListenerAttachable struct {
-	rootCtx     context.Context
-	getListener func(network, addr string) (net.Listener, error)
+	rootCtx context.Context
 
 	UnimplementedTunnelListenerServer
 }
 
-func NewTunnelListenerAttachable(
-	rootCtx context.Context,
-	// getListener is optional, if nil then net.Listen will be used
-	getListener func(network, addr string) (net.Listener, error),
-) TunnelListenerAttachable {
-	if getListener == nil {
-		getListener = net.Listen
-	}
+func NewTunnelListenerAttachable(rootCtx context.Context) TunnelListenerAttachable {
 	return TunnelListenerAttachable{
-		rootCtx:     rootCtx,
-		getListener: getListener,
+		rootCtx: rootCtx,
 	}
 }
 
@@ -48,7 +39,7 @@ func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error 
 		return err
 	}
 
-	l, err := s.getListener(req.GetProtocol(), req.GetAddr())
+	l, err := net.Listen(req.GetProtocol(), req.GetAddr())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
(Was working on this day before vacation, sending out in a spare moment but won't revisit before I'm back in 2 weeks)

---

This change replaces dumb-init with a custom one written in go that also serves session attachables for nested execs.

One motivation is to avoid a few minor headaches around cross-compiling C code (which dumb-init) is written in. Cross-compiling the new go implementation is trivial.

More than that, this allows transplants session attachables from the executor to this init process, which greatly reduces the hardship involved in adding new session attachables.
* See this thread https://github.com/dagger/dagger/pull/8730#issuecomment-2552079719

Rather than having to figure out how to get each attachable to work both in the CLI and in the executor (which involves complicated entering into the container namespaces), we can just have a single implementation of those attachables that works everywhere.

This doesn't go all the way back to the previous shim implementation (and it's associated headaches), only the attachables are running in the container again. We also avoid needing to do more "pass data via internal env var" by instead giving the init one side of a socketpair, which it uses to connect attachables rather than having to do a big dance to establish the connection itself using tons of client-specific metadata.