### PR TITLE
docs: Add PHP snippets to api/arguments

### DIFF
--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -547,13 +547,13 @@ Here's an example of a Dagger Function with an optional argument:
 </TabItem>
 <TabItem value="PHP">
 :::note
-The definition of _optional_ varies between Dagger and PHP.
+The definition of optional varies between Dagger and PHP.
 
-An _optional_ argument to PHP is one that has a default value.
+An optional argument to PHP is one that has a default value.
 
-An _optional_ argument to Dagger can be omitted entirely. It is truly optional.
+An optional argument to Dagger can be omitted entirely. It is truly optional.
 
-To specify a function argument as _optional_, simply make it nullable. When using the Dagger CLI, if the argument is omitted; the PHP SDK will treat this as receiving the value `null`.
+To specify a function argument as optional, simply make it nullable. When using the Dagger CLI, if the argument is omitted; the PHP SDK will treat this as receiving the value `null`.
 :::
 ```php file=./snippets/functions/arguments-optional/php/src/MyModule.php
 ```

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -70,6 +70,17 @@ def hello(self):
 ```typescript file=./snippets/functions/arguments-string/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-string/php/src/MyModule.php
+```
+
+Even though PHP doesn't enforce [type annotations][typing] at runtime,
+it's important to define them with Dagger Functions. The PHP SDK needs the
+typing information at runtime to correctly report to the API.
+
+[typing]: https://www.php.net/manual/en/language.types.type-system.php
+
+</TabItem>
 </Tabs>
 
 Here is an example call for this Dagger Function:
@@ -119,6 +130,10 @@ Here is an example of a Dagger Function that accepts a Boolean argument:
 ```typescript file=./snippets/functions/arguments-boolean/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-boolean/php/src/MyModule.php
+```
+</TabItem>
 </Tabs>
 
 Here is an example call for this Dagger Function:
@@ -153,6 +168,11 @@ Here is an example of a Dagger function that accepts an integer argument:
 
 <TabItem value="TypeScript">
 ```typescript file=./snippets/functions/arguments-return-values-integer/typescript/index.ts
+```
+</TabItem>
+
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-return-values-integer/php/src/MyModule.php
 ```
 </TabItem>
 
@@ -199,6 +219,13 @@ The imported `float` type is a `number` underneath, so you can use it as you wou
 ```typescript file=./snippets/functions/arguments-return-values-float/typescript/index.ts
 ```
 </TabItem>
+
+<TabItem value="PHP">
+
+```php file=./snippets/functions/arguments-return-values-float/php/src/MyModule.php
+```
+</TabItem>
+
 </Tabs>
 
 Here is an example call for this Dagger Function:
@@ -228,6 +255,16 @@ To pass an array argument to a Dagger Function, add the corresponding flag, foll
 </TabItem>
 <TabItem value="TypeScript">
 ```typescript file=./snippets/functions/arguments-array/typescript/index.ts
+```
+</TabItem>
+<TabItem value="PHP">
+:::note
+Lists must have their subtype specified by adding the `#[ListOfType]` attribute to the relevant function argument.
+
+The PHP SDK needs the typing information at runtime to correctly report to the API.
+:::
+
+```php file=./snippets/functions/arguments-array/php/src/MyModule.php
 ```
 </TabItem>
 </Tabs>
@@ -263,6 +300,10 @@ Here's an example of a Dagger Function that accepts a `Directory` as argument. T
 </TabItem>
 <TabItem value="TypeScript">
 ```typescript file=./snippets/functions/arguments-directory/typescript/index.ts
+```
+</TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-directory/php/src/MyModule.php
 ```
 </TabItem>
 </Tabs>
@@ -332,6 +373,10 @@ Here's an example of a Dagger Function that accepts a `File` as argument, reads 
 ```typescript file=./snippets/functions/arguments-file/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-file/php/src/MyModule.php
+```
+</TabItem>
 </Tabs>
 
 Here is an example of passing a local file to this Dagger Function as argument:
@@ -367,6 +412,10 @@ Here is an example of a Dagger Function that accepts a container image reference
 </TabItem>
 <TabItem value="TypeScript">
 ```typescript file=./snippets/functions/arguments-container/typescript/index.ts
+```
+</TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-container/php/src/MyModule.php
 ```
 </TabItem>
 </Tabs>
@@ -412,6 +461,12 @@ Secrets can be passed to Dagger Functions as arguments using the `Secret` core t
 <TabItem value="TypeScript">
 
 ```typescript file=../cookbook/snippets/secret-variable/typescript/index.ts
+```
+
+</TabItem>
+<TabItem value="PHP">
+
+```php file=../cookbook/snippets/secret-variable/php/src/MyModule.php
 ```
 
 </TabItem>
@@ -490,6 +545,19 @@ Here's an example of a Dagger Function with an optional argument:
 ```typescript file=./snippets/functions/arguments-optional/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+:::note
+The definition of _optional_ varies between Dagger and PHP.
+
+An _optional_ argument to PHP is one that has a default value.
+
+An _optional_ argument to Dagger can be omitted entirely. It is truly optional.
+
+To specify a function argument as _optional_, simply make it nullable. When using the Dagger CLI, if the argument is omitted; the PHP SDK will treat this as receiving the value `null`.
+:::
+```php file=./snippets/functions/arguments-optional/php/src/MyModule.php
+```
+</TabItem>
 </Tabs>
 
 Here is an example call for this Dagger Function, with the optional argument:
@@ -533,6 +601,10 @@ Here's an example of a Dagger Function with a default value for a string argumen
 </TabItem>
 <TabItem value="TypeScript">
 ```typescript file=./snippets/functions/arguments-default-string/typescript/index.ts
+```
+</TabItem>
+<TabItem value="PHP">
+```php file=./snippets/functions/arguments-default-string/php/src/MyModule.php
 ```
 </TabItem>
 </Tabs>

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -36,6 +36,13 @@ The default path is set by adding an `@argument` decorator with a `defaultPath` 
 ```typescript file=./snippets/default-paths/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+
+The default path is set by adding a `#[DefaultPath]` Attribute on the corresponding Dagger Function `source` argument.
+
+```php file=./snippets/default-paths/php/src/MyModule.php
+```
+</TabItem>
 </Tabs>
 
 When determining how to resolve a default path, Dagger first identifies a "context directory", and then resolves the path starting from the context directory.

--- a/docs/current_docs/api/snippets/default-paths/php/composer.json
+++ b/docs/current_docs/api/snippets/default-paths/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/default-paths/php/dagger.json
+++ b/docs/current_docs/api/snippets/default-paths/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/default-paths/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/default-paths/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/default-paths/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/default-paths/php/src/MyModule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DaggerModule;
 
 use Dagger\Attribute\{DaggerFunction, DaggerObject, DefaultPath, ReturnsListOfType};
-use Dagger\{File, Directory};
+use Dagger\Directory;
 
 #[DaggerObject]
 class MyModule
@@ -17,13 +17,5 @@ class MyModule
         Directory $source,
     ): array {
         return $source->entries();
-    }
-
-    #[DaggerFunction]
-    public function readFile(
-        #[DefaultPath('./README.md')]
-        File $source
-    ): string {
-        return $source->contents();
     }
 }

--- a/docs/current_docs/api/snippets/default-paths/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/default-paths/php/src/MyModule.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerFunction, DaggerObject, DefaultPath, ReturnsListOfType};
+use Dagger\{File, Directory};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    #[ReturnsListOfType('string')]
+    public function readDir(
+        #[DefaultPath('.')]
+        Directory $source,
+    ): array {
+        return $source->entries();
+    }
+
+    #[DaggerFunction]
+    public function readFile(
+        #[DefaultPath('./README.md')]
+        File $source
+    ): string {
+        return $source->contents();
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-array/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-array/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-array/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-array/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-array/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-array/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-array/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-array/php/src/MyModule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction, ListOfType};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function hello(#[ListOfType('string')]array $names): string
+    {
+        $message = 'Hello';
+
+        if (!empty($names)) {
+            $message .= " " . implode(', ', $names);
+        }
+
+        return $message;
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-boolean/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-boolean/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-boolean/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-boolean/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-boolean/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-boolean/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-boolean/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-boolean/php/src/MyModule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function hello(bool $shout): string
+    {
+        $message = 'Hello, world';
+
+        if ($shout) {
+            return strtoupper($message);
+        }
+
+        return $message;
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-container/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-container/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-container/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-container/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-container/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-container/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-container/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-container/php/src/MyModule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
+use Dagger\Container;
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function osInfo(Container $ctr): string
+    {
+        return $ctr->withExec(['uname', '-a'])->stdout();
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-default-string/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-default-string/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-default-string/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-default-string/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-default-string/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-default-string/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-default-string/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-default-string/php/src/MyModule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerFunction, DaggerObject};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function hello(string $name = 'world'): string
+    {
+        return "Hello, {$name}";
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-directory/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-directory/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-directory/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-directory/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-directory/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-directory/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-directory/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-directory/php/src/MyModule.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction, ListOfType};
+
+use Dagger\Directory;
+use function Dagger\dag;
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function tree(Directory $src, string $depth): string
+    {
+        return dag()
+            ->container()
+            ->from('alpine:latest')
+            ->withMountedDirectory('/mnt', $src)
+            ->withWorkdir('/mnt')
+            ->withExec(['apk', 'add', 'tree'])
+            ->withExec(['tree', '-L', $depth])
+            ->stdout();
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-file/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-file/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-file/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-file/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-file/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-file/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-file/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-file/php/src/MyModule.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction, ListOfType};
+use Dagger\File;
+
+use function Dagger\dag;
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function readFile(File $source): string
+    {
+        return dag()
+            ->container()
+            ->from('alpine:latest')
+            ->withFile('/src/myfile', $source)
+            ->withExec(['cat', '/src/myfile'])
+            ->stdout();
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-optional/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-optional/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-optional/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-optional/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-optional/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-optional/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-optional/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-optional/php/src/MyModule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerFunction, DaggerObject};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function hello(?string $name): string
+    {
+        if (isset($name)) {
+            return "Hello, {$name}";
+        }
+        return 'Hello, world';
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-float/php/src/MyModule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function addFloat(float $a, float $b): float
+    {
+        return $a + $b;
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-return-values-integer/php/src/MyModule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function addInteger(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-string/php/composer.json
+++ b/docs/current_docs/api/snippets/functions/arguments-string/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/api/snippets/functions/arguments-string/php/dagger.json
+++ b/docs/current_docs/api/snippets/functions/arguments-string/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/api/snippets/functions/arguments-string/php/entrypoint.php
+++ b/docs/current_docs/api/snippets/functions/arguments-string/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/api/snippets/functions/arguments-string/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/arguments-string/php/src/MyModule.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
+
+use function Dagger\dag;
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    public function getUser(string $gender): string
+    {
+        return dag()
+            ->container()
+            ->from("alpine:latest")
+            ->withExec(["apk", "add", "curl"])
+            ->withExec(["apk", "add", "jq"])
+            ->withExec([
+                "sh",
+                "-c",
+                "curl https://randomuser.me/api/?gender={$gender} | jq .results[0].name",
+            ])
+            ->stdout();
+    }
+}

--- a/docs/current_docs/cookbook/snippets/secret-variable/php/composer.json
+++ b/docs/current_docs/cookbook/snippets/secret-variable/php/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/my-module",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/docs/current_docs/cookbook/snippets/secret-variable/php/dagger.json
+++ b/docs/current_docs/cookbook/snippets/secret-variable/php/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-module",
+  "engineVersion": "v0.15.2",
+  "sdk": "php",
+  "source": "."
+}

--- a/docs/current_docs/cookbook/snippets/secret-variable/php/entrypoint.php
+++ b/docs/current_docs/cookbook/snippets/secret-variable/php/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/docs/current_docs/cookbook/snippets/secret-variable/php/src/MyModule.php
+++ b/docs/current_docs/cookbook/snippets/secret-variable/php/src/MyModule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerFunction, DaggerObject, Doc};
+use Dagger\Secret;
+
+use function Dagger\dag;
+
+#[DaggerObject]
+class MyModule
+{
+    #[DaggerFunction]
+    #[Doc('Query the Github API')]
+    public function githubApi(Secret $token): string
+    {
+        return dag()
+            ->container()
+            ->from('alpine:3.17')
+            ->withSecretVariable('GITHUB_API_TOKEN', $token)
+            ->withExec(['apk', 'add', 'curl'])
+            ->withExec([
+                'sh',
+                '-c',
+                'curl "https://api.github.com/repos/dagger/dagger/issues"'
+                . ' --header "Authorization: Bearer $GITHUB_API_TOKEN"'
+                . ' --header "Accept: application/vnd.github+json"',
+            ])
+            ->stdout();
+    }
+}


### PR DESCRIPTION
One slight issue with this: We never explain the peculiarities of **returning** an array of values.

In the PHP SDK we have: 
- `#[ListOfType]` as an attribute to put on arguments.
- `#[ReturnsListOfType]` as an attribute to put on the function itself

~~My thoughts are to add a second example function within the `PHP` tab for _array arguments_ what are your thoughts? @jpadams @vikram-dagger @carnage~~
EDIT: Ignore me, I see there is a _Return Values_ section to the documentation