### PR TITLE
fix TestGo/TestExtendCore

### DIFF
--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -1481,7 +1481,7 @@ func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
 		require.Regexp(t, "cannot define methods on objects from outside this module", logs.String())
 	})
 
-	t.Run("in same mod name", func(ctx context.Context, t *testctx.T) {
+	t.Run("in same mod name DONT COMMIT", func(ctx context.Context, t *testctx.T) {
 		var logs safeBuffer
 		c := connect(ctx, t, dagger.WithLogOutput(&logs))
 		_, err := c.Container().From(golangImage).


### PR DESCRIPTION
currently failing to me for mysterious reasons... the error logs look exactly like what I'd expect, yet we fail...


[1 example trace from another PR](https://v3.dagger.cloud/dagger/traces/a73148f1afbe0c472a1a44cad21193a5#6fb5116a9f9953d5:EL66)

running here, it passes? so might be a flake