### PR TITLE
ci: avoid use of `errgroup.WithContext` in checks

### DIFF
--- a/.dagger/checks.go
+++ b/.dagger/checks.go
@@ -31,7 +31,7 @@ func (dev *DaggerDev) Check(ctx context.Context,
 	routes.Add(dev.checksForSDK("sdk/elixir", dev.SDK().Elixir)...)
 	routes.Add(dev.checksForSDK("sdk/dotnet", dev.SDK().Dotnet)...)
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for _, check := range routes.Get(targets...) {
 		ctx, span := Tracer().Start(ctx, check.Name)
 		eg.Go(func() (rerr error) {

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -176,7 +176,7 @@ func (e *DaggerEngine) Lint(
 	ctx context.Context,
 	pkgs []string, // +optional
 ) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	eg.Go(func() error {
 		if len(pkgs) == 0 {
 			allPkgs, err := e.Dagger.containing(ctx, "go.mod")
@@ -301,7 +301,7 @@ func (e *DaggerEngine) Publish(
 		Platforms []*dagger.Container
 		Tags      []string
 	}, len(targets))
-	eg, egCtx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for i, target := range targets {
 		// determine the target tags
 		for _, tag := range tag {
@@ -311,7 +311,7 @@ func (e *DaggerEngine) Publish(
 		// build all the target platforms
 		targetResults[i].Platforms = make([]*dagger.Container, len(target.Platforms))
 		for j, platform := range target.Platforms {
-			egCtx, span := Tracer().Start(egCtx, fmt.Sprintf("building %s [%s]", target.Name, platform))
+			egCtx, span := Tracer().Start(ctx, fmt.Sprintf("building %s [%s]", target.Name, platform))
 			eg.Go(func() (rerr error) {
 				defer func() {
 					if rerr != nil {
@@ -409,7 +409,7 @@ func (e *DaggerEngine) Scan(ctx context.Context) error {
 		commonArgs = append(commonArgs, "--ignorefile=/mnt/ignores/"+ignoreFileNames[0])
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 
 	eg.Go(func() error {
 		// scan the source code

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -172,19 +172,26 @@ func (dev *DaggerDev) Generate(ctx context.Context) (*dagger.Directory, error) {
 
 	eg.Go(func() error {
 		var err error
-		docs, err = dev.Docs().Generate(ctx)
+		docs = dev.Docs().Generate()
+		docs, err = docs.Sync(ctx)
 		return err
 	})
 
 	eg.Go(func() error {
 		var err error
 		sdks, err = dev.SDK().All().Generate(ctx)
+		if err != nil {
+			return err
+		}
+		sdks, err = sdks.Sync(ctx)
 		return err
 	})
 
 	eg.Go(func() error {
+		var err error
 		engine = dev.Engine().Generate()
-		return nil
+		docs, err = engine.Sync(ctx)
+		return err
 	})
 
 	if err := eg.Wait(); err != nil {

--- a/.dagger/scripts.go
+++ b/.dagger/scripts.go
@@ -13,7 +13,7 @@ type Scripts struct {
 
 // Lint scripts files
 func (s Scripts) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	eg.Go(func() error {
 		return dag.Shellcheck().
 			Check(s.Dagger.Source().File("install.sh")).

--- a/.dagger/sdk_all.go
+++ b/.dagger/sdk_all.go
@@ -14,7 +14,7 @@ type AllSDK struct {
 var _ sdkBase = AllSDK{}
 
 func (t AllSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for _, sdk := range t.SDK.allSDKs() {
 		eg.Go(func() error {
 			return sdk.Lint(ctx)
@@ -24,7 +24,7 @@ func (t AllSDK) Lint(ctx context.Context) error {
 }
 
 func (t AllSDK) Test(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for _, sdk := range t.SDK.allSDKs() {
 		eg.Go(func() error {
 			return sdk.Test(ctx)
@@ -34,7 +34,7 @@ func (t AllSDK) Test(ctx context.Context) error {
 }
 
 func (t AllSDK) TestPublish(ctx context.Context, tag string) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for _, sdk := range t.SDK.allSDKs() {
 		eg.Go(func() error {
 			return sdk.TestPublish(ctx, tag)
@@ -44,7 +44,7 @@ func (t AllSDK) TestPublish(ctx context.Context, tag string) error {
 }
 
 func (t AllSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	dirs := make([]*dagger.Directory, len(t.SDK.allSDKs()))
 	for i, sdk := range t.SDK.allSDKs() {
 		eg.Go(func() error {
@@ -73,7 +73,7 @@ func (t AllSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 }
 
 func (t AllSDK) Bump(ctx context.Context, version string) (*dagger.Directory, error) {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	dirs := make([]*dagger.Directory, len(t.SDK.allSDKs()))
 	for i, sdk := range t.SDK.allSDKs() {
 		eg.Go(func() error {

--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -33,7 +33,7 @@ type ElixirSDK struct {
 
 // Lint the Elixir SDK
 func (t ElixirSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	eg.Go(func() (rerr error) {
 		ctx, span := Tracer().Start(ctx, "lint the elixir source")
 		defer func() {

--- a/.dagger/sdk_go.go
+++ b/.dagger/sdk_go.go
@@ -17,7 +17,7 @@ type GoSDK struct {
 
 // Lint the Go SDK
 func (t GoSDK) Lint(ctx context.Context) (rerr error) {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	eg.Go(func() (rerr error) {
 		ctx, span := Tracer().Start(ctx, "lint the go source")
 		defer func() {

--- a/.dagger/sdk_php.go
+++ b/.dagger/sdk_php.go
@@ -28,7 +28,7 @@ type PHPSDK struct {
 
 // Lint the PHP SDK
 func (t PHPSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 
 	eg.Go(func() (rerr error) {
 		ctx, span := Tracer().Start(ctx, "lint the php source")

--- a/.dagger/sdk_python.go
+++ b/.dagger/sdk_python.go
@@ -23,7 +23,7 @@ type PythonSDK struct {
 
 // Lint the Python SDK
 func (t PythonSDK) Lint(ctx context.Context) (rerr error) {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 
 	// TODO: create function in PythonSDKDev to lint any directory as input
 	// but reusing the same linter configuration in the SDK.
@@ -102,7 +102,7 @@ func (t PythonSDK) Test(ctx context.Context) (rerr error) {
 		return err
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	for _, version := range versions {
 		eg.Go(func() error {
 			_, err := dev.

--- a/.dagger/sdk_rust.go
+++ b/.dagger/sdk_rust.go
@@ -32,7 +32,7 @@ type RustSDK struct {
 func (r RustSDK) Lint(ctx context.Context) error {
 	base := r.rustBase(rustDockerStable)
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	eg.Go(func() error {
 		_, err := base.
 			WithExec([]string{"cargo", "check", "--all", "--release"}).

--- a/.dagger/sdk_typescript.go
+++ b/.dagger/sdk_typescript.go
@@ -33,7 +33,7 @@ type TypescriptSDK struct {
 
 // Lint the Typescript SDK
 func (t TypescriptSDK) Lint(ctx context.Context) (rerr error) {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 
 	base := t.nodeJsBase()
 
@@ -119,7 +119,7 @@ func (t TypescriptSDK) Test(ctx context.Context) (rerr error) {
 		return err
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 
 	// Loop over the LTS and Maintenance versions and test them
 	for _, version := range []string{nodeCurrentLTS, nodePreviousLTS} {


### PR DESCRIPTION
This causes some very hard-to-read CI failures when we use this - this means that instead of waiting for *everything* to finish, we bail quickly on the first error. E.g. when linting, we error out on the first lint failure, instead of waiting for all the checks to pass or fail.

For example, of a hard-to-read failure see https://v3.dagger.cloud/dagger/traces/168ed3748bb12bdb7d858df98a9adb94