### PR TITLE
PHP: Small amendments to test data.

### DIFF
--- a/core/integration/module_php_test.go
+++ b/core/integration/module_php_test.go
@@ -206,8 +206,7 @@ func (PHPSuite) TestObjectKind(ctx context.Context, t *testctx.T) {
 
 		out, err := module.
 			WithNewFile("/foo", "hello, world!").
-			With(daggerCall(
-				"capitalize-contents", "--arg=/foo", "contents")).
+			With(daggerCall("capitalize-contents", "--arg=/foo", "contents")).
 			Stdout(ctx)
 
 		require.NoError(t, err)

--- a/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/dagger.json
+++ b/core/integration/testdata/modules/php/object-kind/built-in-to-dagger/dagger.json
@@ -2,7 +2,7 @@
   "name": "built-in-to-dagger",
   "engineVersion": "v0.17.0",
   "sdk": {
-    "source": "php"
+    "source": "../../../sdk/php"
   },
   "source": "."
 }


### PR DESCRIPTION
Change the test module to _correctly_ point to the local sdk.
This is to assert that the current branch passes tests. 

Also a non-behavioural change, in `module_php_test.go`.