### PR TITLE
chore: add git attachable fallback and bump minimum client version

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"dagger.io/dagger"
 	"github.com/creack/pty"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
@@ -945,7 +944,7 @@ func (LegacySuite) TestDirectoryTrailingSlash(ctx context.Context, t *testctx.T)
 	// Ensure that the legacy methods that return paths don't return trailing
 	// slashes for directories.
 
-	c := connect(ctx, t, dagger.WithVersionOverride("v0.16.0"))
+	c := connect(ctx, t)
 
 	modGen := goGitBase(t, c).
 		With(daggerExec("init", "--name=bare", "--sdk=go", "--source=.")).

--- a/engine/session/git.go
+++ b/engine/session/git.go
@@ -31,6 +31,12 @@ func NewGitAttachable(rootCtx context.Context) GitAttachable {
 
 func (s GitAttachable) Register(srv *grpc.Server) {
 	RegisterGitServer(srv, &s)
+
+	// dagger/dagger#9323 renamed the GitCredential attachable to Git
+	// it's easy to provide a fallback
+	serviceDesc := _Git_serviceDesc
+	serviceDesc.ServiceName = "GitCredential"
+	srv.RegisterService(&serviceDesc, &s)
 }
 
 func newGitCredentialErrorResponse(errorType ErrorInfo_ErrorType, message string) *GitCredentialResponse {

--- a/engine/version.go
+++ b/engine/version.go
@@ -35,7 +35,7 @@ var (
 
 	// MinimumClientVersion is used by the engine to determine the minimum
 	// allowed client version that can connect to that engine.
-	MinimumClientVersion = "v0.16.0"
+	MinimumClientVersion = "v0.17.0"
 
 	// MinimumModuleVersion is used by the engine to determine the minimum
 	// allowed module engine version that can connect to this engine.


### PR DESCRIPTION
We haven't actually changed any details of the API - and it's pretty easy to give this as a fallback so that we don't need to bump any engine versions anywhere.

Noted this failure in https://github.com/dagger/dagger.io/pull/4328, where we got the following error while crawling a private module:

```
get module signature: input: moduleSource.asModule failed to get module runtime: failed to query git config: Unimplemented: unknown service Git
```