### PR TITLE
Include support for bun.lock (text based) that was released in Bun 1.2.0

### DIFF
--- a/.changes/unreleased/Added-20250302-205618.yaml
+++ b/.changes/unreleased/Added-20250302-205618.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added support for bun.lock - Bun's text based lock file added in v1.2
+time: 2025-03-02T20:56:18.918284-08:00
+custom:
+    Author: Josh Meads
+    PR: "9745"

--- a/docs/current_docs/configuration/modules.mdx
+++ b/docs/current_docs/configuration/modules.mdx
@@ -83,7 +83,7 @@ Bun runtime support is still experimental. Unexpected results may occur in some 
 When a runtime is not explicitly defined within the `package.json` file, Dagger automatically identifies the appropriate runtime by examining the project's lock files inside the project's `dagger` directory.
 
 - If Dagger finds any of the following lock files : `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`, it automatically selects `node` as the runtime.
-- In the absence of the lock files mentioned above, if a `bun.lockb` file is present, Dagger will choose `bun` as the runtime.
+- In the absence of the lock files mentioned above, if a `bun.lock` or `bun.lockb` file is present, Dagger will choose `bun` as the runtime.
 - If no or only unknown lock files are present, `node` is chosen.
 
 :::warning
@@ -158,7 +158,7 @@ Setting the `runtime` property to `bun` will use the Bun runtime and its package
 When a package manager is not explicitly defined within the `package.json` file, Dagger automatically identifies the appropriate package manager by examining the project's lock files inside the project's `.dagger` directory.
 
 - If Dagger finds any of the following lock files : `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`, it automatically selects the corresponding package manager with a predefined default version: `npm@10.7.0`, `yarn@1.22.22` or `pnpm@8.15.4`.
-- If none of the above mentioned lock files are present, but a `bun.lockb` file is present, Dagger will choose `bun` as the runtime and package manager with a predefined default version: `bun@1.0.11`.
+- If none of the above mentioned lock files are present, but a `bun.lock` or `bun.lockb` file is present, Dagger will choose `bun` as the runtime and package manager with a predefined default version: `bun@1.0.11`.
 - `yarn@1.22.22` is the last default, when nothing mentioned above applies.
 
 :::warning

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -300,6 +300,7 @@ func (t *TypescriptSdk) moduleConfigFiles(path string) []string {
 		"yarn.lock",
 		"pnpm-lock.yaml",
 		"bun.lockb",
+		"bun.lock",
 	}
 
 	for i, file := range modConfigFiles {
@@ -481,7 +482,7 @@ func (t *TypescriptSdk) detectBaseImageRef() (string, error) {
 // DetectRuntime returns the runtime(bun or node) detected for the user's module
 // If a runtime is specfied inside the package.json, it will be used.
 // If a package-lock.json, yarn.lock, or pnpm-lock.yaml is present, node will be used.
-// If a bun.lockb is present, bun will be used.
+// If a bun.lock or bun.lockb is present, bun will be used.
 // If none of the above is present, node will be used.
 //
 // If the runtime is detected and pinned to a specific version, it will also return the pinned version.
@@ -507,7 +508,7 @@ func (t *TypescriptSdk) detectRuntime() error {
 	}
 
 	// Try to detect runtime from lock files
-	if t.moduleConfig.hasFile("bun.lockb") {
+	if t.moduleConfig.hasFile("bun.lockb") || t.moduleConfig.hasFile("bun.lock") {
 		t.moduleConfig.runtime = Bun
 
 		return nil
@@ -559,7 +560,8 @@ func (t *TypescriptSdk) detectPackageManager() (SupportedPackageManager, string,
 		}
 	}
 
-	if t.moduleConfig.hasFile("bun.lockb") {
+	// Bun can additionally output a yarn.lock file, so we need to check for Bun before Yarn.
+	if t.moduleConfig.hasFile("bun.lockb") || t.moduleConfig.hasFile("bun.lock") {
 		return BunManager, "", nil
 	}
 
@@ -645,7 +647,7 @@ func (t *TypescriptSdk) installDependencies(ctr *dagger.Container) (*dagger.Cont
 			WithExec([]string{"npm", "ci"}), nil
 	case BunManager:
 		return ctr.
-			WithExec([]string{"bun", "install", "--no-verify", "--no-progress"}), nil
+			WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--frozen-lockfile"}), nil
 	default:
 		return nil, fmt.Errorf("detected unknown package manager: %s", t.moduleConfig.packageManager)
 	}

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -647,7 +647,7 @@ func (t *TypescriptSdk) installDependencies(ctr *dagger.Container) (*dagger.Cont
 			WithExec([]string{"npm", "ci"}), nil
 	case BunManager:
 		return ctr.
-			WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--frozen-lockfile"}), nil
+			WithExec([]string{"bun", "install", "--no-verify", "--no-progress"}), nil
 	default:
 		return nil, fmt.Errorf("detected unknown package manager: %s", t.moduleConfig.packageManager)
 	}


### PR DESCRIPTION
Adds support for the bun.lock text format released in Bun 1.2.0 [bun.sh/blog/bun-v1.2#introducing-bun-lock](bun.sh/blog/bun-v1.2#introducing-bun-lock). This is Bun's new default.

I can't seem to get the test suite and SDK generation working, I've tried from the docs.
```sh
dagger call sdk typescript generate export --path=.
```

Running `go test` in `src/core` passes though.

Any advice on finishing up the PR would be appreciated, I'll look at the changie stuff and commit that shortly.