### PR TITLE
chore: remove cargo-culted json labels on core types

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -14,7 +14,7 @@ import (
 
 // CacheVolume is a persistent volume with a globally scoped identifier.
 type CacheVolume struct {
-	Keys []string `json:"keys"`
+	Keys []string
 }
 
 func (*CacheVolume) Type() *ast.Type {

--- a/core/container.go
+++ b/core/container.go
@@ -49,8 +49,8 @@ type DefaultTerminalCmdOpts struct {
 }
 
 type ContainerAnnotation struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string
+	Value string
 }
 
 // Container is a content-addressed container.
@@ -58,50 +58,50 @@ type Container struct {
 	Query *Query
 
 	// The container's root filesystem.
-	FS *pb.Definition `json:"fs"`
+	FS *pb.Definition
 
 	// Image configuration (env, workdir, etc)
-	Config specs.ImageConfig `json:"cfg"`
+	Config specs.ImageConfig
 
 	// List of GPU devices that will be exposed to the container
-	EnabledGPUs []string `json:"enabledGPUs,omitempty"`
+	EnabledGPUs []string
 
 	// Mount points configured for the container.
-	Mounts ContainerMounts `json:"mounts,omitempty"`
+	Mounts ContainerMounts
 
 	// Meta is the /dagger filesystem. It will be null if nothing has run yet.
-	Meta *pb.Definition `json:"meta,omitempty"`
+	Meta *pb.Definition
 
 	// The platform of the container's rootfs.
-	Platform Platform `json:"platform,omitempty"`
+	Platform Platform
 
 	// OCI annotations
-	Annotations []ContainerAnnotation `json:"annotations,omitempty"`
+	Annotations []ContainerAnnotation
 
 	// Secrets to expose to the container.
-	Secrets []ContainerSecret `json:"secret_env,omitempty"`
+	Secrets []ContainerSecret
 
 	// Sockets to expose to the container.
-	Sockets []ContainerSocket `json:"sockets,omitempty"`
+	Sockets []ContainerSocket
 
 	// Image reference
-	ImageRef string `json:"image_ref,omitempty"`
+	ImageRef string
 
 	// Ports to expose from the container.
-	Ports []Port `json:"ports,omitempty"`
+	Ports []Port
 
 	// Services to start before running the container.
-	Services ServiceBindings `json:"services,omitempty"`
+	Services ServiceBindings
 
 	// The args to invoke when using the terminal api on this container.
-	DefaultTerminalCmd DefaultTerminalCmdOpts `json:"defaultTerminalCmd,omitempty"`
+	DefaultTerminalCmd DefaultTerminalCmdOpts
 
 	// (Internal-only for now) Environment variables from the engine container, prefixed
 	// with a special value, that will be inherited by this container if set.
-	SystemEnvNames []string `json:"system_envs,omitempty"`
+	SystemEnvNames []string
 
 	// DefaultArgs have been explicitly set by the user
-	DefaultArgs bool `json:"defaultArgs,omitempty"`
+	DefaultArgs bool
 }
 
 func (*Container) Type() *ast.Type {
@@ -174,8 +174,8 @@ func (container *Container) Clone() *Container {
 // provided via the API. It primarily exists to distinguish an unspecified
 // ownership from UID/GID 0 (root) ownership.
 type Ownership struct {
-	UID int `json:"uid"`
-	GID int `json:"gid"`
+	UID int
+	GID int
 }
 
 func (owner Ownership) Opt() llb.ChownOption {
@@ -185,19 +185,19 @@ func (owner Ownership) Opt() llb.ChownOption {
 // ContainerSecret configures a secret to expose, either as an environment
 // variable or mounted to a file path.
 type ContainerSecret struct {
-	Secret    *Secret     `json:"secret"`
-	EnvName   string      `json:"env,omitempty"`
-	MountPath string      `json:"path,omitempty"`
-	Owner     *Ownership  `json:"owner,omitempty"`
-	Mode      fs.FileMode `json:"mode,omitempty"`
+	Secret    *Secret
+	EnvName   string
+	MountPath string
+	Owner     *Ownership
+	Mode      fs.FileMode
 }
 
 // ContainerSocket configures a socket to expose, currently as a Unix socket,
 // but potentially as a TCP or UDP address in the future.
 type ContainerSocket struct {
-	Source        *Socket    `json:"socket"`
-	ContainerPath string     `json:"container_path,omitempty"`
-	Owner         *Ownership `json:"owner,omitempty"`
+	Source        *Socket
+	ContainerPath string
+	Owner         *Ownership
 }
 
 // FSState returns the container's root filesystem mount state. If there is
@@ -228,28 +228,28 @@ func (container *Container) MetaState() (*llb.State, error) {
 // ContainerMount is a mount point configured in a container.
 type ContainerMount struct {
 	// The source of the mount.
-	Source *pb.Definition `json:"source,omitempty"`
+	Source *pb.Definition
 
 	// A path beneath the source to scope the mount to.
-	SourcePath string `json:"source_path,omitempty"`
+	SourcePath string
 
 	// The path of the mount within the container.
-	Target string `json:"target"`
+	Target string
 
 	// Persist changes to the mount under this cache ID.
-	CacheVolumeID string `json:"cache_volume_id,omitempty"`
+	CacheVolumeID string
 
 	// How to share the cache across concurrent runs.
-	CacheSharingMode CacheSharingMode `json:"cache_sharing,omitempty"`
+	CacheSharingMode CacheSharingMode
 
 	// Configure the mount as a tmpfs.
-	Tmpfs bool `json:"tmpfs,omitempty"`
+	Tmpfs bool
 
 	// Configure the size of the mounted tmpfs in bytes
-	Size int `json:"size,omitempty"`
+	Size int
 
 	// Configure the mount as read-only.
-	Readonly bool `json:"readonly,omitempty"`
+	Readonly bool
 }
 
 // SourceState returns the state of the source of the mount.

--- a/core/error.go
+++ b/core/error.go
@@ -3,7 +3,7 @@ package core
 import "github.com/vektah/gqlparser/v2/ast"
 
 type Error struct {
-	Query *Query `json:"-"`
+	Query *Query
 
 	Message string `field:"true" doc:"A description of the error."`
 

--- a/core/file.go
+++ b/core/file.go
@@ -25,12 +25,12 @@ import (
 type File struct {
 	Query *Query
 
-	LLB      *pb.Definition `json:"llb"`
-	File     string         `json:"file"`
-	Platform Platform       `json:"platform"`
+	LLB      *pb.Definition
+	File     string
+	Platform Platform
 
 	// Services necessary to provision the file.
-	Services ServiceBindings `json:"services,omitempty"`
+	Services ServiceBindings
 }
 
 func (*File) Type() *ast.Type {

--- a/core/git.go
+++ b/core/git.go
@@ -15,18 +15,18 @@ import (
 type GitRepository struct {
 	Query *Query
 
-	URL string `json:"url"`
+	URL string
 
-	DiscardGitDir bool `json:"discardGitDir"`
+	DiscardGitDir bool
 
-	SSHKnownHosts string  `json:"sshKnownHosts"`
-	SSHAuthSocket *Socket `json:"sshAuthSocket"`
+	SSHKnownHosts string
+	SSHAuthSocket *Socket
 
-	Services ServiceBindings `json:"services"`
-	Platform Platform        `json:"platform,omitempty"`
+	Services ServiceBindings
+	Platform Platform
 
-	AuthToken  *Secret `json:"authToken"`
-	AuthHeader *Secret `json:"authHeader"`
+	AuthToken  *Secret
+	AuthHeader *Secret
 }
 
 func (*GitRepository) Type() *ast.Type {
@@ -43,8 +43,8 @@ func (*GitRepository) TypeDescription() string {
 type GitRef struct {
 	Query *Query
 
-	Ref  string         `json:"ref"`
-	Repo *GitRepository `json:"repository"`
+	Ref  string
+	Repo *GitRepository
 }
 
 func (*GitRef) Type() *ast.Type {

--- a/core/service.go
+++ b/core/service.go
@@ -45,15 +45,15 @@ type Service struct {
 	CustomHostname string
 
 	// Container is the container to run as a service.
-	Container *Container `json:"container"`
+	Container *Container
 
 	// TunnelUpstream is the service that this service is tunnelling to.
-	TunnelUpstream *dagql.Instance[*Service] `json:"upstream,omitempty"`
+	TunnelUpstream *dagql.Instance[*Service]
 	// TunnelPorts configures the port forwarding rules for the tunnel.
-	TunnelPorts []PortForward `json:"tunnel_ports,omitempty"`
+	TunnelPorts []PortForward
 
 	// The sockets on the host to reverse tunnel
-	HostSockets []*Socket `json:"host_sockets,omitempty"`
+	HostSockets []*Socket
 }
 
 func (*Service) Type() *ast.Type {
@@ -772,9 +772,9 @@ type ServiceBindings []ServiceBinding
 
 type ServiceBinding struct {
 	ID       *call.ID
-	Service  *Service `json:"service"`
-	Hostname string   `json:"hostname"`
-	Aliases  AliasSet `json:"aliases"`
+	Service  *Service
+	Hostname string
+	Aliases  AliasSet
 }
 
 type AliasSet []string

--- a/core/socket.go
+++ b/core/socket.go
@@ -49,7 +49,7 @@ func GetHostIPSocketAccessor(ctx context.Context, query *Query, upstreamHost str
 	// want to include all PortForward values + upstreamHost for the unique accessor
 	jsonBytes, err := json.Marshal(struct {
 		HostEndpoint string      `json:"host_endpoint,omitempty"`
-		PortForward  PortForward `json:"port_forward,omitempty"`
+		PortForward  PortForward `json:"port_forward"`
 	}{upstreamHost, port})
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal host ip socket: %w", err)

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -1096,7 +1096,7 @@ func (k TypeDefKind) ToLiteral() call.Literal {
 }
 
 type FunctionCall struct {
-	Query *Query `json:"-"`
+	Query *Query
 
 	Name       string                  `field:"true" doc:"The name of the function being called."`
 	ParentName string                  `field:"true" doc:"The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module."`


### PR DESCRIPTION
These don't *seem* to be used, and also... conceptually, they shouldn't be. For the most part, these structs shouldn't be getting directly serialized, but the labels imply that they are.

We're really inconsistent with this anyways (as noted multiple times previously), so let's just remove them.