### PR TITLE
fix: Replace custom module in PhpSdkDev

### DIFF
--- a/sdk/php/dagger.json
+++ b/sdk/php/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "php-sdk",
-  "engineVersion": "v0.13.3",
+  "engineVersion": "v0.15.1",
   "sdk": "go",
   "exclude": [
     "vendor/"

--- a/sdk/php/dev/dagger.json
+++ b/sdk/php/dev/dagger.json
@@ -2,12 +2,5 @@
   "name": "php-sdk-dev",
   "engineVersion": "v0.15.1",
   "sdk": "php",
-  "dependencies": [
-    {
-      "name": "always-exec",
-      "source": "github.com/charjr/dagger-always-exec@d478c1aaf4c5290926d2d1978d98d9f0054529eb",
-      "pin": "d478c1aaf4c5290926d2d1978d98d9f0054529eb"
-    }
-  ],
   "source": "."
 }


### PR DESCRIPTION
Thanks to the `:expect` flag on calls to `withExec`
The custom-module _always-exec_ used in the PhpSdkDev is now obsolete.

This PR removes the depedency on the custom module _always-exec_.