### PR TITLE
extend dagger helm chart

### DIFF
--- a/docs/current_docs/ci/integrations/argo-workflows.mdx
+++ b/docs/current_docs/ci/integrations/argo-workflows.mdx
@@ -27,7 +27,7 @@ Create a file called `workflow.yaml` with the following content:
 A few important points to note:
 
 - The workflow uses hardwired artifacts to clone the Git repository and to install the Dagger CLI.
-- `unix:///var/run/dagger/engine.sock` is mounted and specified with the `_EXPERIMENTAL_DAGGER_RUNNER_HOST` environment variable.
+- `unix://run/dagger/engine.sock` is mounted and specified with the `_EXPERIMENTAL_DAGGER_RUNNER_HOST` environment variable.
 - The Dagger CLI is downloaded and installed. Confirm the version and architecture are accurate for your cluster and project.
 - Setting the `DAGGER_CLOUD_TOKEN` environment variable is only necessary if integrating with Dagger Cloud.
 

--- a/docs/current_docs/ci/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/ci/integrations/snippets/argo-workflow.yaml
@@ -24,7 +24,7 @@ spec:
             exec:
               command: ["dagger", "core", "version"]
           volumeMounts:
-            - mountPath: /var/run/dagger
+            - mountPath: /run/dagger
               name: dagger-socket
             - mountPath: /var/lib/dagger
               name: dagger-storage
@@ -50,7 +50,7 @@ spec:
         workingDir: /work
         env:
         - name: "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
-          value: "unix:///var/run/dagger/engine.sock"
+          value: "unix:///run/dagger/engine.sock"
           # assumes the Dagger Cloud token is
           # in a Kubernetes secret named dagger-cloud
         - name: "DAGGER_CLOUD_TOKEN"
@@ -59,5 +59,5 @@ spec:
               name: dagger-cloud
               key: token
         volumeMounts:
-          - mountPath: /var/run/dagger
+          - mountPath: /run/dagger
             name: dagger-socket

--- a/docs/current_docs/ci/integrations/snippets/gitlab-runner-config.yml
+++ b/docs/current_docs/ci/integrations/snippets/gitlab-runner-config.yml
@@ -6,7 +6,7 @@ data:
   config.toml: |
     concurrent = 10
     [[runners]]
-      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST=unix:///var/run/dagger/engine.sock"]
+      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST=unix:///run/dagger/engine.sock"]
       pre_build_script = "export PATH=\"/tmp/:$PATH\""
       name = "GitLab Runner with Dagger"
       url = YOUR-GITLAB-URL
@@ -29,5 +29,5 @@ data:
         run_as_user = 0
         [[runners.kubernetes.volumes.host_path]]
           name = "dagger"
-          mount_path = "/var/run/dagger"
-          host_path = "/var/run/dagger"
+          mount_path = "/run/dagger"
+          host_path = "/run/dagger"

--- a/docs/current_docs/ci/integrations/snippets/tekton-dagger-task.yaml
+++ b/docs/current_docs/ci/integrations/snippets/tekton-dagger-task.yaml
@@ -28,7 +28,7 @@ spec:
         exec:
           command: ["dagger", "core", "version"]
       volumeMounts:
-        - mountPath: /var/run/dagger
+        - mountPath: /run/dagger
           name: dagger-socket
         - mountPath: /var/lib/dagger
           name: dagger-storage
@@ -43,11 +43,11 @@ spec:
       curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
       dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=. --args=.
     volumeMounts:
-      - mountPath: /var/run/dagger
+      - mountPath: /run/dagger
         name: dagger-socket
     env:
       - name: _EXPERIMENTAL_DAGGER_RUNNER_HOST
-        value: unix:///var/run/dagger/engine.sock
+        value: unix:///run/dagger/engine.sock
       - name: DAGGER_CLOUD_TOKEN
         valueFrom:
           secretKeyRef:

--- a/helm/dagger/.changes/unreleased/Added-20250314-104048.yaml
+++ b/helm/dagger/.changes/unreleased/Added-20250314-104048.yaml
@@ -1,0 +1,14 @@
+kind: Added
+body: |-
+    Added a mount for an engine.json file.
+    Added container and host ports.
+    Added a nodeSelector.
+    Added arbitrary volume mounts.
+    Added lifecycle preStop hook.
+    Added podManagementPolicy for StatefulSets.
+    Added an option to disable hostPath mounts.
+    Added PVC template for StatefulSets.
+time: 2025-03-14T10:40:48.080715-04:00
+custom:
+    Author: jholm117
+    PR: "9845"

--- a/helm/dagger/templates/engine-config.yaml
+++ b/helm/dagger/templates/engine-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.engine.config }}
+{{- if (or .Values.engine.config .Values.engine.configJson) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -8,5 +8,12 @@ metadata:
   labels: 
     {{- include "dagger.labels" . | nindent 4 }}
 data:
-  engine.toml: |{{- .Values.engine.config | nindent 4 }}
+  {{- if .Values.engine.config }}
+  engine.toml: |
+    {{- .Values.engine.config | nindent 4 }}
+  {{- end }}
+  {{- if .Values.engine.configJson }}
+  engine.json: |
+    {{- .Values.engine.configJson | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -64,7 +64,7 @@ spec:
             - "--addr"
             - "tcp://0.0.0.0:{{ .Values.engine.port }}"
             - "--addr"
-            - "unix:///var/run/dagger/engine.sock"
+            - "unix:///run/dagger/engine.sock"
             {{- end }}
             {{- if .Values.engine.args }}
             {{- toYaml .Values.engine.args | nindent 12 }}
@@ -128,7 +128,7 @@ spec:
             {{- end }}
             {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: varrundagger
-              mountPath: /var/run/dagger
+              mountPath: /run/dagger
             {{- end }}
             {{- if .Values.engine.config }}
             - name: dagger-engine-config
@@ -153,7 +153,7 @@ spec:
         {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: varrundagger
           hostPath:
-            path: /var/run/dagger-{{ include "dagger.fullname" . }}
+            path: /run/dagger-{{ include "dagger.fullname" . }}
         {{- end }}
         {{- if (or .Values.engine.config .Values.engine.configJson) }}
         - name: dagger-engine-config

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -129,6 +129,7 @@ spec:
             {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: varrundagger
               mountPath: /var/run/dagger
+            {{- end }}
             {{- if .Values.engine.config }}
             - name: dagger-engine-config
               mountPath: /etc/dagger/engine.toml

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -148,12 +148,12 @@ spec:
         {{- if .Values.engine.hostPath.dataVolume.enabled }}
         - name: varlibdagger
           hostPath:
-            path: /var/lib/dagger
+            path: /var/lib/dagger-{{ include "dagger.fullname" . }}
         {{- end }}
         {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: varrundagger
           hostPath:
-            path: /var/run/dagger
+            path: /var/run/dagger-{{ include "dagger.fullname" . }}
         {{- end }}
         {{- if (or .Values.engine.config .Values.engine.configJson) }}
         - name: dagger-engine-config

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -13,9 +13,9 @@ spec:
       name: {{ include "dagger.fullname" . }}-engine
   template:
     metadata:
-      {{- if (or .Values.engine.config .Values.magicache.enabled .Values.engine.annotations) }}
+      {{- if (or .Values.engine.config .Values.engine.configJson .Values.magicache.enabled .Values.engine.annotations) }}
       annotations:
-        {{- if .Values.engine.config }}
+        {{- if (or .Values.engine.config .Values.engine.configJson) }}
         checksum/config: {{ include (print $.Template.BasePath "/engine-config.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.magicache.enabled }}
@@ -29,6 +29,10 @@ spec:
         name: {{ include "dagger.fullname" . }}-engine
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.engine.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.engine.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -54,9 +58,17 @@ spec:
         - name: dagger-engine
           image: {{ if .Values.engine.image.ref }}{{ .Values.engine.image.ref }}{{ else }}registry.dagger.io/engine:v{{ .Chart.Version }}{{ end }}
           imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
-          {{- if .Values.engine.args }}
+          {{- if or .Values.engine.port .Values.engine.args }}
           args:
+            {{- if .Values.engine.port }}
+            - "--addr"
+            - "tcp://0.0.0.0:{{ .Values.engine.port }}"
+            - "--addr"
+            - "unix:///var/run/dagger/engine.sock"
+            {{- end }}
+            {{- if .Values.engine.args }}
             {{- toYaml .Values.engine.args | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if (or .Values.engine.env .Values.magicache.enabled) }}
           env:
@@ -77,6 +89,15 @@ spec:
               name: {{ include "dagger.fullname" . }}-magicache-token
               {{- end }}
           {{- end }}
+          {{- if .Values.engine.port }}
+          ports:
+            - name: dagger
+              containerPort: {{ .Values.engine.port }}
+              protocol: TCP
+              {{- if .Values.engine.hostPort }}
+              hostPort: {{ .Values.engine.hostPort }}
+              {{- end }}
+          {{- end }}
           securityContext:
             privileged: true
             capabilities:
@@ -93,9 +114,19 @@ spec:
             {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}
+          {{- if .Values.engine.lifecycle }}
+          lifecycle:
+            {{- if .Values.engine.lifecycle.preStop }}
+            preStop:
+              {{- toYaml .Values.engine.lifecycle.preStop | nindent 14 }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
+            {{- if .Values.engine.hostPath.dataVolume.enabled }}
             - name: varlibdagger
               mountPath: /var/lib/dagger
+            {{- end }}
+            {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: varrundagger
               mountPath: /var/run/dagger
             {{- if .Values.engine.config }}
@@ -103,20 +134,41 @@ spec:
               mountPath: /etc/dagger/engine.toml
               subPath: engine.toml
             {{- end }}
+            {{- if .Values.engine.configJson }}
+            - name: dagger-engine-config
+              mountPath: /etc/dagger/engine.json
+              subPath: engine.json
+            {{- end }}
+            {{- with .Values.engine.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.engine.terminationGracePeriodSeconds }}
       volumes:
+        {{- if .Values.engine.hostPath.dataVolume.enabled }}
         - name: varlibdagger
           hostPath:
             path: /var/lib/dagger
+        {{- end }}
+        {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: varrundagger
           hostPath:
             path: /var/run/dagger
-        {{- if .Values.engine.config }}
+        {{- end }}
+        {{- if (or .Values.engine.config .Values.engine.configJson) }}
         - name: dagger-engine-config
           configMap:
             name: {{ include "dagger.fullname" . }}-engine-config
             items:
+              {{- if .Values.engine.config }}
               - key: engine.toml
                 path: engine.toml
+              {{- end }}
+              {{- if .Values.engine.configJson }}
+              - key: engine.json
+                path: engine.json
+              {{- end }}
+        {{- end }}
+        {{- with .Values.engine.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -137,6 +137,7 @@ spec:
             {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: run
               mountPath: /var/run/dagger
+            {{- end }}
             {{- if .Values.engine.config }}
             - name: config
               mountPath: /etc/dagger/engine.toml

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -8,17 +8,24 @@ metadata:
   labels:
     {{- include "dagger.labels" . | nindent 4 }}
 spec:
-  # DO NOT RUN MORE THAN 1 REPLICA.
+  # DO NOT RUN MORE THAN 1 REPLICA IF USING HOSTPATH.
   # Only one (1) Engine is able to hold the lock, other replicas will not be able to start.
+  # If using persistent volumes, this is not an issue. Use more than 1 replica if you know that you need it.
   replicas: 1
+  podManagementPolicy: {{ .Values.engine.statefulSet.podManagementPolicy }}
   selector:
     matchLabels:
       name: {{ include "dagger.fullname" . }}-engine
+  {{- if and .Values.engine.statefulSet.persistentVolumeClaim.enabled .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   template:
     metadata:
-      {{- if (or .Values.engine.config .Values.magicache.enabled .Values.engine.annotations) }}
+      {{- if (or .Values.engine.config .Values.engine.configJson .Values.magicache.enabled .Values.engine.annotations) }}
       annotations:
-        {{- if .Values.engine.config }}
+        {{- if (or .Values.engine.config .Values.engine.configJson) }}
         checksum/config: {{ include (print $.Template.BasePath "/engine-config.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.magicache.enabled }}
@@ -32,6 +39,10 @@ spec:
         name: {{ include "dagger.fullname" . }}-engine
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.engine.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.engine.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -57,9 +68,17 @@ spec:
         - name: dagger-engine
           image: {{ if .Values.engine.image.ref }}{{ .Values.engine.image.ref }}{{ else }}registry.dagger.io/engine:v{{ .Chart.Version }}{{ end }}
           imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
-          {{- if .Values.engine.args }}
+          {{- if or .Values.engine.port .Values.engine.args }}
           args:
+            {{- if .Values.engine.port }}
+            - "--addr"
+            - "tcp://0.0.0.0:{{ .Values.engine.port }}"
+            - "--addr"
+            - "unix:///var/run/dagger/engine.sock"
+            {{- end }}
+            {{- if .Values.engine.args }}
             {{- toYaml .Values.engine.args | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if (or .Values.engine.env .Values.magicache.enabled) }}
           env:
@@ -80,12 +99,28 @@ spec:
               name: {{ include "dagger.fullname" . }}-magicache-token
               {{- end }}
           {{- end }}
+          {{- if .Values.engine.port }}
+          ports:
+            - name: dagger
+              containerPort: {{ .Values.engine.port }}
+              protocol: TCP
+              {{- if .Values.engine.hostPort }}
+              hostPort: {{ .Values.engine.hostPort }}
+              {{- end }}
+          {{- end }}
           securityContext:
             privileged: true
             capabilities:
               add:
                 - ALL
           resources: {{- toYaml .Values.engine.resources | nindent 12 }}
+          {{- if .Values.engine.lifecycle }}
+          lifecycle:
+            {{- if .Values.engine.lifecycle.preStop }}
+            preStop:
+              {{- toYaml .Values.engine.lifecycle.preStop | nindent 14 }}
+            {{- end }}
+          {{- end }}
           readinessProbe:
             exec:
               command:
@@ -99,6 +134,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/dagger
+            {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: run
               mountPath: /var/run/dagger
             {{- if .Values.engine.config }}
@@ -106,20 +142,54 @@ spec:
               mountPath: /etc/dagger/engine.toml
               subPath: engine.toml
             {{- end }}
+            {{- if .Values.engine.configJson }}
+            - name: config
+              mountPath: /etc/dagger/engine.json
+              subPath: engine.json
+            {{- end }}
+            {{- with .Values.engine.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.engine.terminationGracePeriodSeconds }}
       volumes:
+        {{- if .Values.engine.hostPath.dataVolume.enabled }}
         - name: data
           hostPath:
             path: /var/lib/dagger-{{ include "dagger.fullname" . }}
+        {{- end }}
+        {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: run
           hostPath:
             path: /var/run/dagger-{{ include "dagger.fullname" . }}
-        {{- if .Values.engine.config }}
+        {{- end }}
+        {{- if (or .Values.engine.config .Values.engine.configJson) }}
         - name: config
           configMap:
             name: {{ include "dagger.fullname" . }}-engine-config
             items:
+              {{- if .Values.engine.config }}
               - key: engine.toml
                 path: engine.toml
+              {{- end }}
+              {{- if .Values.engine.configJson }}
+              - key: engine.json
+                path: engine.json
+              {{- end }}
         {{- end }}
+        {{- with .Values.engine.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.engine.statefulSet.persistentVolumeClaim.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      {{- with .Values.engine.statefulSet.persistentVolumeClaim.storageClassName }}
+      storageClassName: {{ . }}
+      {{- end }}
+      accessModes:
+        {{- toYaml .Values.engine.statefulSet.persistentVolumeClaim.accessModes | nindent 8 }}
+      resources:
+        {{- toYaml .Values.engine.statefulSet.persistentVolumeClaim.resources | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
             - "--addr"
             - "tcp://0.0.0.0:{{ .Values.engine.port }}"
             - "--addr"
-            - "unix:///var/run/dagger/engine.sock"
+            - "unix:///run/dagger/engine.sock"
             {{- end }}
             {{- if .Values.engine.args }}
             {{- toYaml .Values.engine.args | nindent 12 }}
@@ -136,7 +136,7 @@ spec:
               mountPath: /var/lib/dagger
             {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: run
-              mountPath: /var/run/dagger
+              mountPath: /run/dagger
             {{- end }}
             {{- if .Values.engine.config }}
             - name: config
@@ -161,7 +161,7 @@ spec:
         {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: run
           hostPath:
-            path: /var/run/dagger-{{ include "dagger.fullname" . }}
+            path: /run/dagger-{{ include "dagger.fullname" . }}
         {{- end }}
         {{- if (or .Values.engine.config .Values.engine.configJson) }}
         - name: config

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -3,6 +3,17 @@ fullnameOverride: ""
 
 engine:
   ### Customize your Dagger Engine
+  # https://docs.dagger.io/configuration/engine/#configuration
+  #
+  # configJson: |
+  #   {
+  #     "logLevel": "info"
+  #   }
+
+  ### Alternative: Configure Dagger Engine using TOML format.
+  #   Configuration using json should be the default choice, and will take
+  #   precedence over toml if both are provided, however you can use toml for
+  #   any settings that are not supported in the json format.
   #   https://github.com/moby/buildkit/blob/5997099827e676c4b6ce5774c98ade2483e0afe7/cmd/buildkitd/config/config.go
   #
   # config: |
@@ -23,6 +34,38 @@ engine:
   #
   # Set to `StatefulSet` for running multiple Engines per K8s node
   kind: DaemonSet
+
+  ### StatefulSet specific configuration
+  #
+  statefulSet:
+    # PVC retention policy (applies to all PVCs)
+    # Only available in Kubernetes 1.23+
+    persistentVolumeClaimRetentionPolicy:
+      # Options: Delete, Retain
+      whenDeleted: Retain
+      # Options: Delete, Retain
+      whenScaled: Retain
+
+    # Use PersistentVolumeClaim for data volume
+    persistentVolumeClaim:
+      enabled: false
+      # PVC specifications
+      storageClassName: ""
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+
+    # Controls how pods are created during initial scale up,
+    # when replacing pods, and when scaling down.
+    # Options: OrderedReady, Parallel (default: OrderedReady)
+    podManagementPolicy: OrderedReady
+
+  ### Configure the port settings for the Dagger Engine
+  #
+  # port: 1234 # The container port that the Dagger Engine will listen on.
+  # hostPort: 1234    # Optional: Expose the engine port directly on the host node
 
   ### Customize Dagger Engine start args
   args: []
@@ -53,6 +96,8 @@ engine:
   # imagePullSecrets:
   #   - name: image-pull-secret
 
+  # nodeSelector:
+  #   app: dagger
 
   ### Set taints & tolerations for this workload
   #
@@ -71,7 +116,7 @@ engine:
   ### Set priorityClassName to avoid eviction
   priorityClassName: ""
 
-  readinessProbeSettings: 
+  readinessProbeSettings:
     initialDelaySeconds: 5
     timeoutSeconds: 14
     periodSeconds: 15
@@ -88,8 +133,50 @@ engine:
     create: false
     annotations: []
 
-  existingServiceAccount: {}
+  existingServiceAccount:
+    {}
     # name: "default"
+
+  ### Configure lifecycle hooks for the Dagger Engine
+  #
+  lifecycle:
+    # PreStop hook executed before container termination
+    preStop:
+      # exec:
+      #   command: ["/bin/sh", "-c", "sleep 10"]  # Example: graceful shutdown delay
+
+  ### HostPath Volume configuration
+  #
+  hostPath:
+    # Use hostPath for data volume
+    dataVolume:
+      # When disabled, PVC will be used if configured above
+      enabled: true
+
+    # Use hostPath for run volume
+    runVolume:
+      # When disabled, no run volume will be mounted
+      enabled: true
+
+  ### Additional volumes to mount in the Dagger Engine container
+  #
+  # Additional volume mounts for the container
+  volumeMounts: []
+  # - name: config-volume
+  #   mountPath: /etc/config
+  # - name: cache-volume
+  #   mountPath: /var/cache
+
+  # Additional volumes for the pod
+  volumes: []
+  # - name: config-volume
+  #   configMap:
+  #     name: my-config
+  # - name: cache-volume
+  #   emptyDir: {}
+  # - name: shared-data
+  #   persistentVolumeClaim:
+  #     claimName: my-pvc
 
 magicache:
   enabled: false


### PR DESCRIPTION
I added a bunch of configuration options that my org is using and I'm hoping to get them into main so that we don't have to rely on my fork moving forward. 

I tried to make sure the values made sense for both statefulset and daemonset modes but I may have missed the mark there. Definitely open to feedback and let me know if I need to break up the PR I know there are a lot of changes.

Summary of changes:

- add support for configuring the Dagger engine via the `engine.json` file.
- Add container port and optionally bind to a host port.
- Add nodeSelector
- Add arbitrary volume mounts
- Add lifecycle preStop hook
- Add podManagementPolicy
- Add option to disable hostPath mount for run and data volumes.
- Add option to use pvc for data volume in StatefulSet