### PR TITLE
fix: typescript dev node modules

### DIFF
--- a/sdk/typescript/dev/dagger.json
+++ b/sdk/typescript/dev/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-sdk-dev",
-  "engineVersion": "v0.12.7",
+  "engineVersion": "v0.16.3",
   "sdk": {
     "source": "typescript"
   },

--- a/sdk/typescript/dev/node/dagger.json
+++ b/sdk/typescript/dev/node/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "node",
-  "engineVersion": "v0.9.9",
+  "engineVersion": "v0.16.3",
   "sdk": {
     "source": "typescript"
   }

--- a/sdk/typescript/dev/node/src/commands.ts
+++ b/sdk/typescript/dev/node/src/commands.ts
@@ -11,7 +11,7 @@ export class Commands {
 
   @func()
   run(args: string[]): Container {
-    return this.ctr.withExec(["run", ...args])
+    return this.ctr.withExec(["run", ...args], { useEntrypoint: true })
   }
 
   @func()

--- a/sdk/typescript/dev/node/src/index.ts
+++ b/sdk/typescript/dev/node/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { Commands } from "./commands"
 
 @object()
-class Node {
+export class Node {
   @func()
   version = "22.11.0-alpine@sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
 
@@ -105,7 +105,7 @@ class Node {
    */
   @func()
   install(pkgs: string[] = []): Node {
-    this.container = this.container.withExec(["install", ...pkgs], {"useEntrypoint": true})
+    this.container = this.container.withExec(["install", ...pkgs], { useEntrypoint: true })
 
     return this
   }

--- a/sdk/typescript/dev/src/index.ts
+++ b/sdk/typescript/dev/src/index.ts
@@ -1,7 +1,7 @@
 import { dag, Container, object, func, Directory } from "@dagger.io/dagger"
 
 @object()
-class TypescriptSdkDev {
+export class TypescriptSdkDev {
   /**
    * Project dev environment container.
    *


### PR DESCRIPTION
Update Typescript `dev` & `node` modules
- Correctly set `useEntrypoint`
- Update version
- Correctly export class

I tested it with https://docs.dagger.io/ci/quickstart/simplify using `dagger call publish --source=https://github.com/dagger/hello-dagger` and it works fine.