### PR TITLE
LLM: `Query` access, `$_` setting, un-deprecate APIs

### DIFF
--- a/cmd/dagger/llm.go
+++ b/cmd/dagger/llm.go
@@ -94,7 +94,7 @@ func NewLLMSession(ctx context.Context, dag *dagger.Client, llmModel string, she
 }
 
 func (s *LLMSession) reset() {
-	s.llm = s.dag.Llm(dagger.LlmOpts{Model: s.model})
+	s.llm = s.dag.Llm(dagger.LlmOpts{Model: s.model}).WithQuery()
 }
 
 func (s *LLMSession) Fork() *LLMSession {

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -372,7 +372,7 @@ func (h *shellCallHandler) Handle(ctx context.Context, line string) (rerr error)
 		defer h.state.debug(ctx)
 	}
 
-	// Run shell command - optionally sync vars back to LLM after running
+	// Run shell command
 	return h.run(ctx, strings.NewReader(line), "")
 }
 

--- a/core/llm.go
+++ b/core/llm.go
@@ -915,10 +915,10 @@ func (s LLMHook) ExtendLLMType(targetType dagql.ObjectType) error {
 	// Install with<TargetType>()
 	llmType.Extend(
 		dagql.FieldSpec{
-			Name:             "with" + typename,
-			Description:      fmt.Sprintf("Set a variable of type %s in the llm environment", typename),
-			Type:             llmType.Typed(),
-			DeprecatedReason: "use set<TargetType> instead",
+			Name:        "with" + typename,
+			Description: fmt.Sprintf("Set a variable of type %s in the llm environment", typename),
+			Type:        llmType.Typed(),
+			// DeprecatedReason: "use set<TargetType> instead",
 			Args: dagql.InputSpecs{
 				{
 					Name:        "value",
@@ -937,10 +937,10 @@ func (s LLMHook) ExtendLLMType(targetType dagql.ObjectType) error {
 	// Install <targetType>()
 	llmType.Extend(
 		dagql.FieldSpec{
-			Name:             gqlFieldName(typename),
-			Description:      fmt.Sprintf("Retrieve a the current value in the LLM environment, of type %s", typename),
-			Type:             targetType.Typed(),
-			DeprecatedReason: "use get<TargetType> instead",
+			Name:        gqlFieldName(typename),
+			Description: fmt.Sprintf("Retrieve a the current value in the LLM environment, of type %s", typename),
+			Type:        targetType.Typed(),
+			// DeprecatedReason: "use get<TargetType> instead",
 		},
 		func(ctx context.Context, self dagql.Object, args map[string]dagql.Input) (dagql.Typed, error) {
 			llm := self.(dagql.Instance[*LLM]).Self

--- a/core/llm.go
+++ b/core/llm.go
@@ -800,6 +800,20 @@ func (llm *LLM) Variables(ctx context.Context, dag *dagql.Server) ([]*LLMVariabl
 	return vars, nil
 }
 
+func (llm *LLM) CurrentType(ctx context.Context, dag *dagql.Server) (dagql.Nullable[dagql.String], error) {
+	var res dagql.Nullable[dagql.String]
+	llm, err := llm.Sync(ctx, dag)
+	if err != nil {
+		return res, err
+	}
+	if llm.env.Current() == nil {
+		return res, nil
+	}
+	res.Value = dagql.String(llm.env.Current().Type().Name())
+	res.Valid = true
+	return res, nil
+}
+
 // FIXME: deprecated
 func (llm *LLM) WithState(ctx context.Context, objID dagql.IDType, srv *dagql.Server) (*LLM, error) {
 	obj, err := srv.Load(ctx, objID.ID())

--- a/core/llm_env.go
+++ b/core/llm_env.go
@@ -126,6 +126,12 @@ func (env *LLMEnv) Tools(srv *dagql.Server) []LLMTool {
 	typedef := env.typedef(srv, env.Current())
 	typeName := typedef.Name
 	for _, field := range typedef.Fields {
+		if strings.HasPrefix(field.Name, "_") {
+			continue
+		}
+		if strings.HasPrefix(field.Name, "load") && strings.HasSuffix(field.Name, "FromID") {
+			continue
+		}
 		tools = append(tools, LLMTool{
 			Name:        typeName + "_" + field.Name,
 			Description: field.Description,

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -66,7 +66,7 @@ func (s llmSchema) Install() {
 		}).
 			Doc("synchronize LLM state"),
 		dagql.Func("loop", s.loop).
-			Deprecated("use sync").
+			// Deprecated("use sync").
 			Doc("synchronize LLM state"),
 		dagql.Func("tools", s.tools).
 			Doc("print documentation for available tools"),

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -41,6 +41,8 @@ func (s llmSchema) Install() {
 		dagql.Func("withPromptFile", s.withPromptFile).
 			Doc("append the contents of a file to the llm context").
 			ArgDoc("file", "The file to read the prompt from"),
+		dagql.Func("withQuery", s.withQuery).
+			Doc("Provide the entire Query object to the LLM"),
 		dagql.Func("withPromptVar", s.setString).
 			Doc("Add a string variable to the LLM's environment").
 			ArgDoc("name", "The variable name").
@@ -107,6 +109,10 @@ func (s *llmSchema) withPrompt(ctx context.Context, llm *core.LLM, args struct {
 	Prompt string
 }) (*core.LLM, error) {
 	return llm.WithPrompt(ctx, args.Prompt, s.srv)
+}
+
+func (s *llmSchema) withQuery(ctx context.Context, llm *core.LLM, args struct{}) (*core.LLM, error) {
+	return llm.With(ctx, s.srv, s.srv.Root())
 }
 
 func (s *llmSchema) setString(ctx context.Context, llm *core.LLM, args struct {

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -72,6 +72,8 @@ func (s llmSchema) Install() {
 			Doc("print documentation for available tools"),
 		dagql.Func("variables", s.variables).
 			Doc("list variables in the LLM environment"),
+		dagql.Func("currentType", s.currentType).
+			Doc("returns the type of the current state"),
 	}.Install(s.srv)
 	dagql.Fields[*core.LLMVariable]{}.Install(s.srv)
 	hook := core.LLMHook{Server: s.srv}
@@ -187,4 +189,8 @@ func (s *llmSchema) tools(ctx context.Context, llm *core.LLM, _ struct{}) (dagql
 
 func (s *llmSchema) variables(ctx context.Context, llm *core.LLM, _ struct{}) ([]*core.LLMVariable, error) {
 	return llm.Variables(ctx, s.srv)
+}
+
+func (s *llmSchema) currentType(ctx context.Context, llm *core.LLM, _ struct{}) (dagql.Nullable[dagql.String], error) {
+	return llm.CurrentType(ctx, s.srv)
 }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2200,67 +2200,70 @@ type LLM {
   """
   Retrieve a the current value in the LLM environment, of type CacheVolume
   """
-  cacheVolume: CacheVolume! @deprecated(reason: "use get<TargetType> instead")
+  cacheVolume: CacheVolume!
 
   """Retrieve a the current value in the LLM environment, of type Container"""
-  container: Container! @deprecated(reason: "use get<TargetType> instead")
+  container: Container!
 
   """
   Retrieve a the current value in the LLM environment, of type CurrentModule
   """
-  currentModule: CurrentModule! @deprecated(reason: "use get<TargetType> instead")
+  currentModule: CurrentModule!
+
+  """returns the type of the current state"""
+  currentType: String
 
   """Retrieve a the current value in the LLM environment, of type Directory"""
-  directory: Directory! @deprecated(reason: "use get<TargetType> instead")
+  directory: Directory!
 
   """
   Retrieve a the current value in the LLM environment, of type EnumTypeDef
   """
-  enumTypeDef: EnumTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  enumTypeDef: EnumTypeDef!
 
   """
   Retrieve a the current value in the LLM environment, of type EnumValueTypeDef
   """
-  enumValueTypeDef: EnumValueTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  enumValueTypeDef: EnumValueTypeDef!
 
   """Retrieve a the current value in the LLM environment, of type Error"""
-  error: Error! @deprecated(reason: "use get<TargetType> instead")
+  error: Error!
 
   """
   Retrieve a the current value in the LLM environment, of type ErrorValue
   """
-  errorValue: ErrorValue! @deprecated(reason: "use get<TargetType> instead")
+  errorValue: ErrorValue!
 
   """
   Retrieve a the current value in the LLM environment, of type FieldTypeDef
   """
-  fieldTypeDef: FieldTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  fieldTypeDef: FieldTypeDef!
 
   """Retrieve a the current value in the LLM environment, of type File"""
-  file: File! @deprecated(reason: "use get<TargetType> instead")
+  file: File!
 
   """Retrieve a the current value in the LLM environment, of type Function"""
-  function: Function! @deprecated(reason: "use get<TargetType> instead")
+  function: Function!
 
   """
   Retrieve a the current value in the LLM environment, of type FunctionArg
   """
-  functionArg: FunctionArg! @deprecated(reason: "use get<TargetType> instead")
+  functionArg: FunctionArg!
 
   """
   Retrieve a the current value in the LLM environment, of type FunctionCall
   """
-  functionCall: FunctionCall! @deprecated(reason: "use get<TargetType> instead")
+  functionCall: FunctionCall!
 
   """
   Retrieve a the current value in the LLM environment, of type FunctionCallArgValue
   """
-  functionCallArgValue: FunctionCallArgValue! @deprecated(reason: "use get<TargetType> instead")
+  functionCallArgValue: FunctionCallArgValue!
 
   """
   Retrieve a the current value in the LLM environment, of type GeneratedCode
   """
-  generatedCode: GeneratedCode! @deprecated(reason: "use get<TargetType> instead")
+  generatedCode: GeneratedCode!
 
   """Retrieve a variable in the llm environment, of type CacheVolume"""
   getCacheVolume(
@@ -2469,12 +2472,12 @@ type LLM {
   ): TypeDef!
 
   """Retrieve a the current value in the LLM environment, of type GitRef"""
-  gitRef: GitRef! @deprecated(reason: "use get<TargetType> instead")
+  gitRef: GitRef!
 
   """
   Retrieve a the current value in the LLM environment, of type GitRepository
   """
-  gitRepository: GitRepository! @deprecated(reason: "use get<TargetType> instead")
+  gitRepository: GitRepository!
 
   """return the llm message history"""
   history: [String!]!
@@ -2488,12 +2491,12 @@ type LLM {
   """
   Retrieve a the current value in the LLM environment, of type InputTypeDef
   """
-  inputTypeDef: InputTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  inputTypeDef: InputTypeDef!
 
   """
   Retrieve a the current value in the LLM environment, of type InterfaceTypeDef
   """
-  interfaceTypeDef: InterfaceTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  interfaceTypeDef: InterfaceTypeDef!
 
   """return the last llm reply from the history"""
   lastReply: String!
@@ -2501,34 +2504,34 @@ type LLM {
   """
   Retrieve a the current value in the LLM environment, of type ListTypeDef
   """
-  listTypeDef: ListTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  listTypeDef: ListTypeDef!
 
   """Retrieve a the current value in the LLM environment, of type LLM"""
-  lLM: LLM! @deprecated(reason: "use get<TargetType> instead")
+  lLM: LLM!
 
   """synchronize LLM state"""
-  loop: LLM! @deprecated(reason: "use sync")
+  loop: LLM!
 
   """return the model used by the llm"""
   model: String!
 
   """Retrieve a the current value in the LLM environment, of type Module"""
-  module: Module! @deprecated(reason: "use get<TargetType> instead")
+  module: Module!
 
   """
   Retrieve a the current value in the LLM environment, of type ModuleConfigClient
   """
-  moduleConfigClient: ModuleConfigClient! @deprecated(reason: "use get<TargetType> instead")
+  moduleConfigClient: ModuleConfigClient!
 
   """
   Retrieve a the current value in the LLM environment, of type ModuleSource
   """
-  moduleSource: ModuleSource! @deprecated(reason: "use get<TargetType> instead")
+  moduleSource: ModuleSource!
 
   """
   Retrieve a the current value in the LLM environment, of type ObjectTypeDef
   """
-  objectTypeDef: ObjectTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  objectTypeDef: ObjectTypeDef!
 
   """return the provider used by the llm"""
   provider: String!
@@ -2536,16 +2539,16 @@ type LLM {
   """
   Retrieve a the current value in the LLM environment, of type ScalarTypeDef
   """
-  scalarTypeDef: ScalarTypeDef! @deprecated(reason: "use get<TargetType> instead")
+  scalarTypeDef: ScalarTypeDef!
 
   """Retrieve a the current value in the LLM environment, of type SDKConfig"""
-  sdkconfig: SDKConfig @deprecated(reason: "use get<TargetType> instead")
+  sdkconfig: SDKConfig
 
   """Retrieve a the current value in the LLM environment, of type Secret"""
-  secret: Secret! @deprecated(reason: "use get<TargetType> instead")
+  secret: Secret!
 
   """Retrieve a the current value in the LLM environment, of type Service"""
-  service: Service! @deprecated(reason: "use get<TargetType> instead")
+  service: Service!
 
   """Set a variable of type CacheVolume in the llm environment"""
   setCacheVolume(
@@ -2854,22 +2857,22 @@ type LLM {
   ): LLM!
 
   """Retrieve a the current value in the LLM environment, of type Socket"""
-  socket: Socket! @deprecated(reason: "use get<TargetType> instead")
+  socket: Socket!
 
   """Retrieve a the current value in the LLM environment, of type SourceMap"""
-  sourceMap: SourceMap! @deprecated(reason: "use get<TargetType> instead")
+  sourceMap: SourceMap!
 
   """synchronize LLM state"""
   sync: LLMID!
 
   """Retrieve a the current value in the LLM environment, of type Terminal"""
-  terminal: Terminal! @deprecated(reason: "use get<TargetType> instead")
+  terminal: Terminal!
 
   """print documentation for available tools"""
   tools: String!
 
   """Retrieve a the current value in the LLM environment, of type TypeDef"""
-  typeDef: TypeDef! @deprecated(reason: "use get<TargetType> instead")
+  typeDef: TypeDef!
 
   """list variables in the LLM environment"""
   variables: [LLMVariable!]!
@@ -2878,127 +2881,127 @@ type LLM {
   withCacheVolume(
     """The CacheVolume value to assign to the variable"""
     value: CacheVolumeID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Container in the llm environment"""
   withContainer(
     """The Container value to assign to the variable"""
     value: ContainerID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type CurrentModule in the llm environment"""
   withCurrentModule(
     """The CurrentModule value to assign to the variable"""
     value: CurrentModuleID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Directory in the llm environment"""
   withDirectory(
     """The Directory value to assign to the variable"""
     value: DirectoryID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type EnumTypeDef in the llm environment"""
   withEnumTypeDef(
     """The EnumTypeDef value to assign to the variable"""
     value: EnumTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type EnumValueTypeDef in the llm environment"""
   withEnumValueTypeDef(
     """The EnumValueTypeDef value to assign to the variable"""
     value: EnumValueTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Error in the llm environment"""
   withError(
     """The Error value to assign to the variable"""
     value: ErrorID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type ErrorValue in the llm environment"""
   withErrorValue(
     """The ErrorValue value to assign to the variable"""
     value: ErrorValueID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type FieldTypeDef in the llm environment"""
   withFieldTypeDef(
     """The FieldTypeDef value to assign to the variable"""
     value: FieldTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type File in the llm environment"""
   withFile(
     """The File value to assign to the variable"""
     value: FileID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Function in the llm environment"""
   withFunction(
     """The Function value to assign to the variable"""
     value: FunctionID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type FunctionArg in the llm environment"""
   withFunctionArg(
     """The FunctionArg value to assign to the variable"""
     value: FunctionArgID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type FunctionCall in the llm environment"""
   withFunctionCall(
     """The FunctionCall value to assign to the variable"""
     value: FunctionCallID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type FunctionCallArgValue in the llm environment"""
   withFunctionCallArgValue(
     """The FunctionCallArgValue value to assign to the variable"""
     value: FunctionCallArgValueID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type GeneratedCode in the llm environment"""
   withGeneratedCode(
     """The GeneratedCode value to assign to the variable"""
     value: GeneratedCodeID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type GitRef in the llm environment"""
   withGitRef(
     """The GitRef value to assign to the variable"""
     value: GitRefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type GitRepository in the llm environment"""
   withGitRepository(
     """The GitRepository value to assign to the variable"""
     value: GitRepositoryID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type InputTypeDef in the llm environment"""
   withInputTypeDef(
     """The InputTypeDef value to assign to the variable"""
     value: InputTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type InterfaceTypeDef in the llm environment"""
   withInterfaceTypeDef(
     """The InterfaceTypeDef value to assign to the variable"""
     value: InterfaceTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type ListTypeDef in the llm environment"""
   withListTypeDef(
     """The ListTypeDef value to assign to the variable"""
     value: ListTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type LLM in the llm environment"""
   withLLM(
     """The LLM value to assign to the variable"""
     value: LLMID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """swap out the llm model"""
   withModel(
@@ -3010,25 +3013,25 @@ type LLM {
   withModule(
     """The Module value to assign to the variable"""
     value: ModuleID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type ModuleConfigClient in the llm environment"""
   withModuleConfigClient(
     """The ModuleConfigClient value to assign to the variable"""
     value: ModuleConfigClientID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type ModuleSource in the llm environment"""
   withModuleSource(
     """The ModuleSource value to assign to the variable"""
     value: ModuleSourceID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type ObjectTypeDef in the llm environment"""
   withObjectTypeDef(
     """The ObjectTypeDef value to assign to the variable"""
     value: ObjectTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """append a prompt to the llm context"""
   withPrompt(
@@ -3058,49 +3061,49 @@ type LLM {
   withScalarTypeDef(
     """The ScalarTypeDef value to assign to the variable"""
     value: ScalarTypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type SDKConfig in the llm environment"""
   withSDKConfig(
     """The SDKConfig value to assign to the variable"""
     value: SDKConfigID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Secret in the llm environment"""
   withSecret(
     """The Secret value to assign to the variable"""
     value: SecretID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Service in the llm environment"""
   withService(
     """The Service value to assign to the variable"""
     value: ServiceID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Socket in the llm environment"""
   withSocket(
     """The Socket value to assign to the variable"""
     value: SocketID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type SourceMap in the llm environment"""
   withSourceMap(
     """The SourceMap value to assign to the variable"""
     value: SourceMapID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type Terminal in the llm environment"""
   withTerminal(
     """The Terminal value to assign to the variable"""
     value: TerminalID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 
   """Set a variable of type TypeDef in the llm environment"""
   withTypeDef(
     """The TypeDef value to assign to the variable"""
     value: TypeDefID!
-  ): LLM! @deprecated(reason: "use set<TargetType> instead")
+  ): LLM!
 }
 
 """

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3051,6 +3051,9 @@ type LLM {
     value: String!
   ): LLM!
 
+  """Provide the entire Query object to the LLM"""
+  withQuery: LLM!
+
   """Set a variable of type ScalarTypeDef in the llm environment"""
   withScalarTypeDef(
     """The ScalarTypeDef value to assign to the variable"""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -7771,79 +7771,68 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-cacheVolume" href="#LLM-cacheVolume"><code>cacheVolume</code></a> - <span class="property-type"><a href="#definition-CacheVolume"><code>CacheVolume!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type CacheVolume <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-cacheVolume" href="#LLM-cacheVolume"><code>cacheVolume</code></a> - <span class="property-type"><a href="#definition-CacheVolume"><code>CacheVolume!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type CacheVolume </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-container" href="#LLM-container"><code>container</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Container <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-container" href="#LLM-container"><code>container</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Container </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-currentModule" href="#LLM-currentModule"><code>currentModule</code></a> - <span class="property-type"><a href="#definition-CurrentModule"><code>CurrentModule!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type CurrentModule <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-currentModule" href="#LLM-currentModule"><code>currentModule</code></a> - <span class="property-type"><a href="#definition-CurrentModule"><code>CurrentModule!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type CurrentModule </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-directory" href="#LLM-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Directory <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-currentType" href="#LLM-currentType"><code>currentType</code></a> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span> </td>
+                        <td> returns the type of the current state </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-enumTypeDef" href="#LLM-enumTypeDef"><code>enumTypeDef</code></a> - <span class="property-type"><a href="#definition-EnumTypeDef"><code>EnumTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type EnumTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-directory" href="#LLM-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Directory </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-enumValueTypeDef" href="#LLM-enumValueTypeDef"><code>enumValueTypeDef</code></a> - <span class="property-type"><a href="#definition-EnumValueTypeDef"><code>EnumValueTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type EnumValueTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-enumTypeDef" href="#LLM-enumTypeDef"><code>enumTypeDef</code></a> - <span class="property-type"><a href="#definition-EnumTypeDef"><code>EnumTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type EnumTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-error" href="#LLM-error"><code>error</code></a> - <span class="property-type"><a href="#definition-Error"><code>Error!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Error <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-enumValueTypeDef" href="#LLM-enumValueTypeDef"><code>enumValueTypeDef</code></a> - <span class="property-type"><a href="#definition-EnumValueTypeDef"><code>EnumValueTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type EnumValueTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-errorValue" href="#LLM-errorValue"><code>errorValue</code></a> - <span class="property-type"><a href="#definition-ErrorValue"><code>ErrorValue!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ErrorValue <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-error" href="#LLM-error"><code>error</code></a> - <span class="property-type"><a href="#definition-Error"><code>Error!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Error </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-fieldTypeDef" href="#LLM-fieldTypeDef"><code>fieldTypeDef</code></a> - <span class="property-type"><a href="#definition-FieldTypeDef"><code>FieldTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type FieldTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-errorValue" href="#LLM-errorValue"><code>errorValue</code></a> - <span class="property-type"><a href="#definition-ErrorValue"><code>ErrorValue!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ErrorValue </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-file" href="#LLM-file"><code>file</code></a> - <span class="property-type"><a href="#definition-File"><code>File!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type File <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-fieldTypeDef" href="#LLM-fieldTypeDef"><code>fieldTypeDef</code></a> - <span class="property-type"><a href="#definition-FieldTypeDef"><code>FieldTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type FieldTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-function" href="#LLM-function"><code>function</code></a> - <span class="property-type"><a href="#definition-Function"><code>Function!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Function <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-file" href="#LLM-file"><code>file</code></a> - <span class="property-type"><a href="#definition-File"><code>File!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type File </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-functionArg" href="#LLM-functionArg"><code>functionArg</code></a> - <span class="property-type"><a href="#definition-FunctionArg"><code>FunctionArg!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type FunctionArg <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-function" href="#LLM-function"><code>function</code></a> - <span class="property-type"><a href="#definition-Function"><code>Function!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Function </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-functionCall" href="#LLM-functionCall"><code>functionCall</code></a> - <span class="property-type"><a href="#definition-FunctionCall"><code>FunctionCall!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type FunctionCall <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-functionArg" href="#LLM-functionArg"><code>functionArg</code></a> - <span class="property-type"><a href="#definition-FunctionArg"><code>FunctionArg!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type FunctionArg </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-functionCallArgValue" href="#LLM-functionCallArgValue"><code>functionCallArgValue</code></a> - <span class="property-type"><a href="#definition-FunctionCallArgValue"><code>FunctionCallArgValue!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type FunctionCallArgValue <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-functionCall" href="#LLM-functionCall"><code>functionCall</code></a> - <span class="property-type"><a href="#definition-FunctionCall"><code>FunctionCall!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type FunctionCall </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-generatedCode" href="#LLM-generatedCode"><code>generatedCode</code></a> - <span class="property-type"><a href="#definition-GeneratedCode"><code>GeneratedCode!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type GeneratedCode <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-functionCallArgValue" href="#LLM-functionCallArgValue"><code>functionCallArgValue</code></a> - <span class="property-type"><a href="#definition-FunctionCallArgValue"><code>FunctionCallArgValue!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type FunctionCallArgValue </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="LLM-generatedCode" href="#LLM-generatedCode"><code>generatedCode</code></a> - <span class="property-type"><a href="#definition-GeneratedCode"><code>GeneratedCode!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type GeneratedCode </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="LLM-getCacheVolume" href="#LLM-getCacheVolume"><code>getCacheVolume</code></a> - <span class="property-type"><a href="#definition-CacheVolume"><code>CacheVolume!</code></a></span> </td>
@@ -8424,14 +8413,12 @@
                         </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-gitRef" href="#LLM-gitRef"><code>gitRef</code></a> - <span class="property-type"><a href="#definition-GitRef"><code>GitRef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type GitRef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-gitRef" href="#LLM-gitRef"><code>gitRef</code></a> - <span class="property-type"><a href="#definition-GitRef"><code>GitRef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type GitRef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-gitRepository" href="#LLM-gitRepository"><code>gitRepository</code></a> - <span class="property-type"><a href="#definition-GitRepository"><code>GitRepository!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type GitRepository <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-gitRepository" href="#LLM-gitRepository"><code>gitRepository</code></a> - <span class="property-type"><a href="#definition-GitRepository"><code>GitRepository!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type GitRepository </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-history" href="#LLM-history"><code>history</code></a> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span> </td>
@@ -8446,81 +8433,68 @@
                         <td> A unique identifier for this LLM. </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-inputTypeDef" href="#LLM-inputTypeDef"><code>inputTypeDef</code></a> - <span class="property-type"><a href="#definition-InputTypeDef"><code>InputTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type InputTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-inputTypeDef" href="#LLM-inputTypeDef"><code>inputTypeDef</code></a> - <span class="property-type"><a href="#definition-InputTypeDef"><code>InputTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type InputTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-interfaceTypeDef" href="#LLM-interfaceTypeDef"><code>interfaceTypeDef</code></a> - <span class="property-type"><a href="#definition-InterfaceTypeDef"><code>InterfaceTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type InterfaceTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-interfaceTypeDef" href="#LLM-interfaceTypeDef"><code>interfaceTypeDef</code></a> - <span class="property-type"><a href="#definition-InterfaceTypeDef"><code>InterfaceTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type InterfaceTypeDef </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-lastReply" href="#LLM-lastReply"><code>lastReply</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> return the last llm reply from the history </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-listTypeDef" href="#LLM-listTypeDef"><code>listTypeDef</code></a> - <span class="property-type"><a href="#definition-ListTypeDef"><code>ListTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ListTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-listTypeDef" href="#LLM-listTypeDef"><code>listTypeDef</code></a> - <span class="property-type"><a href="#definition-ListTypeDef"><code>ListTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ListTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-lLM" href="#LLM-lLM"><code>lLM</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type LLM <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-lLM" href="#LLM-lLM"><code>lLM</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type LLM </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-loop" href="#LLM-loop"><code>loop</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> synchronize LLM state <span class="deprecation-reason">use sync</span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-loop" href="#LLM-loop"><code>loop</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> synchronize LLM state </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-model" href="#LLM-model"><code>model</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> return the model used by the llm </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-module" href="#LLM-module"><code>module</code></a> - <span class="property-type"><a href="#definition-Module"><code>Module!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Module <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-module" href="#LLM-module"><code>module</code></a> - <span class="property-type"><a href="#definition-Module"><code>Module!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Module </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-moduleConfigClient" href="#LLM-moduleConfigClient"><code>moduleConfigClient</code></a> - <span class="property-type"><a href="#definition-ModuleConfigClient"><code>ModuleConfigClient!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ModuleConfigClient <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-moduleConfigClient" href="#LLM-moduleConfigClient"><code>moduleConfigClient</code></a> - <span class="property-type"><a href="#definition-ModuleConfigClient"><code>ModuleConfigClient!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ModuleConfigClient </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-moduleSource" href="#LLM-moduleSource"><code>moduleSource</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ModuleSource <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-moduleSource" href="#LLM-moduleSource"><code>moduleSource</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ModuleSource </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-objectTypeDef" href="#LLM-objectTypeDef"><code>objectTypeDef</code></a> - <span class="property-type"><a href="#definition-ObjectTypeDef"><code>ObjectTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ObjectTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-objectTypeDef" href="#LLM-objectTypeDef"><code>objectTypeDef</code></a> - <span class="property-type"><a href="#definition-ObjectTypeDef"><code>ObjectTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ObjectTypeDef </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-provider" href="#LLM-provider"><code>provider</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> return the provider used by the llm </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-scalarTypeDef" href="#LLM-scalarTypeDef"><code>scalarTypeDef</code></a> - <span class="property-type"><a href="#definition-ScalarTypeDef"><code>ScalarTypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type ScalarTypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-scalarTypeDef" href="#LLM-scalarTypeDef"><code>scalarTypeDef</code></a> - <span class="property-type"><a href="#definition-ScalarTypeDef"><code>ScalarTypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type ScalarTypeDef </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-sdkconfig" href="#LLM-sdkconfig"><code>sdkconfig</code></a> - <span class="property-type"><a href="#definition-SDKConfig"><code>SDKConfig</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type SDKConfig <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-sdkconfig" href="#LLM-sdkconfig"><code>sdkconfig</code></a> - <span class="property-type"><a href="#definition-SDKConfig"><code>SDKConfig</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type SDKConfig </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-secret" href="#LLM-secret"><code>secret</code></a> - <span class="property-type"><a href="#definition-Secret"><code>Secret!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Secret <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-secret" href="#LLM-secret"><code>secret</code></a> - <span class="property-type"><a href="#definition-Secret"><code>Secret!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Secret </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-service" href="#LLM-service"><code>service</code></a> - <span class="property-type"><a href="#definition-Service"><code>Service!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Service <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-service" href="#LLM-service"><code>service</code></a> - <span class="property-type"><a href="#definition-Service"><code>Service!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Service </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="LLM-setCacheVolume" href="#LLM-setCacheVolume"><code>setCacheVolume</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
@@ -9237,41 +9211,36 @@
                         </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-socket" href="#LLM-socket"><code>socket</code></a> - <span class="property-type"><a href="#definition-Socket"><code>Socket!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Socket <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-socket" href="#LLM-socket"><code>socket</code></a> - <span class="property-type"><a href="#definition-Socket"><code>Socket!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Socket </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-sourceMap" href="#LLM-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type SourceMap <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-sourceMap" href="#LLM-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type SourceMap </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-sync" href="#LLM-sync"><code>sync</code></a> - <span class="property-type"><a href="#definition-LLMID"><code>LLMID!</code></a></span> </td>
                         <td> synchronize LLM state </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-terminal" href="#LLM-terminal"><code>terminal</code></a> - <span class="property-type"><a href="#definition-Terminal"><code>Terminal!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type Terminal <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-terminal" href="#LLM-terminal"><code>terminal</code></a> - <span class="property-type"><a href="#definition-Terminal"><code>Terminal!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type Terminal </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-tools" href="#LLM-tools"><code>tools</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> print documentation for available tools </td>
                       </tr>
                       <tr>
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-typeDef" href="#LLM-typeDef"><code>typeDef</code></a> - <span class="property-type"><a href="#definition-TypeDef"><code>TypeDef!</code></a></span> </td>
-                        <td> Retrieve a the current value in the LLM environment, of type TypeDef <span class="deprecation-reason">use get<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-typeDef" href="#LLM-typeDef"><code>typeDef</code></a> - <span class="property-type"><a href="#definition-TypeDef"><code>TypeDef!</code></a></span> </td>
+                        <td> Retrieve a the current value in the LLM environment, of type TypeDef </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="LLM-variables" href="#LLM-variables"><code>variables</code></a> - <span class="property-type"><a href="#definition-LLMVariable"><code>[LLMVariable!]!</code></a></span> </td>
                         <td> list variables in the LLM environment </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withCacheVolume" href="#LLM-withCacheVolume"><code>withCacheVolume</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type CacheVolume in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withCacheVolume" href="#LLM-withCacheVolume"><code>withCacheVolume</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type CacheVolume in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9287,9 +9256,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withContainer" href="#LLM-withContainer"><code>withContainer</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Container in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withContainer" href="#LLM-withContainer"><code>withContainer</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Container in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9305,9 +9273,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withCurrentModule" href="#LLM-withCurrentModule"><code>withCurrentModule</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type CurrentModule in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withCurrentModule" href="#LLM-withCurrentModule"><code>withCurrentModule</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type CurrentModule in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9323,9 +9290,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withDirectory" href="#LLM-withDirectory"><code>withDirectory</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Directory in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withDirectory" href="#LLM-withDirectory"><code>withDirectory</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Directory in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9341,9 +9307,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withEnumTypeDef" href="#LLM-withEnumTypeDef"><code>withEnumTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type EnumTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withEnumTypeDef" href="#LLM-withEnumTypeDef"><code>withEnumTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type EnumTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9359,9 +9324,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withEnumValueTypeDef" href="#LLM-withEnumValueTypeDef"><code>withEnumValueTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type EnumValueTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withEnumValueTypeDef" href="#LLM-withEnumValueTypeDef"><code>withEnumValueTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type EnumValueTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9377,9 +9341,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withError" href="#LLM-withError"><code>withError</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Error in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withError" href="#LLM-withError"><code>withError</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Error in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9395,9 +9358,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withErrorValue" href="#LLM-withErrorValue"><code>withErrorValue</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ErrorValue in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withErrorValue" href="#LLM-withErrorValue"><code>withErrorValue</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ErrorValue in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9413,9 +9375,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFieldTypeDef" href="#LLM-withFieldTypeDef"><code>withFieldTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type FieldTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFieldTypeDef" href="#LLM-withFieldTypeDef"><code>withFieldTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type FieldTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9431,9 +9392,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFile" href="#LLM-withFile"><code>withFile</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type File in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFile" href="#LLM-withFile"><code>withFile</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type File in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9449,9 +9409,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFunction" href="#LLM-withFunction"><code>withFunction</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Function in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFunction" href="#LLM-withFunction"><code>withFunction</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Function in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9467,9 +9426,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFunctionArg" href="#LLM-withFunctionArg"><code>withFunctionArg</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type FunctionArg in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFunctionArg" href="#LLM-withFunctionArg"><code>withFunctionArg</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type FunctionArg in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9485,9 +9443,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFunctionCall" href="#LLM-withFunctionCall"><code>withFunctionCall</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type FunctionCall in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFunctionCall" href="#LLM-withFunctionCall"><code>withFunctionCall</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type FunctionCall in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9503,9 +9460,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withFunctionCallArgValue" href="#LLM-withFunctionCallArgValue"><code>withFunctionCallArgValue</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type FunctionCallArgValue in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withFunctionCallArgValue" href="#LLM-withFunctionCallArgValue"><code>withFunctionCallArgValue</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type FunctionCallArgValue in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9521,9 +9477,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withGeneratedCode" href="#LLM-withGeneratedCode"><code>withGeneratedCode</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type GeneratedCode in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withGeneratedCode" href="#LLM-withGeneratedCode"><code>withGeneratedCode</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type GeneratedCode in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9539,9 +9494,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withGitRef" href="#LLM-withGitRef"><code>withGitRef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type GitRef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withGitRef" href="#LLM-withGitRef"><code>withGitRef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type GitRef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9557,9 +9511,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withGitRepository" href="#LLM-withGitRepository"><code>withGitRepository</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type GitRepository in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withGitRepository" href="#LLM-withGitRepository"><code>withGitRepository</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type GitRepository in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9575,9 +9528,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withInputTypeDef" href="#LLM-withInputTypeDef"><code>withInputTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type InputTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withInputTypeDef" href="#LLM-withInputTypeDef"><code>withInputTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type InputTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9593,9 +9545,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withInterfaceTypeDef" href="#LLM-withInterfaceTypeDef"><code>withInterfaceTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type InterfaceTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withInterfaceTypeDef" href="#LLM-withInterfaceTypeDef"><code>withInterfaceTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type InterfaceTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9611,9 +9562,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withListTypeDef" href="#LLM-withListTypeDef"><code>withListTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ListTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withListTypeDef" href="#LLM-withListTypeDef"><code>withListTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ListTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9629,9 +9579,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withLLM" href="#LLM-withLLM"><code>withLLM</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type LLM in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withLLM" href="#LLM-withLLM"><code>withLLM</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type LLM in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9664,9 +9613,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withModule" href="#LLM-withModule"><code>withModule</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Module in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withModule" href="#LLM-withModule"><code>withModule</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Module in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9682,9 +9630,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withModuleConfigClient" href="#LLM-withModuleConfigClient"><code>withModuleConfigClient</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ModuleConfigClient in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withModuleConfigClient" href="#LLM-withModuleConfigClient"><code>withModuleConfigClient</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ModuleConfigClient in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9700,9 +9647,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withModuleSource" href="#LLM-withModuleSource"><code>withModuleSource</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ModuleSource in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withModuleSource" href="#LLM-withModuleSource"><code>withModuleSource</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ModuleSource in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9718,9 +9664,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withObjectTypeDef" href="#LLM-withObjectTypeDef"><code>withObjectTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ObjectTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withObjectTypeDef" href="#LLM-withObjectTypeDef"><code>withObjectTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ObjectTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9795,9 +9740,8 @@
                         <td> Provide the entire Query object to the LLM </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withScalarTypeDef" href="#LLM-withScalarTypeDef"><code>withScalarTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type ScalarTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withScalarTypeDef" href="#LLM-withScalarTypeDef"><code>withScalarTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type ScalarTypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9813,9 +9757,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withSDKConfig" href="#LLM-withSDKConfig"><code>withSDKConfig</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type SDKConfig in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withSDKConfig" href="#LLM-withSDKConfig"><code>withSDKConfig</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type SDKConfig in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9831,9 +9774,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withSecret" href="#LLM-withSecret"><code>withSecret</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Secret in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withSecret" href="#LLM-withSecret"><code>withSecret</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Secret in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9849,9 +9791,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withService" href="#LLM-withService"><code>withService</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Service in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withService" href="#LLM-withService"><code>withService</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Service in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9867,9 +9808,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withSocket" href="#LLM-withSocket"><code>withSocket</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Socket in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withSocket" href="#LLM-withSocket"><code>withSocket</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Socket in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9885,9 +9825,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withSourceMap" href="#LLM-withSourceMap"><code>withSourceMap</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type SourceMap in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withSourceMap" href="#LLM-withSourceMap"><code>withSourceMap</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type SourceMap in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9903,9 +9842,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withTerminal" href="#LLM-withTerminal"><code>withTerminal</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type Terminal in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withTerminal" href="#LLM-withTerminal"><code>withTerminal</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type Terminal in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -9921,9 +9859,8 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withTypeDef" href="#LLM-withTypeDef"><code>withTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
-                        <td> Set a variable of type TypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>
-                        </td>
+                        <td data-property-name=""><a class="property-name" id="LLM-withTypeDef" href="#LLM-withTypeDef"><code>withTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Set a variable of type TypeDef in the llm environment </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -9790,6 +9790,10 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="LLM-withQuery" href="#LLM-withQuery"><code>withQuery</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> Provide the entire Query object to the LLM </td>
+                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name="" class="definition-deprecated"><a class="property-name" id="LLM-withScalarTypeDef" href="#LLM-withScalarTypeDef"><code>withScalarTypeDef</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
                         <td> Set a variable of type ScalarTypeDef in the llm environment <span class="deprecation-reason">use set<targettype> instead</targettype></span>

--- a/sdk/elixir/lib/dagger/gen/llm.ex
+++ b/sdk/elixir/lib/dagger/gen/llm.ex
@@ -1879,6 +1879,18 @@ defmodule Dagger.LLM do
     }
   end
 
+  @doc "Provide the entire Query object to the LLM"
+  @spec with_query(t()) :: Dagger.LLM.t()
+  def with_query(%__MODULE__{} = llm) do
+    query_builder =
+      llm.query_builder |> QB.select("withQuery")
+
+    %Dagger.LLM{
+      query_builder: query_builder,
+      client: llm.client
+    }
+  end
+
   @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type SDKConfig in the llm environment"
   @spec with_sdk_config(t(), Dagger.SDKConfig.t()) :: Dagger.LLM.t()

--- a/sdk/elixir/lib/dagger/gen/llm.ex
+++ b/sdk/elixir/lib/dagger/gen/llm.ex
@@ -10,7 +10,7 @@ defmodule Dagger.LLM do
   defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
-  @deprecated "use get<TargetType> instead"
+
   @doc "Retrieve a the current value in the LLM environment, of type CacheVolume"
   @spec cache_volume(t()) :: Dagger.CacheVolume.t()
   def cache_volume(%__MODULE__{} = llm) do
@@ -23,7 +23,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Container"
   @spec container(t()) :: Dagger.Container.t()
   def container(%__MODULE__{} = llm) do
@@ -36,7 +35,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type CurrentModule"
   @spec current_module(t()) :: Dagger.CurrentModule.t()
   def current_module(%__MODULE__{} = llm) do
@@ -49,7 +47,15 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
+  @doc "returns the type of the current state"
+  @spec current_type(t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def current_type(%__MODULE__{} = llm) do
+    query_builder =
+      llm.query_builder |> QB.select("currentType")
+
+    Client.execute(llm.client, query_builder)
+  end
+
   @doc "Retrieve a the current value in the LLM environment, of type Directory"
   @spec directory(t()) :: Dagger.Directory.t()
   def directory(%__MODULE__{} = llm) do
@@ -62,7 +68,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type EnumTypeDef"
   @spec enum_type_def(t()) :: Dagger.EnumTypeDef.t()
   def enum_type_def(%__MODULE__{} = llm) do
@@ -75,7 +80,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type EnumValueTypeDef"
   @spec enum_value_type_def(t()) :: Dagger.EnumValueTypeDef.t()
   def enum_value_type_def(%__MODULE__{} = llm) do
@@ -88,7 +92,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Error"
   @spec error(t()) :: Dagger.Error.t()
   def error(%__MODULE__{} = llm) do
@@ -101,7 +104,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ErrorValue"
   @spec error_value(t()) :: Dagger.ErrorValue.t()
   def error_value(%__MODULE__{} = llm) do
@@ -114,7 +116,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type FieldTypeDef"
   @spec field_type_def(t()) :: Dagger.FieldTypeDef.t()
   def field_type_def(%__MODULE__{} = llm) do
@@ -127,7 +128,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type File"
   @spec file(t()) :: Dagger.File.t()
   def file(%__MODULE__{} = llm) do
@@ -140,7 +140,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Function"
   @spec function(t()) :: Dagger.Function.t()
   def function(%__MODULE__{} = llm) do
@@ -153,7 +152,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type FunctionArg"
   @spec function_arg(t()) :: Dagger.FunctionArg.t()
   def function_arg(%__MODULE__{} = llm) do
@@ -166,7 +164,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type FunctionCall"
   @spec function_call(t()) :: Dagger.FunctionCall.t()
   def function_call(%__MODULE__{} = llm) do
@@ -179,7 +176,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type FunctionCallArgValue"
   @spec function_call_arg_value(t()) :: Dagger.FunctionCallArgValue.t()
   def function_call_arg_value(%__MODULE__{} = llm) do
@@ -192,7 +188,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type GeneratedCode"
   @spec generated_code(t()) :: Dagger.GeneratedCode.t()
   def generated_code(%__MODULE__{} = llm) do
@@ -610,7 +605,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type GitRef"
   @spec git_ref(t()) :: Dagger.GitRef.t()
   def git_ref(%__MODULE__{} = llm) do
@@ -623,7 +617,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type GitRepository"
   @spec git_repository(t()) :: Dagger.GitRepository.t()
   def git_repository(%__MODULE__{} = llm) do
@@ -663,7 +656,6 @@ defmodule Dagger.LLM do
     Client.execute(llm.client, query_builder)
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type InputTypeDef"
   @spec input_type_def(t()) :: Dagger.InputTypeDef.t()
   def input_type_def(%__MODULE__{} = llm) do
@@ -676,7 +668,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type InterfaceTypeDef"
   @spec interface_type_def(t()) :: Dagger.InterfaceTypeDef.t()
   def interface_type_def(%__MODULE__{} = llm) do
@@ -689,7 +680,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type LLM"
   @spec l_lm(t()) :: Dagger.LLM.t()
   def l_lm(%__MODULE__{} = llm) do
@@ -711,7 +701,6 @@ defmodule Dagger.LLM do
     Client.execute(llm.client, query_builder)
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ListTypeDef"
   @spec list_type_def(t()) :: Dagger.ListTypeDef.t()
   def list_type_def(%__MODULE__{} = llm) do
@@ -724,7 +713,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use sync"
   @doc "synchronize LLM state"
   @spec loop(t()) :: Dagger.LLM.t()
   def loop(%__MODULE__{} = llm) do
@@ -746,7 +734,6 @@ defmodule Dagger.LLM do
     Client.execute(llm.client, query_builder)
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Module"
   @spec module(t()) :: Dagger.Module.t()
   def module(%__MODULE__{} = llm) do
@@ -759,7 +746,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ModuleConfigClient"
   @spec module_config_client(t()) :: Dagger.ModuleConfigClient.t()
   def module_config_client(%__MODULE__{} = llm) do
@@ -772,7 +758,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ModuleSource"
   @spec module_source(t()) :: Dagger.ModuleSource.t()
   def module_source(%__MODULE__{} = llm) do
@@ -785,7 +770,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ObjectTypeDef"
   @spec object_type_def(t()) :: Dagger.ObjectTypeDef.t()
   def object_type_def(%__MODULE__{} = llm) do
@@ -807,7 +791,6 @@ defmodule Dagger.LLM do
     Client.execute(llm.client, query_builder)
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type ScalarTypeDef"
   @spec scalar_type_def(t()) :: Dagger.ScalarTypeDef.t()
   def scalar_type_def(%__MODULE__{} = llm) do
@@ -820,7 +803,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type SDKConfig"
   @spec sdkconfig(t()) :: Dagger.SDKConfig.t() | nil
   def sdkconfig(%__MODULE__{} = llm) do
@@ -833,7 +815,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Secret"
   @spec secret(t()) :: Dagger.Secret.t()
   def secret(%__MODULE__{} = llm) do
@@ -846,7 +827,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Service"
   @spec service(t()) :: Dagger.Service.t()
   def service(%__MODULE__{} = llm) do
@@ -1370,7 +1350,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Socket"
   @spec socket(t()) :: Dagger.Socket.t()
   def socket(%__MODULE__{} = llm) do
@@ -1383,7 +1362,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type SourceMap"
   @spec source_map(t()) :: Dagger.SourceMap.t()
   def source_map(%__MODULE__{} = llm) do
@@ -1414,7 +1392,6 @@ defmodule Dagger.LLM do
     end
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type Terminal"
   @spec terminal(t()) :: Dagger.Terminal.t()
   def terminal(%__MODULE__{} = llm) do
@@ -1436,7 +1413,6 @@ defmodule Dagger.LLM do
     Client.execute(llm.client, query_builder)
   end
 
-  @deprecated "use get<TargetType> instead"
   @doc "Retrieve a the current value in the LLM environment, of type TypeDef"
   @spec type_def(t()) :: Dagger.TypeDef.t()
   def type_def(%__MODULE__{} = llm) do
@@ -1469,7 +1445,6 @@ defmodule Dagger.LLM do
     end
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type CacheVolume in the llm environment"
   @spec with_cache_volume(t(), Dagger.CacheVolume.t()) :: Dagger.LLM.t()
   def with_cache_volume(%__MODULE__{} = llm, value) do
@@ -1484,7 +1459,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Container in the llm environment"
   @spec with_container(t(), Dagger.Container.t()) :: Dagger.LLM.t()
   def with_container(%__MODULE__{} = llm, value) do
@@ -1497,7 +1471,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type CurrentModule in the llm environment"
   @spec with_current_module(t(), Dagger.CurrentModule.t()) :: Dagger.LLM.t()
   def with_current_module(%__MODULE__{} = llm, value) do
@@ -1512,7 +1485,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Directory in the llm environment"
   @spec with_directory(t(), Dagger.Directory.t()) :: Dagger.LLM.t()
   def with_directory(%__MODULE__{} = llm, value) do
@@ -1525,7 +1497,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type EnumTypeDef in the llm environment"
   @spec with_enum_type_def(t(), Dagger.EnumTypeDef.t()) :: Dagger.LLM.t()
   def with_enum_type_def(%__MODULE__{} = llm, value) do
@@ -1540,7 +1511,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type EnumValueTypeDef in the llm environment"
   @spec with_enum_value_type_def(t(), Dagger.EnumValueTypeDef.t()) :: Dagger.LLM.t()
   def with_enum_value_type_def(%__MODULE__{} = llm, value) do
@@ -1555,7 +1525,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Error in the llm environment"
   @spec with_error(t(), Dagger.Error.t()) :: Dagger.LLM.t()
   def with_error(%__MODULE__{} = llm, value) do
@@ -1568,7 +1537,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ErrorValue in the llm environment"
   @spec with_error_value(t(), Dagger.ErrorValue.t()) :: Dagger.LLM.t()
   def with_error_value(%__MODULE__{} = llm, value) do
@@ -1583,7 +1551,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type FieldTypeDef in the llm environment"
   @spec with_field_type_def(t(), Dagger.FieldTypeDef.t()) :: Dagger.LLM.t()
   def with_field_type_def(%__MODULE__{} = llm, value) do
@@ -1598,7 +1565,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type File in the llm environment"
   @spec with_file(t(), Dagger.File.t()) :: Dagger.LLM.t()
   def with_file(%__MODULE__{} = llm, value) do
@@ -1611,7 +1577,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Function in the llm environment"
   @spec with_function(t(), Dagger.Function.t()) :: Dagger.LLM.t()
   def with_function(%__MODULE__{} = llm, value) do
@@ -1624,7 +1589,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type FunctionArg in the llm environment"
   @spec with_function_arg(t(), Dagger.FunctionArg.t()) :: Dagger.LLM.t()
   def with_function_arg(%__MODULE__{} = llm, value) do
@@ -1639,7 +1603,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type FunctionCall in the llm environment"
   @spec with_function_call(t(), Dagger.FunctionCall.t()) :: Dagger.LLM.t()
   def with_function_call(%__MODULE__{} = llm, value) do
@@ -1654,7 +1617,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type FunctionCallArgValue in the llm environment"
   @spec with_function_call_arg_value(t(), Dagger.FunctionCallArgValue.t()) :: Dagger.LLM.t()
   def with_function_call_arg_value(%__MODULE__{} = llm, value) do
@@ -1669,7 +1631,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type GeneratedCode in the llm environment"
   @spec with_generated_code(t(), Dagger.GeneratedCode.t()) :: Dagger.LLM.t()
   def with_generated_code(%__MODULE__{} = llm, value) do
@@ -1684,7 +1645,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type GitRef in the llm environment"
   @spec with_git_ref(t(), Dagger.GitRef.t()) :: Dagger.LLM.t()
   def with_git_ref(%__MODULE__{} = llm, value) do
@@ -1697,7 +1657,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type GitRepository in the llm environment"
   @spec with_git_repository(t(), Dagger.GitRepository.t()) :: Dagger.LLM.t()
   def with_git_repository(%__MODULE__{} = llm, value) do
@@ -1712,7 +1671,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type InputTypeDef in the llm environment"
   @spec with_input_type_def(t(), Dagger.InputTypeDef.t()) :: Dagger.LLM.t()
   def with_input_type_def(%__MODULE__{} = llm, value) do
@@ -1727,7 +1685,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type InterfaceTypeDef in the llm environment"
   @spec with_interface_type_def(t(), Dagger.InterfaceTypeDef.t()) :: Dagger.LLM.t()
   def with_interface_type_def(%__MODULE__{} = llm, value) do
@@ -1742,7 +1699,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type LLM in the llm environment"
   @spec with_llm(t(), Dagger.LLM.t()) :: Dagger.LLM.t()
   def with_llm(%__MODULE__{} = llm, value) do
@@ -1755,7 +1711,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ListTypeDef in the llm environment"
   @spec with_list_type_def(t(), Dagger.ListTypeDef.t()) :: Dagger.LLM.t()
   def with_list_type_def(%__MODULE__{} = llm, value) do
@@ -1782,7 +1737,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Module in the llm environment"
   @spec with_module(t(), Dagger.Module.t()) :: Dagger.LLM.t()
   def with_module(%__MODULE__{} = llm, value) do
@@ -1795,7 +1749,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ModuleConfigClient in the llm environment"
   @spec with_module_config_client(t(), Dagger.ModuleConfigClient.t()) :: Dagger.LLM.t()
   def with_module_config_client(%__MODULE__{} = llm, value) do
@@ -1810,7 +1763,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ModuleSource in the llm environment"
   @spec with_module_source(t(), Dagger.ModuleSource.t()) :: Dagger.LLM.t()
   def with_module_source(%__MODULE__{} = llm, value) do
@@ -1825,7 +1777,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ObjectTypeDef in the llm environment"
   @spec with_object_type_def(t(), Dagger.ObjectTypeDef.t()) :: Dagger.LLM.t()
   def with_object_type_def(%__MODULE__{} = llm, value) do
@@ -1891,7 +1842,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type SDKConfig in the llm environment"
   @spec with_sdk_config(t(), Dagger.SDKConfig.t()) :: Dagger.LLM.t()
   def with_sdk_config(%__MODULE__{} = llm, value) do
@@ -1904,7 +1854,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type ScalarTypeDef in the llm environment"
   @spec with_scalar_type_def(t(), Dagger.ScalarTypeDef.t()) :: Dagger.LLM.t()
   def with_scalar_type_def(%__MODULE__{} = llm, value) do
@@ -1919,7 +1868,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Secret in the llm environment"
   @spec with_secret(t(), Dagger.Secret.t()) :: Dagger.LLM.t()
   def with_secret(%__MODULE__{} = llm, value) do
@@ -1932,7 +1880,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Service in the llm environment"
   @spec with_service(t(), Dagger.Service.t()) :: Dagger.LLM.t()
   def with_service(%__MODULE__{} = llm, value) do
@@ -1945,7 +1892,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Socket in the llm environment"
   @spec with_socket(t(), Dagger.Socket.t()) :: Dagger.LLM.t()
   def with_socket(%__MODULE__{} = llm, value) do
@@ -1958,7 +1904,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type SourceMap in the llm environment"
   @spec with_source_map(t(), Dagger.SourceMap.t()) :: Dagger.LLM.t()
   def with_source_map(%__MODULE__{} = llm, value) do
@@ -1971,7 +1916,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type Terminal in the llm environment"
   @spec with_terminal(t(), Dagger.Terminal.t()) :: Dagger.LLM.t()
   def with_terminal(%__MODULE__{} = llm, value) do
@@ -1984,7 +1928,6 @@ defmodule Dagger.LLM do
     }
   end
 
-  @deprecated "use set<TargetType> instead"
   @doc "Set a variable of type TypeDef in the llm environment"
   @spec with_type_def(t(), Dagger.TypeDef.t()) :: Dagger.LLM.t()
   def with_type_def(%__MODULE__{} = llm, value) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5261,6 +5261,7 @@ func (r *InterfaceTypeDef) SourceModuleName(ctx context.Context) (string, error)
 type LLM struct {
 	query *querybuilder.Selection
 
+	currentType *string
 	getString   *string
 	historyJSON *string
 	id          *LLMID
@@ -5286,8 +5287,6 @@ func (r *LLM) WithGraphQLQuery(q *querybuilder.Selection) *LLM {
 }
 
 // Retrieve a the current value in the LLM environment, of type CacheVolume
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) CacheVolume() *CacheVolume {
 	q := r.query.Select("cacheVolume")
 
@@ -5297,8 +5296,6 @@ func (r *LLM) CacheVolume() *CacheVolume {
 }
 
 // Retrieve a the current value in the LLM environment, of type Container
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Container() *Container {
 	q := r.query.Select("container")
 
@@ -5308,8 +5305,6 @@ func (r *LLM) Container() *Container {
 }
 
 // Retrieve a the current value in the LLM environment, of type CurrentModule
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) CurrentModule() *CurrentModule {
 	q := r.query.Select("currentModule")
 
@@ -5318,9 +5313,20 @@ func (r *LLM) CurrentModule() *CurrentModule {
 	}
 }
 
+// returns the type of the current state
+func (r *LLM) CurrentType(ctx context.Context) (string, error) {
+	if r.currentType != nil {
+		return *r.currentType, nil
+	}
+	q := r.query.Select("currentType")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // Retrieve a the current value in the LLM environment, of type Directory
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Directory() *Directory {
 	q := r.query.Select("directory")
 
@@ -5330,8 +5336,6 @@ func (r *LLM) Directory() *Directory {
 }
 
 // Retrieve a the current value in the LLM environment, of type EnumTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) EnumTypeDef() *EnumTypeDef {
 	q := r.query.Select("enumTypeDef")
 
@@ -5341,8 +5345,6 @@ func (r *LLM) EnumTypeDef() *EnumTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type EnumValueTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) EnumValueTypeDef() *EnumValueTypeDef {
 	q := r.query.Select("enumValueTypeDef")
 
@@ -5352,8 +5354,6 @@ func (r *LLM) EnumValueTypeDef() *EnumValueTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type Error
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Error() *Error {
 	q := r.query.Select("error")
 
@@ -5363,8 +5363,6 @@ func (r *LLM) Error() *Error {
 }
 
 // Retrieve a the current value in the LLM environment, of type ErrorValue
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ErrorValue() *ErrorValue {
 	q := r.query.Select("errorValue")
 
@@ -5374,8 +5372,6 @@ func (r *LLM) ErrorValue() *ErrorValue {
 }
 
 // Retrieve a the current value in the LLM environment, of type FieldTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) FieldTypeDef() *FieldTypeDef {
 	q := r.query.Select("fieldTypeDef")
 
@@ -5385,8 +5381,6 @@ func (r *LLM) FieldTypeDef() *FieldTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type File
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) File() *File {
 	q := r.query.Select("file")
 
@@ -5396,8 +5390,6 @@ func (r *LLM) File() *File {
 }
 
 // Retrieve a the current value in the LLM environment, of type Function
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Function() *Function {
 	q := r.query.Select("function")
 
@@ -5407,8 +5399,6 @@ func (r *LLM) Function() *Function {
 }
 
 // Retrieve a the current value in the LLM environment, of type FunctionArg
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) FunctionArg() *FunctionArg {
 	q := r.query.Select("functionArg")
 
@@ -5418,8 +5408,6 @@ func (r *LLM) FunctionArg() *FunctionArg {
 }
 
 // Retrieve a the current value in the LLM environment, of type FunctionCall
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) FunctionCall() *FunctionCall {
 	q := r.query.Select("functionCall")
 
@@ -5429,8 +5417,6 @@ func (r *LLM) FunctionCall() *FunctionCall {
 }
 
 // Retrieve a the current value in the LLM environment, of type FunctionCallArgValue
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) FunctionCallArgValue() *FunctionCallArgValue {
 	q := r.query.Select("functionCallArgValue")
 
@@ -5440,8 +5426,6 @@ func (r *LLM) FunctionCallArgValue() *FunctionCallArgValue {
 }
 
 // Retrieve a the current value in the LLM environment, of type GeneratedCode
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) GeneratedCode() *GeneratedCode {
 	q := r.query.Select("generatedCode")
 
@@ -5795,8 +5779,6 @@ func (r *LLM) GetTypeDef(name string) *TypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type GitRef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) GitRef() *GitRef {
 	q := r.query.Select("gitRef")
 
@@ -5806,8 +5788,6 @@ func (r *LLM) GitRef() *GitRef {
 }
 
 // Retrieve a the current value in the LLM environment, of type GitRepository
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) GitRepository() *GitRepository {
 	q := r.query.Select("gitRepository")
 
@@ -5880,8 +5860,6 @@ func (r *LLM) MarshalJSON() ([]byte, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type InputTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) InputTypeDef() *InputTypeDef {
 	q := r.query.Select("inputTypeDef")
 
@@ -5891,8 +5869,6 @@ func (r *LLM) InputTypeDef() *InputTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type InterfaceTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) InterfaceTypeDef() *InterfaceTypeDef {
 	q := r.query.Select("interfaceTypeDef")
 
@@ -5902,8 +5878,6 @@ func (r *LLM) InterfaceTypeDef() *InterfaceTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type LLM
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) LLM() *LLM {
 	q := r.query.Select("lLM")
 
@@ -5926,8 +5900,6 @@ func (r *LLM) LastReply(ctx context.Context) (string, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type ListTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ListTypeDef() *ListTypeDef {
 	q := r.query.Select("listTypeDef")
 
@@ -5937,8 +5909,6 @@ func (r *LLM) ListTypeDef() *ListTypeDef {
 }
 
 // synchronize LLM state
-//
-// Deprecated: use sync
 func (r *LLM) Loop() *LLM {
 	q := r.query.Select("loop")
 
@@ -5961,8 +5931,6 @@ func (r *LLM) Model(ctx context.Context) (string, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type Module
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Module() *Module {
 	q := r.query.Select("module")
 
@@ -5972,8 +5940,6 @@ func (r *LLM) Module() *Module {
 }
 
 // Retrieve a the current value in the LLM environment, of type ModuleConfigClient
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ModuleConfigClient() *ModuleConfigClient {
 	q := r.query.Select("moduleConfigClient")
 
@@ -5983,8 +5949,6 @@ func (r *LLM) ModuleConfigClient() *ModuleConfigClient {
 }
 
 // Retrieve a the current value in the LLM environment, of type ModuleSource
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ModuleSource() *ModuleSource {
 	q := r.query.Select("moduleSource")
 
@@ -5994,8 +5958,6 @@ func (r *LLM) ModuleSource() *ModuleSource {
 }
 
 // Retrieve a the current value in the LLM environment, of type ObjectTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ObjectTypeDef() *ObjectTypeDef {
 	q := r.query.Select("objectTypeDef")
 
@@ -6018,8 +5980,6 @@ func (r *LLM) Provider(ctx context.Context) (string, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type ScalarTypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) ScalarTypeDef() *ScalarTypeDef {
 	q := r.query.Select("scalarTypeDef")
 
@@ -6029,8 +5989,6 @@ func (r *LLM) ScalarTypeDef() *ScalarTypeDef {
 }
 
 // Retrieve a the current value in the LLM environment, of type SDKConfig
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Sdkconfig() *SDKConfig {
 	q := r.query.Select("sdkconfig")
 
@@ -6040,8 +5998,6 @@ func (r *LLM) Sdkconfig() *SDKConfig {
 }
 
 // Retrieve a the current value in the LLM environment, of type Secret
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Secret() *Secret {
 	q := r.query.Select("secret")
 
@@ -6051,8 +6007,6 @@ func (r *LLM) Secret() *Secret {
 }
 
 // Retrieve a the current value in the LLM environment, of type Service
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Service() *Service {
 	q := r.query.Select("service")
 
@@ -6469,8 +6423,6 @@ func (r *LLM) SetTypeDef(name string, value *TypeDef) *LLM {
 }
 
 // Retrieve a the current value in the LLM environment, of type Socket
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Socket() *Socket {
 	q := r.query.Select("socket")
 
@@ -6480,8 +6432,6 @@ func (r *LLM) Socket() *Socket {
 }
 
 // Retrieve a the current value in the LLM environment, of type SourceMap
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) SourceMap() *SourceMap {
 	q := r.query.Select("sourceMap")
 
@@ -6504,8 +6454,6 @@ func (r *LLM) Sync(ctx context.Context) (*LLM, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type Terminal
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) Terminal() *Terminal {
 	q := r.query.Select("terminal")
 
@@ -6528,8 +6476,6 @@ func (r *LLM) Tools(ctx context.Context) (string, error) {
 }
 
 // Retrieve a the current value in the LLM environment, of type TypeDef
-//
-// Deprecated: use get<TargetType> instead
 func (r *LLM) TypeDef() *TypeDef {
 	q := r.query.Select("typeDef")
 
@@ -6572,8 +6518,6 @@ func (r *LLM) Variables(ctx context.Context) ([]LLMVariable, error) {
 }
 
 // Set a variable of type CacheVolume in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithCacheVolume(value *CacheVolume) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withCacheVolume")
@@ -6585,8 +6529,6 @@ func (r *LLM) WithCacheVolume(value *CacheVolume) *LLM {
 }
 
 // Set a variable of type Container in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithContainer(value *Container) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withContainer")
@@ -6598,8 +6540,6 @@ func (r *LLM) WithContainer(value *Container) *LLM {
 }
 
 // Set a variable of type CurrentModule in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithCurrentModule(value *CurrentModule) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withCurrentModule")
@@ -6611,8 +6551,6 @@ func (r *LLM) WithCurrentModule(value *CurrentModule) *LLM {
 }
 
 // Set a variable of type Directory in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithDirectory(value *Directory) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withDirectory")
@@ -6624,8 +6562,6 @@ func (r *LLM) WithDirectory(value *Directory) *LLM {
 }
 
 // Set a variable of type EnumTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithEnumTypeDef(value *EnumTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withEnumTypeDef")
@@ -6637,8 +6573,6 @@ func (r *LLM) WithEnumTypeDef(value *EnumTypeDef) *LLM {
 }
 
 // Set a variable of type EnumValueTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithEnumValueTypeDef(value *EnumValueTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withEnumValueTypeDef")
@@ -6650,8 +6584,6 @@ func (r *LLM) WithEnumValueTypeDef(value *EnumValueTypeDef) *LLM {
 }
 
 // Set a variable of type Error in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithError(value *Error) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withError")
@@ -6663,8 +6595,6 @@ func (r *LLM) WithError(value *Error) *LLM {
 }
 
 // Set a variable of type ErrorValue in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithErrorValue(value *ErrorValue) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withErrorValue")
@@ -6676,8 +6606,6 @@ func (r *LLM) WithErrorValue(value *ErrorValue) *LLM {
 }
 
 // Set a variable of type FieldTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFieldTypeDef(value *FieldTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFieldTypeDef")
@@ -6689,8 +6617,6 @@ func (r *LLM) WithFieldTypeDef(value *FieldTypeDef) *LLM {
 }
 
 // Set a variable of type File in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFile(value *File) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFile")
@@ -6702,8 +6628,6 @@ func (r *LLM) WithFile(value *File) *LLM {
 }
 
 // Set a variable of type Function in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFunction(value *Function) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFunction")
@@ -6715,8 +6639,6 @@ func (r *LLM) WithFunction(value *Function) *LLM {
 }
 
 // Set a variable of type FunctionArg in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFunctionArg(value *FunctionArg) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFunctionArg")
@@ -6728,8 +6650,6 @@ func (r *LLM) WithFunctionArg(value *FunctionArg) *LLM {
 }
 
 // Set a variable of type FunctionCall in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFunctionCall(value *FunctionCall) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFunctionCall")
@@ -6741,8 +6661,6 @@ func (r *LLM) WithFunctionCall(value *FunctionCall) *LLM {
 }
 
 // Set a variable of type FunctionCallArgValue in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithFunctionCallArgValue(value *FunctionCallArgValue) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withFunctionCallArgValue")
@@ -6754,8 +6672,6 @@ func (r *LLM) WithFunctionCallArgValue(value *FunctionCallArgValue) *LLM {
 }
 
 // Set a variable of type GeneratedCode in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithGeneratedCode(value *GeneratedCode) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withGeneratedCode")
@@ -6767,8 +6683,6 @@ func (r *LLM) WithGeneratedCode(value *GeneratedCode) *LLM {
 }
 
 // Set a variable of type GitRef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithGitRef(value *GitRef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withGitRef")
@@ -6780,8 +6694,6 @@ func (r *LLM) WithGitRef(value *GitRef) *LLM {
 }
 
 // Set a variable of type GitRepository in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithGitRepository(value *GitRepository) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withGitRepository")
@@ -6793,8 +6705,6 @@ func (r *LLM) WithGitRepository(value *GitRepository) *LLM {
 }
 
 // Set a variable of type InputTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithInputTypeDef(value *InputTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withInputTypeDef")
@@ -6806,8 +6716,6 @@ func (r *LLM) WithInputTypeDef(value *InputTypeDef) *LLM {
 }
 
 // Set a variable of type InterfaceTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithInterfaceTypeDef(value *InterfaceTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withInterfaceTypeDef")
@@ -6819,8 +6727,6 @@ func (r *LLM) WithInterfaceTypeDef(value *InterfaceTypeDef) *LLM {
 }
 
 // Set a variable of type LLM in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithLLM(value *LLM) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withLLM")
@@ -6832,8 +6738,6 @@ func (r *LLM) WithLLM(value *LLM) *LLM {
 }
 
 // Set a variable of type ListTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithListTypeDef(value *ListTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withListTypeDef")
@@ -6855,8 +6759,6 @@ func (r *LLM) WithModel(model string) *LLM {
 }
 
 // Set a variable of type Module in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithModule(value *Module) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withModule")
@@ -6868,8 +6770,6 @@ func (r *LLM) WithModule(value *Module) *LLM {
 }
 
 // Set a variable of type ModuleConfigClient in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithModuleConfigClient(value *ModuleConfigClient) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withModuleConfigClient")
@@ -6881,8 +6781,6 @@ func (r *LLM) WithModuleConfigClient(value *ModuleConfigClient) *LLM {
 }
 
 // Set a variable of type ModuleSource in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithModuleSource(value *ModuleSource) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withModuleSource")
@@ -6894,8 +6792,6 @@ func (r *LLM) WithModuleSource(value *ModuleSource) *LLM {
 }
 
 // Set a variable of type ObjectTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithObjectTypeDef(value *ObjectTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withObjectTypeDef")
@@ -6948,8 +6844,6 @@ func (r *LLM) WithQuery() *LLM {
 }
 
 // Set a variable of type SDKConfig in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithSDKConfig(value *SDKConfig) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withSDKConfig")
@@ -6961,8 +6855,6 @@ func (r *LLM) WithSDKConfig(value *SDKConfig) *LLM {
 }
 
 // Set a variable of type ScalarTypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithScalarTypeDef(value *ScalarTypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withScalarTypeDef")
@@ -6974,8 +6866,6 @@ func (r *LLM) WithScalarTypeDef(value *ScalarTypeDef) *LLM {
 }
 
 // Set a variable of type Secret in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithSecret(value *Secret) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withSecret")
@@ -6987,8 +6877,6 @@ func (r *LLM) WithSecret(value *Secret) *LLM {
 }
 
 // Set a variable of type Service in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithService(value *Service) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withService")
@@ -7000,8 +6888,6 @@ func (r *LLM) WithService(value *Service) *LLM {
 }
 
 // Set a variable of type Socket in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithSocket(value *Socket) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withSocket")
@@ -7013,8 +6899,6 @@ func (r *LLM) WithSocket(value *Socket) *LLM {
 }
 
 // Set a variable of type SourceMap in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithSourceMap(value *SourceMap) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withSourceMap")
@@ -7026,8 +6910,6 @@ func (r *LLM) WithSourceMap(value *SourceMap) *LLM {
 }
 
 // Set a variable of type Terminal in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithTerminal(value *Terminal) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withTerminal")
@@ -7039,8 +6921,6 @@ func (r *LLM) WithTerminal(value *Terminal) *LLM {
 }
 
 // Set a variable of type TypeDef in the llm environment
-//
-// Deprecated: use set<TargetType> instead
 func (r *LLM) WithTypeDef(value *TypeDef) *LLM {
 	assertNotNil("value", value)
 	q := r.query.Select("withTypeDef")

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6938,6 +6938,15 @@ func (r *LLM) WithPromptVar(name string, value string) *LLM {
 	}
 }
 
+// Provide the entire Query object to the LLM
+func (r *LLM) WithQuery() *LLM {
+	q := r.query.Select("withQuery")
+
+	return &LLM{
+		query: q,
+	}
+}
+
 // Set a variable of type SDKConfig in the llm environment
 //
 // Deprecated: use set<TargetType> instead

--- a/sdk/php/generated/LLM.php
+++ b/sdk/php/generated/LLM.php
@@ -38,6 +38,15 @@ class LLM extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * returns the type of the current state
+     */
+    public function currentType(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('currentType');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'currentType');
+    }
+
+    /**
      * Retrieve a the current value in the LLM environment, of type Directory
      */
     public function directory(): Directory

--- a/sdk/php/generated/LLM.php
+++ b/sdk/php/generated/LLM.php
@@ -1443,6 +1443,15 @@ class LLM extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Provide the entire Query object to the LLM
+     */
+    public function withQuery(): LLM
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withQuery');
+        return new \Dagger\LLM($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Set a variable of type SDKConfig in the llm environment
      */
     public function withSDKConfig(SDKConfigId|SDKConfig $value): LLM

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5432,30 +5432,13 @@ class LLM(Type):
     def cache_volume(self) -> CacheVolume:
         """Retrieve a the current value in the LLM environment, of type
         CacheVolume
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "cache_volume" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("cacheVolume", _args)
         return CacheVolume(_ctx)
 
     def container(self) -> Container:
-        """Retrieve a the current value in the LLM environment, of type Container
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "container" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Container"""
         _args: list[Arg] = []
         _ctx = self._select("container", _args)
         return Container(_ctx)
@@ -5463,30 +5446,34 @@ class LLM(Type):
     def current_module(self) -> CurrentModule:
         """Retrieve a the current value in the LLM environment, of type
         CurrentModule
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "current_module" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("currentModule", _args)
         return CurrentModule(_ctx)
 
-    def directory(self) -> Directory:
-        """Retrieve a the current value in the LLM environment, of type Directory
+    async def current_type(self) -> str | None:
+        """returns the type of the current state
 
-        .. deprecated::
-            use get<TargetType> instead
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
         """
-        warnings.warn(
-            'Method "directory" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        _args: list[Arg] = []
+        _ctx = self._select("currentType", _args)
+        return await _ctx.execute(str | None)
+
+    def directory(self) -> Directory:
+        """Retrieve a the current value in the LLM environment, of type Directory"""
         _args: list[Arg] = []
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -5494,15 +5481,7 @@ class LLM(Type):
     def enum_type_def(self) -> EnumTypeDef:
         """Retrieve a the current value in the LLM environment, of type
         EnumTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "enum_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("enumTypeDef", _args)
         return EnumTypeDef(_ctx)
@@ -5510,30 +5489,13 @@ class LLM(Type):
     def enum_value_type_def(self) -> EnumValueTypeDef:
         """Retrieve a the current value in the LLM environment, of type
         EnumValueTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "enum_value_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("enumValueTypeDef", _args)
         return EnumValueTypeDef(_ctx)
 
     def error(self) -> Error:
-        """Retrieve a the current value in the LLM environment, of type Error
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "error" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Error"""
         _args: list[Arg] = []
         _ctx = self._select("error", _args)
         return Error(_ctx)
@@ -5541,15 +5503,7 @@ class LLM(Type):
     def error_value(self) -> ErrorValue:
         """Retrieve a the current value in the LLM environment, of type
         ErrorValue
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "error_value" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("errorValue", _args)
         return ErrorValue(_ctx)
@@ -5557,45 +5511,19 @@ class LLM(Type):
     def field_type_def(self) -> FieldTypeDef:
         """Retrieve a the current value in the LLM environment, of type
         FieldTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "field_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("fieldTypeDef", _args)
         return FieldTypeDef(_ctx)
 
     def file(self) -> File:
-        """Retrieve a the current value in the LLM environment, of type File
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "file" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type File"""
         _args: list[Arg] = []
         _ctx = self._select("file", _args)
         return File(_ctx)
 
     def function(self) -> Function:
-        """Retrieve a the current value in the LLM environment, of type Function
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "function" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Function"""
         _args: list[Arg] = []
         _ctx = self._select("function", _args)
         return Function(_ctx)
@@ -5603,15 +5531,7 @@ class LLM(Type):
     def function_arg(self) -> FunctionArg:
         """Retrieve a the current value in the LLM environment, of type
         FunctionArg
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "function_arg" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("functionArg", _args)
         return FunctionArg(_ctx)
@@ -5619,15 +5539,7 @@ class LLM(Type):
     def function_call(self) -> FunctionCall:
         """Retrieve a the current value in the LLM environment, of type
         FunctionCall
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "function_call" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("functionCall", _args)
         return FunctionCall(_ctx)
@@ -5635,15 +5547,7 @@ class LLM(Type):
     def function_call_arg_value(self) -> FunctionCallArgValue:
         """Retrieve a the current value in the LLM environment, of type
         FunctionCallArgValue
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "function_call_arg_value" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("functionCallArgValue", _args)
         return FunctionCallArgValue(_ctx)
@@ -5651,15 +5555,7 @@ class LLM(Type):
     def generated_code(self) -> GeneratedCode:
         """Retrieve a the current value in the LLM environment, of type
         GeneratedCode
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "generated_code" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("generatedCode", _args)
         return GeneratedCode(_ctx)
@@ -6156,16 +6052,7 @@ class LLM(Type):
         return TypeDef(_ctx)
 
     def git_ref(self) -> GitRef:
-        """Retrieve a the current value in the LLM environment, of type GitRef
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "git_ref" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type GitRef"""
         _args: list[Arg] = []
         _ctx = self._select("gitRef", _args)
         return GitRef(_ctx)
@@ -6173,15 +6060,7 @@ class LLM(Type):
     def git_repository(self) -> GitRepository:
         """Retrieve a the current value in the LLM environment, of type
         GitRepository
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "git_repository" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("gitRepository", _args)
         return GitRepository(_ctx)
@@ -6255,15 +6134,7 @@ class LLM(Type):
     def input_type_def(self) -> InputTypeDef:
         """Retrieve a the current value in the LLM environment, of type
         InputTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "input_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("inputTypeDef", _args)
         return InputTypeDef(_ctx)
@@ -6271,30 +6142,13 @@ class LLM(Type):
     def interface_type_def(self) -> InterfaceTypeDef:
         """Retrieve a the current value in the LLM environment, of type
         InterfaceTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "interface_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("interfaceTypeDef", _args)
         return InterfaceTypeDef(_ctx)
 
     def l_lm(self) -> Self:
-        """Retrieve a the current value in the LLM environment, of type LLM
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "l_lm" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type LLM"""
         _args: list[Arg] = []
         _ctx = self._select("lLM", _args)
         return LLM(_ctx)
@@ -6323,30 +6177,13 @@ class LLM(Type):
     def list_type_def(self) -> "ListTypeDef":
         """Retrieve a the current value in the LLM environment, of type
         ListTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "list_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("listTypeDef", _args)
         return ListTypeDef(_ctx)
 
     def loop(self) -> Self:
-        """synchronize LLM state
-
-        .. deprecated::
-            use sync
-        """
-        warnings.warn(
-            'Method "loop" is deprecated: use sync',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """synchronize LLM state"""
         _args: list[Arg] = []
         _ctx = self._select("loop", _args)
         return LLM(_ctx)
@@ -6373,16 +6210,7 @@ class LLM(Type):
         return await _ctx.execute(str)
 
     def module(self) -> "Module":
-        """Retrieve a the current value in the LLM environment, of type Module
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "module" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Module"""
         _args: list[Arg] = []
         _ctx = self._select("module", _args)
         return Module(_ctx)
@@ -6390,15 +6218,7 @@ class LLM(Type):
     def module_config_client(self) -> "ModuleConfigClient":
         """Retrieve a the current value in the LLM environment, of type
         ModuleConfigClient
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "module_config_client" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("moduleConfigClient", _args)
         return ModuleConfigClient(_ctx)
@@ -6406,15 +6226,7 @@ class LLM(Type):
     def module_source(self) -> "ModuleSource":
         """Retrieve a the current value in the LLM environment, of type
         ModuleSource
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "module_source" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("moduleSource", _args)
         return ModuleSource(_ctx)
@@ -6422,15 +6234,7 @@ class LLM(Type):
     def object_type_def(self) -> "ObjectTypeDef":
         """Retrieve a the current value in the LLM environment, of type
         ObjectTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "object_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("objectTypeDef", _args)
         return ObjectTypeDef(_ctx)
@@ -6459,60 +6263,25 @@ class LLM(Type):
     def scalar_type_def(self) -> "ScalarTypeDef":
         """Retrieve a the current value in the LLM environment, of type
         ScalarTypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
         """
-        warnings.warn(
-            'Method "scalar_type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args: list[Arg] = []
         _ctx = self._select("scalarTypeDef", _args)
         return ScalarTypeDef(_ctx)
 
     def sdkconfig(self) -> "SDKConfig":
-        """Retrieve a the current value in the LLM environment, of type SDKConfig
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "sdkconfig" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type SDKConfig"""
         _args: list[Arg] = []
         _ctx = self._select("sdkconfig", _args)
         return SDKConfig(_ctx)
 
     def secret(self) -> "Secret":
-        """Retrieve a the current value in the LLM environment, of type Secret
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "secret" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Secret"""
         _args: list[Arg] = []
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
 
     def service(self) -> "Service":
-        """Retrieve a the current value in the LLM environment, of type Service
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "service" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Service"""
         _args: list[Arg] = []
         _ctx = self._select("service", _args)
         return Service(_ctx)
@@ -7104,31 +6873,13 @@ class LLM(Type):
         return LLM(_ctx)
 
     def socket(self) -> "Socket":
-        """Retrieve a the current value in the LLM environment, of type Socket
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "socket" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Socket"""
         _args: list[Arg] = []
         _ctx = self._select("socket", _args)
         return Socket(_ctx)
 
     def source_map(self) -> "SourceMap":
-        """Retrieve a the current value in the LLM environment, of type SourceMap
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "source_map" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type SourceMap"""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
         return SourceMap(_ctx)
@@ -7153,16 +6904,7 @@ class LLM(Type):
         return self.sync().__await__()
 
     def terminal(self) -> "Terminal":
-        """Retrieve a the current value in the LLM environment, of type Terminal
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "terminal" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type Terminal"""
         _args: list[Arg] = []
         _ctx = self._select("terminal", _args)
         return Terminal(_ctx)
@@ -7189,16 +6931,7 @@ class LLM(Type):
         return await _ctx.execute(str)
 
     def type_def(self) -> "TypeDef":
-        """Retrieve a the current value in the LLM environment, of type TypeDef
-
-        .. deprecated::
-            use get<TargetType> instead
-        """
-        warnings.warn(
-            'Method "type_def" is deprecated: use get<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
+        """Retrieve a the current value in the LLM environment, of type TypeDef"""
         _args: list[Arg] = []
         _ctx = self._select("typeDef", _args)
         return TypeDef(_ctx)
@@ -7227,19 +6960,11 @@ class LLM(Type):
     def with_cache_volume(self, value: CacheVolume) -> Self:
         """Set a variable of type CacheVolume in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The CacheVolume value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_cache_volume" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7249,19 +6974,11 @@ class LLM(Type):
     def with_container(self, value: Container) -> Self:
         """Set a variable of type Container in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Container value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_container" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7271,19 +6988,11 @@ class LLM(Type):
     def with_current_module(self, value: CurrentModule) -> Self:
         """Set a variable of type CurrentModule in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The CurrentModule value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_current_module" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7293,19 +7002,11 @@ class LLM(Type):
     def with_directory(self, value: Directory) -> Self:
         """Set a variable of type Directory in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Directory value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_directory" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7315,19 +7016,11 @@ class LLM(Type):
     def with_enum_type_def(self, value: EnumTypeDef) -> Self:
         """Set a variable of type EnumTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The EnumTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_enum_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7337,19 +7030,11 @@ class LLM(Type):
     def with_enum_value_type_def(self, value: EnumValueTypeDef) -> Self:
         """Set a variable of type EnumValueTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The EnumValueTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_enum_value_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7359,19 +7044,11 @@ class LLM(Type):
     def with_error(self, value: Error) -> Self:
         """Set a variable of type Error in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Error value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_error" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7381,19 +7058,11 @@ class LLM(Type):
     def with_error_value(self, value: ErrorValue) -> Self:
         """Set a variable of type ErrorValue in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ErrorValue value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_error_value" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7403,19 +7072,11 @@ class LLM(Type):
     def with_field_type_def(self, value: FieldTypeDef) -> Self:
         """Set a variable of type FieldTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The FieldTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_field_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7425,19 +7086,11 @@ class LLM(Type):
     def with_file(self, value: File) -> Self:
         """Set a variable of type File in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The File value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_file" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7447,19 +7100,11 @@ class LLM(Type):
     def with_function(self, value: Function) -> Self:
         """Set a variable of type Function in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Function value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_function" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7469,19 +7114,11 @@ class LLM(Type):
     def with_function_arg(self, value: FunctionArg) -> Self:
         """Set a variable of type FunctionArg in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The FunctionArg value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_function_arg" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7491,19 +7128,11 @@ class LLM(Type):
     def with_function_call(self, value: FunctionCall) -> Self:
         """Set a variable of type FunctionCall in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The FunctionCall value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_function_call" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7513,19 +7142,11 @@ class LLM(Type):
     def with_function_call_arg_value(self, value: FunctionCallArgValue) -> Self:
         """Set a variable of type FunctionCallArgValue in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The FunctionCallArgValue value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_function_call_arg_value" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7535,19 +7156,11 @@ class LLM(Type):
     def with_generated_code(self, value: GeneratedCode) -> Self:
         """Set a variable of type GeneratedCode in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The GeneratedCode value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_generated_code" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7557,19 +7170,11 @@ class LLM(Type):
     def with_git_ref(self, value: GitRef) -> Self:
         """Set a variable of type GitRef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The GitRef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_git_ref" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7579,19 +7184,11 @@ class LLM(Type):
     def with_git_repository(self, value: GitRepository) -> Self:
         """Set a variable of type GitRepository in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The GitRepository value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_git_repository" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7601,19 +7198,11 @@ class LLM(Type):
     def with_input_type_def(self, value: InputTypeDef) -> Self:
         """Set a variable of type InputTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The InputTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_input_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7623,19 +7212,11 @@ class LLM(Type):
     def with_interface_type_def(self, value: InterfaceTypeDef) -> Self:
         """Set a variable of type InterfaceTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The InterfaceTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_interface_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7645,19 +7226,11 @@ class LLM(Type):
     def with_llm(self, value: Self) -> Self:
         """Set a variable of type LLM in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The LLM value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_llm" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7667,19 +7240,11 @@ class LLM(Type):
     def with_list_type_def(self, value: "ListTypeDef") -> Self:
         """Set a variable of type ListTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ListTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_list_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7703,19 +7268,11 @@ class LLM(Type):
     def with_module(self, value: "Module") -> Self:
         """Set a variable of type Module in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Module value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_module" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7725,19 +7282,11 @@ class LLM(Type):
     def with_module_config_client(self, value: "ModuleConfigClient") -> Self:
         """Set a variable of type ModuleConfigClient in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ModuleConfigClient value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_module_config_client" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7747,19 +7296,11 @@ class LLM(Type):
     def with_module_source(self, value: "ModuleSource") -> Self:
         """Set a variable of type ModuleSource in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ModuleSource value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_module_source" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7769,19 +7310,11 @@ class LLM(Type):
     def with_object_type_def(self, value: "ObjectTypeDef") -> Self:
         """Set a variable of type ObjectTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ObjectTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_object_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7842,19 +7375,11 @@ class LLM(Type):
     def with_sdk_config(self, value: "SDKConfig") -> Self:
         """Set a variable of type SDKConfig in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The SDKConfig value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_sdk_config" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7864,19 +7389,11 @@ class LLM(Type):
     def with_scalar_type_def(self, value: "ScalarTypeDef") -> Self:
         """Set a variable of type ScalarTypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The ScalarTypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_scalar_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7886,19 +7403,11 @@ class LLM(Type):
     def with_secret(self, value: "Secret") -> Self:
         """Set a variable of type Secret in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Secret value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_secret" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7908,19 +7417,11 @@ class LLM(Type):
     def with_service(self, value: "Service") -> Self:
         """Set a variable of type Service in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Service value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_service" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7930,19 +7431,11 @@ class LLM(Type):
     def with_socket(self, value: "Socket") -> Self:
         """Set a variable of type Socket in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Socket value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_socket" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7952,19 +7445,11 @@ class LLM(Type):
     def with_source_map(self, value: "SourceMap") -> Self:
         """Set a variable of type SourceMap in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The SourceMap value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_source_map" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7974,19 +7459,11 @@ class LLM(Type):
     def with_terminal(self, value: "Terminal") -> Self:
         """Set a variable of type Terminal in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The Terminal value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_terminal" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]
@@ -7996,19 +7473,11 @@ class LLM(Type):
     def with_type_def(self, value: "TypeDef") -> Self:
         """Set a variable of type TypeDef in the llm environment
 
-        .. deprecated::
-            use set<TargetType> instead
-
         Parameters
         ----------
         value:
             The TypeDef value to assign to the variable
         """
-        warnings.warn(
-            'Method "with_type_def" is deprecated: use set<TargetType> instead',
-            DeprecationWarning,
-            stacklevel=4,
-        )
         _args = [
             Arg("value", value),
         ]

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -7833,6 +7833,12 @@ class LLM(Type):
         _ctx = self._select("withPromptVar", _args)
         return LLM(_ctx)
 
+    def with_query(self) -> Self:
+        """Provide the entire Query object to the LLM"""
+        _args: list[Arg] = []
+        _ctx = self._select("withQuery", _args)
+        return LLM(_ctx)
+
     def with_sdk_config(self, value: "SDKConfig") -> Self:
         """Set a variable of type SDKConfig in the llm environment
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6100,6 +6100,11 @@ impl Llm {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// returns the type of the current state
+    pub async fn current_type(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("currentType");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Retrieve a the current value in the LLM environment, of type Directory
     pub fn directory(&self) -> Directory {
         let query = self.selection.select("directory");

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8278,6 +8278,15 @@ impl Llm {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Provide the entire Query object to the LLM
+    pub fn with_query(&self) -> Llm {
+        let query = self.selection.select("withQuery");
+        Llm {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Set a variable of type SDKConfig in the llm environment
     ///
     /// # Arguments

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6545,6 +6545,14 @@ export class LLM extends BaseClient {
   }
 
   /**
+   * Provide the entire Query object to the LLM
+   */
+  withQuery = (): LLM => {
+    const ctx = this._ctx.select("withQuery")
+    return new LLM(ctx)
+  }
+
+  /**
    * Set a variable of type SDKConfig in the llm environment
    * @param value The SDKConfig value to assign to the variable
    * @deprecated use set<TargetType> instead

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -5132,6 +5132,7 @@ export class InterfaceTypeDef extends BaseClient {
 
 export class LLM extends BaseClient {
   private readonly _id?: LLMID = undefined
+  private readonly _currentType?: string = undefined
   private readonly _getString?: string = undefined
   private readonly _historyJSON?: string = undefined
   private readonly _lastReply?: string = undefined
@@ -5146,6 +5147,7 @@ export class LLM extends BaseClient {
   constructor(
     ctx?: Context,
     _id?: LLMID,
+    _currentType?: string,
     _getString?: string,
     _historyJSON?: string,
     _lastReply?: string,
@@ -5157,6 +5159,7 @@ export class LLM extends BaseClient {
     super(ctx)
 
     this._id = _id
+    this._currentType = _currentType
     this._getString = _getString
     this._historyJSON = _historyJSON
     this._lastReply = _lastReply
@@ -5183,7 +5186,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type CacheVolume
-   * @deprecated use get<TargetType> instead
    */
   cacheVolume = (): CacheVolume => {
     const ctx = this._ctx.select("cacheVolume")
@@ -5192,7 +5194,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Container
-   * @deprecated use get<TargetType> instead
    */
   container = (): Container => {
     const ctx = this._ctx.select("container")
@@ -5201,7 +5202,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type CurrentModule
-   * @deprecated use get<TargetType> instead
    */
   currentModule = (): CurrentModule => {
     const ctx = this._ctx.select("currentModule")
@@ -5209,8 +5209,22 @@ export class LLM extends BaseClient {
   }
 
   /**
+   * returns the type of the current state
+   */
+  currentType = async (): Promise<string> => {
+    if (this._currentType) {
+      return this._currentType
+    }
+
+    const ctx = this._ctx.select("currentType")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
    * Retrieve a the current value in the LLM environment, of type Directory
-   * @deprecated use get<TargetType> instead
    */
   directory = (): Directory => {
     const ctx = this._ctx.select("directory")
@@ -5219,7 +5233,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type EnumTypeDef
-   * @deprecated use get<TargetType> instead
    */
   enumTypeDef = (): EnumTypeDef => {
     const ctx = this._ctx.select("enumTypeDef")
@@ -5228,7 +5241,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type EnumValueTypeDef
-   * @deprecated use get<TargetType> instead
    */
   enumValueTypeDef = (): EnumValueTypeDef => {
     const ctx = this._ctx.select("enumValueTypeDef")
@@ -5237,7 +5249,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Error
-   * @deprecated use get<TargetType> instead
    */
   error = (): Error => {
     const ctx = this._ctx.select("error")
@@ -5246,7 +5257,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ErrorValue
-   * @deprecated use get<TargetType> instead
    */
   errorValue = (): ErrorValue => {
     const ctx = this._ctx.select("errorValue")
@@ -5255,7 +5265,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type FieldTypeDef
-   * @deprecated use get<TargetType> instead
    */
   fieldTypeDef = (): FieldTypeDef => {
     const ctx = this._ctx.select("fieldTypeDef")
@@ -5264,7 +5273,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type File
-   * @deprecated use get<TargetType> instead
    */
   file = (): File => {
     const ctx = this._ctx.select("file")
@@ -5273,7 +5281,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Function
-   * @deprecated use get<TargetType> instead
    */
   function_ = (): Function_ => {
     const ctx = this._ctx.select("function")
@@ -5282,7 +5289,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type FunctionArg
-   * @deprecated use get<TargetType> instead
    */
   functionArg = (): FunctionArg => {
     const ctx = this._ctx.select("functionArg")
@@ -5291,7 +5297,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type FunctionCall
-   * @deprecated use get<TargetType> instead
    */
   functionCall = (): FunctionCall => {
     const ctx = this._ctx.select("functionCall")
@@ -5300,7 +5305,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type FunctionCallArgValue
-   * @deprecated use get<TargetType> instead
    */
   functionCallArgValue = (): FunctionCallArgValue => {
     const ctx = this._ctx.select("functionCallArgValue")
@@ -5309,7 +5313,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type GeneratedCode
-   * @deprecated use get<TargetType> instead
    */
   generatedCode = (): GeneratedCode => {
     const ctx = this._ctx.select("generatedCode")
@@ -5631,7 +5634,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type GitRef
-   * @deprecated use get<TargetType> instead
    */
   gitRef = (): GitRef => {
     const ctx = this._ctx.select("gitRef")
@@ -5640,7 +5642,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type GitRepository
-   * @deprecated use get<TargetType> instead
    */
   gitRepository = (): GitRepository => {
     const ctx = this._ctx.select("gitRepository")
@@ -5675,7 +5676,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type InputTypeDef
-   * @deprecated use get<TargetType> instead
    */
   inputTypeDef = (): InputTypeDef => {
     const ctx = this._ctx.select("inputTypeDef")
@@ -5684,7 +5684,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type InterfaceTypeDef
-   * @deprecated use get<TargetType> instead
    */
   interfaceTypeDef = (): InterfaceTypeDef => {
     const ctx = this._ctx.select("interfaceTypeDef")
@@ -5693,7 +5692,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type LLM
-   * @deprecated use get<TargetType> instead
    */
   lLM = (): LLM => {
     const ctx = this._ctx.select("lLM")
@@ -5717,7 +5715,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ListTypeDef
-   * @deprecated use get<TargetType> instead
    */
   listTypeDef = (): ListTypeDef => {
     const ctx = this._ctx.select("listTypeDef")
@@ -5726,7 +5723,6 @@ export class LLM extends BaseClient {
 
   /**
    * synchronize LLM state
-   * @deprecated use sync
    */
   loop = (): LLM => {
     const ctx = this._ctx.select("loop")
@@ -5750,7 +5746,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Module
-   * @deprecated use get<TargetType> instead
    */
   module_ = (): Module_ => {
     const ctx = this._ctx.select("module")
@@ -5759,7 +5754,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ModuleConfigClient
-   * @deprecated use get<TargetType> instead
    */
   moduleConfigClient = (): ModuleConfigClient => {
     const ctx = this._ctx.select("moduleConfigClient")
@@ -5768,7 +5762,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ModuleSource
-   * @deprecated use get<TargetType> instead
    */
   moduleSource = (): ModuleSource => {
     const ctx = this._ctx.select("moduleSource")
@@ -5777,7 +5770,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ObjectTypeDef
-   * @deprecated use get<TargetType> instead
    */
   objectTypeDef = (): ObjectTypeDef => {
     const ctx = this._ctx.select("objectTypeDef")
@@ -5801,7 +5793,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type ScalarTypeDef
-   * @deprecated use get<TargetType> instead
    */
   scalarTypeDef = (): ScalarTypeDef => {
     const ctx = this._ctx.select("scalarTypeDef")
@@ -5810,7 +5801,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type SDKConfig
-   * @deprecated use get<TargetType> instead
    */
   sdkconfig = (): SDKConfig => {
     const ctx = this._ctx.select("sdkconfig")
@@ -5819,7 +5809,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Secret
-   * @deprecated use get<TargetType> instead
    */
   secret = (): Secret => {
     const ctx = this._ctx.select("secret")
@@ -5828,7 +5817,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Service
-   * @deprecated use get<TargetType> instead
    */
   service = (): Service => {
     const ctx = this._ctx.select("service")
@@ -6180,7 +6168,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Socket
-   * @deprecated use get<TargetType> instead
    */
   socket = (): Socket => {
     const ctx = this._ctx.select("socket")
@@ -6189,7 +6176,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type SourceMap
-   * @deprecated use get<TargetType> instead
    */
   sourceMap = (): SourceMap => {
     const ctx = this._ctx.select("sourceMap")
@@ -6209,7 +6195,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type Terminal
-   * @deprecated use get<TargetType> instead
    */
   terminal = (): Terminal => {
     const ctx = this._ctx.select("terminal")
@@ -6233,7 +6218,6 @@ export class LLM extends BaseClient {
 
   /**
    * Retrieve a the current value in the LLM environment, of type TypeDef
-   * @deprecated use get<TargetType> instead
    */
   typeDef = (): TypeDef => {
     const ctx = this._ctx.select("typeDef")
@@ -6260,7 +6244,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type CacheVolume in the llm environment
    * @param value The CacheVolume value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withCacheVolume = (value: CacheVolume): LLM => {
     const ctx = this._ctx.select("withCacheVolume", { value })
@@ -6270,7 +6253,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Container in the llm environment
    * @param value The Container value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withContainer = (value: Container): LLM => {
     const ctx = this._ctx.select("withContainer", { value })
@@ -6280,7 +6262,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type CurrentModule in the llm environment
    * @param value The CurrentModule value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withCurrentModule = (value: CurrentModule): LLM => {
     const ctx = this._ctx.select("withCurrentModule", { value })
@@ -6290,7 +6271,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Directory in the llm environment
    * @param value The Directory value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withDirectory = (value: Directory): LLM => {
     const ctx = this._ctx.select("withDirectory", { value })
@@ -6300,7 +6280,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type EnumTypeDef in the llm environment
    * @param value The EnumTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withEnumTypeDef = (value: EnumTypeDef): LLM => {
     const ctx = this._ctx.select("withEnumTypeDef", { value })
@@ -6310,7 +6289,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type EnumValueTypeDef in the llm environment
    * @param value The EnumValueTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withEnumValueTypeDef = (value: EnumValueTypeDef): LLM => {
     const ctx = this._ctx.select("withEnumValueTypeDef", { value })
@@ -6320,7 +6298,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Error in the llm environment
    * @param value The Error value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withError = (value: Error): LLM => {
     const ctx = this._ctx.select("withError", { value })
@@ -6330,7 +6307,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ErrorValue in the llm environment
    * @param value The ErrorValue value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withErrorValue = (value: ErrorValue): LLM => {
     const ctx = this._ctx.select("withErrorValue", { value })
@@ -6340,7 +6316,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type FieldTypeDef in the llm environment
    * @param value The FieldTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFieldTypeDef = (value: FieldTypeDef): LLM => {
     const ctx = this._ctx.select("withFieldTypeDef", { value })
@@ -6350,7 +6325,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type File in the llm environment
    * @param value The File value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFile = (value: File): LLM => {
     const ctx = this._ctx.select("withFile", { value })
@@ -6360,7 +6334,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Function in the llm environment
    * @param value The Function value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFunction = (value: Function_): LLM => {
     const ctx = this._ctx.select("withFunction", { value })
@@ -6370,7 +6343,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type FunctionArg in the llm environment
    * @param value The FunctionArg value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFunctionArg = (value: FunctionArg): LLM => {
     const ctx = this._ctx.select("withFunctionArg", { value })
@@ -6380,7 +6352,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type FunctionCall in the llm environment
    * @param value The FunctionCall value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFunctionCall = (value: FunctionCall): LLM => {
     const ctx = this._ctx.select("withFunctionCall", { value })
@@ -6390,7 +6361,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type FunctionCallArgValue in the llm environment
    * @param value The FunctionCallArgValue value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withFunctionCallArgValue = (value: FunctionCallArgValue): LLM => {
     const ctx = this._ctx.select("withFunctionCallArgValue", { value })
@@ -6400,7 +6370,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type GeneratedCode in the llm environment
    * @param value The GeneratedCode value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withGeneratedCode = (value: GeneratedCode): LLM => {
     const ctx = this._ctx.select("withGeneratedCode", { value })
@@ -6410,7 +6379,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type GitRef in the llm environment
    * @param value The GitRef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withGitRef = (value: GitRef): LLM => {
     const ctx = this._ctx.select("withGitRef", { value })
@@ -6420,7 +6388,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type GitRepository in the llm environment
    * @param value The GitRepository value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withGitRepository = (value: GitRepository): LLM => {
     const ctx = this._ctx.select("withGitRepository", { value })
@@ -6430,7 +6397,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type InputTypeDef in the llm environment
    * @param value The InputTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withInputTypeDef = (value: InputTypeDef): LLM => {
     const ctx = this._ctx.select("withInputTypeDef", { value })
@@ -6440,7 +6406,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type InterfaceTypeDef in the llm environment
    * @param value The InterfaceTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withInterfaceTypeDef = (value: InterfaceTypeDef): LLM => {
     const ctx = this._ctx.select("withInterfaceTypeDef", { value })
@@ -6450,7 +6415,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type LLM in the llm environment
    * @param value The LLM value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withLLM = (value: LLM): LLM => {
     const ctx = this._ctx.select("withLLM", { value })
@@ -6460,7 +6424,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ListTypeDef in the llm environment
    * @param value The ListTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withListTypeDef = (value: ListTypeDef): LLM => {
     const ctx = this._ctx.select("withListTypeDef", { value })
@@ -6479,7 +6442,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Module in the llm environment
    * @param value The Module value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withModule = (value: Module_): LLM => {
     const ctx = this._ctx.select("withModule", { value })
@@ -6489,7 +6451,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ModuleConfigClient in the llm environment
    * @param value The ModuleConfigClient value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withModuleConfigClient = (value: ModuleConfigClient): LLM => {
     const ctx = this._ctx.select("withModuleConfigClient", { value })
@@ -6499,7 +6460,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ModuleSource in the llm environment
    * @param value The ModuleSource value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withModuleSource = (value: ModuleSource): LLM => {
     const ctx = this._ctx.select("withModuleSource", { value })
@@ -6509,7 +6469,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ObjectTypeDef in the llm environment
    * @param value The ObjectTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withObjectTypeDef = (value: ObjectTypeDef): LLM => {
     const ctx = this._ctx.select("withObjectTypeDef", { value })
@@ -6555,7 +6514,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type SDKConfig in the llm environment
    * @param value The SDKConfig value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withSDKConfig = (value: SDKConfig): LLM => {
     const ctx = this._ctx.select("withSDKConfig", { value })
@@ -6565,7 +6523,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type ScalarTypeDef in the llm environment
    * @param value The ScalarTypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withScalarTypeDef = (value: ScalarTypeDef): LLM => {
     const ctx = this._ctx.select("withScalarTypeDef", { value })
@@ -6575,7 +6532,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Secret in the llm environment
    * @param value The Secret value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withSecret = (value: Secret): LLM => {
     const ctx = this._ctx.select("withSecret", { value })
@@ -6585,7 +6541,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Service in the llm environment
    * @param value The Service value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withService = (value: Service): LLM => {
     const ctx = this._ctx.select("withService", { value })
@@ -6595,7 +6550,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Socket in the llm environment
    * @param value The Socket value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withSocket = (value: Socket): LLM => {
     const ctx = this._ctx.select("withSocket", { value })
@@ -6605,7 +6559,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type SourceMap in the llm environment
    * @param value The SourceMap value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withSourceMap = (value: SourceMap): LLM => {
     const ctx = this._ctx.select("withSourceMap", { value })
@@ -6615,7 +6568,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type Terminal in the llm environment
    * @param value The Terminal value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withTerminal = (value: Terminal): LLM => {
     const ctx = this._ctx.select("withTerminal", { value })
@@ -6625,7 +6577,6 @@ export class LLM extends BaseClient {
   /**
    * Set a variable of type TypeDef in the llm environment
    * @param value The TypeDef value to assign to the variable
-   * @deprecated use set<TargetType> instead
    */
   withTypeDef = (value: TypeDef): LLM => {
     const ctx = this._ctx.select("withTypeDef", { value })


### PR DESCRIPTION
A few experiments:

* Add `LLM.withQuery` for making the whole Query schema available to the LLM
  * `loadFooFromID` fields are skipped
* CLI prompt starts from `Query` so you can jump right into action, with module + deps available
* CLI automatically sets `$_` as the current value after a prompt is done
  * Inspired by Ruby `irb` which sets `_` to the last value
  * Ideally we would do this in shell mode too, not sure how yet
* Un-deprecate `loop`, `withFoo` setters, and `foo` getters for now
  * Jury is still out on these, deprecating is a bit harsh (makes them hard to read in Zed)