### PR TITLE
feat: separate out enum names and values

### DIFF
--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -99,6 +99,18 @@ func (dev *DaggerDev) introspection(ctx context.Context, installer func(*dagger.
 		File("/schema.json"), nil
 }
 
+func (dev *DaggerDev) Introspection(ctx context.Context) (*dagger.File, error) {
+	installer, err := dev.installer(ctx, "sdk")
+	if err != nil {
+		return nil, err
+	}
+	introspection, err := dev.introspection(ctx, installer)
+	if err != nil {
+		return nil, err
+	}
+	return introspection, nil
+}
+
 type gitPublishOpts struct {
 	sdk string
 

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -74,6 +74,7 @@ func (funcs goTemplateFuncs) FuncMap() template.FuncMap {
 		"FormatName":              formatName,
 		"FormatEnum":              funcs.formatEnum,
 		"SortEnumFields":          funcs.sortEnumFields,
+		"GroupEnumByValue":        funcs.groupEnumByValue,
 		"FieldOptionsStructName":  funcs.fieldOptionsStructName,
 		"FieldFunction":           funcs.fieldFunction,
 		"IsArgOptional":           funcs.isArgOptional,
@@ -164,6 +165,19 @@ func (funcs goTemplateFuncs) sortEnumFields(s []introspection.EnumValue) []intro
 		return s[i].Name < s[j].Name
 	})
 	return s
+}
+
+func (funcs goTemplateFuncs) groupEnumByValue(s []introspection.EnumValue) [][]introspection.EnumValue {
+	m := map[string][]introspection.EnumValue{}
+	for _, v := range s {
+		value := v.Directives.EnumValue()
+		m[value] = append(m[value], v)
+	}
+	var result [][]introspection.EnumValue
+	for _, v := range m {
+		result = append(result, v)
+	}
+	return result
 }
 
 func (funcs goTemplateFuncs) formatArrayField(fields []*introspection.Field) string {

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -174,8 +174,11 @@ func (funcs goTemplateFuncs) groupEnumByValue(s []introspection.EnumValue) [][]i
 		m[value] = append(m[value], v)
 	}
 	var result [][]introspection.EnumValue
-	for _, v := range m {
-		result = append(result, v)
+	for _, v := range s {
+		if res, ok := m[v.Name]; ok {
+			result = append(result, res)
+			delete(m, v.Name)
+		}
 	}
 	return result
 }

--- a/cmd/codegen/generator/go/templates/module_enums.go
+++ b/cmd/codegen/generator/go/templates/module_enums.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	. "github.com/dave/jennifer/jen" //nolint:stylecheck
+	"github.com/iancoleman/strcase"
 )
 
 func (ps *parseState) parseGoEnum(t *types.Basic, named *types.Named) (*parsedEnumType, error) {
@@ -36,6 +37,7 @@ func (ps *parseState) parseGoEnum(t *types.Basic, named *types.Named) (*parsedEn
 			continue
 		}
 
+		name := obj.Name()
 		value := ""
 		if objConst.Val().Kind() == constant.String {
 			value = constant.StringVal(objConst.Val())
@@ -49,7 +51,9 @@ func (ps *parseState) parseGoEnum(t *types.Basic, named *types.Named) (*parsedEn
 		}
 
 		valueSpec := &parsedEnumValue{
-			value: value,
+			originalName: name,
+			name:         name,
+			value:        value,
 		}
 		if doc := docForAstSpec(astSpec); doc != nil {
 			valueSpec.doc = doc.Text()
@@ -60,6 +64,20 @@ func (ps *parseState) parseGoEnum(t *types.Basic, named *types.Named) (*parsedEn
 	if len(spec.values) == 0 {
 		// no values, this isn't an enum, it's a scalar alias
 		return nil, nil
+	}
+
+	// trim prefixes for all names (if we can)
+	trim := true
+	for _, v := range spec.values {
+		if !strings.HasPrefix(v.name, spec.name) {
+			trim = false
+			break
+		}
+	}
+	if trim {
+		for _, v := range spec.values {
+			v.name = v.name[len(spec.name):]
+		}
 	}
 
 	// get the comment above the struct (if any)
@@ -88,9 +106,11 @@ type parsedEnumType struct {
 }
 
 type parsedEnumValue struct {
-	value     string
-	doc       string
-	sourceMap *sourceMap
+	originalName string
+	name         string
+	value        string
+	doc          string
+	sourceMap    *sourceMap
 }
 
 var _ NamedParsedType = &parsedEnumType{}
@@ -113,22 +133,24 @@ func (spec *parsedEnumType) TypeDefCode() (*Statement, error) {
 	typeDefCode := Qual("dag", "TypeDef").Call().Dot("WithEnum").Call(withEnumArgsCode...)
 
 	for _, val := range spec.values {
+		// XXX: fallback to ye-olde behavior where name = value on ye-olde dagger versions
 		valueTypeDefCode := []Code{
+			Lit(strcase.ToScreamingSnake(val.name)),
 			Lit(val.value),
 		}
-		var withEnumValueOpts []Code
+		var withEnumMemberOpts []Code
 		if val.doc != "" {
-			withEnumValueOpts = append(withEnumValueOpts, Id("Description").Op(":").Lit(strings.TrimSpace(val.doc)))
+			withEnumMemberOpts = append(withEnumMemberOpts, Id("Description").Op(":").Lit(strings.TrimSpace(val.doc)))
 		}
 		if val.sourceMap != nil {
-			withEnumValueOpts = append(withEnumValueOpts, Id("SourceMap").Op(":").Add(val.sourceMap.TypeDefCode()))
+			withEnumMemberOpts = append(withEnumMemberOpts, Id("SourceMap").Op(":").Add(val.sourceMap.TypeDefCode()))
 		}
-		if len(withEnumValueOpts) > 0 {
+		if len(withEnumMemberOpts) > 0 {
 			valueTypeDefCode = append(valueTypeDefCode,
-				Id("dagger").Dot("TypeDefWithEnumValueOpts").Values(withEnumValueOpts...),
+				Id("dagger").Dot("TypeDefWithEnumMemberOpts").Values(withEnumMemberOpts...),
 			)
 		}
-		typeDefCode = dotLine(typeDefCode, "WithEnumValue").Call(valueTypeDefCode...)
+		typeDefCode = dotLine(typeDefCode, "WithEnumMember").Call(valueTypeDefCode...)
 	}
 
 	return typeDefCode, nil
@@ -152,5 +174,75 @@ func (spec *parsedEnumType) ModuleName() string {
 
 // Extra generated code needed for the object implementation.
 func (spec *parsedEnumType) ImplementationCode() (*Statement, error) {
-	return Empty(), nil
+	code := Empty().
+		Add(spec.isEnumMethodCode()).Line().Line().
+		Add(spec.nameMethodCode()).Line().Line().
+		Add(spec.valueMethodCode()).Line().Line().
+		Add(spec.marshalJSONMethodCode()).Line().Line().
+		Add(spec.unmarshalJSONMethodCode()).Line().Line()
+	return code, nil
+}
+
+func (spec *parsedEnumType) isEnumMethodCode() *Statement {
+	return Func().Params(Id("r").Id(spec.name)).
+		Id("IsEnum").Params().Params().Block()
+}
+
+func (spec *parsedEnumType) nameMethodCode() *Statement {
+	return Func().Params(Id("r").Id(spec.name)).
+		Id("Name").
+		Params().
+		Params(String()).
+		BlockFunc(func(g *Group) {
+			var cases []Code
+			for _, v := range spec.values {
+				raw := strcase.ToScreamingSnake(v.name)
+				cases = append(cases, Case(Id(v.originalName)).Block(Return(Lit(raw))))
+			}
+			g.Switch(Id("r")).Block(cases...)
+			g.Return(Lit(""))
+		})
+}
+
+func (spec *parsedEnumType) valueMethodCode() *Statement {
+	return Func().Params(Id("r").Id(spec.name)).
+		Id("Value").
+		Params().
+		Params(String()).
+		BlockFunc(func(g *Group) {
+			g.Return(String().Call(Id("r")))
+		})
+}
+
+func (spec *parsedEnumType) marshalJSONMethodCode() *Statement {
+	return Func().Params(Id("r").Id(spec.name)).
+		Id("MarshalJSON").
+		Params().
+		Params(Id("[]byte"), Id("error")).
+		BlockFunc(func(g *Group) {
+			g.Return(Id("json").Dot("Marshal").Call(Id("r").Dot("Name").Call()))
+		})
+}
+
+func (spec *parsedEnumType) unmarshalJSONMethodCode() *Statement {
+	return Func().Params(Id("r").Op("*").Id(spec.name)).
+		Id("UnmarshalJSON").
+		Params(Id("bs").Id("[]byte")).
+		Params(Id("error")).
+		BlockFunc(func(g *Group) {
+			g.Var().Id("s").String()
+			g.Id("err").Op(":=").Id("json").Dot("Unmarshal").Call(Id("bs"), Op("&").Id("s"))
+			g.If(Id("err").Op("!=").Nil()).Block(Return(Id("err")))
+
+			var cases []Code
+			for _, v := range spec.values {
+				raw := strcase.ToScreamingSnake(v.name)
+				cases = append(cases, Case(Lit(raw)).Block(Op("*").Id("r").Op("=").Id(v.originalName)))
+			}
+			cases = append(cases, Default().Block(Return(
+				Qual("fmt", "Errorf").Call(Lit("unknown enum value %q"), Id("s")),
+			)))
+			g.Switch(Id("s")).Block(cases...)
+			g.Return(Nil())
+		})
 }

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -168,6 +168,8 @@ type parsedPrimitiveType struct {
 var _ ParsedType = &parsedPrimitiveType{}
 
 func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
+	// FIXME: update to use new TypeDefKind values
+	// this is tricky though because the new values are present on <0.15
 	var kind Code
 	if spec.goType.Kind() == types.Invalid {
 		// NOTE: this is odd, but it doesn't matter, because the module won't

--- a/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
@@ -49,46 +49,37 @@ func (v *{{ $enumName }}) UnmarshalJSON(dt []byte) error {
 
 {{- $needsUnscopedEnums := CheckVersionCompatibility "v0.15.0" | not }}
 const (
-	{{/* XXX: this is a little messy now */}}
 	{{- range $fields := .EnumValues | SortEnumFields | GroupEnumByValue }}
-	{{- $field := index $fields 0 }}
-	{{- $fieldName := ($field.Name | FormatEnum "") }}
-	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
-	{{- $fieldValue := $field.Directives.EnumValue }}
-	{{- if not $fieldValue }}
-		{{- $fieldValue = $field.Name }}
-	{{- end }}
-	{{ $field.Description | Comment }}
-	{{ $fullFieldName }} {{ $enumName }} = "{{ $fieldValue }}"
-	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-	{{- if $needsUnscopedEnums }}
-	{{ $field.Description | Comment }}
-	{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
-	{{ $fieldName }} {{ $enumName }} = {{ $fullFieldName }}
-	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-	{{- end }}
-	{{- $mainFieldName := $fullFieldName }}
+	{{- $mainFieldName := "" }}
+	{{- range $idx, $field := slice $fields }}
+		{{- $fieldName := ($field.Name | FormatEnum "") }}
+		{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
 
-	{{- range $field := (slice $fields 1) }}
+		{{- $fieldValue := "" }}
+		{{ if eq $idx 0 }}
+			{{- $fieldValue = $field.Directives.EnumValue }}
+			{{- if not $fieldValue }}
+				{{- $fieldValue = $field.Name }}
+			{{- end }}
+			{{- $fieldValue = $fieldValue | printf "%q" }}
 
-	{{- $fieldName := ($field.Name | FormatEnum "") }}
-	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
-	{{- $fieldValue := $field.Directives.EnumValue }}
-	{{- if not $fieldValue }}
-		{{- $fieldValue = $field.Name }}
+			{{- $mainFieldName = $fullFieldName }}
+		{{ else }}
+			{{- $fieldValue = $mainFieldName }}
+		{{ end }}
+
+		{{ $field.Description | Comment }}
+		{{ $fullFieldName }} {{ $enumName }} = {{ $fieldValue }}
+		{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+
+		{{- if $needsUnscopedEnums }}
+		{{ $field.Description | Comment }}
+		{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
+		{{ $fieldName }} {{ $enumName }} = {{ $fullFieldName }}
+		{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+		{{- end }}
 	{{- end }}
-	{{ $field.Description | Comment }}
-	{{ $fullFieldName }} {{ $enumName }} = {{ $mainFieldName }}
-	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-	{{- if $needsUnscopedEnums }}
-	{{ $field.Description | Comment }}
-	{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
-	{{ $fieldName }} {{ $enumName }} = {{ $mainFieldName }}
-	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
 	{{- end }}
-	
-	{{- end }}
-	{{ end }}
 )
 
 {{- end }}

--- a/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
@@ -6,20 +6,88 @@ type {{ $enumName }} string
 
 func ({{ $enumName }}) IsEnum() {}
 
-{{- $needsScopedEnums := CheckVersionCompatibility "v0.15.0" | not }}
-const (
-	{{- range $index, $field := .EnumValues | SortEnumFields }}
+func (v {{ $enumName }}) Name() string {
+	switch v {
+	{{- range $fields := .EnumValues | SortEnumFields | GroupEnumByValue }}
+	{{- $field := index $fields 0 }}
 	{{- $fieldName := ($field.Name | FormatEnum "") }}
 	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
+	case {{ $fullFieldName }}:
+		return "{{ $field.Name }}"
+	{{- end }}
+	default:
+		return ""
+	}
+}
+
+func (v {{ $enumName }}) Value() string {
+	return string(v)
+}
+
+func (v *{{ $enumName }}) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *{{ $enumName }}) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+	{{/* XXX: for neatness, we should group here, and return only the "main" ones */}}
+	{{- range $field := .EnumValues | SortEnumFields }}
+	{{- $fieldName := ($field.Name | FormatEnum "") }}
+	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
+	case "{{ $field.Name }}":
+		*v = {{ $fullFieldName }}
+	{{- end }}
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
+{{- $needsUnscopedEnums := CheckVersionCompatibility "v0.15.0" | not }}
+const (
+	{{/* XXX: this is a little messy now */}}
+	{{- range $fields := .EnumValues | SortEnumFields | GroupEnumByValue }}
+	{{- $field := index $fields 0 }}
+	{{- $fieldName := ($field.Name | FormatEnum "") }}
+	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
+	{{- $fieldValue := $field.Directives.EnumValue }}
+	{{- if not $fieldValue }}
+		{{- $fieldValue = $field.Name }}
+	{{- end }}
 	{{ $field.Description | Comment }}
-	{{ $fullFieldName }} {{ $enumName }} = "{{ $field.Name }}"
-	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-	{{ if $needsScopedEnums }}
+	{{ $fullFieldName }} {{ $enumName }} = "{{ $fieldValue }}"
+	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- if $needsUnscopedEnums }}
 	{{ $field.Description | Comment }}
 	{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
 	{{ $fieldName }} {{ $enumName }} = {{ $fullFieldName }}
-	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-	{{ end }}
+	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- end }}
+	{{- $mainFieldName := $fullFieldName }}
+
+	{{- range $field := (slice $fields 1) }}
+
+	{{- $fieldName := ($field.Name | FormatEnum "") }}
+	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
+	{{- $fieldValue := $field.Directives.EnumValue }}
+	{{- if not $fieldValue }}
+		{{- $fieldValue = $field.Name }}
+	{{- end }}
+	{{ $field.Description | Comment }}
+	{{ $fullFieldName }} {{ $enumName }} = {{ $mainFieldName }}
+	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- if $needsUnscopedEnums }}
+	{{ $field.Description | Comment }}
+	{{ print "use " $fullFieldName " instead" | FormatDeprecation }}
+	{{ $fieldName }} {{ $enumName }} = {{ $mainFieldName }}
+	{{- with $field.Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- end }}
+	
+	{{- end }}
 	{{ end }}
 )
 

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -55,6 +55,7 @@ func (funcs typescriptTemplateFuncs) FuncMap() template.FuncMap {
 		"ArgsHaveDescription":       funcs.argsHaveDescription,
 		"SortInputFields":           funcs.sortInputFields,
 		"SortEnumFields":            funcs.sortEnumFields,
+		"GroupEnumByValue":          funcs.groupEnumByValue,
 		"Solve":                     funcs.solve,
 		"Subtract":                  funcs.subtract,
 		"ConvertID":                 commonFunc.ConvertID,
@@ -292,6 +293,22 @@ func (funcs typescriptTemplateFuncs) sortEnumFields(s []introspection.EnumValue)
 		return s[i].Name < s[j].Name
 	})
 	return s
+}
+
+func (funcs typescriptTemplateFuncs) groupEnumByValue(s []introspection.EnumValue) [][]introspection.EnumValue {
+	m := map[string][]introspection.EnumValue{}
+	for _, v := range s {
+		value := v.Directives.EnumValue()
+		m[value] = append(m[value], v)
+	}
+	var result [][]introspection.EnumValue
+	for _, v := range s {
+		if res, ok := m[v.Name]; ok {
+			result = append(result, res)
+			delete(m, v.Name)
+		}
+	}
+	return result
 }
 
 func (funcs typescriptTemplateFuncs) argsHaveDescription(values introspection.InputValues) bool {

--- a/cmd/codegen/generator/typescript/templates/src/types.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/types.ts.gtpl
@@ -35,20 +35,38 @@ export type {{ .Name }} = string & {__{{ .Name }}: never} {{- with .Directives.S
  */
 		{{- end }}
 export enum {{ .Name }} { {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
-		{{- $sortedEnumValues := SortEnumFields .EnumValues }}
-		{{- range $sortedEnumValues }}
-			{{- if .Description }}
-				{{- /* Split comment string into a slice of one line per element. */ -}}
-				{{- $desc := CommentToLines .Description }}
+    {{- $enumName := .Name }}
+	{{- range $fields := .EnumValues | SortEnumFields | GroupEnumByValue }}
+	{{- $mainFieldName := "" }}
+	{{- range $idx, $field := slice $fields }}
+		{{- $fieldName := ($field.Name | FormatEnum) }}
+
+		{{- $fieldValue := "" }}
+		{{ if eq $idx 0 }}
+			{{- $fieldValue = $field.Directives.EnumValue }}
+			{{- if not $fieldValue }}
+				{{- $fieldValue = $field.Name }}
+			{{- end }}
+			{{- $fieldValue = $fieldValue | printf "%q" }}
+
+			{{- $mainFieldName = $fieldName }}
+		{{ else }}
+			{{- $fieldValue = printf "%s.%s" $enumName $mainFieldName }}
+		{{ end }}
+
+		{{- if .Description }}
+			{{- /* Split comment string into a slice of one line per element. */ -}}
+			{{- $desc := CommentToLines .Description }}
 
   /**
-				{{- range $desc }}
+			{{- range $desc }}
    * {{ . }}
-				{{- end }}
-   */
 			{{- end }}
-  {{ .Name | FormatEnum }} = "{{ .Name }}", {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+   */
 		{{- end }}
+		{{ $fieldName }} = {{ $fieldValue }}, {{- with $field.Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- end }}
+	{{- end }}
 }
 	{{- end }}
 

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -2,6 +2,7 @@ package introspection
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 )
 
@@ -290,12 +291,12 @@ func (t Directives) Directive(name string) *Directive {
 type SourceMap struct {
 	Module   string
 	Filename string
-	Line     string
-	Column   string
+	Line     int
+	Column   int
 }
 
 func (sourceMap *SourceMap) Filelink() string {
-	return fmt.Sprintf("%s:%s:%s", sourceMap.Filename, sourceMap.Line, sourceMap.Column)
+	return fmt.Sprintf("%s:%d:%d", sourceMap.Filename, sourceMap.Line, sourceMap.Column)
 }
 
 func (t *Directives) SourceMap() *SourceMap {
@@ -304,11 +305,19 @@ func (t *Directives) SourceMap() *SourceMap {
 		return nil
 	}
 	return &SourceMap{
-		Module:   *d.Arg("module").Value,
-		Filename: *d.Arg("filename").Value,
-		Line:     *d.Arg("line").Value,
-		Column:   *d.Arg("column").Value,
+		Module:   fromJSON[string](*d.Arg("module").Value),
+		Filename: fromJSON[string](*d.Arg("filename").Value),
+		Line:     fromJSON[int](*d.Arg("line").Value),
+		Column:   fromJSON[int](*d.Arg("column").Value),
 	}
+}
+
+func (t *Directives) EnumValue() string {
+	d := t.Directive("enumValue")
+	if d == nil {
+		return ""
+	}
+	return fromJSON[string](*d.Arg("value").Value)
 }
 
 type Directive struct {
@@ -328,4 +337,9 @@ func (t Directive) Arg(name string) *DirectiveArg {
 type DirectiveArg struct {
 	Name  string  `json:"name"`
 	Value *string `json:"value"`
+}
+
+func fromJSON[T any](raw string) (t T) {
+	_ = json.Unmarshal([]byte(raw), &t)
+	return t
 }

--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -76,7 +76,7 @@ dagger config -m github.com/dagger/hello-dagger
 			if err != nil {
 				return fmt.Errorf("failed to get module kind: %w", err)
 			}
-			if kind == dagger.ModuleSourceKindLocalSource {
+			if kind == dagger.ModuleSourceKindLocal {
 				contextDirPath, err := modSrc.LocalContextDirectoryPath(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get local context directory path: %w", err)

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -229,8 +229,8 @@ type enumValue struct {
 var _ DaggerValue = &enumValue{}
 
 func (v *enumValue) Type() string {
-	vs := make([]string, 0, len(v.typedef.Values))
-	for _, v := range v.typedef.Values {
+	vs := make([]string, 0, len(v.typedef.Members))
+	for _, v := range v.typedef.Members {
 		vs = append(vs, v.Name)
 	}
 	return strings.Join(vs, ",")
@@ -245,7 +245,7 @@ func (v *enumValue) Get(ctx context.Context, dag *dagger.Client, modSrc *dagger.
 }
 
 func (v *enumValue) Set(s string) error {
-	for _, allow := range v.typedef.Values {
+	for _, allow := range v.typedef.Members {
 		if strings.EqualFold(s, allow.Name) {
 			v.value = allow.Name
 			return nil
@@ -755,27 +755,27 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 	}
 
 	switch r.TypeDef.Kind {
-	case dagger.TypeDefKindStringKind:
+	case dagger.TypeDefKindString:
 		val, _ := getDefaultValue[string](r)
 		flags.String(name, val, usage)
 		return nil
 
-	case dagger.TypeDefKindIntegerKind:
+	case dagger.TypeDefKindInteger:
 		val, _ := getDefaultValue[int](r)
 		flags.Int(name, val, usage)
 		return nil
 
-	case dagger.TypeDefKindFloatKind:
+	case dagger.TypeDefKindFloat:
 		val, _ := getDefaultValue[float64](r)
 		flags.Float64(name, val, usage)
 		return nil
 
-	case dagger.TypeDefKindBooleanKind:
+	case dagger.TypeDefKindBoolean:
 		val, _ := getDefaultValue[bool](r)
 		flags.Bool(name, val, usage)
 		return nil
 
-	case dagger.TypeDefKindScalarKind:
+	case dagger.TypeDefKindScalar:
 		scalarName := r.TypeDef.AsScalar.Name
 		defVal, _ := getDefaultValue[string](r)
 
@@ -790,7 +790,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 		flags.String(name, defVal, usage)
 		return nil
 
-	case dagger.TypeDefKindEnumKind:
+	case dagger.TypeDefKindEnum:
 		enumName := r.TypeDef.AsEnum.Name
 		defVal, _ := getDefaultValue[string](r)
 
@@ -807,7 +807,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 
 		return nil
 
-	case dagger.TypeDefKindObjectKind:
+	case dagger.TypeDefKindObject:
 		objName := r.TypeDef.AsObject.Name
 
 		if name == "id" && r.TypeDef.AsObject.IsCore() {
@@ -831,7 +831,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			Type: fmt.Sprintf("%q object", objName),
 		}
 
-	case dagger.TypeDefKindInputKind:
+	case dagger.TypeDefKindInput:
 		inputName := r.TypeDef.AsInput.Name
 
 		if val := GetCustomFlagValue(inputName); val != nil {
@@ -845,31 +845,31 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			Type: fmt.Sprintf("%q input", inputName),
 		}
 
-	case dagger.TypeDefKindListKind:
+	case dagger.TypeDefKindList:
 		elementType := r.TypeDef.AsList.ElementTypeDef
 
 		switch elementType.Kind {
-		case dagger.TypeDefKindStringKind:
+		case dagger.TypeDefKindString:
 			val, _ := getDefaultValue[[]string](r)
 			flags.StringSlice(name, val, usage)
 			return nil
 
-		case dagger.TypeDefKindIntegerKind:
+		case dagger.TypeDefKindInteger:
 			val, _ := getDefaultValue[[]int](r)
 			flags.IntSlice(name, val, usage)
 			return nil
 
-		case dagger.TypeDefKindFloatKind:
+		case dagger.TypeDefKindFloat:
 			val, _ := getDefaultValue[[]float64](r)
 			flags.Float64Slice(name, val, usage)
 			return nil
 
-		case dagger.TypeDefKindBooleanKind:
+		case dagger.TypeDefKindBoolean:
 			val, _ := getDefaultValue[[]bool](r)
 			flags.BoolSlice(name, val, usage)
 			return nil
 
-		case dagger.TypeDefKindScalarKind:
+		case dagger.TypeDefKindScalar:
 			scalarName := elementType.AsScalar.Name
 			defVal, _ := getDefaultValue[[]string](r)
 
@@ -885,7 +885,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 			flags.StringSlice(name, defVal, usage)
 			return nil
 
-		case dagger.TypeDefKindEnumKind:
+		case dagger.TypeDefKindEnum:
 			enumName := elementType.AsEnum.Name
 			defVal, _ := getDefaultValue[[]string](r)
 
@@ -903,7 +903,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 
 			return nil
 
-		case dagger.TypeDefKindObjectKind:
+		case dagger.TypeDefKindObject:
 			objName := elementType.AsObject.Name
 
 			val, err := GetCustomFlagValueSlice(objName, nil)
@@ -921,7 +921,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 				Type: fmt.Sprintf("list of %q objects", objName),
 			}
 
-		case dagger.TypeDefKindInputKind:
+		case dagger.TypeDefKindInput:
 			inputName := elementType.AsInput.Name
 
 			val, err := GetCustomFlagValueSlice(inputName, nil)
@@ -939,7 +939,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 				Type: fmt.Sprintf("list of %q inputs", inputName),
 			}
 
-		case dagger.TypeDefKindListKind:
+		case dagger.TypeDefKindList:
 			return &UnsupportedFlagError{
 				Name: name,
 				Type: "list of lists",

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -631,7 +631,7 @@ func makeRequest(ctx context.Context, q *querybuilder.Selection, response any) e
 }
 
 func handleResponse(returnType *modTypeDef, response any, o, e io.Writer) error {
-	if returnType.Kind == dagger.TypeDefKindVoidKind {
+	if returnType.Kind == dagger.TypeDefKindVoid {
 		return nil
 	}
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -177,7 +177,7 @@ If --sdk is specified, the given SDK is installed in the module. You can do this
 				// create them when exporting the generated context directory.
 				AllowNotExists: true,
 				// We can only init local modules
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			alreadyExists, err := modSrc.ConfigExists(ctx)
@@ -276,7 +276,7 @@ var moduleInstallCmd = &cobra.Command{
 
 			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
 				// We can only install dependencies to a local module
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			alreadyExists, err := modSrc.ConfigExists(ctx)
@@ -331,7 +331,7 @@ var moduleInstallCmd = &cobra.Command{
 			}
 
 			switch depSrcKind {
-			case dagger.ModuleSourceKindLocalSource:
+			case dagger.ModuleSourceKindLocal:
 				analytics.Ctx(ctx).Capture(ctx, "module_install", map[string]string{
 					"module_name":   origDepName,
 					"install_name":  installName,
@@ -339,7 +339,7 @@ var moduleInstallCmd = &cobra.Command{
 					"source_kind":   "local",
 					"local_subpath": depRootSubpath,
 				})
-			case dagger.ModuleSourceKindGitSource:
+			case dagger.ModuleSourceKindGit:
 				gitURL, err := depSrc.CloneRef(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get git clone URL: %w", err)
@@ -385,7 +385,7 @@ var moduleUpdateCmd = &cobra.Command{
 
 			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
 				// We can only update dependencies on a local module
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			alreadyExists, err := modSrc.ConfigExists(ctx)
@@ -431,7 +431,7 @@ var moduleUnInstallCmd = &cobra.Command{
 			dag := engineClient.Dagger()
 			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
 				// We can only uninstall dependencies on a local module
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			alreadyExists, err := modSrc.ConfigExists(ctx)
@@ -492,7 +492,7 @@ This command is idempotent: you can run it at any time, any number of times. It 
 
 			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
 				// We can only export updated generated files for a local modules
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			contextDirPath, err := modSrc.LocalContextDirectoryPath(ctx)
@@ -602,7 +602,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 
 			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
 				// can only publish modules that also exist locally for now
-				RequireKind: dagger.ModuleSourceKindLocalSource,
+				RequireKind: dagger.ModuleSourceKindLocal,
 			})
 
 			alreadyExists, err := modSrc.ConfigExists(ctx)

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -209,7 +209,7 @@ func inspectModule(ctx context.Context, dag *dagger.Client, source *dagger.Modul
 
 	// if this is a local module source, make the mod ref relative to the caller
 	// since that is usually a shorter+easier to work with path
-	if res.Source.Kind == dagger.ModuleSourceKindLocalSource {
+	if res.Source.Kind == dagger.ModuleSourceKindLocal {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return nil, err
@@ -249,7 +249,7 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client) (rerr 
 
 	for _, typeDef := range res.TypeDefs {
 		switch typeDef.Kind {
-		case dagger.TypeDefKindObjectKind:
+		case dagger.TypeDefKindObject:
 			obj := typeDef.AsObject
 			// FIXME: we could get the real constructor's name through the field
 			// in Query which would avoid the need to convert the module name,
@@ -271,11 +271,11 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client) (rerr 
 				}
 			}
 			m.Objects = append(m.Objects, typeDef)
-		case dagger.TypeDefKindInterfaceKind:
+		case dagger.TypeDefKindInterface:
 			m.Interfaces = append(m.Interfaces, typeDef)
-		case dagger.TypeDefKindEnumKind:
+		case dagger.TypeDefKindEnum:
 			m.Enums = append(m.Enums, typeDef)
-		case dagger.TypeDefKindInputKind:
+		case dagger.TypeDefKindInput:
 			m.Inputs = append(m.Inputs, typeDef)
 		}
 	}
@@ -551,27 +551,27 @@ type modTypeDef struct {
 
 func (t *modTypeDef) String() string {
 	switch t.Kind {
-	case dagger.TypeDefKindStringKind:
+	case dagger.TypeDefKindString:
 		return "string"
-	case dagger.TypeDefKindIntegerKind:
+	case dagger.TypeDefKindInteger:
 		return "int"
-	case dagger.TypeDefKindFloatKind:
+	case dagger.TypeDefKindFloat:
 		return "float"
-	case dagger.TypeDefKindBooleanKind:
+	case dagger.TypeDefKindBoolean:
 		return "bool"
-	case dagger.TypeDefKindVoidKind:
+	case dagger.TypeDefKindVoid:
 		return "void"
-	case dagger.TypeDefKindScalarKind:
+	case dagger.TypeDefKindScalar:
 		return t.AsScalar.Name
-	case dagger.TypeDefKindEnumKind:
+	case dagger.TypeDefKindEnum:
 		return t.AsEnum.Name
-	case dagger.TypeDefKindInputKind:
+	case dagger.TypeDefKindInput:
 		return t.AsInput.Name
-	case dagger.TypeDefKindObjectKind:
+	case dagger.TypeDefKindObject:
 		return t.AsObject.Name
-	case dagger.TypeDefKindInterfaceKind:
+	case dagger.TypeDefKindInterface:
 		return t.AsInterface.Name
-	case dagger.TypeDefKindListKind:
+	case dagger.TypeDefKindList:
 		return "[]" + t.AsList.ElementTypeDef.String()
 	default:
 		// this should never happen because all values for kind are covered,
@@ -582,23 +582,19 @@ func (t *modTypeDef) String() string {
 
 func (t *modTypeDef) KindDisplay() string {
 	switch t.Kind {
-	case dagger.TypeDefKindStringKind,
-		dagger.TypeDefKindIntegerKind,
-		dagger.TypeDefKindFloatKind,
-		dagger.TypeDefKindBooleanKind:
+	case dagger.TypeDefKindString:
 		return "Scalar"
-	case dagger.TypeDefKindScalarKind,
-		dagger.TypeDefKindVoidKind:
+	case dagger.TypeDefKindScalar:
 		return "Custom scalar"
-	case dagger.TypeDefKindEnumKind:
+	case dagger.TypeDefKindEnum:
 		return "Enum"
-	case dagger.TypeDefKindInputKind:
+	case dagger.TypeDefKindInput:
 		return "Input"
-	case dagger.TypeDefKindObjectKind:
+	case dagger.TypeDefKindObject:
 		return "Object"
-	case dagger.TypeDefKindInterfaceKind:
+	case dagger.TypeDefKindInterface:
 		return "Interface"
-	case dagger.TypeDefKindListKind:
+	case dagger.TypeDefKindList:
 		return "List of " + strings.ToLower(t.AsList.ElementTypeDef.KindDisplay()) + "s"
 	default:
 		return ""
@@ -607,24 +603,21 @@ func (t *modTypeDef) KindDisplay() string {
 
 func (t *modTypeDef) Description() string {
 	switch t.Kind {
-	case dagger.TypeDefKindStringKind,
-		dagger.TypeDefKindIntegerKind,
-		dagger.TypeDefKindFloatKind,
-		dagger.TypeDefKindBooleanKind:
+	case dagger.TypeDefKindString:
 		return "Primitive type."
-	case dagger.TypeDefKindVoidKind:
+	case dagger.TypeDefKindVoid:
 		return ""
-	case dagger.TypeDefKindScalarKind:
+	case dagger.TypeDefKindScalar:
 		return t.AsScalar.Description
-	case dagger.TypeDefKindEnumKind:
+	case dagger.TypeDefKindEnum:
 		return t.AsEnum.Description
-	case dagger.TypeDefKindInputKind:
+	case dagger.TypeDefKindInput:
 		return t.AsInput.Description
-	case dagger.TypeDefKindObjectKind:
+	case dagger.TypeDefKindObject:
 		return t.AsObject.Description
-	case dagger.TypeDefKindInterfaceKind:
+	case dagger.TypeDefKindInterface:
 		return t.AsInterface.Description
-	case dagger.TypeDefKindListKind:
+	case dagger.TypeDefKindList:
 		return t.AsList.ElementTypeDef.Description()
 	default:
 		// this should never happen because all values for kind are covered,
@@ -726,13 +719,13 @@ func GetLeafFunctions(fp functionProvider) []*modFunction {
 
 	for _, fn := range fns {
 		kind := fn.ReturnType.Kind
-		if kind == dagger.TypeDefKindListKind {
+		if kind == dagger.TypeDefKindList {
 			kind = fn.ReturnType.AsList.ElementTypeDef.Kind
 		}
 		switch kind {
-		case dagger.TypeDefKindObjectKind, dagger.TypeDefKindInterfaceKind, dagger.TypeDefKindVoidKind:
+		case dagger.TypeDefKindObject:
 			continue
-		case dagger.TypeDefKindScalarKind:
+		case dagger.TypeDefKindScalar:
 			// FIXME: ID types are coming from TypeDef with the wrong case ("Id")
 			if fn.ReturnType.AsScalar.Name == fmt.Sprintf("%sId", fp.ProviderName()) {
 				continue
@@ -841,18 +834,18 @@ type modScalar struct {
 type modEnum struct {
 	Name        string
 	Description string
-	Values      []*modEnumValue
+	Members     []*modEnumMember
 }
 
 func (e *modEnum) ValueNames() []string {
-	values := make([]string, 0, len(e.Values))
-	for _, v := range e.Values {
+	values := make([]string, 0, len(e.Members))
+	for _, v := range e.Members {
 		values = append(values, v.Name)
 	}
 	return values
 }
 
-type modEnumValue struct {
+type modEnumMember struct {
 	Name        string
 	Description string
 }
@@ -1018,7 +1011,7 @@ func (r *modFunctionArg) Long() string {
 		sb.WriteString(fmt.Sprintf("(default: %s)", defVal))
 	}
 
-	if r.TypeDef.Kind == dagger.TypeDefKindEnumKind {
+	if r.TypeDef.Kind == dagger.TypeDefKindEnum {
 		names := strings.Join(r.TypeDef.AsEnum.ValueNames(), ", ")
 		if multiline {
 			sb.WriteString("\n\n")
@@ -1058,7 +1051,7 @@ func (r *modFunctionArg) defValue() string {
 	}
 	t := r.TypeDef
 	switch t.Kind {
-	case dagger.TypeDefKindStringKind:
+	case dagger.TypeDefKindString:
 		v, err := getDefaultValue[string](r)
 		if err == nil {
 			return fmt.Sprintf("%q", v)

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -315,7 +315,7 @@ func (h *shellCallHandler) run(ctx context.Context, reader io.Reader, name strin
 		if err != nil {
 			return nil, h.checkExecError(err)
 		}
-		if typeDef != nil && typeDef.Kind == dagger.TypeDefKindVoidKind {
+		if typeDef != nil && typeDef.Kind == dagger.TypeDefKindVoid {
 			return nil, nil
 		}
 		buf := new(bytes.Buffer)

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -286,14 +286,14 @@ func shellPreprocessArgs(ctx context.Context, fn *modFunction, args []string) ([
 		name := arg.FlagName()
 
 		switch arg.TypeDef.Kind {
-		case dagger.TypeDefKindListKind:
+		case dagger.TypeDefKindList:
 			switch arg.TypeDef.AsList.ElementTypeDef.Kind {
-			case dagger.TypeDefKindBooleanKind:
+			case dagger.TypeDefKindBoolean:
 				flags.BoolSlice(name, nil, "")
 			default:
 				flags.StringSlice(name, nil, "")
 			}
-		case dagger.TypeDefKindBooleanKind:
+		case dagger.TypeDefKindBoolean:
 			flags.Bool(name, false, "")
 		default:
 			flags.String(name, "", "")
@@ -583,7 +583,7 @@ func (h *shellCallHandler) Result(
 		return nil, fn.ReturnType, err
 	}
 
-	if fn.ReturnType.Kind == dagger.TypeDefKindVoidKind {
+	if fn.ReturnType.Kind == dagger.TypeDefKindVoid {
 		return nil, fn.ReturnType, nil
 	}
 

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -48,7 +48,7 @@ fragment FunctionParts on Function {
 		name
 		description
 		defaultValue
-        defaultPath
+	defaultPath
 		ignore
 		typeDef {
 			...TypeDefRefParts
@@ -89,9 +89,9 @@ query TypeDefs {
 		asEnum {
 			name
 			description
-			values {
+			members {
 				name
-			    description
+				description
 			}
 		}
 		asInterface {

--- a/core/container.go
+++ b/core/container.go
@@ -1751,11 +1751,10 @@ type ImageLayerCompression string
 var ImageLayerCompressions = dagql.NewEnum[ImageLayerCompression]()
 
 var (
-	// FIXME: should be canonicalized as GZIP, ZSTD, ESTARGZ, UNCOMPRESSED
-	CompressionGzip         = ImageLayerCompressions.Register("Gzip")
-	CompressionZstd         = ImageLayerCompressions.Register("Zstd")
-	CompressionEStarGZ      = ImageLayerCompressions.Register("EStarGZ")
-	CompressionUncompressed = ImageLayerCompressions.Register("Uncompressed")
+	CompressionGzip         = ImageLayerCompressions.Register("GZIP")
+	CompressionZstd         = ImageLayerCompressions.Register("ZSTD")
+	CompressionEStarGZ      = ImageLayerCompressions.Register("ESTARGZ")
+	CompressionUncompressed = ImageLayerCompressions.Register("UNCOMPRESSED")
 )
 
 func (proto ImageLayerCompression) Type() *ast.Type {
@@ -1782,14 +1781,14 @@ type ImageMediaTypes string
 var ImageMediaTypesEnum = dagql.NewEnum[ImageMediaTypes]()
 
 var (
-	// FIXME: should be canonicalized as OCI_MEDIA_TYPES, DOCKER_MEDIA_TYPES
-	OCIMediaTypes    = ImageMediaTypesEnum.Register("OCIMediaTypes")
-	DockerMediaTypes = ImageMediaTypesEnum.Register("DockerMediaTypes")
+	OCIMediaTypes    = ImageMediaTypesEnum.Register("OCI")
+	DockerMediaTypes = ImageMediaTypesEnum.Register("DOCKER")
 )
 
 func (proto ImageMediaTypes) Type() *ast.Type {
 	return &ast.Type{
-		NamedType: "ImageMediaTypes",
+		// XXX: renaming types is hard
+		NamedType: "ImageMediaType",
 		NonNull:   true,
 	}
 }

--- a/core/enum.go
+++ b/core/enum.go
@@ -156,6 +156,10 @@ func (e *ModuleEnum) Decoder() dagql.InputDecoder {
 }
 
 func (e *ModuleEnum) DecodeInput(val any) (dagql.Input, error) {
+	if enum, ok := val.(*ModuleEnum); ok {
+		val = enum.Name
+	}
+
 	v, err := (&dagql.EnumValueName{Enum: e.TypeName()}).DecodeInput(val)
 	if err != nil {
 		return nil, err

--- a/core/enum.go
+++ b/core/enum.go
@@ -40,17 +40,25 @@ func (m *ModuleEnumType) ConvertFromSDKResult(ctx context.Context, value any) (d
 
 	switch value := value.(type) {
 	case string:
-		decoder, err := m.getDecoder(ctx)
+		enum, local, err := m.getEnum(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("%T.ConvertFromSDKResult: failed to get decoder: %w", m, err)
+			return nil, fmt.Errorf("%T.ConvertFromSDKResult: failed to get enum: %w", m, err)
 		}
-
-		val, err := decoder.DecodeInput(value)
-		if err != nil {
-			return nil, fmt.Errorf("%T.ConvertFromSDKResult: invalid enum value %q for %q: %w", m, value, m.typeDef.Name, err)
+		// XXX:
+		// targetName := ...
+		for _, member := range enum.TypeDef.Members {
+			if local && member.OriginalName == value {
+				return enum.DecodeInput(member.Name)
+			} else if !local && member.Name == value {
+				return enum.DecodeInput(member.Name)
+			}
 		}
-
-		return val, nil
+		for _, member := range enum.TypeDef.Members {
+			if member.Value == value {
+				return enum.DecodeInput(member.Name)
+			}
+		}
+		return nil, fmt.Errorf("%T.ConvertFromSDKResult: invalid enum value %q for %q", m, value, m.typeDef.Name)
 	default:
 		return nil, fmt.Errorf("unexpected result value type %T for enum %q", value, m.typeDef.Name)
 	}
@@ -60,42 +68,55 @@ func (m *ModuleEnumType) ConvertToSDKInput(ctx context.Context, value dagql.Type
 	if value == nil {
 		return nil, nil
 	}
-	decoder, err := m.getDecoder(ctx)
+
+	enum, local, err := m.getEnum(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%T.ConvertToSDKInput: failed to get decoder: %w", m, err)
+		return nil, fmt.Errorf("%T.ConvertFromSDKResult: failed to get enum: %w", m, err)
 	}
-	return decoder.DecodeInput(value)
+	result, err := enum.DecodeInput(value)
+	if err != nil {
+		return nil, err
+	}
+	enum = result.(*ModuleEnum)
+	if local {
+		return enum.getTypeDef().OriginalName, nil
+	}
+	return enum.getTypeDef().Name, nil
 }
 
 func (m *ModuleEnumType) CollectCoreIDs(ctx context.Context, value dagql.Typed, ids map[digest.Digest]*resource.ID) error {
 	return nil
 }
 
-func (m *ModuleEnumType) getDecoder(ctx context.Context) (dagql.InputDecoder, error) {
+func (m *ModuleEnumType) getEnum(ctx context.Context) (*ModuleEnum, bool, error) {
 	// Check the dependencies
 	srv, err := m.mod.Deps.Schema(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%T.getDecoder: failed to get schema: %w", m, err)
+		return nil, false, fmt.Errorf("%T.getDecoder: failed to get schema: %w", m, err)
 	}
 
-	enumType, ok := srv.ScalarType(m.typeDef.Name)
+	scalar, ok := srv.ScalarType(m.typeDef.Name)
 	if ok {
-		return enumType, nil
+		enum, ok := scalar.(*ModuleEnum)
+		if !ok {
+			return nil, false, fmt.Errorf("%T.getDecoder: incorrect type %T for scalar", m, scalar)
+		}
+		return enum, false, nil
 	}
 
 	// If not check if the enum is part of its own module
 	for _, enumTypeDef := range m.mod.EnumDefs {
 		if enumTypeDef.AsEnum.Value.Name == m.typeDef.Name {
-			return &ModuleEnum{TypeDef: enumTypeDef.AsEnum.Value}, nil
+			return &ModuleEnum{TypeDef: enumTypeDef.AsEnum.Value}, true, nil
 		}
 	}
 
-	return nil, fmt.Errorf("%T.getDecoder: failed to get enum type %q", m, m.typeDef.Name)
+	return nil, false, fmt.Errorf("%T.getDecoder: failed to get enum type %q", m, m.typeDef.Name)
 }
 
 type ModuleEnum struct {
 	TypeDef *EnumTypeDef
-	Value   string
+	Name    string
 }
 
 func (e *ModuleEnum) TypeName() string {
@@ -113,7 +134,7 @@ func (e *ModuleEnum) TypeDescription() string {
 	return formatGqlDescription(e.TypeDef.Description)
 }
 
-func (e *ModuleEnum) TypeDefinition(views ...string) *ast.Definition {
+func (e *ModuleEnum) TypeDefinition(view string) *ast.Definition {
 	def := &ast.Definition{
 		Kind:        ast.Enum,
 		Name:        e.TypeName(),
@@ -128,10 +149,11 @@ func (e *ModuleEnum) TypeDefinition(views ...string) *ast.Definition {
 
 func (e *ModuleEnum) PossibleValues() ast.EnumValueList {
 	var values ast.EnumValueList
-	for _, val := range e.TypeDef.Values {
+	for _, val := range e.TypeDef.Members {
 		def := &ast.EnumValueDefinition{
 			Name:        val.Name,
 			Description: val.Description,
+			Directives:  []*ast.Directive{val.EnumValueDirective()},
 		}
 		if val.SourceMap != nil {
 			def.Directives = append(def.Directives, val.SourceMap.TypeDirective())
@@ -148,7 +170,7 @@ func (e *ModuleEnum) Install(dag *dagql.Server) error {
 }
 
 func (e *ModuleEnum) ToLiteral() call.Literal {
-	return call.NewLiteralEnum(e.Value)
+	return call.NewLiteralEnum(e.Name)
 }
 
 func (e *ModuleEnum) Decoder() dagql.InputDecoder {
@@ -164,22 +186,39 @@ func (e *ModuleEnum) DecodeInput(val any) (dagql.Input, error) {
 	if err != nil {
 		return nil, err
 	}
-	return e.Lookup(v.(*dagql.EnumValueName).Value)
+	return e.Lookup(v.(*dagql.EnumValueName).Name)
 }
 
 func (e *ModuleEnum) Lookup(val string) (dagql.Input, error) {
-	for _, possible := range e.TypeDef.Values {
+	for _, possible := range e.TypeDef.Members {
 		if val == possible.Name {
 			return &ModuleEnum{
 				TypeDef: e.TypeDef,
-				Value:   possible.Name,
+				Name:    possible.Name,
 			}, nil
 		}
 	}
-
+	// XXX: this doesn't seem neccessary...
+	// for _, possible := range e.TypeDef.Members {
+	// 	if val == possible.Value {
+	// 		return &ModuleEnum{
+	// 			TypeDef: e.TypeDef,
+	// 			Name:    possible.Name,
+	// 		}, nil
+	// 	}
+	// }
 	return nil, fmt.Errorf("invalid enum value %q", val)
 }
 
+func (e *ModuleEnum) getTypeDef() *EnumMemberTypeDef {
+	for _, possible := range e.TypeDef.Members {
+		if possible.Name == e.Name {
+			return possible
+		}
+	}
+	return nil
+}
+
 func (e *ModuleEnum) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.Value)
+	return json.Marshal(e.Name)
 }

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3192,7 +3192,7 @@ func (ContainerSuite) TestImport(ctx context.Context, t *testctx.T) {
 	t.Run("Docker", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			Import(c.Container().From(alpineImage).WithEnvVariable("FOO", "bar").AsTarball(dagger.ContainerAsTarballOpts{
-				MediaTypes: dagger.ImageMediaTypesDockerMediaTypes,
+				MediaTypes: dagger.ImageMediaTypeDocker,
 			})).
 			WithExec([]string{"sh", "-c", "echo $FOO"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -3966,7 +3966,7 @@ func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar",
 		},
 		{
-			dagger.ImageLayerCompressionEstarGz,
+			dagger.ImageLayerCompressionEstargz,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 	} {
@@ -4026,7 +4026,7 @@ func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 
 func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 	for _, tc := range []struct {
-		mediaTypes           dagger.ImageMediaTypes
+		mediaTypes           dagger.ImageMediaType
 		expectedOCIMediaType string
 	}{
 		{
@@ -4034,11 +4034,11 @@ func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.ImageMediaTypesOcimediaTypes,
+			dagger.ImageMediaTypeOci,
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 		{
-			dagger.ImageMediaTypesDockerMediaTypes,
+			dagger.ImageMediaTypeDocker,
 			"application/vnd.docker.image.rootfs.diff.tar.gzip",
 		},
 	} {
@@ -4242,7 +4242,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 	for _, dockerVersion := range []string{"20.10", "23.0", "24.0"} {
 		dockerc := dockerSetup(ctx, t, t.Name(), c, dockerVersion, nil)
 
-		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediaTypes, dagger.ImageMediaTypesDockerMediaTypes} {
+		for _, mediaType := range []dagger.ImageMediaType{dagger.ImageMediaTypeOci, dagger.ImageMediaTypeDocker} {
 			mediaType := mediaType
 			for _, compression := range []dagger.ImageLayerCompression{dagger.ImageLayerCompressionGzip, dagger.ImageLayerCompressionZstd, dagger.ImageLayerCompressionUncompressed} {
 				compression := compression

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5603,8 +5603,9 @@ query { host { directory(path: ".") { asModule {
         asEnum {
             name
             description
-            values {
+            members {
                 name
+				value
 				description
 			}
         }

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -1125,14 +1125,14 @@ type Status string
 
 const (
 	// Active status
-	Active Status = "ACTIVE"
+	Active Status = "ACTIVE value"
 
 	// Inactive status
-	Inactive Status = "INACTIVE"
+	Inactive Status = "INACTIVE value"
 )
 
 func New(
-	// +default="INACTIVE"
+	// +default="INACTIVE value"
 	status Status,
 ) *Test {
 	return &Test{Status: status}
@@ -1166,8 +1166,8 @@ func (m *Test) ToStatus(status string) Status {
 class Status(dagger.Enum):
     """Enum for Status"""
 
-    ACTIVE = "ACTIVE", "Active status"
-    INACTIVE = "INACTIVE", "Inactive status"
+    ACTIVE = "ACTIVE value", "Active status"
+    INACTIVE = "INACTIVE value", "Inactive status"
 
 
 @dagger.object_type
@@ -1187,7 +1187,8 @@ class Test:
         # Doing "Status(proto)" will fail in Python, so mock
         # it to force sending the invalid value back to the server.
         class MockEnum(dagger.Enum):
-            INACTIVE = "INACTIVE"
+            ACTIVE = "ACTIVE value"
+            INACTIVE = "INACTIVE value"
             INVALID = "INVALID"
 
         return MockEnum(status)
@@ -1205,12 +1206,12 @@ class Status {
   /**
    * Active status
    */
-  static readonly Active: string = "ACTIVE"
+  static readonly Active: string = "ACTIVE value"
 
   /**
    * Inactive status
    */
-  static readonly Inactive: string = "INACTIVE"
+  static readonly Inactive: string = "INACTIVE value"
 }
 
 @object()
@@ -1218,8 +1219,8 @@ export class Test {
   @func()
   status: Status
 
-  // FIXME: this should be Status.Inactive instead of "INACTIVE"
-  constructor(status: Status = "INACTIVE") {
+  // FIXME: this should be Status.Inactive instead of "INACTIVE value"
+  constructor(status: Status = "INACTIVE value") {
     this.status = status
   }
 
@@ -1250,14 +1251,19 @@ export class Test {
 				c := connect(ctx, t)
 				modGen := modInit(t, c, tc.sdk, tc.source)
 
-				// fromStatus
-				out, err := modGen.With(daggerQuery(`{test{fromStatus(status: "ACTIVE")}}`)).Stdout(ctx)
-				require.NoError(t, err)
-				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatus").String())
-
-				out, err = modGen.With(daggerQuery(`{test{status}}`)).Stdout(ctx)
+				// status property
+				out, err := modGen.With(daggerQuery(`{test{status}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.status").String())
+
+				// fromStatus
+				out, err = modGen.With(daggerQuery(`{test{fromStatus(status: ACTIVE)}}`)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "ACTIVE value", gjson.Get(out, "test.fromStatus").String())
+
+				out, err = modGen.With(daggerQuery(`{test{fromStatus(status: INACTIVE)}}`)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "INACTIVE value", gjson.Get(out, "test.fromStatus").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatus(status: "INVALID")}}`)).Stdout(ctx)
 				requireErrOut(t, err, "invalid enum value")
@@ -1267,15 +1273,15 @@ export class Test {
 				require.NoError(t, err)
 				require.Equal(t, "", gjson.Get(out, "test.fromStatusOpt").String())
 
-				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "ACTIVE")}}`)).Stdout(ctx)
+				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: ACTIVE)}}`)).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatusOpt").String())
+				require.Equal(t, "ACTIVE value", gjson.Get(out, "test.fromStatusOpt").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "INVALID")}}`)).Stdout(ctx)
 				requireErrOut(t, err, "invalid enum value")
 
 				// toStatus
-				out, err = modGen.With(daggerQuery(`{test{toStatus(status: "INACTIVE")}}`)).Stdout(ctx)
+				out, err = modGen.With(daggerQuery(`{test{toStatus(status: "INACTIVE value")}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.toStatus").String())
 
@@ -1286,11 +1292,13 @@ export class Test {
 				mod := inspectModule(ctx, t, modGen)
 				statusEnum := mod.Get("enums.#.asEnum|#(name=TestStatus)")
 				require.Equal(t, "Enum for Status", statusEnum.Get("description").String())
-				require.Len(t, statusEnum.Get("values").Array(), 2)
-				require.Equal(t, "ACTIVE", statusEnum.Get("values.0.name").String())
-				require.Equal(t, "INACTIVE", statusEnum.Get("values.1.name").String())
-				require.Equal(t, "Active status", statusEnum.Get("values.0.description").String())
-				require.Equal(t, "Inactive status", statusEnum.Get("values.1.description").String())
+				require.Len(t, statusEnum.Get("members").Array(), 2)
+				require.Equal(t, "ACTIVE", statusEnum.Get("members.0.name").String())
+				require.Equal(t, "INACTIVE", statusEnum.Get("members.1.name").String())
+				require.Equal(t, "ACTIVE value", statusEnum.Get("members.0.value").String())
+				require.Equal(t, "INACTIVE value", statusEnum.Get("members.1.value").String())
+				require.Equal(t, "Active status", statusEnum.Get("members.0.description").String())
+				require.Equal(t, "Inactive status", statusEnum.Get("members.1.description").String())
 			})
 		}
 	})
@@ -1303,10 +1311,10 @@ type Status string
 
 const (
 	// Active status
-	Active Status = "ACTIVE"
+	Active Status = "ACTIVE value"
 
 	// Inactive status
-	Inactive Status = "INACTIVE"
+	Inactive Status = "INACTIVE value"
 )
 
 type Dep struct{}
@@ -1345,10 +1353,16 @@ import (
 	"dagger/test/internal/dagger"
 )
 
-type Test struct{}
+type Test struct {
+	Status dagger.DepStatus // +private
+}
+
+func New() *Test {
+	return &Test{Status: dagger.DepStatusActive}
+}
 
 func (m *Test) Active() (string) {
-	return string(dagger.DepStatusActive)
+	return string(m.Status)
 }
 
 func (m *Test) Inactive(ctx context.Context) (string, error) {
@@ -1367,13 +1381,16 @@ func (m *Test) Inactive(ctx context.Context) (string, error) {
 			{
 				sdk: "python",
 				source: `import dagger
+import dataclasses
 from dagger import dag, DepStatus
 
 @dagger.object_type
 class Test:
+    status: DepStatus = dataclasses.field(default=DepStatus.ACTIVE, init=False)
+
     @dagger.function
     def active(self) -> str:
-        return str(DepStatus.ACTIVE)
+        return str(self.status)
 
     @dagger.function
     async def inactive(self) -> str:
@@ -1388,9 +1405,15 @@ class Test:
 
 @object()
 export class Test {
+  status: DepStatus
+
+  constructor() {
+    this.status = DepStatus.Active;
+  }
+
   @func()
   active(): string {
-    return DepStatus.Active;
+    return this.status;
   }
 
   @func()
@@ -1414,13 +1437,16 @@ export class Test {
 
 				out, err := modGen.With(daggerQuery(`{test{active inactive}}`)).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "ACTIVE", gjson.Get(out, "test.active").String())
-				require.Equal(t, "INACTIVE", gjson.Get(out, "test.inactive").String())
+				require.Equal(t, "ACTIVE value", gjson.Get(out, "test.active").String())
+				require.Equal(t, "INACTIVE value", gjson.Get(out, "test.inactive").String())
 			})
 		}
 	})
 
 	t.Run("custom conflicting enum type", func(ctx context.Context, t *testctx.T) {
+		// we can't define an enum with the values false/true/null
+		// however, these tests define FALSE/TRUE/NULL, which should be fine!
+
 		depSrc := `package main
 
 type Dep struct{}
@@ -1473,10 +1499,9 @@ func (m *Test) TestNull(ctx context.Context) (string, error) {
 				With(withModInitAt("./dep", "go", depSrc)).
 				With(daggerExec("install", "./dep"))
 
-			_, err := modGen.With(daggerQuery(`{test{testBool}}`)).Stdout(ctx)
-			require.Error(t, err)
-			require.NoError(t, c.Close())
-			require.Contains(t, logs.String(), "invalid enum value false")
+			out, err := modGen.With(daggerQuery(`{test{testBool}}`)).Stdout(ctx)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"test":{"testBool":"false"}}`, out)
 		})
 
 		t.Run("null", func(ctx context.Context, t *testctx.T) {
@@ -1487,10 +1512,9 @@ func (m *Test) TestNull(ctx context.Context) (string, error) {
 				With(withModInitAt("./dep", "go", depSrc)).
 				With(daggerExec("install", "./dep"))
 
-			_, err := modGen.With(daggerQuery(`{test{testNull}}`)).Stdout(ctx)
-			require.Error(t, err)
-			require.NoError(t, c.Close())
-			require.Contains(t, logs.String(), "invalid enum value null")
+			out, err := modGen.With(daggerQuery(`{test{testNull}}`)).Stdout(ctx)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"test":{"testNull":"null"}}`, out)
 		})
 	})
 }

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -1407,20 +1407,20 @@ export class Test {
 		schema := inspectModule(ctx, t, modGen)
 
 		require.Equal(t, "Test Enum", schema.Get("enums.#.asEnum|#(name=TestEnum).description").String())
-		require.Equal(t, "A", schema.Get("enums.#.asEnum|#(name=TestEnum).values.#(name=a).description").String())
-		require.Equal(t, "B", schema.Get("enums.#.asEnum|#(name=TestEnum).values.#(name=b).description").String())
+		require.Equal(t, "A", schema.Get("enums.#.asEnum|#(name=TestEnum).members.#(name=A).description").String())
+		require.Equal(t, "B", schema.Get("enums.#.asEnum|#(name=TestEnum).members.#(name=B).description").String())
 	})
 
 	t.Run("native enum type - correct input / output", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerCall("test-enum", "--test", "b")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, `b`, out)
+		require.Equal(t, `B`, out)
 	})
 
 	t.Run("native enum type - default value by reference", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerCall("test-enum")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, `a`, out)
+		require.Equal(t, `A`, out)
 	})
 }
 

--- a/core/interface.go
+++ b/core/interface.go
@@ -414,7 +414,7 @@ func (iface *InterfaceAnnotatedValue) TypeDescription() string {
 	return iface.TypeDef.Description
 }
 
-func (iface *InterfaceAnnotatedValue) TypeDefinition(views ...string) *ast.Definition {
+func (iface *InterfaceAnnotatedValue) TypeDefinition(view string) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Object,
 		Name: iface.Type().Name(),

--- a/core/module.go
+++ b/core/module.go
@@ -161,7 +161,7 @@ func (mod *Module) Install(ctx context.Context, dag *dagql.Server) error {
 	for _, def := range mod.EnumDefs {
 		enumDef := def.AsEnum.Value
 
-		slog.ExtraDebug("installing enum", "name", mod.Name(), "enum", enumDef.Name, "values", len(enumDef.Values))
+		slog.ExtraDebug("installing enum", "name", mod.Name(), "enum", enumDef.Name, "members", len(enumDef.Members))
 
 		enum := &ModuleEnum{
 			TypeDef: enumDef,
@@ -560,14 +560,14 @@ func (mod *Module) namespaceTypeDef(ctx context.Context, modPath string, typeDef
 			return fmt.Errorf("failed to get mod type for type def: %w", err)
 		}
 		if ok {
-			enum.Values = mtype.TypeDef().AsEnum.Value.Values
+			enum.Members = mtype.TypeDef().AsEnum.Value.Members
 		}
 		if !ok {
 			enum.Name = namespaceObject(enum.OriginalName, mod.Name(), mod.OriginalName)
 			enum.SourceMap = mod.namespaceSourceMap(modPath, enum.SourceMap)
 		}
 
-		for _, value := range enum.Values {
+		for _, value := range enum.Members {
 			value.SourceMap = mod.namespaceSourceMap(modPath, value.SourceMap)
 		}
 	}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -24,9 +24,9 @@ type ModuleSourceKind string
 var ModuleSourceKindEnum = dagql.NewEnum[ModuleSourceKind]()
 
 var (
-	ModuleSourceKindLocal = ModuleSourceKindEnum.Register("LOCAL_SOURCE")
-	ModuleSourceKindGit   = ModuleSourceKindEnum.Register("GIT_SOURCE")
-	ModuleSourceKindDir   = ModuleSourceKindEnum.Register("DIR_SOURCE")
+	ModuleSourceKindLocal = ModuleSourceKindEnum.Register("LOCAL")
+	ModuleSourceKindGit   = ModuleSourceKindEnum.Register("GIT")
+	ModuleSourceKindDir   = ModuleSourceKindEnum.Register("DIR")
 )
 
 func (proto ModuleSourceKind) Type() *ast.Type {

--- a/core/object.go
+++ b/core/object.go
@@ -245,7 +245,7 @@ func (obj *ModuleObject) TypeDescription() string {
 	return formatGqlDescription(obj.TypeDef.Description)
 }
 
-func (obj *ModuleObject) TypeDefinition(views ...string) *ast.Definition {
+func (obj *ModuleObject) TypeDefinition(view string) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Object,
 		Name: obj.Type().Name(),
@@ -330,7 +330,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 		return fmt.Errorf("failed to create function: %w", err)
 	}
 
-	spec, err := fn.metadata.FieldSpec()
+	spec, err := fn.metadata.FieldSpec(ctx, fn)
 	if err != nil {
 		return fmt.Errorf("failed to get field spec: %w", err)
 	}
@@ -436,7 +436,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 	if err != nil {
 		return f, fmt.Errorf("failed to create function %q: %w", fun.Name, err)
 	}
-	spec, err := fun.FieldSpec()
+	spec, err := fun.FieldSpec(ctx, modFun)
 	if err != nil {
 		return f, fmt.Errorf("failed to get field spec: %w", err)
 	}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1310,7 +1310,7 @@ type containerPublishArgs struct {
 	Address           dagql.String
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
-	MediaTypes        core.ImageMediaTypes `default:"OCIMediaTypes"`
+	MediaTypes        core.ImageMediaTypes `default:"OCI"`
 }
 
 func (s *containerSchema) publish(ctx context.Context, parent *core.Container, args containerPublishArgs) (dagql.String, error) {
@@ -1752,7 +1752,7 @@ type containerExportArgs struct {
 	Path              string
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
-	MediaTypes        core.ImageMediaTypes `default:"OCIMediaTypes"`
+	MediaTypes        core.ImageMediaTypes `default:"OCI"`
 	Expand            bool                 `default:"false"`
 }
 
@@ -1799,7 +1799,7 @@ func (s *containerSchema) exportLegacy(ctx context.Context, parent *core.Contain
 type containerAsTarballArgs struct {
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
-	MediaTypes        core.ImageMediaTypes `default:"OCIMediaTypes"`
+	MediaTypes        core.ImageMediaTypes `default:"OCI"`
 }
 
 func (s *containerSchema) asTarball(

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -222,8 +222,9 @@ func (m *CoreMod) TypeDefs(ctx context.Context) ([]*core.TypeDef, error) {
 			}
 
 			for _, value := range introspectionType.EnumValues {
-				typedef.Values = append(typedef.Values, &core.EnumValueTypeDef{
+				typedef.Members = append(typedef.Members, &core.EnumMemberTypeDef{
 					Name:        value.Name,
+					Value:       value.Directives.EnumValue(),
 					Description: value.Description,
 				})
 			}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -177,9 +177,17 @@ func (s *moduleSchema) Install() {
 			ArgDoc("description", `A doc string for the enum, if any`).
 			ArgDoc("sourceMap", `The source map for the enum definition.`),
 
+		// Deprecated, but kept around for old SDKs
 		dagql.Func("withEnumValue", s.typeDefWithEnumValue).
 			Doc(`Adds a static value for an Enum TypeDef, failing if the type is not an enum.`).
 			ArgDoc("value", `The name of the value in the enum`).
+			ArgDoc("description", `A doc string for the value, if any`).
+			ArgDoc("sourceMap", `The source map for the enum value definition.`),
+
+		dagql.Func("withEnumMember", s.typeDefWithEnumMember).
+			Doc(`Adds a static value for an Enum TypeDef, failing if the type is not an enum.`).
+			ArgDoc("name", `The name of the member in the enum`).
+			ArgDoc("value", `The value of the member in the enum`).
 			ArgDoc("description", `A doc string for the value, if any`).
 			ArgDoc("sourceMap", `The source map for the enum value definition.`),
 	}.Install(s.dag)
@@ -190,8 +198,12 @@ func (s *moduleSchema) Install() {
 	dagql.Fields[*core.FieldTypeDef]{}.Install(s.dag)
 	dagql.Fields[*core.ListTypeDef]{}.Install(s.dag)
 	dagql.Fields[*core.ScalarTypeDef]{}.Install(s.dag)
-	dagql.Fields[*core.EnumTypeDef]{}.Install(s.dag)
-	dagql.Fields[*core.EnumValueTypeDef]{}.Install(s.dag)
+	dagql.Fields[*core.EnumTypeDef]{
+		dagql.Func("values", func(ctx context.Context, self *core.EnumTypeDef, _ struct{}) ([]*core.EnumMemberTypeDef, error) {
+			return self.Members, nil
+		}).Deprecated("use members instead").View(BeforeVersion("v0.16.0")),
+	}.Install(s.dag)
+	dagql.Fields[*core.EnumMemberTypeDef]{}.Install(s.dag)
 }
 
 func (s *moduleSchema) typeDef(ctx context.Context, _ *core.Query, args struct{}) (*core.TypeDef, error) {
@@ -329,7 +341,23 @@ func (s *moduleSchema) typeDefWithEnumValue(ctx context.Context, def *core.TypeD
 	if err != nil {
 		return nil, err
 	}
-	return def.WithEnumValue(args.Value, args.Description, sourceMap)
+	return def.WithEnumMember(args.Value, args.Value, args.Description, sourceMap)
+}
+
+func (s *moduleSchema) typeDefWithEnumMember(ctx context.Context, def *core.TypeDef, args struct {
+	Name        string
+	Value       string
+	Description string `default:""`
+	SourceMap   dagql.Optional[core.SourceMapID]
+}) (*core.TypeDef, error) {
+	if args.Value == "" {
+		return nil, fmt.Errorf("enum value must not be empty")
+	}
+	sourceMap, err := s.loadSourceMap(ctx, args.SourceMap)
+	if err != nil {
+		return nil, err
+	}
+	return def.WithEnumMember(args.Name, args.Value, args.Description, sourceMap)
 }
 
 func (s *moduleSchema) generatedCode(ctx context.Context, _ *core.Query, args struct {

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/iancoleman/strcase"
-	"golang.org/x/mod/semver"
 
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/introspection"
 	"github.com/dagger/dagger/engine/buildkit"
@@ -78,31 +78,11 @@ func gqlFieldName(name string) string {
 	return strcase.ToLowerCamel(name)
 }
 
-// AllVersion is a view that contains all versions.
-var AllVersion = dagql.AllView{}
-
-// AfterVersion is a view that checks if a target version is greater than *or*
-// equal to the filtered version.
-type AfterVersion string
-
-func (minVersion AfterVersion) Contains(version string) bool {
-	if version == "" {
-		return true
-	}
-	return semver.Compare(version, string(minVersion)) >= 0
-}
-
-// BeforeVersion is a view that checks if a target version is less than the
-// filtered version.
-type BeforeVersion string
-
-func (maxVersion BeforeVersion) Contains(version string) bool {
-	if version == "" {
-		return false
-	}
-	return semver.Compare(version, string(maxVersion)) < 0
-}
-
 func ptr[T any](v T) *T {
 	return &v
 }
+
+var AllVersion = core.AllVersion
+
+type BeforeVersion = core.BeforeVersion
+type AfterVersion = core.AfterVersion

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -72,7 +72,7 @@ func (fn Function) Clone() *Function {
 	return &cp
 }
 
-func (fn *Function) FieldSpec() (dagql.FieldSpec, error) {
+func (fn *Function) FieldSpec(ctx context.Context, modFun *ModuleFunction) (dagql.FieldSpec, error) {
 	spec := dagql.FieldSpec{
 		Name:        fn.Name,
 		Description: formatGqlDescription(fn.Description),
@@ -88,10 +88,17 @@ func (fn *Function) FieldSpec() (dagql.FieldSpec, error) {
 			if err := dec.Decode(&val); err != nil {
 				return spec, fmt.Errorf("failed to decode default value for arg %q: %w", arg.Name, err)
 			}
-			var err error
-			defaultVal, err = input.Decoder().DecodeInput(val)
+
+			modArg := modFun.args[arg.Name]
+			result, err := modArg.modType.ConvertFromSDKResult(ctx, val)
 			if err != nil {
 				return spec, fmt.Errorf("failed to decode default value for arg %q: %w", arg.Name, err)
+			}
+
+			var ok bool
+			defaultVal, ok = result.(dagql.Input)
+			if !ok {
+				return spec, fmt.Errorf("could not use decoded value as input for arg %q", arg.Name)
 			}
 		}
 		spec.Args = append(spec.Args, dagql.InputSpec{

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -514,7 +514,7 @@ func (typeDef *TypeDef) WithEnum(name, desc string, sourceMap *SourceMap) *TypeD
 	return typeDef
 }
 
-func (typeDef *TypeDef) WithEnumValue(name, desc string, sourceMap *SourceMap) (*TypeDef, error) {
+func (typeDef *TypeDef) WithEnumMember(name, value, desc string, sourceMap *SourceMap) (*TypeDef, error) {
 	if !typeDef.AsEnum.Valid {
 		return nil, fmt.Errorf("cannot add value to non-enum type: %s", typeDef.Kind)
 	}
@@ -527,20 +527,22 @@ func (typeDef *TypeDef) WithEnumValue(name, desc string, sourceMap *SourceMap) (
 	// [a-zA-Z0-9_]*: Following characters can be letters, digits, or underscores (zero or more times)
 	// $            : End of the string
 	pattern := `^[a-zA-Z_][a-zA-Z0-9_]*$`
-
 	if !regexp.MustCompile(pattern).MatchString(name) {
 		return nil, fmt.Errorf("enum value %q is not valid (only letters, digits and underscores are allowed)", name)
 	}
 
 	// Verify if the enum value is duplicated.
-	for _, v := range typeDef.AsEnum.Value.Values {
+	for _, v := range typeDef.AsEnum.Value.Members {
 		if v.Name == name {
-			return nil, fmt.Errorf("enum value %q is already defined", name)
+			return nil, fmt.Errorf("enum %q is already defined", name)
+		}
+		if v.Value == value {
+			return nil, fmt.Errorf("enum %q is already defined with value %q", v.Name, value)
 		}
 	}
 
 	typeDef = typeDef.Clone()
-	typeDef.AsEnum.Value.Values = append(typeDef.AsEnum.Value.Values, NewEnumValueTypeDef(name, desc, sourceMap))
+	typeDef.AsEnum.Value.Members = append(typeDef.AsEnum.Value.Members, NewEnumMemberTypeDef(name, value, desc, sourceMap))
 
 	return typeDef, nil
 }
@@ -939,10 +941,10 @@ func (typeDef *InputTypeDef) ToInputObjectSpec() dagql.InputObjectSpec {
 
 type EnumTypeDef struct {
 	// Name is the standardized name of the enum (CamelCase), as used for the enum in the graphql schema
-	Name        string              `field:"true" doc:"The name of the enum."`
-	Description string              `field:"true" doc:"A doc string for the enum, if any."`
-	Values      []*EnumValueTypeDef `field:"true" doc:"The values of the enum."`
-	SourceMap   *SourceMap          `field:"true" doc:"The location of this enum declaration."`
+	Name        string               `field:"true" doc:"The name of the enum."`
+	Description string               `field:"true" doc:"A doc string for the enum, if any."`
+	Members     []*EnumMemberTypeDef `field:"true" doc:"The members of the enum."`
+	SourceMap   *SourceMap           `field:"true" doc:"The location of this enum declaration."`
 
 	// SourceModuleName is currently only set when returning the TypeDef from the Enum field on Module
 	SourceModuleName string `field:"true" doc:"If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise."`
@@ -965,20 +967,6 @@ func (*EnumTypeDef) TypeDescription() string {
 	return "A definition of a custom enum defined in a Module."
 }
 
-// Implements dagql.Enum interface
-func (enum *EnumTypeDef) ListValues() ast.EnumValueList {
-	var values ast.EnumValueList
-
-	for _, val := range enum.Values {
-		values = append(values, &ast.EnumValueDefinition{
-			Name:        val.Name,
-			Description: val.Description,
-		})
-	}
-
-	return values
-}
-
 func NewEnumTypeDef(name, description string, sourceMap *SourceMap) *EnumTypeDef {
 	return &EnumTypeDef{
 		Name:         strcase.ToCamel(name),
@@ -991,9 +979,9 @@ func NewEnumTypeDef(name, description string, sourceMap *SourceMap) *EnumTypeDef
 func (enum EnumTypeDef) Clone() *EnumTypeDef {
 	cp := enum
 
-	cp.Values = make([]*EnumValueTypeDef, len(enum.Values))
-	for i, value := range enum.Values {
-		cp.Values[i] = value.Clone()
+	cp.Members = make([]*EnumMemberTypeDef, len(enum.Members))
+	for i, value := range enum.Members {
+		cp.Members[i] = value.Clone()
 	}
 	if enum.SourceMap != nil {
 		cp.SourceMap = enum.SourceMap.Clone()
@@ -1002,32 +990,37 @@ func (enum EnumTypeDef) Clone() *EnumTypeDef {
 	return &cp
 }
 
-type EnumValueTypeDef struct {
+type EnumMemberTypeDef struct {
 	Name        string     `field:"true" doc:"The name of the enum value."`
+	Value       string     `field:"true" doc:"The value of the enum value"`
 	Description string     `field:"true" doc:"A doc string for the enum value, if any."`
 	SourceMap   *SourceMap `field:"true" doc:"The location of this enum value declaration."`
+
+	OriginalName string
 }
 
-func (*EnumValueTypeDef) Type() *ast.Type {
+func (*EnumMemberTypeDef) Type() *ast.Type {
 	return &ast.Type{
-		NamedType: "EnumValueTypeDef",
+		NamedType: "EnumMemberTypeDef",
 		NonNull:   true,
 	}
 }
 
-func (*EnumValueTypeDef) TypeDescription() string {
+func (*EnumMemberTypeDef) TypeDescription() string {
 	return "A definition of a value in a custom enum defined in a Module."
 }
 
-func NewEnumValueTypeDef(name, description string, sourceMap *SourceMap) *EnumValueTypeDef {
-	return &EnumValueTypeDef{
-		Name:        name,
-		Description: description,
-		SourceMap:   sourceMap,
+func NewEnumMemberTypeDef(name, value, description string, sourceMap *SourceMap) *EnumMemberTypeDef {
+	return &EnumMemberTypeDef{
+		Name:         strcase.ToScreamingSnake(name),
+		OriginalName: name,
+		Value:        value,
+		Description:  description,
+		SourceMap:    sourceMap,
 	}
 }
 
-func (enumValue EnumValueTypeDef) Clone() *EnumValueTypeDef {
+func (enumValue EnumMemberTypeDef) Clone() *EnumMemberTypeDef {
 	cp := enumValue
 
 	if enumValue.SourceMap != nil {
@@ -1035,6 +1028,21 @@ func (enumValue EnumValueTypeDef) Clone() *EnumValueTypeDef {
 	}
 
 	return &cp
+}
+
+func (enumValue *EnumMemberTypeDef) EnumValueDirective() *ast.Directive {
+	return &ast.Directive{
+		Name: "enumValue",
+		Arguments: ast.ArgumentList{
+			{
+				Name: "value",
+				Value: &ast.Value{
+					Kind: ast.StringValue,
+					Raw:  enumValue.Value,
+				},
+			},
+		},
+	}
 }
 
 type TypeDefKind string
@@ -1046,41 +1054,50 @@ func (k TypeDefKind) String() string {
 var TypeDefKinds = dagql.NewEnum[TypeDefKind]()
 
 var (
-	TypeDefKindString = TypeDefKinds.Register("STRING_KIND",
+	TypeDefKindString = TypeDefKinds.RegisterView("STRING", AfterVersion("v0.16.0"),
 		"A string value.")
-
-	TypeDefKindFloat = TypeDefKinds.Register("FLOAT_KIND",
-		"A float value.")
-
-	TypeDefKindInteger = TypeDefKinds.Register("INTEGER_KIND",
+	_                  = TypeDefKinds.Alias("STRING_KIND", "STRING")
+	TypeDefKindInteger = TypeDefKinds.RegisterView("INTEGER", AfterVersion("v0.16.0"),
 		"An integer value.")
-	TypeDefKindBoolean = TypeDefKinds.Register("BOOLEAN_KIND",
+	_                = TypeDefKinds.Alias("INTEGER_KIND", "INTEGER")
+	TypeDefKindFloat = TypeDefKinds.RegisterView("FLOAT", AfterVersion("v0.16.0"),
+		"A float value.")
+	_                  = TypeDefKinds.Alias("FLOAT_KIND", "FLOAT")
+	TypeDefKindBoolean = TypeDefKinds.RegisterView("BOOLEAN", AfterVersion("v0.16.0"),
 		"A boolean value.")
-	TypeDefKindScalar = TypeDefKinds.Register("SCALAR_KIND",
+	_                 = TypeDefKinds.Alias("BOOLEAN_KIND", "BOOLEAN")
+	TypeDefKindScalar = TypeDefKinds.RegisterView("SCALAR", AfterVersion("v0.16.0"),
 		"A scalar value of any basic kind.")
-	TypeDefKindList = TypeDefKinds.Register("LIST_KIND",
+	_               = TypeDefKinds.Alias("SCALAR_KIND", "SCALAR")
+	TypeDefKindList = TypeDefKinds.RegisterView("LIST", AfterVersion("v0.16.0"),
 		"A list of values all having the same type.",
 		"Always paired with a ListTypeDef.")
-	TypeDefKindObject = TypeDefKinds.Register("OBJECT_KIND",
+	_                 = TypeDefKinds.Alias("LIST_KIND", "LIST")
+	TypeDefKindObject = TypeDefKinds.RegisterView("OBJECT", AfterVersion("v0.16.0"),
 		"A named type defined in the GraphQL schema, with fields and functions.",
 		"Always paired with an ObjectTypeDef.")
-	TypeDefKindInterface = TypeDefKinds.Register("INTERFACE_KIND",
+	_                    = TypeDefKinds.Alias("OBJECT_KIND", "OBJECT")
+	TypeDefKindInterface = TypeDefKinds.RegisterView("INTERFACE", AfterVersion("v0.16.0"),
 		`A named type of functions that can be matched+implemented by other
 		objects+interfaces.`,
 		"Always paired with an InterfaceTypeDef.")
-	TypeDefKindInput = TypeDefKinds.Register("INPUT_KIND",
+	_                = TypeDefKinds.Alias("INTERFACE_KIND", "INTERFACE")
+	TypeDefKindInput = TypeDefKinds.RegisterView("INPUT", AfterVersion("v0.16.0"),
 		`A graphql input type, used only when representing the core API via TypeDefs.`,
 	)
-	TypeDefKindVoid = TypeDefKinds.Register("VOID_KIND",
+	_               = TypeDefKinds.Alias("INPUT_KIND", "INPUT")
+	TypeDefKindVoid = TypeDefKinds.RegisterView("VOID", AfterVersion("v0.16.0"),
 		"A special kind used to signify that no value is returned.",
 		`This is used for functions that have no return value. The outer TypeDef
 		specifying this Kind is always Optional, as the Void is never actually
 		represented.`,
 	)
-	TypeDefKindEnum = TypeDefKinds.Register("ENUM_KIND",
+	_               = TypeDefKinds.Alias("VOID_KIND", "VOID")
+	TypeDefKindEnum = TypeDefKinds.RegisterView("ENUM", AfterVersion("v0.16.0"),
 		"A GraphQL enum type and its values",
 		"Always paired with an EnumTypeDef.",
 	)
+	_ = TypeDefKinds.Alias("ENUM_KIND", "ENUM")
 )
 
 func (k TypeDefKind) Type() *ast.Type {

--- a/core/typedef_test.go
+++ b/core/typedef_test.go
@@ -60,7 +60,7 @@ var Samples = map[TypeDefKind]*TypeDef{
 }
 
 func TestTypeDefConversions(t *testing.T) {
-	for _, val := range TypeDefKinds.PossibleValues() {
+	for _, val := range TypeDefKinds.PossibleValues("") {
 		val := val
 		sample, ok := Samples[TypeDefKind(val.Name)]
 		if !ok {

--- a/core/util.go
+++ b/core/util.go
@@ -17,6 +17,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 
 	"github.com/dagger/dagger/core/reffs"
 	"github.com/dagger/dagger/dagql"
@@ -339,4 +340,29 @@ func (s *SliceSet[T]) Append(element T) {
 		return
 	}
 	*s = append(*s, element)
+}
+
+// AllVersion is a view that contains all versions.
+var AllVersion = dagql.AllView{}
+
+// AfterVersion is a view that checks if a target version is greater than *or*
+// equal to the filtered version.
+type AfterVersion string
+
+func (minVersion AfterVersion) Contains(version string) bool {
+	if version == "" {
+		return true
+	}
+	return semver.Compare(version, string(minVersion)) >= 0
+}
+
+// BeforeVersion is a view that checks if a target version is less than the
+// filtered version.
+type BeforeVersion string
+
+func (maxVersion BeforeVersion) Contains(version string) bool {
+	if version == "" {
+		return false
+	}
+	return semver.Compare(version, string(maxVersion)) < 0
 }

--- a/dagql/introspection/types.go
+++ b/dagql/introspection/types.go
@@ -263,7 +263,7 @@ func Install[T dagql.Typed](srv *dagql.Server) {
 			if self.Value == nil {
 				return dagql.Null[dagql.String](), nil
 			} else {
-				return dagql.NonNull(dagql.NewString(self.Value.Raw)), nil
+				return dagql.NonNull(dagql.NewString(self.Value.String())), nil
 			}
 		}),
 	}.Install(srv)

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -81,13 +81,13 @@ func (class Class[T]) IDType() (IDType, bool) {
 	}
 }
 
-func (class Class[T]) Field(name string, views ...string) (Field[T], bool) {
+func (class Class[T]) Field(name string, view string) (Field[T], bool) {
 	class.fieldsL.Lock()
 	defer class.fieldsL.Unlock()
-	return class.fieldLocked(name, views...)
+	return class.fieldLocked(name, view)
 }
 
-func (class Class[T]) fieldLocked(name string, views ...string) (Field[T], bool) {
+func (class Class[T]) fieldLocked(name string, view string) (Field[T], bool) {
 	fields, ok := class.fields[name]
 	if !ok {
 		return Field[T]{}, false
@@ -99,10 +99,8 @@ func (class Class[T]) fieldLocked(name string, views ...string) (Field[T], bool)
 		if field.ViewFilter == nil {
 			return *field, true
 		}
-		for _, view := range views {
-			if field.ViewFilter.Contains(view) {
-				return *field, true
-			}
+		if field.ViewFilter.Contains(view) {
+			return *field, true
 		}
 	}
 	return Field[T]{}, false
@@ -165,13 +163,13 @@ func (cls Class[T]) Extend(spec FieldSpec, fun FieldFunc, cacheKeyFun FieldCache
 // type may implement Definitive or Descriptive to provide more information.
 //
 // Each currently defined field is installed on the returned definition.
-func (cls Class[T]) TypeDefinition(views ...string) *ast.Definition {
+func (cls Class[T]) TypeDefinition(view string) *ast.Definition {
 	cls.fieldsL.Lock()
 	defer cls.fieldsL.Unlock()
 	var val any = cls.inner
 	var def *ast.Definition
 	if isType, ok := val.(Definitive); ok {
-		def = isType.TypeDefinition(views...)
+		def = isType.TypeDefinition(view)
 	} else {
 		def = &ast.Definition{
 			Kind: ast.Object,
@@ -182,7 +180,7 @@ func (cls Class[T]) TypeDefinition(views ...string) *ast.Definition {
 		def.Description = isType.TypeDescription()
 	}
 	for name := range cls.fields {
-		if field, ok := cls.fieldLocked(name, views...); ok {
+		if field, ok := cls.fieldLocked(name, view); ok {
 			def.Fields = append(def.Fields, field.FieldDefinition())
 		}
 	}
@@ -786,7 +784,7 @@ type Descriptive interface {
 
 // Definitive is a type that knows how to define itself in the schema.
 type Definitive interface {
-	TypeDefinition(views ...string) *ast.Definition
+	TypeDefinition(view string) *ast.Definition
 }
 
 // Fields defines a set of fields for an Object type.
@@ -980,10 +978,10 @@ func (field Field[T]) FieldDefinition() *ast.FieldDefinition {
 	return field.Spec.FieldDefinition()
 }
 
-func definition(kind ast.DefinitionKind, val Type, views ...string) *ast.Definition {
+func definition(kind ast.DefinitionKind, val Type, view string) *ast.Definition {
 	var def *ast.Definition
 	if isType, ok := val.(Definitive); ok {
-		def = isType.TypeDefinition(views...)
+		def = isType.TypeDefinition(view)
 	} else {
 		def = &ast.Definition{
 			Kind: kind,

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -216,6 +216,19 @@ var coreDirectives = []DirectiveSpec{
 			DirectiveLocationInputObject,
 		},
 	},
+	{
+		Name:        "enumValue",
+		Description: FormatDescription(`XXX`),
+		Args: []InputSpec{
+			{
+				Name: "value",
+				Type: String(""),
+			},
+		},
+		Locations: []DirectiveLocation{
+			DirectiveLocationEnumValue,
+		},
+	},
 }
 
 // Root returns the root object of the server. It is suitable for passing to

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -916,6 +916,10 @@ func (e *EnumValues[T]) TypeDefinition(views ...string) *ast.Definition {
 }
 
 func (e *EnumValues[T]) DecodeInput(val any) (Input, error) {
+	if enum, ok := val.(T); ok {
+		val = string(enum)
+	}
+
 	v, err := (&EnumValueName{Enum: e.TypeName()}).DecodeInput(val)
 	if err != nil {
 		return nil, err

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -1,6 +1,7 @@
 package dagql
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -145,7 +146,7 @@ func (Int) TypeName() string {
 	return "Int"
 }
 
-func (i Int) TypeDefinition(views ...string) *ast.Definition {
+func (i Int) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        i.TypeName(),
@@ -242,7 +243,7 @@ func (Float) TypeName() string {
 	return "Float"
 }
 
-func (f Float) TypeDefinition(views ...string) *ast.Definition {
+func (f Float) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        f.TypeName(),
@@ -343,7 +344,7 @@ func (Boolean) TypeName() string {
 	return "Boolean"
 }
 
-func (b Boolean) TypeDefinition(views ...string) *ast.Definition {
+func (b Boolean) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        b.TypeName(),
@@ -428,7 +429,7 @@ func (String) TypeName() string {
 	return "String"
 }
 
-func (s String) TypeDefinition(views ...string) *ast.Definition {
+func (s String) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        s.TypeName(),
@@ -515,7 +516,7 @@ func (s Scalar[T]) TypeName() string {
 	return s.Name
 }
 
-func (s Scalar[T]) TypeDefinition(views ...string) *ast.Definition {
+func (s Scalar[T]) TypeDefinition(view string) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Scalar,
 		Name: s.TypeName(),
@@ -602,7 +603,7 @@ func (i ID[T]) ID() *call.ID {
 var _ ScalarType = ID[Typed]{}
 
 // TypeDefinition returns the GraphQL definition of the type.
-func (i ID[T]) TypeDefinition(views ...string) *ast.Definition {
+func (i ID[T]) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind: ast.Scalar,
 		Name: i.TypeName(),
@@ -874,23 +875,30 @@ func (arr Array[T]) Nth(i int) (Typed, error) {
 	return arr[i-1], nil
 }
 
-type EnumValue interface {
+type enumValue interface {
 	Input
 	~string
 }
 
-// EnumValues is a list of possible values for an Enum.
-type EnumValues[T EnumValue] struct {
-	values       []T
-	descriptions []string
+type EnumValue[T enumValue] struct {
+	Value       T
+	Target      T
+	Description string
+	View        View
 }
 
+// EnumValues is a list of possible values for an Enum.
+type EnumValues[T enumValue] []EnumValue[T]
+
 // NewEnum creates a new EnumType with the given possible values.
-func NewEnum[T EnumValue](vals ...T) *EnumValues[T] {
-	return &EnumValues[T]{
-		values:       vals,
-		descriptions: make([]string, len(vals)),
+func NewEnum[T enumValue](vals ...T) *EnumValues[T] {
+	enum := make(EnumValues[T], 0, len(vals))
+	for _, val := range vals {
+		enum = append(enum, EnumValue[T]{
+			Value: val,
+		})
 	}
+	return &enum
 }
 
 func (e *EnumValues[T]) Type() *ast.Type {
@@ -902,11 +910,11 @@ func (e *EnumValues[T]) TypeName() string {
 	return e.Type().Name()
 }
 
-func (e *EnumValues[T]) TypeDefinition(views ...string) *ast.Definition {
+func (e *EnumValues[T]) TypeDefinition(view string) *ast.Definition {
 	def := &ast.Definition{
 		Kind:       ast.Enum,
 		Name:       e.TypeName(),
-		EnumValues: e.PossibleValues(),
+		EnumValues: e.PossibleValues(view),
 	}
 	var val T
 	if isType, ok := any(val).(Descriptive); ok {
@@ -924,19 +932,47 @@ func (e *EnumValues[T]) DecodeInput(val any) (Input, error) {
 	if err != nil {
 		return nil, err
 	}
-	return e.Lookup(v.(*EnumValueName).Value)
+	return e.Lookup(v.(*EnumValueName).Name)
 }
 
-func (e *EnumValues[T]) PossibleValues() ast.EnumValueList {
+func (e *EnumValues[T]) PossibleValues(view string) ast.EnumValueList {
 	var values ast.EnumValueList
-	for i, val := range e.values {
-		values = append(values, &ast.EnumValueDefinition{
-			Name:        string(val),
-			Description: e.descriptions[i],
-		})
+	for _, val := range *e {
+		if val.View != nil && !val.View.Contains(view) {
+			continue
+		}
+
+		def := &ast.EnumValueDefinition{
+			Name:        string(val.Value),
+			Description: val.Description,
+		}
+		if directive := enumValueDirective(cmp.Or(val.Target, val.Value)); directive != nil {
+			def.Directives = append(def.Directives, directive)
+		}
+		values = append(values, def)
 	}
 
 	return values
+}
+
+func enumValueDirective[T enumValue](value T) *ast.Directive {
+	var zero T
+	if value == zero {
+		return nil
+	}
+
+	return &ast.Directive{
+		Name: "enumValue",
+		Arguments: ast.ArgumentList{
+			{
+				Name: "value",
+				Value: &ast.Value{
+					Kind: ast.StringValue,
+					Raw:  string(value),
+				},
+			},
+		},
+	}
 }
 
 func (e *EnumValues[T]) Literal(val T) call.Literal {
@@ -944,19 +980,47 @@ func (e *EnumValues[T]) Literal(val T) call.Literal {
 }
 
 func (e *EnumValues[T]) Lookup(val string) (T, error) {
-	var enum T
-	for _, possible := range e.values {
-		if val == string(possible) {
-			return possible, nil
+	var zero T
+	for _, possible := range *e {
+		if val == string(possible.Value) {
+			if possible.Target != zero {
+				return possible.Target, nil
+			}
+			return possible.Value, nil
 		}
 	}
-	return enum, fmt.Errorf("invalid enum value %q", val)
+	return zero, fmt.Errorf("invalid enum value %q", val)
 }
 
 func (e *EnumValues[T]) Register(val T, desc ...string) T {
-	e.values = append(e.values, val)
-	e.descriptions = append(e.descriptions, FormatDescription(desc...))
+	*e = append(*e, EnumValue[T]{
+		Value:       val,
+		Description: FormatDescription(desc...),
+	})
 	return val
+}
+
+func (e *EnumValues[T]) RegisterView(val T, view View, desc ...string) T {
+	*e = append(*e, EnumValue[T]{
+		Value:       val,
+		Description: FormatDescription(desc...),
+		View:        view,
+	})
+	return val
+}
+
+func (e *EnumValues[T]) Alias(val T, target T) T {
+	for _, v := range *e {
+		if v.Value == target {
+			*e = append(*e, EnumValue[T]{
+				Value:       val,
+				Target:      v.Value,
+				Description: v.Description,
+			})
+			return val
+		}
+	}
+	panic(fmt.Sprintf("cannot find enum %q", target))
 }
 
 func (e *EnumValues[T]) Install(srv *Server) {
@@ -965,8 +1029,8 @@ func (e *EnumValues[T]) Install(srv *Server) {
 }
 
 type EnumValueName struct {
-	Enum  string
-	Value string
+	Enum string
+	Name string
 }
 
 var _ Input = &EnumValueName{}
@@ -982,7 +1046,7 @@ func (e *EnumValueName) Type() *ast.Type {
 	}
 }
 
-func (e *EnumValueName) TypeDefinition(views ...string) *ast.Definition {
+func (e *EnumValueName) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind: ast.Enum,
 		Name: e.TypeName(),
@@ -990,7 +1054,7 @@ func (e *EnumValueName) TypeDefinition(views ...string) *ast.Definition {
 }
 
 func (e *EnumValueName) ToLiteral() call.Literal {
-	return call.NewLiteralEnum(e.Value)
+	return call.NewLiteralEnum(e.Name)
 }
 
 func (e *EnumValueName) Decoder() InputDecoder {
@@ -1000,9 +1064,9 @@ func (e *EnumValueName) Decoder() InputDecoder {
 func (e *EnumValueName) DecodeInput(val any) (Input, error) {
 	switch x := val.(type) {
 	case *EnumValueName:
-		return &EnumValueName{Enum: e.Enum, Value: x.Value}, nil
+		return &EnumValueName{Enum: e.Enum, Name: x.Name}, nil
 	case string:
-		return &EnumValueName{Enum: e.Enum, Value: x}, nil
+		return &EnumValueName{Enum: e.Enum, Name: x}, nil
 	case bool:
 		return nil, fmt.Errorf("invalid enum value %t", x)
 	case nil:
@@ -1013,7 +1077,7 @@ func (e *EnumValueName) DecodeInput(val any) (Input, error) {
 }
 
 func (e *EnumValueName) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.Value)
+	return json.Marshal(e.Name)
 }
 
 func MustInputSpec(val Type) InputObjectSpec {
@@ -1052,7 +1116,7 @@ func (spec InputObjectSpec) TypeName() string {
 	return spec.Name
 }
 
-func (spec InputObjectSpec) TypeDefinition(views ...string) *ast.Definition {
+func (spec InputObjectSpec) TypeDefinition(view string) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.InputObject,
 		Name:        spec.Name,

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1,3 +1,6 @@
+"""XXX"""
+directive @enumValue(value: String!) on ENUM_VALUE
+
 """
 Indicates that a field may resolve to different values when called repeatedly
 with the same inputs, or that the field has side effects. Impure fields are never cached.
@@ -121,7 +124,7 @@ type Container {
     Defaults to OCI, which is largely compatible with most recent container
     runtimes, but Docker may be needed for older runtimes without OCI support.
     """
-    mediaTypes: ImageMediaTypes = OCIMediaTypes
+    mediaTypes: ImageMediaType = OCI
 
     """
     Identifiers for other platform specific containers.
@@ -246,7 +249,7 @@ type Container {
     Defaults to OCI, which is largely compatible with most recent container
     runtimes, but Docker may be needed for older runtimes without OCI support.
     """
-    mediaTypes: ImageMediaTypes = OCIMediaTypes
+    mediaTypes: ImageMediaType = OCI
 
     """
     Host's destination path (e.g., "./tarball").
@@ -361,7 +364,7 @@ type Container {
     Defaults to OCI, which is largely compatible with most recent registries,
     but Docker may be needed for older registries without OCI support.
     """
-    mediaTypes: ImageMediaTypes = OCIMediaTypes
+    mediaTypes: ImageMediaType = OCI
 
     """
     Identifiers for other platform specific containers.
@@ -1521,6 +1524,29 @@ The `EngineID` scalar type represents an identifier for an object of type Engine
 """
 scalar EngineID
 
+"""A definition of a value in a custom enum defined in a Module."""
+type EnumMemberTypeDef {
+  """A doc string for the enum value, if any."""
+  description: String!
+
+  """A unique identifier for this EnumMemberTypeDef."""
+  id: EnumMemberTypeDefID!
+
+  """The name of the enum value."""
+  name: String!
+
+  """The location of this enum value declaration."""
+  sourceMap: SourceMap!
+
+  """The value of the enum value"""
+  value: String!
+}
+
+"""
+The `EnumMemberTypeDefID` scalar type represents an identifier for an object of type EnumMemberTypeDef.
+"""
+scalar EnumMemberTypeDefID
+
 """A definition of a custom enum defined in a Module."""
 type EnumTypeDef {
   """A doc string for the enum, if any."""
@@ -1528,6 +1554,9 @@ type EnumTypeDef {
 
   """A unique identifier for this EnumTypeDef."""
   id: EnumTypeDefID!
+
+  """The members of the enum."""
+  members: [EnumMemberTypeDef!]!
 
   """The name of the enum."""
   name: String!
@@ -1539,35 +1568,12 @@ type EnumTypeDef {
   If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.
   """
   sourceModuleName: String!
-
-  """The values of the enum."""
-  values: [EnumValueTypeDef!]!
 }
 
 """
 The `EnumTypeDefID` scalar type represents an identifier for an object of type EnumTypeDef.
 """
 scalar EnumTypeDefID
-
-"""A definition of a value in a custom enum defined in a Module."""
-type EnumValueTypeDef {
-  """A doc string for the enum value, if any."""
-  description: String!
-
-  """A unique identifier for this EnumValueTypeDef."""
-  id: EnumValueTypeDefID!
-
-  """The name of the enum value."""
-  name: String!
-
-  """The location of this enum value declaration."""
-  sourceMap: SourceMap!
-}
-
-"""
-The `EnumValueTypeDefID` scalar type represents an identifier for an object of type EnumValueTypeDef.
-"""
-scalar EnumValueTypeDefID
 
 """An environment variable name and value."""
 type EnvVariable {
@@ -2066,16 +2072,16 @@ scalar HostID
 
 """Compression algorithm to use for image layers."""
 enum ImageLayerCompression {
-  Gzip
-  Zstd
-  EStarGZ
-  Uncompressed
+  GZIP
+  ZSTD
+  ESTARGZ
+  UNCOMPRESSED
 }
 
 """Mediatypes to use in published or exported image metadata."""
-enum ImageMediaTypes {
-  OCIMediaTypes
-  DockerMediaTypes
+enum ImageMediaType {
+  OCI
+  DOCKER
 }
 
 """
@@ -2417,9 +2423,9 @@ scalar ModuleSourceID
 
 """The kind of module source."""
 enum ModuleSourceKind {
-  LOCAL_SOURCE
-  GIT_SOURCE
-  DIR_SOURCE
+  LOCAL
+  GIT
+  DIR
 }
 
 """Transport layer network protocol associated to a port."""
@@ -2647,11 +2653,11 @@ type Query {
   """Load a Engine from its ID."""
   loadEngineFromID(id: EngineID!): Engine!
 
+  """Load a EnumMemberTypeDef from its ID."""
+  loadEnumMemberTypeDefFromID(id: EnumMemberTypeDefID!): EnumMemberTypeDef!
+
   """Load a EnumTypeDef from its ID."""
   loadEnumTypeDefFromID(id: EnumTypeDefID!): EnumTypeDef!
-
-  """Load a EnumValueTypeDef from its ID."""
-  loadEnumValueTypeDefFromID(id: EnumValueTypeDefID!): EnumValueTypeDef!
 
   """Load a EnvVariable from its ID."""
   loadEnvVariableFromID(id: EnvVariableID!): EnvVariable!
@@ -3069,6 +3075,23 @@ type TypeDef {
   """
   Adds a static value for an Enum TypeDef, failing if the type is not an enum.
   """
+  withEnumMember(
+    """A doc string for the value, if any"""
+    description: String = ""
+
+    """The name of the member in the enum"""
+    name: String!
+
+    """The source map for the enum value definition."""
+    sourceMap: SourceMapID
+
+    """The value of the member in the enum"""
+    value: String!
+  ): TypeDef!
+
+  """
+  Adds a static value for an Enum TypeDef, failing if the type is not an enum.
+  """
   withEnumValue(
     """A doc string for the value, if any"""
     description: String = ""
@@ -3137,19 +3160,41 @@ scalar TypeDefID
 """Distinguishes the different kinds of TypeDefs."""
 enum TypeDefKind {
   """A string value."""
+  STRING
+
+  """A string value."""
   STRING_KIND
+
+  """An integer value."""
+  INTEGER
+
+  """An integer value."""
+  INTEGER_KIND
+
+  """A float value."""
+  FLOAT
 
   """A float value."""
   FLOAT_KIND
 
-  """An integer value."""
-  INTEGER_KIND
+  """A boolean value."""
+  BOOLEAN
 
   """A boolean value."""
   BOOLEAN_KIND
 
   """A scalar value of any basic kind."""
+  SCALAR
+
+  """A scalar value of any basic kind."""
   SCALAR_KIND
+
+  """
+  A list of values all having the same type.
+  
+  Always paired with a ListTypeDef.
+  """
+  LIST
 
   """
   A list of values all having the same type.
@@ -3163,6 +3208,13 @@ enum TypeDefKind {
   
   Always paired with an ObjectTypeDef.
   """
+  OBJECT
+
+  """
+  A named type defined in the GraphQL schema, with fields and functions.
+  
+  Always paired with an ObjectTypeDef.
+  """
   OBJECT_KIND
 
   """
@@ -3170,7 +3222,19 @@ enum TypeDefKind {
   
   Always paired with an InterfaceTypeDef.
   """
+  INTERFACE
+
+  """
+  A named type of functions that can be matched+implemented by other objects+interfaces.
+  
+  Always paired with an InterfaceTypeDef.
+  """
   INTERFACE_KIND
+
+  """
+  A graphql input type, used only when representing the core API via TypeDefs.
+  """
+  INPUT
 
   """
   A graphql input type, used only when representing the core API via TypeDefs.
@@ -3183,7 +3247,22 @@ enum TypeDefKind {
   This is used for functions that have no return value. The outer TypeDef
   specifying this Kind is always Optional, as the Void is never actually represented.
   """
+  VOID
+
+  """
+  A special kind used to signify that no value is returned.
+  
+  This is used for functions that have no return value. The outer TypeDef
+  specifying this Kind is always Optional, as the Void is never actually represented.
+  """
   VOID_KIND
+
+  """
+  A GraphQL enum type and its values
+  
+  Always paired with an EnumTypeDef.
+  """
+  ENUM
 
   """
   A GraphQL enum type and its values

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -51,8 +51,8 @@
               <li><a href="#query-loadEngineCacheEntrySetFromID">loadEngineCacheEntrySetFromID</a></li>
               <li><a href="#query-loadEngineCacheFromID">loadEngineCacheFromID</a></li>
               <li><a href="#query-loadEngineFromID">loadEngineFromID</a></li>
+              <li><a href="#query-loadEnumMemberTypeDefFromID">loadEnumMemberTypeDefFromID</a></li>
               <li><a href="#query-loadEnumTypeDefFromID">loadEnumTypeDefFromID</a></li>
-              <li><a href="#query-loadEnumValueTypeDefFromID">loadEnumValueTypeDefFromID</a></li>
               <li><a href="#query-loadEnvVariableFromID">loadEnvVariableFromID</a></li>
               <li><a href="#query-loadErrorFromID">loadErrorFromID</a></li>
               <li><a href="#query-loadFieldTypeDefFromID">loadFieldTypeDefFromID</a></li>
@@ -113,10 +113,10 @@
               <li><a href="#definition-EngineCacheEntrySetID">EngineCacheEntrySetID</a></li>
               <li><a href="#definition-EngineCacheID">EngineCacheID</a></li>
               <li><a href="#definition-EngineID">EngineID</a></li>
+              <li><a href="#definition-EnumMemberTypeDef">EnumMemberTypeDef</a></li>
+              <li><a href="#definition-EnumMemberTypeDefID">EnumMemberTypeDefID</a></li>
               <li><a href="#definition-EnumTypeDef">EnumTypeDef</a></li>
               <li><a href="#definition-EnumTypeDefID">EnumTypeDefID</a></li>
-              <li><a href="#definition-EnumValueTypeDef">EnumValueTypeDef</a></li>
-              <li><a href="#definition-EnumValueTypeDefID">EnumValueTypeDefID</a></li>
               <li><a href="#definition-EnvVariable">EnvVariable</a></li>
               <li><a href="#definition-EnvVariableID">EnvVariableID</a></li>
               <li><a href="#definition-Error">Error</a></li>
@@ -142,7 +142,7 @@
               <li><a href="#definition-Host">Host</a></li>
               <li><a href="#definition-HostID">HostID</a></li>
               <li><a href="#definition-ImageLayerCompression">ImageLayerCompression</a></li>
-              <li><a href="#definition-ImageMediaTypes">ImageMediaTypes</a></li>
+              <li><a href="#definition-ImageMediaType">ImageMediaType</a></li>
               <li><a href="#definition-InputTypeDef">InputTypeDef</a></li>
               <li><a href="#definition-InputTypeDefID">InputTypeDefID</a></li>
               <li><a href="#definition-Int">Int</a></li>
@@ -1398,6 +1398,59 @@
               </div>
             </div>
           </section>
+          <section id="query-loadEnumMemberTypeDefFromID" class="operation operation-query" data-traverse-target="query-loadEnumMemberTypeDefFromID">
+            <div class="operation-group-name">
+              <a href="#group-Queries">Queries</a>
+            </div>
+            <h2 class="operation-heading ">
+              <code>loadEnumMemberTypeDefFromID</code>
+            </h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>Load a EnumMemberTypeDef from its ID.</p>
+                </div>
+              </div>
+            </div>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-response doc-copy-section">
+                  <h5>Type</h5>
+                  <p>
+                    <a href="#definition-EnumMemberTypeDef"><code>EnumMemberTypeDef!</code></a>
+                  </p>
+                </div>
+                <div class="operation-arguments test doc-copy-section">
+                  <h5>Arguments</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <span class="property-name"><code>id</code></span> - <span class="property-type"><a href="#definition-EnumMemberTypeDefID"><code>EnumMemberTypeDefID!</code></a></span>
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-example doc-copy-section">
+                  <h5>Example</h5>
+                </div>
+              </div>
+            </div>
+          </section>
           <section id="query-loadEnumTypeDefFromID" class="operation operation-query" data-traverse-target="query-loadEnumTypeDefFromID">
             <div class="operation-group-name">
               <a href="#group-Queries">Queries</a>
@@ -1434,59 +1487,6 @@
                       <tr>
                         <td>
                           <span class="property-name"><code>id</code></span> - <span class="property-type"><a href="#definition-EnumTypeDefID"><code>EnumTypeDefID!</code></a></span>
-                        </td>
-                        <td>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-            <div class="doc-row">
-              <div class="doc-copy">
-                <div class="operation-example doc-copy-section">
-                  <h5>Example</h5>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section id="query-loadEnumValueTypeDefFromID" class="operation operation-query" data-traverse-target="query-loadEnumValueTypeDefFromID">
-            <div class="operation-group-name">
-              <a href="#group-Queries">Queries</a>
-            </div>
-            <h2 class="operation-heading ">
-              <code>loadEnumValueTypeDefFromID</code>
-            </h2>
-            <div class="doc-row">
-              <div class="doc-copy">
-                <div class="operation-description doc-copy-section">
-                  <h5>Description</h5>
-                  <p>Load a EnumValueTypeDef from its ID.</p>
-                </div>
-              </div>
-            </div>
-            <div class="doc-row">
-              <div class="doc-copy">
-                <div class="operation-response doc-copy-section">
-                  <h5>Type</h5>
-                  <p>
-                    <a href="#definition-EnumValueTypeDef"><code>EnumValueTypeDef!</code></a>
-                  </p>
-                </div>
-                <div class="operation-arguments test doc-copy-section">
-                  <h5>Arguments</h5>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>
-                          <span class="property-name"><code>id</code></span> - <span class="property-type"><a href="#definition-EnumValueTypeDefID"><code>EnumValueTypeDefID!</code></a></span>
                         </td>
                         <td>
                         </td>
@@ -3649,7 +3649,7 @@
                                 <p>If this is unset, then if a layer already has a compressed blob in the engine&#39;s cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine&#39;s cache, then it will be compressed using Gzip.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaTypes"><code>ImageMediaTypes</code></a></span></h6>
+                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaType"><code>ImageMediaType</code></a></span></h6>
                                 <p>Use the specified media types for the image&#39;s layers.</p>
                                 <p>Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.</p>
                               </div>
@@ -3808,7 +3808,7 @@
                                 <p>If this is unset, then if a layer already has a compressed blob in the engine&#39;s cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine&#39;s cache, then it will be compressed using Gzip.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaTypes"><code>ImageMediaTypes</code></a></span></h6>
+                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaType"><code>ImageMediaType</code></a></span></h6>
                                 <p>Use the specified media types for the exported image&#39;s layers.</p>
                                 <p>Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.</p>
                               </div>
@@ -3957,7 +3957,7 @@
                                 <p>If this is unset, then if a layer already has a compressed blob in the engine&#39;s cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine&#39;s cache, then it will be compressed using Gzip.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaTypes"><code>ImageMediaTypes</code></a></span></h6>
+                                <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaType"><code>ImageMediaType</code></a></span></h6>
                                 <p>Use the specified media types for the published image&#39;s layers.</p>
                                 <p>Defaults to OCI, which is largely compatible with most recent registries, but Docker may be needed for older registries without OCI support.</p>
                               </div>
@@ -5843,6 +5843,67 @@
               </div>
             </div>
           </section>
+          <section id="definition-EnumMemberTypeDef" class="definition definition-object" data-traverse-target="definition-EnumMemberTypeDef">
+            <div class="definition-group-name">
+              <a href="#group-Types">Types</a>
+            </div>
+            <h2 class="definition-heading">EnumMemberTypeDef</h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="definition-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>A definition of a value in a custom enum defined in a Module.</p>
+                </div>
+                <div class="definition-properties doc-copy-section">
+                  <h5>Fields</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Field Name</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumMemberTypeDef-description" href="#EnumMemberTypeDef-description"><code>description</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> A doc string for the enum value, if any. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumMemberTypeDef-id" href="#EnumMemberTypeDef-id"><code>id</code></a> - <span class="property-type"><a href="#definition-EnumMemberTypeDefID"><code>EnumMemberTypeDefID!</code></a></span> </td>
+                        <td> A unique identifier for this EnumMemberTypeDef. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumMemberTypeDef-name" href="#EnumMemberTypeDef-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The name of the enum value. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumMemberTypeDef-sourceMap" href="#EnumMemberTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td> The location of this enum value declaration. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumMemberTypeDef-value" href="#EnumMemberTypeDef-value"><code>value</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The value of the enum value </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section id="definition-EnumMemberTypeDefID" class="definition definition-scalar" data-traverse-target="definition-EnumMemberTypeDefID">
+            <div class="definition-group-name">
+              <a href="#group-Types">Types</a>
+            </div>
+            <h2 class="definition-heading">EnumMemberTypeDefID</h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="definition-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>The <code>EnumMemberTypeDefID</code> scalar type represents an identifier for an object of type EnumMemberTypeDef.</p>
+                </div>
+              </div>
+            </div>
+          </section>
           <section id="definition-EnumTypeDef" class="definition definition-object" data-traverse-target="definition-EnumTypeDef">
             <div class="definition-group-name">
               <a href="#group-Types">Types</a>
@@ -5873,6 +5934,10 @@
                         <td> A unique identifier for this EnumTypeDef. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="EnumTypeDef-members" href="#EnumTypeDef-members"><code>members</code></a> - <span class="property-type"><a href="#definition-EnumMemberTypeDef"><code>[EnumMemberTypeDef!]!</code></a></span> </td>
+                        <td> The members of the enum. </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="EnumTypeDef-name" href="#EnumTypeDef-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The name of the enum. </td>
                       </tr>
@@ -5883,10 +5948,6 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="EnumTypeDef-sourceModuleName" href="#EnumTypeDef-sourceModuleName"><code>sourceModuleName</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise. </td>
-                      </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumTypeDef-values" href="#EnumTypeDef-values"><code>values</code></a> - <span class="property-type"><a href="#definition-EnumValueTypeDef"><code>[EnumValueTypeDef!]!</code></a></span> </td>
-                        <td> The values of the enum. </td>
                       </tr>
                     </tbody>
                   </table>
@@ -5904,63 +5965,6 @@
                 <div class="definition-description doc-copy-section">
                   <h5>Description</h5>
                   <p>The <code>EnumTypeDefID</code> scalar type represents an identifier for an object of type EnumTypeDef.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section id="definition-EnumValueTypeDef" class="definition definition-object" data-traverse-target="definition-EnumValueTypeDef">
-            <div class="definition-group-name">
-              <a href="#group-Types">Types</a>
-            </div>
-            <h2 class="definition-heading">EnumValueTypeDef</h2>
-            <div class="doc-row">
-              <div class="doc-copy">
-                <div class="definition-description doc-copy-section">
-                  <h5>Description</h5>
-                  <p>A definition of a value in a custom enum defined in a Module.</p>
-                </div>
-                <div class="definition-properties doc-copy-section">
-                  <h5>Fields</h5>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Field Name</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-description" href="#EnumValueTypeDef-description"><code>description</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
-                        <td> A doc string for the enum value, if any. </td>
-                      </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-id" href="#EnumValueTypeDef-id"><code>id</code></a> - <span class="property-type"><a href="#definition-EnumValueTypeDefID"><code>EnumValueTypeDefID!</code></a></span> </td>
-                        <td> A unique identifier for this EnumValueTypeDef. </td>
-                      </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-name" href="#EnumValueTypeDef-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
-                        <td> The name of the enum value. </td>
-                      </tr>
-                      <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-sourceMap" href="#EnumValueTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
-                        <td> The location of this enum value declaration. </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section id="definition-EnumValueTypeDefID" class="definition definition-scalar" data-traverse-target="definition-EnumValueTypeDefID">
-            <div class="definition-group-name">
-              <a href="#group-Types">Types</a>
-            </div>
-            <h2 class="definition-heading">EnumValueTypeDefID</h2>
-            <div class="doc-row">
-              <div class="doc-copy">
-                <div class="definition-description doc-copy-section">
-                  <h5>Description</h5>
-                  <p>The <code>EnumValueTypeDefID</code> scalar type represents an identifier for an object of type EnumValueTypeDef.</p>
                 </div>
               </div>
             </div>
@@ -7147,28 +7151,28 @@
                     <tbody>
                       <tr>
                         <td>
-                          <p><code>Gzip</code></p>
+                          <p><code>GZIP</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>Zstd</code></p>
+                          <p><code>ZSTD</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>EStarGZ</code></p>
+                          <p><code>ESTARGZ</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>Uncompressed</code></p>
+                          <p><code>UNCOMPRESSED</code></p>
                         </td>
                         <td>
                         </td>
@@ -7182,7 +7186,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"Gzip"</span>
+                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"GZIP"</span>
 </code></pre>
                     </body>
                   </html>
@@ -7190,11 +7194,11 @@
               </div>
             </div>
           </section>
-          <section id="definition-ImageMediaTypes" class="definition definition-enum" data-traverse-target="definition-ImageMediaTypes">
+          <section id="definition-ImageMediaType" class="definition definition-enum" data-traverse-target="definition-ImageMediaType">
             <div class="definition-group-name">
               <a href="#group-Types">Types</a>
             </div>
-            <h2 class="definition-heading">ImageMediaTypes</h2>
+            <h2 class="definition-heading">ImageMediaType</h2>
             <div class="doc-row">
               <div class="doc-copy">
                 <div class="definition-description doc-copy-section">
@@ -7213,14 +7217,14 @@
                     <tbody>
                       <tr>
                         <td>
-                          <p><code>OCIMediaTypes</code></p>
+                          <p><code>OCI</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>DockerMediaTypes</code></p>
+                          <p><code>DOCKER</code></p>
                         </td>
                         <td>
                         </td>
@@ -7234,7 +7238,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"OCIMediaTypes"</span>
+                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"OCI"</span>
 </code></pre>
                     </body>
                   </html>
@@ -7964,21 +7968,21 @@
                     <tbody>
                       <tr>
                         <td>
-                          <p><code>LOCAL_SOURCE</code></p>
+                          <p><code>LOCAL</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>GIT_SOURCE</code></p>
+                          <p><code>GIT</code></p>
                         </td>
                         <td>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>DIR_SOURCE</code></p>
+                          <p><code>DIR</code></p>
                         </td>
                         <td>
                         </td>
@@ -7992,7 +7996,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"LOCAL_SOURCE"</span>
+                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"LOCAL"</span>
 </code></pre>
                     </body>
                   </html>
@@ -8944,6 +8948,35 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="TypeDef-withEnumMember" href="#TypeDef-withEnumMember"><code>withEnumMember</code></a> - <span class="property-type"><a href="#definition-TypeDef"><code>TypeDef!</code></a></span> </td>
+                        <td> Adds a static value for an Enum TypeDef, failing if the type is not an enum. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>A doc string for the value, if any</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the member in the enum</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>sourceMap</code></span> - <span class="property-type"><a href="#definition-SourceMapID"><code>SourceMapID</code></a></span></h6>
+                                <p>The source map for the enum value definition.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>value</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The value of the member in the enum</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="TypeDef-withEnumValue" href="#TypeDef-withEnumValue"><code>withEnumValue</code></a> - <span class="property-type"><a href="#definition-TypeDef"><code>TypeDef!</code></a></span> </td>
                         <td> Adds a static value for an Enum TypeDef, failing if the type is not an enum. </td>
                       </tr>
@@ -9170,15 +9203,21 @@
                     <tbody>
                       <tr>
                         <td>
+                          <p><code>STRING</code></p>
+                        </td>
+                        <td> A string value. </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>STRING_KIND</code></p>
                         </td>
                         <td> A string value. </td>
                       </tr>
                       <tr>
                         <td>
-                          <p><code>FLOAT_KIND</code></p>
+                          <p><code>INTEGER</code></p>
                         </td>
-                        <td> A float value. </td>
+                        <td> An integer value. </td>
                       </tr>
                       <tr>
                         <td>
@@ -9188,9 +9227,33 @@
                       </tr>
                       <tr>
                         <td>
+                          <p><code>FLOAT</code></p>
+                        </td>
+                        <td> A float value. </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>FLOAT_KIND</code></p>
+                        </td>
+                        <td> A float value. </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>BOOLEAN</code></p>
+                        </td>
+                        <td> A boolean value. </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>BOOLEAN_KIND</code></p>
                         </td>
                         <td> A boolean value. </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>SCALAR</code></p>
+                        </td>
+                        <td> A scalar value of any basic kind. </td>
                       </tr>
                       <tr>
                         <td>
@@ -9200,11 +9263,29 @@
                       </tr>
                       <tr>
                         <td>
+                          <p><code>LIST</code></p>
+                        </td>
+                        <td>
+                          <p>A list of values all having the same type.</p>
+                          <p>Always paired with a ListTypeDef.</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>LIST_KIND</code></p>
                         </td>
                         <td>
                           <p>A list of values all having the same type.</p>
                           <p>Always paired with a ListTypeDef.</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>OBJECT</code></p>
+                        </td>
+                        <td>
+                          <p>A named type defined in the GraphQL schema, with fields and functions.</p>
+                          <p>Always paired with an ObjectTypeDef.</p>
                         </td>
                       </tr>
                       <tr>
@@ -9218,6 +9299,15 @@
                       </tr>
                       <tr>
                         <td>
+                          <p><code>INTERFACE</code></p>
+                        </td>
+                        <td>
+                          <p>A named type of functions that can be matched+implemented by other objects+interfaces.</p>
+                          <p>Always paired with an InterfaceTypeDef.</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>INTERFACE_KIND</code></p>
                         </td>
                         <td>
@@ -9227,9 +9317,24 @@
                       </tr>
                       <tr>
                         <td>
+                          <p><code>INPUT</code></p>
+                        </td>
+                        <td> A graphql input type, used only when representing the core API via TypeDefs. </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <p><code>INPUT_KIND</code></p>
                         </td>
                         <td> A graphql input type, used only when representing the core API via TypeDefs. </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>VOID</code></p>
+                        </td>
+                        <td>
+                          <p>A special kind used to signify that no value is returned.</p>
+                          <p>This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.</p>
+                        </td>
                       </tr>
                       <tr>
                         <td>
@@ -9238,6 +9343,15 @@
                         <td>
                           <p>A special kind used to signify that no value is returned.</p>
                           <p>This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <p><code>ENUM</code></p>
+                        </td>
+                        <td>
+                          <p>A GraphQL enum type and its values</p>
+                          <p>Always paired with an EnumTypeDef.</p>
                         </td>
                       </tr>
                       <tr>
@@ -9258,7 +9372,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"STRING_KIND"</span>
+                    <body><pre><code class="hljs language-gql"><span class="hljs-symbol">"STRING"</span>
 </code></pre>
                     </body>
                   </html>

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -182,16 +182,16 @@ func LoadEngineFromID(id dagger.EngineID) *dagger.Engine {
 	return client.LoadEngineFromID(id)
 }
 
+// Load a EnumMemberTypeDef from its ID.
+func LoadEnumMemberTypeDefFromID(id dagger.EnumMemberTypeDefID) *dagger.EnumMemberTypeDef {
+	client := initClient()
+	return client.LoadEnumMemberTypeDefFromID(id)
+}
+
 // Load a EnumTypeDef from its ID.
 func LoadEnumTypeDefFromID(id dagger.EnumTypeDefID) *dagger.EnumTypeDef {
 	client := initClient()
 	return client.LoadEnumTypeDefFromID(id)
-}
-
-// Load a EnumValueTypeDef from its ID.
-func LoadEnumValueTypeDefFromID(id dagger.EnumValueTypeDefID) *dagger.EnumValueTypeDef {
-	client := initClient()
-	return client.LoadEnumValueTypeDefFromID(id)
 }
 
 // Load a EnvVariable from its ID.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -123,11 +123,11 @@ type EngineCacheID string
 // The `EngineID` scalar type represents an identifier for an object of type Engine.
 type EngineID string
 
+// The `EnumMemberTypeDefID` scalar type represents an identifier for an object of type EnumMemberTypeDef.
+type EnumMemberTypeDefID string
+
 // The `EnumTypeDefID` scalar type represents an identifier for an object of type EnumTypeDef.
 type EnumTypeDefID string
-
-// The `EnumValueTypeDefID` scalar type represents an identifier for an object of type EnumValueTypeDef.
-type EnumValueTypeDefID string
 
 // The `EnvVariableID` scalar type represents an identifier for an object of type EnvVariable.
 type EnvVariableID string
@@ -415,7 +415,7 @@ type ContainerAsTarballOpts struct {
 	// Use the specified media types for the image's layers.
 	//
 	// Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
-	MediaTypes ImageMediaTypes
+	MediaTypes ImageMediaType
 }
 
 // Returns a File representing the container serialized to a tarball.
@@ -632,7 +632,7 @@ type ContainerExportOpts struct {
 	// Use the specified media types for the exported image's layers.
 	//
 	// Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
-	MediaTypes ImageMediaTypes
+	MediaTypes ImageMediaType
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
 }
@@ -899,7 +899,7 @@ type ContainerPublishOpts struct {
 	// Use the specified media types for the published image's layers.
 	//
 	// Defaults to OCI, which is largely compatible with most recent registries, but Docker may be needed for older registries without OCI support.
-	MediaTypes ImageMediaTypes
+	MediaTypes ImageMediaType
 }
 
 // Publishes this container as a new image to the specified address.
@@ -3078,6 +3078,110 @@ func (r *EngineCacheEntrySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
+// A definition of a value in a custom enum defined in a Module.
+type EnumMemberTypeDef struct {
+	query *querybuilder.Selection
+
+	description *string
+	id          *EnumMemberTypeDefID
+	name        *string
+	value       *string
+}
+
+func (r *EnumMemberTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *EnumMemberTypeDef {
+	return &EnumMemberTypeDef{
+		query: q,
+	}
+}
+
+// A doc string for the enum value, if any.
+func (r *EnumMemberTypeDef) Description(ctx context.Context) (string, error) {
+	if r.description != nil {
+		return *r.description, nil
+	}
+	q := r.query.Select("description")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// A unique identifier for this EnumMemberTypeDef.
+func (r *EnumMemberTypeDef) ID(ctx context.Context) (EnumMemberTypeDefID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response EnumMemberTypeDefID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *EnumMemberTypeDef) XXX_GraphQLType() string {
+	return "EnumMemberTypeDef"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *EnumMemberTypeDef) XXX_GraphQLIDType() string {
+	return "EnumMemberTypeDefID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *EnumMemberTypeDef) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *EnumMemberTypeDef) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+
+// The name of the enum value.
+func (r *EnumMemberTypeDef) Name(ctx context.Context) (string, error) {
+	if r.name != nil {
+		return *r.name, nil
+	}
+	q := r.query.Select("name")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The location of this enum value declaration.
+func (r *EnumMemberTypeDef) SourceMap() *SourceMap {
+	q := r.query.Select("sourceMap")
+
+	return &SourceMap{
+		query: q,
+	}
+}
+
+// The value of the enum value
+func (r *EnumMemberTypeDef) Value(ctx context.Context) (string, error) {
+	if r.value != nil {
+		return *r.value, nil
+	}
+	q := r.query.Select("value")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // A definition of a custom enum defined in a Module.
 type EnumTypeDef struct {
 	query *querybuilder.Selection
@@ -3147,6 +3251,39 @@ func (r *EnumTypeDef) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
+// The members of the enum.
+func (r *EnumTypeDef) Members(ctx context.Context) ([]EnumMemberTypeDef, error) {
+	q := r.query.Select("members")
+
+	q = q.Select("id")
+
+	type members struct {
+		Id EnumMemberTypeDefID
+	}
+
+	convert := func(fields []members) []EnumMemberTypeDef {
+		out := []EnumMemberTypeDef{}
+
+		for i := range fields {
+			val := EnumMemberTypeDef{id: &fields[i].Id}
+			val.query = q.Root().Select("loadEnumMemberTypeDefFromID").Arg("id", fields[i].Id)
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []members
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
 // The name of the enum.
 func (r *EnumTypeDef) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
@@ -3180,129 +3317,6 @@ func (r *EnumTypeDef) SourceModuleName(ctx context.Context) (string, error) {
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
-}
-
-// The values of the enum.
-func (r *EnumTypeDef) Values(ctx context.Context) ([]EnumValueTypeDef, error) {
-	q := r.query.Select("values")
-
-	q = q.Select("id")
-
-	type values struct {
-		Id EnumValueTypeDefID
-	}
-
-	convert := func(fields []values) []EnumValueTypeDef {
-		out := []EnumValueTypeDef{}
-
-		for i := range fields {
-			val := EnumValueTypeDef{id: &fields[i].Id}
-			val.query = q.Root().Select("loadEnumValueTypeDefFromID").Arg("id", fields[i].Id)
-			out = append(out, val)
-		}
-
-		return out
-	}
-	var response []values
-
-	q = q.Bind(&response)
-
-	err := q.Execute(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return convert(response), nil
-}
-
-// A definition of a value in a custom enum defined in a Module.
-type EnumValueTypeDef struct {
-	query *querybuilder.Selection
-
-	description *string
-	id          *EnumValueTypeDefID
-	name        *string
-}
-
-func (r *EnumValueTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *EnumValueTypeDef {
-	return &EnumValueTypeDef{
-		query: q,
-	}
-}
-
-// A doc string for the enum value, if any.
-func (r *EnumValueTypeDef) Description(ctx context.Context) (string, error) {
-	if r.description != nil {
-		return *r.description, nil
-	}
-	q := r.query.Select("description")
-
-	var response string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-// A unique identifier for this EnumValueTypeDef.
-func (r *EnumValueTypeDef) ID(ctx context.Context) (EnumValueTypeDefID, error) {
-	if r.id != nil {
-		return *r.id, nil
-	}
-	q := r.query.Select("id")
-
-	var response EnumValueTypeDefID
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
-func (r *EnumValueTypeDef) XXX_GraphQLType() string {
-	return "EnumValueTypeDef"
-}
-
-// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
-func (r *EnumValueTypeDef) XXX_GraphQLIDType() string {
-	return "EnumValueTypeDefID"
-}
-
-// XXX_GraphQLID is an internal function. It returns the underlying type ID
-func (r *EnumValueTypeDef) XXX_GraphQLID(ctx context.Context) (string, error) {
-	id, err := r.ID(ctx)
-	if err != nil {
-		return "", err
-	}
-	return string(id), nil
-}
-
-func (r *EnumValueTypeDef) MarshalJSON() ([]byte, error) {
-	id, err := r.ID(marshalCtx)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(id)
-}
-
-// The name of the enum value.
-func (r *EnumValueTypeDef) Name(ctx context.Context) (string, error) {
-	if r.name != nil {
-		return *r.name, nil
-	}
-	q := r.query.Select("name")
-
-	var response string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
-// The location of this enum value declaration.
-func (r *EnumValueTypeDef) SourceMap() *SourceMap {
-	q := r.query.Select("sourceMap")
-
-	return &SourceMap{
-		query: q,
-	}
 }
 
 // An environment variable name and value.
@@ -6648,22 +6662,22 @@ func (r *Client) LoadEngineFromID(id EngineID) *Engine {
 	}
 }
 
+// Load a EnumMemberTypeDef from its ID.
+func (r *Client) LoadEnumMemberTypeDefFromID(id EnumMemberTypeDefID) *EnumMemberTypeDef {
+	q := r.query.Select("loadEnumMemberTypeDefFromID")
+	q = q.Arg("id", id)
+
+	return &EnumMemberTypeDef{
+		query: q,
+	}
+}
+
 // Load a EnumTypeDef from its ID.
 func (r *Client) LoadEnumTypeDefFromID(id EnumTypeDefID) *EnumTypeDef {
 	q := r.query.Select("loadEnumTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &EnumTypeDef{
-		query: q,
-	}
-}
-
-// Load a EnumValueTypeDef from its ID.
-func (r *Client) LoadEnumValueTypeDefFromID(id EnumValueTypeDefID) *EnumValueTypeDef {
-	q := r.query.Select("loadEnumValueTypeDefFromID")
-	q = q.Arg("id", id)
-
-	return &EnumValueTypeDef{
 		query: q,
 	}
 }
@@ -7971,6 +7985,35 @@ func (r *TypeDef) WithEnum(name string, opts ...TypeDefWithEnumOpts) *TypeDef {
 	}
 }
 
+// TypeDefWithEnumMemberOpts contains options for TypeDef.WithEnumMember
+type TypeDefWithEnumMemberOpts struct {
+	// A doc string for the value, if any
+	Description string
+	// The source map for the enum value definition.
+	SourceMap *SourceMap
+}
+
+// Adds a static value for an Enum TypeDef, failing if the type is not an enum.
+func (r *TypeDef) WithEnumMember(name string, value string, opts ...TypeDefWithEnumMemberOpts) *TypeDef {
+	q := r.query.Select("withEnumMember")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `description` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Description) {
+			q = q.Arg("description", opts[i].Description)
+		}
+		// `sourceMap` optional argument
+		if !querybuilder.IsZeroValue(opts[i].SourceMap) {
+			q = q.Arg("sourceMap", opts[i].SourceMap)
+		}
+	}
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &TypeDef{
+		query: q,
+	}
+}
+
 // TypeDefWithEnumValueOpts contains options for TypeDef.WithEnumValue
 type TypeDefWithEnumValueOpts struct {
 	// A doc string for the value, if any
@@ -8153,7 +8196,48 @@ type CacheSharingMode string
 
 func (CacheSharingMode) IsEnum() {}
 
+func (v CacheSharingMode) Name() string {
+	switch v {
+	case CacheSharingModeLocked:
+		return "LOCKED"
+	case CacheSharingModePrivate:
+		return "PRIVATE"
+	case CacheSharingModeShared:
+		return "SHARED"
+	default:
+		return ""
+	}
+}
+
+func (v CacheSharingMode) Value() string {
+	return string(v)
+}
+
+func (v *CacheSharingMode) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *CacheSharingMode) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "LOCKED":
+		*v = CacheSharingModeLocked
+	case "PRIVATE":
+		*v = CacheSharingModePrivate
+	case "SHARED":
+		*v = CacheSharingModeShared
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
 const (
+
 	// Shares the cache volume amongst many build pipelines, but will serialize the writes
 	CacheSharingModeLocked CacheSharingMode = "LOCKED"
 
@@ -8169,25 +8253,105 @@ type ImageLayerCompression string
 
 func (ImageLayerCompression) IsEnum() {}
 
+func (v ImageLayerCompression) Name() string {
+	switch v {
+	case ImageLayerCompressionEstargz:
+		return "ESTARGZ"
+	case ImageLayerCompressionGzip:
+		return "GZIP"
+	case ImageLayerCompressionUncompressed:
+		return "UNCOMPRESSED"
+	case ImageLayerCompressionZstd:
+		return "ZSTD"
+	default:
+		return ""
+	}
+}
+
+func (v ImageLayerCompression) Value() string {
+	return string(v)
+}
+
+func (v *ImageLayerCompression) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *ImageLayerCompression) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "ESTARGZ":
+		*v = ImageLayerCompressionEstargz
+	case "GZIP":
+		*v = ImageLayerCompressionGzip
+	case "UNCOMPRESSED":
+		*v = ImageLayerCompressionUncompressed
+	case "ZSTD":
+		*v = ImageLayerCompressionZstd
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
 const (
-	ImageLayerCompressionEstarGz ImageLayerCompression = "EStarGZ"
+	ImageLayerCompressionEstargz ImageLayerCompression = "ESTARGZ"
 
-	ImageLayerCompressionGzip ImageLayerCompression = "Gzip"
+	ImageLayerCompressionGzip ImageLayerCompression = "GZIP"
 
-	ImageLayerCompressionUncompressed ImageLayerCompression = "Uncompressed"
+	ImageLayerCompressionUncompressed ImageLayerCompression = "UNCOMPRESSED"
 
-	ImageLayerCompressionZstd ImageLayerCompression = "Zstd"
+	ImageLayerCompressionZstd ImageLayerCompression = "ZSTD"
 )
 
 // Mediatypes to use in published or exported image metadata.
-type ImageMediaTypes string
+type ImageMediaType string
 
-func (ImageMediaTypes) IsEnum() {}
+func (ImageMediaType) IsEnum() {}
+
+func (v ImageMediaType) Name() string {
+	switch v {
+	case ImageMediaTypeDocker:
+		return "DOCKER"
+	case ImageMediaTypeOci:
+		return "OCI"
+	default:
+		return ""
+	}
+}
+
+func (v ImageMediaType) Value() string {
+	return string(v)
+}
+
+func (v *ImageMediaType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *ImageMediaType) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "DOCKER":
+		*v = ImageMediaTypeDocker
+	case "OCI":
+		*v = ImageMediaTypeOci
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
 
 const (
-	ImageMediaTypesDockerMediaTypes ImageMediaTypes = "DockerMediaTypes"
+	ImageMediaTypeOci ImageMediaType = "OCI"
 
-	ImageMediaTypesOcimediaTypes ImageMediaTypes = "OCIMediaTypes"
+	ImageMediaTypeDocker ImageMediaType = "DOCKER"
 )
 
 // The kind of module source.
@@ -8195,18 +8359,94 @@ type ModuleSourceKind string
 
 func (ModuleSourceKind) IsEnum() {}
 
+func (v ModuleSourceKind) Name() string {
+	switch v {
+	case ModuleSourceKindDir:
+		return "DIR"
+	case ModuleSourceKindGit:
+		return "GIT"
+	case ModuleSourceKindLocal:
+		return "LOCAL"
+	default:
+		return ""
+	}
+}
+
+func (v ModuleSourceKind) Value() string {
+	return string(v)
+}
+
+func (v *ModuleSourceKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *ModuleSourceKind) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "DIR":
+		*v = ModuleSourceKindDir
+	case "GIT":
+		*v = ModuleSourceKindGit
+	case "LOCAL":
+		*v = ModuleSourceKindLocal
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
 const (
-	ModuleSourceKindDirSource ModuleSourceKind = "DIR_SOURCE"
+	ModuleSourceKindDir ModuleSourceKind = "DIR"
 
-	ModuleSourceKindGitSource ModuleSourceKind = "GIT_SOURCE"
+	ModuleSourceKindGit ModuleSourceKind = "GIT"
 
-	ModuleSourceKindLocalSource ModuleSourceKind = "LOCAL_SOURCE"
+	ModuleSourceKindLocal ModuleSourceKind = "LOCAL"
 )
 
 // Transport layer network protocol associated to a port.
 type NetworkProtocol string
 
 func (NetworkProtocol) IsEnum() {}
+
+func (v NetworkProtocol) Name() string {
+	switch v {
+	case NetworkProtocolTcp:
+		return "TCP"
+	case NetworkProtocolUdp:
+		return "UDP"
+	default:
+		return ""
+	}
+}
+
+func (v NetworkProtocol) Value() string {
+	return string(v)
+}
+
+func (v *NetworkProtocol) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *NetworkProtocol) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "TCP":
+		*v = NetworkProtocolTcp
+	case "UDP":
+		*v = NetworkProtocolUdp
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
 
 const (
 	NetworkProtocolTcp NetworkProtocol = "TCP"
@@ -8219,7 +8459,48 @@ type ReturnType string
 
 func (ReturnType) IsEnum() {}
 
+func (v ReturnType) Name() string {
+	switch v {
+	case ReturnTypeAny:
+		return "ANY"
+	case ReturnTypeFailure:
+		return "FAILURE"
+	case ReturnTypeSuccess:
+		return "SUCCESS"
+	default:
+		return ""
+	}
+}
+
+func (v ReturnType) Value() string {
+	return string(v)
+}
+
+func (v *ReturnType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *ReturnType) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "ANY":
+		*v = ReturnTypeAny
+	case "FAILURE":
+		*v = ReturnTypeFailure
+	case "SUCCESS":
+		*v = ReturnTypeSuccess
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
 const (
+
 	// Any execution (exit codes 0-127)
 	ReturnTypeAny ReturnType = "ANY"
 
@@ -8235,47 +8516,174 @@ type TypeDefKind string
 
 func (TypeDefKind) IsEnum() {}
 
+func (v TypeDefKind) Name() string {
+	switch v {
+	case TypeDefKindFloat:
+		return "FLOAT"
+	case TypeDefKindInput:
+		return "INPUT"
+	case TypeDefKindInterface:
+		return "INTERFACE"
+	case TypeDefKindObject:
+		return "OBJECT"
+	case TypeDefKindString:
+		return "STRING"
+	case TypeDefKindVoid:
+		return "VOID"
+	case TypeDefKindEnum:
+		return "ENUM"
+	case TypeDefKindInteger:
+		return "INTEGER"
+	case TypeDefKindList:
+		return "LIST"
+	case TypeDefKindScalar:
+		return "SCALAR"
+	case TypeDefKindBoolean:
+		return "BOOLEAN"
+	default:
+		return ""
+	}
+}
+
+func (v TypeDefKind) Value() string {
+	return string(v)
+}
+
+func (v *TypeDefKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Name())
+}
+
+func (v *TypeDefKind) UnmarshalJSON(dt []byte) error {
+	var s string
+	if err := json.Unmarshal(dt, &s); err != nil {
+		return err
+	}
+	switch s {
+
+	case "BOOLEAN":
+		*v = TypeDefKindBoolean
+	case "BOOLEAN_KIND":
+		*v = TypeDefKindBooleanKind
+	case "ENUM":
+		*v = TypeDefKindEnum
+	case "ENUM_KIND":
+		*v = TypeDefKindEnumKind
+	case "FLOAT":
+		*v = TypeDefKindFloat
+	case "FLOAT_KIND":
+		*v = TypeDefKindFloatKind
+	case "INPUT":
+		*v = TypeDefKindInput
+	case "INPUT_KIND":
+		*v = TypeDefKindInputKind
+	case "INTEGER":
+		*v = TypeDefKindInteger
+	case "INTEGER_KIND":
+		*v = TypeDefKindIntegerKind
+	case "INTERFACE":
+		*v = TypeDefKindInterface
+	case "INTERFACE_KIND":
+		*v = TypeDefKindInterfaceKind
+	case "LIST":
+		*v = TypeDefKindList
+	case "LIST_KIND":
+		*v = TypeDefKindListKind
+	case "OBJECT":
+		*v = TypeDefKindObject
+	case "OBJECT_KIND":
+		*v = TypeDefKindObjectKind
+	case "SCALAR":
+		*v = TypeDefKindScalar
+	case "SCALAR_KIND":
+		*v = TypeDefKindScalarKind
+	case "STRING":
+		*v = TypeDefKindString
+	case "STRING_KIND":
+		*v = TypeDefKindStringKind
+	case "VOID":
+		*v = TypeDefKindVoid
+	case "VOID_KIND":
+		*v = TypeDefKindVoidKind
+	default:
+		return fmt.Errorf("unknown enum value %q", s)
+	}
+	return nil
+}
+
 const (
-	// A boolean value.
-	TypeDefKindBooleanKind TypeDefKind = "BOOLEAN_KIND"
+
+	// A scalar value of any basic kind.
+	TypeDefKindScalar TypeDefKind = "SCALAR"
+	// A scalar value of any basic kind.
+	TypeDefKindScalarKind TypeDefKind = TypeDefKindScalar
+
+	// A string value.
+	TypeDefKindString TypeDefKind = "STRING"
+	// A string value.
+	TypeDefKindStringKind TypeDefKind = TypeDefKindString
 
 	// A GraphQL enum type and its values
 	//
 	// Always paired with an EnumTypeDef.
-	TypeDefKindEnumKind TypeDefKind = "ENUM_KIND"
-
-	// A float value.
-	TypeDefKindFloatKind TypeDefKind = "FLOAT_KIND"
+	TypeDefKindEnum TypeDefKind = "ENUM"
+	// A GraphQL enum type and its values
+	//
+	// Always paired with an EnumTypeDef.
+	TypeDefKindEnumKind TypeDefKind = TypeDefKindEnum
 
 	// A graphql input type, used only when representing the core API via TypeDefs.
-	TypeDefKindInputKind TypeDefKind = "INPUT_KIND"
-
-	// An integer value.
-	TypeDefKindIntegerKind TypeDefKind = "INTEGER_KIND"
+	TypeDefKindInput TypeDefKind = "INPUT"
+	// A graphql input type, used only when representing the core API via TypeDefs.
+	TypeDefKindInputKind TypeDefKind = TypeDefKindInput
 
 	// A named type of functions that can be matched+implemented by other objects+interfaces.
 	//
 	// Always paired with an InterfaceTypeDef.
-	TypeDefKindInterfaceKind TypeDefKind = "INTERFACE_KIND"
+	TypeDefKindInterface TypeDefKind = "INTERFACE"
+	// A named type of functions that can be matched+implemented by other objects+interfaces.
+	//
+	// Always paired with an InterfaceTypeDef.
+	TypeDefKindInterfaceKind TypeDefKind = TypeDefKindInterface
 
 	// A list of values all having the same type.
 	//
 	// Always paired with a ListTypeDef.
-	TypeDefKindListKind TypeDefKind = "LIST_KIND"
+	TypeDefKindList TypeDefKind = "LIST"
+	// A list of values all having the same type.
+	//
+	// Always paired with a ListTypeDef.
+	TypeDefKindListKind TypeDefKind = TypeDefKindList
 
 	// A named type defined in the GraphQL schema, with fields and functions.
 	//
 	// Always paired with an ObjectTypeDef.
-	TypeDefKindObjectKind TypeDefKind = "OBJECT_KIND"
+	TypeDefKindObject TypeDefKind = "OBJECT"
+	// A named type defined in the GraphQL schema, with fields and functions.
+	//
+	// Always paired with an ObjectTypeDef.
+	TypeDefKindObjectKind TypeDefKind = TypeDefKindObject
 
-	// A scalar value of any basic kind.
-	TypeDefKindScalarKind TypeDefKind = "SCALAR_KIND"
+	// A boolean value.
+	TypeDefKindBoolean TypeDefKind = "BOOLEAN"
+	// A boolean value.
+	TypeDefKindBooleanKind TypeDefKind = TypeDefKindBoolean
 
-	// A string value.
-	TypeDefKindStringKind TypeDefKind = "STRING_KIND"
+	// A float value.
+	TypeDefKindFloat TypeDefKind = "FLOAT"
+	// A float value.
+	TypeDefKindFloatKind TypeDefKind = TypeDefKindFloat
+
+	// An integer value.
+	TypeDefKindInteger TypeDefKind = "INTEGER"
+	// An integer value.
+	TypeDefKindIntegerKind TypeDefKind = TypeDefKindInteger
 
 	// A special kind used to signify that no value is returned.
 	//
 	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
-	TypeDefKindVoidKind TypeDefKind = "VOID_KIND"
+	TypeDefKindVoid TypeDefKind = "VOID"
+	// A special kind used to signify that no value is returned.
+	//
+	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
+	TypeDefKindVoidKind TypeDefKind = TypeDefKindVoid
 )

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8349,9 +8349,9 @@ func (v *ImageMediaType) UnmarshalJSON(dt []byte) error {
 }
 
 const (
-	ImageMediaTypeOci ImageMediaType = "OCI"
-
 	ImageMediaTypeDocker ImageMediaType = "DOCKER"
+
+	ImageMediaTypeOci ImageMediaType = "OCI"
 )
 
 // The kind of module source.
@@ -8518,28 +8518,28 @@ func (TypeDefKind) IsEnum() {}
 
 func (v TypeDefKind) Name() string {
 	switch v {
+	case TypeDefKindBoolean:
+		return "BOOLEAN"
+	case TypeDefKindEnum:
+		return "ENUM"
 	case TypeDefKindFloat:
 		return "FLOAT"
 	case TypeDefKindInput:
 		return "INPUT"
+	case TypeDefKindInteger:
+		return "INTEGER"
 	case TypeDefKindInterface:
 		return "INTERFACE"
+	case TypeDefKindList:
+		return "LIST"
 	case TypeDefKindObject:
 		return "OBJECT"
+	case TypeDefKindScalar:
+		return "SCALAR"
 	case TypeDefKindString:
 		return "STRING"
 	case TypeDefKindVoid:
 		return "VOID"
-	case TypeDefKindEnum:
-		return "ENUM"
-	case TypeDefKindInteger:
-		return "INTEGER"
-	case TypeDefKindList:
-		return "LIST"
-	case TypeDefKindScalar:
-		return "SCALAR"
-	case TypeDefKindBoolean:
-		return "BOOLEAN"
 	default:
 		return ""
 	}
@@ -8612,34 +8612,45 @@ func (v *TypeDefKind) UnmarshalJSON(dt []byte) error {
 
 const (
 
-	// A scalar value of any basic kind.
-	TypeDefKindScalar TypeDefKind = "SCALAR"
-	// A scalar value of any basic kind.
-	TypeDefKindScalarKind TypeDefKind = TypeDefKindScalar
+	// A boolean value.
+	TypeDefKindBoolean TypeDefKind = "BOOLEAN"
 
-	// A string value.
-	TypeDefKindString TypeDefKind = "STRING"
-	// A string value.
-	TypeDefKindStringKind TypeDefKind = TypeDefKindString
+	// A boolean value.
+	TypeDefKindBooleanKind TypeDefKind = TypeDefKindBoolean
 
 	// A GraphQL enum type and its values
 	//
 	// Always paired with an EnumTypeDef.
 	TypeDefKindEnum TypeDefKind = "ENUM"
+
 	// A GraphQL enum type and its values
 	//
 	// Always paired with an EnumTypeDef.
 	TypeDefKindEnumKind TypeDefKind = TypeDefKindEnum
 
+	// A float value.
+	TypeDefKindFloat TypeDefKind = "FLOAT"
+
+	// A float value.
+	TypeDefKindFloatKind TypeDefKind = TypeDefKindFloat
+
 	// A graphql input type, used only when representing the core API via TypeDefs.
 	TypeDefKindInput TypeDefKind = "INPUT"
+
 	// A graphql input type, used only when representing the core API via TypeDefs.
 	TypeDefKindInputKind TypeDefKind = TypeDefKindInput
+
+	// An integer value.
+	TypeDefKindInteger TypeDefKind = "INTEGER"
+
+	// An integer value.
+	TypeDefKindIntegerKind TypeDefKind = TypeDefKindInteger
 
 	// A named type of functions that can be matched+implemented by other objects+interfaces.
 	//
 	// Always paired with an InterfaceTypeDef.
 	TypeDefKindInterface TypeDefKind = "INTERFACE"
+
 	// A named type of functions that can be matched+implemented by other objects+interfaces.
 	//
 	// Always paired with an InterfaceTypeDef.
@@ -8649,6 +8660,7 @@ const (
 	//
 	// Always paired with a ListTypeDef.
 	TypeDefKindList TypeDefKind = "LIST"
+
 	// A list of values all having the same type.
 	//
 	// Always paired with a ListTypeDef.
@@ -8658,30 +8670,29 @@ const (
 	//
 	// Always paired with an ObjectTypeDef.
 	TypeDefKindObject TypeDefKind = "OBJECT"
+
 	// A named type defined in the GraphQL schema, with fields and functions.
 	//
 	// Always paired with an ObjectTypeDef.
 	TypeDefKindObjectKind TypeDefKind = TypeDefKindObject
 
-	// A boolean value.
-	TypeDefKindBoolean TypeDefKind = "BOOLEAN"
-	// A boolean value.
-	TypeDefKindBooleanKind TypeDefKind = TypeDefKindBoolean
+	// A scalar value of any basic kind.
+	TypeDefKindScalar TypeDefKind = "SCALAR"
 
-	// A float value.
-	TypeDefKindFloat TypeDefKind = "FLOAT"
-	// A float value.
-	TypeDefKindFloatKind TypeDefKind = TypeDefKindFloat
+	// A scalar value of any basic kind.
+	TypeDefKindScalarKind TypeDefKind = TypeDefKindScalar
 
-	// An integer value.
-	TypeDefKindInteger TypeDefKind = "INTEGER"
-	// An integer value.
-	TypeDefKindIntegerKind TypeDefKind = TypeDefKindInteger
+	// A string value.
+	TypeDefKindString TypeDefKind = "STRING"
+
+	// A string value.
+	TypeDefKindStringKind TypeDefKind = TypeDefKindString
 
 	// A special kind used to signify that no value is returned.
 	//
 	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
 	TypeDefKindVoid TypeDefKind = "VOID"
+
 	// A special kind used to signify that no value is returned.
 	//
 	// This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.

--- a/sdk/go/querybuilder/marshal.go
+++ b/sdk/go/querybuilder/marshal.go
@@ -32,6 +32,8 @@ const (
 
 type enum interface {
 	IsEnum()
+	Name() string
+	Value() string
 }
 
 var (
@@ -59,8 +61,7 @@ func marshalValue(ctx context.Context, v reflect.Value) (string, error) {
 		return fmt.Sprintf("%f", v.Float()), nil
 	case reflect.String:
 		if t.Implements(enumT) {
-			// enums render as their literal value
-			return v.String(), nil
+			return marshalEnumName(v), nil
 		}
 
 		// escape strings following graphQL spec
@@ -148,6 +149,14 @@ func marshalCustom(ctx context.Context, v reflect.Value) (string, error) {
 	}
 
 	return fmt.Sprintf("%q", result[0].String()), nil
+}
+
+func marshalEnumName(v reflect.Value) string {
+	result := v.MethodByName("Name").Call(nil)
+	if len(result) != 1 {
+		panic(result)
+	}
+	return fmt.Sprintf("%q", result[0].String())
 }
 
 func IsZeroValue(value any) bool {

--- a/sdk/python/codegen/src/codegen/ast.py
+++ b/sdk/python/codegen/src/codegen/ast.py
@@ -1,0 +1,49 @@
+import typing
+from typing import Any
+
+import graphql
+
+
+def insert_stubs(introspection: Any, schema: graphql.GraphQLSchema):
+    """Insert ast node stubs into the parsed schema."""
+    for tp in introspection["types"]:
+        if values := tp.get("enumValues"):
+            schema_type = schema.get_type(tp["name"])
+            schema_type = typing.cast(graphql.GraphQLEnumType, schema_type)
+
+            value_defs = []
+            for value in values:
+                schema_value = schema_type.values[value["name"]]
+                schema_value.ast_node = graphql.EnumValueDefinitionNode(
+                    name=graphql.NameNode(value=value["name"]),
+                    description=value["description"],
+                    directives=parse_directives(value["directives"]),
+                )
+                value_defs.append(schema_value.ast_node)
+
+            schema_type.ast_node = graphql.EnumTypeDefinitionNode(
+                values=value_defs,
+                directives=parse_directives(tp["directives"]),
+            )
+
+    # TODO: add support for other graphql declarations
+
+
+def parse_directives(
+    directives: list[dict[str, Any]],
+) -> tuple[graphql.ConstDirectiveNode, ...]:
+    """Parse directives from our dagger non-standard graphql directive application."""
+    result = []
+    for directive in directives:
+        node = graphql.ConstDirectiveNode(
+            name=graphql.NameNode(value=directive["name"]),
+            arguments=tuple(
+                graphql.ConstArgumentNode(
+                    name=graphql.NameNode(value=arg["name"]),
+                    value=graphql.parse_const_value(arg["value"]),
+                )
+                for arg in directive["args"]
+            ),
+        )
+        result.append(node)
+    return tuple(result)

--- a/sdk/python/codegen/src/codegen/cli.py
+++ b/sdk/python/codegen/src/codegen/cli.py
@@ -5,7 +5,7 @@ import sys
 
 import graphql
 
-from codegen import generator
+from codegen import generator, ast
 
 parser = argparse.ArgumentParser(
     prog="python -m codegen", description="Dagger Python SDK"
@@ -46,6 +46,7 @@ def main():
 def codegen(introspection: pathlib.Path, output: pathlib.Path | None):
     result = json.loads(introspection.read_text())
     schema = graphql.build_client_schema(result)
+    ast.insert_stubs(result["__schema"], schema)
     code = generator.generate(schema)
 
     if output:

--- a/sdk/python/codegen/src/codegen/generator.py
+++ b/sdk/python/codegen/src/codegen/generator.py
@@ -24,6 +24,7 @@ from typing import (
     cast,
 )
 
+import graphql
 from graphql import (
     GraphQLArgument,
     GraphQLEnumType,
@@ -152,6 +153,8 @@ class Handler(ABC, Generic[_H]):
     ctx: Context
     """Generation execution context."""
 
+    schema: GraphQLSchema
+
     predicate: ClassVar[Predicate] = staticmethod(lambda _: False)
     """Does this handler render the given type?"""
 
@@ -203,10 +206,10 @@ def generate(schema: GraphQLSchema) -> Iterator[str]:
     ctx = Context(ids=ids)
 
     handlers: tuple[Handler, ...] = (
-        Scalar(ctx),
-        Enum(ctx),
-        Input(ctx),
-        Object(ctx),
+        Scalar(ctx, schema),
+        Enum(ctx, schema),
+        Input(ctx, schema),
+        Object(ctx, schema),
     )
 
     # Split into two iterators to update ctx.remaining.
@@ -716,8 +719,16 @@ class Enum(Handler[GraphQLEnumType]):
         for name, value in sorted(t.values.items()):
             yield ""
 
+            val = None
+            if value.ast_node and (directive := self.schema.get_directive("enumValue")):
+                args = graphql.get_directive_values(directive, value.ast_node)
+                if args:
+                    val = args["value"]
+            if not val:
+                val = value.value
+
             # repr uses single quotes for strings, contrary to black
-            val = repr(value.value).replace("'", '"')
+            val = repr(val).replace("'", '"')
             yield f"{name} = {val}"
 
             if value.description:

--- a/sdk/python/src/dagger/client/_core.py
+++ b/sdk/python/src/dagger/client/_core.py
@@ -1,3 +1,4 @@
+import enum
 import functools
 import logging
 import typing
@@ -30,6 +31,7 @@ from dagger import (
     TransportError,
 )
 from dagger._exceptions import _query_error_from_transport
+from dagger.client import base
 from dagger.client.base import Type
 
 from ._guards import (
@@ -238,6 +240,18 @@ def make_converter(ctx: Context):
         _needs_hook,
         _struct,
     )
+
+    def to_enum_name(val: enum.Enum) -> str:
+        return val.name
+
+    def from_enum_name(name: str, cls: type[enum.Enum]) -> enum.Enum:
+        return cls[name]
+
+    conv.register_unstructure_hook(enum.Enum, to_enum_name)
+    conv.register_structure_hook(enum.Enum, from_enum_name)
+
+    conv.register_unstructure_hook(base.Enum, to_enum_name)
+    conv.register_structure_hook(base.Enum, from_enum_name)
 
     return conv
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -51,14 +51,14 @@ class EngineID(Scalar):
     of type Engine."""
 
 
+class EnumMemberTypeDefID(Scalar):
+    """The `EnumMemberTypeDefID` scalar type represents an identifier for
+    an object of type EnumMemberTypeDef."""
+
+
 class EnumTypeDefID(Scalar):
     """The `EnumTypeDefID` scalar type represents an identifier for an
     object of type EnumTypeDef."""
-
-
-class EnumValueTypeDefID(Scalar):
-    """The `EnumValueTypeDefID` scalar type represents an identifier for
-    an object of type EnumValueTypeDef."""
 
 
 class EnvVariableID(Scalar):
@@ -232,31 +232,31 @@ class CacheSharingMode(Enum):
 class ImageLayerCompression(Enum):
     """Compression algorithm to use for image layers."""
 
-    EStarGZ = "EStarGZ"
+    ESTARGZ = "ESTARGZ"
 
-    Gzip = "Gzip"
+    GZIP = "GZIP"
 
-    Uncompressed = "Uncompressed"
+    UNCOMPRESSED = "UNCOMPRESSED"
 
-    Zstd = "Zstd"
+    ZSTD = "ZSTD"
 
 
-class ImageMediaTypes(Enum):
+class ImageMediaType(Enum):
     """Mediatypes to use in published or exported image metadata."""
 
-    DockerMediaTypes = "DockerMediaTypes"
+    DOCKER = "DOCKER"
 
-    OCIMediaTypes = "OCIMediaTypes"
+    OCI = "OCI"
 
 
 class ModuleSourceKind(Enum):
     """The kind of module source."""
 
-    DIR_SOURCE = "DIR_SOURCE"
+    DIR = "DIR"
 
-    GIT_SOURCE = "GIT_SOURCE"
+    GIT = "GIT"
 
-    LOCAL_SOURCE = "LOCAL_SOURCE"
+    LOCAL = "LOCAL"
 
 
 class NetworkProtocol(Enum):
@@ -283,49 +283,97 @@ class ReturnType(Enum):
 class TypeDefKind(Enum):
     """Distinguishes the different kinds of TypeDefs."""
 
-    BOOLEAN_KIND = "BOOLEAN_KIND"
+    BOOLEAN = "BOOLEAN"
     """A boolean value."""
 
-    ENUM_KIND = "ENUM_KIND"
+    BOOLEAN_KIND = "BOOLEAN"
+    """A boolean value."""
+
+    ENUM = "ENUM"
     """A GraphQL enum type and its values
 
     Always paired with an EnumTypeDef.
     """
 
-    FLOAT_KIND = "FLOAT_KIND"
+    ENUM_KIND = "ENUM"
+    """A GraphQL enum type and its values
+
+    Always paired with an EnumTypeDef.
+    """
+
+    FLOAT = "FLOAT"
     """A float value."""
 
-    INPUT_KIND = "INPUT_KIND"
+    FLOAT_KIND = "FLOAT"
+    """A float value."""
+
+    INPUT = "INPUT"
     """A graphql input type, used only when representing the core API via TypeDefs."""
 
-    INTEGER_KIND = "INTEGER_KIND"
+    INPUT_KIND = "INPUT"
+    """A graphql input type, used only when representing the core API via TypeDefs."""
+
+    INTEGER = "INTEGER"
     """An integer value."""
 
-    INTERFACE_KIND = "INTERFACE_KIND"
+    INTEGER_KIND = "INTEGER"
+    """An integer value."""
+
+    INTERFACE = "INTERFACE"
     """A named type of functions that can be matched+implemented by other objects+interfaces.
 
     Always paired with an InterfaceTypeDef.
     """
 
-    LIST_KIND = "LIST_KIND"
+    INTERFACE_KIND = "INTERFACE"
+    """A named type of functions that can be matched+implemented by other objects+interfaces.
+
+    Always paired with an InterfaceTypeDef.
+    """
+
+    LIST = "LIST"
     """A list of values all having the same type.
 
     Always paired with a ListTypeDef.
     """
 
-    OBJECT_KIND = "OBJECT_KIND"
+    LIST_KIND = "LIST"
+    """A list of values all having the same type.
+
+    Always paired with a ListTypeDef.
+    """
+
+    OBJECT = "OBJECT"
     """A named type defined in the GraphQL schema, with fields and functions.
 
     Always paired with an ObjectTypeDef.
     """
 
-    SCALAR_KIND = "SCALAR_KIND"
+    OBJECT_KIND = "OBJECT"
+    """A named type defined in the GraphQL schema, with fields and functions.
+
+    Always paired with an ObjectTypeDef.
+    """
+
+    SCALAR = "SCALAR"
     """A scalar value of any basic kind."""
 
-    STRING_KIND = "STRING_KIND"
+    SCALAR_KIND = "SCALAR"
+    """A scalar value of any basic kind."""
+
+    STRING = "STRING"
     """A string value."""
 
-    VOID_KIND = "VOID_KIND"
+    STRING_KIND = "STRING"
+    """A string value."""
+
+    VOID = "VOID"
+    """A special kind used to signify that no value is returned.
+
+    This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
+    """
+
+    VOID_KIND = "VOID"
     """A special kind used to signify that no value is returned.
 
     This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
@@ -465,7 +513,7 @@ class Container(Type):
         *,
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
-        media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        media_types: ImageMediaType | None = ImageMediaType.OCI,
     ) -> "File":
         """Returns a File representing the container serialized to a tarball.
 
@@ -495,7 +543,7 @@ class Container(Type):
                 (),
             ),
             Arg("forcedCompression", forced_compression, None),
-            Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("mediaTypes", media_types, ImageMediaType.OCI),
         ]
         _ctx = self._select("asTarball", _args)
         return File(_ctx)
@@ -718,7 +766,7 @@ class Container(Type):
         *,
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
-        media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        media_types: ImageMediaType | None = ImageMediaType.OCI,
         expand: bool | None = False,
     ) -> str:
         """Writes the container as an OCI tarball to the destination file path on
@@ -774,7 +822,7 @@ class Container(Type):
                 (),
             ),
             Arg("forcedCompression", forced_compression, None),
-            Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("mediaTypes", media_types, ImageMediaType.OCI),
             Arg("expand", expand, False),
         ]
         _ctx = self._select("export", _args)
@@ -1014,7 +1062,7 @@ class Container(Type):
         *,
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
-        media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        media_types: ImageMediaType | None = ImageMediaType.OCI,
     ) -> str:
         """Publishes this container as a new image to the specified address.
 
@@ -1067,7 +1115,7 @@ class Container(Type):
                 (),
             ),
             Arg("forcedCompression", forced_compression, None),
-            Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("mediaTypes", media_types, ImageMediaType.OCI),
         ]
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)
@@ -3381,6 +3429,104 @@ class EngineCacheEntrySet(Type):
 
 
 @typecheck
+class EnumMemberTypeDef(Type):
+    """A definition of a value in a custom enum defined in a Module."""
+
+    async def description(self) -> str:
+        """A doc string for the enum value, if any.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("description", _args)
+        return await _ctx.execute(str)
+
+    async def id(self) -> EnumMemberTypeDefID:
+        """A unique identifier for this EnumMemberTypeDef.
+
+        Note
+        ----
+        This is lazily evaluated, no operation is actually run.
+
+        Returns
+        -------
+        EnumMemberTypeDefID
+            The `EnumMemberTypeDefID` scalar type represents an identifier for
+            an object of type EnumMemberTypeDef.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("id", _args)
+        return await _ctx.execute(EnumMemberTypeDefID)
+
+    async def name(self) -> str:
+        """The name of the enum value.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("name", _args)
+        return await _ctx.execute(str)
+
+    def source_map(self) -> "SourceMap":
+        """The location of this enum value declaration."""
+        _args: list[Arg] = []
+        _ctx = self._select("sourceMap", _args)
+        return SourceMap(_ctx)
+
+    async def value(self) -> str:
+        """The value of the enum value
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("value", _args)
+        return await _ctx.execute(str)
+
+
+@typecheck
 class EnumTypeDef(Type):
     """A definition of a custom enum defined in a Module."""
 
@@ -3428,6 +3574,27 @@ class EnumTypeDef(Type):
         _args: list[Arg] = []
         _ctx = self._select("id", _args)
         return await _ctx.execute(EnumTypeDefID)
+
+    async def members(self) -> list[EnumMemberTypeDef]:
+        """The members of the enum."""
+        _args: list[Arg] = []
+        _ctx = self._select("members", _args)
+        _ctx = EnumMemberTypeDef(_ctx)._select("id", [])
+
+        @dataclass
+        class Response:
+            id: EnumMemberTypeDefID
+
+        _ids = await _ctx.execute(list[Response])
+        return [
+            EnumMemberTypeDef(
+                Client.from_context(_ctx)._select(
+                    "loadEnumMemberTypeDefFromID",
+                    [Arg("id", v.id)],
+                )
+            )
+            for v in _ids
+        ]
 
     async def name(self) -> str:
         """The name of the enum.
@@ -3477,104 +3644,6 @@ class EnumTypeDef(Type):
         _args: list[Arg] = []
         _ctx = self._select("sourceModuleName", _args)
         return await _ctx.execute(str)
-
-    async def values(self) -> list["EnumValueTypeDef"]:
-        """The values of the enum."""
-        _args: list[Arg] = []
-        _ctx = self._select("values", _args)
-        _ctx = EnumValueTypeDef(_ctx)._select("id", [])
-
-        @dataclass
-        class Response:
-            id: EnumValueTypeDefID
-
-        _ids = await _ctx.execute(list[Response])
-        return [
-            EnumValueTypeDef(
-                Client.from_context(_ctx)._select(
-                    "loadEnumValueTypeDefFromID",
-                    [Arg("id", v.id)],
-                )
-            )
-            for v in _ids
-        ]
-
-
-@typecheck
-class EnumValueTypeDef(Type):
-    """A definition of a value in a custom enum defined in a Module."""
-
-    async def description(self) -> str:
-        """A doc string for the enum value, if any.
-
-        Returns
-        -------
-        str
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("description", _args)
-        return await _ctx.execute(str)
-
-    async def id(self) -> EnumValueTypeDefID:
-        """A unique identifier for this EnumValueTypeDef.
-
-        Note
-        ----
-        This is lazily evaluated, no operation is actually run.
-
-        Returns
-        -------
-        EnumValueTypeDefID
-            The `EnumValueTypeDefID` scalar type represents an identifier for
-            an object of type EnumValueTypeDef.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("id", _args)
-        return await _ctx.execute(EnumValueTypeDefID)
-
-    async def name(self) -> str:
-        """The name of the enum value.
-
-        Returns
-        -------
-        str
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("name", _args)
-        return await _ctx.execute(str)
-
-    def source_map(self) -> "SourceMap":
-        """The location of this enum value declaration."""
-        _args: list[Arg] = []
-        _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
 
 
 @typecheck
@@ -6818,6 +6887,16 @@ class Client(Root):
         _ctx = self._select("loadEngineFromID", _args)
         return Engine(_ctx)
 
+    def load_enum_member_type_def_from_id(
+        self, id: EnumMemberTypeDefID
+    ) -> EnumMemberTypeDef:
+        """Load a EnumMemberTypeDef from its ID."""
+        _args = [
+            Arg("id", id),
+        ]
+        _ctx = self._select("loadEnumMemberTypeDefFromID", _args)
+        return EnumMemberTypeDef(_ctx)
+
     def load_enum_type_def_from_id(self, id: EnumTypeDefID) -> EnumTypeDef:
         """Load a EnumTypeDef from its ID."""
         _args = [
@@ -6825,16 +6904,6 @@ class Client(Root):
         ]
         _ctx = self._select("loadEnumTypeDefFromID", _args)
         return EnumTypeDef(_ctx)
-
-    def load_enum_value_type_def_from_id(
-        self, id: EnumValueTypeDefID
-    ) -> EnumValueTypeDef:
-        """Load a EnumValueTypeDef from its ID."""
-        _args = [
-            Arg("id", id),
-        ]
-        _ctx = self._select("loadEnumValueTypeDefFromID", _args)
-        return EnumValueTypeDef(_ctx)
 
     def load_env_variable_from_id(self, id: EnvVariableID) -> EnvVariable:
         """Load a EnvVariable from its ID."""
@@ -8007,6 +8076,37 @@ class TypeDef(Type):
         _ctx = self._select("withEnum", _args)
         return TypeDef(_ctx)
 
+    def with_enum_member(
+        self,
+        name: str,
+        value: str,
+        *,
+        description: str | None = "",
+        source_map: SourceMap | None = None,
+    ) -> Self:
+        """Adds a static value for an Enum TypeDef, failing if the type is not an
+        enum.
+
+        Parameters
+        ----------
+        name:
+            The name of the member in the enum
+        value:
+            The value of the member in the enum
+        description:
+            A doc string for the value, if any
+        source_map:
+            The source map for the enum value definition.
+        """
+        _args = [
+            Arg("name", name),
+            Arg("value", value),
+            Arg("description", description, ""),
+            Arg("sourceMap", source_map, None),
+        ]
+        _ctx = self._select("withEnumMember", _args)
+        return TypeDef(_ctx)
+
     def with_enum_value(
         self,
         value: str,
@@ -8184,10 +8284,10 @@ __all__ = [
     "EngineCacheEntrySetID",
     "EngineCacheID",
     "EngineID",
+    "EnumMemberTypeDef",
+    "EnumMemberTypeDefID",
     "EnumTypeDef",
     "EnumTypeDefID",
-    "EnumValueTypeDef",
-    "EnumValueTypeDefID",
     "EnvVariable",
     "EnvVariableID",
     "Error",
@@ -8213,7 +8313,7 @@ __all__ = [
     "Host",
     "HostID",
     "ImageLayerCompression",
-    "ImageMediaTypes",
+    "ImageMediaType",
     "InputTypeDef",
     "InputTypeDefID",
     "InterfaceTypeDef",

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -1,10 +1,14 @@
 import dataclasses
+import enum
 import inspect
 import json
 import logging
 
+from cattrs.preconf.json import make_converter as make_json_converter
+
 import dagger
-from dagger.mod._types import APIName, ContextPath
+from dagger.client import base
+from dagger.mod._types import APIName, ContextPath, Enum
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +102,9 @@ class Parameter:
         if not self.has_default:
             return
         try:
-            self.default_value = dagger.JSON(json.dumps(self.signature.default))
+            conv = make_converter()
+            self.default_value = dagger.JSON(conv.dumps(self.signature.default))
+            # self.default_value = dagger.JSON(json.dumps(self.signature.default))
         except TypeError as e:
             # Rather than failing on a default value that's not JSON
             # serializable and going through hoops to support more and more
@@ -148,3 +154,26 @@ class Parameter:
                     f"parameter '{self.signature.name}'"
                 )
                 raise ValueError(msg)
+
+
+def make_converter():
+    conv = make_json_converter(
+        detailed_validation=True,
+    )
+
+    def to_enum_name(val: enum.Enum) -> str:
+        return val.name
+
+    def from_enum_name(name: str, cls: type[enum.Enum]) -> enum.Enum:
+        return cls[name]
+
+    conv.register_unstructure_hook(enum.Enum, to_enum_name)
+    conv.register_structure_hook(enum.Enum, from_enum_name)
+
+    conv.register_unstructure_hook(base.Enum, to_enum_name)
+    conv.register_structure_hook(base.Enum, from_enum_name)
+
+    conv.register_unstructure_hook(Enum, to_enum_name)
+    conv.register_structure_hook(Enum, from_enum_name)
+
+    return conv

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -8,6 +8,7 @@ from collections.abc import Collection
 from beartype.door import TypeHint
 from cattrs.preconf.json import make_converter as make_json_converter
 
+from dagger.mod._types import Enum
 from dagger.mod._utils import (
     get_doc,
     is_annotated,
@@ -18,6 +19,7 @@ from dagger.mod._utils import (
     strip_annotations,
     syncify,
 )
+from dagger.client import base
 
 logger = logging.getLogger(__name__)
 
@@ -57,11 +59,25 @@ def make_converter():
         is_id_type_subclass,
         dagger_type_structure,
     )
-
     conv.register_unstructure_hook_func(
         is_id_type_subclass,
         dagger_type_unstructure,
     )
+
+    def to_enum_name(val: enum.Enum) -> str:
+        return val.name
+
+    def from_enum_name(name: str, cls: type[enum.Enum]) -> enum.Enum:
+        return cls[name]
+
+    conv.register_unstructure_hook(enum.Enum, to_enum_name)
+    conv.register_structure_hook(enum.Enum, from_enum_name)
+
+    conv.register_unstructure_hook(base.Enum, to_enum_name)
+    conv.register_structure_hook(base.Enum, from_enum_name)
+
+    conv.register_unstructure_hook(Enum, to_enum_name)
+    conv.register_structure_hook(Enum, from_enum_name)
 
     return conv
 

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -179,7 +179,8 @@ class Module:
         for name, cls in self._enums.items():
             enum_def = dag.type_def().with_enum(name, description=get_doc(cls))
             for member in cls:
-                enum_def = enum_def.with_enum_value(
+                enum_def = enum_def.with_enum_member(
+                    str(member.name),
                     str(member.value),
                     description=getattr(member, "description", None),
                 )

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -111,7 +111,7 @@ export type ContainerAsTarballOpts = {
    *
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
    */
-  mediaTypes?: ImageMediaTypes
+  mediaTypes?: ImageMediaType
 }
 
 export type ContainerBuildOpts = {
@@ -167,7 +167,7 @@ export type ContainerExportOpts = {
    *
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
    */
-  mediaTypes?: ImageMediaTypes
+  mediaTypes?: ImageMediaType
 
   /**
    * Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -209,7 +209,7 @@ export type ContainerPublishOpts = {
    *
    * Defaults to OCI, which is largely compatible with most recent registries, but Docker may be needed for older registries without OCI support.
    */
-  mediaTypes?: ImageMediaTypes
+  mediaTypes?: ImageMediaType
 }
 
 export type ContainerTerminalOpts = {
@@ -810,14 +810,14 @@ export type EngineCacheID = string & { __EngineCacheID: never }
 export type EngineID = string & { __EngineID: never }
 
 /**
+ * The `EnumMemberTypeDefID` scalar type represents an identifier for an object of type EnumMemberTypeDef.
+ */
+export type EnumMemberTypeDefID = string & { __EnumMemberTypeDefID: never }
+
+/**
  * The `EnumTypeDefID` scalar type represents an identifier for an object of type EnumTypeDef.
  */
 export type EnumTypeDefID = string & { __EnumTypeDefID: never }
-
-/**
- * The `EnumValueTypeDefID` scalar type represents an identifier for an object of type EnumValueTypeDef.
- */
-export type EnumValueTypeDefID = string & { __EnumValueTypeDefID: never }
 
 /**
  * The `EnvVariableID` scalar type represents an identifier for an object of type EnvVariable.
@@ -984,17 +984,21 @@ export type HostID = string & { __HostID: never }
  * Compression algorithm to use for image layers.
  */
 export enum ImageLayerCompression {
-  Estargz = "EStarGZ",
-  Gzip = "Gzip",
-  Uncompressed = "Uncompressed",
-  Zstd = "Zstd",
+  Estargz = "ESTARGZ",
+
+  Gzip = "GZIP",
+
+  Uncompressed = "UNCOMPRESSED",
+
+  Zstd = "ZSTD",
 }
 /**
  * Mediatypes to use in published or exported image metadata.
  */
-export enum ImageMediaTypes {
-  Dockermediatypes = "DockerMediaTypes",
-  Ocimediatypes = "OCIMediaTypes",
+export enum ImageMediaType {
+  Docker = "DOCKER",
+
+  Oci = "OCI",
 }
 /**
  * The `InputTypeDefID` scalar type represents an identifier for an object of type InputTypeDef.
@@ -1035,15 +1039,18 @@ export type ModuleSourceID = string & { __ModuleSourceID: never }
  * The kind of module source.
  */
 export enum ModuleSourceKind {
-  DirSource = "DIR_SOURCE",
-  GitSource = "GIT_SOURCE",
-  LocalSource = "LOCAL_SOURCE",
+  Dir = "DIR",
+
+  Git = "GIT",
+
+  Local = "LOCAL",
 }
 /**
  * Transport layer network protocol associated to a port.
  */
 export enum NetworkProtocol {
   Tcp = "TCP",
+
   Udp = "UDP",
 }
 /**
@@ -1257,6 +1264,18 @@ export type TypeDefWithEnumOpts = {
   sourceMap?: SourceMap
 }
 
+export type TypeDefWithEnumMemberOpts = {
+  /**
+   * A doc string for the value, if any
+   */
+  description?: string
+
+  /**
+   * The source map for the enum value definition.
+   */
+  sourceMap?: SourceMap
+}
+
 export type TypeDefWithEnumValueOpts = {
   /**
    * A doc string for the value, if any
@@ -1307,67 +1326,132 @@ export enum TypeDefKind {
   /**
    * A boolean value.
    */
-  BooleanKind = "BOOLEAN_KIND",
+  Boolean = "BOOLEAN",
+
+  /**
+   * A boolean value.
+   */
+  BooleanKind = TypeDefKind.Boolean,
 
   /**
    * A GraphQL enum type and its values
    *
    * Always paired with an EnumTypeDef.
    */
-  EnumKind = "ENUM_KIND",
+  Enum = "ENUM",
+
+  /**
+   * A GraphQL enum type and its values
+   *
+   * Always paired with an EnumTypeDef.
+   */
+  EnumKind = TypeDefKind.Enum,
 
   /**
    * A float value.
    */
-  FloatKind = "FLOAT_KIND",
+  Float = "FLOAT",
+
+  /**
+   * A float value.
+   */
+  FloatKind = TypeDefKind.Float,
 
   /**
    * A graphql input type, used only when representing the core API via TypeDefs.
    */
-  InputKind = "INPUT_KIND",
+  Input = "INPUT",
+
+  /**
+   * A graphql input type, used only when representing the core API via TypeDefs.
+   */
+  InputKind = TypeDefKind.Input,
 
   /**
    * An integer value.
    */
-  IntegerKind = "INTEGER_KIND",
+  Integer = "INTEGER",
+
+  /**
+   * An integer value.
+   */
+  IntegerKind = TypeDefKind.Integer,
 
   /**
    * A named type of functions that can be matched+implemented by other objects+interfaces.
    *
    * Always paired with an InterfaceTypeDef.
    */
-  InterfaceKind = "INTERFACE_KIND",
+  Interface = "INTERFACE",
+
+  /**
+   * A named type of functions that can be matched+implemented by other objects+interfaces.
+   *
+   * Always paired with an InterfaceTypeDef.
+   */
+  InterfaceKind = TypeDefKind.Interface,
 
   /**
    * A list of values all having the same type.
    *
    * Always paired with a ListTypeDef.
    */
-  ListKind = "LIST_KIND",
+  List = "LIST",
+
+  /**
+   * A list of values all having the same type.
+   *
+   * Always paired with a ListTypeDef.
+   */
+  ListKind = TypeDefKind.List,
 
   /**
    * A named type defined in the GraphQL schema, with fields and functions.
    *
    * Always paired with an ObjectTypeDef.
    */
-  ObjectKind = "OBJECT_KIND",
+  Object = "OBJECT",
+
+  /**
+   * A named type defined in the GraphQL schema, with fields and functions.
+   *
+   * Always paired with an ObjectTypeDef.
+   */
+  ObjectKind = TypeDefKind.Object,
 
   /**
    * A scalar value of any basic kind.
    */
-  ScalarKind = "SCALAR_KIND",
+  Scalar = "SCALAR",
+
+  /**
+   * A scalar value of any basic kind.
+   */
+  ScalarKind = TypeDefKind.Scalar,
 
   /**
    * A string value.
    */
-  StringKind = "STRING_KIND",
+  String = "STRING",
+
+  /**
+   * A string value.
+   */
+  StringKind = TypeDefKind.String,
 
   /**
    * A special kind used to signify that no value is returned.
    *
    * This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
    */
-  VoidKind = "VOID_KIND",
+  Void = "VOID",
+
+  /**
+   * A special kind used to signify that no value is returned.
+   *
+   * This is used for functions that have no return value. The outer TypeDef specifying this Kind is always Optional, as the Void is never actually represented.
+   */
+  VoidKind = TypeDefKind.Void,
 }
 /**
  * The absence of a value.
@@ -3364,6 +3448,102 @@ export class EngineCacheEntrySet extends BaseClient {
 }
 
 /**
+ * A definition of a value in a custom enum defined in a Module.
+ */
+export class EnumMemberTypeDef extends BaseClient {
+  private readonly _id?: EnumMemberTypeDefID = undefined
+  private readonly _description?: string = undefined
+  private readonly _name?: string = undefined
+  private readonly _value?: string = undefined
+
+  /**
+   * Constructor is used for internal usage only, do not create object from it.
+   */
+  constructor(
+    ctx?: Context,
+    _id?: EnumMemberTypeDefID,
+    _description?: string,
+    _name?: string,
+    _value?: string,
+  ) {
+    super(ctx)
+
+    this._id = _id
+    this._description = _description
+    this._name = _name
+    this._value = _value
+  }
+
+  /**
+   * A unique identifier for this EnumMemberTypeDef.
+   */
+  id = async (): Promise<EnumMemberTypeDefID> => {
+    if (this._id) {
+      return this._id
+    }
+
+    const ctx = this._ctx.select("id")
+
+    const response: Awaited<EnumMemberTypeDefID> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * A doc string for the enum value, if any.
+   */
+  description = async (): Promise<string> => {
+    if (this._description) {
+      return this._description
+    }
+
+    const ctx = this._ctx.select("description")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The name of the enum value.
+   */
+  name = async (): Promise<string> => {
+    if (this._name) {
+      return this._name
+    }
+
+    const ctx = this._ctx.select("name")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The location of this enum value declaration.
+   */
+  sourceMap = (): SourceMap => {
+    const ctx = this._ctx.select("sourceMap")
+    return new SourceMap(ctx)
+  }
+
+  /**
+   * The value of the enum value
+   */
+  value = async (): Promise<string> => {
+    if (this._value) {
+      return this._value
+    }
+
+    const ctx = this._ctx.select("value")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+}
+
+/**
  * A definition of a custom enum defined in a Module.
  */
 export class EnumTypeDef extends BaseClient {
@@ -3421,6 +3601,23 @@ export class EnumTypeDef extends BaseClient {
   }
 
   /**
+   * The members of the enum.
+   */
+  members = async (): Promise<EnumMemberTypeDef[]> => {
+    type members = {
+      id: EnumMemberTypeDefID
+    }
+
+    const ctx = this._ctx.select("members").select("id")
+
+    const response: Awaited<members[]> = await ctx.execute()
+
+    return response.map((r) =>
+      new Client(ctx.copy()).loadEnumMemberTypeDefFromID(r.id),
+    )
+  }
+
+  /**
    * The name of the enum.
    */
   name = async (): Promise<string> => {
@@ -3456,101 +3653,6 @@ export class EnumTypeDef extends BaseClient {
     const response: Awaited<string> = await ctx.execute()
 
     return response
-  }
-
-  /**
-   * The values of the enum.
-   */
-  values = async (): Promise<EnumValueTypeDef[]> => {
-    type values = {
-      id: EnumValueTypeDefID
-    }
-
-    const ctx = this._ctx.select("values").select("id")
-
-    const response: Awaited<values[]> = await ctx.execute()
-
-    return response.map((r) =>
-      new Client(ctx.copy()).loadEnumValueTypeDefFromID(r.id),
-    )
-  }
-}
-
-/**
- * A definition of a value in a custom enum defined in a Module.
- */
-export class EnumValueTypeDef extends BaseClient {
-  private readonly _id?: EnumValueTypeDefID = undefined
-  private readonly _description?: string = undefined
-  private readonly _name?: string = undefined
-
-  /**
-   * Constructor is used for internal usage only, do not create object from it.
-   */
-  constructor(
-    ctx?: Context,
-    _id?: EnumValueTypeDefID,
-    _description?: string,
-    _name?: string,
-  ) {
-    super(ctx)
-
-    this._id = _id
-    this._description = _description
-    this._name = _name
-  }
-
-  /**
-   * A unique identifier for this EnumValueTypeDef.
-   */
-  id = async (): Promise<EnumValueTypeDefID> => {
-    if (this._id) {
-      return this._id
-    }
-
-    const ctx = this._ctx.select("id")
-
-    const response: Awaited<EnumValueTypeDefID> = await ctx.execute()
-
-    return response
-  }
-
-  /**
-   * A doc string for the enum value, if any.
-   */
-  description = async (): Promise<string> => {
-    if (this._description) {
-      return this._description
-    }
-
-    const ctx = this._ctx.select("description")
-
-    const response: Awaited<string> = await ctx.execute()
-
-    return response
-  }
-
-  /**
-   * The name of the enum value.
-   */
-  name = async (): Promise<string> => {
-    if (this._name) {
-      return this._name
-    }
-
-    const ctx = this._ctx.select("name")
-
-    const response: Awaited<string> = await ctx.execute()
-
-    return response
-  }
-
-  /**
-   * The location of this enum value declaration.
-   */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
   }
 }
 
@@ -6281,19 +6383,21 @@ export class Client extends BaseClient {
   }
 
   /**
+   * Load a EnumMemberTypeDef from its ID.
+   */
+  loadEnumMemberTypeDefFromID = (
+    id: EnumMemberTypeDefID,
+  ): EnumMemberTypeDef => {
+    const ctx = this._ctx.select("loadEnumMemberTypeDefFromID", { id })
+    return new EnumMemberTypeDef(ctx)
+  }
+
+  /**
    * Load a EnumTypeDef from its ID.
    */
   loadEnumTypeDefFromID = (id: EnumTypeDefID): EnumTypeDef => {
     const ctx = this._ctx.select("loadEnumTypeDefFromID", { id })
     return new EnumTypeDef(ctx)
-  }
-
-  /**
-   * Load a EnumValueTypeDef from its ID.
-   */
-  loadEnumValueTypeDefFromID = (id: EnumValueTypeDefID): EnumValueTypeDef => {
-    const ctx = this._ctx.select("loadEnumValueTypeDefFromID", { id })
-    return new EnumValueTypeDef(ctx)
   }
 
   /**
@@ -7321,6 +7425,22 @@ export class TypeDef extends BaseClient {
    */
   withEnum = (name: string, opts?: TypeDefWithEnumOpts): TypeDef => {
     const ctx = this._ctx.select("withEnum", { name, ...opts })
+    return new TypeDef(ctx)
+  }
+
+  /**
+   * Adds a static value for an Enum TypeDef, failing if the type is not an enum.
+   * @param name The name of the member in the enum
+   * @param value The value of the member in the enum
+   * @param opts.description A doc string for the value, if any
+   * @param opts.sourceMap The source map for the enum value definition.
+   */
+  withEnumMember = (
+    name: string,
+    value: string,
+    opts?: TypeDefWithEnumMemberOpts,
+  ): TypeDef => {
+    const ctx = this._ctx.select("withEnumMember", { name, value, ...opts })
     return new TypeDef(ctx)
   }
 

--- a/sdk/typescript/src/module/entrypoint/register.ts
+++ b/sdk/typescript/src/module/entrypoint/register.ts
@@ -84,7 +84,7 @@ export async function register(
     })
 
     Object.values(enum_.values).forEach((value) => {
-      typeDef = typeDef.withEnumValue(value.value, {
+      typeDef = typeDef.withEnumMember(value.name, value.value, {
         description: value.description,
         sourceMap: addSourceMap(value),
       })


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8671 - the aim is to fix all the remaining little nits with enums that make them tricky to use (also wanting to unblock #8608).

TODO:
- [x] Tidy up core enum names
- [x] Improved `withEnumMember` API for enum members
- [ ] Kick off migration from `withEnumValue` to `withEnumMember` in all SDKs
	- [x] Go
	- [x] Python
	- [ ] Typescript
- [ ] Backwards compat (this is gonna be bit tricky)
	- [ ] Handle renamed types, `ImageMediaType`->`ImageMediaTypes`, `EnumValueTypeDef`->`EnumMemberTypeDef`
	- [ ] Ensure that codegen for enums in dependencies stays the same
	- [x] Keep old TypeDef field `EnumTypeDef.values`
	- [x] Keep old core enum values (using member aliases)
	- [ ] Add new legacy tests
- [ ] Fix inevitably broken tests
- [ ] Clean up