### PR TITLE
fix: ensure subdir is used in contenthash singleflight key

### DIFF
--- a/core/contenthash.go
+++ b/core/contenthash.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	bkcontenthash "github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/client/llb"
@@ -80,7 +81,8 @@ func GetContentHashFromDef(
 	}
 	ref := workerRef.ImmutableRef
 
-	dgst, _, err := checksumG.Do(ctx, ref.ID(), func(ctx context.Context) (_ digest.Digest, rerr error) {
+	key := ref.ID() + "/" + strings.TrimPrefix(subdir, "/")
+	dgst, _, err := checksumG.Do(ctx, key, func(ctx context.Context) (_ digest.Digest, rerr error) {
 		if err := ref.Finalize(ctx); err != nil {
 			return "", fmt.Errorf("failed to finalize ref: %w", err)
 		}


### PR DESCRIPTION
The previous fix in [`867eed9` (#9697)](https://github.com/dagger/dagger/pull/9697/commits/867eed9655330d5f190a98f9ba7efbb9ba6281c1) to use the subdir in the call to `bkcontenthash.Checksum` was actually only a partial fix.

We need to include the subdir in the singleflight group, or we can end up colliding various operations incorrectly and getting the wrong result.

This was the probably cause of the flake in https://v3.dagger.cloud/dagger/traces/e9e01fff1fc51a3a32f60045c0e39d29?span=87741006fe3539fb#87741006fe3539fb:L912

```
Error Trace:    /app/core/integration/module_test.go:4728
                                        /go/pkg/mod/github.com/dagger/testctx@v0.0.4/testctx.go:295
                                        /go/pkg/mod/github.com/dagger/testctx/oteltest@v0.0.2/log.go:37
                                        /go/pkg/mod/github.com/dagger/testctx/oteltest@v0.0.2/trace.go:80
                                        /go/pkg/mod/github.com/dagger/testctx@v0.0.4/middleware.go:25
                                        /go/pkg/mod/github.com/dagger/testctx@v0.0.4/testctx.go:149
Error:          "root_data.txt\n" does not contain "bar.txt\n"
Test:           TestModule/TestContextDirectoryGit/GitHub_public/context-dir
```