### PR TITLE
feat: add `name` in Directory API

### DIFF
--- a/.changes/unreleased/Added-20250218-190012.yaml
+++ b/.changes/unreleased/Added-20250218-190012.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add `name` function in directory to retrieve current directory name.
+time: 2025-02-18T19:00:12.391528+01:00
+custom:
+  Author: TomChv
+  PR: "9617"

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1214,3 +1214,57 @@ func (DirectorySuite) TestDigest(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", digest)
 	})
 }
+
+func (DirectorySuite) TestDirectoryName(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("empty directory name", func(ctx context.Context, t *testctx.T) {
+		name, err := c.Directory().Name(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "/", name)
+	})
+
+	t.Run("structured directory", func(ctx context.Context, t *testctx.T) {
+		dir := c.Directory().WithDirectory("nested", c.Directory()).WithDirectory("very/nested", c.Directory())
+
+		t.Run("root directory", func(ctx context.Context, t *testctx.T) {
+			rootName, err := dir.Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "/", rootName)
+		})
+
+		t.Run("nested directory", func(ctx context.Context, t *testctx.T) {
+			nestedName, err := dir.Directory("nested").Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "nested", nestedName)
+		})
+
+		t.Run("very nested directory", func(ctx context.Context, t *testctx.T) {
+			veryNestedName, err := dir.Directory("very/nested").Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "nested", veryNestedName)
+		})
+	})
+
+	t.Run("git directory", func(ctx context.Context, t *testctx.T) {
+		dir := c.Git("https://github.com/dagger/dagger#ee32df913f57c876e067bd5ecc159561510b6f50").Head().Tree()
+
+		t.Run("root directory", func(ctx context.Context, t *testctx.T) {
+			rootName, err := dir.Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, ".", rootName)
+		})
+
+		t.Run("nested hidden directory", func(ctx context.Context, t *testctx.T) {
+			nestedName, err := dir.Directory(".dagger").Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, ".dagger", nestedName)
+		})
+
+		t.Run("nested directory", func(ctx context.Context, t *testctx.T) {
+			nestedName, err := dir.Directory("sdk").Directory("go").Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "go", nestedName)
+		})
+	})
+}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1224,6 +1224,11 @@ func (DirectorySuite) TestDirectoryName(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "/", name)
 	})
 
+	t.Run("not found directory", func(ctx context.Context, t *testctx.T) {
+		_, err := c.Directory().Directory("foo").Name(ctx)
+		requireErrOut(t, err, "no such file or directory")
+	})
+
 	t.Run("structured directory", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().WithDirectory("nested", c.Directory()).WithDirectory("very/nested", c.Directory())
 

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -166,8 +166,8 @@ func (FileSuite) TestName(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("not found file", func(ctx context.Context, t *testctx.T) {
-		_, err := c.Host().Directory("path").File("to/file.txt").Name(ctx)
-		require.Error(t, err)
+		_, err := c.Directory().File("to/file.txt").Name(ctx)
+		requireErrOut(t, err, "no such file or directory")
 	})
 }
 

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -164,6 +164,11 @@ func (FileSuite) TestName(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "file.txt", name)
 	})
+
+	t.Run("not found file", func(ctx context.Context, t *testctx.T) {
+		_, err := c.Host().Directory("path").File("to/file.txt").Name(ctx)
+		require.Error(t, err)
+	})
 }
 
 func (FileSuite) TestWithName(ctx context.Context, t *testctx.T) {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
@@ -31,6 +32,8 @@ func (s *directorySchema) Install() {
 			ArgDoc("name", "Name of the sub-pipeline.").
 			ArgDoc("description", "Description of the sub-pipeline.").
 			ArgDoc("labels", "Labels to apply to the sub-pipeline."),
+		dagql.Func("name", s.name).
+			Doc(`Returns the name of the directory.`),
 		dagql.Func("entries", s.entries).
 			Doc(`Returns a list of files and directories at the given path.`).
 			ArgDoc("path", `Location of the directory to look at (e.g., "/src").`),
@@ -180,6 +183,10 @@ type dirWithTimestampsArgs struct {
 
 func (s *directorySchema) withTimestamps(ctx context.Context, parent *core.Directory, args dirWithTimestampsArgs) (*core.Directory, error) {
 	return parent.WithTimestamps(ctx, args.Timestamp)
+}
+
+func (s *directorySchema) name(ctx context.Context, parent *core.Directory, args struct{}) (dagql.String, error) {
+	return dagql.NewString(path.Base(parent.Dir)), nil
 }
 
 type entriesArgs struct {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1291,6 +1291,9 @@ type Directory {
   """A unique identifier for this Directory."""
   id: DirectoryID!
 
+  """Returns the name of the directory."""
+  name: String!
+
   """Force evaluation in the engine."""
   sync: DirectoryID!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -5342,6 +5342,10 @@
                         <td> A unique identifier for this Directory. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="Directory-name" href="#Directory-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Returns the name of the directory. </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="Directory-sync" href="#Directory-sync"><code>sync</code></a> - <span class="property-type"><a href="#definition-DirectoryID"><code>DirectoryID!</code></a></span> </td>
                         <td> Force evaluation in the engine. </td>
                       </tr>

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -156,6 +156,15 @@ defmodule Dagger.Directory do
     Client.execute(directory.client, query_builder)
   end
 
+  @doc "Returns the name of the directory."
+  @spec name(t()) :: {:ok, String.t()} | {:error, term()}
+  def name(%__MODULE__{} = directory) do
+    query_builder =
+      directory.query_builder |> QB.select("name")
+
+    Client.execute(directory.client, query_builder)
+  end
+
   @doc "Force evaluation in the engine."
   @spec sync(t()) :: {:ok, Dagger.Directory.t()} | {:error, term()}
   def sync(%__MODULE__{} = directory) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -2169,6 +2169,7 @@ type Directory struct {
 	digest *string
 	export *string
 	id     *DirectoryID
+	name   *string
 	sync   *DirectoryID
 }
 type WithDirectoryFunc func(r *Directory) *Directory
@@ -2420,6 +2421,19 @@ func (r *Directory) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// Returns the name of the directory.
+func (r *Directory) Name(ctx context.Context) (string, error) {
+	if r.name != nil {
+		return *r.name, nil
+	}
+	q := r.query.Select("name")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // Force evaluation in the engine.

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -150,6 +150,15 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Returns the name of the directory.
+     */
+    public function name(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'name');
+    }
+
+    /**
      * Force evaluation in the engine.
      */
     public function sync(): DirectoryId

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2709,6 +2709,27 @@ class Directory(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(DirectoryID)
 
+    async def name(self) -> str:
+        """Returns the name of the directory.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("name", _args)
+        return await _ctx.execute(str)
+
     async def sync(self) -> Self:
         """Force evaluation in the engine.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4218,6 +4218,11 @@ impl Directory {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Returns the name of the directory.
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Force evaluation in the engine.
     pub async fn sync(&self) -> Result<DirectoryId, DaggerError> {
         let query = self.selection.select("sync");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2681,6 +2681,7 @@ export class Directory extends BaseClient {
   private readonly _id?: DirectoryID = undefined
   private readonly _digest?: string = undefined
   private readonly _export?: string = undefined
+  private readonly _name?: string = undefined
   private readonly _sync?: DirectoryID = undefined
 
   /**
@@ -2691,6 +2692,7 @@ export class Directory extends BaseClient {
     _id?: DirectoryID,
     _digest?: string,
     _export?: string,
+    _name?: string,
     _sync?: DirectoryID,
   ) {
     super(ctx)
@@ -2698,6 +2700,7 @@ export class Directory extends BaseClient {
     this._id = _id
     this._digest = _digest
     this._export = _export
+    this._name = _name
     this._sync = _sync
   }
 
@@ -2835,6 +2838,21 @@ export class Directory extends BaseClient {
     const ctx = this._ctx.select("glob", { pattern })
 
     const response: Awaited<string[]> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * Returns the name of the directory.
+   */
+  name = async (): Promise<string> => {
+    if (this._name) {
+      return this._name
+    }
+
+    const ctx = this._ctx.select("name")
+
+    const response: Awaited<string> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
Based on https://discord.com/channels/707636530424053791/1336739628350439454.

This PR adds a function `name` to the Directory API to retrieve the latest name of the branch.

### TODOS

- [x] API changes
- [x] Client generation
- [x] Integration tests

Fixes #9522 