### PR TITLE
Cache function calls per-client to avoid duped telemetry 

### DIFF
--- a/core/cachekey.go
+++ b/core/cachekey.go
@@ -1,4 +1,4 @@
-package schema
+package core
 
 import (
 	"context"
@@ -18,8 +18,12 @@ const (
 // CachePerClient is a CacheKeyFunc that scopes the cache key to the client by mixing in the client ID to the original digest of the operation.
 // It should be used when the operation should be run for each client, but not more than once for a given client.
 // Canonical examples include loading client filesystem data or referencing client-side sockets/ports.
-func CachePerClient[P dagql.Typed, A any](ctx context.Context, _ dagql.Instance[P], _ A, origDgst digest.Digest) (digest.Digest, error) {
-	// scope the cache key to the client by mixing in the client ID to the original digest
+func CachePerClient[P dagql.Typed, A any](ctx context.Context, inst dagql.Instance[P], args A, origDgst digest.Digest) (digest.Digest, error) {
+	return CachePerClientObject(ctx, inst, args, origDgst)
+}
+
+// CachePerClientObject is the same as CachePerClient but when you have a dagql.Object instead of a dagql.Instance.
+func CachePerClientObject[A any](ctx context.Context, _ dagql.Object, _ A, origDgst digest.Digest) (digest.Digest, error) {
 	clientMD, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get client metadata: %w", err)
@@ -27,10 +31,10 @@ func CachePerClient[P dagql.Typed, A any](ctx context.Context, _ dagql.Instance[
 	if clientMD.ClientID == "" {
 		return "", fmt.Errorf("client ID not found in context")
 	}
-	return hashFrom(origDgst.String(), clientMD.ClientID), nil
+	return HashFrom(origDgst.String(), clientMD.ClientID), nil
 }
 
-func hashFrom(ins ...string) digest.Digest {
+func HashFrom(ins ...string) digest.Digest {
 	h := xxh3.New()
 	for _, in := range ins {
 		h.WriteString(in)

--- a/core/interface.go
+++ b/core/interface.go
@@ -340,6 +340,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 		func(ctx context.Context, self dagql.Object, args map[string]dagql.Input) (dagql.Typed, error) {
 			return iface.ConvertFromSDKResult(ctx, args["id"])
 		},
+		nil,
 	)
 
 	return nil

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -188,6 +188,7 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context) (
 						IfaceType:      ifaceType,
 					}, nil
 				},
+				CachePerClientObject,
 			)
 		}
 	}

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -52,7 +52,7 @@ func (s *cacheSchema) cacheVolumeCacheKey(ctx context.Context, parent dagql.Inst
 		return "", err
 	}
 
-	return hashFrom(origDgst.String(), namespaceKey), nil
+	return core.HashFrom(origDgst.String(), namespaceKey), nil
 }
 
 func (s *cacheSchema) cacheVolume(ctx context.Context, parent dagql.Instance[*core.Query], args cacheArgs) (dagql.Instance[*core.CacheVolume], error) {

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -143,17 +143,17 @@ func (s *hostSchema) Install() {
 	dagql.Fields[*core.Host]{
 		// NOTE: (for near future) we can support force reloading by adding a new arg to this function and providing
 		// a custom cache key function that uses a random value when that arg is true.
-		dagql.NodeFuncWithCacheKey("directory", s.directory, CachePerClient).
+		dagql.NodeFuncWithCacheKey("directory", s.directory, core.CachePerClient).
 			Doc(`Accesses a directory on the host.`).
 			ArgDoc("path", `Location of the directory to access (e.g., ".").`).
 			ArgDoc("exclude", `Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`).
 			ArgDoc("include", `Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
 
-		dagql.FuncWithCacheKey("file", s.file, CachePerClient).
+		dagql.FuncWithCacheKey("file", s.file, core.CachePerClient).
 			Doc(`Accesses a file on the host.`).
 			ArgDoc("path", `Location of the file to retrieve (e.g., "README.md").`),
 
-		dagql.FuncWithCacheKey("unixSocket", s.socket, CachePerClient).
+		dagql.FuncWithCacheKey("unixSocket", s.socket, core.CachePerClient).
 			Doc(`Accesses a Unix socket on the host.`).
 			ArgDoc("path", `Location of the Unix socket (e.g., "/var/run/docker.sock").`),
 
@@ -177,7 +177,7 @@ func (s *hostSchema) Install() {
 				is false, each port maps to a random port chosen by the host.`,
 				`If ports are given and native is true, the ports are additive.`),
 
-		dagql.FuncWithCacheKey("service", s.service, CachePerClient).
+		dagql.FuncWithCacheKey("service", s.service, core.CachePerClient).
 			Doc(`Creates a service that forwards traffic to a specified address via the host.`).
 			ArgDoc("ports",
 				`Ports to expose via the service, forwarding through the host network.`,
@@ -190,7 +190,7 @@ func (s *hostSchema) Install() {
 		dagql.Func("__internalService", s.internalService).
 			Doc(`(Internal-only) "service" but scoped to the exact right buildkit session ID.`),
 
-		dagql.FuncWithCacheKey("setSecretFile", s.setSecretFile, CachePerClient).
+		dagql.FuncWithCacheKey("setSecretFile", s.setSecretFile, core.CachePerClient).
 			Doc(
 				`Sets a secret given a user-defined name and the file path on the host,
 				and returns the secret.`,

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -57,7 +57,7 @@ func (s *moduleSchema) Install() {
 			ArgDoc("line", "The line number within the filename.").
 			ArgDoc("column", "The column number within the line."),
 
-		dagql.FuncWithCacheKey("currentModule", s.currentModule, CachePerClient).
+		dagql.FuncWithCacheKey("currentModule", s.currentModule, core.CachePerClient).
 			Doc(`The module currently being served in the session, if any.`),
 
 		dagql.Func("currentTypeDefs", s.currentTypeDefs).
@@ -66,7 +66,7 @@ func (s *moduleSchema) Install() {
 			Impure("Can change when modules are loaded into the schema.").
 			Doc(`The TypeDef representations of the objects currently being served in the session.`),
 
-		dagql.FuncWithCacheKey("currentFunctionCall", s.currentFunctionCall, CachePerClient).
+		dagql.FuncWithCacheKey("currentFunctionCall", s.currentFunctionCall, core.CachePerClient).
 			Doc(`The FunctionCall context that the SDK caller is currently executing in.`,
 				`If the caller is not currently executing in a function, this will
 				return an error.`),
@@ -86,10 +86,10 @@ func (s *moduleSchema) Install() {
 	}.Install(s.dag)
 
 	dagql.Fields[*core.FunctionCall]{
-		dagql.FuncWithCacheKey("returnValue", s.functionCallReturnValue, CachePerClient).
+		dagql.FuncWithCacheKey("returnValue", s.functionCallReturnValue, core.CachePerClient).
 			Doc(`Set the return value of the function call to the provided value.`).
 			ArgDoc("value", `JSON serialization of the return value.`),
-		dagql.FuncWithCacheKey("returnError", s.functionCallReturnError, CachePerClient).
+		dagql.FuncWithCacheKey("returnError", s.functionCallReturnError, core.CachePerClient).
 			Doc(`Return an error from the function.`).
 			ArgDoc("error", `The error to return.`),
 	}.Install(s.dag)
@@ -166,13 +166,13 @@ func (s *moduleSchema) Install() {
 			Doc(`Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation`).
 			ArgDoc("engineVersion", `The engine version to upgrade to.`),
 
-		dagql.FuncWithCacheKey("resolveFromCaller", s.moduleSourceResolveFromCaller, CachePerClient).
+		dagql.FuncWithCacheKey("resolveFromCaller", s.moduleSourceResolveFromCaller, core.CachePerClient).
 			Doc(`Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.`),
 
-		dagql.FuncWithCacheKey("resolveContextPathFromCaller", s.moduleSourceResolveContextPathFromCaller, CachePerClient).
+		dagql.FuncWithCacheKey("resolveContextPathFromCaller", s.moduleSourceResolveContextPathFromCaller, core.CachePerClient).
 			Doc(`The path to the module source's context directory on the caller's filesystem. Only valid for local sources.`),
 
-		dagql.FuncWithCacheKey("resolveDirectoryFromCaller", s.moduleSourceResolveDirectoryFromCaller, CachePerClient).
+		dagql.FuncWithCacheKey("resolveDirectoryFromCaller", s.moduleSourceResolveDirectoryFromCaller, core.CachePerClient).
 			ArgDoc("path", `The path on the caller's filesystem to load.`).
 			ArgDoc("viewName", `If set, the name of the view to apply to the path.`).
 			ArgDoc("ignore", `Patterns to ignore when loading the directory.`).
@@ -256,13 +256,13 @@ func (s *moduleSchema) Install() {
 		dagql.Func("source", s.currentModuleSource).
 			Doc(`The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).`),
 
-		dagql.FuncWithCacheKey("workdir", s.currentModuleWorkdir, CachePerClient).
+		dagql.FuncWithCacheKey("workdir", s.currentModuleWorkdir, core.CachePerClient).
 			Doc(`Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.`).
 			ArgDoc("path", `Location of the directory to access (e.g., ".").`).
 			ArgDoc("exclude", `Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`).
 			ArgDoc("include", `Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
 
-		dagql.FuncWithCacheKey("workdirFile", s.currentModuleWorkdirFile, CachePerClient).
+		dagql.FuncWithCacheKey("workdirFile", s.currentModuleWorkdirFile, core.CachePerClient).
 			Doc(`Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.`).
 			ArgDoc("path", `Location of the file to retrieve (e.g., "README.md").`),
 	}.Install(s.dag)

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -175,6 +175,7 @@ func isIntrospection(id *call.ID) bool {
 	if id.Receiver() == nil {
 		switch id.Field() {
 		case "__schema",
+			"__schemaJSONFile",
 			"__schemaVersion",
 			"currentTypeDefs",
 			"currentFunctionCall",

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -77,15 +77,6 @@ func (fn *Function) FieldSpec() (dagql.FieldSpec, error) {
 		Name:        fn.Name,
 		Description: formatGqlDescription(fn.Description),
 		Type:        fn.ReturnType.ToTyped(),
-
-		// NB: functions actually _are_ cached per-session, which matches the
-		// lifetime of the server, so we might as well consider them pure. That way
-		// there will be locking around concurrent calls, so the user won't see
-		// multiple in parallel.
-		//
-		// However, we can't *quite* mark them as pure, since Call has special
-		// logic for transferring secrets between cached calls.
-		ImpurityReason: "secrets still need transferring on cached calls",
 	}
 	for _, arg := range fn.Args {
 		input := arg.TypeDef.ToInput()

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -244,6 +244,7 @@ func (s *Server) installObject(class ObjectType) {
 				}
 				return res, nil
 			},
+			nil,
 		)
 	}
 }

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"golang.org/x/exp/constraints"
 
@@ -47,7 +48,8 @@ type ObjectType interface {
 	//
 	// Unlike natively added fields, the extended func is limited to the external
 	// Object interface.
-	Extend(spec FieldSpec, fun FieldFunc)
+	// cacheKeyFun is optional, if not set the default dagql ID cache key will be used.
+	Extend(spec FieldSpec, fun FieldFunc, cacheKeyFun FieldCacheKeyFunc)
 }
 
 type IDType interface {
@@ -59,6 +61,11 @@ type IDType interface {
 // FieldFunc is a function that implements a field on an object while limited
 // to the object's external interface.
 type FieldFunc func(context.Context, Object, map[string]Input) (Typed, error)
+
+// FieldCacheKeyFunc is a function that computes a cache key for a field on an object. The cache key
+// will be used to cache the result of the field call in dagql's cache and serve as the digest of the
+// call's ID.
+type FieldCacheKeyFunc func(context.Context, Object, map[string]Input, digest.Digest) (digest.Digest, error)
 
 type IDable interface {
 	// ID returns the ID of the value.


### PR DESCRIPTION
We previously needed to make function calls impure to handle various
corner cases around Secrets (covered by TestModule/TestSecretNested) in #8358.

However, recently sometime this resulted in us getting duped telemetry
output for calls. It makes sense in that a call may often get
re-evaluated (i.e. it's a base image for multiple vtxs in a DAG). It's
not clear why this only started happening recently though.

Either way, we can fix it by having function calls be cached per-client
via a custom cache key func.

This fixes duped output as repro'd by running:
```
dagger -m github.com/vito/bass call integration --runtime Buildkit
```
* Previously you'd see multiple apko->wolfi outputs appear, now it only
  shows up once as expected.

But keeping the caching per-client rather than fully cached allows us to
still handle the corner cases around Secrets.
* In the long run we'll need to re-arrange how secret transfer works
  (secret providers help a lot here) but this fix should suffice for
  now to at least avoid duped output.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

---

Snuck in an extra quick fix as a separate commit too: [hide __schemaJSONFile from telemetry](https://github.com/dagger/dagger/commit/2212ae30a7640d66a907809103865c662d9f3f80)