### PR TITLE
ci: Reduce the jobs that run in Alternative CI Runners 1

### DIFF
--- a/.github/workflows/alternative-ci-runners-1.yml
+++ b/.github/workflows/alternative-ci-runners-1.yml
@@ -24,13 +24,6 @@ jobs:
       dev: true
       timeout: 20
 
-  test-cli-engine-on-depot-remote-engine:
-    needs: docs-lint-on-depot-remote-engine
-    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
-    with:
-      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
-      timeout: 20
-
   sdk-go-on-depot-remote-engine:
     needs: docs-lint-on-depot-remote-engine
     uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -43,27 +36,3 @@ jobs:
       function: check --targets=sdk/go
       dev: true
       timeout: 15
-
-  sdk-python-on-depot-remote-engine:
-    needs: docs-lint-on-depot-remote-engine
-    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
-    with:
-      function: check --targets=sdk/python
-  sdk-python-dev-on-depot-local-engine:
-    needs: sdk-python-on-depot-remote-engine
-    uses: ./.github/workflows/_dagger_on_depot_local_engine.yml
-    with:
-      function: check --targets=sdk/python
-      dev: true
-
-  sdk-typescript-on-depot-remote-engine:
-    needs: docs-lint-on-depot-remote-engine
-    uses: ./.github/workflows/_dagger_on_depot_remote_engine.yml
-    with:
-      function: check --targets=sdk/typescript
-  sdk-typescript-dev-on-depot-local-engine:
-    needs: sdk-typescript-on-depot-remote-engine
-    uses: ./.github/workflows/_dagger_on_depot_local_engine.yml
-    with:
-      function: check --targets=sdk/typescript
-      dev: true


### PR DESCRIPTION
We have plenty of data re performance characteristics and now want to cost-optimise and stay within a $100/month budget.

Before:
<img width="1758" alt="image" src="https://github.com/user-attachments/assets/e0f5d3a3-96ef-45d6-8dd9-03704de773c9" />


After:
<img width="1758" alt="image" src="https://github.com/user-attachments/assets/00b2c97e-ebdb-4eb4-86d3-5c49dd45060e" />