### PR TITLE
telemetry: handle log records with no trace/span

### DIFF
--- a/sdk/go/telemetry/transform.go
+++ b/sdk/go/telemetry/transform.go
@@ -967,8 +967,14 @@ func ReexportLogsFromPB(ctx context.Context, exp sdklog.Exporter, req *collogspb
 			)
 			for _, rec := range scopeLog.GetLogRecords() {
 				var logRec log.Record
-				tid := trace.TraceID(rec.GetTraceId())
-				sid := trace.SpanID(rec.GetSpanId())
+				var tid trace.TraceID
+				var sid trace.SpanID
+				if rec.GetTraceId() != nil {
+					tid = trace.TraceID(rec.GetTraceId())
+				}
+				if rec.GetSpanId() != nil {
+					sid = trace.SpanID(rec.GetSpanId())
+				}
 				emitCtx := trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID: tid,
 					SpanID:  sid,


### PR DESCRIPTION
These fields are technically optional with OTel logging (logs aren't always associated to a trace or span), so these would panic trying to convert `nil` to a fixed-length array.

Context: [Discord](https://discord.com/channels/707636530424053791/1333326734506070066/1339956738874671165)