### PR TITLE
fix: docs recorder runtime rust panic

### DIFF
--- a/docs/recorder/main.go
+++ b/docs/recorder/main.go
@@ -30,7 +30,7 @@ func getTermcast(wdir *dagger.Directory) *dagger.Termcast {
 	return dag.Termcast(dagger.TermcastOpts{
 		Container: dag.Wolfi().
 			Container(dagger.WolfiContainerOpts{Packages: []string{"docker-cli", "curl"}}).
-			WithFile("/bin/dagger", dag.DaggerCli().Binary()).
+			WithFile("/usr/local/bin/dagger", dag.DaggerCli().Binary()).
 			WithWorkdir("/src").
 			WithMountedDirectory(".", wdir).
 			WithEnvVariable("DOCKER_HOST", "tcp://docker:2375").


### PR DESCRIPTION
This PR fixes the gif generator module for the documentation. Prior to this fix, the gifs showed a Rust error.

Initially, I thought it was due to a glibc version mismatch between the build and the runtime container, but after some brute force line-by-line debugging, I narrowed it down to the one in this PR.

I don't fully understand why that caused the problem, but it did (along with a number of other issues).