### PR TITLE
ci: use dagger-built binaries in goreleaser

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -128,10 +128,6 @@ func (build *Builder) WithGPUSupport() *Builder {
 	return &b
 }
 
-func (build *Builder) CLI(ctx context.Context) (*dagger.File, error) {
-	return build.binary("./cmd/dagger", true, build.race), nil
-}
-
 func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/dagger/dagger/.dagger/build"
 	"github.com/dagger/dagger/.dagger/internal/dagger"
 )
 
@@ -47,6 +46,8 @@ func (cli *CLI) Publish(
 	awsRegion string,
 	awsBucket string,
 	artefactsFQDN string,
+
+	dryRun bool, // +optional
 ) error {
 	ctr, err := publishEnv(ctx)
 	if err != nil {
@@ -54,8 +55,9 @@ func (cli *CLI) Publish(
 	}
 	ctr = ctr.
 		WithWorkdir("/app").
-		WithDirectory("/app", cli.Dagger.Source()).
-		WithDirectory("/app", cli.Dagger.Git.Directory())
+		WithDirectory(".", cli.Dagger.Source()).
+		WithDirectory(".", cli.Dagger.Git.Directory()).
+		WithDirectory("build", cli.goreleaserBinaries())
 
 	if !semver.IsValid(tag) {
 		// all non-semver tags (like "main") are dev builds
@@ -84,6 +86,9 @@ func (cli *CLI) Publish(
 			"--nightly",
 			"--config", ".goreleaser.nightly.yml",
 		)
+	}
+	if dryRun {
+		args = append(args, "--skip=publish")
 	}
 
 	_, err = ctr.
@@ -163,14 +168,27 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 	// a key which is private. For now, this just builds the CLI for the same
 	// targets so there's at least some coverage
 
+	var eg errgroup.Group
+	eg.Go(func() error {
+		_, err := cli.goreleaserBinaries().Sync(ctx)
+		return err
+	})
+	eg.Go(func() error {
+		env, err := publishEnv(ctx)
+		if err != nil {
+			return err
+		}
+		_, err = env.Sync(ctx)
+		return err
+	})
+	return eg.Wait()
+}
+
+func (cli *CLI) goreleaserBinaries() *dagger.Directory {
 	oses := []string{"linux", "windows", "darwin"}
 	arches := []string{"amd64", "arm64", "arm"}
 
-	builder, err := build.NewBuilder(ctx, cli.Dagger.Source())
-	if err != nil {
-		return err
-	}
-	var eg errgroup.Group
+	dir := dag.Directory()
 	for _, os := range oses {
 		for _, arch := range arches {
 			if arch == "arm" && os == "darwin" {
@@ -182,40 +200,16 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 				platform += "/v7" // not always correct but not sure of better way
 			}
 
-			eg.Go(func() error {
-				f, err := builder.
-					WithPlatform(dagger.Platform(platform)).
-					CLI(ctx)
-				if err != nil {
-					return err
-				}
-				_, err = f.Sync(ctx)
-				return err
-			})
+			binary := dag.DaggerCli().Binary(dagger.DaggerCliBinaryOpts{Platform: dagger.Platform(platform)})
+			dest := fmt.Sprintf("dagger_%s_%s/dagger", cli.Dagger.Version, strings.ReplaceAll(platform, "/", "_"))
+			dir = dir.WithFile(dest, binary)
 		}
 	}
-
-	eg.Go(func() error {
-		env, err := publishEnv(ctx)
-		if err != nil {
-			return err
-		}
-		_, err = env.Sync(ctx)
-		return err
-	})
-
-	return eg.Wait()
+	return dir
 }
 
 func publishEnv(ctx context.Context) (*dagger.Container, error) {
 	ctr := dag.Container().From(goReleaserImage)
-
-	// HACK: this can be enabled to force a go update (e.g. when we need it for
-	// a security update)
-	// ctr = ctr.WithDirectory(
-	// 	"/usr/local/go",
-	// 	dag.Container().From("golang:<version>-alpine@sha256:<hash>").Directory("/usr/local/go"),
-	// )
 
 	// install nix
 	ctr = ctr.

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -111,10 +111,9 @@ func (e *DaggerEngine) Container(
 		WithFile(engineEntrypointPath, entrypoint).
 		WithEntrypoint([]string{filepath.Base(engineEntrypointPath)})
 
-	cli, err := builder.CLI(ctx)
-	if err != nil {
-		return nil, err
-	}
+	cli := dag.DaggerCli().Binary(dagger.DaggerCliBinaryOpts{
+		Platform: platform,
+	})
 	ctr = ctr.
 		WithFile(cliPath, cli).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "unix://"+engineUnixSocketPath)

--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -7,14 +7,8 @@ before:
     - go mod download
 
 builds:
-  - env:
-      - CGO_ENABLED=0
-    main: ./cmd/dagger
-    binary: dagger
-    ldflags:
-      - -s -w
-      - -X github.com/dagger/dagger/engine.Version={{.Env.ENGINE_VERSION}}
-      - -X github.com/dagger/dagger/engine.Tag={{.Env.ENGINE_TAG}}
+  - builder: prebuilt
+    binary: ./dagger
     goos:
       - linux
       - windows
@@ -25,6 +19,9 @@ builds:
       - arm
     goarm:
       - "7"
+
+    prebuilt:
+      path: build/dagger_{{ .Env.ENGINE_VERSION }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}_v{{ . }}{{ end }}/dagger
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Internal ticket: https://linear.app/dagger/issue/DEV-4839

It's better to use the dagger-built binaries as part of our goreleaser release, instead of having goreleaser build them itself. This has a few advantages:

- Consistency. The fewer process differences between local builds and release builds, the better.
- Extensibility. At some point in the future, we want to bundle the engine *into* the CLI - this will require the CLI release build to use dagger, instead of being a simple `go build` command that goreleaser can do.
- Security. By splitting out the building and releasing steps, we're now no longer beholden to the release cadence of goreleaser before we can upgrade go versions.