### PR TITLE
ci: add ca-certificates package to the Go module

### DIFF
--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -81,6 +81,7 @@ func New(
 				// The specific version is dictated by Dagger's own requirement
 				// FIXME: make this optional with overlay support
 				"protoc~3.21.12",
+				"ca-certificates",
 			}}).
 			WithEnvVariable("GOLANG_VERSION", version).
 			WithEnvVariable("GOPATH", "/go").


### PR DESCRIPTION
This allows the engine to correctly setup certificates in case there's
any custom certs configured

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
