### PR TITLE
ci: add goreleaser pre-release config

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,0 +1,25 @@
+version: 2
+
+includes:
+  - from_file:
+      path: ./.goreleaser.common.yml
+
+nightly:
+  # version_template will override .Version for nightly builds:
+  # https://goreleaser.com/customization/nightlies/#how-it-works
+  version_template: "{{ .Tag }}"
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    id: sha
+    files:
+      - LICENSE
+    format_overrides:
+      - goos: windows
+        format: zip
+
+blobs:
+  - provider: s3
+    region: "{{ .Env.AWS_REGION }}"
+    bucket: "{{ .Env.AWS_BUCKET }}"
+    directory: "dagger/releases/{{ .Version }}"

--- a/releaser/main.go
+++ b/releaser/main.go
@@ -193,7 +193,16 @@ func (r *Releaser) Publish(
 		Tag:  tag,
 	}
 	if !dryRun {
-		err = r.Dagger.Cli().Publish(ctx, tag, githubOrgName, githubToken, goreleaserKey, awsAccessKeyID, awsSecretAccessKey, awsRegion, awsBucket, artefactsFQDN)
+		_, err := r.Dagger.Cli().
+			Publish(tag, goreleaserKey, githubOrgName, dagger.DaggerDevCliPublishOpts{
+				GithubToken:        githubToken,
+				AwsAccessKeyID:     awsAccessKeyID,
+				AwsSecretAccessKey: awsSecretAccessKey,
+				AwsRegion:          awsRegion,
+				AwsBucket:          awsBucket,
+				ArtefactsFqdn:      artefactsFQDN,
+			}).
+			Sync(ctx)
 		if err != nil {
 			artifact.Errors = append(artifact.Errors, dag.Error(err.Error()))
 		}


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/9626.

When we do pre-releases, like for our LLM branch, we should avoid publishing to our homebrew tap, etc. To handle this, we create a new config and use that for our pre-releases.

(this also includes some nice changes to make it easier to `--dry-run` and debug the cli publish step, by returning the `dist` directory, and having optional secrets)