### PR TITLE
use tag without "v" prefix for prerelease versions

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -7,7 +7,7 @@ includes:
 nightly:
   # version_template will override .Version for nightly builds:
   # https://goreleaser.com/customization/nightlies/#how-it-works
-  version_template: "{{ .Tag }}"
+  version_template: "{{ trimprefix .Tag "v" }}"
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -4,6 +4,11 @@ includes:
   - from_file:
       path: ./.goreleaser.common.yml
 
+nightly:
+  # version_template will override .Version for nightly builds:
+  # https://goreleaser.com/customization/nightlies/#how-it-works
+  version_template: "{{ .Tag }}"
+
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     id: sha


### PR DESCRIPTION
Previously we tried removing this, but then it switched to goreleaser's default template:

    {{ incpatch .Version }}-{{ .ShortCommit }}-nightly

What we really want is the tag, sans "v" - turns out there's a [`trimprefix` template function](https://github.com/goreleaser/goreleaser/blob/4f1b7c81d2ee48af5b804d67cec8c74f44d66ff3/www/docs/customization/templates.md?plain=1#L165) for exactly that.