### PR TITLE
fix(ts-sdk): object name conversion with numbers

### DIFF
--- a/sdk/typescript/src/module/introspector/case_convertor.ts
+++ b/sdk/typescript/src/module/introspector/case_convertor.ts
@@ -1,18 +1,15 @@
 export function convertToPascalCase(input: string): string {
+  // Handle empty string case
+  if (!input) {
+    return ""
+  }
+
+  // Split on word boundaries before uppercase letters, numbers, and special characters
   const words = input
-    .replace(/[^a-zA-Z0-9]/g, " ") // Replace non-alphanumeric characters with spaces
-    .split(/\s+/)
+    .split(/(?=[A-Z0-9])|[^a-zA-Z0-9]|(?<=[a-zA-Z])(?=\d)|(?<=\d)(?=[a-zA-Z])/g)
     .filter((word) => word.length > 0)
 
-  if (words.length === 0) {
-    return "" // No valid words found
-  }
-
-  // It's an edge case when moduleName is already in PascalCase or camelCase
-  if (words.length === 1) {
-    return words[0].charAt(0).toUpperCase() + words[0].slice(1)
-  }
-
+  // Convert each word to proper case
   const pascalCase = words
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("")

--- a/sdk/typescript/src/module/introspector/test/case_convertor.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/case_convertor.spec.ts
@@ -33,5 +33,30 @@ describe("case convertor", function () {
       const result = convertToPascalCase("HelloWorld")
       assert.equal(result, "HelloWorld")
     })
+
+    it("should correctly handle numbers as spacers", function () {
+      const result = convertToPascalCase("hello123world")
+      assert.equal(result, "Hello123World")
+    })
+
+    it("should correctly handle number as first word", function () {
+      const result = convertToPascalCase("123helloworld")
+      assert.equal(result, "123Helloworld")
+    })
+
+    it("should correctly handle number as last word", function () {
+      const result = convertToPascalCase("helloWorld123")
+      assert.equal(result, "HelloWorld123")
+    })
+
+    it("should correctly handle special characters as spacers", function () {
+      const result = convertToPascalCase("hello world")
+      assert.equal(result, "HelloWorld")
+    })
+
+    it("should correctly handle mix cases", function () {
+      const result = convertToPascalCase("123hello-world_here")
+      assert.equal(result, "123HelloWorldHere")
+    })
   })
 })


### PR DESCRIPTION
### Summary

I fixed a small problem linked to module name that contains a number. The generated class name wasn't consistent with the name search by the introspection.
Basically, a module named `m8a`  generated as `M8A` but converted to `M8a` by the introspector instead of `M8A`.
I also added a bunch of tests cases to verify other format

Result of the #9451 reported issue with this branch version:

<img width="947" alt="Screenshot 2025-01-27 at 18 29 36" src="https://github.com/user-attachments/assets/14eff389-7f1e-449b-ac84-75ac8575c673" />

Fixes #9451