### PR TITLE
test: PHP Object signatures for built-in types

### DIFF
--- a/core/integration/module_php_test.go
+++ b/core/integration/module_php_test.go
@@ -199,6 +199,35 @@ func (PHPSuite) TestVoidKind(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (PHPSuite) TestObjectKind(ctx context.Context, t *testctx.T) {
+	t.Run("File", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		module := phpModule(t, c, "object-kind/built-in-to-dagger")
+
+		out, err := module.
+			WithNewFile("/foo", "hello, world!").
+			With(daggerCall(
+				"capitalize-contents", "--arg=/foo", "contents")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "Hello, World!", out)
+	})
+
+	t.Run("Directory", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		module := phpModule(t, c, "object-kind/built-in-to-dagger")
+
+		out, err := module.
+			WithNewFile("/foo/bar", "Hello, World!").
+			With(daggerCall("with-baz", "--arg=/foo", "entries")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "bar\nbaz\n", out)
+	})
+}
+
 func phpModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/php", moduleName))

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/.gitattributes
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/.gitattributes
@@ -1,0 +1,2 @@
+/sdk/** linguist-generated
+/entrypoint.php linguist-generated

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/.gitignore
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/.gitignore
@@ -1,0 +1,2 @@
+/sdk
+/vendor

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/composer.json
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "daggermodule/built-in-to-dagger",
+  "description": "",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "license": "proprietary",
+  "authors": [
+  ],
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./sdk"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "dagger/dagger": "*@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "DaggerModule\\": "src/"
+    }
+  },
+  "config": {
+    "platform": {
+      "php": "8.3.7"
+    }
+  }
+}

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/dagger.json
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "built-in-to-dagger",
+  "engineVersion": "v0.17.0",
+  "sdk": {
+    "source": "php"
+  },
+  "source": "."
+}

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/entrypoint.php
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/entrypoint.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This is the entry point for the module, called from the dagger engine.
+ * Editing this file is highly discouraged and may stop your module from functioning entirely.
+ */
+
+use Symfony\Component\Console\Application;
+use Dagger\Command\EntrypointCommand;
+
+if (file_exists(__DIR__.'/../../autoload.php')) {
+    // The usual location, since this file will reside in vendor/bin
+    require __DIR__.'/../../autoload.php';
+} else {
+    // Useful when doing development on this package
+    require __DIR__.'/vendor/autoload.php';
+}
+
+$console = new Application();
+
+$console->add(new EntrypointCommand());
+$console->setDefaultCommand('dagger:entrypoint');
+
+$console->run();

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/src/BuiltInToDagger.php
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/src/BuiltInToDagger.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DaggerModule;
+
+use Dagger\Attribute\{DaggerFunction, DaggerObject};
+use Dagger\{Directory, File};
+
+use function Dagger\dag;
+
+#[DaggerObject]
+class BuiltInToDagger
+{
+    #[DaggerFunction] public function capitalizeContents(File $arg): File
+    {
+        return dag()
+            ->directory()
+            ->withNewFile('/foo', ucwords($arg->contents()))
+            ->file('/foo');
+    }
+
+    #[DaggerFunction] public function withBaz(Directory $arg): Directory
+    {
+        return dag()->container()
+            ->withDirectory('/foo', $arg)
+            ->withNewFile('/foo/baz', 'Howdy, Planet!')
+            ->directory('/foo');
+    }
+}


### PR DESCRIPTION
Adds 2 tests asserting that the PHP SDK can:
1. Receive an object (built-into-dagger) as an argument.
2. Modify the object.
3. Return the object.

First test asserts it receive and return a `File` with its contents capitalized.

Second test asserts it can receive and return a `Directory` with a new `File` added to it.