### PR TITLE
ci: Add a simpler `call` action for Alternative CI Runners

### DIFF
--- a/.github/actions/call-ci-alt-runner/action.yml
+++ b/.github/actions/call-ci-alt-runner/action.yml
@@ -1,0 +1,97 @@
+name: "dagger call for Alternative CI Runners"
+description: ""
+
+inputs:
+  function:
+    description: "The Dagger function to call"
+    required: true
+
+  module:
+    description: "The Dagger module to call"
+    default: "."
+    required: false
+
+  version:
+    description: "Dagger version to run against"
+    default: "v0.16.3"
+    required: false
+
+  dev-engine:
+    description: "Whether to run against a dev Engine"
+    default: "false"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/actions/call
+        touch ${{ runner.temp }}/actions/call/local-envs
+
+    - name: Install dagger
+      shell: bash
+      env:
+        DAGGER_VERSION: "${{ inputs.version }}"
+      run: |
+        if [[ -x "$(command -v dagger)" ]]; then
+          echo "::group::Checking dagger"
+          version="$(dagger --silent version | cut --fields 2 --delimiter ' ')"
+          if [[ "$version" != "$DAGGER_VERSION" ]]; then
+            echo "dagger ${version} is installed, but needed ${DAGGER_VERSION}"
+            exit 1
+          fi
+          echo "::endgroup::"
+        else
+          echo "::group::Installing dagger"
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
+          echo "::endgroup::"
+        fi
+
+    - name: Start dev dagger
+      shell: bash
+      if: inputs.dev-engine == 'true'
+      run: |
+        echo "::group::Starting dev engine"
+
+        if ! [[ -x "$(command -v docker)" ]]; then
+          echo "docker is not installed"
+          exit 1
+        fi
+        if ! [[ -x "$(command -v dagger)" ]]; then
+          echo "dagger is not installed"
+          exit 1
+        fi
+
+        # put env variables in ${{ runner.temp }}/actions/call/local-envs instead of
+        # $GITHUB_ENV to avoid leaking into parent workflow
+        echo "export PATH=$PWD/bin:$PATH" >> ${{ runner.temp }}/actions/call/local-envs
+
+        echo "::endgroup::"
+
+    - name: Wait for dagger to be ready
+      shell: bash
+      run: |
+        source ${{ runner.temp }}/actions/call/local-envs
+
+        echo "::group::Dagger client version"
+        dagger --silent version
+        echo "::endgroup::"
+
+        echo "::group::Dagger server version"
+        dagger --silent core version
+        echo "::endgroup::"
+
+    - name: ${{ inputs.function }}
+      shell: bash
+      run: |
+        source ${{ runner.temp }}/actions/call/local-envs
+        set -x
+        if [[ -f $HOME/.docker/config.json ]]; then
+          dagger --silent --quiet --mod "${{ inputs.module }}" call --docker-cfg=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+        else
+          dagger --silent --quiet --mod "${{ inputs.module }}" call ${{ inputs.function }}
+        fi
+      env:
+        DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/workflows/_dagger_on_depot_local_engine.yml
+++ b/.github/workflows/_dagger_on_depot_local_engine.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Warm up Engine
         run: dagger core version
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}

--- a/.github/workflows/_dagger_on_magicache_remote_engine.yml
+++ b/.github/workflows/_dagger_on_magicache_remote_engine.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Warm up Engine
         run: dagger core version
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}

--- a/.github/workflows/_dagger_on_namespace_local_engine.yml
+++ b/.github/workflows/_dagger_on_namespace_local_engine.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}

--- a/.github/workflows/_dagger_on_namespace_remote_engine.yml
+++ b/.github/workflows/_dagger_on_namespace_remote_engine.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Warm up Engine
         run: dagger core version
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}

--- a/.github/workflows/_dagger_on_x1_nvme.yml
+++ b/.github/workflows/_dagger_on_x1_nvme.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Warm up Engine
         run: dagger core version
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}

--- a/.github/workflows/_dagger_on_x1_tmpfs.yml
+++ b/.github/workflows/_dagger_on_x1_tmpfs.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Warm up Engine
         run: dagger core version
       - name: ${{ inputs.function }}
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}
       - name: ${{ inputs.function }} (CACHE TEST)
-        uses: ./.github/actions/call
+        uses: ./.github/actions/call-ci-alt-runner
         with:
           function: ${{ inputs.function }}


### PR DESCRIPTION
After all Alternative CI jobs started failing since #9673, this introduces a separate `call` action which is only used by these alternative CI runners. We want something simpler that has a separate lifecyle from the main `call` action that we use in the primary CI runners.

The problem with the current `call` action logging config is that GitHub Actions UI breaks, as well as the Namespace UI, so troubleshooting the source of this issue is very difficult.

I even downloaded the logs locally, which did not make it easier to find the issue. FTR:

    ~/Downloads/logs_35440011783 on ☁️
    ❯ ls -lah
    total 264M
    drwx------ 11 gerhard staff        352 Mar 10 19:24  .
    drwxr-xr-x 59 gerhard _lpoperator 1.9K Mar 10 19:24  ..
    -rw-rw-r--  1 gerhard staff        28M Nov 30  1979 '0_docs-lint-on-namespace-remote-engine _ remote-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        15M Nov 30  1979 '1_docs-lint-on-namespace-local-engine _ local-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        86M Nov 30  1979 '2_test-cli-engine-on-namespace-remote-engine _ remote-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        30M Nov 30  1979 '3_sdk-go-on-namespace-remote-engine _ remote-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        30M Nov 30  1979 '4_sdk-python-on-namespace-remote-engine _ remote-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        31M Nov 30  1979 '5_sdk-typescript-on-namespace-remote-engine _ remote-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        15M Nov 30  1979 '6_sdk-go-dev-on-namespace-local-engine _ local-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        16M Nov 30  1979 '7_sdk-typescript-dev-on-namespace-local-engine _ local-dagger-engine.txt'
    -rw-rw-r--  1 gerhard staff        16M Nov 30  1979 '8_sdk-python-dev-on-namespace-local-engine _ local-dagger-engine.txt'

What's most peculiar about this issue is that the trace in Dagger Cloud doesn't show any issues:
https://v3.dagger.cloud/dagger/traces/57d1391e843c1d8a7cfb473f60c034e2