### PR TITLE
docs: Add PHP snippet to custom functions

### DIFF
--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -56,6 +56,13 @@ Update the `src/index.ts` file with the following code:
 ```typescript file=./snippets/functions/functions-complex/typescript/index.ts
 ```
 </TabItem>
+<TabItem value="PHP">
+
+Update the `src/MyModule.php` file with the following code:
+
+```php file=./snippets/functions/functions-complex/php/src/MyModule.php
+```
+</TabItem>
 </Tabs>
 
 :::caution

--- a/docs/current_docs/api/snippets/functions/functions-complex/php/src/MyModule.php
+++ b/docs/current_docs/api/snippets/functions/functions-complex/php/src/MyModule.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace DaggerModule;
 
-use Dagger\Attribute\DaggerFunction;
-use Dagger\Attribute\DaggerObject;
-use Dagger\Attribute\Doc;
-use Dagger\Directory;
+use Dagger\Attribute\{DaggerObject, DaggerFunction};
 
 use function Dagger\dag;
 


### PR DESCRIPTION
If you check the preview on custom functions You will notice this part doesn't have a PHP snippet: 

```md
## Initialize a Dagger module

<DaggerModuleInit />
```

But I do add that part in the #9541