### PR TITLE
`dagger run`: configure OTel proxy

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -13,10 +15,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/protobuf/proto"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/client"
+	enginetel "github.com/dagger/dagger/engine/telemetry"
 )
 
 var runCmd = &cobra.Command{
@@ -102,8 +110,15 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("generate uuid: %w", err)
 	}
-
 	sessionToken := u.String()
+
+	// Proxy OTel to the CLI and out through its locally configured exporters
+	// so that it makes it to the TUI and into Cloud without having to also
+	// configure the underlying command.
+	otelEnv, err := setupTelemetryProxy(ctx)
+	if err != nil {
+		return fmt.Errorf("setup telemetry proxy: %w", err)
+	}
 
 	return withEngine(ctx, client.Params{
 		SecretToken: sessionToken,
@@ -119,6 +134,7 @@ func run(cmd *cobra.Command, args []string) error {
 		env = append(env, "DAGGER_SESSION_PORT="+sessionPort)
 		env = append(env, "DAGGER_SESSION_TOKEN="+sessionToken)
 		env = append(env, telemetry.PropagationEnv(ctx)...)
+		env = append(env, otelEnv...)
 
 		subCmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
 
@@ -164,4 +180,111 @@ func run(cmd *cobra.Command, args []string) error {
 
 		return cmdErr
 	})
+}
+
+// setupTelemetryProxy creates an OpenTelemetry proxy server and returns
+// environment variables so that child processes can export to it.
+func setupTelemetryProxy(ctx context.Context) ([]string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create telemetry proxy listener: %w", err)
+	}
+
+	otelProto := "http/protobuf"
+	otelEndpoint := "http://" + listener.Addr().String()
+
+	mux := http.NewServeMux()
+
+	// Handle traces
+	mux.HandleFunc("/v1/traces", func(w http.ResponseWriter, r *http.Request) {
+		body, bodyErr := io.ReadAll(r.Body)
+		if bodyErr != nil {
+			http.Error(w, bodyErr.Error(), http.StatusBadRequest)
+			return
+		}
+		var req coltracepb.ExportTraceServiceRequest
+		if unmarshalErr := proto.Unmarshal(body, &req); unmarshalErr != nil {
+			http.Error(w, unmarshalErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		spans := telemetry.SpansFromPB(req.ResourceSpans)
+		forwarder := telemetry.SpanForwarder{Processors: telemetry.SpanProcessors}
+		if exportErr := forwarder.ExportSpans(r.Context(), spans); exportErr != nil {
+			http.Error(w, exportErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// Handle logs
+	mux.HandleFunc("/v1/logs", func(w http.ResponseWriter, r *http.Request) {
+		body, bodyErr := io.ReadAll(r.Body)
+		if bodyErr != nil {
+			http.Error(w, bodyErr.Error(), http.StatusBadRequest)
+			return
+		}
+		var req collogspb.ExportLogsServiceRequest
+		if unmarshalErr := proto.Unmarshal(body, &req); unmarshalErr != nil {
+			http.Error(w, unmarshalErr.Error(), http.StatusBadRequest)
+			return
+		}
+		forwarder := telemetry.LogForwarder{Processors: telemetry.LogProcessors}
+		if exportErr := telemetry.ReexportLogsFromPB(r.Context(), forwarder, &req); exportErr != nil {
+			http.Error(w, exportErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// Handle metrics
+	mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, r *http.Request) {
+		body, bodyErr := io.ReadAll(r.Body)
+		if bodyErr != nil {
+			http.Error(w, bodyErr.Error(), http.StatusBadRequest)
+			return
+		}
+		var req colmetricspb.ExportMetricsServiceRequest
+		if unmarshalErr := proto.Unmarshal(body, &req); unmarshalErr != nil {
+			http.Error(w, unmarshalErr.Error(), http.StatusBadRequest)
+			return
+		}
+		if exportErr := enginetel.ReexportMetricsFromPB(r.Context(), telemetry.MetricExporters, &req); exportErr != nil {
+			http.Error(w, exportErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// Start serving in the background
+	server := &http.Server{Handler: mux}
+
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			slog.Warn("failed to serve telemetry proxy", "error", serveErr)
+		}
+	}()
+
+	// Clean up when the context is canceled
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	return []string{
+		buildkit.OTelExporterProtocolEnv + "=" + otelProto,
+		buildkit.OTelExporterEndpointEnv + "=" + otelEndpoint,
+		buildkit.OTelTracesProtocolEnv + "=" + otelProto,
+		buildkit.OTelTracesEndpointEnv + "=" + otelEndpoint + "/v1/traces",
+		// Indicate that the /v1/trace endpoint accepts live telemetry.
+		buildkit.OTelTracesLiveEnv + "=1",
+		// Dagger sets up log+metric exporters too. Explicitly set them
+		// so things can detect support for it.
+		buildkit.OTelLogsProtocolEnv + "=" + otelProto,
+		buildkit.OTelLogsEndpointEnv + "=" + otelEndpoint + "/v1/logs",
+		buildkit.OTelMetricsProtocolEnv + "=" + otelProto,
+		buildkit.OTelMetricsEndpointEnv + "=" + otelEndpoint + "/v1/metrics",
+	}, nil
 }


### PR DESCRIPTION
Without this change, any OTel instrumentation within the wrapped command will be invisible to the TUI. With this change, we set up an OTel proxy that just delegates to the CLI, so all received OTLP data goes to both the TUI and any other configured OTel exporters (including Cloud).