### PR TITLE
ci: fix report filtering

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           REPORT="/tmp/release-report"
           cat $REPORT | tee $GITHUB_STEP_SUMMARY
-          if grep -q "[!CAUTION]" "$REPORT"; then
+          if grep -q '\[!CAUTION\]' "$REPORT"; then
             # workaround for https://github.com/dagger/dagger/issues/8421
             exit 1
           fi

--- a/releaser/report.md.tmpl
+++ b/releaser/report.md.tmpl
@@ -1,7 +1,7 @@
 # Dagger {{ with .Version -}}
     [{{ . }}](https://github.com/dagger/dagger/releases/tag/{{ . }})
 {{- else -}}
-    [`{{ .Ref }}` (`{{ .Commit }}`])(https://github.com/dagger/dagger/commit/{{ .Commit }})
+    [`{{ .Ref }}` (`{{ .Commit }}`)](https://github.com/dagger/dagger/commit/{{ .Commit }})
 {{- end }}
 
 *Ran at {{ .Date }}*


### PR DESCRIPTION
Oops, https://github.com/dagger/dagger/actions/runs/13177476543/job/36780091370.

Looks like the grep expression wasn't right.

The report looks mostly nice though (also pushed a fix to tidy up the link header formatting):

![image](https://github.com/user-attachments/assets/10d05035-decd-48d4-9a02-239a0fadf2c5)
