### PR TITLE
fix: relatively resolve dependency context directories

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4884,6 +4884,18 @@ func (m *Test) GetRelDepSource() *dagger.Directory {
 		out, err = ctr.With(daggerCall("get-rel-dep-source", "entries")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "yo\n", out)
+
+		// now try calling from outside
+
+		ctr = ctr.WithWorkdir("/")
+
+		out, err = ctr.With(daggerCallAt("work", "get-dep-source", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "yo\n", out)
+
+		out, err = ctr.With(daggerCallAt("work", "get-rel-dep-source", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "yo\n", out)
 	})
 
 	t.Run("as module", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -856,10 +856,15 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 	// depSrc.RootSubpath is ../baz and relative to foo/bar.
 	// depSubpath is the resolved path, i.e. foo/baz.
 	depSubpath := filepath.Join(srcRootSubpath, depRootSubpath)
-
 	if !filepath.IsLocal(depSubpath) {
 		return inst, fmt.Errorf("module dep source root path %q escapes root", depRootSubpath)
 	}
+
+	srcRelHostPath, err := src.SourceRootRelSubPath()
+	if err != nil {
+		return inst, err
+	}
+	depRelHostPath := filepath.Join(srcRelHostPath, depRootSubpath)
 
 	switch src.Kind {
 	case core.ModuleSourceKindGit:
@@ -900,6 +905,7 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 				Field: "moduleSource",
 				Args: []dagql.NamedInput{
 					{Name: "refString", Value: dagql.String(depSubpath)},
+					{Name: "relHostPath", Value: dagql.String(depRelHostPath)},
 				},
 			},
 			dagql.Selector{


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9068.

We need to take into account that dependencies have a *different* relative context directory. The fact this was working before, was that generally, we were only invoking modules from the same location as the `dagger.json` - however, if invoked from above or below, then we'd fail to apply the correct transformation and we'd get the wrong context directory.

Thankfully, it's fairly simple - all we need to do is mirror the logic that modifies the `refString` and apply it to `relHostPath` as well.