### PR TITLE
upgrade to go 1.24

### DIFF
--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -25,7 +25,7 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.23.2"
+	GolangVersion = "1.24.0"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.23.2"
+	// +default="1.24.0"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
There's some performance improvements around maps and memory allocation, interested to see if we get anything noticeable from them: https://go.dev/doc/go1.24