### PR TITLE
Fix failing goreleaser + do random chores in the area

### DIFF
--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -58,8 +58,8 @@ func (cli *CLI) DevBinaries(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v2.4.8"
-	goReleaserImage   = "ghcr.io/goreleaser/goreleaser-pro:" + goReleaserVersion + "-pro"
+	goReleaserVersion = "v2.7.0"
+	goReleaserImage   = "ghcr.io/goreleaser/goreleaser-pro:" + goReleaserVersion
 )
 
 // Publish the CLI using GoReleaser

--- a/.dagger/cli.go
+++ b/.dagger/cli.go
@@ -145,6 +145,7 @@ func (cli *CLI) Publish(
 		With(optEnvVariable("ARTEFACTS_FQDN", artefactsFQDN)).
 		WithEnvVariable("ENGINE_VERSION", cli.Dagger.Version).
 		WithEnvVariable("ENGINE_TAG", cli.Dagger.Tag).
+		WithEnvVariable("GORELEASER_CURRENT_TAG", tag).
 		WithEntrypoint([]string{"/sbin/tini", "--", "/entrypoint.sh"}).
 		WithExec(args, dagger.ContainerWithExecOpts{
 			UseEntrypoint: true,

--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -2,10 +2,6 @@ version: 2
 
 project_name: dagger
 
-before:
-  hooks:
-    - go mod download
-
 builds:
   - builder: prebuilt
     binary: ./dagger

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -16,14 +16,14 @@ archives:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
   - name_template: "{{ .ProjectName }}_head_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     id: head
     files:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 blobs:
   - provider: s3

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -17,7 +17,7 @@ archives:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 blobs:
   - provider: s3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ archives:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 # https://goreleaser.com/customization/homebrew/
 brews:


### PR DESCRIPTION
We build the binaries outside of goreleaser now, so this hook isn't required - additionally it makes the build fail in cases when the goreleaser version is a little bit old.

While I'm here:
- Update goreleaser
- And fix a little bit of the tag detection logic that was making it annoying to test the changes with