### PR TITLE
bundle tsx in the engine image to speed up the TS sdk's node-runtime module init

### DIFF
--- a/.dagger/build/sdk.go
+++ b/.dagger/build/sdk.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"runtime"
 
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/dagger/dagger/.dagger/consts"
 	"github.com/dagger/dagger/.dagger/internal/dagger"
+	"github.com/dagger/dagger/sdk/typescript/runtime/tsdistconsts"
 )
 
 type sdkContent struct {
@@ -69,7 +71,14 @@ func (build *Builder) pythonSDKContent(ctx context.Context) (*sdkContent, error)
 	}, nil
 }
 
+const TypescriptSDKTSXVersion = "4.15.6"
+
 func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, error) {
+	tsxNodeModule := dag.Container().
+		From(tsdistconsts.DefaultNodeImageRef).
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("tsx@%s", TypescriptSDKTSXVersion)}).
+		Directory("/usr/local/lib/node_modules/tsx")
+
 	rootfs := dag.Directory().WithDirectory("/", build.source.Directory("sdk/typescript"), dagger.DirectoryWithDirectoryOpts{
 		Include: []string{
 			"src/**/*.ts",
@@ -86,9 +95,22 @@ func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, er
 		},
 	})
 
+	sdkNodeModules := dag.Container().
+		From(tsdistconsts.DefaultNodeImageRef).
+		WithWorkdir("/work").
+		WithDirectory("/work/sdk", rootfs).
+		WithoutEntrypoint().
+		WithMountedCache("/root/.npm", dag.CacheVolume(fmt.Sprintf("npm-cache-node-%s", tsdistconsts.DefaultNodeVersion))).
+		WithFile("/work/package.json", rootfs.File("./runtime/template/package.json")).
+		WithExec([]string{"npm", "install", "--package-lock-only"}).
+		WithExec([]string{"npm", "ci"}).
+		Directory("/work/node_modules")
+
 	sdkCtrTarball := dag.Container().
 		WithRootfs(rootfs).
 		WithFile("/codegen", build.CodegenBinary()).
+		WithDirectory("/tsx_module", tsxNodeModule).
+		WithDirectory("/sdk_node_modules", sdkNodeModules).
 		AsTarball(dagger.ContainerAsTarballOpts{
 			ForcedCompression: dagger.ImageLayerCompressionZstd,
 		})

--- a/.dagger/build/sdk.go
+++ b/.dagger/build/sdk.go
@@ -95,22 +95,10 @@ func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, er
 		},
 	})
 
-	sdkNodeModules := dag.Container().
-		From(tsdistconsts.DefaultNodeImageRef).
-		WithWorkdir("/work").
-		WithDirectory("/work/sdk", rootfs).
-		WithoutEntrypoint().
-		WithMountedCache("/root/.npm", dag.CacheVolume(fmt.Sprintf("npm-cache-node-%s", tsdistconsts.DefaultNodeVersion))).
-		WithFile("/work/package.json", rootfs.File("./runtime/template/package.json")).
-		WithExec([]string{"npm", "install", "--package-lock-only"}).
-		WithExec([]string{"npm", "ci"}).
-		Directory("/work/node_modules")
-
 	sdkCtrTarball := dag.Container().
 		WithRootfs(rootfs).
 		WithFile("/codegen", build.CodegenBinary()).
 		WithDirectory("/tsx_module", tsxNodeModule).
-		WithDirectory("/sdk_node_modules", sdkNodeModules).
 		AsTarball(dagger.ContainerAsTarballOpts{
 			ForcedCompression: dagger.ImageLayerCompressionZstd,
 		})

--- a/.dagger/go.mod
+++ b/.dagger/go.mod
@@ -6,6 +6,10 @@ require github.com/dagger/dagger/engine/distconsts v0.15.4
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 
+require github.com/dagger/dagger/sdk/typescript/runtime v0.15.3
+
+replace github.com/dagger/dagger/sdk/typescript/runtime => ../sdk/typescript/runtime
+
 require (
 	github.com/99designs/gqlgen v0.17.63
 	github.com/BurntSushi/toml v0.3.1

--- a/dagger.json
+++ b/dagger.json
@@ -1,72 +1,75 @@
 {
-  "name": "dagger-dev",
-  "engineVersion": "v0.15.4",
-  "sdk": {
-    "source": "go"
-  },
-  "dependencies": [
-    {
-      "name": "alpine",
-      "source": "modules/alpine"
+    "name": "dagger-dev",
+    "engineVersion": "v0.15.4",
+    "sdk": {
+        "source": "go"
     },
-    {
-      "name": "dagger-cli",
-      "source": "cmd/dagger"
-    },
-    {
-      "name": "dirdiff",
-      "source": "modules/dirdiff"
-    },
-    {
-      "name": "docusaurus",
-      "source": "github.com/levlaz/daggerverse/docusaurus@main",
-      "pin": "47f5206067011dad0f581d4e7db7afddda32acd0"
-    },
-    {
-      "name": "dotnet-sdk-dev",
-      "source": "sdk/dotnet/dev"
-    },
-    {
-      "name": "elixir-sdk-dev",
-      "source": "sdk/elixir/dev"
-    },
-    {
-      "name": "go",
-      "source": "modules/go"
-    },
-    {
-      "name": "graphql",
-      "source": "modules/graphql"
-    },
-    {
-      "name": "helm",
-      "source": "helm"
-    },
-    {
-      "name": "php-sdk-dev",
-      "source": "sdk/php/dev"
-    },
-    {
-      "name": "ps-analyzer",
-      "source": "modules/ps-analyzer"
-    },
-    {
-      "name": "python-sdk-dev",
-      "source": "sdk/python/dev"
-    },
-    {
-      "name": "shellcheck",
-      "source": "modules/shellcheck"
-    },
-    {
-      "name": "version",
-      "source": "version"
-    },
-    {
-      "name": "wolfi",
-      "source": "modules/wolfi"
-    }
-  ],
-  "source": ".dagger",
-  "include": ["engine/distconsts/**/*"]
+    "dependencies": [
+        {
+            "name": "alpine",
+            "source": "modules/alpine"
+        },
+        {
+            "name": "dagger-cli",
+            "source": "cmd/dagger"
+        },
+        {
+            "name": "dirdiff",
+            "source": "modules/dirdiff"
+        },
+        {
+            "name": "docusaurus",
+            "source": "github.com/levlaz/daggerverse/docusaurus@main",
+            "pin": "47f5206067011dad0f581d4e7db7afddda32acd0"
+        },
+        {
+            "name": "dotnet-sdk-dev",
+            "source": "sdk/dotnet/dev"
+        },
+        {
+            "name": "elixir-sdk-dev",
+            "source": "sdk/elixir/dev"
+        },
+        {
+            "name": "go",
+            "source": "modules/go"
+        },
+        {
+            "name": "graphql",
+            "source": "modules/graphql"
+        },
+        {
+            "name": "helm",
+            "source": "helm"
+        },
+        {
+            "name": "php-sdk-dev",
+            "source": "sdk/php/dev"
+        },
+        {
+            "name": "ps-analyzer",
+            "source": "modules/ps-analyzer"
+        },
+        {
+            "name": "python-sdk-dev",
+            "source": "sdk/python/dev"
+        },
+        {
+            "name": "shellcheck",
+            "source": "modules/shellcheck"
+        },
+        {
+            "name": "version",
+            "source": "version"
+        },
+        {
+            "name": "wolfi",
+            "source": "modules/wolfi"
+        }
+    ],
+    "source": ".dagger",
+    "include": [
+        "engine/distconsts/**/*",
+        "sdk/typescript/runtime/**/*"
+    ]
 }

--- a/sdk/typescript/runtime/go.mod
+++ b/sdk/typescript/runtime/go.mod
@@ -1,4 +1,4 @@
-module main
+module typescript-sdk
 
 go 1.22.7
 

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -4,25 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"main/internal/dagger"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
 
+	"typescript-sdk/internal/dagger"
+	"typescript-sdk/tsdistconsts"
+
 	"github.com/iancoleman/strcase"
 	"golang.org/x/mod/semver"
-)
-
-const (
-	bunVersion  = "1.1.38"
-	nodeVersion = "22.11.0" // LTS version, JOD (https://nodejs.org/en/about/previous-releases)
-
-	nodeImageDigest = "sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
-	bunImageDigest  = "sha256:5148f6742ac31fac28e6eab391ab1f11f6dfc0c8512c7a3679b374ec470f5982"
-
-	nodeImageRef = "node:" + nodeVersion + "-alpine@" + nodeImageDigest
-	bunImageRef  = "oven/bun:" + bunVersion + "-alpine@" + bunImageDigest
 )
 
 type SupportedTSRuntime string
@@ -93,8 +84,9 @@ const (
 	ModSourceDirPath         = "/src"
 	EntrypointExecutableFile = "__dagger.entrypoint.ts"
 
-	SrcDir = "src"
-	GenDir = "sdk"
+	SrcDir         = "src"
+	GenDir         = "sdk"
+	NodeModulesDir = "node_modules"
 
 	schemaPath     = "/schema.json"
 	codegenBinPath = "/codegen"
@@ -191,7 +183,8 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 				Include: t.moduleConfigFiles(t.moduleConfig.subPath),
 			})).
 		WithDirectory(filepath.Join(t.moduleConfig.modulePath(), GenDir), sdk).
-		WithWorkdir(t.moduleConfig.modulePath())
+		WithWorkdir(t.moduleConfig.modulePath()).
+		WithMountedDirectory(filepath.Join(t.moduleConfig.modulePath(), NodeModulesDir), t.SDKSourceDir.Directory("/sdk_node_modules"))
 
 	base = t.configureModule(base)
 
@@ -260,8 +253,8 @@ func (t *TypescriptSdk) Base() (*dagger.Container, error) {
 	case Bun:
 		return ctr.
 			WithoutEntrypoint().
-			WithMountedCache("/root/.bun/install/cache", dag.CacheVolume(fmt.Sprintf("mod-bun-cache-%s", bunVersion)), dagger.ContainerWithMountedCacheOpts{
-				Sharing: dagger.Private,
+			WithMountedCache("/root/.bun/install/cache", dag.CacheVolume(fmt.Sprintf("mod-bun-cache-%s", tsdistconsts.DefaultBunVersion)), dagger.ContainerWithMountedCacheOpts{
+				Sharing: dagger.CacheSharingModePrivate,
 			}), nil
 	case Node:
 		return ctr.
@@ -274,8 +267,10 @@ func (t *TypescriptSdk) Base() (*dagger.Container, error) {
 			WithMountedCache("/root/.npm", dag.CacheVolume(fmt.Sprintf("npm-cache-%s-%s", runtime, version))).
 			WithMountedCache("/root/.cache/yarn", dag.CacheVolume(fmt.Sprintf("yarn-cache-%s-%s", runtime, version))).
 			WithMountedCache("/root/.pnpm-store", dag.CacheVolume(fmt.Sprintf("pnpm-cache-%s-%s", runtime, version))).
-			// Install tsx
-			WithExec([]string{"npm", "install", "-g", "tsx@4.15.6"}), nil
+			// install tsx from its bundled location in the engine image
+			WithMountedDirectory("/usr/local/lib/node_modules/tsx", t.SDKSourceDir.Directory("/tsx_module")).
+			WithExec([]string{"ln", "-s", "/usr/local/lib/node_modules/tsx/dist/cli.mjs", "/usr/local/bin/tsx"}), nil
+
 	default:
 		return nil, fmt.Errorf("unknown runtime: %s", runtime)
 	}
@@ -351,7 +346,9 @@ func (t *TypescriptSdk) configureModule(ctr *dagger.Container) *dagger.Container
 func (t *TypescriptSdk) addSDK() *dagger.Directory {
 	return t.SDKSourceDir.
 		WithoutDirectory("codegen").
-		WithoutDirectory("runtime")
+		WithoutDirectory("runtime").
+		WithoutDirectory("tsx_module").
+		WithoutDirectory("sdk_node_modules")
 }
 
 // generateClient uses the given container to generate the client code.
@@ -402,13 +399,13 @@ func (t *TypescriptSdk) detectBaseImageRef() (string, error) {
 			return fmt.Sprintf("oven/%s:%s-alpine", Bun, version), nil
 		}
 
-		return bunImageRef, nil
+		return tsdistconsts.DefaultBunImageRef, nil
 	case Node:
 		if version != "" {
 			return fmt.Sprintf("%s:%s-alpine", Node, version), nil
 		}
 
-		return nodeImageRef, nil
+		return tsdistconsts.DefaultNodeImageRef, nil
 	default:
 		return "", fmt.Errorf("unknown runtime: %q", runtime)
 	}
@@ -523,6 +520,7 @@ func (t *TypescriptSdk) generateLockFile(ctr *dagger.Container) (*dagger.Contain
 	switch packageManager {
 	case Yarn:
 		// Enable corepack
+		// NOTE: this incidentally fetches and installs node modules, maybe we could install yarn some other way?
 		ctr = ctr.
 			WithExec([]string{"corepack", "enable"}).
 			WithExec([]string{"corepack", "use", fmt.Sprintf("yarn@%s", version)})

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -183,8 +183,7 @@ func (t *TypescriptSdk) CodegenBase(ctx context.Context, modSource *dagger.Modul
 				Include: t.moduleConfigFiles(t.moduleConfig.subPath),
 			})).
 		WithDirectory(filepath.Join(t.moduleConfig.modulePath(), GenDir), sdk).
-		WithWorkdir(t.moduleConfig.modulePath()).
-		WithMountedDirectory(filepath.Join(t.moduleConfig.modulePath(), NodeModulesDir), t.SDKSourceDir.Directory("/sdk_node_modules"))
+		WithWorkdir(t.moduleConfig.modulePath())
 
 	base = t.configureModule(base)
 
@@ -347,8 +346,7 @@ func (t *TypescriptSdk) addSDK() *dagger.Directory {
 	return t.SDKSourceDir.
 		WithoutDirectory("codegen").
 		WithoutDirectory("runtime").
-		WithoutDirectory("tsx_module").
-		WithoutDirectory("sdk_node_modules")
+		WithoutDirectory("tsx_module")
 }
 
 // generateClient uses the given container to generate the client code.

--- a/sdk/typescript/runtime/tsdistconsts/consts.go
+++ b/sdk/typescript/runtime/tsdistconsts/consts.go
@@ -1,0 +1,11 @@
+package tsdistconsts
+
+const (
+	DefaultNodeVersion  = "22.11.0" // LTS version, JOD (https://nodejs.org/en/about/previous-releases)
+	nodeImageDigest     = "sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
+	DefaultNodeImageRef = "node:" + DefaultNodeVersion + "-alpine@" + nodeImageDigest
+
+	DefaultBunVersion  = "1.1.38"
+	bunImageDigest     = "sha256:5148f6742ac31fac28e6eab391ab1f11f6dfc0c8512c7a3679b374ec470f5982"
+	DefaultBunImageRef = "oven/bun:" + DefaultBunVersion + "-alpine@" + bunImageDigest
+)


### PR DESCRIPTION
with a cold cache, this shaves ~7-10 seconds off TS module init with a hello world-ish module. prior to this change, it'd take ~31s on my machine and after it's somewhere in the 24s range. it makes my dev image marginally larger, which is a bit of a tradeoff, but the dev image is already 449Mb and tsx ends up being like 5mb additional. 


~sidenote: mucking with module-sdk "runtime" go.mod dependencies is pretty error-prone in its current state... it matters quite a bit for module init performance that the go-SDK-based SDKs share exact dependencies with the go SDK, and blindly adding `require`s or naively `go mod tidy`-ing can mess that up... i think the intent is that we use `dagger develop` to make things match? that seemed to work decently well, although things may still be off by patch-versions, especially indirect dependencies.~ turns out module code generation already [does this slick thing where it bumps outdated go.mods to the SDK's go.mod version](https://github.com/dagger/dagger/blob/115a4552ed99de13db32aeee1de875490995eca6/cmd/codegen/generator/go/generator.go#L271-L280).

really most the speedup here comes from bundling tsx ~the node_modules end up being pretty marginal because package locks don't tend to align exactly between our container build and individual module builds. we could probably improve that using an approach similar to the go SDK.~ tore the node_modules bundling out of this PR, will try again later on main.

~we prolly need to more holistically document how to manage the go mod dependencies in all these SDK modules. started a thread to do that [here](https://discord.com/channels/707636530424053791/1338997699214839809).~ the go.mods are pretty well-managed by dependabot, as it turns out.

big ups to @TomChv for dealing with my incessant questions :)