### PR TITLE
sdk/java: fix json-smart vuln

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -147,6 +147,13 @@
                 <artifactId>auto-service</artifactId>
                 <version>${auto-service.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+                <scope>runtime</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -319,6 +326,7 @@
         <system-stubs-jupiter.version>2.1.7</system-stubs-jupiter.version>
         <xdg-java.version>0.1.1</xdg-java.version>
         <yasson.version>3.0.4</yasson.version>
+        <json-smart.version>2.5.2</json-smart.version>
     </properties>
 
 </project>

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>netty-handler</artifactId>
             <version>4.1.118.Final</version>
         </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
net.minidev:json-smart │ CVE-2024-57699
fixed in version 2.5.2