### PR TITLE
docs: add install partial to agents page

### DIFF
--- a/docs/current_docs/agents.mdx
+++ b/docs/current_docs/agents.mdx
@@ -3,6 +3,9 @@ slug: /ai-agents
 description: Learn how to build reproducible AI agents with Dagger using OpenAI, Anthropic, Gemini, Llama, DeepSeek, Qwen, and more.
 ---
 
+import PartialInstallCli from './partials/_install-cli.mdx';
+import { daggerVersion } from './partials/version';
+
 # Build AI agents with Dagger
 
 ## Overview
@@ -53,28 +56,9 @@ For more explanation of agent design patterns, see [FAQ](#faq) below.
 
 ## Initial setup
 
-### 1. Install Dagger with llm support
+### 1. Install Dagger
 
-*Note: the latest version is `0.17.0-llm.10`. It was released on March 17, 2025. If you are running an older build, we recommend upgrading.*
-
-You will need a *development version* of Dagger which adds native support for LLM prompting and tool calling.
-
-Once this feature is merged (current target is 0.17), a development build will no longer be required.
-
-Install the development version of LLM-enabled Dagger:
-
-```console
-curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.17.0-llm.10 BIN_DIR=/usr/local/bin sh
-```
-
-You can adjust `BIN_DIR` to customize where the `dagger` CLI is installed.
-
-Verify that your Dagger installation works:
-
-```console
-$ dagger -c version
-v0.17.0-llm.10
-```
+<PartialInstallCli />
 
 ### 2.Configure LLM endpoints
 


### PR DESCRIPTION
Uses the default install partial on the agents installation section.