### PR TITLE
fix: ensure the go sdk uses namespaced volumes

### DIFF
--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -62,12 +62,12 @@ func (s *cacheSchema) cacheVolume(ctx context.Context, parent dagql.Instance[*co
 			return inst, err
 		}
 
-		namespaceKey = name + symbolic
+		namespaceKey = "mod(" + name + symbolic + ")"
 	}
 
 	// if no namespace key, just return the NewCache based on key
 	if namespaceKey == "" {
-		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, core.NewCache(args.Key))
+		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, core.NewCache(":"+args.Key))
 	}
 
 	err = s.srv.Select(ctx, s.srv.Root(), &inst, dagql.Selector{

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -687,7 +687,11 @@ func (sdk *goSDK) base(ctx context.Context) (dagql.Instance[*core.Container], er
 		Args: []dagql.NamedInput{
 			{
 				Name:  "key",
-				Value: dagql.String("modgomodcache"),
+				Value: dagql.String("gomod"),
+			},
+			{
+				Name:  "namespace",
+				Value: dagql.String("internal"),
 			},
 		},
 	}); err != nil {
@@ -713,7 +717,11 @@ func (sdk *goSDK) base(ctx context.Context) (dagql.Instance[*core.Container], er
 		Args: []dagql.NamedInput{
 			{
 				Name:  "key",
-				Value: dagql.String("modgobuildcache"),
+				Value: dagql.String("gobuild"),
+			},
+			{
+				Name:  "namespace",
+				Value: dagql.String("internal"),
 			},
 		},
 	}); err != nil {


### PR DESCRIPTION
Without this, we can end up accidentally using the wrong module by default! This means we end up with distinct cache volumes for these, when they should be shared *everywhere*.

(split out of #9389)