### PR TITLE
ci: Warm up Engines before `dagger call` in Alternative Runners

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -98,7 +98,7 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Dagger server version"
-        echo "{version}" | dagger --silent query
+        dagger --silent core version
         echo "::endgroup::"
 
     - name: ${{ inputs.function }}

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Warm up Engine
+        run: dagger core version
       - name: ${{ inputs.function }}
         uses: ./.github/actions/call
         with:

--- a/.github/workflows/_dagger_on_magicache_remote_engine.yml
+++ b/.github/workflows/_dagger_on_magicache_remote_engine.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Warm up Engine
+        run: dagger core version
       - name: ${{ inputs.function }}
         uses: ./.github/actions/call
         with:

--- a/.github/workflows/_dagger_on_namespace_remote_engine.yml
+++ b/.github/workflows/_dagger_on_namespace_remote_engine.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Warm up Engine
+        run: dagger core version
       - name: ${{ inputs.function }}
         uses: ./.github/actions/call
         with:

--- a/.github/workflows/alternative-ci-runners-3.yml
+++ b/.github/workflows/alternative-ci-runners-3.yml
@@ -14,32 +14,32 @@ permissions:
 
 jobs:
   docs-lint-on-magicache:
-    uses: ./.github/workflows/_dagger_on_magicache.yml
+    uses: ./.github/workflows/_dagger_on_magicache_remote_engine.yml
     with:
       function: docs lint
       timeout: 20
 
   test-cli-engine-on-magicache:
     needs: docs-lint-on-magicache
-    uses: ./.github/workflows/_dagger_on_magicache.yml
+    uses: ./.github/workflows/_dagger_on_magicache_remote_engine.yml
     with:
       function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
       timeout: 20
 
   sdk-go-on-magicache:
     needs: docs-lint-on-magicache
-    uses: ./.github/workflows/_dagger_on_magicache.yml
+    uses: ./.github/workflows/_dagger_on_magicache_remote_engine.yml
     with:
       function: check --targets=sdk/go
 
   sdk-python-on-magicache:
     needs: docs-lint-on-magicache
-    uses: ./.github/workflows/_dagger_on_magicache.yml
+    uses: ./.github/workflows/_dagger_on_magicache_remote_engine.yml
     with:
       function: check --targets=sdk/python
 
   sdk-typescript-on-magicache:
     needs: docs-lint-on-magicache
-    uses: ./.github/workflows/_dagger_on_magicache.yml
+    uses: ./.github/workflows/_dagger_on_magicache_remote_engine.yml
     with:
       function: check --targets=sdk/typescript


### PR DESCRIPTION
We want to see the delta between jobs getting dequeued and calls actually starting, because in some cases cold Engines can add minutes to the job execution time.