### PR TITLE
make function calls cached session-wide

### DIFF
--- a/core/interface.go
+++ b/core/interface.go
@@ -278,7 +278,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 					})
 				}
 
-				res, err := callable.Call(ctx, &CallOpts{
+				postCallRes, err := callable.Call(ctx, &CallOpts{
 					Inputs:       callInputs,
 					ParentTyped:  runtimeVal,
 					ParentFields: runtimeVal.Fields,
@@ -286,6 +286,12 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to call interface function %s.%s: %w", ifaceName, fieldDef.Name, err)
+				}
+				res := postCallRes.Typed
+				if postCallRes.PostCall != nil {
+					if err := postCallRes.PostCall(ctx); err != nil {
+						return nil, fmt.Errorf("failed to run post-call for %s.%s: %w", ifaceName, fieldDef.Name, err)
+					}
 				}
 
 				if fnTypeDef.ReturnType.Underlying().Kind != TypeDefKindInterface {

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -188,7 +188,7 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context) (
 						IfaceType:      ifaceType,
 					}, nil
 				},
-				CachePerClientObject,
+				nil,
 			)
 		}
 	}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
@@ -213,7 +215,7 @@ func (fn *ModuleFunction) setCallInputs(ctx context.Context, opts *CallOpts) ([]
 	return callInputs, nil
 }
 
-func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typed, rerr error) { //nolint: gocyclo
+func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t *dagql.PostCallTyped, rerr error) { //nolint: gocyclo
 	mod := fn.mod
 
 	lg := bklog.G(ctx).WithField("module", mod.Name()).WithField("function", fn.metadata.Name)
@@ -389,18 +391,34 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		return nil, fmt.Errorf("failed to collect IDs: %w", err)
 	}
 
-	for _, id := range returnedIDs {
-		if err := fn.root.AddClientResourcesFromID(ctx, id, clientID, false); err != nil {
-			return nil, fmt.Errorf("failed to add client resources from ID: %w", err)
-		}
-	}
-
 	// NOTE: once generalized function caching is enabled we need to ensure that any non-reproducible
 	// cache entries are linked to the result of this call.
 	// See the previous implementation of this for a reference:
 	// https://github.com/dagger/dagger/blob/7c31db76e07c9a17fcdb3f3c4513c915344c1da8/core/modfunc.go#L483
 
-	return returnValueTyped, nil
+	// Function calls are cached per-session, but every client caller needs to add
+	// secret/socket/etc. resources from the result to their store.
+	callerClientMemo := sync.Map{}
+	return &dagql.PostCallTyped{
+		Typed: returnValueTyped,
+		PostCall: func(ctx context.Context) error {
+			// only run this once per calling client, no need to re-add resources
+			clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get client metadata: %w", err)
+			}
+			if _, alreadyRan := callerClientMemo.LoadOrStore(clientMetadata.ClientID, struct{}{}); alreadyRan {
+				return nil
+			}
+
+			for _, id := range returnedIDs {
+				if err := fn.root.AddClientResourcesFromID(ctx, id, clientID, false); err != nil {
+					return fmt.Errorf("failed to add client resources from ID: %w", err)
+				}
+			}
+			return nil
+		},
+	}, nil
 }
 
 func extractError(ctx context.Context, client *buildkit.Client, baseErr error) (dagql.ID[*Error], bool, error) {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -77,6 +77,11 @@ type Cache interface {
 		digest.Digest,
 		func(context.Context) (Typed, error),
 	) (Typed, bool, error)
+	GetOrInitializeWithPostCall(
+		context.Context,
+		digest.Digest,
+		func(context.Context) (Typed, func(context.Context) error, error),
+	) (Typed, bool, func(context.Context) error, error)
 	GetOrInitializeValue(context.Context, digest.Digest, Typed) (Typed, bool, error)
 }
 


### PR DESCRIPTION
Giving https://github.com/dagger/dagger/pull/9621 another try. I [ended up reverting it for v0.16.1](https://github.com/dagger/dagger/pull/9634#issuecomment-2670392727) because, for some reason, sdk dev tests on main started consistently failing due to a problem with it seemingly out of nowhere. The problem had to do with `.(Enumerable)` assertions not working, which should have been caught much earlier in the original PR itself, but wasn't somehow.

Either way, this makes some adjustments to the original PR to do the unwrapping a bit earlier and avoid all the type assertions.

@vito RE: conversation in discord about this, found how to get it work now. Basically just replaced the `GetOrInitializeOnHit` (which appears to have been unused atm) with a variant `GetOrInitializeWithPostCall`. That way we can move the unwrapping inside a bit but still ensure it always runs even on cache hits.

---

Original PR commit msg:

Recently, function calls were "upgraded" from being tainted (i.e. never cached) to cached-per-client in terms of dagql caching. This helped fixed a problem with duplicated telemetry.

However, we currently have two layers of caching between dagql and buildkit and this cache-per-client logic inadvertently ended up also applying to the buildkit cache key, which increased the amount of cache invalidation there.

This surprisingly didn't have a super noticeable effect on performance at least as far as our tests that always run go.

However, the benchmark tests Connor added did end up hitting this, specifically in BenchmarkLotsOfDeps, which creates a complicated DAG of function calls that, if not cached correctly, will have O(n^2) performance (in memory and time).

The fix here changes function calls to be cached in dagql session-wide and restores the previous buildkit cache key so that we get consistent session-wide cache hits there again too.

There is some complication from secrets, sockets and other client-specific resources though. They need to transfer from return values of function calls to the calling client whether or not the client hit the cache.

To handle that problem, this change adds support for a "post call" callback that, if set, dagql will always execute on results whether or not they were retrieved from cache or an actual execution.

The implementation is admittedly pretty kludgy and ugly right now, but I think we should go with it for now to fix this problem. We are about to embark on quite a bit of work around dagql caching so hopefully we can find a cleaner way of implementing post calls (or some equivalent replacement) at that time.