### PR TITLE
docs: add linkedin meta tags, description to ai agents

### DIFF
--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ai-agents
-description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, or Gemini through containerized modules.
+description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, Gemini, or Ollama through containerized modules.
 ---
 
 # Build AI agents with Dagger

--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /ai-agents
-description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, Gemini, or Ollama through containerized modules.
+description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, Gemini, Llama, DeepSeek, Qwen, and more.
 ---
 
 # Build AI agents with Dagger

--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -1,5 +1,6 @@
 ---
 slug: /ai-agents
+description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, or Gemini through containerized modules.
 ---
 
 # Build AI agents with Dagger

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -128,7 +128,15 @@ const config: Config = {
         content:
           "Dagger is an open-source runtime for composable workflows, powering AI agents and CI/CD with modular, repeatable, and observable pipelines.",
       },
-      { property: "og:image", content: `${url}/img/dagger-factory-share.jpg` },
+      {
+        name: "image",
+        property: "og:image",
+        content: `${url}/img/dagger-factory-share.jpg`,
+      },
+      {
+        name: "author",
+        content: "Dagger",
+      },
       {
         property: "twitter:image",
         content: `${url}/img/dagger-factory-share.jpg`,


### PR DESCRIPTION
Touching up some small paper cuts:

1. Adds meta tags to make LinkedIn shares more visually appealing (https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fdocs.dagger.io%2F)
2. Adds descriptions to key pages for better SEO