### PR TITLE
ci: run provision tests in serial

### DIFF
--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -1240,7 +1240,7 @@ jobs:
                 exit $EXIT_CODE
               env:
                 _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestProvision|TestTelemetry'
+                COMMAND: dagger call -q test specific --race=true --parallel=1 --run='TestProvision|TestTelemetry'
                 DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 NO_OUTPUT: "true"
               shell: bash


### PR DESCRIPTION
These provision tests are pretty disk hungry, since they all start their own docker daemons. So we should avoid spinning up them all in parallel, or we're gonna consume too much disk all at once.

This is an attempt to fix the constantly failing cgroupsv2 jobs on main!