### PR TITLE
fix: allow injecting system ca-certs for wolfi

### DIFF
--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -4,6 +4,7 @@ import "github.com/dagger/dagger/engine/distconsts"
 
 const (
 	alpineImage  = distconsts.AlpineImage
+	wolfiImage   = "cgr.dev/chainguard/wolfi-base"
 	busyboxImage = distconsts.BusyboxImage
 	golangImage  = distconsts.GolangImage
 	debianImage  = "debian:bookworm"

--- a/engine/buildkit/cacerts/distros.go
+++ b/engine/buildkit/cacerts/distros.go
@@ -30,7 +30,7 @@ More distros to handle:
 /*
 debianLike includes:
 * Debian/Ubuntu/other derivatives
-* Alpine
+* Alpine/Wolfi
 * Gentoo
 
 Which are obviously not all Debian derivatives... They all use
@@ -81,12 +81,14 @@ func (d *debianLike) detect() (bool, error) {
 			[]byte("debian"),
 			[]byte("ubuntu"),
 			[]byte("alpine"),
+			[]byte("wolfi"),
 			[]byte("gentoo"),
 		},
 		[][]byte{
 			[]byte("debian"),
 			[]byte("ubuntu"),
 			[]byte("alpine"),
+			[]byte("wolfi"),
 			[]byte("gentoo"),
 		},
 	)

--- a/engine/buildkit/containerfs/fs.go
+++ b/engine/buildkit/containerfs/fs.go
@@ -282,11 +282,17 @@ func (ctrFS *ContainerFS) PathExists(path string) (bool, error) {
 
 func (ctrFS *ContainerFS) OSReleaseFileContains(ids [][]byte, idLikes [][]byte) (bool, error) {
 	f, err := ctrFS.Open("/etc/os-release")
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return false, err
+	}
+	if f == nil {
+		f, err = ctrFS.Open("/usr/lib/os-release")
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+	if f == nil {
+		return false, nil
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)


### PR DESCRIPTION
And while in the area, updated the logic for reading the `os-release` file (so as to allow a fallback according to https://www.linux.org/docs/man5/os-release.html).