### PR TITLE
Use less `engine.toml`

### DIFF
--- a/.changes/unreleased/Breaking-20250205-162857.yaml
+++ b/.changes/unreleased/Breaking-20250205-162857.yaml
@@ -1,0 +1,7 @@
+kind: Breaking
+body: |
+    To match automatic configuration, `insecure-entitlements` now includes `security.insecure` when configuring the engine manually.
+time: 2025-02-05T16:28:57.336211843Z
+custom:
+    Author: jedevc
+    PR: "9513"

--- a/.dagger/mage/engine.go
+++ b/.dagger/mage/engine.go
@@ -45,15 +45,15 @@ func (t Engine) Dev(ctx context.Context) error {
 	}
 
 	gpuSupport := os.Getenv(util.GPUSupportEnvName) != ""
-	trace := os.Getenv(util.TraceEnvName) != ""
 	race := os.Getenv(util.RaceEnvName) != ""
+	logLevel := os.Getenv(util.LogLevelEnvName)
 
 	args := []string{"dev-export", "--platform=" + platforms.DefaultString()}
 	if gpuSupport {
 		args = append(args, "--experimental-gpu-support=true")
 	}
-	if trace {
-		args = append(args, "--trace=true")
+	if logLevel != "" {
+		args = append(args, "--log-level="+logLevel)
 	}
 	if race {
 		args = append(args, "--race=true")

--- a/.dagger/mage/util/const.go
+++ b/.dagger/mage/util/const.go
@@ -7,6 +7,6 @@ const (
 	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
 	GPUSupportEnvName  = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
 
-	TraceEnvName = "TRACE"
-	RaceEnvName  = "RACE"
+	RaceEnvName     = "RACE"
+	LogLevelEnvName = "LOG_LEVEL"
 )

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -272,7 +272,7 @@ func (dev *DaggerDev) DevExport(
 	// +optional
 	race bool,
 	// +optional
-	trace bool,
+	logLevel string,
 
 	// Set target distro
 	// +optional
@@ -296,8 +296,8 @@ func (dev *DaggerDev) DevExport(
 	if race {
 		engine = engine.WithRace()
 	}
-	if trace {
-		engine = engine.WithTrace()
+	if logLevel != "" {
+		engine = engine.WithLogLevel(logLevel)
 	}
 	enginePlatformSpec := platformSpec
 	enginePlatformSpec.OS = "linux"

--- a/.dagger/test.go
+++ b/.dagger/test.go
@@ -296,13 +296,9 @@ func (t *Test) goTest(
 
 func (t *Test) testCmd(ctx context.Context) (*dagger.Container, error) {
 	engine := t.Dagger.Engine().
-		WithConfig(`registry."registry:5000"`, `http = true`).
-		WithConfig(`registry."privateregistry:5000"`, `http = true`).
-		WithConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`).
-		WithConfig(`grpc`, `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).
-		WithArg(`network-name`, `dagger-dev`).
-		WithArg(`network-cidr`, `10.88.0.0/16`).
-		WithArg(`debugaddr`, `0.0.0.0:6060`)
+		WithBuildkitConfig(`registry."registry:5000"`, `http = true`).
+		WithBuildkitConfig(`registry."privateregistry:5000"`, `http = true`).
+		WithBuildkitConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`)
 	devEngine, err := engine.Container(ctx, "", nil, false)
 	if err != nil {
 		return nil, err
@@ -334,6 +330,12 @@ func (t *Test) testCmd(ctx context.Context) (*dagger.Container, error) {
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume("dagger-dev-engine-test-state"+identity.NewID())).
 		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{
+				"--addr", "tcp://0.0.0.0:1234",
+				"--network-name", "dagger-dev",
+				"--network-cidr", "10.88.0.0/16",
+				"--debugaddr", "0.0.0.0:6060",
+			},
 			UseEntrypoint:            true,
 			InsecureRootCapabilities: true,
 		})

--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -43,9 +43,8 @@ func setDefaultBuildkitConfig(cfg *bkconfig.Config, netConf *networkConfig) {
 		cfg.Root = distconsts.EngineDefaultStateDir
 	}
 
-	if len(cfg.GRPC.Address) == 0 {
-		cfg.GRPC.Address = []string{appdefaults.Address}
-	}
+	// always include default address
+	cfg.GRPC.Address = append([]string{appdefaults.Address}, cfg.GRPC.Address...)
 
 	isTrue := true
 	cfg.Workers.OCI.Enabled = &isTrue

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -381,21 +381,6 @@ func main() { //nolint:gocyclo
 			os.RemoveAll(lockPath)
 		}()
 
-		ents := c.GlobalStringSlice("allow-insecure-entitlement")
-		if len(ents) > 0 {
-			bkcfg.Entitlements = []string{}
-			for _, e := range ents {
-				switch e {
-				case "security.insecure":
-					bkcfg.Entitlements = append(bkcfg.Entitlements, e)
-				case "network.host":
-					bkcfg.Entitlements = append(bkcfg.Entitlements, e)
-				default:
-					return fmt.Errorf("invalid entitlement : %s", e)
-				}
-			}
-		}
-
 		bklog.G(ctx).Debug("creating engine server")
 		srv, err := server.NewServer(ctx, &server.NewServerOpts{
 			Name:           engineName,

--- a/docs/current_docs/configuration/engine.mdx
+++ b/docs/current_docs/configuration/engine.mdx
@@ -175,13 +175,13 @@ To disable the use of `insecureRootCapabilities`:
 
 </TabItem>
 <TabItem value="engine.toml">
-To explicitly enable the use of `insecureRootCapabilities`:
+To explicitly enable the use of `insecureRootCapabilities` (the default):
 
 ```toml
 insecure-entitlements = ["security.insecure"]
 ```
 
-To disable the use of `insecureRootCapabilities`:
+To disable the use of `insecureRootCapabilities`, explicitly set `insecure-entitlements` to the empty array:
 
 ```toml
 insecure-entitlements = []

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	GC GCConfig `json:"gc,omitempty"`
 
 	// Security allows configuring various security settings for the engine.
-	Security Security `json:"security,omitempty"`
+	Security *Security `json:"security,omitempty"`
 }
 
 type LogLevel string


### PR DESCRIPTION
This PR has a little collection of fixes:
- Avoid use of `engine.toml` for our own CI *where possible* (it's still needed for configuring registries now, patch incoming for that soon hopefully).
- Simplifies our own CIs construction of engine config + args.
- Fixes https://github.com/dagger/dagger/issues/9009 by requiring `security.insecure` to explicitly be *unset* if it's not being used.