### PR TITLE
fix(sdk/elixir): fix Hex is missing because `local.hex` cached

### DIFF
--- a/sdk/elixir/dagger.json
+++ b/sdk/elixir/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-sdk",
-  "engineVersion": "v0.13.0",
+  "engineVersion": "v0.15.2",
   "sdk": "go",
   "source": "runtime"
 }

--- a/sdk/elixir/dev/dagger.json
+++ b/sdk/elixir/dev/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-sdk-dev",
   "engineVersion": "v0.15.2",
-  "sdk": "elixir@v0.14.0",
+  "sdk": "elixir",
   "source": "."
 }

--- a/sdk/elixir/runtime/go.mod
+++ b/sdk/elixir/runtime/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/99designs/gqlgen v0.17.57
 	github.com/Khan/genqlient v0.7.0
 	github.com/iancoleman/strcase v0.3.0
-	github.com/vektah/gqlparser/v2 v2.5.19
+	github.com/vektah/gqlparser/v2 v2.5.20
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
@@ -35,7 +35,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/sdk/elixir/runtime/go.sum
+++ b/sdk/elixir/runtime/go.sum
@@ -31,8 +31,8 @@ github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq
 github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/vektah/gqlparser/v2 v2.5.19 h1:bhCPCX1D4WWzCDvkPl4+TP1N8/kLrWnp43egplt7iSg=
-github.com/vektah/gqlparser/v2 v2.5.19/go.mod h1:y7kvl5bBlDeuWIvLtA9849ncyvx6/lj06RsMrEjVy3U=
+github.com/vektah/gqlparser/v2 v2.5.20 h1:kPaWbhBntxoZPaNdBaIPT1Kh0i1b/onb5kXgEdP5JCo=
+github.com/vektah/gqlparser/v2 v2.5.20/go.mod h1:xMl+ta8a5M1Yo1A1Iwt/k7gSpscwSnHZdw7tfhEGfTM=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88 h1:oM0GTNKGlc5qHctWeIGTVyda4iFFalOzMZ3Ehj5rwB4=

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -183,10 +183,8 @@ func (m *ElixirSdk) GenerateCode(introspectionJSON *dagger.File) *dagger.Directo
 }
 
 func (m *ElixirSdk) baseContainer(ctr *dagger.Container) *dagger.Container {
-	mixCache := dag.CacheVolume(".mix")
 	return ctr.
 		From(elixirImage).
-		WithMountedCache("/root/.mix", mixCache).
 		WithExec([]string{"apk", "add", "--no-cache", "git"}).
 		WithExec([]string{"mix", "local.hex", "--force"}).
 		WithExec([]string{"mix", "local.rebar", "--force"})


### PR DESCRIPTION
This changeset remove `/root/.mix` cache volume out of the runtime because sometimes, the `mix local.hex --force` got cached, cause `/root/.mix` cache volume got empty.

And also update dev module to use latest version of `elixir` SDK and bump `engineVersion` in dagger.json.