### PR TITLE
ci: fix goreleaser prereleases (again again)

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -11,7 +11,7 @@ nightly:
   version_template: "{{ trimprefix .Tag \"v\" }}"
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+  - name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     id: sha
     files:
       - LICENSE


### PR DESCRIPTION
Nope, `Tag` is not set in this context helpfully, so instead just use `v` + Version here.