### PR TITLE
sdk/java: fix vulnerabilities in deps

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -39,6 +39,11 @@
                 <version>${netty-common.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty-handler.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.json</groupId>
                 <artifactId>jakarta.json-api</artifactId>
                 <version>${jakarta.json-api.version}</version>
@@ -310,6 +315,7 @@
         <slf4j-simple.version>2.0.16</slf4j-simple.version>
         <smallrye-graphql.version>2.12.1</smallrye-graphql.version>
         <netty-common.version>4.1.117.Final</netty-common.version>
+        <netty-handler.version>4.1.118.Final</netty-handler.version>
         <system-stubs-jupiter.version>2.1.7</system-stubs-jupiter.version>
         <xdg-java.version>0.1.1</xdg-java.version>
         <yasson.version>3.0.4</yasson.version>

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -38,6 +38,11 @@
             <version>3.0.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.118.Final</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -32,6 +32,12 @@
             <scope>runtime</scope>
             <version>2.0.16</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>3.0.4</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
fixes vulnerability inside transitive dependency:

    org.eclipse.parsson:parsson │ CVE-2023-7272
    io.netty:netty-handler | CVE-2025-24970

This should fix the `scan` CI issue on other PRs