### PR TITLE
Attempt to fix PHP flake with more lax session output parsing

### DIFF
--- a/sdk/php/src/Connection/CliDownloader.php
+++ b/sdk/php/src/Connection/CliDownloader.php
@@ -16,7 +16,7 @@ class CliDownloader implements LoggerAwareInterface
 {
     public const DAGGER_CLI_BIN_PREFIX = 'dagger-';
 
-    private NullLogger $logger;
+    private LoggerInterface $logger;
 
     public function __construct()
     {
@@ -25,6 +25,7 @@ class CliDownloader implements LoggerAwareInterface
 
     public function setLogger(LoggerInterface $logger): void
     {
+        $this->logger = $logger;
     }
 
     public function download(string $version = null): string

--- a/sdk/php/src/Connection/ProcessSessionConnection.php
+++ b/sdk/php/src/Connection/ProcessSessionConnection.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\InputStream;
 
 /**
  * @deprecated
@@ -49,7 +50,7 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
         ]);
 
         $process->setTimeout(null);
-        $process->setPty(true);
+        $process->setInput(new InputStream());
         $process->start(function ($type, $output) {
             if (Process::ERR === $type) {
                 $this->logger->error($output);


### PR DESCRIPTION
This is an attempt to fix the PHP flake from https://github.com/dagger/dagger/issues/9346.

What *appears* to be happening is that despite confirming that the output we read has `session_token` in it, we're somehow decoding a JSON object that doesn't have the `port` property.

Not really sure how this can possibly be happening - but assuming that the PHP library works as intended (not unreasonable), and that the `dagger session` code is good (we don't see any other flakes like this for other SDKs), then something is wrong here. Having mixed progress output into the stdout (which happens when a PTY is used) could *potentially* be the cause here? It would also explain why this seems flaky, since it depends on timing of writing to a buffer.

Anyways, probably worth a go, no other SDK opens a PTY like this.