### PR TITLE
ci: fix typo in --image flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           function: |-
             publish \
             --tag="${{ github.ref_name }}" --commit="${{ github.sha }}" \
-            --image="$DAGGER_ENGINE_IMAGE" \
+            --registry-image="$DAGGER_ENGINE_IMAGE" \
             --registry-username="$DAGGER_ENGINE_IMAGE_USERNAME" \
             --registry-password=env:DAGGER_ENGINE_IMAGE_PASSWORD \
             --goreleaser-key=env:GORELEASER_KEY \


### PR DESCRIPTION
Follow up to #9356.

Ooops.

https://github.com/dagger/dagger/actions/runs/12953852890/job/36134451106

![image](https://github.com/user-attachments/assets/b1682977-8c6d-4a69-85a3-74ef273bc198)
