### PR TITLE
ci: fixup dependabot config schema violation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directories:
       - "/"
       - "/sdk/go"
-    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Oops. Fixup from https://github.com/dagger/dagger/pull/9235.

Dependabot not having a neat way to check the schema before merging is annoying.