### PR TITLE
fix duration scrubber for golden tests

### DIFF
--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -30,6 +30,7 @@ import (
 	"gotest.tools/v3/golden"
 
 	"dagger.io/dagger/telemetry"
+
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/slog"
@@ -262,7 +263,7 @@ var scrubs = []scrubber{
 	},
 	// Durations
 	{
-		regexp.MustCompile(`\b(\d+m)?\d+\.\d+s\b`),
+		regexp.MustCompile(`\b(\d+m)?\d+(\.\d+)?s\b`),
 		"1m2.345s",
 		"X.Xs",
 	},


### PR DESCRIPTION
The previous version was able to catch things like:
 - `1m2.345s`
 - `12.34s`

But wasn't able to catch:
 - `1m23s`

But it looks like it happens, sometimes:

```
+++ actual
@@ -11,7 +11,7 @@
 │ ✔ starting session X.Xs

-✔ load module X.Xs
+✔ load module 1m13s
 │ ✔ finding module configuration X.Xs
-│ ✔ initializing module X.Xs
+│ ✔ initializing module 1m12s
 │ ✔ inspecting module metadata X.Xs
 │ ✔ loading type definitions X.X
```

For instance: https://v3.dagger.cloud/dagger/traces/d3cd71a1531096b0071621d896b3ebe6?span=f3e3b1f9b2b1f4aa&logs#f3e3b1f9b2b1f4aa