### PR TITLE
[Typescript SDK] Fix type declaration path in package.json

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "author": "hello@dagger.io",
   "license": "Apache-2.0",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/src/index.d.ts",
   "type": "module",
   "files": [
     "dist/"


### PR DESCRIPTION
I was having trouble loading the type declaration file in my project. I noticed that the "types" path in the package.json didn't match the actual location of the declaration file. I tried updating it with a `yarn patch` operation in my project and the issue was gone!

