### PR TITLE
tests: scrub redis memory overcommit warning

### DIFF
--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -385,6 +385,12 @@ var scrubs = []scrubber{
 		"9.3 kB",
 		"X.X B",
 	},
+	// Memory overcommit warning for redis
+	{
+		regexp.MustCompile(`.+WARNING Memory overcommit.+\n`),
+		"# WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.\n",
+		"",
+	},
 }
 
 func TestScrubbers(t *testing.T) {

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -25,7 +25,6 @@ Expected stderr:
 │ $ .from(address: "redis"): Container! X.Xs CACHED
 │ ✔ .withExposedPort(port: 6379): Container! X.Xs
 │ ✔ .asService: Service! X.Xs
-│ ┃ X:M XX XXX 20XX XX:XX:XX.XXX # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX * Redis version=X.X.X, bits=64, commit=00000000, modified=0, pid=X, just started
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf


### PR DESCRIPTION
Follow up from https://github.com/dagger/dagger/pull/9887#discussion_r2002117267.

Looks like it just needed the newline at the end :tada: