### PR TITLE
fix "waitid: no child processes" error in secret cmd provider

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -21,6 +21,15 @@ import (
 )
 
 func main() {
+	switch os.Args[0] {
+	case "/.init":
+		mainInit()
+	case "/proc/self/exe":
+		mainSession()
+	}
+}
+
+func mainInit() {
 	sigCh := make(chan os.Signal, 16)
 	// Handle every signal other than a few exceptions noted at the end.
 	// Importantly, by handling all these signals, the child process will start with
@@ -90,7 +99,9 @@ func main() {
 	}
 
 	if _, ok := os.LookupEnv("DAGGER_SESSION_TOKEN"); ok {
-		go serveSession()
+		if err := startSessionSubprocess(); err != nil {
+			panic(err)
+		}
 	}
 
 	// run the child in a new session
@@ -117,8 +128,7 @@ func main() {
 	}
 	child, err := os.StartProcess(fullPath, os.Args[1:], &os.ProcAttr{
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-
-		Sys: &sysProcAttr,
+		Sys:   &sysProcAttr,
 	})
 	if err != nil {
 		panic(err)
@@ -180,7 +190,17 @@ func main() {
 	}
 }
 
-func serveSession() {
+func startSessionSubprocess() error {
+	// start the session subprocess
+	cmd := exec.Command("/proc/self/exe")
+	cmd.ExtraFiles = []*os.File{os.NewFile(3, "session-conn")}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+	return cmd.Start()
+}
+
+func mainSession() {
 	ctx := context.Background()
 
 	attachables := []bksession.Attachable{


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/9572

This has been flaking on our CI an annoying amount, occasionally locally too.

It seems that the problem happens specifically with a secret command provider being executed in a nested dagger exec.

The problem is that we run our nested exec session attachable server in our custom init process, which creates a race condition between different goroutines trying to wait on child processes.

Our init process obviously has to handle SIGCHLD and waiting on processes since that's part of an init's job. But the secret cmd provider also spins up child processes and tries to wait on them (all using the go stdlib). This leads to a race condition where, if the init's SIGCHLD handling waits on the cmd subprocess first, the go stdlib can error out due to `waitid: no child processes`.

The fix here runs the session attachable server in a separate child process, which ensures it will be the one to wait on the child process from cmd secret providers. An alternative would have been to do some complicated synchronization between cmd secret provider code + the init SIGCHLD handling, but that did not seem worth the complexity.

Verified by running `TestCall/TestArgTypes/secret_args/cmd` locally; previously could hit the error after a few retries, can't anymore.