### PR TITLE
chore: match go toolchain to distributed version

### DIFF
--- a/dagql/idtui/viztest/go.mod
+++ b/dagql/idtui/viztest/go.mod
@@ -2,7 +2,7 @@ module dagger/viztest
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/compatcheck/go.mod
+++ b/modules/compatcheck/go.mod
@@ -2,7 +2,7 @@ module dagger/compatcheck
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/josephburnett/jd/v2 v2.0.0-20240818191833-6125a15c637a

--- a/modules/dirdiff/go.mod
+++ b/modules/dirdiff/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/dirdiff
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/gha/examples/go/go.mod
+++ b/modules/gha/examples/go/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/gha/examples/go
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/go/go.mod
+++ b/modules/go/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/go
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/golangci/go.mod
+++ b/modules/golangci/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/golangci
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/graphql/go.mod
+++ b/modules/graphql/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/graphql
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/markdown/go.mod
+++ b/modules/markdown/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/markdown
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/ps-analyzer/go.mod
+++ b/modules/ps-analyzer/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/ps-analyzer
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/ruff/go.mod
+++ b/modules/ruff/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/ruff
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/shellcheck/go.mod
+++ b/modules/shellcheck/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/shellcheck
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/modules/wolfi/go.mod
+++ b/modules/wolfi/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/modules/wolfi
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/sdk/dotnet/dev/go.mod
+++ b/sdk/dotnet/dev/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/sdk/dotnet/dev
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/sdk/elixir/runtime/go.mod
+++ b/sdk/elixir/runtime/go.mod
@@ -2,7 +2,7 @@ module elixir-sdk
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/99designs/gqlgen v0.17.68

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,7 +2,7 @@ module dagger.io/dagger
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.23.6
 
 retract (
 	// retract SDK releases with known issues

--- a/sdk/python/runtime/go.mod
+++ b/sdk/python/runtime/go.mod
@@ -2,7 +2,7 @@ module python-sdk
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/sdk/typescript/runtime/go.mod
+++ b/sdk/typescript/runtime/go.mod
@@ -2,7 +2,7 @@ module typescript-sdk
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require github.com/iancoleman/strcase v0.3.0
 


### PR DESCRIPTION
Otherwise, the go sdk is attempting to download go1.24 - we don't want that, especially as we're not really able to use any of those features.