### PR TITLE
ci: fix permissions error on pull request comment

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,13 +1,15 @@
 name: needs/changelog
 
 on:
-  pull_request:
+  # WARNING! pull_request_target is dangerous and *must not* run user code.
+  # See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  pull_request_target:
     types:
       - opened
       - synchronize
       - labeled
       - unlabeled
-      
+
 permissions:
   contents: read
   pull-requests: write
@@ -19,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Fetch refs
@@ -46,7 +49,7 @@ jobs:
           fi
 
       - name: Add comment
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         if: always() && github.event.action == 'labeled' && steps.check.outcome != 'success'
         with:
           message: |


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/actions/runs/12602450696/job/35125546961?pr=9309

```
Run thollander/actions-comment-pull-request@v2
  with:
    message: This PR has been marked with `needs/changelog`, but no changelog has been created.
  
  Run `changie new` to generate one (see [CONTRIBUTING.md](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md) for details).
  
    GITHUB_TOKEN: ***
    mode: upsert
    create_if_not_exists: true
Error: Resource not accessible by integration
```

If the PR comes from a fork, then we cannot get a write token for pull-requests, so we can't write a comment to the PR.

To be able to get access to this, we need to instead trigger on `pull_request_target`. This uses the job definition from `main` instead.