### PR TITLE
shell bubbletea followups

### DIFF
--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -143,12 +143,17 @@ func (db *DB) UpdatedSnapshots(filter map[SpanID]bool) []SpanSnapshot {
 }
 
 func (db *DB) ImportSnapshots(snapshots []SpanSnapshot) {
-	for _, snapshot := range snapshots {
+	spans := make([]*Span, len(snapshots))
+	for i, snapshot := range snapshots {
 		span := db.findOrAllocSpan(snapshot.ID)
 		span.Received = true
 		snapshot.Version += span.Version // don't reset the version
 		span.SpanSnapshot = snapshot
 		db.integrateSpan(span)
+		spans[i] = span
+	}
+	for _, span := range spans {
+		span.PropagateStatusToParentsAndLinks()
 	}
 }
 
@@ -210,9 +215,13 @@ func (db *DB) RemainingSnapshots() []SpanSnapshot {
 
 var _ sdktrace.SpanExporter = (*DB)(nil)
 
-func (db *DB) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+func (db *DB) ExportSpans(ctx context.Context, otelSpans []sdktrace.ReadOnlySpan) error {
+	spans := make([]*Span, len(otelSpans))
+	for i, otelSpan := range otelSpans {
+		spans[i] = db.recordOTelSpan(otelSpan)
+	}
 	for _, span := range spans {
-		db.recordOTelSpan(span)
+		span.PropagateStatusToParentsAndLinks()
 	}
 	return nil
 }
@@ -336,7 +345,7 @@ func (db *DB) newSpan(spanID SpanID) *Span {
 	}
 }
 
-func (db *DB) recordOTelSpan(span sdktrace.ReadOnlySpan) {
+func (db *DB) recordOTelSpan(span sdktrace.ReadOnlySpan) *Span {
 	spanID := SpanID{span.SpanContext().SpanID()}
 
 	// mark the span as updated so we sync it to the frontend,
@@ -376,6 +385,7 @@ func (db *DB) recordOTelSpan(span sdktrace.ReadOnlySpan) {
 
 	// integrate the span's data into the DB's live objects
 	db.integrateSpan(spanData)
+	return spanData
 }
 
 type Activity struct {
@@ -680,9 +690,6 @@ func (db *DB) integrateSpan(span *Span) { //nolint: gocyclo
 		}
 		db.CauseSpans[id].Add(span)
 	}
-
-	// update span states, propagating them up through parents, too
-	span.PropagateStatusToParentsAndLinks()
 
 	// finally, install the span if we don't already have it
 	//

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -73,6 +73,9 @@ func (opts FrontendOpts) ShouldShow(db *DB, span *Span) bool {
 		// debug reveals all
 		return true
 	}
+	if span.Reveal {
+		return true
+	}
 	if opts.FocusedSpan == span.ID {
 		// prevent focused span from disappearing
 		return true

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -407,41 +407,10 @@ func (fe *frontendPretty) FinalRender(w io.Writer) error {
 	return renderPrimaryOutput(fe.db)
 }
 
-func (fe *frontendPretty) flush() tea.Cmd {
-	if fe.shell == nil {
-		return nil
+func (fe *frontendPretty) flush() {
+	if fe.program != nil {
+		go fe.program.Send(flushMsg{})
 	}
-	buf := new(strings.Builder)
-	out := NewOutput(buf, termenv.WithProfile(fe.profile))
-
-	// unfocus, so we don't print a permanently focused one
-	// (but also because we'll have a new thing to focus on anyway)
-	fe.FocusedSpan = dagui.SpanID{}
-
-	r := newRenderer(fe.db, 100, fe.FrontendOpts)
-
-	for _, row := range fe.rows.Order {
-		var shouldFlush bool
-		if row.Depth == 0 && !row.IsRunningOrChildRunning && fe.sawEOF[row.Span.ID] {
-			// we're a top-level completed span and we've seen EOF, so flush
-			shouldFlush = true
-		}
-		if row.Parent != nil && fe.flushed[row.Parent.Span.ID] {
-			// our parent flushed, so we should too
-			shouldFlush = true
-		}
-		if !shouldFlush {
-			continue
-		}
-		if !fe.flushed[row.Span.ID] {
-			fe.renderRow(out, r, row, "", false)
-			fe.flushed[row.Span.ID] = true
-		}
-	}
-	if buf.Len() > 0 {
-		return tea.Printf("%s", strings.TrimLeft(buf.String(), "\n"))
-	}
-	return nil
 }
 
 func (fe *frontendPretty) SpanExporter() sdktrace.SpanExporter {
@@ -452,9 +421,15 @@ type prettySpanExporter struct {
 	*frontendPretty
 }
 
+// flushMsg is sent after spans are exported and the view is recalculated. When
+// this message is received, top-level finished spans are printed to the
+// scrollback.
+type flushMsg struct{}
+
 func (fe prettySpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
+	defer fe.flush()
 	defer fe.recalculateViewLocked() // recalculate view *after* updating the db
 	slog.Debug("frontend exporting spans", "spans", len(spans))
 	return fe.db.ExportSpans(ctx, spans)
@@ -478,6 +453,7 @@ type prettyLogExporter struct {
 func (fe prettyLogExporter) Export(ctx context.Context, logs []sdklog.Record) error {
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
+	defer fe.flush()
 	if err := fe.db.LogExporter().Export(ctx, logs); err != nil {
 		return err
 	}
@@ -972,6 +948,36 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 			tea.DisableMouse,
 		)
 
+	case flushMsg:
+		if fe.shell == nil {
+			return fe, nil
+		}
+		buf := new(strings.Builder)
+		out := NewOutput(buf, termenv.WithProfile(fe.profile))
+		r := newRenderer(fe.db, 100, fe.FrontendOpts)
+		for _, row := range fe.rows.Order {
+			var shouldFlush bool
+			if row.Depth == 0 && !row.IsRunningOrChildRunning && fe.sawEOF[row.Span.ID] {
+				// we're a top-level completed span and we've seen EOF, so flush
+				shouldFlush = true
+			}
+			if row.Parent != nil && fe.flushed[row.Parent.Span.ID] {
+				// our parent flushed, so we should too
+				shouldFlush = true
+			}
+			if !shouldFlush {
+				continue
+			}
+			if !fe.flushed[row.Span.ID] {
+				fe.renderRow(out, r, row, "", false)
+				fe.flushed[row.Span.ID] = true
+			}
+		}
+		if buf.Len() > 0 {
+			return fe, tea.Printf("%s", strings.TrimLeft(buf.String(), "\n"))
+		}
+		return fe, nil
+
 	case backgroundMsg:
 		fe.backgrounded = true
 		cmd := msg.cmd
@@ -1028,14 +1034,9 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 			ctx, cancel := context.WithCancelCause(fe.shellCtx)
 			fe.shellInterrupt = cancel
 
-			return fe, tea.Batch(
-				// flush the progress to the scrollback
-				fe.flush(),
-				// run the shell command
-				func() tea.Msg {
-					return shellDoneMsg{fe.shell(ctx, value)}
-				},
-			)
+			return fe, func() tea.Msg {
+				return shellDoneMsg{fe.shell(ctx, value)}
+			}
 		}
 		return fe, nil
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1316,8 +1316,8 @@ func (fe *frontendPretty) renderRow(out TermOutput, r *renderer, row *dagui.Trac
 		return false
 	}
 	if fe.shell != nil {
-		defer func() {
-			if row.IsLastChild() {
+		if row.IsLastChild() {
+			defer func() {
 				root := row.Root()
 				if logs := fe.logs.Logs[root.Span.ID]; logs != nil && logs.UsedHeight() > 0 {
 					logDepth := 0
@@ -1326,8 +1326,8 @@ func (fe *frontendPretty) renderRow(out TermOutput, r *renderer, row *dagui.Trac
 					}
 					fe.renderLogs(out, r, logs, logDepth, logs.UsedHeight(), prefix, highlight)
 				}
-			}
-		}()
+			}()
+		}
 		if row.Depth == 0 {
 			// navigating history and there's a previous row
 			if (!fe.editlineFocused && row.Previous != nil) ||
@@ -1336,13 +1336,7 @@ func (fe *frontendPretty) renderRow(out TermOutput, r *renderer, row *dagui.Trac
 			}
 			fe.renderStep(out, r, row.Span, row.Chained, row.Depth, prefix)
 			fe.renderStepError(out, r, row.Span, 0, prefix)
-			if logs := fe.logs.Logs[row.Span.ID]; logs != nil && logs.UsedHeight() > 0 && !row.ShowingChildren {
-				logDepth := 0
-				if fe.Verbosity < dagui.ExpandCompletedVerbosity {
-					logDepth = -1
-				}
-				fe.renderLogs(out, r, logs, logDepth, logs.UsedHeight(), prefix, highlight)
-			}
+			fe.renderDebug(out, row.Span, prefix+Block25+" ")
 			return true
 		}
 	}
@@ -1412,6 +1406,12 @@ func (fe *frontendPretty) renderDebug(out TermOutput, span *dagui.Span, prefix s
 					vt.WriteMarkdown([]byte("  - " + effect.Name + "\n"))
 				}
 			}
+		}
+	}
+	if len(span.RevealedSpans.Order) > 0 {
+		vt.WriteMarkdown([]byte("\n\n## Revealed spans\n\n"))
+		for _, revealed := range span.RevealedSpans.Order {
+			vt.WriteMarkdown([]byte("- " + revealed.Name + "\n"))
 		}
 	}
 	fmt.Fprint(out, prefix+vt.View())

--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -104,6 +104,18 @@ func (v *Viztest) RevealedSpans(ctx context.Context) (res string, rerr error) {
 	return v.Echo(ctx, "hello from Go! it is currently "+time.Now().String())
 }
 
+func (v *Viztest) RevealAndLog(ctx context.Context) (res string, rerr error) {
+	ctx, span := Tracer().Start(ctx, "revealed span",
+		trace.WithAttributes(attribute.Bool("dagger.io/ui.reveal", true)))
+	res, err := v.Echo(ctx, "hello from Go! it is currently "+time.Now().String())
+	if err != nil {
+		return "", err
+	}
+	span.End()
+	fmt.Println("i did stuff, here's the result:", res)
+	return res, nil
+}
+
 func (*Viztest) ManySpans(
 	ctx context.Context,
 	n int,


### PR DESCRIPTION
* [x] Better detection for incomplete input
* [x] Print logs _after_ printing child rows so it appears at the bottom of the screen
* [x] Figure out how to deal with scrollback, current attempt leaves long output chopped off :(
  * brought back flush-on-complete for now, which seems less bad
* [x] Fix revealed status not being propagated in case where revealed span arrives in same batch as its parents but is processed before them