### PR TITLE
fix: don't set `SSH_ASKPASS` to `echo`

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5480,7 +5480,7 @@ func privateRepoSetup(c *dagger.Client, t *testctx.T, tc vcsTestCase) (dagger.Wi
 				WithExec([]string{
 					"git", "config", "--global",
 					"credential.https://" + tc.expectedHost + ".helper",
-					`!f() { test "$1" = get && echo "password=` + token + `"; }; f`,
+					`!f() { test "$1" = get && echo -e "password=` + token + `\nusername=git"; }; f`,
 				})
 		}
 

--- a/engine/session/gitcredential.go
+++ b/engine/session/gitcredential.go
@@ -85,7 +85,6 @@ func (s GitCredentialAttachable) GetCredential(ctx context.Context, req *GitCred
 
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
-		"SSH_ASKPASS=echo",
 	)
 
 	// Run the command

--- a/engine/session/gitcredential.go
+++ b/engine/session/gitcredential.go
@@ -86,6 +86,9 @@ func (s GitCredentialAttachable) GetCredential(ctx context.Context, req *GitCred
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
 	)
+	if req.Protocol != "http" && req.Protocol != "https" {
+		cmd.Env = append(cmd.Env, "SSH_ASKPASS=echo")
+	}
 
 	// Run the command
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
I don't really have context for why this was added (somewhere in https://github.com/dagger/dagger/pull/8805), but it's definitely not right, resulting in *always* setting a completely incorrect auth token.

See the following:

    $ GIT_TERMINAL_PROMPT=0 SSH_ASKPASS=echo git credential fill <<EOF
    protocol=https
    host=github.com
    EOF

    protocol=https
    host=github.com
    username=Username for 'https://github.com':
    password=Password for 'https://Username%20for%20%27https%3A%2F%2Fgithub.com%27%3A%20@github.com':

This outputs the prompts into the username/password fields, instead of *correctly* erroring out, and not attaching this as an authentication token.

I'm not actually sure if this was causing user-facing bugs, but I hit this while working on a total refactor of the git implementation.