### PR TITLE
docs: Move Engine page one level up in nav

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -102,6 +102,7 @@ module.exports = {
         "api/cache-volumes",
         "api/secrets",
         "api/terminal",
+        "api/engine",
         {
           type: "category",
           label: "Calling the API",
@@ -131,7 +132,6 @@ module.exports = {
             "api/interfaces",
             "api/custom-types",
             "api/state",
-            "api/engine",
           ],
         },
         {


### PR DESCRIPTION
The Engine API page should live under the Dagger API section, instead of its current location under the Custom Functions section. 