### PR TITLE
docs: add technical-content-summarizer example agent

### DIFF
--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -46,6 +46,7 @@ Here are several example repositories containing examples of Dagger modules with
 - [tictactoe](https://github.com/kpenfound/agents/tree/main/tictactoe): an agent that plays Tic Tac Toe with a human player.
 - [dockerfile-optimizer](https://github.com/dagger/agents/tree/main/dockerfile-optimizer): an agent that analyzes your Dockerfile and suggests improvements for better efficiency, security, and best practices.
 - [test-debugger](https://github.com/kpenfound/greetings-api/blob/main/DEBUGGER_AGENT.md): an agent that automatically debugs failing tests in CI.
+- [technical-content-summarizer](https://github.com/jasonmccallister/technical-content-summarizer): an agent that accepts a URL, optional min and max character length and forbidden words and summarizes the content for a non-technical audience.
 
 ## Initial setup
 


### PR DESCRIPTION
Adds a link to the technical-content-summarizer example agent.