### PR TITLE
error out in dagger query/listen if dagger.json totally invalid

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -763,23 +763,44 @@ func optionalModCmdWrapper(
 			SecretToken: presetSecretToken,
 		}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			_, explicitModRefSet := getExplicitModuleSourceRef()
+
+			if disableHostRW {
+				// we could never possibly load a module, don't even try
+				if explicitModRefSet {
+					return fmt.Errorf("cannot load module with --disable-host-read-write enabled")
+				}
+				return fn(ctx, engineClient, nil, cmd, cmdArgs)
+			}
+
 			dag := engineClient.Dagger()
-			loadedMod, err := dag.ModuleSource(getModuleSourceRefWithDefault()).
-				AsModule().
-				Sync(ctx)
+			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault(), dagger.ModuleSourceOpts{
+				AllowNotExists: true,
+			})
+			configExists, err := modSrc.ConfigExists(ctx)
 			if err != nil {
-				if !explicitModRefSet {
-					// the user didn't explicitly try to run with a module, so just run in default mode
+				if strings.Contains(err.Error(), "rpc error: code = Unimplemented desc") {
+					// this is a very obscure corner case: when running `dagger listen --disable-host-read-write`
+					// and then running `dagger query` against that listener, we will not have disableHostRW set
+					// true but do need to ignore this error about filesync being disabled
 					return fn(ctx, engineClient, nil, cmd, cmdArgs)
 				}
-				return fmt.Errorf("failed to get configured module: %w", err)
-			} else {
-				err := loadedMod.Serve(ctx)
+				return fmt.Errorf("failed to check if module exists: %w", err)
+			}
+			switch {
+			case configExists:
+				mod := modSrc.AsModule()
+				err := mod.Serve(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to serve module: %w", err)
 				}
+				return fn(ctx, engineClient, mod, cmd, cmdArgs)
+			case explicitModRefSet:
+				// the user explicitly asked for a module but we didn't find one
+				return fmt.Errorf("failed to get configured module: %w", err)
+			default:
+				// user didn't ask for a module, so just run in default mode since we didn't find one
+				return fn(ctx, engineClient, nil, cmd, cmdArgs)
 			}
-			return fn(ctx, engineClient, loadedMod, cmd, cmdArgs)
 		})
 	}
 }

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -1645,3 +1645,23 @@ func (CLISuite) TestDaggerUpdate(ctx context.Context, t *testctx.T) {
 		})
 	}
 }
+
+func (CLISuite) TestInvalidModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("normal context dir", func(ctx context.Context, t *testctx.T) {
+		modGen := goGitBase(t, c).
+			WithNewFile("dagger.json", `{"name": "broke", "engineVersion": "v100.0.0", "sdk": 666}`)
+
+		_, err := modGen.With(daggerQuery(`{version}`)).Stdout(ctx)
+		requireErrOut(t, err, `failed to check if module exists`)
+	})
+
+	t.Run("fallback context dir", func(ctx context.Context, t *testctx.T) {
+		modGen := daggerCliBase(t, c).
+			WithNewFile("dagger.json", `{"name": "broke", "engineVersion": "v100.0.0", "sdk": 666}`)
+
+		_, err := modGen.With(daggerQuery(`{version}`)).Stdout(ctx)
+		requireErrOut(t, err, `failed to check if module exists`)
+	})
+}


### PR DESCRIPTION
The fallback behavior of these commands when failing to load a module meant that even if a dagger.json was found but completely invalid, we silently went ahead and skipped the module load. The intention was to only fallback when no module was found though.

Those commands now error out as expected in that case.