### PR TITLE
Revert "PHP: Ensure up to date dependencies of the generated code"

### DIFF
--- a/sdk/php/runtime/main.go
+++ b/sdk/php/runtime/main.go
@@ -124,7 +124,7 @@ func (m *PhpSdk) CodegenBase(
 		WithWorkdir(srcPath).
 		WithExec([]string{"/init-template.sh", name}).
 		// composer install adds the lock file so we want this even in Codegen.
-		WithExec([]string{"composer", "update", "--with-all-dependencies", "--minimal-changes", "dagger/dagger"}).
+		WithExec([]string{"composer", "install"}).
 		WithEntrypoint([]string{filepath.Join(srcPath, "entrypoint.php")})
 
 	return ctr, nil


### PR DESCRIPTION
This reverts https://github.com/dagger/dagger/pull/9625 - looks like the PHP tests have started failing after it, not sure why.

cc @carnage @charjr 

Example failure: https://v3.dagger.cloud/dagger/traces/1e0e5e64a1c90d597a534d6e8a6faf82?span=1f0ea2d68e44a4e2&logs

The tests that are failing:

https://github.com/dagger/dagger/blob/bf712c4d46992979e9b92a1b9728413b0565e928/core/integration/module_php_test.go#L18-L31

These only started failing on `main` because these tests fetch the version of the PHP SDK from main. While these checks are somewhat important, we should probably have a test for the commit - similar to how it's done for `TestJava`.