### PR TITLE
Revert "engine: sync cache volumes on-demand (#8323)"

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -412,6 +412,13 @@ func main() { //nolint:gocyclo
 			go logTraceMetrics(context.Background())
 		}
 
+		bklog.G(ctx).Debug("starting optional cache mount synchronization")
+		err = srv.SolverCache.StartCacheMountSynchronization(ctx)
+		if err != nil {
+			bklog.G(ctx).WithError(err).Error("failed to start cache mount synchronization")
+			// continue on, doesn't need to be fatal
+		}
+
 		// start serving on the listeners for actual clients
 		bklog.G(ctx).Debug("starting main engine api listeners")
 		srv.Register(grpcServer)

--- a/core/cache.go
+++ b/core/cache.go
@@ -14,7 +14,7 @@ import (
 
 // CacheVolume is a persistent volume with a globally scoped identifier.
 type CacheVolume struct {
-	Key string `json:"keys"`
+	Keys []string `json:"keys"`
 }
 
 func (*CacheVolume) Type() *ast.Type {
@@ -28,19 +28,23 @@ func (*CacheVolume) TypeDescription() string {
 	return "A directory whose contents persist across runs."
 }
 
-func NewCache(key string) *CacheVolume {
-	return &CacheVolume{Key: key}
+func NewCache(keys ...string) *CacheVolume {
+	return &CacheVolume{Keys: keys}
 }
 
 func (cache *CacheVolume) Clone() *CacheVolume {
 	cp := *cache
+	cp.Keys = cloneSlice(cp.Keys)
 	return &cp
 }
 
 // Sum returns a checksum of the cache tokens suitable for use as a cache key.
 func (cache *CacheVolume) Sum() string {
 	hash := sha256.New()
-	_, _ = hash.Write([]byte(cache.Key + "\x00"))
+	for _, tok := range cache.Keys {
+		_, _ = hash.Write([]byte(tok + "\x00"))
+	}
+
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 

--- a/core/container.go
+++ b/core/container.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/containerd/containerd/content"
@@ -237,9 +238,6 @@ type ContainerMount struct {
 
 	// Persist changes to the mount under this cache ID.
 	CacheVolumeID string `json:"cache_volume_id,omitempty"`
-
-	// Name of the underlying cache volume for this container mount.
-	CacheVolumeName string `json:"cache_volume_name,omitempty"`
 
 	// How to share the cache across concurrent runs.
 	CacheSharingMode CacheSharingMode `json:"cache_sharing,omitempty"`
@@ -644,6 +642,8 @@ func (container *Container) WithMountedFile(ctx context.Context, target string, 
 	return container.withMounted(ctx, target, file.LLB, file.File, file.Services, owner, readonly)
 }
 
+var SeenCacheKeys = new(sync.Map)
+
 func (container *Container) WithMountedCache(ctx context.Context, target string, cache *CacheVolume, source *Directory, sharingMode CacheSharingMode, owner string) (*Container, error) {
 	container = container.Clone()
 
@@ -656,7 +656,6 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 	mount := ContainerMount{
 		Target:           target,
 		CacheVolumeID:    cache.Sum(),
-		CacheVolumeName:  cache.Key,
 		CacheSharingMode: sharingMode,
 	}
 
@@ -683,6 +682,8 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 
 	// set image ref to empty string
 	container.ImageRef = ""
+
+	SeenCacheKeys.Store(cache.Keys[0], struct{}{})
 
 	return container, nil
 }

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
-	"github.com/dagger/dagger/engine/cache"
 	"github.com/dagger/dagger/network"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/identity"
@@ -255,12 +254,6 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		}
 
 		if mnt.CacheVolumeID != "" {
-			// append the list of cache volumes
-			execMD.CacheVolumes = append(execMD.CacheVolumes, &cache.CacheVolume{
-				Name:   mnt.CacheVolumeName,
-				Target: mnt.Target,
-			})
-
 			var sharingMode llb.CacheMountSharingMode
 			switch mnt.CacheSharingMode {
 			case CacheSharingModeShared:

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containerd/console"
 	runc "github.com/containerd/go-runc"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine/cache"
 	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
@@ -103,8 +102,6 @@ type ExecutionMetadata struct {
 
 	// If true, skip injecting dagger-init into the container.
 	NoInit bool
-
-	CacheVolumes []*cache.CacheVolume
 }
 
 const executionMetadataKey = "dagger.executionMetadata"
@@ -165,7 +162,6 @@ func (w *Worker) Run(
 		w.injectInit,
 		w.generateBaseSpec,
 		w.filterEnvs,
-		w.setupCacheVolumes,
 		w.setupRootfs,
 		w.setUserGroup,
 		w.setExitCodePath,

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -405,32 +405,6 @@ func (w *Worker) filterEnvs(_ context.Context, state *execState) error {
 	return nil
 }
 
-// setupCacheVolumes synchronizes the cache volumes that are in use for this
-// execution
-func (w *Worker) setupCacheVolumes(ctx context.Context, state *execState) error {
-	// only sync if there are cache volumes and the `daggerCacheManager` was set
-	if w.execMD == nil || len(w.execMD.CacheVolumes) == 0 || w.daggerCacheManager == nil {
-		return nil
-	}
-
-	for _, m := range state.spec.Mounts {
-		for _, cv := range w.execMD.CacheVolumes {
-			if cv.Target == m.Destination {
-				cv.Mount = &mount.Mount{
-					Type:    m.Type,
-					Source:  m.Source,
-					Options: m.Options,
-				}
-			}
-		}
-	}
-
-	if err := w.daggerCacheManager.DownloadCacheMounts(ctx, w.execMD.CacheVolumes); err != nil {
-		bklog.G(ctx).Warnf("optional cache volume synchronization failed: %v", err)
-	}
-	return nil
-}
-
 func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 	var err error
 	state.rootfsPath, err = os.MkdirTemp("", "rootfs")

--- a/engine/buildkit/worker.go
+++ b/engine/buildkit/worker.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	runc "github.com/containerd/go-runc"
-	"github.com/dagger/dagger/engine/cache"
 	"github.com/docker/docker/pkg/idtools"
 	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/executor"
@@ -59,8 +58,6 @@ type sharedWorkerState struct {
 	parallelismSem   *semaphore.Weighted
 	workerCache      bkcache.Manager
 
-	daggerCacheManager cache.Manager
-
 	running map[string]*execState
 	mu      sync.RWMutex
 }
@@ -113,11 +110,6 @@ func NewWorker(opts *NewWorkerOpts) *Worker {
 
 		running: make(map[string]*execState),
 	}}
-}
-
-func (w *Worker) SetCacheManager(manager cache.Manager) *Worker {
-	w.daggerCacheManager = manager
-	return w
 }
 
 func (w *Worker) Executor() executor.Executor {

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -3,15 +3,12 @@ package cache
 import (
 	"bufio"
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd/archive"
@@ -26,275 +23,185 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dagger/dagger/core"
 )
 
-type CacheVolume struct {
-	Name   string
-	Target string
-	Mount  *mount.Mount
-}
-
-func (m *manager) syncAllCacheMounts(ctx context.Context) error {
-	cacheMounts := []*CacheVolume{}
-	for _, cm := range m.syncedCacheMounts {
-		// skip all cache mounts that do not have a sync URL
-		if cm.mountConfig.URL == "" {
-			continue
-		}
-		cacheMounts = append(cacheMounts, &CacheVolume{Name: cm.mountConfig.Name})
+func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
+	getCacheMountConfigResp, err := m.cacheClient.GetCacheMountConfig(ctx, GetCacheMountConfigRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get cache mount config: %w", err)
 	}
-
-	return m.downloadCacheMounts(ctx, cacheMounts)
-}
-
-func (m *manager) initSyncedCacheMounts(ctx context.Context) {
-	m.cacheMountsInit.Do(func() {
-		m.seenCacheMounts = &sync.Map{}
-
-		// initialize the map before the potential failure below
-		m.syncedCacheMounts = map[string]*syncedCacheMount{}
-
-		response, err := m.cacheClient.GetCacheMountConfig(ctx, GetCacheMountConfigRequest{})
-		if err != nil {
-			bklog.G(ctx).Warnf("(optional) failed to download cache mount config: %v", err)
-			return
-		}
-
-		for _, mount := range response.SyncedCacheMounts {
-			m.syncedCacheMounts[mount.Name] = &syncedCacheMount{
-				init:        sync.Once{},
-				mountConfig: mount,
-			}
-		}
-	})
-}
-
-// DownloadCacheMounts synchronizes the specified list of cache mounts.
-// NOTE: this is a synchronous operation that will download data from object storage
-// providers.
-func (m *manager) DownloadCacheMounts(ctx context.Context, cacheMounts []*CacheVolume) error {
-	// if SyncOnBoot is on then we skip synchronizing the cache mounts
-	// NOTE: each cache mount is synchronized only once using sync.Once, technically
-	// we don't need this check since the function won't actually do anything. However
-	// if would still spawn a few goroutines that we know is unnecessary, so its
-	// better to just exit more quickly.
-	if m.SyncOnBoot {
-		return nil
-	}
-
-	return m.downloadCacheMounts(ctx, cacheMounts)
-}
-
-func (m *manager) downloadCacheMounts(ctx context.Context, cacheMounts []*CacheVolume) error {
-	var eg errgroup.Group
-	for _, cm := range cacheMounts {
-		m.seenCacheMounts.Store(cm.Name, true)
-
-		cacheMount, ok := m.syncedCacheMounts[cm.Name]
-		if !ok {
-			bklog.G(ctx).Infof("cache mount %s not in config", cm.Name)
-			continue
-		}
-		cacheMount.mount = cm.Mount
-
-		eg.Go(func() error {
-			cacheMount.init.Do(func() {
-				// NOTE: synchronizing cache mounts is optional and we do not want
-				// the engine to fail if this fail. This function is being called
-				// while a container is being executed so its important we handle
-				// errors gracefully.
-				if err := m.downloadCacheMount(ctx, cacheMount); err != nil {
-					bklog.G(ctx).Warnf("(optional) failed to sync cache mount %s: %v", cacheMount.mountConfig.Name, err)
-				}
-			})
-			return nil
-		})
-	}
-
-	return eg.Wait()
-}
-
-func (m *manager) downloadCacheMount(ctx context.Context, syncedCacheMount *syncedCacheMount) error {
-	if syncedCacheMount == nil {
-		return nil
-	}
-
-	mc := syncedCacheMount.mountConfig
-
-	bklog.G(ctx).Debugf("downloading cache mount %s", mc.Name)
-
-	remoteApplierFunc := func(ctx context.Context, mnt mount.Mount) error {
-		cacheMountDir := mnt.Source // relies on our check that this is a bind mount in withCacheMount
-
-		// if there's any existing data in the cache mount, we'll just leave it alone
-		// NOTE: there's cases in which this heuristic isn't ideal, such as when a
-		// remote cache mount has "better" contents than this one, but this will suffice
-		// for now
-		dirents, err := os.ReadDir(cacheMountDir)
-		if err != nil {
-			return fmt.Errorf("failed to read cache mount dir: %w", err)
-		}
-		if len(dirents) > 0 {
-			bklog.G(ctx).Debugf("cache mount %q already has data, skipping", mc.Name)
-			return nil
-		}
-
-		fsApplier := apply.NewFileSystemApplier(&cacheMountProvider{
-			httpClient: m.httpClient,
-			url:        mc.URL,
-		})
-		_, err = fsApplier.Apply(ctx, ocispecs.Descriptor{
-			Digest:    mc.Digest,
-			Size:      mc.Size,
-			MediaType: mc.MediaType,
-		}, []mount.Mount{mnt})
-		if err != nil {
-			if removeErr := removeAllUnderDir(cacheMountDir); removeErr != nil {
-				err = errors.Join(err, fmt.Errorf("failed to empty out cache mount dir after failure %q: %w", cacheMountDir, removeErr))
-			}
-			return fmt.Errorf("failed to apply cache mount: %w", err)
-		}
-
-		bklog.G(ctx).Debugf("downloaded cache mount %s", mc.Name)
-		return nil
-	}
-
-	if syncedCacheMount.mount != nil {
-		return remoteApplierFunc(ctx, *syncedCacheMount.mount)
-	}
-
-	cacheKey := cacheKeyFromMountName(mc.Name)
-
-	return withCacheMount(ctx, m.MountManager, cacheKey, remoteApplierFunc)
-}
-
-func (m *manager) UploadCacheMounts(ctx context.Context) error {
-	return m.uploadSeenCacheMounts(ctx)
-}
-
-// uploadSeenCacheMounts uploads to object storage all cache mounts that were seen
-// whose digest is different than the one stored upstream.
-func (m *manager) uploadSeenCacheMounts(ctx context.Context) error {
-	// if seenCacheMounts is not set then are no cache mounts that should be synced
-	if m.seenCacheMounts == nil {
-		return nil
-	}
-
-	seenCacheMounts := map[string]struct{}{}
-	m.seenCacheMounts.Range(func(k any, v any) bool {
-		seenCacheMounts[k.(string)] = struct{}{}
-		return true
-	})
+	syncedCacheMounts := getCacheMountConfigResp.SyncedCacheMounts
 
 	var eg errgroup.Group
-	for cacheMountName := range seenCacheMounts {
+	for _, syncedCacheMount := range syncedCacheMounts {
+		if syncedCacheMount.URL == "" {
+			// nothing to download, have to start fresh, skip it until we sync back to cloud at shutdown
+			continue
+		}
 		eg.Go(func() error {
-			bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
-			cacheKey := cacheKeyFromMountName(cacheMountName)
-
+			bklog.G(ctx).Debugf("syncing cache mount locally %s", syncedCacheMount.Name)
+			cacheKey := cacheKeyFromMountName(syncedCacheMount.Name)
 			return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
-				// First compress the mount into the content store. We can't stream direct to S3 because we want
-				// to tell S3 the checksum of the whole thing when we open the request there. Apparently there
-				// is a way to include the checksum as a trailer, but it is poorly documented and seems to require
-				// a different streaming request type, which is giving me a headache right now. Can optimize in future.
+				cacheMountDir := mnt.Source // relies on our check that this is a bind mount in withCacheMount
 
-				// add a temporary lease so our content doesn't get pruned immediately from the store
-				ctx, done, err := leaseutil.WithLease(ctx, m.Worker.LeaseManager(), leaseutil.MakeTemporary)
+				// if there's any existing data in the cache mount, we'll just leave it alone
+				// NOTE: there's cases in which this heuristic isn't ideal, such as when a
+				// remote cache mount has "better" contents than this one, but this will suffice
+				// for now
+				dirents, err := os.ReadDir(cacheMountDir)
 				if err != nil {
-					return fmt.Errorf("failed to create lease: %w", err)
+					return fmt.Errorf("failed to read cache mount dir: %w", err)
 				}
-				defer done(ctx)
-
-				// compress the mount to a tar.zstd and write to the content store
-				contentRef := "dagger-cachemount-" + cacheMountName
-				contentWriter, err := m.Worker.ContentStore().Writer(ctx, content.WithRef(contentRef))
-				if err != nil {
-					return fmt.Errorf("failed to create content writer: %w", err)
-				}
-				defer contentWriter.Close()
-				writeBuffer := bufio.NewWriterSize(contentWriter, 1024*1024)
-				compressor, err := zstd.NewWriter(writeBuffer, zstd.WithEncoderLevel(zstd.SpeedDefault))
-				if err != nil {
-					return fmt.Errorf("failed to create compressor: %w", err)
-				}
-				defer compressor.Close()
-				// mnt.Source relies on our check that this is a bind mount in withCacheMount
-				err = archive.WriteDiff(ctx, compressor, "", mnt.Source)
-				if err != nil {
-					return fmt.Errorf("failed to write diff: %w", err)
-				}
-				if err := compressor.Close(); err != nil {
-					return fmt.Errorf("failed to close compressor: %w", err)
-				}
-				writeBuffer.Flush()
-				if err := contentWriter.Commit(ctx, 0, ""); err != nil {
-					if errors.Is(err, errdefs.ErrAlreadyExists) {
-						// we should be releasing these, but if it was already there, that's weird but fine
-						bklog.G(ctx).Debugf("cache mount %q already committed", cacheMountName)
-					} else {
-						return fmt.Errorf("failed to commit content: %w", err)
-					}
-				}
-				contentDigest := contentWriter.Digest()
-
-				// now that we have the digest we can upload from the content store to the url
-				contentReaderAt, err := m.Worker.ContentStore().ReaderAt(ctx, ocispecs.Descriptor{
-					Digest: contentDigest,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to create content reader: %w", err)
-				}
-				defer contentReaderAt.Close()
-				contentLength := contentReaderAt.Size()
-				getURLResp, err := m.cacheClient.GetCacheMountUploadURL(ctx, GetCacheMountUploadURLRequest{
-					CacheName: cacheMountName,
-					Digest:    contentDigest,
-					Size:      contentLength,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to get cache mount upload url: %w", err)
-				}
-
-				if getURLResp.Skip {
-					bklog.G(ctx).Debugf("skipped pushing cache mount %s", cacheMountName)
+				if len(dirents) > 0 {
+					bklog.G(ctx).Debugf("cache mount %q already has data, skipping", syncedCacheMount.Name)
 					return nil
 				}
 
-				contentReader := io.NewSectionReader(contentReaderAt, 0, contentLength)
-				httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, getURLResp.URL, contentReader)
+				fsApplier := apply.NewFileSystemApplier(&cacheMountProvider{
+					httpClient: m.httpClient,
+					url:        syncedCacheMount.URL,
+				})
+				_, err = fsApplier.Apply(ctx, ocispecs.Descriptor{
+					Digest:    syncedCacheMount.Digest,
+					Size:      syncedCacheMount.Size,
+					MediaType: syncedCacheMount.MediaType,
+				}, []mount.Mount{mnt})
 				if err != nil {
-					return fmt.Errorf("failed to create http request: %w", err)
-				}
-				httpReq.ContentLength = contentLength // set it here, go stdlib will ignore if set on Header (??!!)
-				for k, v := range getURLResp.Headers {
-					httpReq.Header.Set(k, v)
-				}
-				resp, err := m.httpClient.Do(httpReq)
-				if err != nil {
-					return fmt.Errorf("failed to upload cache mount: %w", err)
-				}
-				defer resp.Body.Close()
-				if resp.StatusCode != http.StatusOK {
-					return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
+					if removeErr := removeAllUnderDir(cacheMountDir); removeErr != nil {
+						err = errors.Join(err, fmt.Errorf("failed to empty out cache mount dir after failure %q: %w", cacheMountDir, removeErr))
+					}
+					return fmt.Errorf("failed to apply cache mount: %w", err)
 				}
 
-				bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
+				bklog.G(ctx).Debugf("synced cache mount locally %s", syncedCacheMount.Name)
 				return nil
 			})
 		})
 	}
-	return eg.Wait()
+	err = eg.Wait()
+	if err != nil {
+		return err
+	}
+
+	m.stopCacheMountSync = func(ctx context.Context) error {
+		var eg errgroup.Group
+
+		seenCacheMounts := map[string]struct{}{}
+		core.SeenCacheKeys.Range(func(k any, v any) bool {
+			seenCacheMounts[k.(string)] = struct{}{}
+			return true
+		})
+
+		for cacheMountName := range seenCacheMounts {
+			eg.Go(func() error {
+				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
+				cacheKey := cacheKeyFromMountName(cacheMountName)
+
+				return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
+					// First compress the mount into the content store. We can't stream direct to S3 because we want
+					// to tell S3 the checksum of the whole thing when we open the request there. Apparently there
+					// is a way to include the checksum as a trailer, but it is poorly documented and seems to require
+					// a different streaming request type, which is giving me a headache right now. Can optimize in future.
+
+					// add a temporary lease so our content doesn't get pruned immediately from the store
+					ctx, done, err := leaseutil.WithLease(ctx, m.Worker.LeaseManager(), leaseutil.MakeTemporary)
+					if err != nil {
+						return fmt.Errorf("failed to create lease: %w", err)
+					}
+					defer done(ctx)
+
+					// compress the mount to a tar.zstd and write to the content store
+					contentRef := "dagger-cachemount-" + cacheMountName
+					contentWriter, err := m.Worker.ContentStore().Writer(ctx, content.WithRef(contentRef))
+					if err != nil {
+						return fmt.Errorf("failed to create content writer: %w", err)
+					}
+					defer contentWriter.Close()
+					writeBuffer := bufio.NewWriterSize(contentWriter, 1024*1024)
+					compressor, err := zstd.NewWriter(writeBuffer, zstd.WithEncoderLevel(zstd.SpeedDefault))
+					if err != nil {
+						return fmt.Errorf("failed to create compressor: %w", err)
+					}
+					defer compressor.Close()
+					// mnt.Source relies on our check that this is a bind mount in withCacheMount
+					err = archive.WriteDiff(ctx, compressor, "", mnt.Source)
+					if err != nil {
+						return fmt.Errorf("failed to write diff: %w", err)
+					}
+					if err := compressor.Close(); err != nil {
+						return fmt.Errorf("failed to close compressor: %w", err)
+					}
+					writeBuffer.Flush()
+					if err := contentWriter.Commit(ctx, 0, ""); err != nil {
+						if errors.Is(err, errdefs.ErrAlreadyExists) {
+							// we should be releasing these, but if it was already there, that's weird but fine
+							bklog.G(ctx).Debugf("cache mount %q already committed", cacheMountName)
+						} else {
+							return fmt.Errorf("failed to commit content: %w", err)
+						}
+					}
+					contentDigest := contentWriter.Digest()
+
+					// now that we have the digest we can upload from the content store to the url
+					contentReaderAt, err := m.Worker.ContentStore().ReaderAt(ctx, ocispecs.Descriptor{
+						Digest: contentDigest,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to create content reader: %w", err)
+					}
+					defer contentReaderAt.Close()
+					contentLength := contentReaderAt.Size()
+					getURLResp, err := m.cacheClient.GetCacheMountUploadURL(ctx, GetCacheMountUploadURLRequest{
+						CacheName: cacheMountName,
+						Digest:    contentDigest,
+						Size:      contentLength,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to get cache mount upload url: %w", err)
+					}
+
+					if getURLResp.Skip {
+						bklog.G(ctx).Debugf("skipped pushing cache mount %s", cacheMountName)
+						return nil
+					}
+
+					contentReader := io.NewSectionReader(contentReaderAt, 0, contentLength)
+					httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, getURLResp.URL, contentReader)
+					if err != nil {
+						return fmt.Errorf("failed to create http request: %w", err)
+					}
+					httpReq.ContentLength = contentLength // set it here, go stdlib will ignore if set on Header (??!!)
+					for k, v := range getURLResp.Headers {
+						httpReq.Header.Set(k, v)
+					}
+					resp, err := m.httpClient.Do(httpReq)
+					if err != nil {
+						return fmt.Errorf("failed to upload cache mount: %w", err)
+					}
+					defer resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
+					}
+
+					bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
+					return nil
+				})
+			})
+		}
+		return eg.Wait()
+	}
+
+	return nil
 }
 
-// cacheKeyFromMountName is a copy of core.NewCache().Sum(). This is because
-// we cannot import `core` here without creating an import cycle:
-// - engine/buildkit imports cache
-//   - cache imports core
-//   - core imports engine/buildkit
 func cacheKeyFromMountName(name string) string {
-	hash := sha256.New()
-	_, _ = hash.Write([]byte(name + "\x00"))
-	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	// Turn the human-readable name into the key we use internally
+	// NOTE: this will be problematic if backwards incompatible changes are made
+	// to the key format and client<->server are out of sync. That's a general
+	// problem though too, so just accepting it for now.
+	return core.NewCache(name).Sum()
 }
 
 func withCacheMount(ctx context.Context, mountManager *mounts.MountManager, cacheKey string, cb func(ctx context.Context, mnt mount.Mount) error) error {


### PR DESCRIPTION
This reverts commit f2c5dc5d2908ecbafaf6dbe4c5663791161a40a8. The main reason why we're revering #8323 is because some strange behaviors that we haven't had the time to test and we prefer to take this out of the upcoming release so we can take the proper time to diagnose.