### PR TITLE
fix: ensure that all commands that update dagger.json bump engineVersion

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -447,7 +447,7 @@ func (m *Dep) Dummy() error {
 `,
 		)).
 		WithWorkdir("/work").
-		With(daggerExec("install", "./dep")).
+		With(daggerExec("install", "./dep", "--compat=skip")).
 		With(daggerQuery(`{test{test}}`)).
 		Stdout(ctx)
 
@@ -593,7 +593,7 @@ class Dep:
 `,
 		)).
 		WithWorkdir("/work").
-		With(daggerExec("install", "./dep")).
+		With(daggerExec("install", "./dep", "--compat=skip")).
 		With(daggerCall("greet")).
 		Stdout(ctx)
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -319,8 +319,9 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### Options
 
 ```
-  -m, --mod string    Path to the module directory. Either local path or a remote git repo
-  -n, --name string   Name to use for the dependency in the module. Defaults to the name of the module being installed.
+      --compat string   Engine API version to target (default "latest")
+  -m, --mod string      Path to the module directory. Either local path or a remote git repo
+  -n, --name string     Name to use for the dependency in the module. Defaults to the name of the module being installed.
 ```
 
 ### Options inherited from parent commands
@@ -532,6 +533,12 @@ dagger uninstall [options] <module>
 dagger uninstall hello
 ```
 
+### Options
+
+```
+      --compat string   Engine API version to target (default "latest")
+```
+
 ### Options inherited from parent commands
 
 ```
@@ -566,6 +573,12 @@ dagger update [options] <module>
 
 ```
 "dagger update github.com/shykes/daggerverse/hello@v0.3.0" or "dagger update hello"
+```
+
+### Options
+
+```
+      --compat string   Engine API version to target (default "latest")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9576.

We need to add this into our calls to `AsModule` to get the engine version to update.