### PR TITLE
core(fix): load a module with no SDK

### DIFF
--- a/.changes/unreleased/Added-20250410-190818.yaml
+++ b/.changes/unreleased/Added-20250410-190818.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: add the ability to load a module without specifying an SDK
+time: 2025-04-10T19:08:18.75139555Z
+custom:
+    Author: grouville, tiborvass
+    PR: "9984"

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -1686,3 +1686,89 @@ func (CLISuite) TestInvalidModule(ctx context.Context, t *testctx.T) {
 		requireErrOut(t, err, `failed to check if module exists`)
 	})
 }
+
+func (CLISuite) TestNoSDK(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	helloCode := `package main
+
+// A Dagger module to say hello to the world!
+type Hello struct{}
+
+// Hello prints out a greeting
+func (m *Hello) Hello() string {
+	return "hi"
+}
+`
+
+	// Set up the base container with Dagger CLI
+	base := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work")
+
+	// Create the nested module structure and initialize modules
+	testCtr := base.
+		// Initialize 'hello' module with Go SDK
+		WithWorkdir("/work/test/nosdk/hello").
+		With(daggerExec("init", "--sdk=go", "--name=hello")).
+		WithNewFile("main.go", helloCode).
+		// Initialize 'nosdk' module and install 'hello'
+		WithWorkdir("/work/test/nosdk").
+		With(daggerExec("init", "--name=nosdk")).
+		With(daggerExec("install", "./hello")).
+		// Initialize 'test' module and install 'nosdk'
+		WithWorkdir("/work/test").
+		With(daggerExec("init", "--name=test")).
+		With(daggerExec("install", "./nosdk"))
+
+	// Verify that the top-level 'test' module has no SDK
+	daggerJSON, err := testCtr.File("dagger.json").Contents(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, daggerJSON, `"sdk"`)
+
+	t.Run("shell help does not segfault and stdlib functions are shown", func(ctx context.Context, t *testctx.T) {
+		out, err := testCtr.With(daggerShell(".help")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container") // stdlib
+		require.Contains(t, out, "directory") // stdlib
+		require.Contains(t, out, "Use \".help <command> | <function>\" for more information.")
+	})
+
+	t.Run("core types are still available and working", func(ctx context.Context, t *testctx.T) {
+		out, err := testCtr.With(daggerShell("container | from alpine | with-exec echo Hello | stdout")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "Hello\n", out)
+	})
+
+	t.Run("functions with no SDK show just the headers", func(ctx context.Context, t *testctx.T) {
+		out, err := testCtr.With(daggerExec("functions")).Stdout(ctx)
+		require.NoError(t, err)
+
+		// Split output into lines and verify it's empty except for headers
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		require.LessOrEqual(t, len(lines), 2, "Should only show headers or be empty")
+
+		// If there are lines, they should only be "Name, Description" header
+		if len(lines) > 0 {
+			for _, line := range lines {
+				// Skip empty lines
+				if strings.TrimSpace(line) == "" {
+					continue
+				}
+				require.Contains(t, line, "Name", "Should only contain header")
+				require.Contains(t, line, "Description", "Should only contain header")
+			}
+		}
+	})
+
+	t.Run("call a module without sdk", func(ctx context.Context, t *testctx.T) {
+		_, err := testCtr.WithWorkdir("/work/test/nosdk").With(daggerExec("call")).Stdout(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-sdk module can load module with sdk", func(ctx context.Context, t *testctx.T) {
+		out, err := testCtr.WithWorkdir("/work/test/nosdk").With(daggerShell("hello | hello")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hi", out)
+	})
+}


### PR DESCRIPTION
Fixes #9203

- Fixes panics and errors on operations made on modules initialized with no sdk
- [x] TODO: add tests

Co-authored-by @tiborvass 