### PR TITLE
docs: Add Java syntax highlighting

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -120,7 +120,7 @@ const config: Config = {
     sidebarCollapsed: false,
     metadata: [{ name: "og:image", content: "/img/favicon.png" }],
     prism: {
-      additionalLanguages: ["php", "rust", "elixir", "bash", "toml", "powershell"],
+      additionalLanguages: ["php", "rust", "elixir", "bash", "toml", "powershell", "java"],
       theme: prismThemes.dracula,
     },
     navbar: {


### PR DESCRIPTION
part of Java SDK work, but doesn't need to wait