### PR TITLE
fix: gha module dev dagger step

### DIFF
--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -33,9 +33,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -45,7 +49,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -35,9 +35,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -47,7 +51,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -35,9 +35,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -47,7 +51,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -214,9 +218,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -226,7 +234,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -393,9 +401,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -405,7 +417,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -572,9 +584,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -584,7 +600,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -751,9 +767,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -763,7 +783,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -930,9 +950,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -942,7 +966,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1120,9 +1144,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1132,7 +1160,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1307,9 +1335,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1319,7 +1351,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1494,9 +1526,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1506,7 +1542,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1681,9 +1717,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1693,7 +1733,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1868,9 +1908,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1880,9 +1924,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -2109,9 +2153,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2121,9 +2169,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -2350,9 +2398,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2362,9 +2414,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -35,9 +35,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -47,7 +51,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash

--- a/.github/workflows/helm.gen.yml
+++ b/.github/workflows/helm.gen.yml
@@ -35,9 +35,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -47,7 +51,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -35,9 +35,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -47,7 +51,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -214,9 +218,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -226,9 +234,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -436,9 +444,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -448,7 +460,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -615,9 +627,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -627,9 +643,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -837,9 +853,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -849,7 +869,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1016,9 +1036,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1028,9 +1052,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -1238,9 +1262,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1250,7 +1278,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1417,9 +1445,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1429,9 +1461,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -1639,9 +1671,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1651,7 +1687,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -1818,9 +1854,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -1830,9 +1870,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -2040,9 +2080,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2052,7 +2096,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -2219,9 +2263,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2231,9 +2279,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -2441,9 +2489,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2453,7 +2505,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -2620,9 +2672,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2632,9 +2688,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5
@@ -2842,9 +2898,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -2854,7 +2914,7 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
                 DAGGER_VERSION: v0.15.3
               shell: bash
@@ -3021,9 +3081,13 @@ jobs:
 
                 # Ensure the dir is writable otherwise fallback to tmpdir
                 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                    prefix_dir="$(mktemp -d)"
+                  prefix_dir="$(mktemp -d)"
                 fi
-                printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
 
                 # If the dagger version is 'latest', set the version back to an empty
                 # string. This allows the install script to detect and install the latest
@@ -3033,9 +3097,9 @@ jobs:
                 fi
 
                 # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: latest
+                DAGGER_VERSION_FILE: dagger.json
               shell: bash
             - name: Install go
               uses: actions/setup-go@v5

--- a/modules/gha/scripts/install-dagger.sh
+++ b/modules/gha/scripts/install-dagger.sh
@@ -6,9 +6,13 @@ prefix_dir="${RUNNER_TEMP:-/usr/local}"
 
 # Ensure the dir is writable otherwise fallback to tmpdir
 if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-    prefix_dir="$(mktemp -d)"
+  prefix_dir="$(mktemp -d)"
 fi
-printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+if [ -f "$DAGGER_VERSION_FILE" ]; then
+  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+fi
 
 # If the dagger version is 'latest', set the version back to an empty
 # string. This allows the install script to detect and install the latest
@@ -18,4 +22,4 @@ if [[ "$DAGGER_VERSION" == "latest" ]]; then
 fi
 
 # The install.sh script creates path ${prefix_dir}/bin
-curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin sh
+curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh

--- a/modules/gha/steps.go
+++ b/modules/gha/steps.go
@@ -47,7 +47,7 @@ func (j *Job) installDaggerSteps() []api.JobStep {
 	return []api.JobStep{
 		// Install latest dagger to bootstrap dev dagger
 		// FIXME: let's daggerize this, using dagger in dagger :)
-		j.bashStep("install-dagger", map[string]string{"DAGGER_VERSION": "latest"}),
+		j.bashStep("install-dagger", map[string]string{"DAGGER_VERSION_FILE": "dagger.json"}),
 		{
 			Name: "Install go",
 			Uses: "actions/setup-go@v5",


### PR DESCRIPTION
We've actually been installing the wrong version here :thinking: 

See: https://github.com/dagger/dagger/actions/runs/13289937745/job/37107902281

In the install step, we install v0.15.4 - but we haven't yet updated to it.

This whole step should be better daggerized, but delaying that at least until the work for `hack/build` is done, see https://github.com/dagger/dagger/pull/9555.