### PR TITLE
feat: expose dagger codegen binary in dagger module engine container

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -239,6 +239,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 	}
 	bins := []binAndPath{
 		{path: consts.EngineServerPath, file: build.engineBinary(build.race)},
+		{path: consts.CodegenBinaryPath, file: build.CodegenBinary()},
 		{path: "/usr/bin/dial-stdio", file: build.dialstdioBinary()},
 		{path: "/opt/cni/bin/dnsname", file: build.dnsnameBinary()},
 		{path: consts.RuncPath, file: build.runcBin()},

--- a/.dagger/consts/versions.go
+++ b/.dagger/consts/versions.go
@@ -4,6 +4,7 @@ import "github.com/dagger/dagger/engine/distconsts"
 
 const (
 	EngineServerPath = "/usr/local/bin/dagger-engine"
+	CodegenBinaryPath = "/usr/local/bin/dagger-codegen"
 	RuncPath         = distconsts.RuncPath
 	DaggerInitPath   = distconsts.DaggerInitPath
 )


### PR DESCRIPTION
See my [message on Dagger Discord](https://discord.com/channels/707636530424053791/1334842695633473536/1334842695633473536).

Demo

```shell
# Checkout to my PR
dagger shell

⋈ engine | container | with-exec usr/local/bin/dagger-codegen help  | stdout
Usage:
  codegen [flags]
  codegen [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  introspect

Flags:
  -h, --help                             help for codegen
      --introspection-json-path string   optional path to file containing pre-computed graphql introspection JSON
      --lang string                      language to generate (default "go")
      --merge                            merge module deps with project's
      --module-context-path string       path to context directory of the module
      --module-name string               name of module to generate code for
  -o, --output string                    output directory (default ".")

Use "codegen [command] --help" for more information about a command.
```