### PR TITLE
chore: get call id digest before attaching to logrus

### DIFF
--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -1143,7 +1143,7 @@ func (w *Worker) runContainer(ctx context.Context, state *execState) (rerr error
 	if w.execMD != nil {
 		lg = lg.WithField("caller_client_id", w.execMD.CallerClientID)
 		if w.execMD.CallID != nil {
-			lg = lg.WithField("call_id", w.execMD.CallID.Digest)
+			lg = lg.WithField("call_id", w.execMD.CallID.Digest())
 		}
 		if w.execMD.ClientID != "" {
 			lg = lg.WithField("nested_client_id", w.execMD.ClientID)


### PR DESCRIPTION
This avoids the annoying `"can not add field "call_id"` messages that can appear in our logs.

```
time="2025-02-11T12:05:08Z" level=debug msg="starting container" logrus_error="can not add field \"call_id\"" ...
```

See the logic in logrus that generates this error: https://github.com/sirupsen/logrus/blob/d1e6332644483cfee14de11099f03645561d55f8/entry.go#L140