### PR TITLE
fix: transfer secret during `LoadContext`

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 )
 
@@ -424,6 +425,14 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 			); err != nil {
 				return inst, fmt.Errorf("failed to select context directory subpath: %w", err)
 			}
+		}
+
+		mainClientCallerID, err := src.Query.MainClientCallerID(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("failed to retrieve mainClientCallerID: %w", err)
+		}
+		if err := src.Query.AddClientResourcesFromID(ctx, &resource.ID{ID: *ctxDir.ID()}, mainClientCallerID, false); err != nil {
+			return inst, fmt.Errorf("failed to add client resources from ID: %w", err)
 		}
 
 		return MakeDirectoryContentHashed(ctx, bk, ctxDir)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9524.

`LoadContext` could easily produce a `Directory` that's dependent on a `Secret`. We have logic to ensure that `Secret`s are all correctly transferred between various clients.

The underlying bug was occurring because of this chain of events:
- Main client session loads all the dependencies, and we inject git credentials
- We enter the top-level module `A` client session, and call the target function `ContainerEcho`, which calls `B`'s `ContainerEcho`, which in turn calls `LoadContext` to load the contextual argument from the dependency git context
- `B` returns a value dependent on the loaded git context, which then triggers the secret transfer code to try and transfer the git credential secret from `B` back to `A`.
	- However! :warning: this fails, because the credential was never loaded into `B`.

The fix is pretty simple - when we call `LoadContext` we need to transfer the secret from the main session which loaded all the modules. This fixes the bug, because now `B` will have access to the secret, so it can be transferred out to `A`.

I've manually verified this fix, but to test this, I'll need a private copy of the module here: https://github.com/dagger/dagger-test-modules/blob/main/context-dir/src/main.go (not sure if we have a PAT setup for this purpose :thinking:)