### PR TITLE
engine dev tooling: test dumps

### DIFF
--- a/.dagger/bench.go
+++ b/.dagger/bench.go
@@ -121,7 +121,7 @@ func (b *Bench) bench(
 		)
 	}
 
-	cmd, err := b.Test.testCmd(ctx)
+	cmd, _, err := b.Test.testCmd(ctx)
 	if err != nil {
 		return err
 	}

--- a/hack/build
+++ b/hack/build
@@ -25,6 +25,7 @@ engine |\
         ${_EXPERIMENTAL_DAGGER_GPU_SUPPORT:+--gpu-support} |\
     start \
         --name=$CONTAINER \
+        --debug \
         ${DAGGER_CLOUD_TOKEN:+--cloud-token=env://DAGGER_CLOUD_TOKEN} \
         ${DAGGER_CLOUD_URL:+--cloud-url=${DAGGER_CLOUD_URL-}} &
 


### PR DESCRIPTION
fixes https://github.com/dagger/dagger/issues/9794

code complete, but currently broken because directory.WithNewFile() takes a string for content and I think passing these profiles through UTF-8 encoding breaks them. Gonna switch to pulling them with curl and passing actual files around.

I'm also getting 500s for cpu profiles rn, not sure why. 

taking a default 30s cpu profile
```
dagger call test dump --run="TestCache/TestVolume" --pkg=./core/integration --route=pprof/profile --delay=1s export --path=/tmp/dump0
```

or taking a heap dump every 3s:
```
dagger call test dump --run="TestCache/TestVolume" --pkg=./core/integration --delay=1s --interval=3s export --path=/tmp/dump1
```

