### PR TITLE
Use ClientID for keying started tunnels

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -797,6 +797,23 @@ func (f *Foo) TestServiceUpEntrypoint(ctx context.Context, app *dagger.File) (st
 	if err != nil {
 		return "", err
 	}
+	go ctr.AsService().Up(ctx, dagger.ServiceUpOpts{
+		Ports: []dagger.PortForward{
+			{
+				Protocol: dagger.NetworkProtocolTcp,
+				Frontend: 8080,
+				Backend:  8080,
+			},
+		},
+	})
+	return fetch()
+}
+
+func (f *Foo) TestContainerUpEntrypoint(ctx context.Context, app *dagger.File) (string, error) {
+	ctr, err := f.StartEntrypointByDefault(ctx, app)
+	if err != nil {
+		return "", err
+	}
 	go ctr.Up(ctx, dagger.ContainerUpOpts{
 		Ports: []dagger.PortForward{
 			{
@@ -806,24 +823,7 @@ func (f *Foo) TestServiceUpEntrypoint(ctx context.Context, app *dagger.File) (st
 			},
 		},
 	})
-
-	for range 10 {
-		time.Sleep(2 * time.Second)
-		client := http.Client{
-			Timeout: 2 * time.Second,
-		}
-		resp, err := client.Get("http://localhost:8080/hello")
-		if err != nil {
-			continue
-		}
-		defer resp.Body.Close()
-		dt, err := io.ReadAll(resp.Body)
-		if err != nil {
-			continue
-		}
-		return string(dt), nil
-	}
-	return "", fmt.Errorf("could not fetch")
+	return fetch()
 }
 
 func (f *Foo) StartEntrypointByDefault(ctx context.Context, app *dagger.File) (*dagger.Container, error) {
@@ -854,6 +854,23 @@ func (f *Foo) TestServiceUpWithExec(ctx context.Context, app *dagger.File) (stri
 	if err != nil {
 		return "", err
 	}
+	go ctr.AsService().Up(ctx, dagger.ServiceUpOpts{
+		Ports: []dagger.PortForward{
+			{
+				Protocol: dagger.NetworkProtocolTcp,
+				Frontend: 8080,
+				Backend:  8080,
+			},
+		},
+	})
+	return fetch()
+}
+
+func (f *Foo) TestContainerUpWithExec(ctx context.Context, app *dagger.File) (string, error) {
+	ctr, err := f.UseWithExecWhenAvailable(ctx, app)
+	if err != nil {
+		return "", err
+	}
 	go ctr.Up(ctx, dagger.ContainerUpOpts{
 		Ports: []dagger.PortForward{
 			{
@@ -863,24 +880,7 @@ func (f *Foo) TestServiceUpWithExec(ctx context.Context, app *dagger.File) (stri
 			},
 		},
 	})
-
-	for range 10 {
-		time.Sleep(2 * time.Second)
-		client := http.Client{
-			Timeout: 2 * time.Second,
-		}
-		resp, err := client.Get("http://localhost:8080/hello")
-		if err != nil {
-			continue
-		}
-		defer resp.Body.Close()
-		dt, err := io.ReadAll(resp.Body)
-		if err != nil {
-			continue
-		}
-		return string(dt), nil
-	}
-	return "", fmt.Errorf("could not fetch")
+	return fetch()
 }
 
 func (f *Foo) UseWithExecWhenAvailable(ctx context.Context, app *dagger.File) (*dagger.Container, error) {
@@ -891,6 +891,28 @@ func (f *Foo) UseWithExecWhenAvailable(ctx context.Context, app *dagger.File) (*
 		WithDefaultArgs([]string{"/bin/app", "via-default-args"}).
 		WithExec([]string{"/bin/app", "via-withExec"}).
 		WithExposedPort(8080), nil
+}
+
+func fetch() (string, error) {
+	for range 10 {
+		time.Sleep(2 * time.Second)
+		client := http.Client{
+			Timeout: 2 * time.Second,
+		}
+		resp, err := client.Get("http://localhost:8080/hello")
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		defer resp.Body.Close()
+		dt, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		return string(dt), nil
+	}
+	return "", fmt.Errorf("could not fetch")
 }
 `
 
@@ -920,6 +942,12 @@ func (f *Foo) UseWithExecWhenAvailable(ctx context.Context, app *dagger.File) (*
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "args: /bin/app,via-entrypoint,/bin/app,via-default-args", output)
+
+		output, err = ctr.
+			With(daggerExec("call", "test-container-up-entrypoint", "--app=app")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "args: /bin/app,via-entrypoint,/bin/app,via-default-args", output)
 	})
 
 	// verify that the engine uses the entrypoint when serving the legacy AsService api
@@ -932,6 +960,12 @@ func (f *Foo) UseWithExecWhenAvailable(ctx context.Context, app *dagger.File) (*
 
 		output, err = ctr.
 			With(daggerExec("call", "test-service-up-with-exec", "--app=app")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "args: /bin/app,via-withExec", output)
+
+		output, err = ctr.
+			With(daggerExec("call", "test-container-up-with-exec", "--app=app")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "args: /bin/app,via-withExec", output)

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -319,7 +319,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 	if err != nil {
 		return void, fmt.Errorf("failed to get host services: %w", err)
 	}
-	runningSvc, err := svcs.Start(ctx, hostSvc.ID(), hostSvc.Self)
+	runningSvc, err := svcs.Start(ctx, hostSvc.ID(), hostSvc.Self, true)
 	if err != nil {
 		return void, fmt.Errorf("failed to start host service: %w", err)
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -98,7 +98,7 @@ func (svc *Service) Hostname(ctx context.Context, id *call.ID) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		upstream, err := svcs.Get(ctx, id)
+		upstream, err := svcs.Get(ctx, id, true)
 		if err != nil {
 			return "", err
 		}
@@ -119,7 +119,7 @@ func (svc *Service) Ports(ctx context.Context, id *call.ID) ([]Port, error) {
 		if err != nil {
 			return nil, err
 		}
-		running, err := svcs.Get(ctx, id)
+		running, err := svcs.Get(ctx, id, svc.TunnelUpstream != nil)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func (svc *Service) Endpoint(ctx context.Context, id *call.ID, port int, scheme 
 		if err != nil {
 			return "", err
 		}
-		tunnel, err := svcs.Get(ctx, id)
+		tunnel, err := svcs.Get(ctx, id, true)
 		if err != nil {
 			return "", err
 		}
@@ -202,7 +202,7 @@ func (svc *Service) StartAndTrack(ctx context.Context, id *call.ID) error {
 	if err != nil {
 		return err
 	}
-	_, err = svcs.Start(ctx, id, svc)
+	_, err = svcs.Start(ctx, id, svc, svc.TunnelUpstream != nil)
 	return err
 }
 
@@ -211,7 +211,7 @@ func (svc *Service) Stop(ctx context.Context, id *call.ID, kill bool) error {
 	if err != nil {
 		return err
 	}
-	return svcs.Stop(ctx, id, kill)
+	return svcs.Stop(ctx, id, kill, svc.TunnelUpstream != nil)
 }
 
 func (svc *Service) Start(
@@ -226,7 +226,7 @@ func (svc *Service) Start(
 	case svc.Container != nil:
 		return svc.startContainer(ctx, id, interactive, forwardStdin, forwardStdout, forwardStderr)
 	case svc.TunnelUpstream != nil:
-		return svc.startTunnel(ctx, id)
+		return svc.startTunnel(ctx)
 	case len(svc.HostSockets) > 0:
 		return svc.startReverseTunnel(ctx, id)
 	default:
@@ -538,12 +538,8 @@ func (svc *Service) startContainer(
 			Service: svc,
 			Host:    fullHost,
 			Ports:   ctr.Ports,
-			Key: ServiceKey{
-				Digest:    dig,
-				SessionID: clientMetadata.SessionID,
-			},
-			Stop: stopSvc,
-			Wait: waitSvc,
+			Stop:    stopSvc,
+			Wait:    waitSvc,
 		}, nil
 	case <-exited:
 		if exitErr != nil {
@@ -553,7 +549,7 @@ func (svc *Service) startContainer(
 	}
 }
 
-func (svc *Service) startTunnel(ctx context.Context, id *call.ID) (running *RunningService, rerr error) {
+func (svc *Service) startTunnel(ctx context.Context) (running *RunningService, rerr error) {
 	svcCtx, stop := context.WithCancelCause(context.WithoutCancel(ctx))
 	defer func() {
 		if rerr != nil {
@@ -576,7 +572,7 @@ func (svc *Service) startTunnel(ctx context.Context, id *call.ID) (running *Runn
 		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
 	}
 
-	upstream, err := svcs.Start(svcCtx, svc.TunnelUpstream.ID(), svc.TunnelUpstream.Self)
+	upstream, err := svcs.Start(svcCtx, svc.TunnelUpstream.ID(), svc.TunnelUpstream.Self, true)
 	if err != nil {
 		return nil, fmt.Errorf("start upstream: %w", err)
 	}
@@ -626,16 +622,10 @@ func (svc *Service) startTunnel(ctx context.Context, id *call.ID) (running *Runn
 		closers[i] = closeListener
 	}
 
-	dig := id.Digest()
-
 	return &RunningService{
 		Service: svc,
-		Key: ServiceKey{
-			Digest:    dig,
-			SessionID: clientMetadata.SessionID,
-		},
-		Host:  dialHost,
-		Ports: ports,
+		Host:    dialHost,
+		Ports:   ports,
 		Stop: func(_ context.Context, _ bool) error {
 			stop(errors.New("service stop called"))
 			svcs.Detach(svcCtx, upstream)
@@ -649,8 +639,6 @@ func (svc *Service) startTunnel(ctx context.Context, id *call.ID) (running *Runn
 }
 
 func (svc *Service) startReverseTunnel(ctx context.Context, id *call.ID) (running *RunningService, rerr error) {
-	dig := id.Digest()
-
 	host, err := svc.Hostname(ctx, id)
 	if err != nil {
 		return nil, err
@@ -739,12 +727,8 @@ func (svc *Service) startReverseTunnel(ctx context.Context, id *call.ID) (runnin
 
 		return &RunningService{
 			Service: svc,
-			Key: ServiceKey{
-				Digest:    dig,
-				SessionID: clientMetadata.SessionID,
-			},
-			Host:  fullHost,
-			Ports: checkPorts,
+			Host:    fullHost,
+			Ports:   checkPorts,
 			Stop: func(context.Context, bool) (rerr error) {
 				defer telemetry.End(span, func() error { return rerr })
 				stop(errors.New("service stop called"))

--- a/core/services_test.go
+++ b/core/services_test.go
@@ -34,16 +34,16 @@ func TestServicesStartHappy(t *testing.T) {
 	svc2 := newStartable("fake-2")
 
 	startOne := func(t *testing.T, stub *fakeStartable) {
-		_, err := services.Get(ctx, stub.ID())
+		_, err := services.Get(ctx, stub.ID(), false)
 		require.Error(t, err)
 
 		expected := stub.Succeed()
 
-		running, err := services.Start(ctx, stub.ID(), stub)
+		running, err := services.Start(ctx, stub.ID(), stub, false)
 		require.NoError(t, err)
 		require.Equal(t, expected, running)
 
-		running, err = services.Get(ctx, stub.ID())
+		running, err = services.Get(ctx, stub.ID(), false)
 		require.NoError(t, err)
 		require.Equal(t, expected, running)
 	}
@@ -73,14 +73,14 @@ func TestServicesStartHappyDifferentServers(t *testing.T) {
 
 		expected := stub.Succeed()
 
-		_, err := services.Get(ctx, stub.ID())
+		_, err := services.Get(ctx, stub.ID(), false)
 		require.Error(t, err)
 
-		running, err := services.Start(ctx, stub.ID(), stub)
+		running, err := services.Start(ctx, stub.ID(), stub, false)
 		require.NoError(t, err)
 		require.Equal(t, expected, running)
 
-		running, err = services.Get(ctx, stub.ID())
+		running, err = services.Get(ctx, stub.ID(), false)
 		require.NoError(t, err)
 		require.Equal(t, expected, running)
 	}
@@ -108,10 +108,10 @@ func TestServicesStartSad(t *testing.T) {
 
 	expected := stub.Fail()
 
-	_, err := services.Start(ctx, stub.ID(), stub)
+	_, err := services.Start(ctx, stub.ID(), stub, false)
 	require.Equal(t, expected, err)
 
-	_, err = services.Get(ctx, stub.ID())
+	_, err = services.Get(ctx, stub.ID(), false)
 	require.Error(t, err)
 }
 
@@ -129,7 +129,7 @@ func TestServicesStartConcurrentHappy(t *testing.T) {
 
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
-		_, err := services.Start(ctx, stub.ID(), stub)
+		_, err := services.Start(ctx, stub.ID(), stub, false)
 		return err
 	})
 
@@ -140,7 +140,7 @@ func TestServicesStartConcurrentHappy(t *testing.T) {
 
 	// start another attempt
 	eg.Go(func() error {
-		_, err := services.Start(ctx, stub.ID(), stub)
+		_, err := services.Start(ctx, stub.ID(), stub, false)
 		return err
 	})
 
@@ -175,7 +175,7 @@ func TestServicesStartConcurrentSad(t *testing.T) {
 
 	errs := make(chan error, 100)
 	go func() {
-		_, err := services.Start(ctx, stub.ID(), stub)
+		_, err := services.Start(ctx, stub.ID(), stub, false)
 		errs <- err
 	}()
 
@@ -186,7 +186,7 @@ func TestServicesStartConcurrentSad(t *testing.T) {
 
 	// start another attempt
 	go func() {
-		_, err := services.Start(ctx, stub.ID(), stub)
+		_, err := services.Start(ctx, stub.ID(), stub, false)
 		errs <- err
 	}()
 
@@ -212,7 +212,7 @@ func TestServicesStartConcurrentSad(t *testing.T) {
 	require.Equal(t, 2, stub.Starts())
 
 	// make sure Get doesn't wait for any attempts, as they've all failed
-	_, err := services.Get(ctx, stub.ID())
+	_, err := services.Get(ctx, stub.ID(), false)
 	require.Error(t, err)
 }
 
@@ -230,7 +230,7 @@ func TestServicesStartConcurrentSadThenHappy(t *testing.T) {
 
 	errs := make(chan error, 100)
 	go func() {
-		_, err := services.Start(ctx, stub.ID(), stub)
+		_, err := services.Start(ctx, stub.ID(), stub, false)
 		errs <- err
 	}()
 
@@ -242,7 +242,7 @@ func TestServicesStartConcurrentSadThenHappy(t *testing.T) {
 	// start a few more attempts
 	for range 3 {
 		go func() {
-			_, err := services.Start(ctx, stub.ID(), stub)
+			_, err := services.Start(ctx, stub.ID(), stub, false)
 			errs <- err
 		}()
 	}


### PR DESCRIPTION
Found while working on some improved tests in #9381, when I discovered that some tests were mistakenly missing from `LegacyTest`.

Essentially, what I wanted to test was - `AsService.Up` works, and `Container.Up` works. But in this test, I end up calling these within the *same* session. I think at some point maybe this *used* to work, but now we have this logic: https://github.com/dagger/dagger/blob/504787f4370a4032788161af0defdcb8b64bd17f/core/services.go#L145-L148

The key we use for started services is the session ID - but a started tunnel is local to the client. So the call to `Up` succeeds the second time it's called, but a new tunnel is never actually created.

The solution here is:
- Use the `SessionID` for keying normal Services.
- Use the `ClientID` for keying tunnels (which are client specific).