### PR TITLE
add examples page

### DIFF
--- a/docs/current_docs/examples.mdx
+++ b/docs/current_docs/examples.mdx
@@ -37,12 +37,12 @@ Explore these functional AI agent examples built with Dagger:
 
 ## Cookbook Examples
 
-The [Dagger Cookbook](/cookbook/cookbook) contains practical code examples for common tasks:
+The [Dagger Cookbook](/cookbook) contains practical code examples for common tasks:
 
-- [Filesystem Operations](/cookbook/cookbook#filesystem): Working with files and directories
-- [Build Operations](/cookbook/cookbook#builds): Building applications and container images
-- [Service Management](/cookbook/cookbook#services): Working with services and networking
-- [Secret Handling](/cookbook/cookbook#secrets): Managing sensitive data securely
+- [Filesystem Operations](/cookbook#filesystem): Working with files and directories
+- [Build Operations](/cookbook#builds): Building applications and container images
+- [Service Management](/cookbook#services): Working with services and networking
+- [Secret Handling](/cookbook#secrets): Managing sensitive data securely
 
 ## Contributing Examples
 

--- a/docs/current_docs/examples.mdx
+++ b/docs/current_docs/examples.mdx
@@ -44,7 +44,7 @@ The [Dagger Cookbook](/cookbook) contains practical code examples for common tas
 - [Service Management](/cookbook#services): Working with services and networking
 - [Secret Handling](/cookbook#secrets): Managing sensitive data securely
 
-## Contributing Examples
+## Contribute Examples
 
 Have you created a Dagger example you'd like to share?
 

--- a/docs/current_docs/examples.mdx
+++ b/docs/current_docs/examples.mdx
@@ -1,0 +1,52 @@
+---
+slug: /examples
+description: Explore real-world examples of Dagger in action, from AI agents to CI/CD implementations.
+---
+
+# Examples
+
+This page showcases real-world examples of Dagger in action, with a focus on working implementations you can study and adapt.
+
+## AI Agent Examples
+
+Explore these functional AI agent examples built with Dagger:
+
+- [Toy Programmer](https://github.com/shykes/toy-programmer): A simple programmer micro-agent for demonstration purposes
+
+- [Melvin](https://github.com/dagger/agents/tree/main/melvin): An experimental open-source coding agent made of small composable modules
+
+- [Multi-Agent Demo](https://github.com/kpenfound/agents/tree/main/multiagent-demo): A demonstration using multiple LLMs to collaboratively solve a problem
+
+- [Go Coder](https://github.com/kpenfound/agents/tree/main/go-coder): A Go programmer agent that receives assignments from GitHub issues and creates PRs with solutions
+
+- [Cypress Test Writer](https://github.com/jpadams/cypress-test-writer): An agent that compares two git branches for UI changes and creates Cypress tests to cover the differences
+
+- [Tic Tac Toe](https://github.com/kpenfound/agents/tree/main/tictactoe): An agent that plays Tic Tac Toe with a human player
+
+- [Dockerfile Optimizer](https://github.com/samalba/agents/tree/main/dockerfile-optimizer): An agent that analyzes Dockerfiles and suggests improvements for better efficiency, security, and best practices
+
+- [Test Debugger](https://github.com/kpenfound/greetings-api/blob/main/DEBUGGER_AGENT.md): An agent that automatically debugs failing tests in CI
+
+- [Technical Content Summarizer](https://github.com/jasonmccallister/technical-content-summarizer): An agent that summarizes technical content from a URL for a non-technical audience
+
+- [SWE Agent](https://github.com/kpenfound/greetings-api/blob/main/SWE_AGENT.md): An agent that gets assigned GitHub issues and solves them with pull requests
+
+## CI/CD Examples
+
+- [Hello Dagger](https://github.com/dagger/hello-dagger): A simple example demonstrating Dagger's CI capabilities with a Vue.js application
+
+## Cookbook Examples
+
+The [Dagger Cookbook](/cookbook/cookbook) contains practical code examples for common tasks:
+
+- [Filesystem Operations](/cookbook/cookbook#filesystem): Working with files and directories
+- [Build Operations](/cookbook/cookbook#builds): Building applications and container images
+- [Service Management](/cookbook/cookbook#services): Working with services and networking
+- [Secret Handling](/cookbook/cookbook#secrets): Managing sensitive data securely
+
+## Contributing Examples
+
+Have you created a Dagger example you'd like to share?
+
+- Share it on our [Discord](https://discord.gg/dagger-io)
+- Share it on X (Twitter) and tag [@dagger_io](https://twitter.com/dagger_io)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -33,6 +33,11 @@ module.exports = {
       id: "agents",
     },
     {
+      type: "doc",
+      label: "Examples",
+      id: "examples",
+    },
+    {
       type: "category",
       label: "Dagger for CI",
       items: [


### PR DESCRIPTION
Add a new top-level page in docs to list all our examples.