### PR TITLE
ci: fix typo in cloud front distribution flag

### DIFF
--- a/releaser/main.go
+++ b/releaser/main.go
@@ -148,7 +148,7 @@ func (r *Releaser) Publish(
 	awsSecretAccessKey *dagger.Secret, // +optional
 	awsRegion string, // +optional
 	awsBucket string, // +optional
-	awsCloudFrontDistribution string, // +optional
+	awsCloudfrontDistribution string, // +optional
 	artefactsFQDN string, // +optional
 
 	discordWebhook *dagger.Secret, // +optional
@@ -189,7 +189,7 @@ func (r *Releaser) Publish(
 		if err != nil {
 			artifact.Errors = append(artifact.Errors, dag.Error(err.Error()))
 		}
-		err = r.Dagger.Cli().PublishMetadata(ctx, awsAccessKeyID, awsSecretAccessKey, awsRegion, awsBucket, awsCloudFrontDistribution)
+		err = r.Dagger.Cli().PublishMetadata(ctx, awsAccessKeyID, awsSecretAccessKey, awsRegion, awsBucket, awsCloudfrontDistribution)
 		if err != nil {
 			artifact.Errors = append(artifact.Errors, dag.Error(err.Error()))
 		}


### PR DESCRIPTION
:scream: https://github.com/dagger/dagger/pull/9443 didn't catch everything.

We really need a better way of type-checking this kind of thing - wonder if dagger shell could do this.