### PR TITLE
python: avoid telemetry shutdown issue from upstream

### DIFF
--- a/sdk/python/src/dagger/telemetry.py
+++ b/sdk/python/src/dagger/telemetry.py
@@ -113,7 +113,7 @@ class _DaggerPropagationConfigurator(_BaseConfigurator):
             context.attach(ctx)
 
 
-class LiveSpanProcessor(sdktrace.ConcurrentMultiSpanProcessor):
+class LiveSpanProcessor(sdktrace.SynchronousMultiSpanProcessor):
     """Live span processor implementation.
 
     It's a SpanProcessor whose on_start calls on_end on the underlying


### PR DESCRIPTION
This avoids https://github.com/open-telemetry/opentelemetry-python/issues/4461 until https://github.com/open-telemetry/opentelemetry-python/pull/4462 is released.

Fixes https://github.com/dagger/dagger/issues/9764