### PR TITLE
chore: hide typedef registration in progress output (and in CLI)

### DIFF
--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -85,7 +85,7 @@ func (db *DB) WalkSpans(opts FrontendOpts, spans []*Span, f func(*TraceTree)) {
 		// If the span should be hidden, don't even collect it into the tree so we
 		// can track relationships between rows accurately (e.g. chaining pipeline
 		// calls).
-		if !opts.ShouldShow(span) {
+		if !opts.ShouldShow(db, span) {
 			return
 		}
 


### PR DESCRIPTION
Hide these from the supported functions available on the command line (since they're for SDKs only).

Additionally, move the helper for this into the `dagui` package, so that we can use it to hide output in the progress view - this has the largest impact when building complex modules in CI (which uses plain progress output), like in our own CI (for example: https://github.com/dagger/dagger/actions/runs/12928659633/job/36056419424#step:5:209)

This was prompted by noticing our plain progress output has once again become kind of difficult to read - this is a fairly low hanging piece of fruit to tidy this up a bit.