### PR TITLE
fix(ts-sdk): extend timeout for all tests

### DIFF
--- a/sdk/typescript/.mocharc.json
+++ b/sdk/typescript/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["ts"],
   "spec": "**/*.spec.ts",
-  "loader": "ts-node/esm"
+  "loader": "ts-node/esm",
+  "timeout": 60000
 }

--- a/sdk/typescript/src/module/introspector/test/scan.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/scan.spec.ts
@@ -123,6 +123,8 @@ ${jsonResult}
 
   describe("Should throw error on invalid module", function () {
     it("Should throw an error when no files are provided", async function () {
+      this.timeout(60000)
+
       try {
         await scan([], "")
         assert.fail("Should throw an error")
@@ -132,6 +134,8 @@ ${jsonResult}
     })
 
     it("Should throw an error if the module is invalid", async function () {
+      this.timeout(60000)
+
       try {
         const files = await listFiles(`${rootDirectory}/invalid`)
 
@@ -143,6 +147,8 @@ ${jsonResult}
     })
 
     it("Should throw an error if the module class has no decorators", async function () {
+      this.timeout(60000)
+
       try {
         const files = await listFiles(`${rootDirectory}/noDecorators`)
 
@@ -157,6 +163,8 @@ ${jsonResult}
     })
 
     it("Should throw an error if a primitive type is used", async function () {
+      this.timeout(60000)
+
       try {
         const files = await listFiles(`${rootDirectory}/primitives`)
 


### PR DESCRIPTION
Attempt to fixes the flakes around TS test that timeout (example: https://github.com/dagger/dagger/actions/runs/12770326585/job/35594928990?pr=9384)