### PR TITLE
ci: fix failing helm job with version incompat

### DIFF
--- a/helm/.dagger/main.go
+++ b/helm/.dagger/main.go
@@ -112,7 +112,9 @@ func runDaggerQuery(ctx context.Context, engineName string, engineKind string, k
 		return err
 	}
 
-	stdout, err := kubectl.WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", fmt.Sprintf("kube-pod://%s?namespace=dagger", podName)).
+	stdout, err := kubectl.
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", fmt.Sprintf("kube-pod://%s?namespace=dagger", podName)).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v0.16.0-000000000000").
 		WithExec([]string{"dagger", "query"}, dagger.ContainerWithExecOpts{
 			Stdin: `{
 				container {


### PR DESCRIPTION
Due to details in our version comparisons, the recent min version bump to v0.16 has caused our helm job to start breaking. See https://github.com/dagger/dagger/actions/runs/13409473465/job/37456077136.

This is because the helm job starts an image from *main*. This is not ideal, and the versions between these are kind of mutually incompatible. We might want to loosen these at some point a bit, but I don't really have the time to reason through the implications of that *right* now - so this should quickly unblock that job from passing.