### PR TITLE
helm: Add runtimeClassName option

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -6,11 +6,13 @@ metadata:
   name: {{ include "dagger.fullname" . }}-engine
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
     {{- include "dagger.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      name: {{ include "dagger.fullname" . }}-engine
+      app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
+      {{- include "dagger.labels" . | nindent 6 }}
   template:
     metadata:
       {{- if (or .Values.engine.config .Values.magicache.enabled) }}
@@ -23,7 +25,7 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        name: {{ include "dagger.fullname" . }}-engine
+        app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
       {{- with .Values.engine.tolerations }}
@@ -42,6 +44,9 @@ spec:
       serviceAccountName: {{ include "dagger.serviceAccountName" . }}
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}
+      {{- end }}
+      {{- if .Values.engine.runtimeClassName }}
+      runtimeClassName: {{ .Values.engine.runtimeClassName }}
       {{- end }}
       containers:
         - name: dagger-engine

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "dagger.fullname" . }}-engine
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
     {{- include "dagger.labels" . | nindent 4 }}
 spec:
   # DO NOT RUN MORE THAN 1 REPLICA.
@@ -13,7 +14,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ include "dagger.fullname" . }}-engine
+      app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
+      {{- include "dagger.labels" . | nindent 6 }}
   template:
     metadata:
       {{- if (or .Values.engine.config .Values.magicache.enabled) }}
@@ -26,7 +28,7 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        name: {{ include "dagger.fullname" . }}-engine
+        app.kubernetes.io/name: {{ include "dagger.fullname" . }}-engine
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
       {{- with .Values.engine.tolerations }}
@@ -45,6 +47,9 @@ spec:
       serviceAccountName: {{ include "dagger.serviceAccountName" . }}
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}
+      {{- end }}
+      {{- if .Values.engine.runtimeClassName }}
+      runtimeClassName: {{ .Values.engine.runtimeClassName }}
       {{- end }}
       containers:
         - name: dagger-engine

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -60,6 +60,9 @@ engine:
   ### Set priorityClassName to avoid eviction
   priorityClassName: ""
 
+  ### Set runtimeClassName to use an alternative runtime, e.g. kata, gvisor, etc.
+  runtimeClassName: ""
+
   readinessProbeSettings: 
     initialDelaySeconds: 5
     timeoutSeconds: 14


### PR DESCRIPTION
So that the Engine can run in alternative runtimes, such as kata, gvisor etc.

This is a follow-up to:
- https://github.com/dagger/dagger/pull/9249