### PR TITLE
fix load of full dir when no dagger.json 

### DIFF
--- a/.changes/unreleased/Fixed-20250220-163221.yaml
+++ b/.changes/unreleased/Fixed-20250220-163221.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Improve load time when dagger commands run in directories with no dagger.json
+time: 2025-02-20T16:32:21.452320328-08:00
+custom:
+  Author: sipsma
+  PR: "9659"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5333,6 +5333,21 @@ export class Dep {
 	}
 }
 
+func (ModuleSuite) TestLoadWhenNoModule(ctx context.Context, t *testctx.T) {
+	// verify that if a module is loaded from a directory w/ no module we don't
+	// load extra files
+	c := connect(ctx, t)
+
+	tmpDir := t.TempDir()
+	fileName := "foo"
+	filePath := filepath.Join(tmpDir, fileName)
+	require.NoError(t, os.WriteFile(filePath, []byte("foo"), 0o644))
+
+	ents, err := c.ModuleSource(tmpDir).ContextDirectory().Entries(ctx)
+	require.NoError(t, err)
+	require.Empty(t, ents)
+}
+
 func daggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -339,31 +339,10 @@ func (s *moduleSourceSchema) localModuleSource(
 	}
 
 	if !daggerCfgFound {
-		// Even if dagger.json doesn't exist yet, the source root dir may exist and have contents we should load
-		// (e.g. a module source file from a previous module whose dagger.json was deleted).
+		// fill in an empty dir at the source root so the context dir digest incorporates that path
 		var srcRootDir dagql.Instance[*core.Directory]
-		_, err := bk.StatCallerHostPath(ctx, sourceRootPath, true)
-		switch {
-		case err == nil:
-			err := s.dag.Select(ctx, s.dag.Root(), &srcRootDir,
-				dagql.Selector{Field: "host"},
-				dagql.Selector{
-					Field: "directory",
-					Args: []dagql.NamedInput{
-						{Name: "path", Value: dagql.String(sourceRootPath)},
-					},
-				},
-			)
-			if err != nil {
-				return inst, fmt.Errorf("failed to load local module source root: %w", err)
-			}
-		case codes.NotFound == status.Code(err):
-			// fill in an empty dir at the source root so the context dir digest incorporates that path
-			if err := s.dag.Select(ctx, s.dag.Root(), &srcRootDir, dagql.Selector{Field: "directory"}); err != nil {
-				return inst, fmt.Errorf("failed to create empty directory for source root subpath: %w", err)
-			}
-		default:
-			return inst, fmt.Errorf("failed to stat source root path: %w", err)
+		if err := s.dag.Select(ctx, s.dag.Root(), &srcRootDir, dagql.Selector{Field: "directory"}); err != nil {
+			return inst, fmt.Errorf("failed to create empty directory for source root subpath: %w", err)
 		}
 
 		err = s.dag.Select(ctx, s.dag.Root(), &localSrc.ContextDirectory,


### PR DESCRIPTION
There was some leftover logic that resulted in the full source root dir
being loaded when no dagger.json was found, which in the case of
`dagger` commands being run in a dir w/ no module present could result
in lots of files being loaded.

This just removes that logic. This is most important for the shell,
which is totally valid to use outside a module dir, but also allows the
CLI to error out faster for `call`, `functions`, etc.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>