### PR TITLE
fix(sdk/java): dependencies to build should be outside of src

### DIFF
--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -21,7 +21,7 @@ const (
 
 	ModSourceDirPath = "/src"
 	ModDirPath       = "/opt/module"
-	GenPath          = "dagger-io"
+	GenPath          = "/dagger-io"
 )
 
 type JavaSdk struct {
@@ -36,10 +36,6 @@ type moduleConfig struct {
 
 func (c *moduleConfig) modulePath() string {
 	return filepath.Join(ModSourceDirPath, c.subPath)
-}
-
-func (c *moduleConfig) genPath() string {
-	return filepath.Join(ModSourceDirPath, GenPath)
 }
 
 func New(
@@ -115,8 +111,8 @@ func (m *JavaSdk) buildJavaDependencies(
 		// Mount the introspection JSON file used to generate the SDK
 		WithMountedFile("/schema.json", introspectionJSON).
 		// Copy the SDK source directory, so all the files needed to build the dependencies
-		WithDirectory(m.moduleConfig.genPath(), m.SDKSourceDir).
-		WithWorkdir(m.moduleConfig.genPath()).
+		WithDirectory(GenPath, m.SDKSourceDir).
+		WithWorkdir(GenPath).
 		// Build and install the java modules one by one
 		// - dagger-codegen-maven-plugin: this plugin will be used to generate the SDK code, from the introspection file,
 		//   this means including the ability to call other projects (not part of the main dagger SDK)
@@ -219,12 +215,12 @@ func (m *JavaSdk) generateCode(
 		// to a build system or an IDE without to interfere with the user source code
 		WithDirectory(
 			filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "dagger-io"),
-			javaDeps.Directory(filepath.Join(m.moduleConfig.genPath(), "dagger-java-sdk", "src", "main", "java"))).
+			javaDeps.Directory(filepath.Join(GenPath, "dagger-java-sdk", "src", "main", "java"))).
 		// copy the generated SDK files to target/generated-sources/dagger-module
 		// those are all the types generated from the introspection
 		WithDirectory(
 			filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "dagger-module"),
-			javaDeps.Directory(filepath.Join(m.moduleConfig.genPath(), "dagger-java-sdk", "target", "generated-sources", "dagger"))).
+			javaDeps.Directory(filepath.Join(GenPath, "dagger-java-sdk", "target", "generated-sources", "dagger"))).
 		Directory(ModSourceDirPath)
 }
 


### PR DESCRIPTION
When a Java module is initialized with no subdirectory (for instance `dagger init --sdk=java my-module`) some temporary files will be copied to the user directory because they are under the `ModSourceDirPath` (`/src`).
Those files are a temporary copy of the `sdk/java`. From there the different files will be generated, built, packaged, but we don't want them to be exported to the user.

This change simply move the temporary copy of `sdk/java` out of `/src`, this ensures those files will be out of the exported ones.

---

Current (`main`) status:

```console
$ dagger init --sdk=java my-module
$ cd my-module
$ ls
LICENSE     dagger-io   dagger.json pom.xml     src         target
$ ls dagger-io
LICENSE                          dagger-codegen-maven-plugin      dagger-java-samples              pom.xml
README.md                        dagger-java-annotation-processor dagger-java-sdk
```

Expected:

```console
$ dagger init --sdk=java my-module
$ cd my-module
$ ls
LICENSE     dagger.json pom.xml     src         target
```
