### PR TITLE
add TestAllowLLM, currently hanging mysteriously

### DIFF
--- a/core/integration/llmtest/go-programmer/main.go
+++ b/core/integration/llmtest/go-programmer/main.go
@@ -21,6 +21,7 @@ func (m *GoProgrammer) Run(
 	return m.llm(assignment).ToyWorkspace().Container()
 }
 
+// this is a hack at least until we can return the LLM type to have a better way to save/replay history
 func (m *GoProgrammer) Save(
 	ctx context.Context,
 	assignment string,

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -36,6 +36,15 @@ func daggerShellNoMod(script string) dagger.WithContainerFunc {
 	}
 }
 
+func daggerShellAllowAllLLM(script string) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		return c.WithExec([]string{"dagger", "--allow-llm=all"}, dagger.ContainerWithExecOpts{
+			Stdin:                         script,
+			ExperimentalPrivilegedNesting: true,
+		})
+	}
+}
+
 func (ShellSuite) TestDefaultToModule(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/engine/session/prompt.go
+++ b/engine/session/prompt.go
@@ -48,7 +48,6 @@ func (p PromptAttachable) Register(srv *grpc.Server) {
 	RegisterPromptServer(srv, p)
 }
 
-// right now this is hardcoded to allow llm prompts, but could easily be extended to other prompt use cases
 func (p PromptAttachable) PromptBool(ctx context.Context, req *BoolRequest) (*BoolResponse, error) {
 	if req.Prompt == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid input: Prompt required")


### PR DESCRIPTION
putting this up as draft so maybe @jedevc can see something dumb i'm doing in here that's making this hang... i've tried invoking via shell and call plus various ways of passing the allowed module. still seems like regardless of what I do it hangs. 

the daggerCliBase technique + daggerForwardSecrets thing works for the TestAPILimit test right above this one, so if it's something in the test code, it's a typo I can't see even though i'm looking right at it... one thing that's not in this draft is that i'm actually calling this using the commented out impl for daggerForwardSecrets.

one other possibility is there is some code path that blocks on a tty read, and we don't have a tty here. tomorrow i'm gonna try to pivot to using `hostDaggerExec` and `newTUIConsole` so we can actually try to interact with the prompt that might or might not be displaying here.