### PR TITLE
shell: fix running multiple top-level queries

### DIFF
--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -152,7 +152,7 @@ func (c *ShellCommand) Execute(ctx context.Context, h *shellCallHandler, args []
 	for i, arg := range args {
 		if strings.HasPrefix(arg, shellStatePrefix) {
 			w := strings.NewReader(arg)
-			v, err := h.Result(ctx, w, false, nil)
+			v, _, err := h.Result(ctx, w, nil)
 			if err != nil {
 				return fmt.Errorf("cannot expand command argument at %d", i)
 			}

--- a/cmd/dagger/shell_state.go
+++ b/cmd/dagger/shell_state.go
@@ -107,10 +107,10 @@ func (st ShellState) WriteTo(w io.Writer) error {
 		return err
 	}
 
-	w.Write([]byte(shellStatePrefix))
-	w.Write(buf.Bytes())
+	// Use a single write call so we can decode it in the runner's stdout write handler
+	_, err := w.Write(append([]byte(shellStatePrefix), buf.Bytes()...))
 
-	return nil
+	return err
 }
 
 // Function returns the last function in the chain, if not empty


### PR DESCRIPTION
Fixes an important issue reported by @jedevc where you can’t run multiple Dagger functions in a script (i.e., encoded shell state). 

Also fixes another issue where even if you have multiple commands, their output is only shown at the very end, when the interpreter’s runner has finished.

## Before

Previously, all output from a run was getting buffered and then analyzed has a whole after the runner had finished. However, if there were multiple commands returning state that needs to make an API request to resolve, could be ignored except for the first one:

```
⋈ container; directory
defaultArgs: []
entrypoint: []
mounts: []
platform: linux/arm64
user: ""
workdir: ""
```

Notice that only the container is shown.

## After

Now, queries are resolved as the runner is executing and attempting to write the final output of commands. This also means that output will be shown as we get it and no longer need to wait until the very end.

```
⋈ container; directory
defaultArgs: []
entrypoint: []
mounts: []
platform: linux/arm64
user: ""
workdir: ""
digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
entries: []
```

Now the empty directory object is shown after the container.