### PR TITLE
update default engine unix sock to /run/dagger/engine.sock

### DIFF
--- a/.changes/unreleased/Changed-20250317-102936.yaml
+++ b/.changes/unreleased/Changed-20250317-102936.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |-
+  The default unix socket used to connect to the engine is now at /run/dagger/engine.sock
+
+  The previous socket path still exists for backwards compatibility but may be removed in a future version.
+time: 2025-03-17T10:29:36.720646434-07:00
+custom:
+  Author: sipsma
+  PR: "9866"

--- a/.dagger/config.go
+++ b/.dagger/config.go
@@ -19,7 +19,7 @@ const (
 	engineTOMLPath       = "/etc/dagger/engine.toml"
 	engineJSONPath       = "/etc/dagger/engine.json"
 	engineEntrypointPath = "/usr/local/bin/dagger-entrypoint.sh"
-	engineUnixSocketPath = "/var/run/buildkit/buildkitd.sock"
+	engineUnixSocketPath = "/var/run/dagger/engine.sock"
 	cliPath              = "/usr/local/bin/dagger"
 )
 

--- a/cmd/dialstdio/main.go
+++ b/cmd/dialstdio/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/moby/buildkit/util/appdefaults"
+	"github.com/dagger/dagger/engine"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +22,7 @@ var (
 func init() {
 	syscall.Umask(0)
 
-	rootCmd.PersistentFlags().StringVar(&addr, "addr", appdefaults.Address, "The address serving the grpc api")
+	rootCmd.PersistentFlags().StringVar(&addr, "addr", engine.DefaultEngineSockAddr, "The address serving the grpc api")
 	rootCmd.PersistentFlags().IntVar(&timeoutSeconds, "timeout", 5, "The timeout in seconds for connecting to the grpc api")
 }
 

--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -15,6 +15,10 @@ import (
 	"github.com/dagger/dagger/engine/server"
 )
 
+const (
+	daggerEngineSockAddr = "unix:///run/dagger/engine.sock"
+)
+
 func defaultBuildkitConfigPath() string {
 	if userns.RunningInUserNS() {
 		return filepath.Join(appdefaults.UserConfigDir(), "buildkitd.toml")
@@ -43,8 +47,8 @@ func setDefaultBuildkitConfig(cfg *bkconfig.Config, netConf *networkConfig) {
 		cfg.Root = distconsts.EngineDefaultStateDir
 	}
 
-	// always include default address
-	cfg.GRPC.Address = append([]string{appdefaults.Address}, cfg.GRPC.Address...)
+	// always include default addresses
+	cfg.GRPC.Address = append([]string{appdefaults.Address, daggerEngineSockAddr}, cfg.GRPC.Address...)
 
 	isTrue := true
 	cfg.Workers.OCI.Enabled = &isTrue

--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -11,12 +11,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/engine/server"
-)
-
-const (
-	daggerEngineSockAddr = "unix:///run/dagger/engine.sock"
 )
 
 func defaultBuildkitConfigPath() string {
@@ -48,7 +45,7 @@ func setDefaultBuildkitConfig(cfg *bkconfig.Config, netConf *networkConfig) {
 	}
 
 	// always include default addresses
-	cfg.GRPC.Address = append([]string{appdefaults.Address, daggerEngineSockAddr}, cfg.GRPC.Address...)
+	cfg.GRPC.Address = append([]string{appdefaults.Address, engine.DefaultEngineSockAddr}, cfg.GRPC.Address...)
 
 	isTrue := true
 	cfg.Workers.OCI.Enabled = &isTrue

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -51,7 +51,7 @@ import (
 )
 
 func init() {
-	apicaps.ExportedProduct = "buildkit"
+	apicaps.ExportedProduct = "dagger-engine"
 	stack.SetVersionInfo(version.Version, version.Revision)
 
 	//nolint:staticcheck // SA1019 deprecated
@@ -239,8 +239,7 @@ func main() { //nolint:gocyclo
 		fmt.Println(c.App.Name, version.Package, c.App.Version, version.Revision)
 	}
 	app := cli.NewApp()
-	app.Name = "buildkitd"
-	app.Usage = "build daemon"
+	app.Name = "dagger-engine"
 	app.Version = version.Version
 
 	addFlags(app)
@@ -367,7 +366,7 @@ func main() { //nolint:gocyclo
 		}
 
 		bklog.G(ctx).Debug("creating engine lockfile")
-		lockPath := filepath.Join(root, "buildkitd.lock")
+		lockPath := filepath.Join(root, "dagger-engine.lock")
 		lock := flock.New(lockPath)
 		locked, err := lock.TryLock()
 		if err != nil {
@@ -468,7 +467,7 @@ func main() { //nolint:gocyclo
 	profiler.Attach(app)
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "buildkitd: %+v\n", err)
+		fmt.Fprintf(os.Stderr, "dagger-engine: %+v\n", err)
 		os.Exit(1)
 	}
 }

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -64,7 +64,7 @@ func devEngineContainer(c *dagger.Client, withs ...func(*dagger.Container) *dagg
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		WithDefaultArgs([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/buildkit/buildkitd.sock",
+			"--addr", "unix:///var/run/dagger/engine.sock",
 			// avoid network conflicts with other tests
 			"--network-name", deviceName,
 			"--network-cidr", cidr,

--- a/docs/current_docs/ci/integrations/argo-workflows.mdx
+++ b/docs/current_docs/ci/integrations/argo-workflows.mdx
@@ -27,7 +27,7 @@ Create a file called `workflow.yaml` with the following content:
 A few important points to note:
 
 - The workflow uses hardwired artifacts to clone the Git repository and to install the Dagger CLI.
-- `unix:///var/run/dagger/buildkitd.sock` is mounted and specified with the `_EXPERIMENTAL_DAGGER_RUNNER_HOST` environment variable.
+- `unix:///var/run/dagger/engine.sock` is mounted and specified with the `_EXPERIMENTAL_DAGGER_RUNNER_HOST` environment variable.
 - The Dagger CLI is downloaded and installed. Confirm the version and architecture are accurate for your cluster and project.
 - Setting the `DAGGER_CLOUD_TOKEN` environment variable is only necessary if integrating with Dagger Cloud.
 

--- a/docs/current_docs/ci/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/ci/integrations/snippets/argo-workflow.yaml
@@ -24,7 +24,7 @@ spec:
             exec:
               command: ["dagger", "core", "version"]
           volumeMounts:
-            - mountPath: /var/run/buildkit
+            - mountPath: /var/run/dagger
               name: dagger-socket
             - mountPath: /var/lib/dagger
               name: dagger-storage
@@ -50,7 +50,7 @@ spec:
         workingDir: /work
         env:
         - name: "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
-          value: "unix:///var/run/dagger/buildkitd.sock"
+          value: "unix:///var/run/dagger/engine.sock"
           # assumes the Dagger Cloud token is
           # in a Kubernetes secret named dagger-cloud
         - name: "DAGGER_CLOUD_TOKEN"

--- a/docs/current_docs/ci/integrations/snippets/gitlab-runner-config.yml
+++ b/docs/current_docs/ci/integrations/snippets/gitlab-runner-config.yml
@@ -6,7 +6,7 @@ data:
   config.toml: |
     concurrent = 10
     [[runners]]
-      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST=unix:///var/run/dagger/buildkitd.sock"]
+      environment = ["HOME=/tmp","FF_GITLAB_REGISTRY_HELPER_IMAGE=1", "_EXPERIMENTAL_DAGGER_RUNNER_HOST=unix:///var/run/dagger/engine.sock"]
       pre_build_script = "export PATH=\"/tmp/:$PATH\""
       name = "GitLab Runner with Dagger"
       url = YOUR-GITLAB-URL

--- a/docs/current_docs/ci/integrations/snippets/tekton-dagger-task.yaml
+++ b/docs/current_docs/ci/integrations/snippets/tekton-dagger-task.yaml
@@ -28,7 +28,7 @@ spec:
         exec:
           command: ["dagger", "core", "version"]
       volumeMounts:
-        - mountPath: /var/run/buildkit
+        - mountPath: /var/run/dagger
           name: dagger-socket
         - mountPath: /var/lib/dagger
           name: dagger-storage
@@ -47,7 +47,7 @@ spec:
         name: dagger-socket
     env:
       - name: _EXPERIMENTAL_DAGGER_RUNNER_HOST
-        value: unix:///var/run/dagger/buildkitd.sock
+        value: unix:///var/run/dagger/engine.sock
       - name: DAGGER_CLOUD_TOKEN
         valueFrom:
           secretKeyRef:

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -4,6 +4,8 @@ const (
 	EngineImageRepo = "registry.dagger.io/engine"
 	Package         = "github.com/dagger/dagger"
 
+	DefaultEngineSockAddr = "unix:///run/dagger/engine.sock"
+
 	DaggerNameEnv = "_EXPERIMENTAL_DAGGER_ENGINE_NAME"
 
 	DaggerVersionEnv        = "_EXPERIMENTAL_DAGGER_VERSION"

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -97,7 +97,7 @@ spec:
             - name: varlibdagger
               mountPath: /var/lib/dagger
             - name: varrundagger
-              mountPath: /var/run/buildkit
+              mountPath: /var/run/dagger
             {{- if .Values.engine.config }}
             - name: dagger-engine-config
               mountPath: /etc/dagger/engine.toml

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
             - name: data
               mountPath: /var/lib/dagger
             - name: run
-              mountPath: /var/run/buildkit
+              mountPath: /var/run/dagger
             {{- if .Values.engine.config }}
             - name: config
               mountPath: /etc/dagger/engine.toml

--- a/modules/compatcheck/main.go
+++ b/modules/compatcheck/main.go
@@ -127,7 +127,7 @@ func engineServiceWithVersion(version string, withs ...func(*dagger.Container) *
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
 		WithExec([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/buildkit/buildkitd.sock",
+			"--addr", "unix:///var/run/dagger/engine.sock",
 			// // avoid network conflicts with other tests
 			"--network-name", deviceName,
 			"--network-cidr", cidr,

--- a/modules/daggerverse/main.go
+++ b/modules/daggerverse/main.go
@@ -152,7 +152,7 @@ func (h *Daggerverse) BumpDaggerVersion(
 		WithExposedPort(1234).
 		WithDefaultArgs([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/buildkit/buildkitd.sock",
+			"--addr", "unix:///var/run/dagger/engine.sock",
 			"--network-cidr", "10.12.34.0/24",
 		}).AsService(dagger.ContainerAsServiceOpts{InsecureRootCapabilities: true, UseEntrypoint: true})
 


### PR DESCRIPTION
For less confusion and more consistency in naming, this updates the engine listener to use `unix:///run/dagger/engine.sock`.

For now, I'm leaving around the old `unix:///run/buildkit/buildkitd.sock` too to avoid backwards incompatibility. The two socks are just different listeners for the same server so there's no harm in both existing for now.

This updates everywhere I could find `buildkitd.sock` across Helm charts, various docs on integrations, etc. So it's worth a double check those all look correct to others now.