### PR TITLE
ci: un-pin php sdk to use same version as engine tag

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"os/exec"
@@ -105,6 +106,10 @@ func main() {
 	if filepath.Base(fullPath) == fullPath {
 		// search for the executable in $PATH
 		fullPath, err = exec.LookPath(fullPath)
+		if errors.Is(err, exec.ErrDot) {
+			// NOTE: backwards compat with dumb-init
+			err = nil
+		}
 		if err != nil {
 			panic(err)
 		}

--- a/sdk/php/dev/dagger.json
+++ b/sdk/php/dev/dagger.json
@@ -1,7 +1,7 @@
 {
   "name": "php-sdk-dev",
-  "engineVersion": "v0.13.3",
-  "sdk": "php@05cab0d6502599671a9da7d338011edd3a76129c",
+  "engineVersion": "v0.15.1",
+  "sdk": "php",
   "dependencies": [
     {
       "name": "always-exec",


### PR DESCRIPTION
We were pinned to an old version of the php sdk that didn't have the proper OTEL work that allowed us to actually observe errors happening.

By unpinning it, we'll always get the same version as the engine.