### PR TITLE
tests: avoid image pull in docker driver provision test

### DIFF
--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -29,6 +29,10 @@ func (ProvisionSuite) TestDockerDriver(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		dockerc := dockerSetup(ctx, t, "provisioner", c, "", nil)
 		dockerc = dockerc.WithMountedFile("/bin/dagger", daggerCliFile(t, c))
+		// HACK: pre-download builtin image tag (since the original might not
+		// actually have been pushed to the registry)
+		dockerc, err := dockerLoadEngine(ctx, c, dockerc, "registry.dagger.io/engine:"+engine.Tag)
+		require.NoError(t, err)
 
 		out, err := dockerc.
 			WithExec([]string{"dagger", "query"}, dagger.ContainerWithExecOpts{Stdin: "{version}"}).Stdout(ctx)


### PR DESCRIPTION
The image we use here by default is the image built off of main - but that may actually not have been built, which is sad, and causes flakes in this test.

The solution here is to just avoid the image pull step, by pre-loading the image.