### PR TITLE
engine: fix panic when starting engine with local cache GC disabled

### DIFF
--- a/core/query.go
+++ b/core/query.go
@@ -90,7 +90,7 @@ type Server interface {
 	PruneEngineLocalCacheEntries(context.Context) (*EngineCacheEntrySet, error)
 
 	// The default local cache policy to use for automatic local cache GC.
-	EngineLocalCachePolicy() bkclient.PruneInfo
+	EngineLocalCachePolicy() *bkclient.PruneInfo
 
 	// The nearest ancestor client that is not a module (either a caller from the host like the CLI
 	// or a nested exec). Useful for figuring out where local sources should be resolved from through

--- a/core/schema/engine.go
+++ b/core/schema/engine.go
@@ -52,6 +52,9 @@ func (s *engineSchema) localCache(ctx context.Context, parent *core.Engine, args
 		return nil, err
 	}
 	policy := parent.Query.Clone().EngineLocalCachePolicy()
+	if policy == nil {
+		return &core.EngineCache{Query: parent.Query}, nil
+	}
 	return &core.EngineCache{
 		Query:         parent.Query,
 		ReservedSpace: int(policy.ReservedSpace),

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dagger/dagger/core"
 )
 
-func (srv *Server) EngineLocalCachePolicy() bkclient.PruneInfo {
+func (srv *Server) EngineLocalCachePolicy() *bkclient.PruneInfo {
 	return srv.workerDefaultGCPolicy
 }
 
@@ -170,10 +170,13 @@ func getGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, root string) []bkcl
 	return out
 }
 
-func getDefaultGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, root string) bkclient.PruneInfo {
+func getDefaultGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, root string) *bkclient.PruneInfo {
 	// the last policy is the default one
 	policies := getGCPolicy(cfg, bkcfg, root)
-	return policies[len(policies)-1]
+	if len(policies) == 0 {
+		return nil
+	}
+	return &policies[len(policies)-1]
 }
 
 func defaultGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, dstat disk.DiskStat) []config.GCPolicy {

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -113,7 +113,7 @@ type Server struct {
 	workerCacheMetaDB     *metadata.Store
 	workerCache           bkcache.Manager
 	workerSourceManager   *source.Manager
-	workerDefaultGCPolicy bkclient.PruneInfo
+	workerDefaultGCPolicy *bkclient.PruneInfo
 
 	bkSessionManager *bksession.Manager
 


### PR DESCRIPTION
 prevents a panic from happening when starging the engine with local cache GC disabled.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
