### PR TITLE
helm: Enable setting imagePullSecrets

### DIFF
--- a/.changes/unreleased/Added-20250218-113020.yaml
+++ b/.changes/unreleased/Added-20250218-113020.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'helm: Enable setting imagePullSecrets'
+time: 2025-02-18T11:30:20.657036Z
+custom:
+    Author: vmaffet
+    PR: "9609"

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -43,6 +43,10 @@ spec:
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}
       {{- end }}
+      {{- with .Values.engine.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: dagger-engine
           image: {{ if .Values.engine.image.ref }}{{ .Values.engine.image.ref }}{{ else }}registry.dagger.io/engine:v{{ .Chart.Version }}{{ end }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -46,6 +46,10 @@ spec:
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}
       {{- end }}
+      {{- with .Values.engine.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: dagger-engine
           image: {{ if .Values.engine.image.ref }}{{ .Values.engine.image.ref }}{{ else }}registry.dagger.io/engine:v{{ .Chart.Version }}{{ end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -43,6 +43,12 @@ engine:
     # ref: registry.dagger.io/engine:main
     pullPolicy: IfNotPresent
 
+  ### Image pull secret to use for registry authentication.
+  imagePullSecrets: []
+  # imagePullSecrets:
+  #   - name: image-pull-secret
+
+
   ### Set taints & tolerations for this workload
   #
   # tolerations:


### PR DESCRIPTION
This PR enables setting `imagePullSecrets` making it easier to use private custom Dagger images. 