### PR TITLE
mitigate upstream otel goroutine leak in telemetry flush

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -176,6 +176,13 @@ func (client *daggerClient) FlushTelemetry(ctx context.Context) error {
 	var errs error
 	if client.tracerProvider != nil {
 		slog.ExtraDebug("force flushing client traces")
+		// FIXME: mitigation for goroutine leak fixed upstream in
+		// https://github.com/open-telemetry/opentelemetry-go/pull/6363
+		// Just give this context a real generous timeout for now so if we
+		// are canceled we don't leak
+		// Can undo this once we've picked up the upstream fix.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+		defer cancel()
 		errs = errors.Join(errs, client.tracerProvider.ForceFlush(ctx))
 	}
 	if client.loggerProvider != nil {


### PR DESCRIPTION
There's a problem upstream where a canceled context during `batchSpanProcessor.ForceFlush` leaks a goroutine. I saw this actually happen while testing stuff and it's extra bad because it leaks quite a substantial amount of memory that's indirectly referenced in our various span processors.

For now, this just mitigates it. I have [an upstream fix](https://github.com/open-telemetry/opentelemetry-go/pull/6363) that we will hopefully pick up someday after it's released and we've upgraded.

cc @vito I don't really love the mitigation of just giving this a long timeout, but not sure what's better, let me know if you can think of anything better.