### PR TITLE
fix(helm): sanitize version label

### DIFF
--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "dagger.labels" -}}
 helm.sh/chart: {{ include "dagger.chart" . }}
 {{ include "dagger.selectorLabels" . }}
-app.kubernetes.io/version: v{{ .Chart.Version }}
+app.kubernetes.io/version: v{{ .Chart.Version | replace "+" "_" | trunc 62 | trimSuffix "-" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}
 {{- if .Values.engine.labels }}


### PR DESCRIPTION
The Helm `app.kubernetes.io/version` label is not sanitized. This can lead to incorrect template generation on some system updating the version.

For example with flux, we need to use an OCI registry as the source of the helm chart (because HEAD requests on `registry.dagger.io/dagger-helm/dagger:<tag>` fails with 403 unauth, preventing usage of HelmRepository resource). The default behavior of flux is [to append the digest](https://fluxcd.io/flux/components/helm/helmreleases/#chart-reference) to the version: `<version>+<digest[0:12]>`.