### PR TITLE
Ensure consistent `/run/dagger/engine.sock` path

### DIFF
--- a/.dagger/config.go
+++ b/.dagger/config.go
@@ -19,7 +19,6 @@ const (
 	engineTOMLPath       = "/etc/dagger/engine.toml"
 	engineJSONPath       = "/etc/dagger/engine.json"
 	engineEntrypointPath = "/usr/local/bin/dagger-entrypoint.sh"
-	engineUnixSocketPath = "/var/run/dagger/engine.sock"
 	cliPath              = "/usr/local/bin/dagger"
 )
 

--- a/.dagger/engine.go
+++ b/.dagger/engine.go
@@ -113,7 +113,7 @@ func (e *DaggerEngine) Container(
 	})
 	ctr = ctr.
 		WithFile(cliPath, cli).
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "unix://"+engineUnixSocketPath)
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", distconsts.DefaultEngineSockAddr)
 
 	return ctr, nil
 }

--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -38,8 +38,6 @@ func defaultBuildkitConfig() (bkconfig.Config, error) {
 }
 
 func setDefaultBuildkitConfig(cfg *bkconfig.Config, netConf *networkConfig) {
-	orig := *cfg
-
 	if cfg.Root == "" {
 		cfg.Root = distconsts.EngineDefaultStateDir
 	}
@@ -72,21 +70,6 @@ func setDefaultBuildkitConfig(cfg *bkconfig.Config, netConf *networkConfig) {
 	}
 	if cfg.Workers.Containerd.Platforms == nil {
 		cfg.Workers.Containerd.Platforms = server.FormatPlatforms(archutil.SupportedPlatforms(false))
-	}
-
-	if userns.RunningInUserNS() {
-		// if buildkitd is being executed as the mapped-root (not only EUID==0 but also $USER==root)
-		// in a user namespace, we need to enable the rootless mode but
-		// we don't want to honor $HOME for setting up default paths.
-		if u := os.Getenv("USER"); u != "" && u != "root" {
-			if orig.Root == "" {
-				cfg.Root = appdefaults.UserRoot()
-			}
-			if len(orig.GRPC.Address) == 0 {
-				cfg.GRPC.Address = []string{appdefaults.UserAddress()}
-			}
-			appdefaults.EnsureUserAddressDir()
-		}
 	}
 }
 

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -535,7 +535,7 @@ func applyMainFlags(c *cli.Context, cfg *bkconfig.Config) error {
 	}
 
 	if c.IsSet("addr") || len(cfg.GRPC.Address) == 0 {
-		cfg.GRPC.Address = c.StringSlice("addr")
+		cfg.GRPC.Address = append(cfg.GRPC.Address, c.StringSlice("addr")...)
 	}
 
 	if c.IsSet("allow-insecure-entitlement") {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -64,7 +64,6 @@ func devEngineContainer(c *dagger.Client, withs ...func(*dagger.Container) *dagg
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		WithDefaultArgs([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/dagger/engine.sock",
 			// avoid network conflicts with other tests
 			"--network-name", deviceName,
 			"--network-cidr", cidr,

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -1,10 +1,12 @@
 package engine
 
+import "github.com/dagger/dagger/engine/distconsts"
+
 const (
 	EngineImageRepo = "registry.dagger.io/engine"
 	Package         = "github.com/dagger/dagger"
 
-	DefaultEngineSockAddr = "unix:///run/dagger/engine.sock"
+	DefaultEngineSockAddr = distconsts.DefaultEngineSockAddr
 
 	DaggerNameEnv = "_EXPERIMENTAL_DAGGER_ENGINE_NAME"
 

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -7,6 +7,8 @@ package distconsts
 
 const (
 	EngineContainerName = "dagger-engine.dev"
+
+	DefaultEngineSockAddr = "unix:///run/dagger/engine.sock"
 )
 
 const (

--- a/modules/compatcheck/main.go
+++ b/modules/compatcheck/main.go
@@ -127,7 +127,6 @@ func engineServiceWithVersion(version string, withs ...func(*dagger.Container) *
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
 		WithExec([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/dagger/engine.sock",
 			// // avoid network conflicts with other tests
 			"--network-name", deviceName,
 			"--network-cidr", cidr,

--- a/modules/daggerverse/main.go
+++ b/modules/daggerverse/main.go
@@ -152,7 +152,6 @@ func (h *Daggerverse) BumpDaggerVersion(
 		WithExposedPort(1234).
 		WithDefaultArgs([]string{
 			"--addr", "tcp://0.0.0.0:1234",
-			"--addr", "unix:///var/run/dagger/engine.sock",
 			"--network-cidr", "10.12.34.0/24",
 		}).AsService(dagger.ContainerAsServiceOpts{InsecureRootCapabilities: true, UseEntrypoint: true})
 


### PR DESCRIPTION
We were using `/var/run/dagger/engine.sock` in a couple of places (after https://github.com/dagger/dagger/pull/9866), so this patch removes those.

Some of them just need to be renamed, but others should be entirely removed - the `--addr` flag shouldn't ever need to manually append the socket, we should automatically always add it.