### PR TITLE
life alert: the _human_help tool so LLMs know they can ask clarifying questions

### DIFF
--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -223,7 +223,9 @@ func (c *AnthropicClient) SendQuery(ctx context.Context, history []ModelMessage,
 
 	// Check that we have some accumulated content.
 	if len(acc.Content) == 0 {
-		return nil, fmt.Errorf("no response from model. stop reason: %s", acc.StopReason)
+		return nil, &ModelFinishedError{
+			Reason: string(acc.StopReason),
+		}
 	}
 
 	// Process the accumulated content into a generic LLMResponse.

--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -223,7 +223,7 @@ func (c *AnthropicClient) SendQuery(ctx context.Context, history []ModelMessage,
 
 	// Check that we have some accumulated content.
 	if len(acc.Content) == 0 {
-		return nil, fmt.Errorf("no response from model")
+		return nil, fmt.Errorf("no response from model. stop reason: %s", acc.StopReason)
 	}
 
 	// Process the accumulated content into a generic LLMResponse.

--- a/core/llm_env.go
+++ b/core/llm_env.go
@@ -535,6 +535,10 @@ func (env *LLMEnv) IsDone() bool {
 	return env.returned || env.wantType == ""
 }
 
+func (env *LLMEnv) WantsType() string {
+	return env.wantType
+}
+
 func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	builtins := []LLMTool{
 		{
@@ -590,7 +594,7 @@ func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 			}),
 		})
 	}
-	builtins = append(builtins, env.UserPromptTool(srv))
+	// builtins = append(builtins, env.UserPromptTool(srv))
 	for typeName := range env.typeCount {
 		tools, err := env.tools(srv, typeName)
 		if err != nil {

--- a/core/llm_env.go
+++ b/core/llm_env.go
@@ -55,7 +55,7 @@ type LLMEnv struct {
 	needsSystemPrompt bool
 	// The return type that we want from the LLM.
 	wantType string
-	Returned bool
+	returned bool
 }
 
 func NewLLMEnv(endpoint *LLMEndpoint) *LLMEnv {
@@ -530,6 +530,11 @@ func (env *LLMEnv) ReadVariable(name string) (string, bool) {
 	return val, found
 }
 
+// TODO: validate, might belong on LLM, wanted to involve 'dirty' initially
+func (env *LLMEnv) IsDone() bool {
+	return env.returned || env.wantType == ""
+}
+
 func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	builtins := []LLMTool{
 		{
@@ -574,7 +579,7 @@ func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 			Call: ToolFunc(func(ctx context.Context, args struct {
 				ID string `name:"id"`
 			}) (any, error) {
-				env.Returned = true
+				env.returned = true
 				obj, err := env.GetObject(args.ID, typeName)
 				if err != nil {
 					return nil, err

--- a/core/llm_env.go
+++ b/core/llm_env.go
@@ -594,7 +594,6 @@ func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 			}),
 		})
 	}
-	// builtins = append(builtins, env.UserPromptTool(srv))
 	for typeName := range env.typeCount {
 		tools, err := env.tools(srv, typeName)
 		if err != nil {
@@ -688,34 +687,6 @@ func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 		}
 	}
 	return builtins, nil
-}
-
-func (env *LLMEnv) UserPromptTool(dag *dagql.Server) LLMTool {
-	return LLMTool{
-		Name:        "_human_help",
-		Description: "Request help from the human user by interactively asking a clarifying question. Use when struggling.",
-		Schema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"question": map[string]any{
-					"type":        "string",
-					"description": "Question to present for your human user to answer interactively. Be concise.",
-				},
-			},
-			"required": []string{"question"},
-		},
-		Call: func(ctx context.Context, args any) (any, error) {
-			query, ok := dagql.UnwrapAs[*Query](dag.Root())
-			if !ok {
-				return nil, fmt.Errorf("expected *core.Query, got %T", dag.Root())
-			}
-			bk, err := query.Buildkit(ctx)
-			if err != nil {
-				return nil, err
-			}
-			return bk.PromptHumanHelp(ctx, args.(map[string]any)["question"].(string))
-		},
-	}
 }
 
 func (env *LLMEnv) toolToID(tool LLMTool, args any) (*call.ID, error) {

--- a/core/llm_env.go
+++ b/core/llm_env.go
@@ -583,13 +583,13 @@ func (env *LLMEnv) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 			Call: ToolFunc(func(ctx context.Context, args struct {
 				ID string `name:"id"`
 			}) (any, error) {
-				env.returned = true
 				obj, err := env.GetObject(args.ID, typeName)
 				if err != nil {
 					return nil, err
 				}
 				prev := env.Current()
 				env.Select(obj)
+				env.returned = true
 				return env.currentState(prev)
 			}),
 		})

--- a/core/llm_google.go
+++ b/core/llm_google.go
@@ -218,11 +218,15 @@ func (c *GenaiClient) SendQuery(ctx context.Context, history []ModelMessage, too
 		}
 
 		if len(res.Candidates) == 0 {
-			return nil, fmt.Errorf("no response from model")
+			return nil, &ModelFinishedError{
+				Reason: "no response from model",
+			}
 		}
 		candidate := res.Candidates[0]
 		if candidate.Content == nil {
-			return nil, fmt.Errorf("no content?")
+			return nil, &ModelFinishedError{
+				Reason: candidate.FinishReason.String(),
+			}
 		}
 
 		for _, part := range candidate.Content.Parts {

--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -178,18 +178,28 @@ func (c *OpenAIClient) SendQuery(ctx context.Context, history []ModelMessage, to
 		return nil, stream.Err()
 	}
 
-	if len(acc.ChatCompletion.Choices) == 0 {
-		return nil, fmt.Errorf("no response from model")
+	if len(acc.Choices) == 0 {
+		return nil, &ModelFinishedError{
+			Reason: "no response from model",
+		}
 	}
 
-	toolCalls, err := convertOpenAIToolCalls(acc.Choices[0].Message.ToolCalls)
+	choice := acc.Choices[0]
+
+	toolCalls, err := convertOpenAIToolCalls(choice.Message.ToolCalls)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert tool calls: %w", err)
 	}
 
+	if choice.Message.Content == "" && len(toolCalls) == 0 {
+		return nil, &ModelFinishedError{
+			Reason: choice.FinishReason,
+		}
+	}
+
 	// Convert OpenAI response to generic LLMResponse
 	return &LLMResponse{
-		Content:   acc.Choices[0].Message.Content,
+		Content:   choice.Message.Content,
 		ToolCalls: toolCalls,
 		TokenUsage: LLMTokenUsage{
 			InputTokens:  acc.Usage.PromptTokens,

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -162,7 +162,7 @@ func (s *llmSchema) withPromptFile(ctx context.Context, llm *core.LLM, args stru
 }
 
 func (s *llmSchema) loop(ctx context.Context, llm *core.LLM, args struct{}) (*core.LLM, error) {
-	return llm.Sync(ctx, s.srv)
+	return llm, llm.Sync(ctx, s.srv)
 }
 
 func (s *llmSchema) attempt(_ context.Context, llm *core.LLM, _ struct {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1085,6 +1085,8 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		if fe.activeStringPrompt != nil {
 			fe.activeStringPrompt.result <- value
 			// fe.editline = nil
+			fe.activeStringPrompt = nil
+			fe.editlineFocused = false
 		} else if fe.shell != nil {
 			ctx, cancel := context.WithCancelCause(fe.shellCtx)
 			fe.shellInterrupt = cancel
@@ -1309,6 +1311,13 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 	case promptString:
 		fe.activeStringPrompt = &msg
 		fe.initEditline()
+		// fe.editline.MaxHistorySize = 1000
+		// if history, err := history.LoadHistory(historyFile); err == nil {
+		// 	fe.editline.SetHistory(history)
+		// }
+		// hopefully fix weird prompt display?
+		fe.editline.Update(nil)
+
 		return fe, nil
 
 	default:

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1002,6 +1002,9 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		// if input ends with a pipe, then it's not complete
 		fe.editline.CheckInputComplete = msg.handler.IsComplete
 
+		// put the bowtie on
+		fe.updatePrompt()
+
 		return fe, tea.Batch(
 			tea.Printf(`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`),
 			fe.editline.Focus(),
@@ -1317,8 +1320,6 @@ func (fe *frontendPretty) initEditline() {
 	}
 	// hopefully fix weird prompt display?
 	fe.editline.Update(nil)
-	// put the bowtie on
-	fe.updatePrompt()
 }
 
 type UpdatePromptMsg struct{}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1002,20 +1002,6 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		// if input ends with a pipe, then it's not complete
 		fe.editline.CheckInputComplete = msg.handler.IsComplete
 
-		// restore history
-		fe.editline.MaxHistorySize = 1000
-		if history, err := history.LoadHistory(historyFile); err == nil {
-			fe.editline.SetHistory(history)
-		}
-
-		// put the bowtie on
-		fe.updatePrompt()
-
-		// HACK: for some reason editline's first paint is broken (only shows
-		// first 2 chars of prompt, doesn't show cursor). Sending it a message
-		// - any message - fixes it.
-		fe.editline.Update(nil)
-
 		return fe, tea.Batch(
 			tea.Printf(`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`),
 			fe.editline.Focus(),
@@ -1311,12 +1297,6 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 	case promptString:
 		fe.activeStringPrompt = &msg
 		fe.initEditline()
-		// fe.editline.MaxHistorySize = 1000
-		// if history, err := history.LoadHistory(historyFile); err == nil {
-		// 	fe.editline.SetHistory(history)
-		// }
-		// hopefully fix weird prompt display?
-		fe.editline.Update(nil)
 
 		return fe, nil
 
@@ -1330,6 +1310,15 @@ func (fe *frontendPretty) initEditline() {
 	fe.editline = editline.New(fe.window.Width, fe.window.Height)
 	fe.editline.HideKeyMap = true
 	fe.editlineFocused = true
+	// restore history
+	fe.editline.MaxHistorySize = 1000
+	if history, err := history.LoadHistory(historyFile); err == nil {
+		fe.editline.SetHistory(history)
+	}
+	// hopefully fix weird prompt display?
+	fe.editline.Update(nil)
+	// put the bowtie on
+	fe.updatePrompt()
 }
 
 type UpdatePromptMsg struct{}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -632,6 +632,11 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 		fmt.Fprint(countOut, fe.viewBoolPrompt(countOut))
 	}
 
+	if fe.activeStringPrompt != nil {
+		fmt.Fprintln(countOut)
+		fmt.Fprint(countOut, fe.viewStringPrompt(countOut))
+	}
+
 	if fe.editline == nil {
 		fmt.Fprint(countOut, fe.viewKeymap())
 	}
@@ -639,11 +644,6 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 	if logs := fe.logs.Logs[fe.ZoomedSpan]; logs != nil && logs.UsedHeight() > 0 {
 		fmt.Fprintln(below)
 		fe.renderLogs(countOut, r, logs, -1, fe.window.Height/3, progPrefix, false)
-	}
-
-	if fe.activeStringPrompt != nil {
-		fmt.Fprintln(countOut)
-		fmt.Fprint(countOut, fe.viewStringPrompt(countOut))
 	}
 
 	belowOut := strings.TrimRight(below.String(), "\n")
@@ -942,7 +942,10 @@ func (fe *frontendPretty) View() string {
 		prog += "\n"
 		if view := strings.TrimSpace(fe.view.String()); view != "" {
 			prog += view
-			prog += "\n\n"
+			prog += "\n"
+			if fe.activeStringPrompt == nil {
+				prog += "\n"
+			}
 		}
 		return prog + fe.editlineView()
 	}

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -678,6 +678,22 @@ func (c *Client) PromptAllowLLM(ctx context.Context, moduleRepoURL string) error
 	return fmt.Errorf("module %s was denied LLM access; pass --allow-llm=%s or --allow-llm=all to allow", moduleRepoURL, moduleRepoURL)
 }
 
+func (c *Client) PromptHumanHelp(ctx context.Context, question string) (string, error) {
+	caller, err := c.GetMainClientCaller()
+	if err != nil {
+		return "", fmt.Errorf("failed to get main client caller to to prompt user for human help: %w", err)
+	}
+
+	response, err := session.NewPromptClient(caller.Conn()).PromptString(ctx, &session.StringRequest{
+		Prompt:  question,
+		Default: "The user did not respond.",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to prompt user for human help: %w", err)
+	}
+	return response.Response, nil
+}
+
 func (c *Client) GetGitConfig(ctx context.Context) ([]*session.GitConfigEntry, error) {
 	md, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {

--- a/engine/session/prompt.pb.go
+++ b/engine/session/prompt.pb.go
@@ -134,15 +134,114 @@ func (m *BoolResponse) GetResponse() bool {
 	return false
 }
 
+type StringRequest struct {
+	// the prompt to display to the user
+	Prompt string `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	// the default value to return if the user doesn't respond
+	Default string `protobuf:"bytes,2,opt,name=default,proto3" json:"default,omitempty"`
+}
+
+func (m *StringRequest) Reset()      { *m = StringRequest{} }
+func (*StringRequest) ProtoMessage() {}
+func (*StringRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2532b5caf780ac64, []int{2}
+}
+func (m *StringRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StringRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StringRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StringRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringRequest.Merge(m, src)
+}
+func (m *StringRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *StringRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_StringRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StringRequest proto.InternalMessageInfo
+
+func (m *StringRequest) GetPrompt() string {
+	if m != nil {
+		return m.Prompt
+	}
+	return ""
+}
+
+func (m *StringRequest) GetDefault() string {
+	if m != nil {
+		return m.Default
+	}
+	return ""
+}
+
+type StringResponse struct {
+	// the response from the user
+	Response string `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+}
+
+func (m *StringResponse) Reset()      { *m = StringResponse{} }
+func (*StringResponse) ProtoMessage() {}
+func (*StringResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2532b5caf780ac64, []int{3}
+}
+func (m *StringResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StringResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StringResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StringResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringResponse.Merge(m, src)
+}
+func (m *StringResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *StringResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_StringResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StringResponse proto.InternalMessageInfo
+
+func (m *StringResponse) GetResponse() string {
+	if m != nil {
+		return m.Response
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*BoolRequest)(nil), "BoolRequest")
 	proto.RegisterType((*BoolResponse)(nil), "BoolResponse")
+	proto.RegisterType((*StringRequest)(nil), "StringRequest")
+	proto.RegisterType((*StringResponse)(nil), "StringResponse")
 }
 
 func init() { proto.RegisterFile("prompt.proto", fileDescriptor_2532b5caf780ac64) }
 
 var fileDescriptor_2532b5caf780ac64 = []byte{
-	// 231 bytes of a gzipped FileDescriptorProto
+	// 279 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x29, 0x28, 0xca, 0xcf,
 	0x2d, 0x28, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x57, 0x4a, 0xe5, 0xe2, 0x76, 0xca, 0xcf, 0xcf,
 	0x09, 0x4a, 0x2d, 0x2c, 0x4d, 0x2d, 0x2e, 0x11, 0x12, 0xe3, 0x62, 0x83, 0x48, 0x4b, 0x30, 0x2a,
@@ -150,14 +249,17 @@ var fileDescriptor_2532b5caf780ac64 = []byte{
 	0x25, 0xa9, 0x79, 0x25, 0xde, 0xa9, 0x95, 0x12, 0x4c, 0x60, 0x69, 0x54, 0x41, 0x21, 0x09, 0x2e,
 	0xf6, 0x94, 0xd4, 0xb4, 0xc4, 0xd2, 0x9c, 0x12, 0x09, 0x66, 0x05, 0x46, 0x0d, 0x8e, 0x20, 0x18,
 	0x57, 0x49, 0x8b, 0x8b, 0x07, 0x62, 0x4d, 0x71, 0x41, 0x7e, 0x5e, 0x71, 0xaa, 0x90, 0x14, 0x17,
-	0x47, 0x11, 0x94, 0x0d, 0xb6, 0x89, 0x23, 0x08, 0xce, 0x37, 0x32, 0xe6, 0x62, 0x0b, 0x80, 0xd8,
-	0xaa, 0xc9, 0xc5, 0x05, 0x61, 0x81, 0xf4, 0x0a, 0xf1, 0xe8, 0x21, 0xb9, 0x54, 0x8a, 0x57, 0x0f,
-	0xd9, 0x40, 0x27, 0xdb, 0x0b, 0x0f, 0xe5, 0x18, 0x6e, 0x3c, 0x94, 0x63, 0xf8, 0xf0, 0x50, 0x8e,
-	0xb1, 0xe1, 0x91, 0x1c, 0xe3, 0x8a, 0x47, 0x72, 0x8c, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24,
-	0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8b, 0x47, 0x72, 0x0c, 0x1f, 0x1e, 0xc9, 0x31, 0x4e, 0x78,
-	0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x51, 0xec, 0xc5, 0xa9, 0xc5,
-	0xc5, 0x99, 0xf9, 0x79, 0x49, 0x6c, 0xe0, 0xd0, 0x30, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xb5,
-	0xab, 0x48, 0x06, 0x1d, 0x01, 0x00, 0x00,
+	0x47, 0x11, 0x94, 0x0d, 0xb6, 0x89, 0x23, 0x08, 0xce, 0x57, 0x72, 0xe4, 0xe2, 0x0d, 0x2e, 0x29,
+	0xca, 0xcc, 0x4b, 0x27, 0xe4, 0x28, 0x24, 0xeb, 0x20, 0xce, 0x81, 0x5b, 0xa7, 0xc3, 0xc5, 0x07,
+	0x33, 0x02, 0x87, 0x85, 0x9c, 0x08, 0x0b, 0x8d, 0x52, 0xb8, 0xd8, 0x02, 0x20, 0x26, 0x6a, 0x72,
+	0x71, 0x41, 0x58, 0x20, 0xc7, 0x0a, 0xf1, 0xe8, 0x21, 0x05, 0x8d, 0x14, 0xaf, 0x1e, 0x8a, 0x0f,
+	0xf4, 0xb9, 0x78, 0x20, 0x4a, 0x21, 0x16, 0x09, 0xf1, 0xe9, 0xa1, 0x38, 0x5a, 0x8a, 0x5f, 0x0f,
+	0xd5, 0x05, 0x4e, 0xb6, 0x17, 0x1e, 0xca, 0x31, 0xdc, 0x78, 0x28, 0xc7, 0xf0, 0xe1, 0xa1, 0x1c,
+	0x63, 0xc3, 0x23, 0x39, 0xc6, 0x15, 0x8f, 0xe4, 0x18, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48,
+	0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x17, 0x8f, 0xe4, 0x18, 0x3e, 0x3c, 0x92, 0x63, 0x9c, 0xf0,
+	0x58, 0x8e, 0xe1, 0xc2, 0x63, 0x39, 0x86, 0x1b, 0x8f, 0xe5, 0x18, 0xa2, 0xd8, 0x8b, 0x53, 0x8b,
+	0x8b, 0x33, 0xf3, 0xf3, 0x92, 0xd8, 0xc0, 0xf1, 0x65, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xf1,
+	0x14, 0xcb, 0x13, 0xbf, 0x01, 0x00, 0x00,
 }
 
 func (this *BoolRequest) Equal(that interface{}) bool {
@@ -214,6 +316,57 @@ func (this *BoolResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *StringRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StringRequest)
+	if !ok {
+		that2, ok := that.(StringRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Prompt != that1.Prompt {
+		return false
+	}
+	if this.Default != that1.Default {
+		return false
+	}
+	return true
+}
+func (this *StringResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StringResponse)
+	if !ok {
+		that2, ok := that.(StringResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Response != that1.Response {
+		return false
+	}
+	return true
+}
 func (this *BoolRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -232,6 +385,27 @@ func (this *BoolResponse) GoString() string {
 	}
 	s := make([]string, 0, 5)
 	s = append(s, "&session.BoolResponse{")
+	s = append(s, "Response: "+fmt.Sprintf("%#v", this.Response)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StringRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&session.StringRequest{")
+	s = append(s, "Prompt: "+fmt.Sprintf("%#v", this.Prompt)+",\n")
+	s = append(s, "Default: "+fmt.Sprintf("%#v", this.Default)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StringResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&session.StringResponse{")
 	s = append(s, "Response: "+fmt.Sprintf("%#v", this.Response)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
@@ -258,6 +432,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type PromptClient interface {
 	PromptBool(ctx context.Context, in *BoolRequest, opts ...grpc.CallOption) (*BoolResponse, error)
+	PromptString(ctx context.Context, in *StringRequest, opts ...grpc.CallOption) (*StringResponse, error)
 }
 
 type promptClient struct {
@@ -277,9 +452,19 @@ func (c *promptClient) PromptBool(ctx context.Context, in *BoolRequest, opts ...
 	return out, nil
 }
 
+func (c *promptClient) PromptString(ctx context.Context, in *StringRequest, opts ...grpc.CallOption) (*StringResponse, error) {
+	out := new(StringResponse)
+	err := c.cc.Invoke(ctx, "/Prompt/PromptString", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PromptServer is the server API for Prompt service.
 type PromptServer interface {
 	PromptBool(context.Context, *BoolRequest) (*BoolResponse, error)
+	PromptString(context.Context, *StringRequest) (*StringResponse, error)
 }
 
 // UnimplementedPromptServer can be embedded to have forward compatible implementations.
@@ -288,6 +473,9 @@ type UnimplementedPromptServer struct {
 
 func (*UnimplementedPromptServer) PromptBool(ctx context.Context, req *BoolRequest) (*BoolResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PromptBool not implemented")
+}
+func (*UnimplementedPromptServer) PromptString(ctx context.Context, req *StringRequest) (*StringResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PromptString not implemented")
 }
 
 func RegisterPromptServer(s *grpc.Server, srv PromptServer) {
@@ -312,6 +500,24 @@ func _Prompt_PromptBool_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Prompt_PromptString_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StringRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PromptServer).PromptString(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/Prompt/PromptString",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PromptServer).PromptString(ctx, req.(*StringRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Prompt_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "Prompt",
 	HandlerType: (*PromptServer)(nil),
@@ -319,6 +525,10 @@ var _Prompt_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PromptBool",
 			Handler:    _Prompt_PromptBool_Handler,
+		},
+		{
+			MethodName: "PromptString",
+			Handler:    _Prompt_PromptString_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -405,6 +615,73 @@ func (m *BoolResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *StringRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StringRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Default) > 0 {
+		i -= len(m.Default)
+		copy(dAtA[i:], m.Default)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Default)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Prompt) > 0 {
+		i -= len(m.Prompt)
+		copy(dAtA[i:], m.Prompt)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Prompt)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StringResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Response) > 0 {
+		i -= len(m.Response)
+		copy(dAtA[i:], m.Response)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Response)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintPrompt(dAtA []byte, offset int, v uint64) int {
 	offset -= sovPrompt(v)
 	base := offset
@@ -448,6 +725,36 @@ func (m *BoolResponse) Size() (n int) {
 	return n
 }
 
+func (m *StringRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Prompt)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	l = len(m.Default)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	return n
+}
+
+func (m *StringResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Response)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	return n
+}
+
 func sovPrompt(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -471,6 +778,27 @@ func (this *BoolResponse) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&BoolResponse{`,
+		`Response:` + fmt.Sprintf("%v", this.Response) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StringRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StringRequest{`,
+		`Prompt:` + fmt.Sprintf("%v", this.Prompt) + `,`,
+		`Default:` + fmt.Sprintf("%v", this.Default) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StringResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StringResponse{`,
 		`Response:` + fmt.Sprintf("%v", this.Response) + `,`,
 		`}`,
 	}, "")
@@ -667,6 +995,202 @@ func (m *BoolResponse) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Response = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPrompt(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StringRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPrompt
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StringRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StringRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Prompt", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Prompt = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Default", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Default = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPrompt(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StringResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPrompt
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StringResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StringResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Response", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Response = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipPrompt(dAtA[iNdEx:])

--- a/engine/session/prompt.proto
+++ b/engine/session/prompt.proto
@@ -4,6 +4,7 @@ option go_package = "session";
 
 service Prompt {
   rpc PromptBool(BoolRequest) returns (BoolResponse);
+  rpc PromptString(StringRequest) returns (StringResponse);
 }
 
 message BoolRequest {
@@ -18,4 +19,16 @@ message BoolRequest {
 message BoolResponse {
     // the response from the user
     bool response = 1;
+}
+
+message StringRequest {
+    // the prompt to display to the user
+    string prompt = 1;
+    // the default value to return if the user doesn't respond
+    string default = 2;
+}
+
+message StringResponse {
+    // the response from the user
+    string response = 1;
 }


### PR DESCRIPTION
sorta working? if i ask gemini to use the tool, it does, prompts me, and reads my responses afaict. gemini also happens to ask pretty good clarifying questions, like maybe better than the ones it does with the overarching prompt.

[in this example trace](https://v3.dagger.cloud/dagger/traces/a84432a7625aa7bf25b59a315f3ac400#2e4386ff943c33ff), i ask to gemini to write a curl clone and ask clarifying questions.

![Screenshot 2025-03-26 at 4 39 57 PM](https://github.com/user-attachments/assets/e45fa40f-c801-4cd5-ab0a-fe336fe58d1a)

it even asks me to do its job for it lmao:
![Screenshot 2025-03-26 at 4 42 13 PM](https://github.com/user-attachments/assets/d0bd59f8-2d60-47a4-8973-db73b14be142)

and for a way to run the program, which is in fact missing from the workspace implementation?
![Screenshot 2025-03-26 at 4 38 51 PM](https://github.com/user-attachments/assets/e9c37a9e-c853-4c17-bec6-7b48bffb16b4)


the web trace view seems pretty good atm, tui's still got some rough edges.
- [ ] history of previous answers, and don't accidentally overwrite the previous history (including history that was added this session... i suspect this requires modifications to editline? otherwise we gotta figure out how to find and re-use the current editline if it exists...
- [ ] there's something weird about the "PS1" part of the prompt display, like it doesn't wanna show the module name and the prompt logo until after I start typing
- [ ] passing a script on `-c` nil panics
```
panic({0x1026066c0?, 0x103e75440?})
        /usr/lib/go/src/runtime/panic.go:785 +0x124
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).keys(0x140006fb448, 0x0?)
        /app/dagql/idtui/frontend_pretty.go:561 +0xde8
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).renderKeymap(_, _, {0x103ed7620, 0x400, {0x0, 0x0}, 0x0, {0x102895518, 0x10240f3a0}, {0x0, ...}, ...})
        /app/dagql/idtui/frontend_pretty.go:531 +0x44
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).viewKeymap(0x140006fb448)
        /app/dagql/idtui/frontend_pretty.go:718 +0x1d0
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).editlineView(0x140006fb448)
        /app/dagql/idtui/frontend_pretty.go:949 +0xa4
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).View(0x140006fb448)
        /app/dagql/idtui/frontend_pretty.go:943 +0x204
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x140004dc780, {0x10289ae70?, 0x140006fb448?}, 0x1400031b030)
        /go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:510 +0x6e4
github.com/charmbracelet/bubbletea.(*Program).Run(0x140004dc780)
        /go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.4/tea.go:647 +0x8ec
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).runWithTUI(0x140006fb448, {0x1028a2238?, 0x14000526ed0?}, 0x140001b88d0?)
        /app/dagql/idtui/frontend_pretty.go:314 +0x360
github.com/dagger/dagger/dagql/idtui.(*frontendPretty).Run(0x140006fb448, {0x1028a2238?, 0x14000526ed0?}, {0x0, 0x0, 0x1, 0x5f5e100, 0x3b9aca00, 0x0, 0x0, ...}, ...)
        /app/dagql/idtui/frontend_pretty.go:211 +0xfc
```
