### PR TITLE
docs: Update GH action version x.y.z

### DIFF
--- a/docs/current_docs/integrations/snippets/github-ghcr.yml
+++ b/docs/current_docs/integrations/snippets/github-ghcr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Call Dagger Function to build and publish to ghcr.io
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"
           verb: call

--- a/docs/current_docs/integrations/snippets/github-hello.yml
+++ b/docs/current_docs/integrations/snippets/github-hello.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"
           verb: call

--- a/docs/current_docs/integrations/snippets/github-test-build.yml
+++ b/docs/current_docs/integrations/snippets/github-test-build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"
           verb: call
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"
           verb: call


### PR DESCRIPTION
Complies with new GH Actions immutable actions style
![image](https://github.com/user-attachments/assets/6a0df675-ad18-4b4a-b051-ad7f918440bf)
![image](https://github.com/user-attachments/assets/b1d9f3b3-9ceb-4e43-9eac-9819b7cfe356)

We likely can relax this to `@8.0` or `@8` or `@v8`, but being strictly correct for the launch of immutable actions.
