### PR TITLE
helm: Enable setting engine pod annotations

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -13,7 +13,7 @@ spec:
       name: {{ include "dagger.fullname" . }}-engine
   template:
     metadata:
-      {{- if (or .Values.engine.config .Values.magicache.enabled) }}
+      {{- if (or .Values.engine.config .Values.magicache.enabled .Values.engine.annotations) }}
       annotations:
         {{- if .Values.engine.config }}
         checksum/config: {{ include (print $.Template.BasePath "/engine-config.yaml") . | sha256sum }}
@@ -21,6 +21,9 @@ spec:
         {{- if .Values.magicache.enabled }}
         checksum/secret: {{ include (print $.Template.BasePath "/magicache-secret.yaml") . | sha256sum }}
         {{- end }}
+      {{- with .Values.engine.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
         name: {{ include "dagger.fullname" . }}-engine

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       name: {{ include "dagger.fullname" . }}-engine
   template:
     metadata:
-      {{- if (or .Values.engine.config .Values.magicache.enabled) }}
+      {{- if (or .Values.engine.config .Values.magicache.enabled .Values.engine.annotations) }}
       annotations:
         {{- if .Values.engine.config }}
         checksum/config: {{ include (print $.Template.BasePath "/engine-config.yaml") . | sha256sum }}
@@ -24,6 +24,9 @@ spec:
         {{- if .Values.magicache.enabled }}
         checksum/secret: {{ include (print $.Template.BasePath "/magicache-secret.yaml") . | sha256sum }}
         {{- end }}
+      {{- with .Values.engine.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
         name: {{ include "dagger.fullname" . }}-engine

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -14,6 +14,9 @@ engine:
   #     mirrors = ["mirror.gcr.io"]
   #   [log]
   #     format = "json"
+
+  annotations: {}
+
   labels: {}
 
   ### `DaemonSet` guarantees a single Engine per K8s node (default behaviour)


### PR DESCRIPTION
This PR enables setting the engine pod annotations in the same way as the labels.