### PR TITLE
fix(sdk/java): code completion on VS Code

### DIFF
--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -63,6 +63,10 @@
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
+                    <!--
+                    This plugin configuration is required by Dagger to generate the module.
+                    Please do not remove or modify it.
+                    -->
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
@@ -108,6 +112,35 @@
 
         <plugins>
             <plugin>
+                <!--
+                This plugin configuration helps VS Code editor (and others) to find
+                the generated code created by `dagger init` and `dagger develop` and
+                helps for code completion.
+                -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/dagger-io</source>
+                                <source>${project.build.directory}/generated-sources/dagger-module</source>
+                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to generate the module.
+                Please do not remove or modify it.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>


### PR DESCRIPTION
The VS Code java plugin is missing some features for years: the ability to code complete based on the target/generated-sources files. This allows to explicitly instruct maven/vs code by adding the generated source directories as source directories so that code completion can happen.

Also added some comments to the pom.xml file to help understand which are the critical parts of the file that shouldn't be touched by the user.