### PR TITLE
serve dependences for shell prompt mode

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -190,7 +190,7 @@ func (h *shellCallHandler) Initialize(ctx context.Context) error {
 	var cfg *configuredModule
 
 	if !shellNoLoadModule {
-		def, cfg, err = h.maybeLoadModule(ctx, ref)
+		def, cfg, err = h.maybeLoadModuleAndDeps(ctx, ref)
 		if err != nil {
 			return err
 		}

--- a/cmd/dagger/shell_fs.go
+++ b/cmd/dagger/shell_fs.go
@@ -59,7 +59,7 @@ func (h *shellCallHandler) ChangeDir(ctx context.Context, path string) error {
 
 	var subpath string
 
-	def, cfg, err := h.maybeLoadModule(ctx, path)
+	def, cfg, err := h.maybeLoadModuleAndDeps(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,28 @@ func (h *shellCallHandler) maybeLoadModule(ctx context.Context, path string) (*m
 	def, err := h.getOrInitDef(cfg.Digest, func() (*moduleDef, error) {
 		return initializeModule(ctx, h.dag, cfg.Source)
 	})
+
 	return def, cfg, err
+}
+
+func (h *shellCallHandler) maybeLoadModuleAndDeps(ctx context.Context, path string) (*moduleDef, *configuredModule, error) {
+	def, cfg, err := h.maybeLoadModule(ctx, path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if def != nil {
+		for _, dep := range def.Dependencies {
+			serveCtx, serveSpan := Tracer().Start(ctx, "initializing dependency module")
+			err := dep.Source.AsModule().Serve(serveCtx)
+			telemetry.End(serveSpan, func() error { return err })
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to serve dependency module: %w", err)
+			}
+		}
+	}
+
+	return def, cfg, nil
 }
 
 // parseModRef transforms user input into a full module reference that can be used with


### PR DESCRIPTION
this lets prompt users `dagger install` modules on the CLI and then manipulate them in prompt mode as though the LLM was acting "inside" the `dagger -m` toplevel module.

there's a alternate approach where we do a bit more and call
```go
	def, err := h.getOrInitDef(cfg.Digest, func() (*moduleDef, error) {
		return initializeModule(ctx, h.dag, cfg.Source)
	})
```
for each dep to initialize it, but at least in my naive implementation that didn't seem to add any additional functionality. @TomChv speculated that that route might allow us to wire in shell completions. Not sure which way is more correct, thoughts @helderco?

i want to automated-test this, but it's proving difficult because of conflicting requirements between needing a TTY to manipulate prompt mode, but also needing historyJSON from the prompt LLM to save a recording. this should be mergable as-is, @marcosnils and I have both manually tested it thoroughly. 