### PR TITLE
chore: revert back to using go 1.23

### DIFF
--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.24.0-alpine").
+		From("golang:1.23.6-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DagOpWrapper caches an arbitrary dagql field as a buildkit operation
-func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, R]) dagql.NodeFuncHandler[T, A, R] {
+func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (R, error)) func(ctx context.Context, self dagql.Instance[T], args A) (R, error) {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst R, err error) {
 		if _, ok := core.DagOpFromContext[core.RawDagOp](ctx); ok {
 			return fn(ctx, self, args)
@@ -27,7 +27,9 @@ func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](srv *dagql.Server, fn dag
 // DagOpFileWrapper caches a file field as a buildkit operation - this is
 // more specialized than DagOpWrapper, since that serializes the value to
 // JSON, so we'd just end up with a cached ID instead of the actual content.
-func DagOpFileWrapper[T dagql.Typed, A any](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]]) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]] {
+//
+// func DagOpFileWrapper[T dagql.Typed, A any](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]]) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]] {
+func DagOpFileWrapper[T dagql.Typed, A any](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.File], error)) func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.File], error) {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.File], err error) {
 		if _, ok := core.DagOpFromContext[core.DirectoryDagOp](ctx); ok {
 			return fn(ctx, self, args)
@@ -75,7 +77,9 @@ func DagOpFileWrapper[T dagql.Typed, A any](srv *dagql.Server, fn dagql.NodeFunc
 
 // DagOpDirectoryWrapper caches a directory field as a buildkit operation,
 // similar to DagOpFileWrapper.
-func DagOpDirectoryWrapper[T dagql.Typed, A any](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]]) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]] {
+//
+// func DagOpDirectoryWrapper[T dagql.Typed, A any](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]]) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]] {
+func DagOpDirectoryWrapper[T dagql.Typed, A any](srv *dagql.Server, fn func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.Directory], error)) func(ctx context.Context, self dagql.Instance[T], args A) (dagql.Instance[*core.Directory], error) {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.Directory], err error) {
 		if _, ok := core.DagOpFromContext[core.DirectoryDagOp](ctx); ok {
 			return fn(ctx, self, args)

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "dagger-dev",
-  "engineVersion": "v0.16.1",
+  "engineVersion": "v0.16.2",
   "sdk": {
     "source": "go"
   },

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1417,7 +1417,7 @@ func (fe *frontendPretty) renderStepLogs(out TermOutput, r *renderer, row *dagui
 func (fe *frontendPretty) renderStepError(out TermOutput, r *renderer, span *dagui.Span, depth int, prefix string) {
 	for _, span := range span.Errors().Order {
 		// only print the first line
-		for line := range strings.SplitSeq(span.Status.Description, "\n") {
+		for _, line := range strings.Split(span.Status.Description, "\n") {
 			if line == "" {
 				continue
 			}

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -658,10 +658,11 @@ func (v ExactView) Contains(s string) bool {
 	return s == string(v)
 }
 
-type (
-	FuncHandler[T Typed, A any, R any]     = func(ctx context.Context, self T, args A) (R, error)
-	NodeFuncHandler[T Typed, A any, R any] = func(ctx context.Context, self Instance[T], args A) (R, error)
-)
+// not available until go1.24 (see dagger/dagger#9759)
+// type (
+// 	FuncHandler[T Typed, A any, R any]     = func(ctx context.Context, self T, args A) (R, error)
+// 	NodeFuncHandler[T Typed, A any, R any] = func(ctx context.Context, self Instance[T], args A) (R, error)
+// )
 
 // Func is a helper for defining a field resolver and schema.
 //
@@ -681,7 +682,9 @@ type (
 //
 // To configure a description for the field in the schema, call .Doc on the
 // result.
-func Func[T Typed, A any, R any](name string, fn FuncHandler[T, A, R]) Field[T] {
+//
+// func Func[T Typed, A any, R any](name string, fn FuncHandler[T, A, R]) Field[T] {
+func Func[T Typed, A any, R any](name string, fn func(ctx context.Context, self T, args A) (R, error)) Field[T] {
 	return NodeFunc(name, func(ctx context.Context, self Instance[T], args A) (R, error) {
 		return fn(ctx, self.Self, args)
 	})
@@ -690,7 +693,8 @@ func Func[T Typed, A any, R any](name string, fn FuncHandler[T, A, R]) Field[T] 
 // FuncWithCacheKey is like Func but allows specifying a custom digest that will be used to cache the operation in dagql.
 func FuncWithCacheKey[T Typed, A any, R any](
 	name string,
-	fn FuncHandler[T, A, R],
+	// fn FuncHandler[T, A, R],
+	fn func(ctx context.Context, self T, args A) (R, error),
 	cacheFn GetCacheConfigFunc[T, A],
 ) Field[T] {
 	return NodeFuncWithCacheKey(name, func(ctx context.Context, self Instance[T], args A) (R, error) {
@@ -700,14 +704,17 @@ func FuncWithCacheKey[T Typed, A any, R any](
 
 // NodeFunc is the same as Func, except it passes the Instance instead of the
 // receiver so that you can access its ID.
-func NodeFunc[T Typed, A any, R any](name string, fn NodeFuncHandler[T, A, R]) Field[T] {
+//
+// func NodeFunc[T Typed, A any, R any](name string, fn NodeFuncHandler[T, A, R]) Field[T] {
+func NodeFunc[T Typed, A any, R any](name string, fn func(ctx context.Context, self Instance[T], args A) (R, error)) Field[T] {
 	return NodeFuncWithCacheKey(name, fn, nil)
 }
 
 // NodeFuncWithCacheKey is like NodeFunc but allows specifying a custom digest that will be used to cache the operation in dagql.
 func NodeFuncWithCacheKey[T Typed, A any, R any](
 	name string,
-	fn NodeFuncHandler[T, A, R],
+	// fn NodeFuncHandler[T, A, R],
+	fn func(ctx context.Context, self Instance[T], args A) (R, error),
 	cacheFn GetCacheConfigFunc[T, A],
 ) Field[T] {
 	var zeroArgs A

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -25,7 +25,7 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.24.1"
+	GolangVersion = "1.23.6"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/dagger/dagger
 
-go 1.24
+go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.23.6
 
 require (
 	dagger.io/dagger v0.16.2
@@ -95,7 +95,7 @@ require (
 	github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
 	github.com/urfave/cli v1.22.16
 	github.com/vektah/gqlparser/v2 v2.5.23
-	github.com/vito/bubbline v0.0.0-20250227004723-9472f5b7eb83
+	github.com/vito/bubbline v0.0.0-20250304164440-1d709bc8e9a2
 	github.com/vito/go-sse v1.1.2
 	github.com/vito/midterm v0.2.2
 	github.com/zeebo/xxh3 v1.0.2
@@ -129,11 +129,6 @@ require (
 	modernc.org/sqlite v1.36.0
 	mvdan.cc/sh/v3 v3.10.1-0.20250103084315-5e4be7920b8b
 	resenje.org/singleflight v0.4.3
-)
-
-require (
-	github.com/charmbracelet/bubbles v0.20.0 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 )
 
 require (
@@ -179,6 +174,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/bubbles v0.20.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
@@ -282,6 +278,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/samber/lo v1.47.0 // indirect
 	github.com/samber/slog-common v0.18.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQ
 github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn4UKG+hGqeJs=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/vito/bubbline v0.0.0-20250227004723-9472f5b7eb83 h1:BmivYZTJJQXAVZjJaRTVZWH2a3vbFchE/e09pf2jVAo=
-github.com/vito/bubbline v0.0.0-20250227004723-9472f5b7eb83/go.mod h1:+6KVEQP/dL1Q/ZPb7eegi9el3oH/dkwYDXqyKeqmiNE=
+github.com/vito/bubbline v0.0.0-20250304164440-1d709bc8e9a2 h1:2lAjmi6JYUtxLvNqliMGv8tHFye8vmtzZjGqSsX0DtY=
+github.com/vito/bubbline v0.0.0-20250304164440-1d709bc8e9a2/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/go-sse v1.1.2 h1:FLQ1J0tMGN7pKa3KOyZCHojYDR0Z/L/y+3ejUO3P+tM=
 github.com/vito/go-sse v1.1.2/go.mod h1:2wkcaQ+jtlZ94Uve8gYZjFpL68luAjssTINA2hpgcZs=
 github.com/vito/midterm v0.2.2 h1:Uo+nk1n/GYbh29Ha0y+NdIfMuzcUyTvRreurs4YQLYM=

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.24.1"
+	// +default="1.23.6"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
Should fix #9759 (temporarily, hopefully go 1.24.1 will have a fix for this).

Not a simple revert commit, since we've started using new features :cry: (however, this PR should be easily revertable later on)