### PR TITLE
shell: fix stderr from failed execs not showing

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -179,6 +179,12 @@ func (fc *FuncCommand) Command() *cobra.Command {
 						// Return the same ExecError exit code.
 						var ex *dagger.ExecError
 						if errors.As(err, &ex) {
+							tty := !silent && (hasTTY && progress == "auto" || progress == "tty")
+							// Only the pretty frontend prints the stderr of
+							// the exec error in the final render
+							if !tty && ex.Stderr != "" {
+								c.PrintErrln(ex.Stderr)
+							}
 							return ExitError{Code: ex.ExitCode}
 						}
 						return Fail

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -182,7 +182,12 @@ func (fc *FuncCommand) Command() *cobra.Command {
 							tty := !silent && (hasTTY && progress == "auto" || progress == "tty")
 							// Only the pretty frontend prints the stderr of
 							// the exec error in the final render
+							if !tty && ex.Stdout != "" {
+								c.Println("Stdout:")
+								c.Println(ex.Stdout)
+							}
 							if !tty && ex.Stderr != "" {
+								c.PrintErrln("Stderr:")
 								c.PrintErrln(ex.Stderr)
 							}
 							return ExitError{Code: ex.ExitCode}

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -2527,3 +2527,37 @@ func (CallSuite) TestCore(ctx context.Context, t *testctx.T) {
 		require.Contains(t, out, "Alpine Linux")
 	})
 }
+
+func (CallSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
+	t.Run("no TUI", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		_, err := daggerCliBase(t, c).
+			With(daggerExec(
+				"core", "--silent",
+				"container",
+				"from", "--address", alpineImage,
+				"with-exec", "--args", "ls,wat",
+				"stdout",
+			)).
+			Sync(ctx)
+
+		requireErrOut(t, err, "ls: wat: No such file or directory")
+	})
+
+	t.Run("plain", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		_, err := daggerCliBase(t, c).
+			With(daggerExec(
+				"core", "--progress", "plain",
+				"container",
+				"from", "--address", alpineImage,
+				"with-exec", "--args", "ls,wat",
+				"stdout",
+			)).
+			Sync(ctx)
+
+		requireErrOut(t, err, "ls: wat: No such file or directory")
+	})
+}

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -665,6 +665,15 @@ func (ShellSuite) TestCommandStateArgs(ctx context.Context, t *testctx.T) {
 	requireErrOut(t, err, `"foo" not found`)
 }
 
+func (ShellSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	script := fmt.Sprintf("container | from %s | with-exec ls wat | stdout", alpineImage)
+	_, err := daggerCliBase(t, c).
+		With(daggerShell(script)).
+		Sync(ctx)
+	requireErrOut(t, err, "ls: wat: No such file or directory")
+}
+
 func (ShellSuite) TestInstall(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9264
Fixes https://github.com/dagger/dagger/issues/8893
# Before

```shell
❯ dagger core --silent container from --address alpine with-exec --args ls,wat stdout

Error: input: container.from.withExec.stdout process "ls wat" did not complete successfully: exit code: 1
```

```shell
⋈ container | from alpine | with-exec ls wat | stdout
Error: input: container.from.withExec.stdout process "ls wat" did not complete successfully: exit code: 1
⋈ 
```

# After

```shell
❯ dagger core --silent container from --address alpine with-exec --args ls,wat stdout

Error: input: container.from.withExec.stdout process "ls wat" did not complete successfully: exit code: 1

ls: wat: No such file or directory
exit status 1
```


```shell
⋈ container | from alpine | with-exec ls wat | stdout
Error: input: container.from.withExec.stdout process "ls wat" did not complete successfully: exit code: 1

ls: wat: No such file or directory
⋈ 
```
