### PR TITLE
fix: avoid importing buildkit to the CLI

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -22,7 +22,7 @@ import (
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/idtui"
-	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 )
@@ -274,17 +274,17 @@ func setupTelemetryProxy(ctx context.Context) ([]string, error) {
 	}()
 
 	return []string{
-		buildkit.OTelExporterProtocolEnv + "=" + otelProto,
-		buildkit.OTelExporterEndpointEnv + "=" + otelEndpoint,
-		buildkit.OTelTracesProtocolEnv + "=" + otelProto,
-		buildkit.OTelTracesEndpointEnv + "=" + otelEndpoint + "/v1/traces",
+		engine.OTelExporterProtocolEnv + "=" + otelProto,
+		engine.OTelExporterEndpointEnv + "=" + otelEndpoint,
+		engine.OTelTracesProtocolEnv + "=" + otelProto,
+		engine.OTelTracesEndpointEnv + "=" + otelEndpoint + "/v1/traces",
 		// Indicate that the /v1/trace endpoint accepts live telemetry.
-		buildkit.OTelTracesLiveEnv + "=1",
+		engine.OTelTracesLiveEnv + "=1",
 		// Dagger sets up log+metric exporters too. Explicitly set them
 		// so things can detect support for it.
-		buildkit.OTelLogsProtocolEnv + "=" + otelProto,
-		buildkit.OTelLogsEndpointEnv + "=" + otelEndpoint + "/v1/logs",
-		buildkit.OTelMetricsProtocolEnv + "=" + otelProto,
-		buildkit.OTelMetricsEndpointEnv + "=" + otelEndpoint + "/v1/metrics",
+		engine.OTelLogsProtocolEnv + "=" + otelProto,
+		engine.OTelLogsEndpointEnv + "=" + otelEndpoint + "/v1/logs",
+		engine.OTelMetricsProtocolEnv + "=" + otelProto,
+		engine.OTelMetricsEndpointEnv + "=" + otelEndpoint + "/v1/metrics",
 	}, nil
 }

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -65,17 +65,6 @@ const (
 	// this is set by buildkit, we cannot change
 	BuildkitSessionIDHeader = "x-docker-expose-session-uuid"
 
-	OTelTraceParentEnv      = "TRACEPARENT"
-	OTelExporterProtocolEnv = "OTEL_EXPORTER_OTLP_PROTOCOL"
-	OTelExporterEndpointEnv = "OTEL_EXPORTER_OTLP_ENDPOINT"
-	OTelTracesProtocolEnv   = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
-	OTelTracesEndpointEnv   = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
-	OTelTracesLiveEnv       = "OTEL_EXPORTER_OTLP_TRACES_LIVE"
-	OTelLogsProtocolEnv     = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
-	OTelLogsEndpointEnv     = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
-	OTelMetricsProtocolEnv  = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
-	OTelMetricsEndpointEnv  = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
-
 	buildkitQemuEmulatorMountPoint = "/dev/.buildkit_qemu_emulator"
 
 	cgroupSampleInterval     = 3 * time.Second
@@ -729,18 +718,18 @@ func (w *Worker) setupOTel(ctx context.Context, state *execState) error {
 	otelProto := "http/protobuf"
 	otelEndpoint := "http://" + listener.Addr().String()
 	state.spec.Process.Env = append(state.spec.Process.Env,
-		OTelExporterProtocolEnv+"="+otelProto,
-		OTelExporterEndpointEnv+"="+otelEndpoint,
-		OTelTracesProtocolEnv+"="+otelProto,
-		OTelTracesEndpointEnv+"="+otelEndpoint+"/v1/traces",
+		engine.OTelExporterProtocolEnv+"="+otelProto,
+		engine.OTelExporterEndpointEnv+"="+otelEndpoint,
+		engine.OTelTracesProtocolEnv+"="+otelProto,
+		engine.OTelTracesEndpointEnv+"="+otelEndpoint+"/v1/traces",
 		// Indicate that the /v1/trace endpoint accepts live telemetry.
-		OTelTracesLiveEnv+"=1",
+		engine.OTelTracesLiveEnv+"=1",
 		// Dagger sets up log+metric exporters too. Explicitly set them
 		// so things can detect support for it.
-		OTelLogsProtocolEnv+"="+otelProto,
-		OTelLogsEndpointEnv+"="+otelEndpoint+"/v1/logs",
-		OTelMetricsProtocolEnv+"="+otelProto,
-		OTelMetricsEndpointEnv+"="+otelEndpoint+"/v1/metrics",
+		engine.OTelLogsProtocolEnv+"="+otelProto,
+		engine.OTelLogsEndpointEnv+"="+otelEndpoint+"/v1/logs",
+		engine.OTelMetricsProtocolEnv+"="+otelProto,
+		engine.OTelMetricsEndpointEnv+"="+otelEndpoint+"/v1/metrics",
 	)
 
 	// Telemetry propagation (traceparent, tracestate, baggage, etc)

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -75,6 +75,19 @@ const (
 	SessionMethodNameMetaKey = "X-Docker-Expose-Session-Grpc-Method"
 )
 
+const (
+	OTelTraceParentEnv      = "TRACEPARENT"
+	OTelExporterProtocolEnv = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	OTelExporterEndpointEnv = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	OTelTracesProtocolEnv   = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+	OTelTracesEndpointEnv   = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	OTelTracesLiveEnv       = "OTEL_EXPORTER_OTLP_TRACES_LIVE"
+	OTelLogsProtocolEnv     = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
+	OTelLogsEndpointEnv     = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+	OTelMetricsProtocolEnv  = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	OTelMetricsEndpointEnv  = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+)
+
 var ProxyEnvNames = []string{
 	HTTPProxyEnvName,
 	HTTPSProxyEnvName,


### PR DESCRIPTION
This was bad, since the CLI is built for Windows, but our buildkit package uses Unix constants.

We can just move the offending environment variable names into `engine`, which is safe to import from the CLI.