### PR TITLE
ci: fix macos install docker step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
         shell: bash
 
       - name: "Install Docker"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.14
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.16
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,10 +77,9 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
       - name: "Report"
         if: always()
-        redirect: $GITHUB_STEP_SUMMARY
         run: |
           REPORT="/tmp/release-report"
-          cat $REPORT
+          cat $REPORT | tee $GITHUB_STEP_SUMMARY
           if grep -q "[!CAUTION]" "$REPORT"; then
             # workaround for https://github.com/dagger/dagger/issues/8421
             exit 1


### PR DESCRIPTION
v16 of the action we're using has a fix for the error we're seeing on main https://github.com/dagger/dagger/actions/runs/13067469981/job/36462427359:

```
Updating Homebrew
  Error: Unknown option: --preinstall
  Usage: brew update, up [options]
  
  Fetch the newest version of Homebrew and all formulae from GitHub using git(1)
  and perform any necessary migrations.
  
        --merge                      Use git merge to apply updates (rather than
                                     git rebase).
        --auto-update                Run on auto-updates (e.g. before brew
                                     install). Skips some slower steps.
    -f, --force                      Always do a slower, full update check (even
                                     if unnecessary).
    -q, --quiet                      Make some output more quiet.
    -v, --verbose                    Print the directories checked and git
                                     operations performed.
    -d, --debug                      Display a trace of all shell commands as they
                                     are executed.
    -h, --help                       Show this message.
```

The fix is in https://github.com/douglascamata/setup-docker-macos-action/compare/v1-alpha.15...v1-alpha.16.