### PR TITLE
ci(publish): Do not overwrite version for pre-releases

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -4,11 +4,6 @@ includes:
   - from_file:
       path: ./.goreleaser.common.yml
 
-nightly:
-  # version_template will override .Version for nightly builds:
-  # https://goreleaser.com/customization/nightlies/#how-it-works
-  version_template: "{{ .Tag }}"
-
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     id: sha


### PR DESCRIPTION
Otherwise this will append v to versions when publishing to S3, which we do not want.