### PR TITLE
docs: use scoped enum in continue-after-errors snippets

### DIFF
--- a/docs/current_docs/cookbook/snippets/continue-after-errors/go/main.go
+++ b/docs/current_docs/cookbook/snippets/continue-after-errors/go/main.go
@@ -31,7 +31,7 @@ func (m *MyModule) Test(ctx context.Context) (*TestResult, error) {
 		// add script with execution permission to simulate a testing tool
 		WithNewFile("/run-tests", script, dagger.ContainerWithNewFileOpts{Permissions: 0o750}).
 		// run-tests but allow any return code
-		WithExec([]string{"/run-tests"}, dagger.ContainerWithExecOpts{Expect: dagger.Any}).
+		WithExec([]string{"/run-tests"}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny}).
 		// the result of `sync` is the container, which allows continued chaining
 		Sync(ctx)
 	if err != nil {


### PR DESCRIPTION
This should have been done with https://github.com/dagger/dagger/pull/8669, but looks like this change was missed.

Glancing through the cookbook, I can't see any other examples like this.

Thanks to @vikram-dagger for flagging :pray: 