### PR TITLE
fix: avoid restoring stdout after making stdin raw

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -747,12 +747,11 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 				ExecCommand: cmd,
 				before: func() error {
 					if stdin, ok := fe.stdin.(*os.File); ok {
-						ttyFd := int(os.Stdout.Fd())
 						oldState, err := term.MakeRaw(int(stdin.Fd()))
 						if err != nil {
 							return err
 						}
-						restore = func() error { return term.Restore(ttyFd, oldState) }
+						restore = func() error { return term.Restore(int(stdin.Fd()), oldState) }
 					}
 
 					return nil


### PR DESCRIPTION
This just looks like a typo from #9244 - I don't think we actually intend to do this?