### PR TITLE
feat(engine/secret): add support for ttl for vault

### DIFF
--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"fmt"
 	"io"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagger/dagger/dagql/call"
@@ -182,4 +184,117 @@ func (SecretSuite) TestBigScrubbed(ctx context.Context, t *testctx.T) {
 	stdout, err := sec.Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "***", stdout)
+}
+func (SecretSuite) TestVaultSecretsProviderTTL(ctx context.Context, t *testctx.T) {
+	var baseContainer = func(c *dagger.Client, vault *dagger.Service) *dagger.Container {
+		return c.Container().
+			From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithFile("/bin/vault", c.Container().From("hashicorp/vault").File("/bin/vault")).
+			WithEnvVariable("VAULT_ADDR", "http://vault:8200").
+			WithEnvVariable("VAULT_TOKEN", "vault-root-token").
+			WithServiceBinding("vault", vault)
+	}
+
+	var verifySecretFromVault = func(ctx context.Context, base *dagger.Container, secretURL string, tcname string) (string, error) {
+		return base.
+			WithWorkdir("/work").
+			With(daggerExec("init", "--sdk=go", "--name=foo", "--source=.")).
+			WithNewFile("main.go", `package main
+
+import (
+	"context"
+	"dagger/foo/internal/dagger"
+	"fmt"
+	"time"
+)
+
+type Foo struct{}	
+
+// This function sets the value of secret in vault, gets its plaintext value. Then
+// this function updates the value of secret in vault (to simulate expired or changed secret), and sleeps for 5s to allow for ttl (if any) 
+// to expire. It then gets its plaintext value again.
+// After that it returns both the values as string, which our tescase then verifies.
+func (m *Foo) VerifySecret(ctx context.Context, vault *dagger.Service, secret *dagger.Secret, tc string) (string, error) {
+	_, err := dag.Container().From("hashicorp/vault").
+		WithEnvVariable("VAULT_ADDR", "http://vault:8200").
+		WithEnvVariable("VAULT_TOKEN", "vault-root-token").
+		WithServiceBinding("vault", vault).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("vault kv put secret/%s username=\"admin\" password=\"original-password\"", tc)}).
+		Sync(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	original, err := secret.Plaintext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// simulate an update in secret while the pipeline is running
+	_, err = dag.Container().From("hashicorp/vault").
+		WithEnvVariable("VAULT_ADDR", "http://vault:8200").
+		WithEnvVariable("VAULT_TOKEN", "vault-root-token").
+		WithServiceBinding("vault", vault).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("vault kv put secret/%s username=\"admin\" password=\"updated-password\"", tc)}).Sync(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// wait for ttl to expire, to simulate a long running process
+	time.Sleep(5 * time.Second)
+
+	// now the pipeline needs secret again.
+	updated, err := secret.Plaintext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("original: %s\nupdated: %s", original, updated), nil
+}
+`).
+			With(daggerCall("-vvv", "verify-secret", fmt.Sprintf("--secret=%s", secretURL), "--vault=tcp://vault:8200", fmt.Sprintf("--tc=%s", tcname))).Stdout(ctx)
+	}
+
+	testcases := []struct {
+		name                    string
+		secret                  string
+		expectedUpdatedPassword string
+	}{
+		{
+			name:                    "without-ttl",
+			secret:                  "vault://without-ttl.password",
+			expectedUpdatedPassword: "original-password",
+		},
+		{
+			name:                    "with-ttl",
+			secret:                  "vault://with-ttl.password?ttl=2s",
+			expectedUpdatedPassword: "updated-password",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+
+			vault, err := c.Container().
+				From("hashicorp/vault").
+				WithEnvVariable("VAULT_DEV_ROOT_TOKEN_ID", "vault-root-token").
+				WithEnvVariable("VAULT_LOG_LEVEL", "debug").
+				WithExposedPort(8200).
+				AsService(dagger.ContainerAsServiceOpts{
+					UseEntrypoint:                 true,
+					ExperimentalPrivilegedNesting: true,
+					InsecureRootCapabilities:      true,
+				}).Start(ctx)
+			require.NoError(t, err)
+
+			base := baseContainer(c, vault).
+				WithEnvVariable("CACHE_BUSTER", tc.name)
+
+			output, err := verifySecretFromVault(ctx, base, tc.secret, tc.name)
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf("original: original-password\nupdated: %s", tc.expectedUpdatedPassword), output)
+		})
+	}
 }

--- a/engine/client/secretprovider/secretprovider.go
+++ b/engine/client/secretprovider/secretprovider.go
@@ -24,7 +24,7 @@ var resolvers = map[string]SecretResolver{
 }
 
 func ResolverForID(id string) (SecretResolver, string, error) {
-	scheme, path, ok := strings.Cut(id, "://")
+	scheme, pathWithQuery, ok := strings.Cut(id, "://")
 	if !ok {
 		return nil, "", fmt.Errorf("parse %q: malformed id", id)
 	}
@@ -33,7 +33,7 @@ func ResolverForID(id string) (SecretResolver, string, error) {
 	if !ok {
 		return nil, "", fmt.Errorf("unsupported secret provider: %q", scheme)
 	}
-	return resolver, path, nil
+	return resolver, pathWithQuery, nil
 }
 
 type SecretProvider struct {


### PR DESCRIPTION
This PR adds the support for ttl in secrets provider. Currently it is only supported for vault (as we are caching only vault secrets at the moment).

Also, I noticed we support only kv based secrets in vault, and we can possibly extend the secrets provider to also support dynamic cred engines such as `aws`, `postgres` etc, but that is out of scope for this work item, so just putting it out here for the record.

This PR still needs a design review/approval from the team. cc @marcosnils 