### PR TITLE
docs: Explain enums are not supported by PHP SDK

### DIFF
--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 # Enumerations
 
+:::important
+The information on this page is only applicable to Go, Python and TypeScript SDKs. Interfaces are not currently supported in the PHP SDK.
+:::
+
 Dagger supports custom enumeration (enum) types, which can be used to restrict possible values for a string argument. Enum values are strictly validated, preventing common mistakes like accidentally passing null, true, or false.
 
 :::note

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 # Enumerations
 
 :::important
-The information on this page is only applicable to Go, Python and TypeScript SDKs. Interfaces are not currently supported in the PHP SDK.
+The information on this page is only applicable to Go, Python and TypeScript SDKs. Enumerations are not currently supported in the PHP SDK.
 :::
 
 Dagger supports custom enumeration (enum) types, which can be used to restrict possible values for a string argument. Enum values are strictly validated, preventing common mistakes like accidentally passing null, true, or false.


### PR DESCRIPTION
Enums will be supported in the future, however they are unsupported currently. This informs users who visit the page that the PHP SDK does not currently support enums.