### PR TITLE
shell: consolidate `.doc` and `.help`

### DIFF
--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -50,7 +50,7 @@ func (m *Test) Container() *dagger.Container {
 }
 `,
 	).
-		With(daggerShell("container | with-exec cat,/etc/os-release | stdout")).
+		With(daggerShell("container | with-exec cat /etc/os-release | stdout")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "Alpine Linux")
@@ -148,15 +148,13 @@ func (Other) Version() string {
 
 	t.Run("current module doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".doc")).
+			With(daggerShell(".help .")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "MODULE")
 		require.Contains(t, out, "Main module")
 		require.Contains(t, out, "ENTRYPOINT")
 		require.Contains(t, out, "Usage: . [options]")
-		require.Contains(t, out, "AVAILABLE FUNCTIONS")
-		require.Contains(t, out, "Encouragement")
 	})
 
 	t.Run("current module function takes precedence over dependency", func(ctx context.Context, t *testctx.T) {
@@ -169,7 +167,7 @@ func (Other) Version() string {
 
 	t.Run("current module function doc takes precedence over dependency", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".doc go")).
+			With(daggerShell(".help go")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "Encouragement")
@@ -186,7 +184,7 @@ func (Other) Version() string {
 
 	t.Run("disambiguate dependency function doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".deps | .doc go")).
+			With(daggerShell(".deps | .help go")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "MODULE")
@@ -203,7 +201,7 @@ func (Other) Version() string {
 
 	t.Run("current module function doc takes precedence over stdlib", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".doc version")).
+			With(daggerShell(".help version")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "Test version")
@@ -219,7 +217,7 @@ func (Other) Version() string {
 
 	t.Run("disambiguate stdlib command doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".stdlib | .doc version")).
+			With(daggerShell(".stdlib | .help version")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "Get the current Dagger Engine version.")
@@ -236,7 +234,7 @@ func (Other) Version() string {
 
 	t.Run("dependency module function doc takes precedence over stdlib", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".doc git")).
+			With(daggerShell(".help git")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "A git helper")
@@ -254,7 +252,7 @@ func (Other) Version() string {
 
 	t.Run("other module doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".doc other")).
+			With(daggerShell(".help other")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "A local module")
@@ -289,7 +287,7 @@ func (Other) Version() string {
 
 	t.Run("dep doc type", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell("dep | .doc")).
+			With(daggerShell("dep | .help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "OBJECT")
@@ -309,7 +307,7 @@ func (Other) Version() string {
 
 	t.Run("deps doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".deps | .doc")).
+			With(daggerShell(".deps | .help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Regexp(t, regexp.MustCompile(`\n  dep +Dependency module`), out)
@@ -319,7 +317,7 @@ func (Other) Version() string {
 
 	t.Run("deps doc module", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".deps | .doc go")).
+			With(daggerShell(".deps | .help go")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "MODULE")
@@ -338,7 +336,7 @@ func (Other) Version() string {
 
 	t.Run("stdlib doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".stdlib | .doc")).
+			With(daggerShell(".stdlib | .help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "version")
@@ -348,7 +346,7 @@ func (Other) Version() string {
 
 	t.Run("stdlib doc function", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".stdlib | .doc git")).
+			With(daggerShell(".stdlib | .help git")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Regexp(t, regexp.MustCompile(`^Queries a Git repository`), out)
@@ -367,7 +365,7 @@ func (Other) Version() string {
 
 	t.Run("core doc", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".core | .doc")).
+			With(daggerShell(".core | .help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "load-container-from-id")
@@ -376,7 +374,7 @@ func (Other) Version() string {
 
 	t.Run("core doc function", func(ctx context.Context, t *testctx.T) {
 		out, err := setup.
-			With(daggerShell(".core | .doc load-container-from-id")).
+			With(daggerShell(".core | .help load-container-from-id")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Regexp(t, regexp.MustCompile(`^Load a Container from its ID`), out)
@@ -393,18 +391,13 @@ func (ShellSuite) TestNoModule(ctx context.Context, t *testctx.T) {
 		_, err := modGen.With(daggerShell(".deps")).Sync(ctx)
 		requireErrOut(t, err, "module not loaded")
 	})
-
-	t.Run("no default module doc", func(ctx context.Context, t *testctx.T) {
-		_, err := modGen.With(daggerShell(".doc")).Sync(ctx)
-		requireErrOut(t, err, "module not loaded")
-	})
 }
 
 func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("sanity check", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShell(".doc")).
+			With(daggerShell(".help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-echo")
@@ -412,16 +405,17 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 
 	t.Run("forced no load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		_, err := modInit(t, c, "go", "").
-			With(daggerShellNoMod(".deps")).
-			Sync(ctx)
-		requireErrOut(t, err, "module not loaded")
+		out, err := modInit(t, c, "go", "").
+			With(daggerShellNoMod(".help")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "container-echo")
 	})
 
 	t.Run("dynamically loaded", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoMod(".use .; .doc")).
+			With(daggerShellNoMod(".use .; .help")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-echo")
@@ -430,16 +424,16 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	t.Run("stateless load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoMod(". | .doc container-echo")).
+			With(daggerShellNoMod(". | .help container-echo")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "echoes whatever string argument")
 	})
 
-	t.Run("stateless .doc load", func(ctx context.Context, t *testctx.T) {
+	t.Run("stateless .help load", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := modInit(t, c, "go", "").
-			With(daggerShellNoMod(".doc .")).
+			With(daggerShellNoMod(".help .")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "MODULE")
@@ -658,7 +652,7 @@ func (ShellSuite) TestSliceFlag(ctx context.Context, t *testctx.T) {
 
 func (ShellSuite) TestCommandStateArgs(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
-	script := fmt.Sprintf("FOO=$(container | from %s | with-exec -- echo -n foo | stdout); .doc $FOO", alpineImage)
+	script := fmt.Sprintf("FOO=$(container | from %s | with-exec -- echo -n foo | stdout); .help $FOO", alpineImage)
 	_, err := daggerCliBase(t, c).
 		With(daggerShell(script)).
 		Sync(ctx)


### PR DESCRIPTION
Now `.help` without arguments shows available "commands", not just builtins, including top level functions and dependencies.
```console
❯ dagger shell -c .help
BUILTIN COMMANDS
  .core         Load any core Dagger type
  .deps         Dependencies from the module loaded in the current context
  .help         Show documentation for a command, a module, or a function
  .install      Install a dependency
  .login        Log in to Dagger Cloud
  .logout       Log out from Dagger Cloud
  .stdlib       Standard library functions
  .uninstall    Uninstall a dependency
  .update       Update a dependency
  .use          Set a module as the default for the session

AVAILABLE MODULE FUNCTIONS
  version               -
  tag                   -
  mod-codegen           When set, module codegen is automatically applied when retrieving the Dagger source code
  mod-codegen-targets   -
  check                 Check that everything works. Use this as CI entrypoint.
  with-mod-codegen      Enable module auto-codegen when retrieving the dagger source code
  cli                   Develop the Dagger CLI
  source                Return the Dagger source code
  go                    Dagger's Go toolchain
  engine                Develop the Dagger engine container
  docs                  Develop the Dagger documentation
  scripts               Run Dagger scripts
  test                  Run all tests
  bench                 Run all benchmarks
  generate              Run all code generation - SDKs, docs, etc
  sdk                   Develop Dagger SDKs
  dev                   Creates a dev container that has a running CLI connected to a dagger engine
  dev-export            Creates an static dev build

AVAILABLE MODULE DEPENDENCIES
  alpine           A Dagger Module to integrate with Alpine Linux
  dagger-cli       -
  dirdiff          -
  docusaurus       Docusaurus Dagger Module
  dotnet-sdk-dev   A dev module for dagger-dotnet-sdk.
  elixir-sdk-dev   A module for help developing Elixir SDK.
  go               -
  graphql          -
  helm             -
  php-sdk-dev      -
  ps-analyzer      The PowerShell Script Analyzer (PSScriptAnalyzer) for Dagger.
  python-sdk-dev   The Python SDK's development module.
  shellcheck       -
  version          Shared logic for managing Dagger versions
  wolfi            A Dagger Module to integrate with Wolfi Linux

STANDARD COMMANDS
  cache-volume   Constructs a cache volume for a given cache key.
  container      Creates a scratch container.
  directory      Creates an empty directory.
  engine         The Dagger engine container configuration and state
  git            Queries a Git repository.
  host           Queries the host environment.
  http           Returns a file containing an http remote url content.
  set-secret     Sets a secret given a user defined name to its plaintext and returns the secret.
  version        Get the current Dagger Engine version.

Use ".help <command> | <function> | <dependency>" for more information.
```
To see the docs for current module, need to provide path (previously it was `.doc` without arguments):
```console
(dagger-dev) ⋈ .help .
```