### PR TITLE
fix: fix return list type is not slice of pointer of struct

### DIFF
--- a/.changes/unreleased/Breaking-20250325-220753.yaml
+++ b/.changes/unreleased/Breaking-20250325-220753.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Any functions that returns []T are now return []*T instead.
+time: 2025-03-25T22:07:53.448282027+07:00
+custom:
+    Author: wingyplus
+    PR: "9575"

--- a/cmd/codegen/generator/functions.go
+++ b/cmd/codegen/generator/functions.go
@@ -33,11 +33,11 @@ type FormatTypeFuncs interface {
 // CommonFunctions formatting function with global shared template functions.
 type CommonFunctions struct {
 	schemaVersion   string
-	formatTypeFuncs FormatTypeFuncs
+	FormatTypeFuncs FormatTypeFuncs
 }
 
 func NewCommonFunctions(schemaVersion string, formatTypeFuncs FormatTypeFuncs) *CommonFunctions {
-	return &CommonFunctions{schemaVersion: schemaVersion, formatTypeFuncs: formatTypeFuncs}
+	return &CommonFunctions{schemaVersion: schemaVersion, FormatTypeFuncs: formatTypeFuncs}
 }
 
 // IsSelfChainable returns true if an object type has any fields that return that same type.
@@ -102,7 +102,7 @@ func (c *CommonFunctions) IsIDableObject(t *introspection.TypeRef) (bool, error)
 // unless it's an ID that will be converted which needs to be formatted
 // as an input (for chaining).
 func (c *CommonFunctions) FormatReturnType(f introspection.Field, scopes ...string) (string, error) {
-	return c.formatType(f.TypeRef, strings.Join(scopes, ""), c.ConvertID(f))
+	return c.FormatType(f.TypeRef, strings.Join(scopes, ""), c.ConvertID(f))
 }
 
 func (c *CommonFunctions) ToLowerCase(s string) string {
@@ -180,19 +180,19 @@ func (c *CommonFunctions) ConvertID(f introspection.Field) bool {
 //
 // Example: `String` -> `string`
 func (c *CommonFunctions) FormatInputType(r *introspection.TypeRef, scopes ...string) (string, error) {
-	return c.formatType(r, strings.Join(scopes, ""), true)
+	return c.FormatType(r, strings.Join(scopes, ""), true)
 }
 
 // FormatOutputType formats a GraphQL type into the SDK language output
 //
 // Example: `String` -> `string`
 func (c *CommonFunctions) FormatOutputType(r *introspection.TypeRef, scopes ...string) (string, error) {
-	return c.formatType(r, strings.Join(scopes, ""), false)
+	return c.FormatType(r, strings.Join(scopes, ""), false)
 }
 
-// formatType loops through the type reference to transform it into its SDK language.
-func (c *CommonFunctions) formatType(r *introspection.TypeRef, scope string, input bool) (representation string, err error) {
-	ff := c.formatTypeFuncs.WithScope(scope)
+// FormatType loops through the type reference to transform it into its SDK language.
+func (c *CommonFunctions) FormatType(r *introspection.TypeRef, scope string, input bool) (representation string, err error) {
+	ff := c.FormatTypeFuncs.WithScope(scope)
 
 	for ref := r; ref != nil; ref = ref.OfType {
 		switch ref.Kind {

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -141,11 +141,11 @@ type {{ $field | FieldOptionsStructName }} struct {
     }
 
     {{$eleType := $field.TypeRef | InnerType}}
-    convert := func(fields []{{ $field.Name | ToLowerCase }}) {{ $field.TypeRef | FormatOutputType }} {
-        out := {{ $field.TypeRef | FormatOutputType }}{}
+    convert := func(fields []*{{ $field.Name | ToLowerCase }}) {{ $field | FormatReturnType }} {
+        out := {{ $field | FormatReturnType }}{}
 
         for i := range fields {
-            val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
+            val := &{{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
             {{- if $eleType | IsIDableObject }}
               val.query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
             {{- end }}
@@ -157,7 +157,7 @@ type {{ $field | FieldOptionsStructName }} struct {
     {{- end }}
 
     {{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
-	var response []{{ $field.Name | ToLowerCase }}
+	var response []*{{ $field.Name | ToLowerCase }}
     {{- else }}
 	var response {{ $field.TypeRef | FormatOutputType }}
     {{- end  }}

--- a/cmd/dagger/llm.go
+++ b/cmd/dagger/llm.go
@@ -308,7 +308,7 @@ func (s *LLMSession) syncVarsFromLLM(ctx context.Context) error {
 
 	// assign all outputs
 	for _, output := range outputs {
-		if err := assign(&output); err != nil {
+		if err := assign(output); err != nil {
 			return err
 		}
 	}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -663,7 +663,7 @@ func collectLocalModulesRecursive(ctx context.Context, base *dagger.ModuleSource
 		return err
 	}
 	for _, dep := range deps {
-		err := collectLocalModulesRecursive(ctx, &dep, m)
+		err := collectLocalModulesRecursive(ctx, dep, m)
 		if err != nil {
 			return err
 		}

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -155,7 +155,7 @@ type moduleDef struct {
 type clientGeneratorModuleDef struct {
 	Source *dagger.ModuleSource
 
-	Dependencies []dagger.ModuleSource
+	Dependencies []*dagger.ModuleSource
 }
 
 func (m *moduleDef) Short() string {

--- a/cmd/engine/.dagger/build/sdk.go
+++ b/cmd/engine/.dagger/build/sdk.go
@@ -122,6 +122,7 @@ const TypescriptSDKTSXVersion = "4.15.6"
 func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, error) {
 	tsxNodeModule := dag.Container(dagger.ContainerOpts{Platform: build.platform}).
 		From(tsdistconsts.DefaultNodeImageRef).
+		WithExec([]string{"npm", "install", "-g", "npm"}).
 		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("tsx@%s", TypescriptSDKTSXVersion)}).
 		Directory("/usr/local/lib/node_modules/tsx")
 

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -351,7 +351,7 @@ type cacheEntryVals struct {
 	ActivelyUsed              bool
 }
 
-func getCacheEntryVals(ctx context.Context, t *testctx.T, ent dagger.EngineCacheEntry) *cacheEntryVals {
+func getCacheEntryVals(ctx context.Context, t *testctx.T, ent *dagger.EngineCacheEntry) *cacheEntryVals {
 	t.Helper()
 
 	vals := &cacheEntryVals{}

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -75,7 +75,7 @@ func CurrentModule() *dagger.CurrentModule {
 }
 
 // The TypeDef representations of the objects currently being served in the session.
-func CurrentTypeDefs(ctx context.Context) ([]dagger.TypeDef, error) {
+func CurrentTypeDefs(ctx context.Context) ([]*dagger.TypeDef, error) {
 	client := initClient()
 	return client.CurrentTypeDefs(ctx)
 }

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -820,7 +820,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 }
 
 // Retrieves the list of environment variables passed to commands.
-func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
+func (r *Container) EnvVariables(ctx context.Context) ([]*EnvVariable, error) {
 	q := r.query.Select("envVariables")
 
 	q = q.Select("id")
@@ -829,18 +829,18 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 		Id EnvVariableID
 	}
 
-	convert := func(fields []envVariables) []EnvVariable {
-		out := []EnvVariable{}
+	convert := func(fields []*envVariables) []*EnvVariable {
+		out := []*EnvVariable{}
 
 		for i := range fields {
-			val := EnvVariable{id: &fields[i].Id}
+			val := &EnvVariable{id: &fields[i].Id}
 			val.query = q.Root().Select("loadEnvVariableFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []envVariables
+	var response []*envVariables
 
 	q = q.Bind(&response)
 
@@ -951,7 +951,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 // Retrieves the list of exposed ports.
 //
 // This includes ports already exposed by the image, even if not explicitly added with dagger.
-func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
+func (r *Container) ExposedPorts(ctx context.Context) ([]*Port, error) {
 	q := r.query.Select("exposedPorts")
 
 	q = q.Select("id")
@@ -960,18 +960,18 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 		Id PortID
 	}
 
-	convert := func(fields []exposedPorts) []Port {
-		out := []Port{}
+	convert := func(fields []*exposedPorts) []*Port {
+		out := []*Port{}
 
 		for i := range fields {
-			val := Port{id: &fields[i].Id}
+			val := &Port{id: &fields[i].Id}
 			val.query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []exposedPorts
+	var response []*exposedPorts
 
 	q = q.Bind(&response)
 
@@ -1108,7 +1108,7 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 }
 
 // Retrieves the list of labels passed to container.
-func (r *Container) Labels(ctx context.Context) ([]Label, error) {
+func (r *Container) Labels(ctx context.Context) ([]*Label, error) {
 	q := r.query.Select("labels")
 
 	q = q.Select("id")
@@ -1117,18 +1117,18 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 		Id LabelID
 	}
 
-	convert := func(fields []labels) []Label {
-		out := []Label{}
+	convert := func(fields []*labels) []*Label {
+		out := []*Label{}
 
 		for i := range fields {
-			val := Label{id: &fields[i].Id}
+			val := &Label{id: &fields[i].Id}
 			val.query = q.Root().Select("loadLabelFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []labels
+	var response []*labels
 
 	q = q.Bind(&response)
 
@@ -3342,7 +3342,7 @@ func (r *EngineCacheEntrySet) DiskSpaceBytes(ctx context.Context) (int, error) {
 }
 
 // The list of individual cache entries in the set
-func (r *EngineCacheEntrySet) Entries(ctx context.Context) ([]EngineCacheEntry, error) {
+func (r *EngineCacheEntrySet) Entries(ctx context.Context) ([]*EngineCacheEntry, error) {
 	q := r.query.Select("entries")
 
 	q = q.Select("id")
@@ -3351,18 +3351,18 @@ func (r *EngineCacheEntrySet) Entries(ctx context.Context) ([]EngineCacheEntry, 
 		Id EngineCacheEntryID
 	}
 
-	convert := func(fields []entries) []EngineCacheEntry {
-		out := []EngineCacheEntry{}
+	convert := func(fields []*entries) []*EngineCacheEntry {
+		out := []*EngineCacheEntry{}
 
 		for i := range fields {
-			val := EngineCacheEntry{id: &fields[i].Id}
+			val := &EngineCacheEntry{id: &fields[i].Id}
 			val.query = q.Root().Select("loadEngineCacheEntryFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []entries
+	var response []*entries
 
 	q = q.Bind(&response)
 
@@ -3532,7 +3532,7 @@ func (r *EnumTypeDef) SourceModuleName(ctx context.Context) (string, error) {
 }
 
 // The values of the enum.
-func (r *EnumTypeDef) Values(ctx context.Context) ([]EnumValueTypeDef, error) {
+func (r *EnumTypeDef) Values(ctx context.Context) ([]*EnumValueTypeDef, error) {
 	q := r.query.Select("values")
 
 	q = q.Select("id")
@@ -3541,18 +3541,18 @@ func (r *EnumTypeDef) Values(ctx context.Context) ([]EnumValueTypeDef, error) {
 		Id EnumValueTypeDefID
 	}
 
-	convert := func(fields []values) []EnumValueTypeDef {
-		out := []EnumValueTypeDef{}
+	convert := func(fields []*values) []*EnumValueTypeDef {
+		out := []*EnumValueTypeDef{}
 
 		for i := range fields {
-			val := EnumValueTypeDef{id: &fields[i].Id}
+			val := &EnumValueTypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadEnumValueTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []values
+	var response []*values
 
 	q = q.Bind(&response)
 
@@ -3725,7 +3725,7 @@ func (r *Env) Input(name string) *Binding {
 }
 
 // return all input values for the environment
-func (r *Env) Inputs(ctx context.Context) ([]Binding, error) {
+func (r *Env) Inputs(ctx context.Context) ([]*Binding, error) {
 	q := r.query.Select("inputs")
 
 	q = q.Select("id")
@@ -3734,18 +3734,18 @@ func (r *Env) Inputs(ctx context.Context) ([]Binding, error) {
 		Id BindingID
 	}
 
-	convert := func(fields []inputs) []Binding {
-		out := []Binding{}
+	convert := func(fields []*inputs) []*Binding {
+		out := []*Binding{}
 
 		for i := range fields {
-			val := Binding{id: &fields[i].Id}
+			val := &Binding{id: &fields[i].Id}
 			val.query = q.Root().Select("loadBindingFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []inputs
+	var response []*inputs
 
 	q = q.Bind(&response)
 
@@ -3768,7 +3768,7 @@ func (r *Env) Output(name string) *Binding {
 }
 
 // return all output values for the environment
-func (r *Env) Outputs(ctx context.Context) ([]Binding, error) {
+func (r *Env) Outputs(ctx context.Context) ([]*Binding, error) {
 	q := r.query.Select("outputs")
 
 	q = q.Select("id")
@@ -3777,18 +3777,18 @@ func (r *Env) Outputs(ctx context.Context) ([]Binding, error) {
 		Id BindingID
 	}
 
-	convert := func(fields []outputs) []Binding {
-		out := []Binding{}
+	convert := func(fields []*outputs) []*Binding {
+		out := []*Binding{}
 
 		for i := range fields {
-			val := Binding{id: &fields[i].Id}
+			val := &Binding{id: &fields[i].Id}
 			val.query = q.Root().Select("loadBindingFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []outputs
+	var response []*outputs
 
 	q = q.Bind(&response)
 
@@ -4315,7 +4315,7 @@ func (r *Error) Message(ctx context.Context) (string, error) {
 }
 
 // The extensions of the error.
-func (r *Error) Values(ctx context.Context) ([]ErrorValue, error) {
+func (r *Error) Values(ctx context.Context) ([]*ErrorValue, error) {
 	q := r.query.Select("values")
 
 	q = q.Select("id")
@@ -4324,18 +4324,18 @@ func (r *Error) Values(ctx context.Context) ([]ErrorValue, error) {
 		Id ErrorValueID
 	}
 
-	convert := func(fields []values) []ErrorValue {
-		out := []ErrorValue{}
+	convert := func(fields []*values) []*ErrorValue {
+		out := []*ErrorValue{}
 
 		for i := range fields {
-			val := ErrorValue{id: &fields[i].Id}
+			val := &ErrorValue{id: &fields[i].Id}
 			val.query = q.Root().Select("loadErrorValueFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []values
+	var response []*values
 
 	q = q.Bind(&response)
 
@@ -4755,7 +4755,7 @@ func (r *Function) WithGraphQLQuery(q *querybuilder.Selection) *Function {
 }
 
 // Arguments accepted by the function, if any.
-func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
+func (r *Function) Args(ctx context.Context) ([]*FunctionArg, error) {
 	q := r.query.Select("args")
 
 	q = q.Select("id")
@@ -4764,18 +4764,18 @@ func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
 		Id FunctionArgID
 	}
 
-	convert := func(fields []args) []FunctionArg {
-		out := []FunctionArg{}
+	convert := func(fields []*args) []*FunctionArg {
+		out := []*FunctionArg{}
 
 		for i := range fields {
-			val := FunctionArg{id: &fields[i].Id}
+			val := &FunctionArg{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFunctionArgFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []args
+	var response []*args
 
 	q = q.Bind(&response)
 
@@ -5138,7 +5138,7 @@ func (r *FunctionCall) MarshalJSON() ([]byte, error) {
 }
 
 // The argument values the function is being invoked with.
-func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, error) {
+func (r *FunctionCall) InputArgs(ctx context.Context) ([]*FunctionCallArgValue, error) {
 	q := r.query.Select("inputArgs")
 
 	q = q.Select("id")
@@ -5147,18 +5147,18 @@ func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, e
 		Id FunctionCallArgValueID
 	}
 
-	convert := func(fields []inputArgs) []FunctionCallArgValue {
-		out := []FunctionCallArgValue{}
+	convert := func(fields []*inputArgs) []*FunctionCallArgValue {
+		out := []*FunctionCallArgValue{}
 
 		for i := range fields {
-			val := FunctionCallArgValue{id: &fields[i].Id}
+			val := &FunctionCallArgValue{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFunctionCallArgValueFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []inputArgs
+	var response []*inputArgs
 
 	q = q.Bind(&response)
 
@@ -5926,7 +5926,7 @@ func (r *InputTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *InputTypeDef
 }
 
 // Static fields defined on this input object, if any.
-func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
+func (r *InputTypeDef) Fields(ctx context.Context) ([]*FieldTypeDef, error) {
 	q := r.query.Select("fields")
 
 	q = q.Select("id")
@@ -5935,18 +5935,18 @@ func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 		Id FieldTypeDefID
 	}
 
-	convert := func(fields []fields) []FieldTypeDef {
-		out := []FieldTypeDef{}
+	convert := func(fields []*fields) []*FieldTypeDef {
+		out := []*FieldTypeDef{}
 
 		for i := range fields {
-			val := FieldTypeDef{id: &fields[i].Id}
+			val := &FieldTypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []fields
+	var response []*fields
 
 	q = q.Bind(&response)
 
@@ -6041,7 +6041,7 @@ func (r *InterfaceTypeDef) Description(ctx context.Context) (string, error) {
 }
 
 // Functions defined on this interface, if any.
-func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
+func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]*Function, error) {
 	q := r.query.Select("functions")
 
 	q = q.Select("id")
@@ -6050,18 +6050,18 @@ func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
 		Id FunctionID
 	}
 
-	convert := func(fields []functions) []Function {
-		out := []Function{}
+	convert := func(fields []*functions) []*Function {
+		out := []*Function{}
 
 		for i := range fields {
-			val := Function{id: &fields[i].Id}
+			val := &Function{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []functions
+	var response []*functions
 
 	q = q.Bind(&response)
 
@@ -6696,7 +6696,7 @@ func (r *Module) WithGraphQLQuery(q *querybuilder.Selection) *Module {
 }
 
 // The dependencies of the module.
-func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
+func (r *Module) Dependencies(ctx context.Context) ([]*Module, error) {
 	q := r.query.Select("dependencies")
 
 	q = q.Select("id")
@@ -6705,18 +6705,18 @@ func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
 		Id ModuleID
 	}
 
-	convert := func(fields []dependencies) []Module {
-		out := []Module{}
+	convert := func(fields []*dependencies) []*Module {
+		out := []*Module{}
 
 		for i := range fields {
-			val := Module{id: &fields[i].Id}
+			val := &Module{id: &fields[i].Id}
 			val.query = q.Root().Select("loadModuleFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []dependencies
+	var response []*dependencies
 
 	q = q.Bind(&response)
 
@@ -6742,7 +6742,7 @@ func (r *Module) Description(ctx context.Context) (string, error) {
 }
 
 // Enumerations served by this module.
-func (r *Module) Enums(ctx context.Context) ([]TypeDef, error) {
+func (r *Module) Enums(ctx context.Context) ([]*TypeDef, error) {
 	q := r.query.Select("enums")
 
 	q = q.Select("id")
@@ -6751,18 +6751,18 @@ func (r *Module) Enums(ctx context.Context) ([]TypeDef, error) {
 		Id TypeDefID
 	}
 
-	convert := func(fields []enums) []TypeDef {
-		out := []TypeDef{}
+	convert := func(fields []*enums) []*TypeDef {
+		out := []*TypeDef{}
 
 		for i := range fields {
-			val := TypeDef{id: &fields[i].Id}
+			val := &TypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []enums
+	var response []*enums
 
 	q = q.Bind(&response)
 
@@ -6824,7 +6824,7 @@ func (r *Module) MarshalJSON() ([]byte, error) {
 }
 
 // Interfaces served by this module.
-func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
+func (r *Module) Interfaces(ctx context.Context) ([]*TypeDef, error) {
 	q := r.query.Select("interfaces")
 
 	q = q.Select("id")
@@ -6833,18 +6833,18 @@ func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
 		Id TypeDefID
 	}
 
-	convert := func(fields []interfaces) []TypeDef {
-		out := []TypeDef{}
+	convert := func(fields []*interfaces) []*TypeDef {
+		out := []*TypeDef{}
 
 		for i := range fields {
-			val := TypeDef{id: &fields[i].Id}
+			val := &TypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []interfaces
+	var response []*interfaces
 
 	q = q.Bind(&response)
 
@@ -6870,7 +6870,7 @@ func (r *Module) Name(ctx context.Context) (string, error) {
 }
 
 // Objects served by this module.
-func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
+func (r *Module) Objects(ctx context.Context) ([]*TypeDef, error) {
 	q := r.query.Select("objects")
 
 	q = q.Select("id")
@@ -6879,18 +6879,18 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 		Id TypeDefID
 	}
 
-	convert := func(fields []objects) []TypeDef {
-		out := []TypeDef{}
+	convert := func(fields []*objects) []*TypeDef {
+		out := []*TypeDef{}
 
 		for i := range fields {
-			val := TypeDef{id: &fields[i].Id}
+			val := &TypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []objects
+	var response []*objects
 
 	q = q.Bind(&response)
 
@@ -7193,7 +7193,7 @@ func (r *ModuleSource) Commit(ctx context.Context) (string, error) {
 }
 
 // The clients generated for the module.
-func (r *ModuleSource) ConfigClients(ctx context.Context) ([]ModuleConfigClient, error) {
+func (r *ModuleSource) ConfigClients(ctx context.Context) ([]*ModuleConfigClient, error) {
 	q := r.query.Select("configClients")
 
 	q = q.Select("id")
@@ -7202,18 +7202,18 @@ func (r *ModuleSource) ConfigClients(ctx context.Context) ([]ModuleConfigClient,
 		Id ModuleConfigClientID
 	}
 
-	convert := func(fields []configClients) []ModuleConfigClient {
-		out := []ModuleConfigClient{}
+	convert := func(fields []*configClients) []*ModuleConfigClient {
+		out := []*ModuleConfigClient{}
 
 		for i := range fields {
-			val := ModuleConfigClient{id: &fields[i].Id}
+			val := &ModuleConfigClient{id: &fields[i].Id}
 			val.query = q.Root().Select("loadModuleConfigClientFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []configClients
+	var response []*configClients
 
 	q = q.Bind(&response)
 
@@ -7248,7 +7248,7 @@ func (r *ModuleSource) ContextDirectory() *Directory {
 }
 
 // The dependencies of the module source.
-func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleSource, error) {
+func (r *ModuleSource) Dependencies(ctx context.Context) ([]*ModuleSource, error) {
 	q := r.query.Select("dependencies")
 
 	q = q.Select("id")
@@ -7257,18 +7257,18 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleSource, error)
 		Id ModuleSourceID
 	}
 
-	convert := func(fields []dependencies) []ModuleSource {
-		out := []ModuleSource{}
+	convert := func(fields []*dependencies) []*ModuleSource {
+		out := []*ModuleSource{}
 
 		for i := range fields {
-			val := ModuleSource{id: &fields[i].Id}
+			val := &ModuleSource{id: &fields[i].Id}
 			val.query = q.Root().Select("loadModuleSourceFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []dependencies
+	var response []*dependencies
 
 	q = q.Bind(&response)
 
@@ -7695,7 +7695,7 @@ func (r *ObjectTypeDef) Description(ctx context.Context) (string, error) {
 }
 
 // Static fields defined on this object, if any.
-func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
+func (r *ObjectTypeDef) Fields(ctx context.Context) ([]*FieldTypeDef, error) {
 	q := r.query.Select("fields")
 
 	q = q.Select("id")
@@ -7704,18 +7704,18 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 		Id FieldTypeDefID
 	}
 
-	convert := func(fields []fields) []FieldTypeDef {
-		out := []FieldTypeDef{}
+	convert := func(fields []*fields) []*FieldTypeDef {
+		out := []*FieldTypeDef{}
 
 		for i := range fields {
-			val := FieldTypeDef{id: &fields[i].Id}
+			val := &FieldTypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []fields
+	var response []*fields
 
 	q = q.Bind(&response)
 
@@ -7728,7 +7728,7 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 }
 
 // Functions defined on this object, if any.
-func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
+func (r *ObjectTypeDef) Functions(ctx context.Context) ([]*Function, error) {
 	q := r.query.Select("functions")
 
 	q = q.Select("id")
@@ -7737,18 +7737,18 @@ func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
 		Id FunctionID
 	}
 
-	convert := func(fields []functions) []Function {
-		out := []Function{}
+	convert := func(fields []*functions) []*Function {
+		out := []*Function{}
 
 		for i := range fields {
-			val := Function{id: &fields[i].Id}
+			val := &Function{id: &fields[i].Id}
 			val.query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []functions
+	var response []*functions
 
 	q = q.Bind(&response)
 
@@ -8016,7 +8016,7 @@ func (r *Client) CurrentModule() *CurrentModule {
 }
 
 // The TypeDef representations of the objects currently being served in the session.
-func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
+func (r *Client) CurrentTypeDefs(ctx context.Context) ([]*TypeDef, error) {
 	q := r.query.Select("currentTypeDefs")
 
 	q = q.Select("id")
@@ -8025,18 +8025,18 @@ func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
 		Id TypeDefID
 	}
 
-	convert := func(fields []currentTypeDefs) []TypeDef {
-		out := []TypeDef{}
+	convert := func(fields []*currentTypeDefs) []*TypeDef {
+		out := []*TypeDef{}
 
 		for i := range fields {
-			val := TypeDef{id: &fields[i].Id}
+			val := &TypeDef{id: &fields[i].Id}
 			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []currentTypeDefs
+	var response []*currentTypeDefs
 
 	q = q.Bind(&response)
 
@@ -9226,7 +9226,7 @@ func (r *Service) MarshalJSON() ([]byte, error) {
 }
 
 // Retrieves the list of ports provided by the service.
-func (r *Service) Ports(ctx context.Context) ([]Port, error) {
+func (r *Service) Ports(ctx context.Context) ([]*Port, error) {
 	q := r.query.Select("ports")
 
 	q = q.Select("id")
@@ -9235,18 +9235,18 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 		Id PortID
 	}
 
-	convert := func(fields []ports) []Port {
-		out := []Port{}
+	convert := func(fields []*ports) []*Port {
+		out := []*Port{}
 
 		for i := range fields {
-			val := Port{id: &fields[i].Id}
+			val := &Port{id: &fields[i].Id}
 			val.query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
 		return out
 	}
-	var response []ports
+	var response []*ports
 
 	q = q.Bind(&response)
 


### PR DESCRIPTION
Fixes #9556

Fix any methods that return list of object must return in form of `[]*T`.

The go template override `FormatReturnType` to make it works and expose `FormatType` from common functions type make it accessible from `FormatReturnType`.