### PR TITLE
feat: add deno support on Typescript SDK

### DIFF
--- a/sdk/typescript/runtime/bin/__deno_config_updator.ts
+++ b/sdk/typescript/runtime/bin/__deno_config_updator.ts
@@ -1,0 +1,73 @@
+const denoConfigPath = "./deno.json"
+const daggerImports = {
+  "@dagger.io/dagger": "./sdk/src/index.ts",
+  "@dagger.io/telemetry": "./sdk/src/telemetry/index.ts",
+}
+const unstableFlags = [
+  "bare-node-builtins",
+  "sloppy-imports",
+  "node-globals",
+  "byonm",
+]
+
+// Read the deno.json file
+const denoConfigFile = Deno.readTextFileSync(denoConfigPath)
+  // Cleanup comments
+  .split("\n")
+  .reduce((acc: string[], line: string) => {
+    if (line.includes("//") || (line.includes("/*") && line.includes("*/"))) {
+      return acc
+    }
+
+    return [...acc, line]
+  }, [])
+  .join("\n")
+
+const denoConfig = JSON.parse(denoConfigFile)
+
+// Update imports statements
+if (!denoConfig.imports) {
+  denoConfig.imports = {}
+}
+
+for (const [key, value] of Object.entries(daggerImports)) {
+  if (!denoConfig.imports[key]) {
+    denoConfig.imports[key] = value
+  }
+}
+
+// Update workspace statements to include SDK
+if (!denoConfig.workspace) {
+  denoConfig.workspace = []
+}
+
+if (!denoConfig.workspace.includes("./sdk")) {
+  denoConfig.workspace.push("./sdk")
+}
+
+// Update unstable features
+if (!denoConfig.unstable) {
+  denoConfig.unstable = []
+}
+
+for (const flag of unstableFlags) {
+  if (!denoConfig.unstable.includes(flag)) {
+    denoConfig.unstable.push(flag)
+  }
+}
+
+// Update compiler options
+if (!denoConfig.compilerOptions) {
+  denoConfig.compilerOptions = {}
+}
+
+denoConfig.compilerOptions.experimentalDecorators = true
+
+// Update nodeModulesDir
+if (!denoConfig.nodeModulesDir) {
+  denoConfig.nodeModulesDir = "auto"
+}
+denoConfig.nodeModulesDir = "auto"
+
+// Write file back
+Deno.writeTextFileSync(denoConfigPath, JSON.stringify(denoConfig, null, 2))

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -21,15 +21,17 @@ type SupportedTSRuntime string
 const (
 	Bun  SupportedTSRuntime = "bun"
 	Node SupportedTSRuntime = "node"
+	Deno SupportedTSRuntime = "deno"
 )
 
 type SupportedPackageManager string
 
 const (
-	Yarn       SupportedPackageManager = "yarn"
-	Pnpm       SupportedPackageManager = "pnpm"
-	Npm        SupportedPackageManager = "npm"
-	BunManager SupportedPackageManager = "bun"
+	Yarn        SupportedPackageManager = "yarn"
+	Pnpm        SupportedPackageManager = "pnpm"
+	Npm         SupportedPackageManager = "npm"
+	BunManager  SupportedPackageManager = "bun"
+	DenoManager SupportedPackageManager = "deno"
 )
 
 const (
@@ -56,6 +58,12 @@ type packageJSONConfig struct {
 	} `json:"dagger"`
 }
 
+type denoJSONConfig struct {
+	Dagger *struct {
+		BaseImage string `json:"baseImage"`
+	} `json:"dagger"`
+}
+
 type moduleConfig struct {
 	runtime        SupportedTSRuntime
 	runtimeVersion string
@@ -63,6 +71,7 @@ type moduleConfig struct {
 	// Custom base image
 	image             string
 	packageJSONConfig *packageJSONConfig
+	denoJSONConfig    *denoJSONConfig
 
 	packageManager        SupportedPackageManager
 	packageManagerVersion string
@@ -114,6 +123,11 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *dagger.Mod
 	case Bun:
 		return ctr.
 			WithEntrypoint([]string{"bun", t.moduleConfig.entrypointPath()}), nil
+	case Deno:
+		return ctr.
+			WithEntrypoint([]string{
+				"deno", "run", "-A", t.moduleConfig.entrypointPath(),
+			}), nil
 	case Node:
 		return ctr.
 			// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
@@ -301,6 +315,10 @@ func (t *TypescriptSdk) moduleConfigFiles(path string) []string {
 		"pnpm-lock.yaml",
 		"bun.lockb",
 		"bun.lock",
+
+		// Deno
+		"deno.json",
+		"deno.lock",
 	}
 
 	for i, file := range modConfigFiles {
@@ -324,6 +342,10 @@ func (t *TypescriptSdk) Base() (*dagger.Container, error) {
 			WithMountedCache("/root/.bun/install/cache", dag.CacheVolume(fmt.Sprintf("mod-bun-cache-%s", tsdistconsts.DefaultBunVersion)), dagger.ContainerWithMountedCacheOpts{
 				Sharing: dagger.Private,
 			}), nil
+	case Deno:
+		return ctr.
+			WithoutEntrypoint().
+			WithMountedCache("/root/.deno/cache", dag.CacheVolume(fmt.Sprintf("mod-deno-cache-%s", tsdistconsts.DefaultDenoVersion))), nil
 	case Node:
 		return ctr.
 			WithoutEntrypoint().
@@ -390,24 +412,35 @@ func (t *TypescriptSdk) addTemplate(ctx context.Context, ctr *dagger.Container) 
 func (t *TypescriptSdk) configureModule(ctr *dagger.Container) *dagger.Container {
 	runtime := t.moduleConfig.runtime
 
-	// If there's a package.json, run the tsconfig updator script and install the genDir.
-	// else, copy the template config files.
-	if t.moduleConfig.packageJSONConfig != nil {
-		if runtime == Bun {
-			ctr = ctr.
-				WithExec([]string{"bun", "/opt/module/bin/__tsconfig.updator.ts"}).
-				WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--summary", "./sdk"})
-		} else {
-			ctr = ctr.
-				WithExec([]string{"tsx", "/opt/module/bin/__tsconfig.updator.ts"}).
-				WithExec([]string{"npm", "pkg", "set", "type=module"}).
-				WithExec([]string{"npm", "pkg", "set", "dependencies[@dagger.io/dagger]=./sdk"})
-		}
-	} else {
-		ctr = ctr.WithDirectory(".", ctr.Directory("/opt/module/template"), dagger.ContainerWithDirectoryOpts{Include: []string{"*.json"}})
+	// If there's a package.json in bun & node, run the tsconfig updator script and install the genDir.
+	templateSetup := func() *dagger.Container {
+		return ctr.WithDirectory(".",
+			ctr.Directory("/opt/module/template"), dagger.ContainerWithDirectoryOpts{Include: []string{"*.json"}})
 	}
 
-	return ctr
+	switch runtime {
+	case Bun:
+		if t.moduleConfig.packageJSONConfig == nil {
+			return templateSetup()
+		}
+
+		return ctr.
+			WithExec([]string{"bun", "/opt/module/bin/__tsconfig.updator.ts"}).
+			WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--summary", "./sdk"})
+	case Node:
+		if t.moduleConfig.packageJSONConfig == nil {
+			return templateSetup()
+		}
+
+		return ctr.
+			WithExec([]string{"tsx", "/opt/module/bin/__tsconfig.updator.ts"}).
+			WithExec([]string{"npm", "pkg", "set", "type=module"}).
+			WithExec([]string{"npm", "pkg", "set", "dependencies[@dagger.io/dagger]=./sdk"})
+	case Deno:
+		return ctr.WithExec([]string{"deno", "run", "-A", "/opt/module/bin/__deno_config_updator.ts"})
+	default:
+		return ctr
+	}
 }
 
 // addSDK returns a directory with the SDK sources.
@@ -474,6 +507,15 @@ func (t *TypescriptSdk) detectBaseImageRef() (string, error) {
 		}
 
 		return tsdistconsts.DefaultNodeImageRef, nil
+	case Deno:
+		if t.moduleConfig.denoJSONConfig != nil && t.moduleConfig.denoJSONConfig.Dagger != nil {
+			value := t.moduleConfig.denoJSONConfig.Dagger.BaseImage
+			if value != "" {
+				return value, nil
+			}
+		}
+
+		return tsdistconsts.DefaultDenoImageRef, nil
 	default:
 		return "", fmt.Errorf("unknown runtime: %q", runtime)
 	}
@@ -522,6 +564,13 @@ func (t *TypescriptSdk) detectRuntime() error {
 		return nil
 	}
 
+	if t.moduleConfig.hasFile("deno.json") ||
+		t.moduleConfig.hasFile("deno.lock") {
+		t.moduleConfig.runtime = Deno
+
+		return nil
+	}
+
 	return nil
 }
 
@@ -538,6 +587,11 @@ func (t *TypescriptSdk) detectPackageManager() (SupportedPackageManager, string,
 	// If the runtime is Bun, we should use BunManager
 	if t.moduleConfig.runtime == Bun {
 		return BunManager, "", nil
+	}
+
+	// If the runtime is deno, we should use the DenoManager
+	if t.moduleConfig.runtime == Deno {
+		return DenoManager, "", nil
 	}
 
 	// If we find a package.json, we check if the packageManager is specified in `packageManager` field.
@@ -624,6 +678,8 @@ func (t *TypescriptSdk) generateLockFile(ctr *dagger.Container) (*dagger.Contain
 	case BunManager:
 		return ctr.
 			WithExec([]string{"bun", "install", "--no-verify", "--no-progress"}), nil
+	case DenoManager:
+		return ctr, nil
 	default:
 		return nil, fmt.Errorf("detected unknown package manager: %s", packageManager)
 	}
@@ -648,6 +704,9 @@ func (t *TypescriptSdk) installDependencies(ctr *dagger.Container) (*dagger.Cont
 	case BunManager:
 		return ctr.
 			WithExec([]string{"bun", "install", "--no-verify", "--no-progress"}), nil
+	case DenoManager:
+		return ctr.
+			WithExec([]string{"deno", "install"}), nil
 	default:
 		return nil, fmt.Errorf("detected unknown package manager: %s", t.moduleConfig.packageManager)
 	}
@@ -703,6 +762,21 @@ func (t *TypescriptSdk) analyzeModuleConfig(ctx context.Context, modSource *dagg
 		}
 
 		t.moduleConfig.packageJSONConfig = &packageJSONConfig
+	}
+
+	if t.moduleConfig.hasFile("deno.json") {
+		var denoJSONConfig denoJSONConfig
+
+		content, err := t.moduleConfig.source.File("deno.json").Contents(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to read deno.json: %w", err)
+		}
+
+		if err := json.Unmarshal([]byte(content), &denoJSONConfig); err != nil {
+			return fmt.Errorf("failed to unmarshal deno.json: %w", err)
+		}
+
+		t.moduleConfig.denoJSONConfig = &denoJSONConfig
 	}
 
 	if err := t.detectRuntime(); err != nil {

--- a/sdk/typescript/runtime/tsdistconsts/consts.go
+++ b/sdk/typescript/runtime/tsdistconsts/consts.go
@@ -8,4 +8,8 @@ const (
 	DefaultBunVersion  = "1.1.38"
 	bunImageDigest     = "sha256:5148f6742ac31fac28e6eab391ab1f11f6dfc0c8512c7a3679b374ec470f5982"
 	DefaultBunImageRef = "oven/bun:" + DefaultBunVersion + "-alpine@" + bunImageDigest
+
+	DefaultDenoVersion  = "2.2.4"
+	denoImageDigest     = "sha256:1d8c91cb71602ac152c1a7e49654aaa9f6c9dbe8c82e43221adf913f89683987"
+	DefaultDenoImageRef = "denoland/deno:alpine-" + DefaultDenoVersion + "@" + denoImageDigest
 )

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,3 @@
-export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
 
 // Default client bindings


### PR DESCRIPTION
Setup to use deno with Dagger:

```
deno init
dagger init --name=test --sdk=typescript --source=.
```

Dagger will automatically update the `deno.json` to support the SDK library.

Integration tests are added.
We do not directly run the test on the library since it's not useful, deno already ensure compatibility with node.

Minimum required `deno.json` to support `dagger`:

```json
{
  "imports": {
    "@dagger.io/dagger": "./sdk/src/index.ts",
    "@dagger.io/telemetry": "./sdk/src/telemetry/index.ts"
  },
  "workspace": [
    "./sdk"
  ],
  "unstable": [
    "bare-node-builtins",
    "sloppy-imports",
    "node-globals",
    "byonm"
  ],
  "compilerOptions": {
    "experimentalDecorators": true // require for compability with node decorator
  },
  "nodeModulesDir": "auto"
}
```