### PR TITLE
fix: move fix for context transfer secret

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -333,6 +333,14 @@ func (src *ModuleSource) LoadContext(
 			return inst, fmt.Errorf("failed to select directory: %w", err)
 		}
 
+		mainClientCallerID, err := src.Query.MainClientCallerID(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("failed to retrieve mainClientCallerID: %w", err)
+		}
+		if err := src.Query.AddClientResourcesFromID(ctx, &resource.ID{ID: *inst.ID()}, mainClientCallerID, false); err != nil {
+			return inst, fmt.Errorf("failed to add client resources from ID: %w", err)
+		}
+
 		return inst, nil
 
 	case ModuleSourceKindGit:


### PR DESCRIPTION
Looks like a recent refactor moved this - it *should* be for local sources, as well as dir sources.

Re-applied from #9530.

> [!WARNING]
>
> This *absolutely* needs a test - sloppy work from me, since I didn't do that originally - would have avoided this lol.