### PR TITLE
fix(sdk/elixir): fix sdk crash due because of String.to_existing_atom

### DIFF
--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/dagger/testctx"
@@ -15,6 +16,25 @@ func TestElixir(t *testing.T) {
 }
 
 func (ElixirSuite) TestInit(ctx context.Context, t *testctx.T) {
+	t.Run("from local", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		sdkSrc, err := filepath.Abs("../../sdk/elixir/")
+		require.NoError(t, err)
+
+		out, err := goGitBase(t, c).
+			WithDirectory("/work/sdk/elixir", c.Host().Directory(sdkSrc)).
+			With(daggerExec(
+				"init",
+				"--name=bare",
+				"--sdk=./sdk/elixir")).
+			With(daggerCall("container-echo", "--string-arg", "hello", "stdout")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", out)
+	})
+
 	t.Run("from upstream", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 

--- a/sdk/elixir/lib/dagger/mod.ex
+++ b/sdk/elixir/lib/dagger/mod.ex
@@ -59,7 +59,7 @@ defmodule Dagger.Mod do
     Enum.into(input_args, %{}, fn arg ->
       {:ok, name} = Dagger.FunctionCallArgValue.name(arg)
       {:ok, value} = Dagger.FunctionCallArgValue.value(arg)
-      {String.to_existing_atom(name), value}
+      {Macro.underscore(name), value}
     end)
   end
 
@@ -68,7 +68,7 @@ defmodule Dagger.Mod do
     for {name, arg_def} <- arg_defs do
       {:ok, value} =
         input_args
-        |> Map.fetch!(name)
+        |> Map.fetch!(to_string(name))
         |> Decoder.decode(arg_def[:type], dag)
 
       value


### PR DESCRIPTION
Instead of convert input arguments from `FunctionCallArgValue` to atom.
Convert argument name in argument definition to string instead.
