### PR TITLE
shell: run from root command

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -184,6 +184,10 @@ var rootCmd = &cobra.Command{
 
 		return nil
 	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SetArgs(append([]string{"shell"}, args...))
+		return cmd.Execute()
+	},
 }
 
 func checkForUpdates(ctx context.Context, w io.Writer) {

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -102,8 +102,12 @@ func init() {
 	funcListCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	listenCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	queryCmd.PersistentFlags().AddFlagSet(moduleFlags)
-	shellCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	configCmd.PersistentFlags().AddFlagSet(moduleFlags)
+
+	shellCmd.PersistentFlags().AddFlagSet(moduleFlags)
+	rootCmd.Flags().AddFlagSet(moduleFlags)
+	shellAddFlags(shellCmd)
+	shellAddFlags(rootCmd)
 
 	moduleInitCmd.Flags().StringVar(&sdk, "sdk", "", "Optionally install a Dagger SDK")
 	moduleInitCmd.Flags().StringVar(&moduleName, "name", "", "Name of the new module (defaults to parent directory name)")

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -50,10 +50,10 @@ var (
 	shellNoLoadModule bool
 )
 
-func init() {
-	shellCmd.Flags().StringVarP(&shellCode, "code", "c", "", "Command to be executed")
-	shellCmd.Flags().BoolVar(&shellNoLoadModule, "no-mod", false, "Don't load module during shell startup (mutually exclusive with --mod)")
-	shellCmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
+func shellAddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&shellCode, "code", "c", "", "Command to be executed")
+	cmd.Flags().BoolVar(&shellNoLoadModule, "no-mod", false, "Don't load module during shell startup (mutually exclusive with --mod)")
+	cmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
 }
 
 var shellCmd = &cobra.Command{
@@ -406,7 +406,7 @@ func (h *shellCallHandler) runInteractive(ctx context.Context) error {
 	h.repl = true
 
 	h.withTerminal(func(_ io.Reader, _, stderr io.Writer) error {
-		fmt.Fprintln(stderr, `Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`)
+		fmt.Fprintln(stderr, `Experimental Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`)
 		return nil
 	})
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -9,13 +9,20 @@ pagination_prev: null
 
 A tool to run CI/CD pipelines in containers, anywhere
 
+```
+dagger [flags]
+```
+
 ### Options
 
 ```
+  -c, --code string                  Command to be executed
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+  -m, --mod string                   Path to the module directory. Either local path or a remote git repo
   -E, --no-exit                      Leave the TUI running after completion
+      --no-mod                       Don't load module during shell startup (mutually exclusive with --mod)
       --progress string              Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
   -s, --silent                       Do not show progress at all


### PR DESCRIPTION
This brings the shell to the root command. Also added "Experimental" on the welcome message when entering the interpreter mode:

```console
❯ dagger -c version
v0.16.0-010101000000-dev-4a017b8bfbc1
❯ dagger
Experimental Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.
. ⋈
```