### PR TITLE
Ensure that java module objects and functions are public

### DIFF
--- a/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
+++ b/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
@@ -84,7 +84,7 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
           }
           if (!element.getModifiers().contains(Modifier.PUBLIC)) {
             throw new RuntimeException(
-                "The object %s must be public if annotated with @Object".formatted(qName));
+                "The class %s must be public if annotated with @Object".formatted(qName));
           }
 
           List<FieldInfo> fieldInfoInfos =

--- a/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
+++ b/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
@@ -82,6 +82,11 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
           if (name.isEmpty()) {
             name = typeElement.getSimpleName().toString();
           }
+          if (!element.getModifiers().contains(Modifier.PUBLIC)) {
+            throw new RuntimeException(
+                "The object %s must be public if annotated with @Object".formatted(qName));
+          }
+
           List<FieldInfo> fieldInfoInfos =
               typeElement.getEnclosedElements().stream()
                   .filter(elt -> elt.getKind() == ElementKind.FIELD)
@@ -113,6 +118,11 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                         String fqName = elt.getSimpleName().toString();
                         if (fName.isEmpty()) {
                           fName = fqName;
+                        }
+                        if (!elt.getModifiers().contains(Modifier.PUBLIC)) {
+                          throw new RuntimeException(
+                              "The method %s#%s must be public if annotated with @Function"
+                                  .formatted(qName, fqName));
                         }
 
                         List<ParameterInfo> parameterInfos =


### PR DESCRIPTION
This PR adds two checks in the annotation processor for Java modules. It verifies that Objects (annotated with `@Object`) and Functions (annotated with `@Function`) are declared as public.
This prevents runtime exceptions such as `java.lang.IllegalAccessException` or `java.lang.NoSuchMethodException` when calling module functions.







