### PR TITLE
Add compatibility changes for ThunderCompute

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -66,6 +66,8 @@ type Container struct {
 	// List of GPU devices that will be exposed to the container
 	EnabledGPUs []string `json:"enabledGPUs,omitempty"`
 
+	EnableThunder bool `json:"enableThunder,omitempty"`
+
 	// Mount points configured for the container.
 	Mounts ContainerMounts `json:"mounts,omitempty"`
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -98,6 +98,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	execMD.RedirectStderrPath = opts.RedirectStderr
 	execMD.SystemEnvNames = container.SystemEnvNames
 	execMD.EnabledGPUs = container.EnabledGPUs
+	execMD.EnableThunder = container.EnableThunder
 
 	if opts.NoInit {
 		execMD.NoInit = true
@@ -118,6 +119,12 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	if len(execMD.EnabledGPUs) > 0 {
 		if gpuSupportEnabled := os.Getenv("_EXPERIMENTAL_DAGGER_GPU_SUPPORT"); gpuSupportEnabled == "" {
 			return nil, fmt.Errorf("GPU support is not enabled, set _EXPERIMENTAL_DAGGER_GPU_SUPPORT")
+		}
+	}
+
+	if execMD.EnableThunder {
+		if thunderSupportEnabled := os.Getenv("_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT"); thunderSupportEnabled == "" {
+			return nil, fmt.Errorf("Thunder support is not enabled, set _EXPERIMENTAL_DAGGER_THUNDER_SUPPORT")
 		}
 	}
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -964,10 +964,31 @@ type containerGpuArgs struct {
 }
 
 func (s *containerSchema) withGPU(ctx context.Context, parent *core.Container, args containerGpuArgs) (*core.Container, error) {
+	container := parent.Clone()
+
+	// Check if Thunder support is enabled
+	if thunderEnabled := os.Getenv("_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT"); thunderEnabled != "" {
+		container.EnableThunder = true
+		// Still set the GPU devices as they might be needed for proper device mapping
+		container.EnabledGPUs = args.Devices
+		return container, nil
+	}
+
+	// Fall back to regular GPU support
 	return parent.WithGPU(ctx, args.ContainerGPUOpts)
 }
 
 func (s *containerSchema) withAllGPUs(ctx context.Context, parent *core.Container, args struct{}) (*core.Container, error) {
+	container := parent.Clone()
+
+	// Check if Thunder support is enabled
+	if thunderEnabled := os.Getenv("_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT"); thunderEnabled != "" {
+		container.EnableThunder = true
+		container.EnabledGPUs = []string{"all"}
+		return container, nil
+	}
+
+	// Fall back to regular GPU support
 	return parent.WithGPU(ctx, core.ContainerGPUOpts{Devices: []string{"all"}})
 }
 

--- a/docs/current_docs/configuration/custom-runner.mdx
+++ b/docs/current_docs/configuration/custom-runner.mdx
@@ -150,6 +150,51 @@ The default user `ubuntu` does not have access to the Docker socket. Fix this wi
 :::
 
 </TabItem>
+<TabItem value="Thunder Compute">
+
+Use the following commands to deploy a GPU-enabled Dagger runner on Fly.io:
+
+```shell
+export TNR_API_TOKEN=TNR_API_TOKEN
+dagger -m github.com/jackowfish/thunder-dagger-module call deploy --token=$TNR_API_TOKEN --gpu=t4 | bash
+```
+
+:::note
+The Thunder Compute module exports commands to add the runner ssh keys to your local ssh agent - piping them to your shell will execute them, but you can also run them manually.
+:::
+
+The Dagger Function returns a message in your terminal, with an environment variable to export. For example:
+
+```shell
+export _EXPERIMENTAL_DAGGER_RUNNER_HOST=ssh://root@11.22.33.44:22
+```
+
+Copy and paste the previous command in your active terminal. From now on, Dagger will execute all function calls using the remote Dagger Engine running on Thunder Compute.
+
+To check if the runner is running, you can use the following command:
+
+```shell
+dagger -m github.com/jackowfish/thunder-dagger-module call status --token=$TNR_API_TOKEN
+# This returns a printout with the status of the runner
+Active Thunder instances:
+
+Instance ID: daggerw1234567890
+Status: running
+Host: 11.22.33.44
+```
+
+To stop using the remote Dagger Engine on Thunder Compute and return to using your local Dagger Engine, use the following commands:
+
+```shell
+unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+dagger -m github.com/jackowfish/thunder-dagger-module call destroy --instance-id=instance-id --token=$TNR_API_TOKEN | bash
+```
+
+:::note
+The Thunder Compute module exports commands to remove the runner ssh keys from your local ssh agent - piping them to your shell will execute them, but you can also run them manually.
+:::
+
+</TabItem>
 </Tabs>
 
 Once your GPU-enabled Dagger runner is configured, use the following Dagger Function to test if Dagger has access to the GPU:

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -97,6 +97,8 @@ type ExecutionMetadata struct {
 
 	EnabledGPUs []string
 
+	EnableThunder bool
+
 	// Path to the SSH auth socket. Used for Dagger-in-Dagger support.
 	SSHAuthSocketPath string
 
@@ -170,6 +172,7 @@ func (w *Worker) Run(
 		w.setupSecretScrubbing,
 		w.setProxyEnvs,
 		w.enableGPU,
+		w.setupThunderMounts,
 		w.createCWD,
 		w.setupNestedClient,
 		w.installCACerts,

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -265,6 +265,7 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	c.connector, err = driver.Provision(provisionCtx, remote, &drivers.DriverOpts{
 		DaggerCloudToken: cloudToken,
 		GPUSupport:       os.Getenv(drivers.EnvGPUSupport),
+		ThunderSupport:   os.Getenv(drivers.EnvThunderSupport),
 	})
 	provisionCancel()
 	telemetry.End(provisionSpan, func() error { return err })

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -150,6 +150,10 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *Driver
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", EnvGPUSupport, opts.GPUSupport))
 		cmd.Args = append(cmd.Args, "-e", EnvGPUSupport, "--gpus", "all")
 	}
+	if opts.ThunderSupport != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", EnvThunderSupport, opts.ThunderSupport))
+		cmd.Args = append(cmd.Args, "-e", EnvThunderSupport)
+	}
 
 	cmd.Args = append(cmd.Args, imageRef, "--debug")
 

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -25,11 +25,13 @@ type Connector interface {
 type DriverOpts struct {
 	DaggerCloudToken string
 	GPUSupport       string
+	ThunderSupport   string
 }
 
 const (
 	EnvDaggerCloudToken = "DAGGER_CLOUD_TOKEN"
 	EnvGPUSupport       = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+	EnvThunderSupport   = "_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT"
 )
 
 var drivers = map[string]Driver{}

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -28,6 +28,7 @@ const (
 	DaggerMinimumVersionEnv = "_EXPERIMENTAL_DAGGER_MIN_VERSION"
 
 	GPUSupportEnv = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+	ThunderSupportEnv = "_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT"
 	RunnerHostEnv = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
 )
 
@@ -42,7 +43,7 @@ func RunnerHost() string {
 		// semi-reasonable)
 		return "docker-container://" + distconsts.EngineContainerName
 	}
-	if os.Getenv(GPUSupportEnv) != "" {
+	if os.Getenv(GPUSupportEnv) != "" || os.Getenv(ThunderSupportEnv) != "" {
 		tag += "-gpu"
 	}
 	return fmt.Sprintf("docker-image://%s:%s", EngineImageRepo, tag)


### PR DESCRIPTION
<div align="left">
  <kbd style="background-color: #6e7681; color: white; padding: 4px 8px; border-radius: 4px; font-size: 12px">🚧 DRAFT</kbd>
</div>

# Add Thunder Platform Support for GPU Workloads

This PR adds support for running Dagger pipelines on Thunder's cloud GPU infrastructure, providing an alternative to local GPU execution.

## Changes

- Added Thunder support in the container builder and executor
- Implemented Thunder-specific container configuration and mounts
- Added environment variables for Thunder authentication and configuration
- Integrated with existing GPU detection and enablement flow
- Added proper library and device mapping support

## Usage

To use Thunder for GPU workloads:

1. Set `_EXPERIMENTAL_DAGGER_THUNDER_SUPPORT=true`
2. Configure Thunder via environment variables:
   - `TNR_API_TOKEN`: Authentication token
   - `TNR_GPU_TYPE`: GPU type (default: t4)
   - `TNR_GPU_COUNT`: Number of GPUs (default: 1)

## Notes

This implementation maintains compatibility with existing GPU workflows while adding Thunder support. When Thunder support is enabled, it takes precedence over local GPU execution.