### PR TITLE
chore(sdk/java): improve versioning

### DIFF
--- a/.dagger/sdk_java.go
+++ b/.dagger/sdk_java.go
@@ -128,6 +128,14 @@ func (t JavaSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 			"-DgenerateBackupPoms=false",
 			"-Dproperty=daggerengine.version",
 			"-DnewVersion=" + version,
+		}).
+		WithWorkdir("runtime/template").
+		WithExec([]string{
+			"mvn",
+			"versions:set-property",
+			"-DgenerateBackupPoms=false",
+			"-Dproperty=dagger.module.deps",
+			"-DnewVersion=" + version + "-template-module",
 		})
 
 	poms := []string{
@@ -136,6 +144,7 @@ func (t JavaSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 		"/sdk/java/dagger-java-sdk/pom.xml",
 		"/sdk/java/dagger-java-samples/pom.xml",
 		"/sdk/java/pom.xml",
+		"/sdk/java/runtime/template/pom.xml",
 	}
 
 	bumped := dag.Directory()

--- a/core/integration/testdata/modules/java/construct/dagger.json
+++ b/core/integration/testdata/modules/java/construct/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "construct",
-  "engineVersion": "v0.16.2",
+  "engineVersion": "v0.16.3-010101000000-dev-43f71432100c",
   "sdk": {
     "source": "../../sdk/java"
   }

--- a/core/integration/testdata/modules/java/construct/pom.xml
+++ b/core/integration/testdata/modules/java/construct/pom.xml
@@ -12,18 +12,19 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dagger.module.deps>0.16.3-construct-module</dagger.module.deps>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-sdk</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
         </dependency>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -63,6 +64,10 @@
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
+                    <!--
+                    This plugin configuration is required by Dagger to generate the module.
+                    Please do not remove or modify it.
+                    -->
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
@@ -71,7 +76,7 @@
                             <path>
                                 <groupId>io.dagger</groupId>
                                 <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>1.0.0-SNAPSHOT</version>
+                                <version>${dagger.module.deps}</version>
                             </path>
                         </annotationProcessorPaths>
                         <annotationProcessors>
@@ -108,6 +113,35 @@
 
         <plugins>
             <plugin>
+                <!--
+                This plugin configuration helps VS Code editor (and others) to find
+                the generated code created by `dagger init` and `dagger develop` and
+                helps for code completion.
+                -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/dagger-io</source>
+                                <source>${project.build.directory}/generated-sources/dagger-module</source>
+                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to generate the module.
+                Please do not remove or modify it.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>

--- a/core/integration/testdata/modules/java/defaults/dagger.json
+++ b/core/integration/testdata/modules/java/defaults/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "defaults",
-  "engineVersion": "v0.16.2",
+  "engineVersion": "v0.16.3-010101000000-dev-43f71432100c",
   "sdk": {
     "source": "../../sdk/java"
   }

--- a/core/integration/testdata/modules/java/defaults/pom.xml
+++ b/core/integration/testdata/modules/java/defaults/pom.xml
@@ -12,18 +12,19 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dagger.module.deps>0.16.3-defaults-module</dagger.module.deps>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-sdk</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
         </dependency>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -63,6 +64,10 @@
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
+                    <!--
+                    This plugin configuration is required by Dagger to generate the module.
+                    Please do not remove or modify it.
+                    -->
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
@@ -71,7 +76,7 @@
                             <path>
                                 <groupId>io.dagger</groupId>
                                 <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>1.0.0-SNAPSHOT</version>
+                                <version>${dagger.module.deps}</version>
                             </path>
                         </annotationProcessorPaths>
                         <annotationProcessors>
@@ -108,6 +113,35 @@
 
         <plugins>
             <plugin>
+                <!--
+                This plugin configuration helps VS Code editor (and others) to find
+                the generated code created by `dagger init` and `dagger develop` and
+                helps for code completion.
+                -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/dagger-io</source>
+                                <source>${project.build.directory}/generated-sources/dagger-module</source>
+                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to generate the module.
+                Please do not remove or modify it.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>

--- a/core/integration/testdata/modules/java/fields/dagger.json
+++ b/core/integration/testdata/modules/java/fields/dagger.json
@@ -1,5 +1,7 @@
 {
   "name": "fields",
-  "engineVersion": "v0.16.2",
-  "sdk": "../../sdk/java"
+  "engineVersion": "v0.16.3-010101000000-dev-43f71432100c",
+  "sdk": {
+    "source": "../../sdk/java"
+  }
 }

--- a/core/integration/testdata/modules/java/fields/pom.xml
+++ b/core/integration/testdata/modules/java/fields/pom.xml
@@ -12,18 +12,19 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dagger.module.deps>0.16.3-fields-module</dagger.module.deps>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-sdk</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
         </dependency>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -46,6 +47,10 @@
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
+                    <!--
+                    This plugin configuration is required by Dagger to generate the module.
+                    Please do not remove or modify it.
+                    -->
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
@@ -54,7 +59,7 @@
                             <path>
                                 <groupId>io.dagger</groupId>
                                 <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>1.0.0-SNAPSHOT</version>
+                                <version>${dagger.module.deps}</version>
                             </path>
                         </annotationProcessorPaths>
                         <annotationProcessors>
@@ -91,6 +96,35 @@
 
         <plugins>
             <plugin>
+                <!--
+                This plugin configuration helps VS Code editor (and others) to find
+                the generated code created by `dagger init` and `dagger develop` and
+                helps for code completion.
+                -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/dagger-io</source>
+                                <source>${project.build.directory}/generated-sources/dagger-module</source>
+                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to generate the module.
+                Please do not remove or modify it.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>

--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -195,8 +195,8 @@ func (m *JavaSdk) addTemplate(
 	}
 
 	changes := []repl{
-		{"dagger-module", kebabName},
-		{"daggermodule", pkgName},
+		{"dagger-module-placeholder", kebabName},
+		{"daggermoduleplaceholder", pkgName},
 	}
 
 	// Edit template content so that they match the dagger module name

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.dagger.modules.daggermodule</groupId>
-    <artifactId>dagger-module</artifactId>
+    <artifactId>dagger-module-placeholder</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <name>dagger-module</name>
+    <name>dagger-module-placeholder</name>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -12,18 +12,19 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dagger.module.deps>0.16.2-template-module</dagger.module.deps>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-sdk</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
         </dependency>
         <dependency>
             <groupId>io.dagger</groupId>
             <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${dagger.module.deps}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -75,7 +76,7 @@
                             <path>
                                 <groupId>io.dagger</groupId>
                                 <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>1.0.0-SNAPSHOT</version>
+                                <version>${dagger.module.deps}</version>
                             </path>
                         </annotationProcessorPaths>
                         <annotationProcessors>

--- a/sdk/java/runtime/template/src/main/java/io/dagger/modules/daggermodule/DaggerModule.java
+++ b/sdk/java/runtime/template/src/main/java/io/dagger/modules/daggermodule/DaggerModule.java
@@ -1,4 +1,4 @@
-package io.dagger.modules.daggermodule;
+package io.dagger.modules.daggermoduleplaceholder;
 
 import static io.dagger.client.Dagger.dag;
 

--- a/sdk/java/runtime/template/src/main/java/io/dagger/modules/daggermodule/package-info.java
+++ b/sdk/java/runtime/template/src/main/java/io/dagger/modules/daggermodule/package-info.java
@@ -1,5 +1,5 @@
 /** DaggerModule example */
 @Module
-package io.dagger.modules.daggermodule;
+package io.dagger.modules.daggermoduleplaceholder;
 
 import io.dagger.module.annotation.Module;


### PR DESCRIPTION
Improve versioning to prepare the publication of the different components to maven central.
Related to #9194 

> [!WARNING]
> **Breaking change**
> This requires some changes in your module source code.
>
> In order to allow the build of the module to be successful, you need to define a property in the module's `pom.xml` to set the different versions:
> - set the property `dagger.module.deps` (the value can be anything at first, a `dagger develop` will update it)
>
>     ```xml
>     <dagger.module.deps>0.16.3-template-module</dagger.module.deps>
>     ```
>
> - set the version of `io.dagger:dagger-java-sdk` and `io.dagger:dagger-java-annotation-processor` to this property. Be careful, the `dagger-java-annotation-processor` is set two times, one time as a dependency, one time as the annotation processor in the `maven-compiler-plugin`
>
>     ```xml
>     <dependency>
>       <groupId>io.dagger</groupId>
>       <artifactId>dagger-java-sdk</artifactId>
>       <version>${dagger.module.deps}</version>
>     </dependency>
>     ```
>
> The full change might look like this:
>
> ```diff
> diff --git a/modules/construct/pom.xml b/modules/construct/pom.xml
> index fccd4c1da..df2fa6250 100644
> --- a/modules/construct/pom.xml
> +++ b/modules//construct/pom.xml
> @@ -12,18 +12,19 @@
>      <properties>
>          <maven.compiler.release>17</maven.compiler.release>
>          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
> +        <dagger.module.deps>0.16.3-construct-module</dagger.module.deps>
>      </properties>
>
>      <dependencies>
>          <dependency>
>              <groupId>io.dagger</groupId>
>              <artifactId>dagger-java-sdk</artifactId>
> -            <version>1.0.0-SNAPSHOT</version>
> +            <version>${dagger.module.deps}</version>
>          </dependency>
>          <dependency>
>              <groupId>io.dagger</groupId>
>              <artifactId>dagger-java-annotation-processor</artifactId>
> -            <version>1.0.0-SNAPSHOT</version>
> +            <version>${dagger.module.deps}</version>
>              <scope>provided</scope>
>          </dependency>
>          <dependency>
> @@ -71,7 +76,7 @@
>                              <path>
>                                  <groupId>io.dagger</groupId>
>                                  <artifactId>dagger-java-annotation-processor</artifactId>
> -                                <version>1.0.0-SNAPSHOT</version>
> +                                <version>${dagger.module.deps}</version>
>                              </path>
>                          </annotationProcessorPaths>
>                          <annotationProcessors>
> ```


The PR is composed of two main aspects (split in two commits, the last one is a small fix regarding the "internal" deps):

1. update the different `pom.xml` to set the version based on the Dagger engine version.

    That way when `bump` is called, all the components of the Java SDK will get the right version. This helps to work locally with the different libraries and avoid conflicts (especially on IDE side) between SDK built locally (without modules) and the deps from the modules.

2. automatically set the different versions in user module:

    This will set the version for the dependencies built specifically for the module. The user `pom.xml` will be updated when we `dagger develop` to reflect the version used. As some of the dependencies are specific to a module (because it can have different dependencies so different generated code) the version includes the module name and an extra `-template` suffix to make it clear.
