### PR TITLE
ci: Run testdev-cgroupsv2 in larger & faster CI runners

### DIFF
--- a/.github/dagger.json
+++ b/.github/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ci",
-  "engineVersion": "v0.16.2",
+  "engineVersion": "v0.16.3",
   "sdk": {
     "source": "go"
   },

--- a/.github/main.go
+++ b/.github/main.go
@@ -11,7 +11,8 @@ import (
 const (
 	daggerVersion      = "v0.16.3"
 	upstreamRepository = "dagger/dagger"
-	defaultRunner      = "ubuntu-latest"
+	ubuntuVersion      = "24.04"
+	defaultRunner      = "ubuntu-" + ubuntuVersion
 	publicToken        = "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 	timeoutMinutes     = 20
 )
@@ -177,10 +178,9 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 		WithJob(runner.Job("scan-engine", "engine scan")).
 		With(splitTests(runner, "testdev-", true, []testSplit{
 			{"cgroupsv2", []string{"TestProvision", "TestTelemetry"}, &dagger.GhaJobOpts{
-				// HACK: our main runners don't support cgroupsv2
-				Runner: []string{"ubuntu-latest"},
-				// NOTE: needed to silence redis warning logs in tests
-				SetupCommands: []string{"sudo sysctl -w vm.overcommit_memory=1"},
+				// NOTE: Our CI runners do not support cgroupsv2 as of 2025.03
+				// @gerhard @matipan @jedevc have more details
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
 				Runner: []string{PlatinumRunner(true)},
@@ -301,6 +301,27 @@ func Runner(
 	)
 }
 
+// Assemble an alternative runner name for a workflow
+func AltRunner(
+	cpus int,
+) string {
+	mem := cpus * 2
+	runner := fmt.Sprintf(
+		"nscloud-ubuntu-%s-amd64-%dx%d",
+		ubuntuVersion,
+		cpus,
+		mem)
+
+	// Fall back to default runner if repository is not upstream
+	// (this is GHA DSL and will be evaluated by the GHA runner)
+	return fmt.Sprintf(
+		"${{ github.repository == '%s' && '%s' || '%s' }}",
+		upstreamRepository,
+		runner,
+		defaultRunner,
+	)
+}
+
 // Bronze runner: Multi-tenant instance, 4 cpu
 func BronzeRunner(
 	// Enable docker-in-docker
@@ -335,4 +356,9 @@ func PlatinumRunner(
 	dind bool,
 ) string {
 	return Runner(3, daggerVersion, 32, true, dind)
+}
+
+// Alternative Gold runner: Single-tenant with Docker, 16 cpu
+func AltGoldRunner() string {
+	return AltRunner(16)
 }

--- a/.github/main.go
+++ b/.github/main.go
@@ -183,19 +183,19 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{AltGoldRunner()},
 			}},
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"cli-engine", []string{"TestCLI", "TestEngine"}, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"everything-else", nil, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltPlatinumRunner()},
 			}},
 		}))
 
@@ -361,4 +361,9 @@ func PlatinumRunner(
 // Alternative Gold runner: Single-tenant with Docker, 16 cpu
 func AltGoldRunner() string {
 	return AltRunner(16)
+}
+
+// Alternative Platinum runner: Single-tenant with Docker, 32 cpu
+func AltPlatinumRunner() string {
+	return AltRunner(32)
 }

--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
     deploy:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: deploy
         steps:
             - name: Checkout

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     docs:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: docs
         steps:
             - name: Checkout

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -1262,7 +1262,7 @@ jobs:
         timeout-minutes: 30
     testdev-cli-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-cli-engine
         steps:
             - name: Checkout
@@ -1520,7 +1520,7 @@ jobs:
         timeout-minutes: 30
     testdev-container:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-container
         steps:
             - name: Checkout
@@ -1778,7 +1778,7 @@ jobs:
         timeout-minutes: 30
     testdev-everything-else:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
         name: testdev-everything-else
         steps:
             - name: Checkout
@@ -2036,7 +2036,7 @@ jobs:
         timeout-minutes: 30
     testdev-module-runtimes:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-module-runtimes
         steps:
             - name: Checkout
@@ -2294,7 +2294,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     cli-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-24.04' }}
         name: cli-test-publish
         steps:
             - name: Checkout
@@ -216,7 +216,7 @@ jobs:
         timeout-minutes: 20
     engine-lint:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-24.04' }}
         name: engine-lint
         steps:
             - name: Checkout
@@ -413,7 +413,7 @@ jobs:
         timeout-minutes: 20
     engine-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-16c-st' || 'ubuntu-24.04' }}
         name: engine-test-publish
         steps:
             - name: Checkout
@@ -610,7 +610,7 @@ jobs:
         timeout-minutes: 20
     scan-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: scan-engine
         steps:
             - name: Checkout
@@ -807,7 +807,7 @@ jobs:
         timeout-minutes: 20
     scripts:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: scripts
         steps:
             - name: Checkout
@@ -1004,7 +1004,7 @@ jobs:
         timeout-minutes: 20
     testdev-cgroupsv-2:
         runs-on:
-            - ubuntu-latest
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-cgroupsv2
         steps:
             - name: Checkout
@@ -1101,9 +1101,6 @@ jobs:
                 # Run a simple query to "warm up" the engine
                 dagger version
                 dagger core version
-              shell: bash
-            - name: sudo sysctl -w vm.overcommit_memory=1
-              run: sudo sysctl -w vm.overcommit_memory=1
               shell: bash
             - name: scripts/exec.sh
               id: exec
@@ -1265,7 +1262,7 @@ jobs:
         timeout-minutes: 30
     testdev-cli-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-cli-engine
         steps:
             - name: Checkout
@@ -1523,7 +1520,7 @@ jobs:
         timeout-minutes: 30
     testdev-container:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-container
         steps:
             - name: Checkout
@@ -1781,7 +1778,7 @@ jobs:
         timeout-minutes: 30
     testdev-everything-else:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-everything-else
         steps:
             - name: Checkout
@@ -2039,7 +2036,7 @@ jobs:
         timeout-minutes: 30
     testdev-module-runtimes:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-module-runtimes
         steps:
             - name: Checkout
@@ -2297,7 +2294,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     github:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: Github
         steps:
             - name: Checkout

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     dotnet:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: dotnet
         steps:
             - name: Checkout
@@ -216,7 +216,7 @@ jobs:
         timeout-minutes: 20
     dotnet-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: dotnet-dev
         steps:
             - name: Checkout
@@ -455,7 +455,7 @@ jobs:
         timeout-minutes: 20
     elixir:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: elixir
         steps:
             - name: Checkout
@@ -652,7 +652,7 @@ jobs:
         timeout-minutes: 20
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: elixir-dev
         steps:
             - name: Checkout
@@ -891,7 +891,7 @@ jobs:
         timeout-minutes: 20
     go:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: go
         steps:
             - name: Checkout
@@ -1088,7 +1088,7 @@ jobs:
         timeout-minutes: 20
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: go-dev
         steps:
             - name: Checkout
@@ -1327,7 +1327,7 @@ jobs:
         timeout-minutes: 20
     java:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: java
         steps:
             - name: Checkout
@@ -1524,7 +1524,7 @@ jobs:
         timeout-minutes: 20
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: java-dev
         steps:
             - name: Checkout
@@ -1763,7 +1763,7 @@ jobs:
         timeout-minutes: 20
     php:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: php
         steps:
             - name: Checkout
@@ -1960,7 +1960,7 @@ jobs:
         timeout-minutes: 20
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: php-dev
         steps:
             - name: Checkout
@@ -2199,7 +2199,7 @@ jobs:
         timeout-minutes: 20
     python:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: python
         steps:
             - name: Checkout
@@ -2396,7 +2396,7 @@ jobs:
         timeout-minutes: 20
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: python-dev
         steps:
             - name: Checkout
@@ -2635,7 +2635,7 @@ jobs:
         timeout-minutes: 20
     rust:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: rust
         steps:
             - name: Checkout
@@ -2832,7 +2832,7 @@ jobs:
         timeout-minutes: 20
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: rust-dev
         steps:
             - name: Checkout
@@ -3071,7 +3071,7 @@ jobs:
         timeout-minutes: 20
     typescript:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-4c' || 'ubuntu-24.04' }}
         name: typescript
         steps:
             - name: Checkout
@@ -3268,7 +3268,7 @@ jobs:
         timeout-minutes: 20
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-latest' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-16-3-8c-dind' || 'ubuntu-24.04' }}
         name: typescript-dev
         steps:
             - name: Checkout

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -25,6 +25,7 @@ Expected stderr:
 │ $ .from(address: "redis"): Container! X.Xs CACHED
 │ ✔ .withExposedPort(port: 6379): Container! X.Xs
 │ ✔ .asService: Service! X.Xs
+│ ┃ X:M XX XXX 20XX XX:XX:XX.XXX # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX * Redis version=X.X.X, bits=64, commit=00000000, modified=0, pid=X, just started
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf


### PR DESCRIPTION
Considering how well this worked for that one job, this PR made the change for all other `testdev-*` jobs in the `Engine & CLI` workflow. FTR:

| Job Name | Before (P99) | After |
|---------|-------------------|-------------------|
| testdev-everything-else | 1220s (20m 20s) | 973s (16m 13s) |
| testdev-cgroupsv2 | 1199s (19m 59s) | 383s (6m 23s) |
| testdev-module-runtimes | 753s (12m 33s) | 770s (12m 50s) |
| testdev-modules | 695s (11m 35s) | 631s (10m 31s) |
| testdev-container | 513s (8m 33s) | 460s (7m 40s) |
| testdev-cli-engine | 505s (8m 25s) | 446s (7m 26s) |

---

LGTM 👍

<img width="1888" alt="image" src="https://github.com/user-attachments/assets/498c6e3c-5a47-4f5f-8ccc-f33ee5916483" />

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/f060eea7-63c9-4317-9c22-fb21fcad8159" />

---

As a follow-up, we might want to fallback to the original runners if the initial runner was to fail for any reason. While I don't think that will mitigate high queue times, it would add a retry mechanism, including when hitting timeouts. Example from a different GitHub repo:
<img width="950" alt="image" src="https://github.com/user-attachments/assets/15789c38-cc28-4b39-8a81-3805684a4abe" />