### PR TITLE
fix: avoid prompting users to upgrade from pre-release versions

### DIFF
--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -64,7 +64,7 @@ func long() string {
 }
 
 func updateAvailable(ctx context.Context) (string, error) {
-	if engine.IsDevVersion(engine.Version) {
+	if !engine.IsFinalRelease(engine.Version) {
 		return "", nil
 	}
 

--- a/engine/version.go
+++ b/engine/version.go
@@ -80,7 +80,7 @@ func cleanVersion(v string) string {
 }
 
 func CheckVersionCompatibility(version string, minVersion string) bool {
-	if IsDevVersion(version) && IsDevVersion(Version) {
+	if isDevVersion(version) && isDevVersion(Version) {
 		// Both our version and our target version are dev versions - in this
 		// case, strip pre-release info from our target, we should pretend it's
 		// just the real thing here.
@@ -90,7 +90,7 @@ func CheckVersionCompatibility(version string, minVersion string) bool {
 }
 
 func CheckMaxVersionCompatibility(version string, maxVersion string) bool {
-	if IsDevVersion(version) && IsDevVersion(Version) {
+	if isDevVersion(version) && isDevVersion(Version) {
 		// see CheckVersionCompatibility
 		version = BaseVersion(version)
 	}
@@ -121,7 +121,11 @@ func BaseVersion(version string) string {
 	return version
 }
 
-func IsDevVersion(version string) bool {
+func IsFinalRelease(version string) bool {
+	return semver.IsValid(version) && semver.Prerelease(version) == ""
+}
+
+func isDevVersion(version string) bool {
 	if version == "" {
 		return true
 	}


### PR DESCRIPTION
[As noticed by @jpadams](https://discord.com/channels/707636530424053791/1319379215849881631/1341950857033420830) during the release of v0.16:

> ```
> A new release of dagger is available: v0.16.0-llm.1 → v0.16.0
> To upgrade, see https://docs.dagger.io/install
> ```
> danger of leaving a bunch of daggers lying around

We really shouldn't be prompting users to upgrade from pre-releases (that have been cut directly off of `main`, or from another branch). We were doing this already for dev builds, but we should extend this to prereleases as well.

1. Users who do this should know what they're doing.
2. It's very confusing, since `llm.1` isn't actually included in `v0.16.0` so the ugprade prompt is actually wrong.

(fyi @aluzzardi, I *think* this new behavior is the expected one, but just wanted to check!)