### PR TITLE
feat(sdk/php): support float type

### DIFF
--- a/sdk/php/.changes/unreleased/Added-20250118-002701.yaml
+++ b/sdk/php/.changes/unreleased/Added-20250118-002701.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add float type support
+time: 2025-01-18T00:27:01.978716437+07:00
+custom:
+    Author: wingyplus
+    PR: "9411"

--- a/sdk/php/src/Command/EntrypointCommand.php
+++ b/sdk/php/src/Command/EntrypointCommand.php
@@ -155,6 +155,7 @@ class EntrypointCommand extends Command
         switch ($type->typeDefKind) {
             case TypeDefKind::BOOLEAN_KIND:
             case TypeDefKind::INTEGER_KIND:
+	    case TypeDefKind::FLOAT_KIND:
             case TypeDefKind::STRING_KIND:
             case TypeDefKind::VOID_KIND:
                 return $typeDef->withKind($type->typeDefKind);

--- a/sdk/php/src/Command/EntrypointCommand.php
+++ b/sdk/php/src/Command/EntrypointCommand.php
@@ -153,9 +153,9 @@ class EntrypointCommand extends Command
         $typeDef = dag()->typeDef();
 
         switch ($type->typeDefKind) {
+            case TypeDefKind::FLOAT_KIND:
             case TypeDefKind::BOOLEAN_KIND:
             case TypeDefKind::INTEGER_KIND:
-	    case TypeDefKind::FLOAT_KIND:
             case TypeDefKind::STRING_KIND:
             case TypeDefKind::VOID_KIND:
                 return $typeDef->withKind($type->typeDefKind);

--- a/sdk/php/src/Service/DecodesValue.php
+++ b/sdk/php/src/Service/DecodesValue.php
@@ -55,6 +55,7 @@ final readonly class DecodesValue
         switch ($type->typeDefKind) {
             case TypeDefKind::BOOLEAN_KIND:
             case TypeDefKind::INTEGER_KIND:
+            case TypeDefKind::FLOAT_KIND:
             case TypeDefKind::STRING_KIND:
                 return json_decode($value, true);
             case TypeDefKind::SCALAR_KIND:

--- a/sdk/php/src/ValueObject/Type.php
+++ b/sdk/php/src/ValueObject/Type.php
@@ -55,7 +55,7 @@ final readonly class Type
                 return TypeDefKind::BOOLEAN_KIND;
             case 'int':
                 return TypeDefKind::INTEGER_KIND;
-	    case 'float':
+            case 'float':
                 return TypeDefKind::FLOAT_KIND;
             case 'string':
                 return TypeDefKind::STRING_KIND;

--- a/sdk/php/src/ValueObject/Type.php
+++ b/sdk/php/src/ValueObject/Type.php
@@ -55,6 +55,8 @@ final readonly class Type
                 return TypeDefKind::BOOLEAN_KIND;
             case 'int':
                 return TypeDefKind::INTEGER_KIND;
+	    case 'float':
+                return TypeDefKind::FLOAT_KIND;
             case 'string':
                 return TypeDefKind::STRING_KIND;
             case 'null':

--- a/sdk/php/src/ValueObject/Type.php
+++ b/sdk/php/src/ValueObject/Type.php
@@ -53,10 +53,10 @@ final readonly class Type
         switch ($nameOfType) {
             case 'bool':
                 return TypeDefKind::BOOLEAN_KIND;
-            case 'int':
-                return TypeDefKind::INTEGER_KIND;
             case 'float':
                 return TypeDefKind::FLOAT_KIND;
+            case 'int':
+                return TypeDefKind::INTEGER_KIND;
             case 'string':
                 return TypeDefKind::STRING_KIND;
             case 'null':

--- a/sdk/php/tests/Unit/ValueObject/TypeTest.php
+++ b/sdk/php/tests/Unit/ValueObject/TypeTest.php
@@ -26,14 +26,6 @@ use ReflectionType;
 class TypeTest extends TestCase
 {
     #[Test]
-    public function itCannotSupportFloat(): void
-    {
-        self::expectException(Dagger\Exception\UnsupportedType::class);
-
-        new Type('float');
-    }
-
-    #[Test]
     public function itShouldNotBeConstructedForArrays(): void
     {
         self::expectException(\DomainException::class);

--- a/sdk/php/tests/Unit/ValueObject/TypeTest.php
+++ b/sdk/php/tests/Unit/ValueObject/TypeTest.php
@@ -110,6 +110,16 @@ class TypeTest extends TestCase
             $reflectReturnType(fn(): ?int => 1),
         ];
 
+        yield 'float' =>  [
+            new Type('float', false),
+            $reflectReturnType(fn(): float => 3.14),
+        ];
+
+        yield 'nullable float' =>  [
+            new Type('float', true),
+            $reflectReturnType(fn(): ?float => 3.14),
+        ];
+
         yield 'string' =>  [
             new Type('string', false),
             $reflectReturnType(fn(): string => ''),

--- a/sdk/php/tests/Unit/ValueObject/TypeTest.php
+++ b/sdk/php/tests/Unit/ValueObject/TypeTest.php
@@ -100,16 +100,6 @@ class TypeTest extends TestCase
             $reflectReturnType(fn(): ?bool => false),
         ];
 
-        yield 'int' =>  [
-            new Type('int', false),
-            $reflectReturnType(fn(): int => 1),
-        ];
-
-        yield 'nullable int' =>  [
-            new Type('int', true),
-            $reflectReturnType(fn(): ?int => 1),
-        ];
-
         yield 'float' =>  [
             new Type('float', false),
             $reflectReturnType(fn(): float => 3.14),
@@ -118,6 +108,16 @@ class TypeTest extends TestCase
         yield 'nullable float' =>  [
             new Type('float', true),
             $reflectReturnType(fn(): ?float => 3.14),
+        ];
+
+        yield 'int' =>  [
+            new Type('int', false),
+            $reflectReturnType(fn(): int => 1),
+        ];
+
+        yield 'nullable int' =>  [
+            new Type('int', true),
+            $reflectReturnType(fn(): ?int => 1),
         ];
 
         yield 'string' =>  [


### PR DESCRIPTION
This PR follow up #9396.

## How to test this feature

I create a module named `potato` and put the following code to `src/Potato.php`:

```php
<?php

declare(strict_types=1);

namespace DaggerModule;

use Dagger\Attribute\DaggerFunction;
use Dagger\Attribute\DaggerObject;
use Dagger\Attribute\Doc;
use Dagger\Container;
use Dagger\Directory;

use function Dagger\dag;

#[DaggerObject]
#[Doc('A generated module for Potato functions')]
class Potato
{
    #[DaggerFunction]
    public function acceptFloat(float $value): float {
        return $value;
    }
}
```

Then run `dagger call accept-float --value=1.245`, the cli will output:

```
✔ connect 0.3s
✔ load module 16.8s
✔ parsing command line arguments 0.0s

✔ potato: Potato! 0.0s
✔ .acceptFloat(value: 1.245000): Float! 0.5s

1.245
```