### PR TITLE
fix(sdk/java): handle float type (and others)

### DIFF
--- a/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
+++ b/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
@@ -609,10 +609,22 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
   }
 
   static TypeInfo tiFromName(String name) {
-    if (name.equals("int")) {
-      return new TypeInfo(name, TypeKind.INT.name());
-    } else if (name.equals("boolean")) {
+    if (name.equals("boolean")) {
       return new TypeInfo(name, TypeKind.BOOLEAN.name());
+    } else if (name.equals("byte")) {
+      return new TypeInfo(name, TypeKind.BYTE.name());
+    } else if (name.equals("short")) {
+      return new TypeInfo(name, TypeKind.SHORT.name());
+    } else if (name.equals("int")) {
+      return new TypeInfo(name, TypeKind.INT.name());
+    } else if (name.equals("long")) {
+      return new TypeInfo(name, TypeKind.LONG.name());
+    } else if (name.equals("char")) {
+      return new TypeInfo(name, TypeKind.CHAR.name());
+    } else if (name.equals("float")) {
+      return new TypeInfo(name, TypeKind.FLOAT.name());
+    } else if (name.equals("double")) {
+      return new TypeInfo(name, TypeKind.DOUBLE.name());
     } else if (name.equals("void")) {
       return new TypeInfo(name, TypeKind.VOID.name());
     } else {
@@ -623,10 +635,22 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
   static CodeBlock typeName(TypeInfo ti) {
     try {
       TypeKind tk = TypeKind.valueOf(ti.kindName());
-      if (tk == TypeKind.INT) {
-        return CodeBlock.of("$T", int.class);
-      } else if (tk == TypeKind.BOOLEAN) {
+      if (tk == TypeKind.BOOLEAN) {
         return CodeBlock.of("$T", boolean.class);
+      } else if (tk == TypeKind.BYTE) {
+        return CodeBlock.of("$T", byte.class);
+      } else if (tk == TypeKind.SHORT) {
+        return CodeBlock.of("$T", short.class);
+      } else if (tk == TypeKind.INT) {
+        return CodeBlock.of("$T", int.class);
+      } else if (tk == TypeKind.LONG) {
+        return CodeBlock.of("$T", long.class);
+      } else if (tk == TypeKind.CHAR) {
+        return CodeBlock.of("$T", char.class);
+      } else if (tk == TypeKind.FLOAT) {
+        return CodeBlock.of("$T", float.class);
+      } else if (tk == TypeKind.DOUBLE) {
+        return CodeBlock.of("$T", double.class);
       } else if (tk == TypeKind.VOID) {
         return CodeBlock.of("$T", void.class);
       } else if (tk == TypeKind.ARRAY) {

--- a/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/gen/entrypoint/entrypoint.java
+++ b/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/gen/entrypoint/entrypoint.java
@@ -127,6 +127,11 @@ public class Entrypoint {
                     dag.function("defaultPlatform",
                         dag.typeDef().withScalar("Platform"))
                         .withDescription("return the default platform as a Scalar value"))
+                .withFunction(
+                    dag.function("addFloat",
+                        dag.typeDef().withKind(TypeDefKind.FLOAT_KIND))
+                        .withArg("a", dag.typeDef().withKind(TypeDefKind.FLOAT_KIND))
+                        .withArg("b", dag.typeDef().withKind(TypeDefKind.FLOAT_KIND)))
                 .withField("source", dag.typeDef().withObject("Directory"), new TypeDef.WithFieldArguments().withDescription("Project source directory"))
                 .withField("version", dag.typeDef().withKind(TypeDefKind.STRING_KIND)));
     return module.id();
@@ -229,6 +234,18 @@ public class Entrypoint {
         } else if (fnName.equals("defaultPlatform")) {
           Method fn = clazz.getMethod("defaultPlatform");
           Platform res = (Platform) fn.invoke(obj);
+          return JsonConverter.toJSON(res);
+        } else if (fnName.equals("addFloat")) {
+          float a = 0;
+          if (inputArgs.get("a") != null) {
+            a = (float) JsonConverter.fromJSON(dag, inputArgs.get("a"), float.class);
+          }
+          float b = 0;
+          if (inputArgs.get("b") != null) {
+            b = (float) JsonConverter.fromJSON(dag, inputArgs.get("b"), float.class);
+          }
+          Method fn = clazz.getMethod("addFloat", float.class, float.class);
+          float res = (float) fn.invoke(obj, a, b);
           return JsonConverter.toJSON(res);
         }
       }

--- a/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/module/DaggerJava.java
+++ b/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/module/DaggerJava.java
@@ -117,7 +117,13 @@ public class DaggerJava extends AbstractModule {
 
   /** return the default platform as a Scalar value */
   @Function
-  public Platform defaultPlatform() throws InterruptedException, ExecutionException, DaggerQueryException {
+  public Platform defaultPlatform()
+      throws InterruptedException, ExecutionException, DaggerQueryException {
     return dag.defaultPlatform();
+  }
+
+  @Function
+  public float addFloat(float a, float b) {
+    return a + b;
   }
 }


### PR DESCRIPTION
While working on the Java SDK documentation, I realized `float` type is not correctly handled.

This fixes it and adds it to the main test to ensure we can generate the code.