### PR TITLE
ci: allow tagging arbitrary pre-releases

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -79,7 +79,7 @@ func (cli *CLI) Publish(
 	}
 
 	args := []string{"release", "--clean", "--skip=validate", "--verbose"}
-	if tag != "" {
+	if tag != "" && semver.Prerelease(tag) == "" {
 		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", tag))
 	} else {
 		args = append(args,

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/moby/buildkit/identity"
 	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/.dagger/build"
@@ -287,13 +286,6 @@ func (e *DaggerEngine) Publish(
 	// +optional
 	registryPassword *dagger.Secret,
 ) error {
-	for _, t := range tag {
-		if semver.IsValid(t) {
-			tag = append(tag, "latest")
-			break
-		}
-	}
-
 	// collect all the targets that we are trying to build together, along with
 	// where they need to go to
 	targetResults := make([]struct {

--- a/releaser/main.go
+++ b/releaser/main.go
@@ -174,7 +174,7 @@ func (r *Releaser) Publish(
 
 	tags := []string{tag, commit}
 	if semver.IsValid(version) && semver.Prerelease(version) == "" {
-		// this is a full semver release
+		// this is a public release
 		tags = append(tags, "latest")
 	}
 	err := r.Dagger.Engine().Publish(ctx, tags, dagger.DaggerDevDaggerEnginePublishOpts{


### PR DESCRIPTION
Based off of @gerhard's work in [`2273cd2` (#9504)](https://github.com/dagger/dagger/pull/9504/commits/2273cd29a5283f35a767f18a532a7b7c9ff0f3ff).

We should be able to merge this directly to `main`, and once `llm` is rebased, the tagging should work a bit easier.