### PR TITLE
fix: ensure modules/gha handles empty dagger version

### DIFF
--- a/modules/gha/steps.go
+++ b/modules/gha/steps.go
@@ -35,7 +35,7 @@ func (j *Job) warmEngineStep() api.JobStep {
 }
 
 func (j *Job) installDaggerSteps() []api.JobStep {
-	if v := j.DaggerVersion; (v == "latest") || (semver.IsValid(v)) {
+	if v := j.DaggerVersion; v == "" || v == "latest" || semver.IsValid(v) {
 		return []api.JobStep{
 			j.bashStep("install-dagger", map[string]string{"DAGGER_VERSION": v}),
 		}


### PR DESCRIPTION
See discussion in https://discord.com/channels/707636530424053791/1323311418325471315/1328681959211274323, raised by @wingyplus.

This fixes the issue where an dagger version will be treated as if we should try and install the dev version of dagger.