### PR TITLE
quick fix to wolfi build errors to unblock failing engine builds

### DIFF
--- a/modules/alpine/main.go
+++ b/modules/alpine/main.go
@@ -259,8 +259,15 @@ func (m *Alpine) withPkgs(
 			Exclude: pkg.rmFileNames,
 		})
 		ctr = ctr.With(pkgscript("post-install", pkg.name, pkg.postInstall))
+		// HACK: quick fix for busybox trigger needing to be run before glibc trigger (which needs /usr/bin/sh symlink to busybox created)
+		if pkg.name == "busybox" {
+			ctr = ctr.With(pkgscript("trigger", pkg.name, pkg.trigger))
+		}
 	}
 	for _, pkg := range alpinePkgs {
+		if pkg.name == "busybox" {
+			continue
+		}
 		ctr = ctr.With(pkgscript("trigger", pkg.name, pkg.trigger))
 	}
 


### PR DESCRIPTION
Wolfi made a change that causes glibc triggers to require busybox triggers having already run:
https://github.com/wolfi-dev/os/commit/8229c0379cada98fb9504dd19a068dbbe2bd0d98

This isn't obviously wrong, but our current alpine module likely runs triggers in a slightly different order and we thus end up with a glibc trigger running, trying to execute /usr/bin/sh and then failing because the busybox symlink (created in its trigger) hasn't been installed yet.

The fix here is a quick hack to unblock. Will look at something more robust to follow up with.