### PR TITLE
fix panic when dagger call/functions called in dir with no modules

### DIFF
--- a/.changes/unreleased/Fixed-20250220-153742.yaml
+++ b/.changes/unreleased/Fixed-20250220-153742.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fixed panic when dagger call or dagger functions called in directory with no
+  modules. It now errors cleanly instead.
+time: 2025-02-20T15:37:42.759956892-08:00
+custom:
+  Author: sipsma
+  PR: "9658"

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -50,7 +50,7 @@ func maybeInitializeDefaultModule(ctx context.Context, dag *dagger.Client) (*mod
 		modRef = moduleURLDefault
 	}
 
-	if def, err := initializeModule(ctx, dag, modRef); def != nil || err != nil {
+	if def, err := initializeModule(ctx, dag, modRef); def != nil {
 		return def, modRef, err
 	}
 
@@ -79,7 +79,7 @@ func initializeModule(
 		return nil, fmt.Errorf("failed to get configured module: %w", err)
 	}
 	if !configExists {
-		return nil, nil
+		return nil, fmt.Errorf("module not found: %s", srcRef)
 	}
 
 	serveCtx, serveSpan := Tracer().Start(ctx, "initializing module", telemetry.Encapsulate())

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -2592,3 +2592,14 @@ func (CallSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
 		requireErrOut(t, err, "ls: wat: No such file or directory")
 	})
 }
+
+func (CallSuite) TestErrNoModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	_, err := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerCall()).
+		Stdout(ctx)
+	requireErrOut(t, err, "module not found")
+}

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -1186,6 +1186,14 @@ func (m *OtherObj) FnE() *dagger.Container {
 		require.Contains(t, lines, "other-field-d   doc for OtherFieldD")
 		require.Contains(t, lines, "fn-e            doc for FnE")
 	})
+
+	t.Run("no module present errors nicely", func(ctx context.Context, t *testctx.T) {
+		_, err := ctr.
+			WithWorkdir("/empty").
+			With(daggerFunctions()).
+			Stdout(ctx)
+		requireErrOut(t, err, `module not found`)
+	})
 }
 
 func (CLISuite) TestDaggerUnInstall(ctx context.Context, t *testctx.T) {

--- a/hack/with-dev
+++ b/hack/with-dev
@@ -9,4 +9,5 @@ pushd $MAGEDIR > /dev/null
 eval $(go run main.go -w $DAGGER_SRC_ROOT engine:devenv)
 popd > /dev/null
 
+export PATH=$DAGGER_SRC_ROOT/bin:$PATH
 exec "$@"


### PR DESCRIPTION
Calling `dagger functions` or `dagger call` was panicking rather than erroring cleanly due to an oversight in `initializeModule`. Now it errors nicely.