### PR TITLE
shell: change prefix for interpreter builtins

### DIFF
--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -178,7 +178,7 @@ func (h *shellCallHandler) BuiltinCommand(name string) (*ShellCommand, error) {
 			return c, nil
 		}
 	}
-	return nil, fmt.Errorf("command not found %q", name)
+	return nil, fmt.Errorf("command not found: %q", name)
 }
 
 func (h *shellCallHandler) StdlibCommand(name string) (*ShellCommand, error) {
@@ -187,7 +187,7 @@ func (h *shellCallHandler) StdlibCommand(name string) (*ShellCommand, error) {
 			return c, nil
 		}
 	}
-	return nil, fmt.Errorf("command not found %q", name)
+	return nil, fmt.Errorf("command not found: %q", name)
 }
 
 func (h *shellCallHandler) Builtins() []*ShellCommand {
@@ -238,7 +238,7 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 						return err
 					}
 					if c == nil {
-						err = fmt.Errorf("command not found %q", args[0])
+						err = fmt.Errorf("command not found: %q", args[0])
 						if !strings.HasPrefix(args[0], ".") {
 							if builtin, _ := h.BuiltinCommand("." + args[0]); builtin != nil {
 								err = fmt.Errorf("%w, did you mean %q?", err, "."+args[0])

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -31,7 +31,7 @@ func (h *shellCallHandler) Exec(next interp.ExecHandlerFunc) interp.ExecHandlerF
 		// This avoids interpreter builtins running first, which would make it
 		// impossible to have a function named "echo", for example. We can
 		// remove `.dag` from this point onward.
-		if args[0] == ".dag" {
+		if args[0] == shellInternalCmd {
 			args = args[1:]
 		}
 

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -703,7 +703,7 @@ directory | with-new-file test bar | file test | contents
 	t.Run("async", func(ctx context.Context, t *testctx.T) {
 		script := `
 directory | with-new-file test foo | file test | contents &
-directory | with-new-file test bar | file test | contents & ..wait
+directory | with-new-file test bar | file test | contents & _wait
 `
 		c := connect(ctx, t)
 		out, err := daggerCliBase(t, c).
@@ -714,5 +714,24 @@ directory | with-new-file test bar | file test | contents & ..wait
 		if out != "foobar" && out != "barfoo" {
 			t.Errorf("unexpected output: %q", out)
 		}
+	})
+}
+
+func (ShellSuite) TestInterpreterBuiltins(ctx context.Context, t *testctx.T) {
+	t.Run("builtin", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := daggerCliBase(t, c).
+			With(daggerShell(`_echo foobar`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "foobar\n", out)
+	})
+
+	t.Run("internal", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		_, err := daggerCliBase(t, c).
+			With(daggerShell(`__dag`)).
+			Sync(ctx)
+		requireErrOut(t, err, "reserved for internal use")
 	})
 }


### PR DESCRIPTION
Something I've wanted to do for a while. Instead of `..`, should use `_` for interpreter builtins:

https://github.com/dagger/dagger/blob/6d0fd95302bfdfca7446aec2b8155b1949a1e88f/cmd/dagger/shell.go#L254-L265

## Before

```
..echo foo & ..echo bar & ..wait
```

## After

```
_echo foo & _echo bar & _wait
```
