### PR TITLE
fix: ensure trailing slashes in `Container.WithFiles` doesn't change behavior

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -580,13 +580,14 @@ func (container *Container) WithDirectory(ctx context.Context, subdir string, sr
 func (container *Container) WithFile(ctx context.Context, destPath string, src *File, permissions *int, owner string) (*Container, error) {
 	container = container.Clone()
 
-	return container.writeToPath(ctx, path.Dir(destPath), func(dir *Directory) (*Directory, error) {
+	dir, file := filepath.Split(filepath.Clean(destPath))
+	return container.writeToPath(ctx, dir, func(dir *Directory) (*Directory, error) {
 		ownership, err := container.ownership(ctx, owner)
 		if err != nil {
 			return nil, err
 		}
 
-		return dir.WithFile(ctx, path.Base(destPath), src, permissions, ownership)
+		return dir.WithFile(ctx, file, src, permissions, ownership)
 	})
 }
 
@@ -608,20 +609,21 @@ func (container *Container) WithoutPaths(ctx context.Context, destPaths ...strin
 func (container *Container) WithFiles(ctx context.Context, destDir string, src []*File, permissions *int, owner string) (*Container, error) {
 	container = container.Clone()
 
-	return container.writeToPath(ctx, path.Dir(destDir), func(dir *Directory) (*Directory, error) {
+	dir, file := filepath.Split(filepath.Clean(destDir))
+	return container.writeToPath(ctx, path.Dir(dir), func(dir *Directory) (*Directory, error) {
 		ownership, err := container.ownership(ctx, owner)
 		if err != nil {
 			return nil, err
 		}
 
-		return dir.WithFiles(ctx, path.Base(destDir), src, permissions, ownership)
+		return dir.WithFiles(ctx, file, src, permissions, ownership)
 	})
 }
 
 func (container *Container) WithNewFile(ctx context.Context, dest string, content []byte, permissions fs.FileMode, owner string) (*Container, error) {
 	container = container.Clone()
 
-	dir, file := filepath.Split(dest)
+	dir, file := filepath.Split(filepath.Clean(dest))
 	return container.writeToPath(ctx, dir, func(dir *Directory) (*Directory, error) {
 		ownership, err := container.ownership(ctx, owner)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9448.

The code that propagates operations to a container's underlying directory wasn't quite correct. It was incorrectly making the assumption that combining `filepath.Dir` + `filepath.Base` gives you the original path.

However, when passing a path with a trailing slash to `filepath.Dir`, you actually get the entire input - instead of going up a level. So, instead, we should avoid this, and instead `filepath.Clean` the input so that we ensure we never have a trailing slash. We can also make these methods consistent, and use `filepath.Split` as well (while we're in the area, this doesn't actually have a behavior change).