### PR TITLE
shell: fix data race coordinating with the bubbletea program

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -64,6 +64,8 @@ type Frontend interface {
 
 	// Opts returns the opts of the currently running frontend.
 	Opts() *dagui.FrontendOpts
+	SetCustomExit(fn func())
+	SetVerbosity(n int)
 
 	// SetPrimary tells the frontend which span should be treated like the focal
 	// point of the command. Its output will be displayed at the end, and its

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -204,6 +204,18 @@ func (fe *frontendPlain) Opts() *dagui.FrontendOpts {
 	return &fe.FrontendOpts
 }
 
+func (fe *frontendPlain) SetCustomExit(fn func()) {
+	fe.mu.Lock()
+	fe.Opts().CustomExit = fn
+	fe.mu.Unlock()
+}
+
+func (fe *frontendPlain) SetVerbosity(n int) {
+	fe.mu.Lock()
+	fe.Opts().Verbosity = n
+	fe.mu.Unlock()
+}
+
 func (fe *frontendPlain) SetPrimary(spanID dagui.SpanID) {
 	fe.mu.Lock()
 	fe.db.PrimarySpan = spanID

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -179,6 +179,18 @@ func (fe *frontendPretty) Opts() *dagui.FrontendOpts {
 	return &fe.FrontendOpts
 }
 
+func (fe *frontendPretty) SetCustomExit(fn func()) {
+	fe.mu.Lock()
+	fe.Opts().CustomExit = fn
+	fe.mu.Unlock()
+}
+
+func (fe *frontendPretty) SetVerbosity(n int) {
+	fe.mu.Lock()
+	fe.Opts().Verbosity = n
+	fe.mu.Unlock()
+}
+
 func (fe *frontendPretty) SetPrimary(spanID dagui.SpanID) {
 	fe.mu.Lock()
 	fe.db.SetPrimarySpan(spanID)


### PR DESCRIPTION
This fixes the following data race when setting the `CustomExit` in the REPL:

```
==================
WARNING: DATA RACE
Read at 0x00c0003eb6e8 by goroutine 34:
    github.com/dagger/dagger/dagql/idtui.(*frontendPretty).recalculateViewLocked()
        /Users/helder/Projects/dagger/dagql/idtui/frontend_pretty.go:518 +0x54
    github.com/dagger/dagger/dagql/idtui.FrontendSpanExporter.ExportSpans.deferwrap2()
        /Users/helder/Projects/dagger/dagql/idtui/frontend_pretty.go:340 +0x34
    runtime.deferreturn()
        /Users/helder/.local/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.darwin-arm64/src/runtime/panic.go:605 +0x5c
    go.opentelemetry.io/otel/sdk/trace.(*batchSpanProcessor).exportSpans()
        /Users/helder/.local/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/batch_span_processor.go:277 +0x30c
    go.opentelemetry.io/otel/sdk/trace.(*batchSpanProcessor).processQueue()
        /Users/helder/.local/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/batch_span_processor.go:305 +0x3f0
    go.opentelemetry.io/otel/sdk/trace.NewBatchSpanProcessor.func1()
        /Users/helder/.local/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/batch_span_processor.go:117 +0x78

Previous write at 0x00c0003eb6e8 by goroutine 32:
    main.(*shellCallHandler).runInteractive()
        /Users/helder/Projects/dagger/cmd/dagger/shell.go:420 +0x528
    main.(*shellCallHandler).RunAll()
        /Users/helder/Projects/dagger/cmd/dagger/shell.go:217 +0x870
    main.init.func16.1()
        /Users/helder/Projects/dagger/cmd/dagger/shell.go:63 +0x284
    main.init.func16.withEngine.2()
        /Users/helder/Projects/dagger/cmd/dagger/engine.go:63 +0x690
    github.com/dagger/dagger/dagql/idtui.(*frontendPretty).spawn()
        /Users/helder/Projects/dagger/dagql/idtui/frontend_pretty.go:711 +0x7c
    github.com/dagger/dagger/dagql/idtui.(*frontendPretty).spawn-fm()
        <autogenerated>:1 +0x20
    github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/helder/.local/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:324 +0x9c

Goroutine 34 (running) created at:
    go.opentelemetry.io/otel/sdk/trace.NewBatchSpanProcessor()
        /Users/helder/.local/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.27.0/trace/batch_span_processor.go:115 +0x42c
    dagger.io/dagger/telemetry.NewLiveSpanProcessor()
        /Users/helder/Projects/dagger/sdk/go/telemetry/live.go:17 +0x80
    dagger.io/dagger/telemetry.Init()
        /Users/helder/Projects/dagger/sdk/go/telemetry/init.go:405 +0x65c
    main.initEngineTelemetry()
        /Users/helder/Projects/dagger/cmd/dagger/engine.go:82 +0x464
    main.init.func16.withEngine.2()
        /Users/helder/Projects/dagger/cmd/dagger/engine.go:28 +0x4c
    github.com/dagger/dagger/dagql/idtui.(*frontendPretty).spawn()
        /Users/helder/Projects/dagger/dagql/idtui/frontend_pretty.go:711 +0x7c
    github.com/dagger/dagger/dagql/idtui.(*frontendPretty).spawn-fm()
        <autogenerated>:1 +0x20
    github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/helder/.local/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:324 +0x9c

Goroutine 32 (running) created at:
    github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1()
        /Users/helder/.local/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.2.4/tea.go:318 +0x1b0
==================
```