### PR TITLE
docs: Improves metadata and tags for better social sharing and SEO

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   favicon: "img/favicon.svg",
 
   // Set the production url of your site here
-  url: "https://docs.dagger.io",
+  url: url,
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,6 +6,8 @@ import remarkTemplate from "./plugins/remark-template";
 
 import { daggerVersion } from "./current_docs/partials/version";
 
+const url = "https://docs.dagger.io";
+
 const config: Config = {
   title: "Dagger",
   tagline:
@@ -121,8 +123,8 @@ const config: Config = {
   themeConfig: {
     sidebarCollapsed: false,
     metadata: [
-      { name: "og:image", content: "/img/dagger-factory.jpg" },
-      { name: "twitter:image", content: "/img/dagger-factory.jpg" },
+      { name: "og:image", content: `${url}/img/dagger-factory.jpg` },
+      { name: "twitter:image", content: `${url}/img/dagger-factory.jpg` },
     ],
     prism: {
       additionalLanguages: [

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,10 +4,12 @@ import { themes as prismThemes } from "prism-react-renderer";
 import remarkCodeImport from "remark-code-import";
 import remarkTemplate from "./plugins/remark-template";
 
-import { daggerVersion } from './current_docs/partials/version';
+import { daggerVersion } from "./current_docs/partials/version";
 
 const config: Config = {
   title: "Dagger",
+  tagline:
+    "Open-source runtime for composable workflows, powering AI agents and CI/CD with modular, repeatable, and observable pipelines.",
   favicon: "img/favicon.svg",
 
   // Set the production url of your site here
@@ -36,7 +38,7 @@ const config: Config = {
   },
   scripts: [
     {
-      src: '/js/commonroom.js',
+      src: "/js/commonroom.js",
       async: true,
     },
   ],
@@ -109,7 +111,7 @@ const config: Config = {
         },
         textContentMappings: {
           "title.indexPage": "TypeScript SDK Reference",
-          "footer.text": ""
+          "footer.text": "",
         },
         requiredToBeDocumented: ["Class"],
       },
@@ -118,9 +120,20 @@ const config: Config = {
   themes: ["@docusaurus/theme-mermaid"],
   themeConfig: {
     sidebarCollapsed: false,
-    metadata: [{ name: "og:image", content: "/img/favicon.png" }],
+    metadata: [
+      { name: "og:image", content: "/img/dagger-factory.jpg" },
+      { name: "twitter:image", content: "/img/dagger-factory.jpg" },
+    ],
     prism: {
-      additionalLanguages: ["php", "rust", "elixir", "bash", "toml", "powershell", "java"],
+      additionalLanguages: [
+        "php",
+        "rust",
+        "elixir",
+        "bash",
+        "toml",
+        "powershell",
+        "java",
+      ],
       theme: prismThemes.dracula,
     },
     navbar: {
@@ -201,7 +214,7 @@ const config: Config = {
             {
               label: "Community Content",
               to: "https://dagger.io/community-content",
-            }
+            },
           ],
         },
         {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -123,6 +123,11 @@ const config: Config = {
   themeConfig: {
     sidebarCollapsed: false,
     metadata: [
+      {
+        name: "description",
+        content:
+          "Dagger is an open-source runtime for composable workflows, powering AI agents and CI/CD with modular, repeatable, and observable pipelines.",
+      },
       { name: "og:image", content: `${url}/img/dagger-factory.jpg` },
       { name: "twitter:image", content: `${url}/img/dagger-factory.jpg` },
     ],


### PR DESCRIPTION
All of the links from X look like the below image, this change uses the new dagger-factory.jpg icon for social sharing to make the links posted on X look more interesting. Hopefully this makes the link more interesting to capture the users attention.

1. Adds default descriptions and image urls for social sharing
2. Sets default metadata description - default is to use the second heading (e.g. the docs landing page description is "what is Dagger"). Individual markdown pages can still override the description using markdown front matter
3. Updates the default image URL to be complete as it's better for links (I believe its actually required)

Sharing docs links on X screenshot:
<img width="745" alt="Screenshot 2025-03-10 at 10 48 45 AM" src="https://github.com/user-attachments/assets/652ffe32-c45e-4fbb-9d66-a14be34d16fd" />

Updated links will look like the following:
<img width="636" alt="Screenshot 2025-03-10 at 12 04 37 PM" src="https://github.com/user-attachments/assets/803f9586-cf13-41e8-88f8-6e5f446a4dca" />