### PR TITLE
fix(sdk/java): handle & inside javadoc

### DIFF
--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
@@ -171,6 +171,6 @@ public class Helpers {
 
   /** Fix using '$' char in javadoc */
   static String escapeJavadoc(String str) {
-    return str.replace("$", "$$");
+    return str.replace("$", "$$").replace("&", "&amp;");
   }
 }

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ObjectVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ObjectVisitor.java
@@ -19,7 +19,7 @@ class ObjectVisitor extends AbstractVisitor {
   TypeSpec generateType(Type type) {
     TypeSpec.Builder classBuilder =
         TypeSpec.classBuilder(Helpers.formatName(type))
-            .addJavadoc(type.getDescription())
+            .addJavadoc(Helpers.escapeJavadoc(type.getDescription()))
             .addModifiers(Modifier.PUBLIC)
             .addField(
                 FieldSpec.builder(
@@ -124,7 +124,7 @@ class ObjectVisitor extends AbstractVisitor {
                                 ? arg.getType().formatOutput()
                                 : arg.getType().formatInput(),
                             Helpers.formatName(arg))
-                        .addJavadoc(arg.getDescription() + "\n")
+                        .addJavadoc(Helpers.escapeJavadoc(arg.getDescription()) + "\n")
                         .build())
             .toList();
     fieldMethodBuilder.addParameters(mandatoryParams);


### PR DESCRIPTION
Javadoc comments are wrapped between HTML `<p>` tags. In this case `&` is not a valid entity and generates the following error:

    error: bad HTML entity
      * <p><br/>Set chart & app version<br/></p>

This happen when you generate the documentation using `mvnw package -Pjavadoc`

This commit escapes the `&` char and also call the `Helpers.escapeJavadoc` method for type and arg descriptions in addition to the already done field one.

---

The fix is quite basic, just for `&`. Maybe we need something more resilient, like to use some kind of escape html, but at least that solves this one issue.

cc @jcsirot 