### PR TITLE
feat: add float support for golang

### DIFF
--- a/.changes/unreleased/Added-20250117-154447.yaml
+++ b/.changes/unreleased/Added-20250117-154447.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |
+  Add float support in the engine.
+
+  Note: the precision of float is limited to float64 inside the engine.
+  And any call will serialize/deserialize the value to float64.
+time: 2025-01-17T15:44:47.089106+01:00
+custom:
+  Author: TomChv
+  PR: "9396"

--- a/cmd/codegen/generator/go/templates/format.go
+++ b/cmd/codegen/generator/go/templates/format.go
@@ -37,7 +37,7 @@ func (f *FormatTypeFunc) FormatKindScalarInt(representation string) string {
 }
 
 func (f *FormatTypeFunc) FormatKindScalarFloat(representation string) string {
-	representation += "float"
+	representation += "float64"
 	return representation
 }
 

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -182,6 +182,8 @@ func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
 			kind = Id("dagger").Dot("TypeDefKindIntegerKind")
 		case types.IsBoolean:
 			kind = Id("dagger").Dot("TypeDefKindBooleanKind")
+		case types.IsFloat:
+			kind = Id("dagger").Dot("TypeDefKindFloatKind")
 		default:
 			return nil, fmt.Errorf("unsupported basic type: %+v", spec.goType)
 		}

--- a/cmd/codegen/generator/typescript/templates/format.go
+++ b/cmd/codegen/generator/typescript/templates/format.go
@@ -38,7 +38,7 @@ func (f *FormatTypeFunc) FormatKindScalarInt(representation string) string {
 }
 
 func (f *FormatTypeFunc) FormatKindScalarFloat(representation string) string {
-	representation += "number"
+	representation += "float"
 	return representation
 }
 

--- a/cmd/codegen/generator/typescript/templates/src/header.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/header.ts.gtpl
@@ -9,6 +9,11 @@ inherited by futures objects and common types.
  */
 import { Context } from "../common/context.js"
 
+/**
+ * Declare a number as float in the Dagger API.
+ */
+export type float = number
+
 class BaseClient {
   /**
    * @hidden

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -845,6 +845,11 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 		flags.Int(name, val, usage)
 		return nil
 
+	case dagger.TypeDefKindFloatKind:
+		val, _ := getDefaultValue[float64](r)
+		flags.Float64(name, val, usage)
+		return nil
+
 	case dagger.TypeDefKindBooleanKind:
 		val, _ := getDefaultValue[bool](r)
 		flags.Bool(name, val, usage)
@@ -932,6 +937,11 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 		case dagger.TypeDefKindIntegerKind:
 			val, _ := getDefaultValue[[]int](r)
 			flags.IntSlice(name, val, usage)
+			return nil
+
+		case dagger.TypeDefKindFloatKind:
+			val, _ := getDefaultValue[[]float64](r)
+			flags.Float64Slice(name, val, usage)
 			return nil
 
 		case dagger.TypeDefKindBooleanKind:

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -571,6 +571,8 @@ func (t *modTypeDef) String() string {
 		return "string"
 	case dagger.TypeDefKindIntegerKind:
 		return "int"
+	case dagger.TypeDefKindFloatKind:
+		return "float"
 	case dagger.TypeDefKindBooleanKind:
 		return "bool"
 	case dagger.TypeDefKindVoidKind:
@@ -598,6 +600,7 @@ func (t *modTypeDef) KindDisplay() string {
 	switch t.Kind {
 	case dagger.TypeDefKindStringKind,
 		dagger.TypeDefKindIntegerKind,
+		dagger.TypeDefKindFloatKind,
 		dagger.TypeDefKindBooleanKind:
 		return "Scalar"
 	case dagger.TypeDefKindScalarKind,
@@ -622,6 +625,7 @@ func (t *modTypeDef) Description() string {
 	switch t.Kind {
 	case dagger.TypeDefKindStringKind,
 		dagger.TypeDefKindIntegerKind,
+		dagger.TypeDefKindFloatKind,
 		dagger.TypeDefKindBooleanKind:
 		return "Primitive type."
 	case dagger.TypeDefKindVoidKind:

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5217,9 +5217,7 @@ func (m *Test) TestFloat32(n float32) float32 {
 
 func (m *Test) Dep(ctx context.Context, n float64) (float64, error) {
 	return dag.Dep().Dep(ctx, n)
-}
-
-`,
+}`,
 		},
 	}
 
@@ -5238,7 +5236,6 @@ func (m *Test) Dep(ctx context.Context, n float64) (float64, error) {
 				With(daggerExec("init", "--name=test", "--sdk="+tc.sdk, "--source=.")).
 				With(sdkSource(tc.sdk, tc.source)).
 				With(daggerExec("install", "./dep"))
-
 
 			t.Run("float64", func(ctx context.Context, t *testctx.T) {
 				out, err := modGen.With(daggerCall("test", "--n=3.14")).Stdout(ctx)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5219,6 +5219,28 @@ func (m *Test) Dep(ctx context.Context, n float64) (float64, error) {
 	return dag.Dep().Dep(ctx, n)
 }`,
 		},
+		{
+			sdk: "typescript",
+			source: `import { dag, float, object, func } from "@dagger.io/dagger"
+
+@object()
+export class Test {
+  @func()
+  test(n: float): float {
+    return n
+  }
+
+  @func()
+  testFloat32(n: float): float {
+    return n
+  }
+
+  @func()
+  async dep(n: float): Promise<float> {
+    return dag.dep().dep(n)
+  }
+}`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5241,6 +5241,26 @@ export class Test {
   }
 }`,
 		},
+		{
+			sdk: "python",
+			source: `import dagger
+from dagger import dag
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def test(self, n: float) -> float:
+        return n
+
+    @dagger.function
+    def testFloat32(self, n: float) -> float:
+        return n
+
+    @dagger.function
+    async def dep(self, n: float) -> float:
+        return await dag.dep().dep(n)
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -1903,6 +1903,6 @@ export class Test {
 		`))
 
 		_, err := modGen.With(daggerCall("test")).Stdout(ctx)
-		requireErrOut(t, err, "cannot return float '4.4' if return type is number (integer), please use 'float' as return type instead")
+		requireErrOut(t, err, "Error: cannot return float '4.4' if return type is 'number' (integer), please use 'float' as return type instead")
 	})
 }

--- a/core/module.go
+++ b/core/module.go
@@ -286,7 +286,7 @@ func (mod *Module) ModTypeFor(ctx context.Context, typeDef *TypeDef, checkDirect
 	var err error
 
 	switch typeDef.Kind {
-	case TypeDefKindString, TypeDefKindInteger, TypeDefKindBoolean, TypeDefKindVoid:
+	case TypeDefKindString, TypeDefKindInteger, TypeDefKindFloat, TypeDefKindBoolean, TypeDefKindVoid:
 		modType, ok = mod.modTypeForPrimitive(typeDef)
 	case TypeDefKindList:
 		modType, ok, err = mod.modTypeForList(ctx, typeDef, checkDirectDeps)

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -63,7 +63,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 	var modType core.ModType
 
 	switch typeDef.Kind {
-	case core.TypeDefKindString, core.TypeDefKindInteger, core.TypeDefKindBoolean, core.TypeDefKindVoid:
+	case core.TypeDefKindString, core.TypeDefKindInteger, core.TypeDefKindFloat, core.TypeDefKindBoolean, core.TypeDefKindVoid:
 		modType = &core.PrimitiveType{Def: typeDef}
 
 	case core.TypeDefKindList:
@@ -426,6 +426,8 @@ func introspectionRefToTypeDef(introspectionType *introspection.TypeRef, nonNull
 			typeDef.Kind = core.TypeDefKindString
 		case string(introspection.ScalarInt):
 			typeDef.Kind = core.TypeDefKindInteger
+		case string(introspection.ScalarFloat):
+			typeDef.Kind = core.TypeDefKindFloat
 		case string(introspection.ScalarBoolean):
 			typeDef.Kind = core.TypeDefKindBoolean
 		case string(introspection.ScalarVoid):

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -557,7 +557,7 @@ func (typeDef *TypeDef) IsSubtypeOf(otherDef *TypeDef) bool {
 	}
 
 	switch typeDef.Kind {
-	case TypeDefKindString, TypeDefKindInteger, TypeDefKindFloat,TypeDefKindBoolean, TypeDefKindVoid:
+	case TypeDefKindString, TypeDefKindInteger, TypeDefKindFloat, TypeDefKindBoolean, TypeDefKindVoid:
 		return typeDef.Kind == otherDef.Kind
 	case TypeDefKindScalar:
 		return typeDef.AsScalar.Value.Name == otherDef.AsScalar.Value.Name

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -354,6 +354,8 @@ func (typeDef *TypeDef) ToTyped() dagql.Typed {
 		typed = dagql.String("")
 	case TypeDefKindInteger:
 		typed = dagql.Int(0)
+	case TypeDefKindFloat:
+		typed = dagql.Float(0)
 	case TypeDefKindBoolean:
 		typed = dagql.Boolean(false)
 	case TypeDefKindScalar:
@@ -386,6 +388,8 @@ func (typeDef *TypeDef) ToInput() dagql.Input {
 		typed = dagql.String("")
 	case TypeDefKindInteger:
 		typed = dagql.Int(0)
+	case TypeDefKindFloat:
+		typed = dagql.Float(0)
 	case TypeDefKindBoolean:
 		typed = dagql.Boolean(false)
 	case TypeDefKindScalar:
@@ -553,7 +557,7 @@ func (typeDef *TypeDef) IsSubtypeOf(otherDef *TypeDef) bool {
 	}
 
 	switch typeDef.Kind {
-	case TypeDefKindString, TypeDefKindInteger, TypeDefKindBoolean, TypeDefKindVoid:
+	case TypeDefKindString, TypeDefKindInteger, TypeDefKindFloat,TypeDefKindBoolean, TypeDefKindVoid:
 		return typeDef.Kind == otherDef.Kind
 	case TypeDefKindScalar:
 		return typeDef.AsScalar.Value.Name == otherDef.AsScalar.Value.Name
@@ -1046,6 +1050,10 @@ var TypeDefKinds = dagql.NewEnum[TypeDefKind]()
 var (
 	TypeDefKindString = TypeDefKinds.Register("STRING_KIND",
 		"A string value.")
+
+	TypeDefKindFloat = TypeDefKinds.Register("FLOAT_KIND",
+		"A float value.")
+
 	TypeDefKindInteger = TypeDefKinds.Register("INTEGER_KIND",
 		"An integer value.")
 	TypeDefKindBoolean = TypeDefKinds.Register("BOOLEAN_KIND",

--- a/core/typedef_test.go
+++ b/core/typedef_test.go
@@ -13,6 +13,9 @@ var Samples = map[TypeDefKind]*TypeDef{
 	TypeDefKindString: {
 		Kind: TypeDefKindString,
 	},
+	TypeDefKindFloat: {
+		Kind: TypeDefKindFloat,
+	},
 	TypeDefKindInteger: {
 		Kind: TypeDefKindInteger,
 	},

--- a/docs/current_docs/integrations/snippets/google-cloud-run/go/querybuilder/marshal.go
+++ b/docs/current_docs/integrations/snippets/google-cloud-run/go/querybuilder/marshal.go
@@ -55,6 +55,8 @@ func marshalValue(ctx context.Context, v reflect.Value) (string, error) {
 		return fmt.Sprintf("%t", v.Bool()), nil
 	case reflect.Int:
 		return fmt.Sprintf("%d", v.Int()), nil
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%f", v.Float()), nil
 	case reflect.String:
 		if t.Implements(enumT) {
 			// enums render as their literal value

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3263,6 +3263,9 @@ enum TypeDefKind {
   """A string value."""
   STRING_KIND
 
+  """A float value."""
+  FLOAT_KIND
+
   """An integer value."""
   INTEGER_KIND
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -9662,6 +9662,12 @@
                       </tr>
                       <tr>
                         <td>
+                          <p><code>FLOAT_KIND</code></p>
+                        </td>
+                        <td> A float value. </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>INTEGER_KIND</code></p>
                         </td>
                         <td> An integer value. </td>

--- a/sdk/elixir/lib/dagger/gen/type_def_kind.ex
+++ b/sdk/elixir/lib/dagger/gen/type_def_kind.ex
@@ -4,6 +4,7 @@ defmodule Dagger.TypeDefKind do
 
   @type t() ::
           :STRING_KIND
+          | :FLOAT_KIND
           | :INTEGER_KIND
           | :BOOLEAN_KIND
           | :SCALAR_KIND
@@ -17,6 +18,10 @@ defmodule Dagger.TypeDefKind do
   @doc "A string value."
   @spec string_kind() :: :STRING_KIND
   def string_kind(), do: :STRING_KIND
+
+  @doc "A float value."
+  @spec float_kind() :: :FLOAT_KIND
+  def float_kind(), do: :FLOAT_KIND
 
   @doc "An integer value."
   @spec integer_kind() :: :INTEGER_KIND
@@ -79,6 +84,7 @@ defmodule Dagger.TypeDefKind do
   def from_string(string)
 
   def from_string("STRING_KIND"), do: :STRING_KIND
+  def from_string("FLOAT_KIND"), do: :FLOAT_KIND
   def from_string("INTEGER_KIND"), do: :INTEGER_KIND
   def from_string("BOOLEAN_KIND"), do: :BOOLEAN_KIND
   def from_string("SCALAR_KIND"), do: :SCALAR_KIND

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8684,6 +8684,9 @@ const (
 	// Always paired with an EnumTypeDef.
 	TypeDefKindEnumKind TypeDefKind = "ENUM_KIND"
 
+	// A float value.
+	TypeDefKindFloatKind TypeDefKind = "FLOAT_KIND"
+
 	// A graphql input type, used only when representing the core API via TypeDefs.
 	TypeDefKindInputKind TypeDefKind = "INPUT_KIND"
 

--- a/sdk/go/querybuilder/marshal.go
+++ b/sdk/go/querybuilder/marshal.go
@@ -55,6 +55,8 @@ func marshalValue(ctx context.Context, v reflect.Value) (string, error) {
 		return fmt.Sprintf("%t", v.Bool()), nil
 	case reflect.Int:
 		return fmt.Sprintf("%d", v.Int()), nil
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%f", v.Float()), nil
 	case reflect.String:
 		if t.Implements(enumT) {
 			// enums render as their literal value

--- a/sdk/php/generated/TypeDefKind.php
+++ b/sdk/php/generated/TypeDefKind.php
@@ -16,6 +16,9 @@ enum TypeDefKind: string
     /** A string value. */
     case STRING_KIND = 'STRING_KIND';
 
+    /** A float value. */
+    case FLOAT_KIND = 'FLOAT_KIND';
+
     /** An integer value. */
     case INTEGER_KIND = 'INTEGER_KIND';
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -305,6 +305,9 @@ class TypeDefKind(Enum):
     Always paired with an EnumTypeDef.
     """
 
+    FLOAT_KIND = "FLOAT_KIND"
+    """A float value."""
+
     INPUT_KIND = "INPUT_KIND"
     """A graphql input type, used only when representing the core API via TypeDefs."""
 

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -97,6 +97,7 @@ def to_typedef(annotation: type) -> "TypeDef":  # noqa: C901, PLR0911
     builtins = {
         str: dagger.TypeDefKind.STRING_KIND,
         int: dagger.TypeDefKind.INTEGER_KIND,
+        float: dagger.TypeDefKind.FLOAT_KIND,
         bool: dagger.TypeDefKind.BOOLEAN_KIND,
         type(None): dagger.TypeDefKind.VOID_KIND,
     }

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8875,6 +8875,8 @@ pub enum TypeDefKind {
     BooleanKind,
     #[serde(rename = "ENUM_KIND")]
     EnumKind,
+    #[serde(rename = "FLOAT_KIND")]
+    FloatKind,
     #[serde(rename = "INPUT_KIND")]
     InputKind,
     #[serde(rename = "INTEGER_KIND")]

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -4,6 +4,11 @@
  */
 import { Context } from "../common/context.js"
 
+/**
+ * Declare a number as float in the Dagger API.
+ */
+export type float = number
+
 class BaseClient {
   /**
    * @hidden
@@ -1357,6 +1362,11 @@ export enum TypeDefKind {
    * Always paired with an EnumTypeDef.
    */
   EnumKind = "ENUM_KIND",
+
+  /**
+   * A float value.
+   */
+  FloatKind = "FLOAT_KIND",
 
   /**
    * A graphql input type, used only when representing the core API via TypeDefs.

--- a/sdk/typescript/src/module/entrypoint/load.ts
+++ b/sdk/typescript/src/module/entrypoint/load.ts
@@ -186,6 +186,7 @@ export async function loadValue(
     case TypeDefKind.StringKind:
     case TypeDefKind.IntegerKind:
     case TypeDefKind.BooleanKind:
+    case TypeDefKind.FloatKind:
     case TypeDefKind.VoidKind:
     case TypeDefKind.ScalarKind:
     case TypeDefKind.EnumKind:

--- a/sdk/typescript/src/module/entrypoint/register.ts
+++ b/sdk/typescript/src/module/entrypoint/register.ts
@@ -222,6 +222,7 @@ function isPrimitiveType(type: ScannerTypeDef<TypeDefKind>): boolean {
     type.kind === TypeDefKind.BooleanKind ||
     type.kind === TypeDefKind.IntegerKind ||
     type.kind === TypeDefKind.StringKind ||
+    type.kind === TypeDefKind.FloatKind ||
     type.kind === TypeDefKind.EnumKind
   )
 }

--- a/sdk/typescript/src/module/introspector/dagger_module/module.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/module.ts
@@ -91,7 +91,12 @@ export class DaggerModule {
 
   public description: string | undefined
 
-  private references: References = {}
+  private references: References = {
+    // Float is a special case, it's an alias of number but it serves to declare a float type
+    // in the Dagger API.
+    // So we auto register it because it will be detected as a referenced type by the introspector.
+    float: { kind: TypeDefKind.FloatKind },
+  }
 
   constructor(
     public name: string,

--- a/sdk/typescript/src/module/introspector/dagger_module/reference.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/reference.ts
@@ -6,6 +6,7 @@ export type References = { [name: string]: TypeDef<TypeDefKind> }
 export type ReferencableType =
   | TypeDef<TypeDefKind.ObjectKind>
   | TypeDef<TypeDefKind.EnumKind>
+  | TypeDef<TypeDefKind.FloatKind>
   | TypeDef<TypeDefKind.ScalarKind>
   | TypeDef<TypeDefKind.InterfaceKind>
 

--- a/sdk/typescript/src/module/introspector/test/scan.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/scan.spec.ts
@@ -67,6 +67,10 @@ describe("scan by reference TypeScript", function () {
       directory: "objectParam",
     },
     {
+      name: "Should correctly scan multiple args",
+      directory: "multiArgs",
+    },
+    {
       name: "Should correctly scan multiple objects as fields",
       directory: "multipleObjectsAsFields",
     },

--- a/sdk/typescript/src/module/introspector/test/testdata/list/expected.json
+++ b/sdk/typescript/src/module/introspector/test/testdata/list/expected.json
@@ -68,6 +68,31 @@
               "name": "Integer"
             }
           }
+        },
+        "floats": {
+          "name": "floats",
+          "description": "",
+          "arguments": {
+            "n": {
+              "name": "n",
+              "description": "",
+              "type": {
+                "kind": "LIST_KIND",
+                "typeDef": {
+                  "kind": "FLOAT_KIND"
+                }
+              },
+              "isVariadic": true,
+              "isNullable": false,
+              "isOptional": true
+            }
+          },
+          "returnType": {
+            "kind": "LIST_KIND",
+            "typeDef": {
+              "kind": "FLOAT_KIND"
+            }
+          }
         }
       },
       "properties": {}

--- a/sdk/typescript/src/module/introspector/test/testdata/list/index.ts
+++ b/sdk/typescript/src/module/introspector/test/testdata/list/index.ts
@@ -1,4 +1,4 @@
-import { float } from "../../../../../api/client.gen.js"
+import type { float } from "../../../../../api/client.gen.js"
 import { func, object } from "../../../../decorators.js"
 
 @object()

--- a/sdk/typescript/src/module/introspector/test/testdata/list/index.ts
+++ b/sdk/typescript/src/module/introspector/test/testdata/list/index.ts
@@ -1,3 +1,4 @@
+import { float } from "../../../../../api/client.gen.js"
 import { func, object } from "../../../../decorators.js"
 
 @object()
@@ -21,5 +22,10 @@ export class List {
   @func()
   create(...n: number[]): Integer[] {
     return n.map((v) => new Integer(v))
+  }
+
+  @func()
+  floats(...n: float[]): float[] {
+    return n
   }
 }

--- a/sdk/typescript/src/module/introspector/test/testdata/multiArgs/expected.json
+++ b/sdk/typescript/src/module/introspector/test/testdata/multiArgs/expected.json
@@ -33,7 +33,7 @@
               "name": "c",
               "description": "",
               "type": {
-                "kind": "INTEGER_KIND"
+                "kind": "FLOAT_KIND"
               },
               "isVariadic": false,
               "isNullable": false,
@@ -41,7 +41,7 @@
             }
           },
           "returnType": {
-            "kind": "INTEGER_KIND"
+            "kind": "FLOAT_KIND"
           }
         }
       },

--- a/sdk/typescript/src/module/introspector/test/testdata/multiArgs/index.ts
+++ b/sdk/typescript/src/module/introspector/test/testdata/multiArgs/index.ts
@@ -1,10 +1,11 @@
+import type { float } from "../../../../../api/client.gen.js"
 import { func, object } from "../../../../decorators.js"
 
 @object()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export class MultiArgs {
   @func()
-  compute(a: number, b: number, c: number): number {
+  compute(a: number, b: number, c: float): float {
     return a * b + c
   }
 }

--- a/sdk/typescript/src/module/introspector/typescript_module/ast.ts
+++ b/sdk/typescript/src/module/introspector/typescript_module/ast.ts
@@ -285,8 +285,16 @@ export class AST {
   ): TypeDef<TypeDefKind> | undefined {
     if (type.flags & ts.TypeFlags.String)
       return { kind: TypeDefKind.StringKind }
-    if (type.flags & ts.TypeFlags.Number)
+    if (type.flags & ts.TypeFlags.Number) {
+      // Float will be interpreted as number by the TypeScript compiler so we need to check if the
+      // text is "float" to know if it's a float or an integer.
+      // It can also be interpreted as a reference, but this is handled separately at an upper level.
+      if (node.getText().includes("float")) {
+        return { kind: TypeDefKind.FloatKind }
+      }
+
       return { kind: TypeDefKind.IntegerKind }
+    }
     if (type.flags & ts.TypeFlags.Boolean)
       return { kind: TypeDefKind.BooleanKind }
     if (type.flags & ts.TypeFlags.Void) return { kind: TypeDefKind.VoidKind }
@@ -342,7 +350,7 @@ export class AST {
 
     switch (type) {
       case "string":
-      case "number":
+      case "number": // float is also included here
       case "bigint":
       case "boolean":
       case "object":


### PR DESCRIPTION
### Summary

Add float support and fixes #9280.

Doc page available on https://github.com/dagger/dagger/pull/9408

### Examples

**Go**
```go
package main

import "context"

type Test struct{}

func (m *Test) Test(n float64) float64 {
	return n
}

func (m *Test) TestFloat32(n float32) float32 {
	return n
}
```

**Typescript**

⚠️ Since there's no `float` in Typescript, I created a custom `float` type in the client gen so user can declare a type as `FLOAT_KIND`.

```ts
import { float, object, func } from "@dagger.io/dagger"

@object()
export class Test {
  @func()
  test(n: float): float {
    return n
  }
}
```

**Python**

```python
import dagger
from dagger import dag


@dagger.object_type
class Test:
    @dagger.function
    def test(self, n: float) -> float:
        return n
```

### TODO

- [x] Add `FLOAT_KIND` to client binding `TypeDef`
- [x] Add float support for marshal/unmarshal
- [x] Add float support on CLI
- [x] Add integrations tests
- [x] Add Go support
- [x] Add Typescript support
- [x] Add Python support 
- [x] Update doc pages https://github.com/dagger/dagger/pull/9408