### PR TITLE
fix: prevent double buildkit caching on remote git operations

### DIFF
--- a/core/dagop.go
+++ b/core/dagop.go
@@ -294,3 +294,8 @@ func DagOpFromContext[T buildkit.CustomOp](ctx context.Context) (t T, ok bool) {
 	}
 	return t, ok
 }
+
+func DagOpInContext[T buildkit.CustomOp](ctx context.Context) bool {
+	_, ok := DagOpFromContext[T](ctx)
+	return ok
+}

--- a/core/git.go
+++ b/core/git.go
@@ -55,6 +55,11 @@ func (repo *GitRepository) PBDefinitions(ctx context.Context) ([]*pb.Definition,
 	return repo.Backend.PBDefinitions(ctx)
 }
 
+func (repo *GitRepository) UseDagOp() bool {
+	_, ok := repo.Backend.(*LocalGitRepository)
+	return ok
+}
+
 func (repo *GitRepository) Head(ctx context.Context) (*GitRef, error) {
 	ref, err := repo.Backend.Head(ctx)
 	if err != nil {
@@ -100,6 +105,11 @@ func (*GitRef) TypeDescription() string {
 
 func (ref *GitRef) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	return ref.Backend.PBDefinitions(ctx)
+}
+
+func (ref *GitRef) UseDagOp() bool {
+	_, ok := ref.Backend.(*LocalGitRef)
+	return ok
 }
 
 func (ref *GitRef) Commit(ctx context.Context) (string, error) {
@@ -249,7 +259,7 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 	if err != nil {
 		return nil, err
 	}
-	return NewDirectorySt(ctx, ref.Query, st, "", ref.Repo.Platform, ref.Repo.Services)
+	return NewDirectorySt(ctx, ref.Query, st, "/", ref.Repo.Platform, ref.Repo.Services)
 }
 
 func (ref *RemoteGitRef) Commit(ctx context.Context) (string, error) {

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -10,18 +10,34 @@ import (
 )
 
 // DagOpWrapper caches an arbitrary dagql field as a buildkit operation
-func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](srv *dagql.Server, fn dagql.NodeFuncHandler[T, A, R]) dagql.NodeFuncHandler[T, A, R] {
+func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](
+	srv *dagql.Server,
+	fn dagql.NodeFuncHandler[T, A, R],
+) dagql.NodeFuncHandler[T, A, R] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst R, err error) {
-		if _, ok := core.DagOpFromContext[core.RawDagOp](ctx); ok {
+		if core.DagOpInContext[core.RawDagOp](ctx) {
 			return fn(ctx, self, args)
 		}
-
-		deps, err := extractLLBDependencies(ctx, self.Self)
-		if err != nil {
-			return inst, err
-		}
-		return core.NewRawDagOp[R](ctx, srv, currentIDForDagOp(ctx), deps)
+		return DagOp(ctx, srv, self, args, fn)
 	}
+}
+
+// DagOp creates a RawDagOp from an arbitrary operation
+//
+// NOTE: prefer DagOpWrapper where possible, this is for low-level plumbing,
+// where more control over *which* operations should be cached is needed.
+func DagOp[T dagql.Typed, A any, R dagql.Typed](
+	ctx context.Context,
+	srv *dagql.Server,
+	self dagql.Instance[T],
+	args A,
+	fn dagql.NodeFuncHandler[T, A, R],
+) (inst R, err error) {
+	deps, err := extractLLBDependencies(ctx, self.Self)
+	if err != nil {
+		return inst, err
+	}
+	return core.NewRawDagOp[R](ctx, srv, currentIDForDagOp(ctx), deps)
 }
 
 type PathFunc[T dagql.Typed] func(ctx context.Context, val dagql.Instance[T]) (string, error)
@@ -35,32 +51,47 @@ func DagOpFileWrapper[T dagql.Typed, A any](
 	pfn PathFunc[T],
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.File], err error) {
-		if _, ok := core.DagOpFromContext[core.FSDagOp](ctx); ok {
+		if core.DagOpInContext[core.FSDagOp](ctx) {
 			return fn(ctx, self, args)
 		}
-
-		deps, err := extractLLBDependencies(ctx, self.Self)
-		if err != nil {
-			return inst, err
-		}
-
-		filename := "file"
-		if pfn != nil {
-			// NOTE: if set, the path function must be *somewhat* stable -
-			// since it becomes part of the op, then any changes to this
-			// invalidate the cache
-			filename, err = pfn(ctx, self)
-			if err != nil {
-				return inst, err
-			}
-		}
-
-		file, err := core.NewFileDagOp(ctx, srv, currentIDForDagOp(ctx), deps, filename)
-		if err != nil {
-			return inst, err
-		}
-		return dagql.NewInstanceForCurrentID(ctx, srv, self, file)
+		return DagOpFile(ctx, srv, self, args, fn, pfn)
 	}
+}
+
+// DagOpFile creates a FSDagOp from an operation that returns a File
+//
+// NOTE: prefer DagOpFileWrapper where possible, this is for low-level
+// plumbing, where more control over *which* operations should be cached is
+// needed.
+func DagOpFile[T dagql.Typed, A any](
+	ctx context.Context,
+	srv *dagql.Server,
+	self dagql.Instance[T],
+	args A,
+	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]],
+	pfn PathFunc[T],
+) (inst dagql.Instance[*core.File], _ error) {
+	deps, err := extractLLBDependencies(ctx, self.Self)
+	if err != nil {
+		return inst, err
+	}
+
+	filename := "file"
+	if pfn != nil {
+		// NOTE: if set, the path function must be *somewhat* stable -
+		// since it becomes part of the op, then any changes to this
+		// invalidate the cache
+		filename, err = pfn(ctx, self)
+		if err != nil {
+			return inst, err
+		}
+	}
+
+	file, err := core.NewFileDagOp(ctx, srv, currentIDForDagOp(ctx), deps, filename)
+	if err != nil {
+		return inst, err
+	}
+	return dagql.NewInstanceForCurrentID(ctx, srv, self, file)
 }
 
 // DagOpDirectoryWrapper caches a directory field as a buildkit operation,
@@ -71,29 +102,42 @@ func DagOpDirectoryWrapper[T dagql.Typed, A any](
 	pfn PathFunc[T],
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.Directory], err error) {
-		if _, ok := core.DagOpFromContext[core.FSDagOp](ctx); ok {
+		if core.DagOpInContext[core.FSDagOp](ctx) {
 			return fn(ctx, self, args)
 		}
-
-		deps, err := extractLLBDependencies(ctx, self.Self)
-		if err != nil {
-			return inst, err
-		}
-
-		filename := "/"
-		if pfn != nil {
-			filename, err = pfn(ctx, self)
-			if err != nil {
-				return inst, err
-			}
-		}
-
-		dir, err := core.NewDirectoryDagOp(ctx, srv, currentIDForDagOp(ctx), deps, filename)
-		if err != nil {
-			return inst, err
-		}
-		return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
+		return DagOpDirectory(ctx, srv, self, args, fn, pfn)
 	}
+}
+
+// NOTE: prefer DagOpDirectoryWrapper where possible, this is for low-level
+// plumbing, where more control over *which* operations should be cached is
+// needed.
+func DagOpDirectory[T dagql.Typed, A any](
+	ctx context.Context,
+	srv *dagql.Server,
+	self dagql.Instance[T],
+	args A,
+	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]],
+	pfn PathFunc[T],
+) (inst dagql.Instance[*core.Directory], _ error) {
+	deps, err := extractLLBDependencies(ctx, self.Self)
+	if err != nil {
+		return inst, err
+	}
+
+	filename := "/"
+	if pfn != nil {
+		filename, err = pfn(ctx, self)
+		if err != nil {
+			return inst, err
+		}
+	}
+
+	dir, err := core.NewDirectoryDagOp(ctx, srv, currentIDForDagOp(ctx), deps, filename)
+	if err != nil {
+		return inst, err
+	}
+	return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
 }
 
 const runDagOpDigestMixin = "runDagOpDigestMixin"


### PR DESCRIPTION
This was *probably* causing flakes, and had the potential to cause big issues. Should hopefully fix the issue noted in https://github.com/dagger/dagger/pull/9730#discussion_r1989264862.

Essentially, for remote operations we were caching twice:
- The DagOp for the `Git.tree` operation (with a cache key of the git ID)
- The underlying git operation (with a cache key of the git commit) This was very confusing to think about, and probably could have resulted in lots of weird cache issues.

The simple fix here is to just remove the extra DagOp layer when caching remote git sources, and to take more manual control over DagOp caching in this case.

Ideally! We would have core interfaces, which would then allow us to have different specializations of `GitRef` and `GitRepository` at the dagql handler level, so we wouldn't actually need this kind of refactor. But it's not *super* trivial to add them, so this is quick hacky fix to get the behavior working as desired.