### PR TITLE
feat: add git diff functionality

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -803,7 +803,7 @@ func (v *gitRefValue) Get(ctx context.Context, dag *dagger.Client, _ *dagger.Mod
 		if ref := gitURL.Fragment.Ref; ref != "" {
 			return repo.Ref(ref), nil
 		}
-		return repo.Head(), nil
+		return repo.Working(), nil
 	}
 
 	// Otherwise it's a local dir path
@@ -817,7 +817,7 @@ func (v *gitRefValue) Get(ctx context.Context, dag *dagger.Client, _ *dagger.Mod
 	if ref != "" {
 		return repo.Ref(ref), nil
 	}
-	return repo.Head(), nil
+	return repo.Working(), nil
 }
 
 // AddFlag adds a flag appropriate for the argument type. Should return a


### PR DESCRIPTION
Opening as a base to discuss!

x-linking https://github.com/dagger/dagger/issues/8520 for how this should interact with modules (tl;dr we can use contextual git).

## Usage

```
# get the diff of the working directory
$ dagger core host directory --path=. as-git working diff

# get the diff to a specified target
$ dagger core host directory --path=. as-git working diff --target=<commit-sha>

# determine if a git directory is dirty or not
$ dagger core host directory --path=. as-git working dirty
```

## Changes

- All `GitRef`s can now be `diff`ed against arbitrary commits.
- `GitRepository.working` is a variant of `Git.head` that gets the current state, but *includes* any changes to the working directory. This means that:
	- `GitRef.diff` with no args will return a non-empty diff
	- `GitRef.dirty` will return true
	- `GitRef.tree` will return a directory with the working directory changes
	- `GitRef.commit` returns a `<commit>-dirty`

### Caveats

- `GitRef.diff` for remote refs doesn't work very well because of shallow-cloning (see #7637, working on a fix for this as part of https://github.com/dagger/dagger/pull/9980)

## To debate

- Is this at all the right API?
	- We can always add *more*, but it's harder to take it away.
	- Can this be used as useful info for LLMs?
- Should `GitRef.diff` take a `String`? Or a `GitRef`?

Let the bikeshedding begin!