### PR TITLE
add TestLLM/TestAllowLLM, TestLLM/TestAPILimit, and fix bug in nested client --allow-llm metadata propagation

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -91,7 +91,9 @@ func withEngine(
 		params.Interactive = interactive
 		params.InteractiveCommand = interactiveCommandParsed
 
-		params.PromptHandler = Frontend
+		if hasTTY {
+			params.PromptHandler = Frontend
+		}
 
 		// Connect to and run with the engine
 		sess, ctx, err := client.Connect(ctx, params)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -93,7 +93,11 @@ func getCompatVersion() string {
 
 func init() {
 	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to the module directory. Either local path or a remote git repo")
-	moduleFlags.StringSliceVar(&allowedLLMModules, "allow-llm", nil, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
+	var defaultAllowLLM []string
+	if allowLLMEnv := os.Getenv("DAGGER_ALLOW_LLM"); allowLLMEnv != "" {
+		defaultAllowLLM = strings.Split(allowLLMEnv, ",")
+	}
+	moduleFlags.StringSliceVar(&allowedLLMModules, "allow-llm", defaultAllowLLM, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
 
 	for _, fc := range funcCmds {
 		if !fc.DisableModuleLoad {

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -224,6 +224,15 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 		}
 	})
 
+	t.Run("noninteractive prompt fail", func(ctx context.Context, t *testctx.T) {
+		args := []string{modelFlag, "save", "--string-arg", "greet me"}
+
+		_, err = daggerCliBase(t, c).
+			With(daggerCallAt(directCallModuleRef, args...)).
+			Stdout(ctx)
+		require.Error(t, err)
+	})
+
 	// // TODO, not yet implemented
 	// t.Run("environment variable", func(ctx context.Context, t *testctx.T) {
 	// 	_, err = daggerCliBase(t, c).

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -159,9 +159,9 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	// llm-test-module passes a prompt to LLM and sets a random string variable to bust cache
-	directCallModuleRef := "github.com/cwlbraa/dagger-test-modules/llm-dir-module-depender/llm-test-module"
+	directCallModuleRef := "github.com/dagger/dagger-test-modules/llm-dir-module-depender/llm-test-module"
 	// llm-dir-module-depender depends on directCall module via a relative path
-	dependerModuleRef := "github.com/cwlbraa/dagger-test-modules/llm-dir-module-depender"
+	dependerModuleRef := "github.com/dagger/dagger-test-modules/llm-dir-module-depender"
 
 	recording := "llmtest/allow-llm.golden"
 	if golden.FlagUpdate() {

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -216,7 +216,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 			t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 				args := []string{"--allow-llm", tc.allowLLM, modelFlag, "save", "--string-arg", "greet me"}
 
-				_, err = daggerCliBase(t, c).
+				_, err := daggerCliBase(t, c).
 					With(daggerCallAt(tc.module, args...)).
 					Stdout(ctx)
 				require.NoError(t, err)
@@ -227,14 +227,14 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	t.Run("noninteractive prompt fail", func(ctx context.Context, t *testctx.T) {
 		args := []string{modelFlag, "save", "--string-arg", "greet me"}
 
-		_, err = daggerCliBase(t, c).
+		_, err := daggerCliBase(t, c).
 			With(daggerCallAt(directCallModuleRef, args...)).
 			Stdout(ctx)
 		require.Error(t, err)
 	})
 
 	t.Run("environment variable", func(ctx context.Context, t *testctx.T) {
-		_, err = daggerCliBase(t, c).
+		_, err := daggerCliBase(t, c).
 			WithEnvVariable("DAGGER_ALLOW_LLM", "all").
 			With(daggerCallAt(dependerModuleRef, modelFlag, "save", "--string-arg", "greet me")).
 			Stdout(ctx)
@@ -242,7 +242,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("shell allow all", func(ctx context.Context, t *testctx.T) {
-		_, err = daggerCliBase(t, c).
+		_, err := daggerCliBase(t, c).
 			WithExec([]string{"dagger", "-m", dependerModuleRef, "--allow-llm=all"}, dagger.ContainerWithExecOpts{
 				Stdin:                         fmt.Sprintf(`. %s | save "greet me"`, modelFlag),
 				ExperimentalPrivilegedNesting: true,
@@ -252,7 +252,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("shell interactive module loads", func(ctx context.Context, t *testctx.T) {
-		_, err = daggerCliBase(t, c).
+		_, err := daggerCliBase(t, c).
 			WithExec([]string{"dagger", "--allow-llm", directCallModuleRef}, dagger.ContainerWithExecOpts{
 				Stdin:                         fmt.Sprintf(`%s %s | save "greet me"`, dependerModuleRef, modelFlag),
 				ExperimentalPrivilegedNesting: true,
@@ -332,7 +332,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 				)
 				defer console.Close()
 
-				err = cmd.Start()
+				err := cmd.Start()
 				require.NoError(t, err)
 
 				_, err = console.ExpectString("attempted to access the LLM API. Allow it?")

--- a/core/integration/llmtest/allow-llm.golden
+++ b/core/integration/llmtest/allow-llm.golden
@@ -1,0 +1,29 @@
+[
+  {
+    "role": "user",
+    "content": "greet me",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "user",
+    "content": "The variable \"CACHE_BUSTER\" has been set to String.",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "assistant",
+    "content": "I don't see any specific tools available for greeting functionality among the provided functions. The available tools are mainly focused on object management and manipulation (_objects, _selectTools, _save, _undo, _current, _scratch).\n\nWhile I can certainly say \"Hello! How can I help you today?\" as part of our conversation, I cannot perform a specific greeting function since it's not available in the tool set.\n\nIs there something specific you'd like to do with the available object management tools instead?",
+    "token_usage": {
+      "InputTokens": 644,
+      "OutputTokens": 107,
+      "TotalTokens": 751
+    }
+  }
+]

--- a/core/integration/llmtest/go-programmer/main.go
+++ b/core/integration/llmtest/go-programmer/main.go
@@ -21,6 +21,7 @@ func (m *GoProgrammer) Run(
 	return m.llm(assignment).ToyWorkspace().Container()
 }
 
+// this is a hack at least until we can return the LLM type to have a better way to save/replay history
 func (m *GoProgrammer) Save(
 	ctx context.Context,
 	assignment string,

--- a/core/llm.go
+++ b/core/llm.go
@@ -680,10 +680,10 @@ func (llm *LLM) allowed(ctx context.Context) error {
 
 	bk, err := llm.Query.Buildkit(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("llm sync failed fetching bk client for llm allow prompting: %w", err)
 	}
 
-	return bk.AllowLLM(ctx, moduleUrl)
+	return bk.PromptAllowLLM(ctx, moduleUrl)
 }
 
 func (llm *LLM) History(ctx context.Context, dag *dagql.Server) ([]string, error) {

--- a/core/llm.go
+++ b/core/llm.go
@@ -671,9 +671,9 @@ func (llm *LLM) allowed(ctx context.Context) error {
 		return fmt.Errorf("llm sync failed fetching client metadata from context: %w", err)
 	}
 
-	moduleUrl := module.Source.Self.Git.Symbolic
+	moduleURL := module.Source.Self.Git.Symbolic
 	for _, allowedModule := range md.AllowedLLMModules {
-		if allowedModule == "all" || moduleUrl == allowedModule {
+		if allowedModule == "all" || moduleURL == allowedModule {
 			return nil
 		}
 	}
@@ -683,7 +683,7 @@ func (llm *LLM) allowed(ctx context.Context) error {
 		return fmt.Errorf("llm sync failed fetching bk client for llm allow prompting: %w", err)
 	}
 
-	return bk.PromptAllowLLM(ctx, moduleUrl)
+	return bk.PromptAllowLLM(ctx, moduleURL)
 }
 
 func (llm *LLM) History(ctx context.Context, dag *dagql.Server) ([]string, error) {

--- a/core/llm.go
+++ b/core/llm.go
@@ -654,11 +654,6 @@ func (llm *LLM) Sync(ctx context.Context, dag *dagql.Server) (*LLM, error) {
 }
 
 func (llm *LLM) allowed(ctx context.Context) error {
-	bk, err := llm.Query.Buildkit(ctx)
-	if err != nil {
-		return err
-	}
-
 	module, err := llm.Query.CurrentModule(ctx)
 	if err != nil {
 		// allow non-module calls
@@ -671,7 +666,24 @@ func (llm *LLM) allowed(ctx context.Context) error {
 		return nil
 	}
 
-	return bk.AllowLLM(ctx, module.Source.Self.Git.CloneRef)
+	md, err := engine.ClientMetadataFromContext(ctx) // not mainclient
+	if err != nil {
+		return fmt.Errorf("llm sync failed fetching client metadata from context: %w", err)
+	}
+
+	moduleUrl := module.Source.Self.Git.Symbolic
+	for _, allowedModule := range md.AllowedLLMModules {
+		if allowedModule == "all" || moduleUrl == allowedModule {
+			return nil
+		}
+	}
+
+	bk, err := llm.Query.Buildkit(ctx)
+	if err != nil {
+		return err
+	}
+
+	return bk.AllowLLM(ctx, moduleUrl)
 }
 
 func (llm *LLM) History(ctx context.Context, dag *dagql.Server) ([]string, error) {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -657,20 +657,10 @@ func (c *Client) GetCredential(ctx context.Context, protocol, host, path string)
 }
 
 func (c *Client) AllowLLM(ctx context.Context, moduleRepoURL string) error {
-	md, err := engine.ClientMetadataFromContext(ctx) // not mainclient
-	if err != nil {
-		return fmt.Errorf("llm sync failed fetching client metadata from context: %w", err)
-	}
-	for _, allowedModule := range md.AllowedLLMModules {
-		if allowedModule == "all" || moduleRepoURL == allowedModule {
-			return nil
-		}
-	}
-
 	// the flag hasn't allowed this LLM call, so prompt the user
 	caller, err := c.GetMainClientCaller()
 	if err != nil {
-		return fmt.Errorf("failed to get main client caller for %q: %w", md.ClientID, err)
+		return fmt.Errorf("failed to get main client caller to to prompt for allow llm: %w", err)
 	}
 
 	response, err := session.NewPromptClient(caller.Conn()).PromptBool(ctx, &session.BoolRequest{

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -656,7 +656,7 @@ func (c *Client) GetCredential(ctx context.Context, protocol, host, path string)
 	}
 }
 
-func (c *Client) AllowLLM(ctx context.Context, moduleRepoURL string) error {
+func (c *Client) PromptAllowLLM(ctx context.Context, moduleRepoURL string) error {
 	// the flag hasn't allowed this LLM call, so prompt the user
 	caller, err := c.GetMainClientCaller()
 	if err != nil {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -919,8 +919,10 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // size.
 func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Request, execMD *buildkit.ExecutionMetadata) {
 	clientVersion := engine.Version
+	allowedLLMModules := execMD.AllowedLLMModules
 	if md, _ := engine.ClientMetadataFromHTTPHeaders(r.Header); md != nil {
 		clientVersion = md.ClientVersion
+		allowedLLMModules = md.AllowedLLMModules
 	}
 
 	httpHandlerFunc(srv.serveHTTPToClient, &ClientInitOpts{
@@ -933,7 +935,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			ClientStableID:    execMD.ClientStableID,
 			Labels:            map[string]string{},
 			SSHAuthSocketPath: execMD.SSHAuthSocketPath,
-			AllowedLLMModules: execMD.AllowedLLMModules,
+			AllowedLLMModules: allowedLLMModules,
 		},
 		CallID:              execMD.CallID,
 		CallerClientID:      execMD.CallerClientID,

--- a/engine/session/prompt.go
+++ b/engine/session/prompt.go
@@ -48,7 +48,6 @@ func (p PromptAttachable) Register(srv *grpc.Server) {
 	RegisterPromptServer(srv, p)
 }
 
-// right now this is hardcoded to allow llm prompts, but could easily be extended to other prompt use cases
 func (p PromptAttachable) PromptBool(ctx context.Context, req *BoolRequest) (*BoolResponse, error) {
 	if req.Prompt == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid input: Prompt required")


### PR DESCRIPTION
this PR adds tests for the `--allow-llm` flag and its associated policies.

in the process of writing these tests I found and fixed a bug in nested client allow-llm propagation that made ExperimentalPrivilegedNesting clients always try to prompt the user  and did a little refactoring to make the code easier to navigate. 

As part of this PR, I intend to:
- [x] add an env var way of setting this flag (cc @samalba)
- [x] look for a way for the prompt functionality to fail fast in the cases where it knows its can't read from tty. currently it just hangs.
- [x] write tests that exercise the interactive prompt flow, emulating existing terminal tests. ~Currently I only exercise the happy-paths that don't prompt.~
- [x] requires https://github.com/dagger/dagger-test-modules/pull/8 is merged and references to those modules in this PR are fixed to point at dagger/dagger-test-modules instead of cwlbraa/dagger-test-modules.
- [ ] intentionally not doing: (automatically) testing the prompt-response-history functionality -- it's stateful enough to be annoying to test. happy to add something if somebody has an idea of how to work around the fact that all the hostDaggerCall tests share the same history file.
