### PR TITLE
ci: Add alternative CI Runners 4

### DIFF
--- a/.github/workflows/_dagger_on_x1_nvme.yml
+++ b/.github/workflows/_dagger_on_x1_nvme.yml
@@ -1,4 +1,4 @@
-name: Dagger with Magicache
+name: Dagger on Experimental NVMe
 
 on:
   workflow_call:
@@ -12,11 +12,14 @@ on:
         type: number
         default: 10
         required: false
+      nvme:
+        description: "NVMe instance"
+        type: number
+        default: 1
 jobs:
-  remote-dagger-engine:
+  remote-dagger-engine-nvme:
     if: ${{ github.repository == 'dagger/dagger' }}
-    runs-on:
-        - 'dagger-g3-v0-15-3-16c-st-magic'
+    runs-on: dagger-x1-v0-15-3-16c-nvme-${{ inputs.nvme }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/_dagger_on_x1_tmpfs.yml
+++ b/.github/workflows/_dagger_on_x1_tmpfs.yml
@@ -1,4 +1,4 @@
-name: Dagger with Magicache
+name: Dagger on Experimental TMPFS
 
 on:
   workflow_call:
@@ -13,10 +13,9 @@ on:
         default: 10
         required: false
 jobs:
-  remote-dagger-engine:
+  remote-dagger-engine-tmpfs:
     if: ${{ github.repository == 'dagger/dagger' }}
-    runs-on:
-        - 'dagger-g3-v0-15-3-16c-st-magic'
+    runs-on: dagger-x1-v0-15-3-16c-tmpfs-1
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/alternative-ci-runners-4.yml
+++ b/.github/workflows/alternative-ci-runners-4.yml
@@ -1,0 +1,50 @@
+name: Alternative CI Runners 4
+
+on:
+  # Run the workflow every day TWICE:
+  # 1. 9:06AM UTC (low activity)
+  # 2. 9:26AM UTC (cache test - high chance of no code changes)
+  schedule:
+    - cron: "6,26 9 * * *"
+  # Enable manual trigger for on-demand runs - helps when debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-lint-on-x1-nvme:
+    uses: ./.github/workflows/_dagger_on_x1_nvme.yml
+    with:
+      function: docs lint
+      timeout: 20
+      nvme: 1
+
+  test-cli-engine-on-x1-nvme:
+    needs: docs-lint-on-x1-nvme
+    uses: ./.github/workflows/_dagger_on_x1_nvme.yml
+    with:
+      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
+      timeout: 20
+      nvme: 1
+
+  sdk-go-on-x1-nvme:
+    needs: docs-lint-on-x1-nvme
+    uses: ./.github/workflows/_dagger_on_x1_nvme.yml
+    with:
+      function: check --targets=sdk/go
+      nvme: 2
+
+  sdk-python-on-x1-nvme:
+    needs: docs-lint-on-x1-nvme
+    uses: ./.github/workflows/_dagger_on_x1_nvme.yml
+    with:
+      function: check --targets=sdk/python
+      nvme: 3
+
+  sdk-typescript-on-x1-nvme:
+    needs: docs-lint-on-x1-nvme
+    uses: ./.github/workflows/_dagger_on_x1_nvme.yml
+    with:
+      function: check --targets=sdk/typescript
+      nvme: 4

--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -6,6 +6,7 @@ on:
       - "Alternative CI Runners 1"
       - "Alternative CI Runners 2"
       - "Alternative CI Runners 3"
+      - "Alternative CI Runners 4"
       - "Benchmark"
       - "daggerverse-preview"
       - "docs"


### PR DESCRIPTION
Experimental (X1) runners on always-on infrastructure:
- CPU: EPYC 9454P
- MEM: 256GB DDR5 ECC
- NVMe: MZQL21T9HCJR-00A07
- NET: 10G