### PR TITLE
remove rogue \n escape

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1007,7 +1007,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		fe.editline.Update(nil)
 
 		return fe, tea.Batch(
-			tea.Printf(`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.\n`),
+			tea.Printf(`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`),
 			fe.editline.Focus(),
 			tea.DisableMouse,
 		)


### PR DESCRIPTION
Don't think this is even needed anymore with the scrollback changes. I'm already seeing a blank line beneath it.