### PR TITLE
Update docs to highlight Podman Desktop on Mac issue

### DIFF
--- a/docs/current_docs/ci/integrations/podman.mdx
+++ b/docs/current_docs/ci/integrations/podman.mdx
@@ -25,19 +25,20 @@ sudo ln -s $(which podman) /usr/local/bin/docker
 
 :::note
 Podman Desktop on Mac and RHEL 8.x users may need to additionally execute `modprobe iptable_nat`.
-:::
 
-To access the VM used by Podman Desktop on Mac 
+To access the virtual machine used by Podman Desktop on Mac, use the commands below:
 
 ```shell
 # list podman machines
 podman machine list 
 
-# ssh to the machine
+# log in to machine
 podman machine ssh podman-machine-default
 
+# execute command
 sudo modprobe iptable_nat
 ```
+:::
 
 ## Resources
 

--- a/docs/current_docs/ci/integrations/podman.mdx
+++ b/docs/current_docs/ci/integrations/podman.mdx
@@ -24,8 +24,20 @@ sudo ln -s $(which podman) /usr/local/bin/docker
 ```
 
 :::note
-RHEL 8.x users may need to additionally execute `modprobe iptable_nat`.
+Podman Desktop on Mac and RHEL 8.x users may need to additionally execute `modprobe iptable_nat`.
 :::
+
+To access the VM used by Podman Desktop on Mac 
+
+```shell
+# list podman machines
+podman machine list 
+
+# ssh to the machine
+podman machine ssh podman-machine-default
+
+sudo modprobe iptable_nat
+```
 
 ## Resources
 

--- a/docs/current_docs/troubleshooting.mdx
+++ b/docs/current_docs/troubleshooting.mdx
@@ -56,7 +56,7 @@ You should now be able to re-run your Dagger Function successfully.
 
 The Dagger Engine requires the `iptable_nat` Linux kernel module in order to function properly. On some Linux distributions this module is not loaded by default.
 
-Known effected platforms include Red Hat Enterprise Linux (8.x and 9.x) and Podman Desktop on Mac.
+Known affected platforms include Red Hat Enterprise Linux (8.x and 9.x) and Podman Desktop on Mac.
 
 You can load this module by running `sudo modprobe iptable_nat`.
 

--- a/docs/current_docs/troubleshooting.mdx
+++ b/docs/current_docs/troubleshooting.mdx
@@ -54,7 +54,9 @@ You should now be able to re-run your Dagger Function successfully.
 
 ## Dagger restarts with a "CNI setup error"
 
-The Dagger Engine requires the `iptable_nat` Linux kernel module in order to function properly. On some Linux distributions (including Red Hat Enterprise Linux 8.x and 9.x), this module is not loaded by default.
+The Dagger Engine requires the `iptable_nat` Linux kernel module in order to function properly. On some Linux distributions this module is not loaded by default.
+
+Known effected platforms include Red Hat Enterprise Linux (8.x and 9.x) and Podman Desktop on Mac.
 
 You can load this module by running `sudo modprobe iptable_nat`.
 


### PR DESCRIPTION
I faced this issue when running Podman Desktop on my mac. 

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/07d034e1-3387-46ac-927b-79929bf64403" />

Debugging the logs on the container led to an error updating the iptables and this was the fix.

The issue is already documented but it wasn;t obvious it effected me.


