### PR TITLE
feat: add dagop

### DIFF
--- a/core/dagop.go
+++ b/core/dagop.go
@@ -2,61 +2,73 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/buildkit"
+	bkcache "github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	bksession "github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/worker"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
-type DagOp struct {
+func init() {
+	buildkit.RegisterCustomOp(DirectoryDagOp{})
+	buildkit.RegisterCustomOp(RawDagOp{})
+}
+
+// NewDirectoryDagOp takes a target ID for a Directory, and returns a Directory
+// for it, computing the actual dagql query inside a buildkit operation, which
+// allows for efficiently caching the result.
+func NewDirectoryDagOp(ctx context.Context, srv *dagql.Server, id *call.ID, inputs []llb.State) (*Directory, error) {
+	requiredType := (&Directory{}).Type().NamedType
+	if id.Type().NamedType() != requiredType {
+		return nil, fmt.Errorf("expected %s to be selected, instead got %s", requiredType, id.Type().NamedType())
+	}
+	dagOp := DirectoryDagOp{ID: id}
+
+	st, err := buildkit.NewCustomLLB(ctx, dagOp, inputs,
+		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Display()),
+		buildkit.WithPassthrough())
+	if err != nil {
+		return nil, err
+	}
+
+	query, ok := srv.Root().(dagql.Instance[*Query])
+	if !ok {
+		return nil, fmt.Errorf("server root was %T", srv.Root())
+	}
+
+	return NewDirectorySt(ctx, query.Self, st, "", Platform{}, nil)
+}
+
+type DirectoryDagOp struct {
 	ID *call.ID
 }
 
-func DagLLB(ctx context.Context, srv *dagql.Server, sels []dagql.Selector, inputs []llb.State) (llb.State, error) {
-	id, err := srv.SelectID(ctx, srv.Root(), sels...)
-	if err != nil {
-		return llb.State{}, err
-	}
-
-	requiredType := (&Directory{}).Type().NamedType
-	if id.Type().NamedType() != requiredType {
-		return llb.State{}, fmt.Errorf("expected %s to be selected, instead got %s", requiredType, id.Type().NamedType())
-	}
-	op := DagOp{ID: id}
-	return buildkit.NewCustomLLB(ctx, op, inputs, llb.WithCustomName("dagop"), buildkit.WithPassthrough())
+func (op DirectoryDagOp) Name() string {
+	return "dagop.directory"
 }
 
-func (op DagOp) Name() string {
-	return "dagop"
-}
-
-func (op DagOp) Backend() buildkit.CustomOpBackend {
+func (op DirectoryDagOp) Backend() buildkit.CustomOpBackend {
 	return &op
 }
 
-func (op DagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
+func (op DirectoryDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
 	return op.ID.Digest(), nil
 }
 
-type dagOpContextKey struct{}
-
-func withDagOpContext(ctx context.Context, op *DagOp) context.Context {
-	return context.WithValue(ctx, dagOpContextKey{}, op)
-}
-
-func DagOpFromContext(ctx context.Context) *DagOp {
-	if val := ctx.Value(dagOpContextKey{}); val != nil {
-		return val.(*DagOp)
-	}
-	return nil
-}
-
-func (op DagOp) Exec(ctx context.Context, inputs []solver.Result, srv *dagql.Server) (outputs []solver.Result, err error) {
-	obj, err := srv.Load(withDagOpContext(ctx, &op), op.ID)
+func (op DirectoryDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, err error) {
+	obj, err := opt.Server.Load(withDagOpContext(ctx, op), op.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +77,6 @@ func (op DagOp) Exec(ctx context.Context, inputs []solver.Result, srv *dagql.Ser
 		// shouldn't happen, should have errored in DagLLB already
 		return nil, fmt.Errorf("expected Directory to be selected, instead got %T", obj)
 	}
-
 	if inst.Self.Dir != "" && inst.Self.Dir != "/" {
 		return nil, fmt.Errorf("directory %q is not root", inst.Self.Dir)
 	}
@@ -81,6 +92,130 @@ func (op DagOp) Exec(ctx context.Context, inputs []solver.Result, srv *dagql.Ser
 	return []solver.Result{ref}, nil
 }
 
-func init() {
-	buildkit.RegisterCustomOp(DagOp{})
+// NewRawDagOp takes a target ID for any JSON-serializable dagql type, and returns
+// it, computing the actual dagql query inside a buildkit operation, which
+// allows for efficiently caching the result.
+func NewRawDagOp[T dagql.Typed](ctx context.Context, srv *dagql.Server, id *call.ID, inputs []llb.State) (t T, err error) {
+	dagOp := RawDagOp{ID: id, Filename: "output.json"}
+	st, err := buildkit.NewCustomLLB(ctx, dagOp, inputs,
+		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Display()),
+		buildkit.WithPassthrough())
+	if err != nil {
+		return t, err
+	}
+
+	query, ok := srv.Root().(dagql.Instance[*Query])
+	if !ok {
+		return t, fmt.Errorf("server root was %T", srv.Root())
+	}
+
+	f, err := NewFileSt(ctx, query.Self, st, dagOp.Filename, Platform{}, nil)
+	if err != nil {
+		return t, err
+	}
+	dt, err := f.Contents(ctx)
+	if err != nil {
+		return t, err
+	}
+	err = json.Unmarshal(dt, &t)
+	return t, err
+}
+
+type RawDagOp struct {
+	ID       *call.ID
+	Filename string
+}
+
+func (op RawDagOp) Name() string {
+	return "dagop.raw"
+}
+
+func (op RawDagOp) Backend() buildkit.CustomOpBackend {
+	return &op
+}
+
+func (op RawDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
+	return op.ID.Digest(), nil
+}
+
+func (op RawDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, retErr error) {
+	result, err := opt.Server.LoadType(withDagOpContext(ctx, op), op.ID)
+	if err != nil {
+		return nil, err
+	}
+	if wrapped, ok := result.(dagql.Wrapper); ok {
+		result = wrapped.Unwrap()
+	}
+
+	ref, err := opt.Cache.New(ctx, nil, g,
+		bkcache.WithRecordType(client.UsageRecordTypeRegular),
+		bkcache.WithDescription(op.Name()))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create new mutable")
+	}
+	defer func() {
+		if retErr != nil && ref != nil {
+			ref.Release(context.WithoutCancel(ctx))
+		}
+	}()
+
+	mount, err := ref.Mount(ctx, false, g)
+	if err != nil {
+		return nil, err
+	}
+	lm := snapshot.LocalMounter(mount)
+	dir, err := lm.Mount()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil && lm != nil {
+			lm.Unmount()
+		}
+	}()
+
+	f, err := os.Create(filepath.Join(dir, op.Filename))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil && f != nil {
+			f.Close()
+		}
+	}()
+
+	enc := json.NewEncoder(f)
+	err = enc.Encode(result)
+	if err != nil {
+		return nil, err
+	}
+	err = f.Close()
+	if err != nil {
+		return nil, err
+	}
+	f = nil
+
+	lm.Unmount()
+	lm = nil
+
+	snap, err := ref.Commit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ref = nil
+
+	return []solver.Result{worker.NewWorkerRefResult(snap, opt.Worker)}, nil
+}
+
+type dagOpContextKey string
+
+func withDagOpContext(ctx context.Context, op buildkit.CustomOp) context.Context {
+	return context.WithValue(ctx, dagOpContextKey(op.Name()), op)
+}
+
+func DagOpFromContext[T buildkit.CustomOp](ctx context.Context) (t T, ok bool) {
+	if val := ctx.Value(dagOpContextKey(t.Name())); val != nil {
+		t, ok = val.(T)
+	}
+	return t, ok
 }

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver"
+	"github.com/opencontainers/go-digest"
+)
+
+type DagOp struct {
+	ID *call.ID
+}
+
+func DagLLB(ctx context.Context, srv *dagql.Server, sels []dagql.Selector, inputs []llb.State) (llb.State, error) {
+	id, err := srv.SelectID(ctx, srv.Root(), sels...)
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	requiredType := (&Directory{}).Type().NamedType
+	if id.Type().NamedType() != requiredType {
+		return llb.State{}, fmt.Errorf("expected %s to be selected, instead got %s", requiredType, id.Type().NamedType())
+	}
+	op := DagOp{ID: id}
+	return buildkit.NewCustomLLB(ctx, op, inputs, llb.WithCustomName("dagop"), buildkit.WithPassthrough())
+}
+
+func (op DagOp) Name() string {
+	return "dagop"
+}
+
+func (op DagOp) Backend() buildkit.CustomOpBackend {
+	return &op
+}
+
+func (op DagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
+	return op.ID.Digest(), nil
+}
+
+type dagOpContextKey struct{}
+
+func withDagOpContext(ctx context.Context, op *DagOp) context.Context {
+	return context.WithValue(ctx, dagOpContextKey{}, op)
+}
+
+func DagOpFromContext(ctx context.Context) *DagOp {
+	if val := ctx.Value(dagOpContextKey{}); val != nil {
+		return val.(*DagOp)
+	}
+	return nil
+}
+
+func (op DagOp) Exec(ctx context.Context, inputs []solver.Result, srv *dagql.Server) (outputs []solver.Result, err error) {
+	obj, err := srv.Load(withDagOpContext(ctx, &op), op.ID)
+	if err != nil {
+		return nil, err
+	}
+	inst, ok := obj.(dagql.Instance[*Directory])
+	if !ok {
+		// shouldn't happen, should have errored in DagLLB already
+		return nil, fmt.Errorf("expected Directory to be selected, instead got %T", obj)
+	}
+
+	if inst.Self.Dir != "" && inst.Self.Dir != "/" {
+		return nil, fmt.Errorf("directory %q is not root", inst.Self.Dir)
+	}
+
+	res, err := inst.Self.Evaluate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := res.Ref.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []solver.Result{ref}, nil
+}
+
+func init() {
+	buildkit.RegisterCustomOp(DagOp{})
+}

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -37,7 +37,7 @@ func NewDirectoryDagOp(ctx context.Context, srv *dagql.Server, id *call.ID, inpu
 	dagOp := DirectoryDagOp{ID: id}
 
 	st, err := buildkit.NewCustomLLB(ctx, dagOp, inputs,
-		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Display()),
+		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Name()),
 		buildkit.WithPassthrough())
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (op DirectoryDagOp) Exec(ctx context.Context, g bksession.Group, inputs []s
 func NewRawDagOp[T dagql.Typed](ctx context.Context, srv *dagql.Server, id *call.ID, inputs []llb.State) (t T, err error) {
 	dagOp := RawDagOp{ID: id, Filename: "output.json"}
 	st, err := buildkit.NewCustomLLB(ctx, dagOp, inputs,
-		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Display()),
+		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Name()),
 		buildkit.WithPassthrough())
 	if err != nil {
 		return t, err

--- a/core/interface.go
+++ b/core/interface.go
@@ -439,13 +439,15 @@ var _ HasPBDefinitions = (*InterfaceAnnotatedValue)(nil)
 func (iface *InterfaceAnnotatedValue) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	defs := []*pb.Definition{}
 	objDef := iface.UnderlyingType.TypeDef().AsObject.Value
-	for name, val := range iface.Fields {
-		fieldDef, ok := objDef.FieldByOriginalName(name)
+	for _, field := range objDef.Fields {
+		// TODO: we skip over private fields, we can't convert them anyways (this is a bug)
+		name := field.OriginalName
+		val, ok := iface.Fields[name]
 		if !ok {
-			// TODO: private field; skip. (this is a bug)
+			// missing field
 			continue
 		}
-		fieldType, ok, err := iface.UnderlyingType.SourceMod().ModTypeFor(ctx, fieldDef.TypeDef, true)
+		fieldType, ok, err := iface.UnderlyingType.SourceMod().ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get mod type for field %q: %w", name, err)
 		}

--- a/core/object.go
+++ b/core/object.go
@@ -214,14 +214,15 @@ var _ HasPBDefinitions = (*ModuleObject)(nil)
 func (obj *ModuleObject) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	defs := []*pb.Definition{}
 	objDef := obj.TypeDef
-	for name, val := range obj.Fields {
-		fieldDef, ok := objDef.FieldByOriginalName(name)
+	for _, field := range objDef.Fields {
+		// TODO: we skip over private fields, we can't convert them anyways (this is a bug)
+		name := field.OriginalName
+		val, ok := obj.Fields[name]
 		if !ok {
-			// TODO: must be a private field; skip, since we can't convert it anyhow.
-			// (this is a bug)
+			// missing field
 			continue
 		}
-		fieldType, ok, err := obj.Module.ModTypeFor(ctx, fieldDef.TypeDef, true)
+		fieldType, ok, err := obj.Module.ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get mod type for field %q: %w", name, err)
 		}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -568,7 +568,7 @@ func (s *containerSchema) Install() {
 			View(BeforeVersion("v0.12.0")).
 			Extend(),
 
-		dagql.NodeFunc("asTarball", DagOpFileMiddleware(s.srv, s.asTarball)).
+		dagql.NodeFunc("asTarball", DagOpFileWrapper(s.srv, s.asTarball)).
 			Doc(`Returns a File representing the container serialized to a tarball.`).
 			ArgDoc("platformVariants",
 				`Identifiers for other platform specific containers.`,

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -566,7 +568,7 @@ func (s *containerSchema) Install() {
 			View(BeforeVersion("v0.12.0")).
 			Extend(),
 
-		dagql.NodeFunc("asTarball", s.asTarball).
+		dagql.NodeFunc("asTarball", DagOpFileMiddleware(s.srv, s.asTarball)).
 			Doc(`Returns a File representing the container serialized to a tarball.`).
 			ArgDoc("platformVariants",
 				`Identifiers for other platform specific containers.`,
@@ -1807,44 +1809,6 @@ func (s *containerSchema) asTarball(
 	parent dagql.Instance[*core.Container],
 	args containerAsTarballArgs,
 ) (inst dagql.Instance[*core.File], err error) {
-	if op := core.DagOpFromContext(ctx); op == nil {
-		fs, err := parent.Self.FSState()
-		if err != nil {
-			return inst, err
-		}
-
-		filename := "/container.tar"
-		st, err := core.DagLLB(ctx, s.srv,
-			[]dagql.Selector{
-				{
-					Field: "directory",
-				},
-				{
-					Field: "withFile",
-					Args: []dagql.NamedInput{
-						{
-							Name:  "path",
-							Value: dagql.String(filename),
-						},
-						{
-							Name:  "source",
-							Value: dagql.NewID[*core.File](dagql.CurrentID(ctx).WithMetadata("", true)),
-						},
-					},
-				},
-			}, []llb.State{fs},
-		)
-		if err != nil {
-			return inst, err
-		}
-
-		f, err := core.NewFileSt(ctx, parent.Self.Query, st, filename, parent.Self.Platform, parent.Self.Services)
-		if err != nil {
-			return inst, err
-		}
-		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, f)
-	}
-
 	platformVariants, err := dagql.LoadIDs(ctx, s.srv, args.PlatformVariants)
 	if err != nil {
 		return inst, err
@@ -1934,13 +1898,29 @@ func (s *containerSchema) asTarball(
 	defer os.RemoveAll(tmpDir)
 	fileName := identity.NewID() + ".tar"
 
-	def, err := bk.ContainerImageToTarball(ctx, engineHostPlatform.Spec(), tmpDir, fileName, inputByPlatform, opts)
+	err = bk.ContainerImageToTarball(ctx, engineHostPlatform.Spec(), filepath.Join(tmpDir, fileName), inputByPlatform, opts)
 	if err != nil {
 		return inst, fmt.Errorf("container image to tarball file conversion failed: %w", err)
 	}
-	dgst, err := core.GetContentHashFromDef(ctx, bk, def, "/")
+	localDef, err := llb.Local(tmpDir,
+		llb.SessionID(bk.ID()), // see engine/server/bk_session.go, we have a special session that points to our engine host
+		llb.SharedKeyHint(bk.ID()),
+		llb.IncludePatterns([]string{fileName}),
+		llb.WithCustomName(fmt.Sprintf("container-image-to-tarball-%s", fileName)),
+		buildkit.WithTracePropagation(ctx),
+	).Marshal(ctx, llb.Platform(engineHostPlatform.Spec()))
 	if err != nil {
-		return inst, fmt.Errorf("failed to get content hash from definition: %w", err)
+		return inst, fmt.Errorf("failed to create llb definition for container image to tarball: %w", err)
+	}
+	def := localDef.ToPB()
+
+	// force-evaluate to get this definitely into the llb.Local cache
+	_, err = bk.Solve(ctx, bkgw.SolveRequest{
+		Definition: def,
+		Evaluate:   true,
+	})
+	if err != nil {
+		return inst, err
 	}
 
 	fileInst, err := dagql.NewInstanceForCurrentID(ctx, s.srv, parent,
@@ -1949,7 +1929,7 @@ func (s *containerSchema) asTarball(
 	if err != nil {
 		return inst, err
 	}
-	return fileInst.WithMetadata(dgst, true), nil
+	return fileInst, err
 }
 
 type containerImportArgs struct {

--- a/core/schema/middlewares.go
+++ b/core/schema/middlewares.go
@@ -1,0 +1,137 @@
+package schema
+
+import (
+	"context"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+	"github.com/moby/buildkit/client/llb"
+)
+
+// DagOpMiddleware caches an arbitrary dagql field as a buildkit operation
+func DagOpMiddleware[T dagql.Typed, A any, R dagql.Typed](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (R, error)) func(ctx context.Context, self dagql.Instance[T], args A) (R, error) {
+	return func(ctx context.Context, self dagql.Instance[T], args A) (inst R, err error) {
+		if _, ok := core.DagOpFromContext[core.RawDagOp](ctx); ok {
+			return fn(ctx, self, args)
+		}
+
+		deps, err := extractLLBDependencies(ctx, self.Self)
+		if err != nil {
+			return inst, err
+		}
+		return core.NewRawDagOp[R](ctx, srv, dagql.CurrentID(ctx).WithMetadata("", true), deps)
+	}
+}
+
+// DagOpFileMiddleware caches a file field as a buildkit operation - this is
+// more specialized than DagOpMiddleware, since that serializes the value to
+// JSON, so we'd just end up with a cached ID instead of the actual content.
+func DagOpFileMiddleware[T dagql.Typed, A any](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.File], error)) func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.File], error) {
+	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.File], err error) {
+		if _, ok := core.DagOpFromContext[core.DirectoryDagOp](ctx); ok {
+			return fn(ctx, self, args)
+		}
+
+		deps, err := extractLLBDependencies(ctx, self.Self)
+		if err != nil {
+			return inst, err
+		}
+
+		filename := "file"
+		id, err := srv.SelectID(ctx, srv.Root(),
+			dagql.Selector{
+				Field: "directory",
+			},
+			dagql.Selector{
+				Field: "withFile",
+				Args: []dagql.NamedInput{
+					{
+						Name:  "path",
+						Value: dagql.String(filename),
+					},
+					{
+						Name:  "source",
+						Value: dagql.NewID[*core.File](dagql.CurrentID(ctx).WithMetadata("", true)),
+					},
+				},
+			},
+		)
+		if err != nil {
+			return inst, err
+		}
+
+		dir, err := core.NewDirectoryDagOp(ctx, srv, id, deps)
+		if err != nil {
+			return inst, err
+		}
+		f, err := dir.File(ctx, filename)
+		if err != nil {
+			return inst, err
+		}
+		return dagql.NewInstanceForCurrentID(ctx, srv, self, f)
+	}
+}
+
+// DagOpDirectoryMiddleware caches a directory field as a buildkit operation,
+// similar to DagOpFileMiddleware.
+func DagOpDirectoryMiddleware[T dagql.Typed, A any](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.Directory], error)) func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.Directory], error) {
+	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.Directory], err error) {
+		if _, ok := core.DagOpFromContext[core.DirectoryDagOp](ctx); ok {
+			return fn(ctx, self, args)
+		}
+
+		deps, err := extractLLBDependencies(ctx, self.Self)
+		if err != nil {
+			return inst, err
+		}
+
+		id, err := srv.SelectID(ctx, srv.Root(),
+			dagql.Selector{
+				Field: "directory",
+			},
+			dagql.Selector{
+				Field: "withDirectory",
+				Args: []dagql.NamedInput{
+					{
+						Name:  "path",
+						Value: dagql.String(""),
+					},
+					{
+						Name:  "source",
+						Value: dagql.NewID[*core.Directory](dagql.CurrentID(ctx).WithMetadata("", true)),
+					},
+				},
+			},
+		)
+		if err != nil {
+			return inst, err
+		}
+
+		dir, err := core.NewDirectoryDagOp(ctx, srv, id, deps)
+		if err != nil {
+			return inst, err
+		}
+		return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
+	}
+}
+
+func extractLLBDependencies(ctx context.Context, a any) ([]llb.State, error) {
+	hasPBs, ok := a.(core.HasPBDefinitions)
+	if !ok {
+		return nil, nil
+	}
+
+	depsDefs, err := hasPBs.PBDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deps := make([]llb.State, 0, len(depsDefs))
+	for _, def := range depsDefs {
+		op, err := llb.NewDefinitionOp(def)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, llb.NewState(op))
+	}
+	return deps, nil
+}

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -91,6 +91,10 @@ func (d DynamicArrayOutput) Type() *ast.Type {
 
 var _ Enumerable = DynamicArrayOutput{}
 
+func (d DynamicArrayOutput) Element() Typed {
+	return d.Elem
+}
+
 func (d DynamicArrayOutput) Len() int {
 	return len(d.Values)
 }
@@ -256,6 +260,10 @@ func (d DynamicArrayInput) SetField(val reflect.Value) error {
 }
 
 var _ Enumerable = DynamicArrayInput{}
+
+func (d DynamicArrayInput) Element() Typed {
+	return d.Elem
+}
 
 func (d DynamicArrayInput) Len() int {
 	return len(d.Values)

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -211,6 +211,14 @@ func (id *ID) Display() string {
 	return fmt.Sprintf("%s: %s", id.Path(), id.typ.ToAST())
 }
 
+func (id *ID) Name() string {
+	name := id.pb.Field
+	if id.receiver != nil {
+		name = id.receiver.typ.NamedType() + "." + name
+	}
+	return name
+}
+
 // Return a new ID that's the selection of the nth element of the return value of the existing ID.
 // The new digest is derived from the existing ID's digest and the nth index.
 func (id *ID) SelectNth(nth int) *ID {
@@ -288,7 +296,8 @@ func (id *ID) Append(
 	return newID
 }
 
-// Return a new ID that's the same as before except with the given metadata changed.
+// WithMetadata returns a new ID that's the same as before except with the
+// given metadata changed.
 // customDigest, if not empty string, will become the ID's digest.
 // tainted sets the ID's tainted flag.
 func (id *ID) WithMetadata(customDigest digest.Digest, tainted bool) *ID {
@@ -302,6 +311,11 @@ func (id *ID) WithMetadata(customDigest digest.Digest, tainted bool) *ID {
 		customDigest,
 		id.args...,
 	)
+}
+
+// WithTaint is a shorthand for WithMetadata that sets the id as tainted
+func (id *ID) WithTaint() *ID {
+	return id.WithMetadata("", true)
 }
 
 func (id *ID) Encode() (string, error) {

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -136,6 +136,38 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, 8, res.Point.ShiftLeft.Neighbors[3].Y)
 }
 
+func TestSelectID(t *testing.T) {
+	ctx := context.Background()
+	srv := dagql.NewServer(Query{})
+	points.Install[Query](srv)
+
+	id, err := srv.SelectID(ctx, srv.Root(),
+		dagql.Selector{
+			Field: "point",
+			Args: []dagql.NamedInput{
+				{
+					Name:  "x",
+					Value: dagql.NewInt(6),
+				},
+				{
+					Name:  "y",
+					Value: dagql.NewInt(7),
+				},
+			},
+		},
+		dagql.Selector{
+			Field: "shiftLeft",
+		},
+	)
+	require.NoError(t, err)
+
+	loaded, err := srv.Load(ctx, id)
+	require.NoError(t, err)
+	point := loaded.(dagql.Instance[*points.Point])
+	assert.Equal(t, point.Self.X, 5)
+	assert.Equal(t, point.Self.Y, 7)
+}
+
 func TestSelectArray(t *testing.T) {
 	ctx := context.Background()
 	srv := dagql.NewServer(Query{})

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -664,6 +664,13 @@ func (v ExactView) Contains(s string) bool {
 	return s == string(v)
 }
 
+type (
+	FuncHandler[T Typed, A any, R any]     = func(ctx context.Context, self T, args A) (R, error)
+	NodeFuncHandler[T Typed, A any, R any] = func(ctx context.Context, self Instance[T], args A) (R, error)
+
+	CacheKeyHandler[T Typed, A any, R any] = func(ctx context.Context, self Instance[T], args A, origDgst digest.Digest) (digest.Digest, error)
+)
+
 // Func is a helper for defining a field resolver and schema.
 //
 // The function must accept a context.Context, the receiver, and a struct of
@@ -682,7 +689,7 @@ func (v ExactView) Contains(s string) bool {
 //
 // To configure a description for the field in the schema, call .Doc on the
 // result.
-func Func[T Typed, A any, R any](name string, fn func(ctx context.Context, self T, args A) (R, error)) Field[T] {
+func Func[T Typed, A any, R any](name string, fn FuncHandler[T, A, R]) Field[T] {
 	return NodeFunc(name, func(ctx context.Context, self Instance[T], args A) (R, error) {
 		return fn(ctx, self.Self, args)
 	})
@@ -691,8 +698,8 @@ func Func[T Typed, A any, R any](name string, fn func(ctx context.Context, self 
 // FuncWithCacheKey is like Func but allows specifying a custom digest that will be used to cache the operation in dagql.
 func FuncWithCacheKey[T Typed, A any, R any](
 	name string,
-	fn func(ctx context.Context, self T, args A) (R, error),
-	cacheKeyFn func(ctx context.Context, self Instance[T], args A, origDgst digest.Digest) (digest.Digest, error),
+	fn FuncHandler[T, A, R],
+	cacheKeyFn CacheKeyHandler[T, A, R],
 ) Field[T] {
 	return NodeFuncWithCacheKey(name, func(ctx context.Context, self Instance[T], args A) (R, error) {
 		return fn(ctx, self.Self, args)
@@ -701,15 +708,15 @@ func FuncWithCacheKey[T Typed, A any, R any](
 
 // NodeFunc is the same as Func, except it passes the Instance instead of the
 // receiver so that you can access its ID.
-func NodeFunc[T Typed, A any, R any](name string, fn func(ctx context.Context, self Instance[T], args A) (R, error)) Field[T] {
+func NodeFunc[T Typed, A any, R any](name string, fn NodeFuncHandler[T, A, R]) Field[T] {
 	return NodeFuncWithCacheKey(name, fn, nil)
 }
 
 // NodeFuncWithCacheKey is like NodeFunc but allows specifying a custom digest that will be used to cache the operation in dagql.
 func NodeFuncWithCacheKey[T Typed, A any, R any](
 	name string,
-	fn func(ctx context.Context, self Instance[T], args A) (R, error),
-	cacheKeyFn func(ctx context.Context, self Instance[T], args A, origDgst digest.Digest) (digest.Digest, error),
+	fn NodeFuncHandler[T, A, R],
+	cacheKeyFn CacheKeyHandler[T, A, R],
 ) Field[T] {
 	var zeroArgs A
 	inputs, argsErr := inputSpecsForType(zeroArgs, true)

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -520,6 +520,22 @@ func (s *Server) Load(ctx context.Context, id *call.ID) (Object, error) {
 	return s.toSelectable(id, res)
 }
 
+func (s *Server) LoadType(ctx context.Context, id *call.ID) (Typed, error) {
+	var base Object
+	var err error
+	if id.Receiver() != nil {
+		base, err = s.Load(ctx, id.Receiver())
+		if err != nil {
+			return nil, fmt.Errorf("load base: %w", err)
+		}
+	} else {
+		base = s.root
+	}
+
+	res, _, err := base.Call(ctx, s, id)
+	return res, err
+}
+
 // Select evaluates a series of chained field selections starting from the
 // given object and assigns the final result value into dest.
 func (s *Server) Select(ctx context.Context, self Object, dest any, sels ...Selector) error {

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -99,6 +99,15 @@ type Object interface {
 	//
 	// Any Nullable values are automatically unwrapped.
 	Select(context.Context, *Server, Selector) (Typed, *call.ID, error)
+
+	// ReturnType gets the return type of the field selected by the given
+	// selector.
+	//
+	// The returned value is the raw Typed value returned from the field; it must
+	// be instantiated with a class for further selection.
+	//
+	// Any Nullable values are automatically unwrapped.
+	ReturnType(context.Context, Selector) (Typed, *call.ID, error)
 }
 
 // A type that has a callback attached that needs to always run before returned to a caller

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -760,6 +760,8 @@ func (i ID[T]) Load(ctx context.Context, server *Server) (Instance[T], error) {
 
 // Enumerable is a value that has a length and allows indexing.
 type Enumerable interface {
+	// Element returns the element of the Enumerable.
+	Element() Typed
 	// Len returns the number of elements in the Enumerable.
 	Len() int
 	// Nth returns the Nth element of the Enumerable, with 1 representing the
@@ -895,6 +897,11 @@ func (i Array[T]) Type() *ast.Type {
 }
 
 var _ Enumerable = Array[Typed]{}
+
+func (arr Array[T]) Element() Typed {
+	var t T
+	return t
+}
 
 func (arr Array[T]) Len() int {
 	return len(arr)

--- a/engine/buildkit/op.go
+++ b/engine/buildkit/op.go
@@ -1,0 +1,175 @@
+package buildkit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend"
+	bksession "github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/solver"
+	"github.com/opencontainers/go-digest"
+)
+
+type CustomOpWrapper struct {
+	Name    string
+	Backend CustomOpBackend
+
+	ClientMetadata engine.ClientMetadata
+
+	server   dagqlServer
+	original solver.Op
+}
+
+type CustomOp interface {
+	Name() string
+	Backend() CustomOpBackend
+}
+
+type CustomOpBackend interface {
+	CacheKey(ctx context.Context) (digest.Digest, error)
+	Exec(ctx context.Context, inputs []solver.Result, server *dagql.Server) (outputs []solver.Result, err error)
+}
+
+var customOps = map[string]CustomOp{}
+
+func RegisterCustomOp(op CustomOp) {
+	customOps[op.Name()] = op
+}
+
+func NewCustomLLB(ctx context.Context, op CustomOp, inputs []llb.State, opts ...llb.ConstraintsOpt) (llb.State, error) {
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return llb.State{}, fmt.Errorf("failed to get client metadata: %w", err)
+	}
+
+	opWrapped := CustomOpWrapper{
+		Name:           op.Name(),
+		Backend:        op.Backend(),
+		ClientMetadata: *clientMetadata,
+	}
+
+	// pre-populate a reasonable underlying representation that has some inputs
+	var a *llb.FileAction
+	a = llb.Rm("/")
+	for _, input := range inputs {
+		if a == nil {
+			a = llb.Copy(input, "/", "/")
+		} else {
+			a = a.Copy(input, "/", "/")
+		}
+	}
+	st := llb.Scratch()
+	if a != nil {
+		st = st.File(a)
+	}
+	customOpOpt, err := opWrapped.AsConstraintsOpt()
+	if err != nil {
+		return llb.State{}, fmt.Errorf("constraints opt: %w", err)
+	}
+
+	marshalOpts := append([]llb.ConstraintsOpt{customOpOpt}, opts...)
+	def, err := st.Marshal(ctx, marshalOpts...)
+	if err != nil {
+		return llb.State{}, fmt.Errorf("marshal root: %w", err)
+	}
+
+	f, err := llb.NewDefinitionOp(def.ToPB())
+	if err != nil {
+		return llb.State{}, err
+	}
+	return llb.NewState(f), nil
+}
+
+func (op *CustomOpWrapper) CacheMap(ctx context.Context, g bksession.Group, index int) (*solver.CacheMap, bool, error) {
+	cm, ok, err := op.original.CacheMap(ctx, g, index)
+	if err != nil {
+		return cm, ok, err
+	}
+	if cm != nil {
+		key, err := op.Backend.CacheKey(ctx)
+		if err != nil {
+			return cm, ok, err
+		}
+		cm.Digest = digest.FromString(string(cm.Digest) + "+" + string(key))
+	}
+	return cm, ok, err
+}
+
+func (op *CustomOpWrapper) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result) (outputs []solver.Result, err error) {
+	ctx = engine.ContextWithClientMetadata(ctx, &op.ClientMetadata)
+
+	server, err := op.server.DagqlServer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not find dagql server: %w", err)
+	}
+
+	return op.Backend.Exec(ctx, inputs, server)
+}
+
+func (op *CustomOpWrapper) Acquire(ctx context.Context) (release solver.ReleaseFunc, err error) {
+	return op.original.Acquire(ctx)
+}
+
+const customOpKey = "dagger.customOp"
+
+func (w *Worker) customOpFromVtx(vtx solver.Vertex, s frontend.FrontendLLBBridge, sm *bksession.Manager) (solver.Op, bool, error) {
+	if vtx == nil {
+		return nil, false, nil
+	}
+	customOp, ok, err := customOpFromDescription(vtx.Options().Description)
+	if err != nil {
+		return customOp, ok, err
+	}
+	if customOp != nil {
+		op, err := w.Worker.ResolveOp(vtx, s, sm)
+		if err != nil {
+			return customOp, ok, err
+		}
+		customOp.original = op
+		customOp.server = w.dagqlServer
+	}
+	return customOp, ok, nil
+}
+
+func customOpFromDescription(desc map[string]string) (*CustomOpWrapper, bool, error) {
+	if desc == nil {
+		return nil, false, nil
+	}
+
+	bs, ok := desc[customOpKey]
+	if !ok {
+		return nil, false, nil
+	}
+
+	wrapper := struct {
+		Backend json.RawMessage
+		CustomOpWrapper
+	}{}
+	if err := json.Unmarshal([]byte(bs), &wrapper); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal custom op: %w", err)
+	}
+
+	op, ok := customOps[wrapper.Name]
+	if !ok {
+		return nil, false, fmt.Errorf("no custom op %q", wrapper.Name)
+	}
+	wrapper.CustomOpWrapper.Backend = op.Backend()
+	if err := json.Unmarshal(wrapper.Backend, &wrapper.CustomOpWrapper.Backend); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal custom op %q: %w", wrapper.Name, err)
+	}
+	return &wrapper.CustomOpWrapper, true, nil
+}
+
+func (op CustomOpWrapper) AsConstraintsOpt() (llb.ConstraintsOpt, error) {
+	bs, err := json.Marshal(op)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal custom op: %w", err)
+	}
+	return llb.WithDescription(map[string]string{
+		customOpKey: string(bs),
+	}), nil
+}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -69,19 +69,19 @@ type ClientMetadata struct {
 	InteractiveCommand []string `json:"interactive_command"`
 
 	// Import configuration for Buildkit's remote cache
-	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry
+	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry `json:"upstream_cache_import_config"`
 
 	// Export configuration for Buildkit's remote cache
-	UpstreamCacheExportConfig []*controlapi.CacheOptionsEntry
+	UpstreamCacheExportConfig []*controlapi.CacheOptionsEntry `json:"upstream_cache_export_config"`
 
 	// Dagger Cloud Token
-	CloudToken string
+	CloudToken string `json:"cloud_token"`
 
 	// Disable analytics
-	DoNotTrack bool
+	DoNotTrack bool `json:"do_not_track"`
 
 	// SSH auth socket path
-	SSHAuthSocketPath string
+	SSHAuthSocketPath string `json:"ssh_auth_socket_path"`
 }
 
 type clientMetadataCtxKey struct{}

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -466,6 +466,7 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		TelemetryPubSub:  srv.telemetryPubSub,
 		BKSessionManager: srv.bkSessionManager,
 		SessionHandler:   srv,
+		DagqlServer:      srv,
 
 		Runc:                srv.runc,
 		DefaultCgroupParent: srv.cgroupParent,

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -935,6 +935,18 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 
 const InstrumentationLibrary = "dagger.io/engine.server"
 
+func (srv *Server) DagqlServer(ctx context.Context) (*dagql.Server, error) {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	schema, err := client.deps.Schema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
 func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opts *ClientInitOpts) (rerr error) {
 	ctx := r.Context()
 	ctx, cancel := context.WithCancelCause(ctx)


### PR DESCRIPTION
Fixes #6927, enables #9098, and continues the project of rebuilding the Ship of Theseus :tada:

This PR introduces a new way of marrying dagger's dagql and buildkit's LLB. Currently, dagql is used to query the graphql API schema, while LLB is used to query the buildkit dag. dagql is much more flexible and easy to extend, while LLB has significantly better caching behavior.

`DagOp` allows us to combine the best of both worlds. Essentially, it allows us to execute a graphql selection *as a buildkit op* - caching it exactly as a native buildkit operation.

## How it works

- We inject custom "LLB" by piggybacking on the `Description` map of an existing LLB operation. Then during `ResolveOp`, we transform this into a magical `CustomOpWrapper`. This LLB is very hacky, but such is life :shrug: Without entirely ripping out LLB (or forking that package), there's not really a neat way of handling this.
- The `CustomOpWrapper` delegates all of it's operations to `Register`ed `CustomOp`s - at the moment, only `DagOp`.
	- Note: since `CustomOp`s are serialized into a `string`, then the `DagOp` has to be JSON-marshallable. This means we have to do some hackery around sending `ID`s instead of `Selector`s directly.
- The `DagOp` evaluates the query, and gets the result as a root `Directory` - it then evaluates this the `Directory`s ref, and returns it.

This effectively allows the dagql query execution to be cached!

## Performance

To show this off, I've ported `AsTarball` to use this (to fix #6927). Essentially, `AsTarball` attempts to self-call itself *inside* a `DagOp` (using a similar technique to #8724). This now means that if the `Container` receiver hasn't changed, then the `File` result isn't forced to be re-evaluated (which it was before).

Just this simple transformation seems to shave a couple seconds off an engine build with `dagger call engine container`.

Without this patch:

```
$ time dagger call engine container
...
Full trace at https://dagger.cloud/jedevc/traces/85dea4974204db7872fb31f732bbdcb2
dagger call engine container  5.77s user 1.31s system 25% cpu 27.576 total
```

With this patch:

```
$ time dagger call engine container
...
Full trace at https://dagger.cloud/jedevc/traces/b384cb5631d72ebaddab576fae164d24
dagger-with-dev dagger call engine container  6.38s user 1.45s system 30% cpu 25.252 total
```

In the traces, you can see that before, the tar unpacking as part of unbundling the SDK images is uncached, while after, they are:

Before:
![image](https://github.com/user-attachments/assets/74d69886-6aec-4dec-a038-f3ab1b5c861c)
After:
![image](https://github.com/user-attachments/assets/980be363-ee54-4159-a259-355a436337d6)

## TODO

- [x] Work out some better serialization for `Selector`s, `ID`s might not be it (#9204 is probably related)
- [x] Ensure we get reasonable purity in `AsTarball`
- [x] Work out how to test this