### PR TITLE
allow to disable streaming on OpenAI compatible engines

### DIFF
--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dagger/dagger/dagql"
 	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/dagger/dagger/dagql"
 )
 
 type LLMTestQuery struct{}
@@ -35,17 +36,18 @@ func TestLlmConfig(t *testing.T) {
 	srv := dagql.NewServer(q)
 
 	vars := map[string]string{
-		"file://.env":                "",
-		"env://ANTHROPIC_API_KEY":    "anthropic-api-key",
-		"env://ANTHROPIC_BASE_URL":   "anthropic-base-url",
-		"env://ANTHROPIC_MODEL":      "anthropic-model",
-		"env://OPENAI_API_KEY":       "openai-api-key",
-		"env://OPENAI_AZURE_VERSION": "openai-azure-version",
-		"env://OPENAI_BASE_URL":      "openai-base-url",
-		"env://OPENAI_MODEL":         "openai-model",
-		"env://GEMINI_API_KEY":       "gemini-api-key",
-		"env://GEMINI_BASE_URL":      "gemini-base-url",
-		"env://GEMINI_MODEL":         "gemini-model",
+		"file://.env":                    "",
+		"env://ANTHROPIC_API_KEY":        "anthropic-api-key",
+		"env://ANTHROPIC_BASE_URL":       "anthropic-base-url",
+		"env://ANTHROPIC_MODEL":          "anthropic-model",
+		"env://OPENAI_API_KEY":           "openai-api-key",
+		"env://OPENAI_AZURE_VERSION":     "openai-azure-version",
+		"env://OPENAI_BASE_URL":          "openai-base-url",
+		"env://OPENAI_MODEL":             "openai-model",
+		"env://OPENAI_DISABLE_STREAMING": "t",
+		"env://GEMINI_API_KEY":           "gemini-api-key",
+		"env://GEMINI_BASE_URL":          "gemini-base-url",
+		"env://GEMINI_MODEL":             "gemini-model",
 	}
 
 	dagql.Fields[LLMTestQuery]{
@@ -75,9 +77,77 @@ func TestLlmConfig(t *testing.T) {
 	assert.Equal(t, "openai-azure-version", r.OpenAIAzureVersion)
 	assert.Equal(t, "openai-base-url", r.OpenAIBaseURL)
 	assert.Equal(t, "openai-model", r.OpenAIModel)
+	assert.True(t, r.OpenAIDisableStreaming)
 	assert.Equal(t, "gemini-api-key", r.GeminiAPIKey)
 	assert.Equal(t, "gemini-base-url", r.GeminiBaseURL)
 	assert.Equal(t, "gemini-model", r.GeminiModel)
+}
+
+func TestLlmConfigDisableStreaming(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		envFile  string
+		expected bool
+	}{
+		{
+			"not disabled by default",
+			"",
+			false,
+		},
+		{
+			"explicitly not disabled, FALSE",
+			"OPENAI_DISABLE_STREAMING=FALSE",
+			false,
+		},
+		{
+			"explicitly not disabled, 0",
+			"OPENAI_DISABLE_STREAMING=0",
+			false,
+		},
+		{
+			"disabled, true",
+			"OPENAI_DISABLE_STREAMING=true",
+			true,
+		},
+		{
+			"disabled, 1",
+			"OPENAI_DISABLE_STREAMING=1",
+			true,
+		},
+		{
+			"empty value",
+			"OPENAI_DISABLE_STREAMING=",
+			false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			q := LLMTestQuery{}
+
+			srv := dagql.NewServer(q)
+			dagql.Fields[LLMTestQuery]{
+				dagql.Func("secret", func(ctx context.Context, self LLMTestQuery, args struct {
+					URI string
+				}) (mockSecret, error) {
+					return mockSecret{uri: args.URI}, nil
+				}),
+			}.Install(srv)
+
+			dagql.Fields[mockSecret]{
+				dagql.Func("plaintext", func(ctx context.Context, self mockSecret, _ struct{}) (string, error) {
+					if self.uri == "file://.env" {
+						return tc.envFile, nil
+					}
+					return "", nil
+				}),
+			}.Install(srv)
+
+			ctx := context.Background()
+			r, err := NewLLMRouter(ctx, srv)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, r.OpenAIDisableStreaming)
+		})
+	}
 }
 
 func TestLlmConfigEnvFile(t *testing.T) {
@@ -103,6 +173,7 @@ OPENAI_API_KEY=openai-api-key
 OPENAI_AZURE_VERSION=openai-azure-version
 OPENAI_BASE_URL=openai-base-url
 OPENAI_MODEL=openai-model
+OPENAI_DISABLE_STREAMING=TRUE
 GEMINI_API_KEY=gemini-api-key
 GEMINI_BASE_URL=gemini-base-url
 GEMINI_MODEL=gemini-model`, nil
@@ -121,6 +192,7 @@ GEMINI_MODEL=gemini-model`, nil
 	assert.Equal(t, "openai-azure-version", r.OpenAIAzureVersion)
 	assert.Equal(t, "openai-base-url", r.OpenAIBaseURL)
 	assert.Equal(t, "openai-model", r.OpenAIModel)
+	assert.True(t, r.OpenAIDisableStreaming)
 	assert.Equal(t, "gemini-api-key", r.GeminiAPIKey)
 	assert.Equal(t, "gemini-base-url", r.GeminiBaseURL)
 	assert.Equal(t, "gemini-model", r.GeminiModel)


### PR DESCRIPTION
Some engines are not able to managed tools and streaming at the same time, like llama.cpp.
This allows to define an environment variable to disable streaming:

    OPENAI_DISABLE_STREAMING

This uses strconv.ParseBool so 1, t, T, TRUE, true, True will set disable the streaming while 0, f, F, FALSE, false, False will keep it.

By default streaming is not disabled.

Streaming will be disabled only if tools are used. If a query doesn't define any tools, streaming will be used.

Fixes #9969