### PR TITLE
fix: add version compat check when parsing module config

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5039,11 +5039,16 @@ func schemaVersion(ctx context.Context) (string, error) {
 			WithNewFile("main.go", moduleSrc)
 
 		work = work.With(daggerExec("develop"))
-		daggerJSON, err := work.
+		_, err := work.
 			File("dagger.json").
 			Contents(ctx)
-		require.NoError(t, err)
-		require.Equal(t, engine.Version, gjson.Get(daggerJSON, "engineVersion").String())
+
+		// sadly, just no way to handle this :(
+		// in the future, the format of dagger.json might change dramatically,
+		// and so there's no real way to know from the older version how to
+		// convert it back down
+		require.Error(t, err)
+		requireErrOut(t, err, `module requires dagger v100.0.0, but you have`)
 	})
 
 	t.Run("from missing", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -255,9 +255,9 @@ func (s *moduleSourceSchema) localModuleSource(
 				if err != nil {
 					return inst, fmt.Errorf("failed to read module config file: %w", err)
 				}
-				var modCfg modules.ModuleConfigWithUserFields
-				if err := json.Unmarshal(contents, &modCfg); err != nil {
-					return inst, fmt.Errorf("failed to decode module config: %w", err)
+				modCfg, err := modules.ParseModuleConfig(contents)
+				if err != nil {
+					return inst, err
 				}
 
 				namedDep, ok := modCfg.DependencyByName(localPath)
@@ -690,9 +690,9 @@ func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.Mod
 		return fmt.Errorf("source root path must be set")
 	}
 
-	modCfg := &modules.ModuleConfigWithUserFields{}
-	if err := json.Unmarshal(configBytes, modCfg); err != nil {
-		return fmt.Errorf("failed to unmarshal module config: %w", err)
+	modCfg, err := modules.ParseModuleConfig(configBytes)
+	if err != nil {
+		return err
 	}
 
 	src.ModuleName = modCfg.Name


### PR DESCRIPTION
We should explicitly avoid trying to even parse future-versioned `dagger.json`s. This avoids us from getting completely useless and unreadable errors when running an old dagger version against a new config file.

Note - this *does* remove one tiny piece of functionality, which we probably should never had in the first place. You now can't downgrade a `dagger.json` `engineVersion` from a version that the engine doesn't know about. This was always a bit dodgy in the first place, since we could have changed the format at any point, and there's no guarantee that any of the fields have remained similar.