### PR TITLE
perf(sdk/elixir): optimize function call time

### DIFF
--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -68,6 +68,8 @@ func (m *ElixirSdk) ModuleRuntime(
 	return ctr.
 		WithWorkdir(elixirApplication).
 		WithExec([]string{"mix", "deps.get", "--only", "dev"}).
+		WithExec([]string{"mix", "deps.compile"}).
+		WithExec([]string{"mix", "compile"}).
 		WithEntrypoint([]string{
 			"mix", "cmd",
 			"--cd", path.Join(ModSourceDirPath, subPath, elixirApplication),


### PR DESCRIPTION
Before this PR, the function call was not getting cache because the compilation occurred every time it ran the `mix run` command. In this PR, add a compilation step before trigger the entrypoint to ensure a function will compile only once during initialization.

## Benchmark

### Before

![Screenshot 2025-01-29 002149](https://github.com/user-attachments/assets/e13bf3f8-f4d4-40ce-8d54-331638d2a132)

The `dagger functions` takes around 3 seconds each run and the `container-echo` function call takes around 11 seconds

### After

![Screenshot 2025-01-29 002203](https://github.com/user-attachments/assets/5f672557-610f-4c96-8006-758cee0ce3f1)

I noticed that `dagger functions` is a bit slower on the first run (~15 seconds) but it gets faster on the second round at around 1-2 seconds

The `container-echo` function call uses under 10 seconds and it get faster on the second run.