### PR TITLE
shell: bring shell out of experimental

### DIFF
--- a/.changes/unreleased/Changed-20250319-123632.yaml
+++ b/.changes/unreleased/Changed-20250319-123632.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Stabilized Dagger Shell
+time: 2025-03-19T12:36:32.465472-01:00
+custom:
+    Author: helderco
+    PR: "9896"

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -122,9 +122,10 @@ func init() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:           "dagger",
-	Short:         "A tool to run CI/CD pipelines in containers, anywhere",
-	SilenceErrors: true, // handled in func main() instead
+	Use:                   "dagger [options] [file...]",
+	Short:                 "A tool to run CI/CD pipelines in containers, anywhere",
+	SilenceErrors:         true, // handled in func main() instead
+	DisableFlagsInUseLine: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, CLI parsing worked just fine; no
 		// need to show usage for runtime errors

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -123,7 +123,7 @@ func init() {
 
 var rootCmd = &cobra.Command{
 	Use:                   "dagger [options] [file...]",
-	Short:                 "A tool to run CI/CD pipelines in containers, anywhere",
+	Short:                 "A tool to run composable workflows in containers",
 	SilenceErrors:         true, // handled in func main() instead
 	DisableFlagsInUseLine: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -36,7 +36,7 @@ var (
 )
 
 func shellAddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&shellCode, "code", "c", "", "Command to be executed")
+	cmd.Flags().StringVarP(&shellCode, "code", "c", "", "Execute shell script passed in as string")
 	cmd.Flags().BoolVarP(&shellNoLoadModule, "no-mod", "n", false, "Don't load module during shell startup (mutually exclusive with --mod)")
 	cmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
 }
@@ -59,9 +59,6 @@ var shellCmd = &cobra.Command{
 		})
 	},
 	Hidden: true,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
 }
 
 func newTerminalWriter(fn func([]byte) (int, error)) *terminalWriter {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -36,7 +36,7 @@ var (
 )
 
 func shellAddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&shellCode, "code", "c", "", "Execute shell script passed in as string")
+	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a dagger shell command")
 	cmd.Flags().BoolVarP(&shellNoLoadModule, "no-mod", "n", false, "Don't load module during shell startup (mutually exclusive with --mod)")
 	cmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
 }

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -363,6 +363,7 @@ loaded as the default automatically, making its functions available at the top l
 Without arguments, the current working directory is replaced by the initial context.
 `,
 			GroupID: moduleGroup.ID,
+			Hidden:  true,
 			Args:    MaximumArgs(1),
 			State:   NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
@@ -377,6 +378,7 @@ Without arguments, the current working directory is replaced by the initial cont
 			Use:         ".pwd",
 			Description: "Print the current working directory's absolute path",
 			GroupID:     moduleGroup.ID,
+			Hidden:      true,
 			Args:        NoArgs,
 			State:       NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, _ []string, _ *ShellState) error {
@@ -390,6 +392,7 @@ Without arguments, the current working directory is replaced by the initial cont
 			Use:         ".ls [path]",
 			Description: "List files in the current working directory",
 			GroupID:     moduleGroup.ID,
+			Hidden:      true,
 			Args:        MaximumArgs(1),
 			State:       NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
@@ -421,6 +424,7 @@ Without arguments, the current working directory is replaced by the initial cont
 			Use:         shellDepsCmdName,
 			Description: "Dependencies from the module loaded in the current context",
 			GroupID:     moduleGroup.ID,
+			Hidden:      true,
 			Args:        NoArgs,
 			State:       NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, _ []string, _ *ShellState) error {
@@ -440,6 +444,7 @@ Without arguments, the current working directory is replaced by the initial cont
 		&ShellCommand{
 			Use:         shellStdlibCmdName,
 			Description: "Standard library functions",
+			Hidden:      true,
 			Args:        NoArgs,
 			State:       NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, _ []string, _ *ShellState) error {
@@ -455,6 +460,7 @@ Without arguments, the current working directory is replaced by the initial cont
 		&ShellCommand{
 			Use:         ".core [function]",
 			Description: "Load any core Dagger type",
+			Hidden:      true,
 			State:       NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
 				return h.Save(ctx, h.NewCoreState())
@@ -541,6 +547,7 @@ func cobraToShellCommand(c *cobra.Command) *ShellCommand {
 		Use:         "." + c.Use,
 		Description: c.Short,
 		GroupID:     c.GroupID,
+		Hidden:      true,
 		State:       NoState,
 		Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
 			// Re-execute the dagger command (hack)

--- a/cmd/dagger/shell_completion_test.go
+++ b/cmd/dagger/shell_completion_test.go
@@ -31,8 +31,7 @@ func Middleware() []testctx.Middleware[*testing.T] {
 	}
 }
 
-type DaggerCMDSuite struct {
-}
+type DaggerCMDSuite struct{}
 
 func TestDaggerCMD(tt *testing.T) {
 	testctx.New(tt, Middleware()...).RunTests(DaggerCMDSuite{})
@@ -79,20 +78,23 @@ func (DaggerCMDSuite) TestShellAutocomplete(ctx context.Context, t *testctx.T) {
 		`container <--$packages > | directory`,
 		`container | directory <--$expand >`,
 
-		// .deps builtin
-		`.deps | <$alpine >`,
-		`.deps | <a$lpine >`,
+		// TODO: These have been hidden. Uncomment when stable, or put them
+		// bethind a feature flag so they can be tested even if hidden.
 
-		// .stdlib builtin
-		`.stdlib | <$container >`,
-		`.stdlib | <con$tainer >`,
-		`.stdlib | container <--$platform >`,
-		`.stdlib | container | <dir$ectory >`,
-
-		// .core builtin
-		`.core | <con$tainer >`,
-		`.core | container <--$platform >`,
-		`.core | container | <dir$ectory >`,
+		// // .deps builtin
+		// `.deps | <$alpine >`,
+		// `.deps | <a$lpine >`,
+		//
+		// // .stdlib builtin
+		// `.stdlib | <$container >`,
+		// `.stdlib | <con$tainer >`,
+		// `.stdlib | container <--$platform >`,
+		// `.stdlib | container | <dir$ectory >`,
+		//
+		// // .core builtin
+		// `.core | <con$tainer >`,
+		// `.core | container <--$platform >`,
+		// `.core | container | <dir$ectory >`,
 
 		// FIXME: avoid inserting extra spaces
 		// `<contain$er> `,

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -966,7 +966,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 
 		return fe, tea.Batch(
 			tea.Printf(
-				`Experimental Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`+
+				`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`+
 					"\n"),
 			fe.editline.Focus(),
 			tea.DisableMouse,

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -7,7 +7,7 @@ pagination_prev: null
 # CLI Reference
 ## dagger
 
-A tool to run CI/CD pipelines in containers, anywhere
+A tool to run composable workflows in containers
 
 ```
 dagger [options] [file...]
@@ -16,7 +16,7 @@ dagger [options] [file...]
 ### Options
 
 ```
-  -c, --code string                  Execute shell script passed in as string
+  -c, --command string               Execute a dagger shell command
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -79,7 +79,7 @@ dagger call [options]
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger config
 
@@ -123,7 +123,7 @@ dagger config -m github.com/dagger/hello-dagger
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger core
 
@@ -156,7 +156,7 @@ dagger core [options]
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger develop
 
@@ -212,7 +212,7 @@ dagger develop [options]
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger functions
 
@@ -252,7 +252,7 @@ dagger functions [options] [function]...
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger init
 
@@ -303,7 +303,7 @@ dagger init --sdk=python
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger install
 
@@ -347,7 +347,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger login
 
@@ -373,7 +373,7 @@ dagger login [options] [org]
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger logout
 
@@ -399,7 +399,7 @@ dagger logout
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger query
 
@@ -461,7 +461,7 @@ EOF
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger run
 
@@ -520,7 +520,7 @@ dagger run python main.py
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger uninstall
 
@@ -562,7 +562,7 @@ dagger uninstall hello
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger update
 
@@ -604,7 +604,7 @@ dagger update [options] <module>
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 
 ## dagger version
 
@@ -636,5 +636,5 @@ dagger version
 
 ### SEE ALSO
 
-* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -10,13 +10,13 @@ pagination_prev: null
 A tool to run CI/CD pipelines in containers, anywhere
 
 ```
-dagger [flags]
+dagger [options] [file...]
 ```
 
 ### Options
 
 ```
-  -c, --code string                  Command to be executed
+  -c, --code string                  Execute shell script passed in as string
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")


### PR DESCRIPTION
## Bikeshedding

### Hide `dagger shell`?

Removed the "Experimental" annotation in `dagger shell` (was shown in `--help`) but kept it hidden to avoid confusion over using `dagger shell` vs `dagger`. May want to expose it anyway.

<img width="1106" alt="Screenshot 2025-03-18 at 23 41 00" src="https://github.com/user-attachments/assets/0667cc39-b873-48fd-9239-95e86758dc14" />


### Hide shell builtins?

Hid the following shell builtins:
- Filesystem navigation: `.cd`, `.ls`, `.pwd`
- Scoping: `.stdlib`, `.deps`, `.core`
- Cobra subprocesses: `.install`, `.update`, `.upgrade`, `.login`, `.logout`

This is what remains:

<img width="812" alt="Screenshot 2025-03-18 at 23 38 18" src="https://github.com/user-attachments/assets/66d09cc2-be96-430c-8101-49749885b44f" />


### REPL Experimental?

Removed the "Experimental" notice when you start an interactive session (REPL). Could consider the TUI in interactive mode still experimental, while not the entire shell.

<img width="832" alt="Screenshot 2025-03-18 at 23 37 10" src="https://github.com/user-attachments/assets/7ab30ffa-cee5-4744-961d-51376cc9c8aa" />

