### PR TITLE
More `Container.up` consistencies

### DIFF
--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -65,8 +65,8 @@ func (ModuleSuite) TestDaggerUp(ctx context.Context, t *testctx.T) {
 		{
 			name:         "container port map with explicit args",
 			endpointFn:   daggerUpAndGetEndpoint,
-			trafficPort:  "23102",
-			daggerArgs:   []string{"call", "ctr", "without-exposed-port", "--port", defaultTrafficPortForContainerTests, "with-exposed-port", "--port", "23102", "up", "--args", "python,-m,http.server,23102", "--ports", "23102:23102"},
+			trafficPort:  "23103",
+			daggerArgs:   []string{"call", "ctr", "without-exposed-port", "--port", defaultTrafficPortForContainerTests, "with-exposed-port", "--port", "23103", "up", "--args", "python,-m,http.server,23103", "--ports", "23103:23103"},
 			cachedModDir: modDirForAsContainerTests,
 		},
 		{

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -54,6 +54,7 @@ func (s *serviceSchema) Install() {
 
 		dagql.NodeFunc("up", s.containerUpLegacy).
 			View(BeforeVersion("v0.15.2")).
+			Impure("Starts a host tunnel, possibly with ports that change each time it's started.").
 			Doc(`Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.`,
 				`Be sure to set any exposed ports before calling this api.`).
 			ArgDoc("random", `Bind each tunnel port to a random port on the host.`).
@@ -62,6 +63,7 @@ func (s *serviceSchema) Install() {
 
 		dagql.NodeFunc("up", s.containerUp).
 			View(AfterVersion("v0.15.2")).
+			Impure("Starts a host tunnel, possibly with ports that change each time it's started.").
 			Doc(`Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.`,
 				`Be sure to set any exposed ports before calling this api.`).
 			ArgDoc("random", `Bind each tunnel port to a random port on the host.`).


### PR DESCRIPTION
Quick follow-up to https://github.com/dagger/dagger/pull/9231 before v0.15.2.

First, a fix to a flake that could occasionally occur when there was a host port conflict :scream:

Then, `Container.up` should also be marked as impure, just like `Service.up`, since it modifies host state.