### PR TITLE
feat: add libsecret provider

### DIFF
--- a/engine/client/secretprovider/libsecret.go
+++ b/engine/client/secretprovider/libsecret.go
@@ -1,0 +1,134 @@
+package secretprovider
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/jedevc/go-libsecret"
+)
+
+// libsecretProvider looks up secrets using libsecret, which connects to
+// gnome-keyring and other similar providers.
+// https://specifications.freedesktop.org/secret-service-spec/latest/ref-dbus-api.html.
+//
+// Format:
+// - libsecret://<collection>/<id>
+// - libsecret://<collection>/<label>
+// - libsecret://<collection>?<key>=<value>
+func libsecretProvider(_ context.Context, key string) ([]byte, error) {
+	uri, err := url.Parse("libsecret://" + key)
+	if err != nil {
+		return nil, fmt.Errorf("key in bad format: %w", err)
+	}
+	uri.Path = strings.TrimPrefix(uri.Path, "/")
+
+	svc, err := libsecret.NewService()
+	if err != nil {
+		return nil, err
+	}
+	session, err := svc.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	collections, err := svc.Collections()
+	if err != nil {
+		return nil, err
+	}
+	var collection *libsecret.Collection
+	for _, candidate := range collections {
+		name := path.Base(string(candidate.Path()))
+		if name == uri.Hostname() {
+			collection = &candidate
+			break
+		}
+	}
+	if collection == nil {
+		return nil, fmt.Errorf("collection %s not found", uri.Hostname())
+	}
+
+	err = svc.Unlock(collection)
+	if err != nil {
+		return nil, err
+	}
+
+	// get all items
+	items, err := collection.Items()
+	if err != nil {
+		return nil, err
+	}
+
+	// filter items using the path
+	var matching []libsecret.Item
+	if uri.Path == "" {
+		// path is empty, just grab all
+		// libsecret://<collection>
+		matching = items
+		if len(uri.Query()) == 0 {
+			return nil, fmt.Errorf("item %s must be filtered", key)
+		}
+	}
+	if matching == nil {
+		for _, candidate := range items {
+			name := path.Base(string(candidate.Path()))
+			if name == uri.Path {
+				// path contains an auto-generated item specific identifier
+				// libsecret://<collection>/<id>
+				matching = append(matching, candidate)
+			}
+		}
+	}
+	if matching == nil {
+		for _, candidate := range items {
+			label, err := candidate.Label()
+			if err != nil {
+				return nil, err
+			}
+			if label == uri.Path {
+				// path contains the human-readable label
+				// libsecret://<collection>/<label>
+				matching = append(matching, candidate)
+			}
+		}
+	}
+	items = matching
+
+	// filter items using attributes
+	matching = nil
+	for _, item := range items {
+		attrs, err := item.Attributes()
+		if err != nil {
+			return nil, err
+		}
+		matches := true
+		for k, vs := range uri.Query() {
+			v := vs[0]
+			if attrs[k] != v {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			matching = append(matching, item)
+		}
+	}
+	items = matching
+
+	if len(items) == 0 {
+		return nil, fmt.Errorf("item %s not found", key)
+	}
+	if len(items) > 1 {
+		return nil, fmt.Errorf("too many items found for %s", key)
+	}
+
+	item := items[0]
+	secret, err := item.GetSecret(session)
+	if err != nil {
+		return nil, fmt.Errorf("could not get secret %s: %w", key, err)
+	}
+
+	return secret.Value, nil
+}

--- a/engine/client/secretprovider/secretprovider.go
+++ b/engine/client/secretprovider/secretprovider.go
@@ -15,11 +15,12 @@ import (
 type SecretResolver func(context.Context, string) ([]byte, error)
 
 var resolvers = map[string]SecretResolver{
-	"env":   envProvider,
-	"file":  fileProvider,
-	"cmd":   cmdProvider,
-	"op":    opProvider,
-	"vault": vaultProvider,
+	"env":       envProvider,
+	"file":      fileProvider,
+	"cmd":       cmdProvider,
+	"op":        opProvider,
+	"vault":     vaultProvider,
+	"libsecret": libsecretProvider,
 }
 
 func ResolverForID(id string) (SecretResolver, string, error) {

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackpal/gateway v1.0.16
+	github.com/jedevc/go-libsecret v0.0.0-20250327192457-f925a032ae4f
 	github.com/joho/godotenv v1.5.1
 	github.com/juju/ansiterm v1.0.0
 	github.com/klauspost/compress v1.18.0
@@ -235,6 +236,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
+github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
@@ -443,6 +445,8 @@ github.com/jackpal/gateway v1.0.16 h1:mTBRuHSW8qviVqX7kXnxKevqlfS/OA01ys6k6fxSX7
 github.com/jackpal/gateway v1.0.16/go.mod h1:IOn1OUbso/cGYmnCBZbCEqhNCLSz0xxdtIpUpri5/nA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jedevc/go-libsecret v0.0.0-20250327192457-f925a032ae4f h1:AA4TqL5MbBQZRC1V+/0pjHXGbZIuYsR8YFWNRTVuh6o=
+github.com/jedevc/go-libsecret v0.0.0-20250327192457-f925a032ae4f/go.mod h1:CadMq008qMk2051tDUQFFrWqm1qRFPX4rNUfR0guDr0=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=


### PR DESCRIPTION
This was scratching an itch :laughing: 

On my laptop, I use GNOME, which provides `gnome-keyring` for storing passwords/keys, etc - it's fairly neat, and integrates with the desktop environment to prompt for the unlock password, etc. I can use it to store encrypted passwords for things like API keys, etc.

To do this, we can integrate with `libsecret`, which allows accessing this info. This is pretty much as close to a standard as there is across Linux desktop environments, it's also supported in KDE by KWallet for example (though I haven't personally tried that).