### PR TITLE
ci: Rename Docs job to docs

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -71,7 +71,7 @@ func New() *CI {
 		withWorkflow(
 			ci.DaggerRunner,
 			false,
-			"Docs",
+			"docs",
 			"docs lint",
 		).
 		withWorkflow(

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -1,5 +1,5 @@
 # This file was generated. See https://daggerverse.dev/mod/github.com/dagger/dagger/modules/gha
-name: Docs
+name: docs
 "on":
     push:
         branches:
@@ -20,7 +20,7 @@ jobs:
     docs:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-15-1-4c' || 'ubuntu-latest' }}
-        name: Docs
+        name: docs
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -8,7 +8,7 @@ on:
       - "Alternative CI Runners 3"
       - "Benchmark"
       - "daggerverse-preview"
-      - "Docs"
+      - "docs"
       - "Engine & CLI"
       - "Github"
       - "Helm"


### PR DESCRIPTION
So that it matches the filter when comparing the duration of this job in alternative runners.