### PR TITLE
docs: remove the laravel-assistant link

### DIFF
--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -43,7 +43,6 @@ Here are several example repositories containing examples of Dagger modules with
 - [multiagent](https://github.com/kpenfound/agents/tree/main/multiagent-demo): a demo using multiple LLMs to solve a problem
 - [go-coder](https://github.com/kpenfound/agents/tree/main/go-coder): a Go programmer micro-agent that receives assignments from GitHub issues and creates PRs with it's solutions
 - [cypress-test-writer](https://github.com/jpadams/cypress-test-writer): an agent that compares two branches in git for a UI change and creates a Cypress test to cover the change.
-- [laravel-assistant](https://github.com/jasonmccallister/laravel-assistant): an agent that reviews git changes in a local Laravel project to generate tests.
 - [tictactoe](https://github.com/kpenfound/agents/tree/main/tictactoe): an agent that plays Tic Tac Toe with a human player.
 - [dockerfile-optimizer](https://github.com/samalba/agents/tree/main/dockerfile-optimizer): an agent that analyzes your Dockerfile and suggests improvements for better efficiency, security, and best practices.
 - [test-debugger](https://github.com/kpenfound/greetings-api/blob/main/DEBUGGER_AGENT.md): an agent that automatically debugs failing tests in CI.


### PR DESCRIPTION
Removes the laravel-assistant link to avoid confusion until a complete example and video are available.