### PR TITLE
docs: remove duplicate examples in nav

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -45,11 +45,6 @@ module.exports = {
       id: "examples",
     },
     {
-      type: "doc",
-      label: "Examples",
-      id: "examples",
-    },
-    {
       type: "category",
       label: "Dagger for CI",
       items: [


### PR DESCRIPTION
Removes the double links in the nav to the examples docs page.