### PR TITLE
shell: show available functions in `.help <module>`

### DIFF
--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -662,6 +662,8 @@ Without arguments, the current working directory is replaced by the initial cont
 	def := h.GetDef(nil)
 
 	for _, fn := range def.GetCoreFunctions() {
+		def.LoadFunctionTypeDefs(fn)
+
 		// TODO: Don't hardcode this list.
 		promoted := []string{
 			"llm",

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -422,11 +422,11 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 							return h.Print(ctx, h.DepsHelp())
 						}
 						// Example: `.deps | .help <dependency>`
-						depSt, depDef, err := h.GetDependency(ctx, args[0])
+						_, depDef, err := h.GetDependency(ctx, args[0])
 						if err != nil {
 							return err
 						}
-						return h.Print(ctx, h.ModuleDoc(depSt, depDef))
+						return h.Print(ctx, h.ModuleDoc(depDef))
 
 					case st.IsCore():
 						// Document core
@@ -447,7 +447,7 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 						}
 						// Document module
 						// Example: `.help [module]`
-						return h.Print(ctx, h.ModuleDoc(st, def))
+						return h.Print(ctx, h.ModuleDoc(def))
 					}
 				}
 

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -585,9 +585,7 @@ Without arguments, the current working directory is replaced by the initial cont
 				}
 
 				// Update handler state with new definition
-				h.mu.Lock()
 				h.modDefs.Store(def.SourceDigest, newDef)
-				h.mu.Unlock()
 
 				// Reload type definitions
 				if err := newDef.loadTypeDefs(ctx, h.dag); err != nil {

--- a/cmd/dagger/shell_help.go
+++ b/cmd/dagger/shell_help.go
@@ -488,7 +488,9 @@ func (h *shellCallHandler) ModuleDoc(st *ShellState, m *moduleDef) string {
 				return f.CmdName(), f.Short()
 			}),
 		)
-		doc.Add("", `Use ".help <function>" for more information on a function.`)
+		doc.Add("", fmt.Sprintf(`Use "%s | .help <function>" for more information on a function.`,
+			strings.TrimSuffix(usage, " [options]"),
+		))
 	}
 
 	return doc.String()

--- a/cmd/dagger/shell_help.go
+++ b/cmd/dagger/shell_help.go
@@ -429,7 +429,7 @@ func (h *shellCallHandler) FunctionFullUseLine(md *moduleDef, fn *modFunction) s
 	return usage
 }
 
-func (h *shellCallHandler) ModuleDoc(st *ShellState, m *moduleDef) string {
+func (h *shellCallHandler) ModuleDoc(m *moduleDef) string {
 	var doc ShellDoc
 
 	meta := new(strings.Builder)

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -154,7 +154,7 @@ func (Other) Version() string {
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "MODULE")
-		require.Contains(t, out, "Main module")
+		require.Contains(t, out, "Test main object")
 		require.Contains(t, out, "ENTRYPOINT")
 		require.Contains(t, out, "Usage: . [options]")
 	})
@@ -241,7 +241,7 @@ func (Other) Version() string {
 		require.NoError(t, err)
 		require.Contains(t, out, "A git helper")
 		require.Contains(t, out, "ENTRYPOINT")
-		require.NotContains(t, out, "AVAILABLE FUNCTIONS")
+		require.Contains(t, out, "AVAILABLE FUNCTIONS")
 	})
 
 	t.Run("other module function", func(ctx context.Context, t *testctx.T) {
@@ -259,7 +259,7 @@ func (Other) Version() string {
 		require.NoError(t, err)
 		require.Contains(t, out, "A local module")
 		require.NotContains(t, out, "ENTRYPOINT")
-		require.NotContains(t, out, "AVAILABLE FUNCTIONS")
+		require.Contains(t, out, "AVAILABLE FUNCTIONS")
 	})
 
 	t.Run("current module required constructor arg error", func(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
## What?

This is an experiment to see if including a module's top-level functions in `.help <module>` makes sense.

## Why?

Some people asked why `.help <module>` didn’t show top level functions. Short answer is to keep it consistent with `.help <function>` since a `<module>` is basically the first **function** in a module, or its entrypoint (aka, constructor).

The list of a module’s functions comes from the object type that the entrypoint returns: the main object. This is like an object type returned by any other function where you list its functions with:
```shell
<function> | .help
```
So similarly, for a module’s functions:
```shell
<module> | .help
```

If we add the list of functions in a function’s “Returns” section, it’ll distract from the main part of `.help <function> | <module>` which is its usage, arguments, and description.

## How?

I wondered if it was helpful to at least show the function names (to avoid overwhelm), and not the descriptions:

```console
⋈ .help dagger-dev
MODULE
  dagger-dev

  Everything you need to develop the Dagger Engine
  https://dagger.io

ENTRYPOINT
  Usage: . [options]

  OPTIONAL ARGUMENTS
    --source Directory    (default: "/")
    --docker-cfg Secret

RETURNS
  DaggerDev - A dev environment for the DaggerDev Engine

  Available functions:
    - version
    - tag
    - mod-codegen
    - mod-codegen-targets
    - check
    - with-mod-codegen
    - cli
    - source
    - go
    - engine
    - docs
    - scripts
    - test
    - bench
    - generate
    - sdk
    - dev

  Use ". | .help" for more details.
  Use ". | .help <function>" for more information on a function.
```

However, in some cases it can be too much, for example:

```console
⋈ .help container
Creates a scratch container.

Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.

USAGE
  container [options]

OPTIONAL ARGUMENTS
  --platform Platform   Platform to initialize the container with.

RETURNS
  Container - An OCI-compatible container, also known as a Docker container.

  Available functions:
    - as-service
    - as-tarball
    - build
    - default-args
    - directory
    - entrypoint
    - env-variable
    - env-variables
    - exit-code
    - experimental-with-all-gp-us
    - experimental-with-gpu
    - export
    - exposed-ports
    - file
    - from
    - image-ref
    - import
    - label
    - labels
    - mounts
    - platform
    - publish
    - rootfs
    - stderr
    - stdout
    - sync
    - terminal
    - up
    - user
    - with-annotation
    - with-default-args
    - with-default-terminal-cmd
    - with-directory
    - with-entrypoint
    - with-env-variable
    - with-exec
    - with-exposed-port
    - with-file
    - with-files
    - with-label
    - with-mounted-cache
    - with-mounted-directory
    - with-mounted-file
    - with-mounted-secret
    - with-mounted-temp
    - with-new-file
    - with-registry-auth
    - with-rootfs
    - with-secret-variable
    - with-service-binding
    - with-unix-socket
    - with-user
    - with-workdir
    - without-annotation
    - without-default-args
    - without-directory
    - without-entrypoint
    - without-env-variable
    - without-exposed-port
    - without-file
    - without-files
    - without-label
    - without-mount
    - without-registry-auth
    - without-secret-variable
    - without-unix-socket
    - without-user
    - without-workdir
    - workdir

  Use "container | .help" for more details.
  Use "container | .help <function>" for more information on a function.
```

## Bikeshedding ✅

I think the focus should be on the usage, not returned functions. We could special case only `<module>` instead of `<function>` as well, at the cost of consistency.

So, keep the list or just `Use "container | .help" for more details."`?

<pre>
Creates a scratch container.

Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.

USAGE
  container [options]

OPTIONAL ARGUMENTS
  --platform Platform   Platform to initialize the container with.

RETURNS
  Container - An OCI-compatible container, also known as a Docker container.

  <strong>Use "container | .help" for more details.</strong>
</pre>

## Conclusion

- Don't add list of functions to `.help <function>` but keep message for getting more details
- Recover list of functions, with descriptions in `.help <module>` since it was lost in the merge with `.doc`
- Changed module description to prefer the main object's, and only using the module's general description as a fallback