### PR TITLE
obs: add spans for go/module sdk runtime and codegen methods

### DIFF
--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"dagger.io/dagger/telemetry"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/dagger/dagger/core"
@@ -243,7 +244,9 @@ func (s *moduleSchema) newModuleSDK(
 }
 
 // Codegen calls the Codegen function on the SDK Module
-func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.GeneratedCode, error) {
+func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (_ *core.GeneratedCode, rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: run codegen")
+	defer telemetry.End(span, func() error { return rerr })
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdk.mod.Self.Name(), err)
@@ -270,7 +273,9 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source da
 }
 
 // Runtime calls the Runtime function on the SDK Module
-func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.Container, error) {
+func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (_ *core.Container, rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: load runtime")
+	defer telemetry.End(span, func() error { return rerr })
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.Self.Name(), err)
@@ -402,7 +407,9 @@ func (sdk *goSDK) Codegen(
 	ctx context.Context,
 	deps *core.ModDeps,
 	source dagql.Instance[*core.ModuleSource],
-) (*core.GeneratedCode, error) {
+) (_ *core.GeneratedCode, rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "go SDK: run codegen")
+	defer telemetry.End(span, func() error { return rerr })
 	ctr, err := sdk.baseWithCodegen(ctx, deps, source)
 	if err != nil {
 		return nil, err
@@ -442,7 +449,9 @@ func (sdk *goSDK) Runtime(
 	ctx context.Context,
 	deps *core.ModDeps,
 	source dagql.Instance[*core.ModuleSource],
-) (*core.Container, error) {
+) (_ *core.Container, rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "go SDK: load runtime")
+	defer telemetry.End(span, func() error { return rerr })
 	ctr, err := sdk.baseWithCodegen(ctx, deps, source)
 	if err != nil {
 		return nil, err

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/viztest/broken/broken
@@ -19,10 +19,12 @@ Expected stderr:
 │ │ │ ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 │ │ │ │ ✔ initialize dependencies X.Xs
 │ │ │ │ ✔ build module X.Xs
-│ │ │ │ │ ✘ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs
-│ │ │ │ │ ┃ # dagger/broken
-│ │ │ │ │ ┃ ./main.go:6:6: undefined: ctx
-│ │ │ │ │ ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
+│ │ │ │ │ ✔ go SDK: run codegen X.Xs
+│ │ │ │ │ ✔ go SDK: load runtime X.Xs
+│ │ │ │ │ │ ✘ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs
+│ │ │ │ │ │ ┃ # dagger/broken
+│ │ │ │ │ │ ┃ ./main.go:6:6: undefined: ctx
+│ │ │ │ │ │ ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 │ │ ✘ .initialize: Module! X.Xs
 │ │ ! failed to initialize module: failed to call module "broken" to get functions: call constructor: process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 


### PR DESCRIPTION
if you're digging on SDK/module init performance, these spans make it much harder to get confused about which step you're in, and child spans of these steps dominate module init runtime and look similar --- you'll see the codegen binary invoked by the go SDK and then again by your module SDK, for example. 

These spans also make it very clear where Codegen ends and Runtime begins, which can be confusing bc at least in for ts, the tail end of codegen installs runtime dependencies like corepack, and in a flat trace the corepack download looks like it could be part of either SDK interface method.

I'm open to suggestions on other places one might add spans to make these steps clearer.