### PR TITLE
docs: remove unneccessary import in python dockerfile snippet

### DIFF
--- a/docs/current_docs/cookbook/snippets/builds/dockerfile/python/main.py
+++ b/docs/current_docs/cookbook/snippets/builds/dockerfile/python/main.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 import dagger
-from dagger import Doc, dag, function, object_type
+from dagger import Doc, function, object_type
 
 
 @object_type
@@ -15,8 +15,5 @@ class MyModule:
         ],
     ) -> str:
         """Build and publish image from existing Dockerfile"""
-        ref = (
-            src.docker_build()  # build from Dockerfile
-            .publish("ttl.sh/hello-dagger")
-        )
+        ref = src.docker_build().publish("ttl.sh/hello-dagger")  # build from Dockerfile
         return await ref


### PR DESCRIPTION
Follow-up from https://github.com/dagger/dagger/pull/9446.

This is currently causing the python linter to fail.