### PR TITLE
ci: Run all Engine & CLI tests against a dev engine only

### DIFF
--- a/.github/dagger.json
+++ b/.github/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ci",
-  "engineVersion": "v0.16.1",
+  "engineVersion": "v0.16.2",
   "sdk": {
     "source": "go"
   },

--- a/.github/main.go
+++ b/.github/main.go
@@ -168,29 +168,20 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 		})).
 		WithJob(runner.Job("scripts", "check --targets=scripts")).
 		WithJob(runner.Job("cli-test-publish", "cli test-publish")).
-		WithJob(runner.Job("engine-test-publish", "engine publish --image=dagger-engine.dev --tag=main --dry-run")).
+		WithJob(runner.Job("cli-test-publish", "cli test-publish", dagger.GhaJobOpts{
+			Runner: []string{GoldRunner(false)},
+		})).
+		WithJob(runner.Job("engine-test-publish", "engine publish --image=dagger-engine.dev --tag=main --dry-run", dagger.GhaJobOpts{
+			Runner: []string{GoldRunner(false)},
+		})).
 		WithJob(runner.Job("scan-engine", "engine scan")).
-		With(splitTests(runner, "test-", false, []testSplit{
-			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
-				Runner: []string{GoldRunner(false)},
-			}},
-			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
-				Runner: []string{GoldRunner(false)},
-			}},
-			{"cli-engine", []string{"TestCLI", "TestEngine"}, &dagger.GhaJobOpts{
-				Runner: []string{GoldRunner(false)},
-			}},
+		With(splitTests(runner, "testdev-", true, []testSplit{
 			{"cgroupsv2", []string{"TestProvision", "TestTelemetry"}, &dagger.GhaJobOpts{
 				// HACK: our main runners don't support cgroupsv2
 				Runner: []string{"ubuntu-latest"},
 				// NOTE: needed to silence redis warning logs in tests
 				SetupCommands: []string{"sudo sysctl -w vm.overcommit_memory=1"},
 			}},
-			{"everything-else", nil, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(false)},
-			}},
-		})).
-		With(splitTests(runner, "testdev-", true, []testSplit{
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
 				Runner: []string{PlatinumRunner(true)},
 			}},
@@ -198,6 +189,12 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{PlatinumRunner(true)},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
+				Runner: []string{PlatinumRunner(true)},
+			}},
+			{"cli-engine", []string{"TestCLI", "TestEngine"}, &dagger.GhaJobOpts{
+				Runner: []string{PlatinumRunner(true)},
+			}},
+			{"everything-else", nil, &dagger.GhaJobOpts{
 				Runner: []string{PlatinumRunner(true)},
 			}},
 		}))

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     cli-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-16c-st' || 'ubuntu-latest' }}
         name: cli-test-publish
         steps:
             - name: Checkout
@@ -397,7 +397,7 @@ jobs:
         timeout-minutes: 20
     engine-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-16c-st' || 'ubuntu-latest' }}
         name: engine-test-publish
         steps:
             - name: Checkout
@@ -962,10 +962,10 @@ jobs:
                 DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
               shell: bash
         timeout-minutes: 20
-    test-cgroupsv-2:
+    testdev-cgroupsv-2:
         runs-on:
             - ubuntu-latest
-        name: test-cgroupsv2
+        name: testdev-cgroupsv2
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -998,7 +998,44 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: v0.16.2
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$DAGGER_SOURCE/bin:$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -1161,11 +1198,22 @@ jobs:
                 overwrite: "true"
                 path: ${{ steps.exec.outputs.stderr_file }}
               if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
         timeout-minutes: 30
-    test-cli-engine:
+    testdev-cli-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-16c-st' || 'ubuntu-latest' }}
-        name: test-cli-engine
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-32c-dind-st' || 'ubuntu-latest' }}
+        name: testdev-cli-engine
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -1198,7 +1246,44 @@ jobs:
                 # The install.sh script creates path ${prefix_dir}/bin
                 curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
               env:
-                DAGGER_VERSION: v0.16.2
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$DAGGER_SOURCE/bin:$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
               shell: bash
             - name: scripts/warm-engine.sh
               id: warm-engine
@@ -1358,596 +1443,16 @@ jobs:
                 overwrite: "true"
                 path: ${{ steps.exec.outputs.stderr_file }}
               if: always()
-        timeout-minutes: 30
-    test-everything-else:
-        runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-32c-st' || 'ubuntu-latest' }}
-        name: test-everything-else
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: scripts/install-dagger.sh
-              id: install-dagger
-              run: |
-                #!/bin/bash
-
-                set -o pipefail
-                # Fallback to /usr/local for backwards compatability
-                prefix_dir="${RUNNER_TEMP:-/usr/local}"
-
-                # Ensure the dir is writable otherwise fallback to tmpdir
-                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                  prefix_dir="$(mktemp -d)"
-                fi
-                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
-
-                if [ -f "$DAGGER_VERSION_FILE" ]; then
-                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
-                fi
-
-                # If the dagger version is 'latest', set the version back to an empty
-                # string. This allows the install script to detect and install the latest
-                # version itself
-                if [[ "$DAGGER_VERSION" == "latest" ]]; then
-                  DAGGER_VERSION=
-                fi
-
-                # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
-              env:
-                DAGGER_VERSION: v0.16.2
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
               shell: bash
-            - name: scripts/warm-engine.sh
-              id: warm-engine
-              run: |
-                #!/bin/bash
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                # Run a simple query to "warm up" the engine
-                dagger version
-                dagger core version
-              shell: bash
-            - name: scripts/exec.sh
-              id: exec
-              run: |
-                #!/bin/bash --noprofile --norc -e -o pipefail
-
-                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
-                    set -x
-                    env
-                    which dagger
-                    pwd
-                    ls -l
-                    ps aux
-                fi
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
-                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
-
-                # Ensure the command is provided as an environment variable
-                if [ -z "$COMMAND" ]; then
-                  echo "Error: Please set the COMMAND environment variable."
-                  exit 1
-                fi
-
-                tmp=$(mktemp -d)
-                (
-                    cd $tmp
-
-                    # Create named pipes (FIFOs) for stdout and stderr
-                    mkfifo stdout.fifo stderr.fifo
-
-                    # Set up tee to capture and display stdout and stderr
-                    if [ -n "$NO_OUTPUT" ]; then
-                        tee stdout.txt < stdout.fifo > /dev/null &
-                        tee stderr.txt < stderr.fifo > /dev/null &
-                    else
-                        tee stdout.txt < stdout.fifo &
-                        tee stderr.txt < stderr.fifo >&2 &
-                    fi
-                )
-
-                # Run the command, capturing stdout and stderr in the FIFOs
-                set +e
-                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
-                EXIT_CODE=$?
-                set -e
-                # Wait for all background jobs to finish
-                wait
-
-                # Extra trace URL
-                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
-
-                {
-                cat <<'.'
-                ## Dagger trace
-
-                .
-
-                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
-                    cat <<.
-                Cloud token must be rotated. Please follow these steps:
-
-                1. Go to [Dagger Cloud](https://dagger.cloud)
-                2. Click on your profile icon in the bottom left corner
-                3. Click on "Organization Settings"
-                4. Click on "Regenerate token"
-                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
-                .
-                elif [ -n "$TRACE_URL" ]; then
-                    echo "[$TRACE_URL]($TRACE_URL)"
-                else
-                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
-                fi
-
-                cat <<'.'
-
-                ## Dagger version
-
-                ```
-                .
-
-                dagger version
-
-                cat <<'.'
-                ```
-
-                ## Pipeline command
-
-                ```bash
-                .
-
-                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
-                echo " $COMMAND"
-
-                cat <<'.'
-                ```
-
-                ## Pipeline output
-
-                ```
-                .
-
-                cat $tmp/stdout.txt
-
-                cat <<'.'
-                ```
-
-                ## Pipeline logs
-
-                ```
-                .
-
-                tail -n 1000 $tmp/stderr.txt
-
-                cat <<'.'
-                ```
-                .
-
-                } >"${GITHUB_STEP_SUMMARY}"
-
-                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
-                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
-
-                exit $EXIT_CODE
-              env:
-                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                COMMAND: dagger call -q test specific --race=true --parallel=16 --skip='TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava|TestCLI|TestEngine|TestProvision|TestTelemetry'
-                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                NO_OUTPUT: "true"
-              shell: bash
-            - name: Upload call logs
-              uses: actions/upload-artifact@v4
-              with:
-                name: call-logs-${{ runner.name }}-${{ github.job }}exec
-                overwrite: "true"
-                path: ${{ steps.exec.outputs.stderr_file }}
               if: always()
-        timeout-minutes: 30
-    test-module-runtimes:
-        runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-16c-st' || 'ubuntu-latest' }}
-        name: test-module-runtimes
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: scripts/install-dagger.sh
-              id: install-dagger
-              run: |
-                #!/bin/bash
-
-                set -o pipefail
-                # Fallback to /usr/local for backwards compatability
-                prefix_dir="${RUNNER_TEMP:-/usr/local}"
-
-                # Ensure the dir is writable otherwise fallback to tmpdir
-                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                  prefix_dir="$(mktemp -d)"
-                fi
-                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
-
-                if [ -f "$DAGGER_VERSION_FILE" ]; then
-                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
-                fi
-
-                # If the dagger version is 'latest', set the version back to an empty
-                # string. This allows the install script to detect and install the latest
-                # version itself
-                if [[ "$DAGGER_VERSION" == "latest" ]]; then
-                  DAGGER_VERSION=
-                fi
-
-                # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
-              env:
-                DAGGER_VERSION: v0.16.2
-              shell: bash
-            - name: scripts/warm-engine.sh
-              id: warm-engine
-              run: |
-                #!/bin/bash
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                # Run a simple query to "warm up" the engine
-                dagger version
-                dagger core version
-              shell: bash
-            - name: scripts/exec.sh
-              id: exec
-              run: |
-                #!/bin/bash --noprofile --norc -e -o pipefail
-
-                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
-                    set -x
-                    env
-                    which dagger
-                    pwd
-                    ls -l
-                    ps aux
-                fi
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
-                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
-
-                # Ensure the command is provided as an environment variable
-                if [ -z "$COMMAND" ]; then
-                  echo "Error: Please set the COMMAND environment variable."
-                  exit 1
-                fi
-
-                tmp=$(mktemp -d)
-                (
-                    cd $tmp
-
-                    # Create named pipes (FIFOs) for stdout and stderr
-                    mkfifo stdout.fifo stderr.fifo
-
-                    # Set up tee to capture and display stdout and stderr
-                    if [ -n "$NO_OUTPUT" ]; then
-                        tee stdout.txt < stdout.fifo > /dev/null &
-                        tee stderr.txt < stderr.fifo > /dev/null &
-                    else
-                        tee stdout.txt < stdout.fifo &
-                        tee stderr.txt < stderr.fifo >&2 &
-                    fi
-                )
-
-                # Run the command, capturing stdout and stderr in the FIFOs
-                set +e
-                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
-                EXIT_CODE=$?
-                set -e
-                # Wait for all background jobs to finish
-                wait
-
-                # Extra trace URL
-                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
-
-                {
-                cat <<'.'
-                ## Dagger trace
-
-                .
-
-                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
-                    cat <<.
-                Cloud token must be rotated. Please follow these steps:
-
-                1. Go to [Dagger Cloud](https://dagger.cloud)
-                2. Click on your profile icon in the bottom left corner
-                3. Click on "Organization Settings"
-                4. Click on "Regenerate token"
-                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
-                .
-                elif [ -n "$TRACE_URL" ]; then
-                    echo "[$TRACE_URL]($TRACE_URL)"
-                else
-                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
-                fi
-
-                cat <<'.'
-
-                ## Dagger version
-
-                ```
-                .
-
-                dagger version
-
-                cat <<'.'
-                ```
-
-                ## Pipeline command
-
-                ```bash
-                .
-
-                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
-                echo " $COMMAND"
-
-                cat <<'.'
-                ```
-
-                ## Pipeline output
-
-                ```
-                .
-
-                cat $tmp/stdout.txt
-
-                cat <<'.'
-                ```
-
-                ## Pipeline logs
-
-                ```
-                .
-
-                tail -n 1000 $tmp/stderr.txt
-
-                cat <<'.'
-                ```
-                .
-
-                } >"${GITHUB_STEP_SUMMARY}"
-
-                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
-                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
-
-                exit $EXIT_CODE
-              env:
-                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava'
-                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                NO_OUTPUT: "true"
-              shell: bash
-            - name: Upload call logs
+            - name: Upload dev engine logs
               uses: actions/upload-artifact@v4
               with:
-                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
                 overwrite: "true"
-                path: ${{ steps.exec.outputs.stderr_file }}
-              if: always()
-        timeout-minutes: 30
-    test-modules:
-        runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-16c-st' || 'ubuntu-latest' }}
-        name: test-modules
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: scripts/install-dagger.sh
-              id: install-dagger
-              run: |
-                #!/bin/bash
-
-                set -o pipefail
-                # Fallback to /usr/local for backwards compatability
-                prefix_dir="${RUNNER_TEMP:-/usr/local}"
-
-                # Ensure the dir is writable otherwise fallback to tmpdir
-                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                  prefix_dir="$(mktemp -d)"
-                fi
-                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
-
-                if [ -f "$DAGGER_VERSION_FILE" ]; then
-                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
-                fi
-
-                # If the dagger version is 'latest', set the version back to an empty
-                # string. This allows the install script to detect and install the latest
-                # version itself
-                if [[ "$DAGGER_VERSION" == "latest" ]]; then
-                  DAGGER_VERSION=
-                fi
-
-                # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
-              env:
-                DAGGER_VERSION: v0.16.2
-              shell: bash
-            - name: scripts/warm-engine.sh
-              id: warm-engine
-              run: |
-                #!/bin/bash
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                # Run a simple query to "warm up" the engine
-                dagger version
-                dagger core version
-              shell: bash
-            - name: scripts/exec.sh
-              id: exec
-              run: |
-                #!/bin/bash --noprofile --norc -e -o pipefail
-
-                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
-                    set -x
-                    env
-                    which dagger
-                    pwd
-                    ls -l
-                    ps aux
-                fi
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-
-                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
-                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
-
-                # Ensure the command is provided as an environment variable
-                if [ -z "$COMMAND" ]; then
-                  echo "Error: Please set the COMMAND environment variable."
-                  exit 1
-                fi
-
-                tmp=$(mktemp -d)
-                (
-                    cd $tmp
-
-                    # Create named pipes (FIFOs) for stdout and stderr
-                    mkfifo stdout.fifo stderr.fifo
-
-                    # Set up tee to capture and display stdout and stderr
-                    if [ -n "$NO_OUTPUT" ]; then
-                        tee stdout.txt < stdout.fifo > /dev/null &
-                        tee stderr.txt < stderr.fifo > /dev/null &
-                    else
-                        tee stdout.txt < stdout.fifo &
-                        tee stderr.txt < stderr.fifo >&2 &
-                    fi
-                )
-
-                # Run the command, capturing stdout and stderr in the FIFOs
-                set +e
-                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
-                EXIT_CODE=$?
-                set -e
-                # Wait for all background jobs to finish
-                wait
-
-                # Extra trace URL
-                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
-
-                {
-                cat <<'.'
-                ## Dagger trace
-
-                .
-
-                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
-                    cat <<.
-                Cloud token must be rotated. Please follow these steps:
-
-                1. Go to [Dagger Cloud](https://dagger.cloud)
-                2. Click on your profile icon in the bottom left corner
-                3. Click on "Organization Settings"
-                4. Click on "Regenerate token"
-                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
-                .
-                elif [ -n "$TRACE_URL" ]; then
-                    echo "[$TRACE_URL]($TRACE_URL)"
-                else
-                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
-                fi
-
-                cat <<'.'
-
-                ## Dagger version
-
-                ```
-                .
-
-                dagger version
-
-                cat <<'.'
-                ```
-
-                ## Pipeline command
-
-                ```bash
-                .
-
-                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
-                echo " $COMMAND"
-
-                cat <<'.'
-                ```
-
-                ## Pipeline output
-
-                ```
-                .
-
-                cat $tmp/stdout.txt
-
-                cat <<'.'
-                ```
-
-                ## Pipeline logs
-
-                ```
-                .
-
-                tail -n 1000 $tmp/stderr.txt
-
-                cat <<'.'
-                ```
-                .
-
-                } >"${GITHUB_STEP_SUMMARY}"
-
-                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
-                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
-
-                exit $EXIT_CODE
-              env:
-                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestModule'
-                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                NO_OUTPUT: "true"
-              shell: bash
-            - name: Upload call logs
-              uses: actions/upload-artifact@v4
-              with:
-                name: call-logs-${{ runner.name }}-${{ github.job }}exec
-                overwrite: "true"
-                path: ${{ steps.exec.outputs.stderr_file }}
+                path: /tmp/actions-call-engine.log
               if: always()
         timeout-minutes: 30
     testdev-container:
@@ -2173,6 +1678,251 @@ jobs:
               env:
                 _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestContainer'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-everything-else:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-2-32c-dind-st' || 'ubuntu-latest' }}
+        name: testdev-everything-else
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$DAGGER_SOURCE/bin:$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --skip='TestProvision|TestTelemetry|TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava|TestContainer|TestCLI|TestEngine'
                 DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 NO_OUTPUT: "true"
               shell: bash


### PR DESCRIPTION
We spoke about this with Erik, Justin & Connor a few times in the last few weeks, and the consensus is that we want all Engine tests to run against **dev** Engines (the next version that ships), and there is marginal value in running them against an already released version.

The thinking goes that if all tests continue running the same (or better) in the next version of Dagger, then we are confident in the upcoming release.

While we might want to do the same for all other jobs in this workflow, we want to take a smaller step since we are planning to try out a different CI runner type.