### PR TITLE
shell: accept shift+tab for toggling mode

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -492,6 +492,20 @@ func (h *shellCallHandler) ReactToInput(ctx context.Context, msg tea.KeyMsg) tea
 		return func() tea.Msg {
 			return idtui.UpdatePromptMsg{}
 		}
+	case "shift+tab":
+		switch h.mode {
+		case modeShell:
+			h.mode = modePrompt
+			return func() tea.Msg {
+				h.llm(ctx) // initialize LLM
+				return idtui.UpdatePromptMsg{}
+			}
+		case modePrompt:
+			h.mode = modeShell
+			return func() tea.Msg {
+				return idtui.UpdatePromptMsg{}
+			}
+		}
 	}
 	return nil
 }

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1152,6 +1152,11 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 				fe.editline.Reset()
 			case "ctrl+l":
 				return fe.clearScrollback()
+			case "shift+tab":
+				cmd := fe.shell.ReactToInput(fe.runCtx, msg)
+				if cmd != nil {
+					return fe, cmd
+				}
 			case "esc":
 				fe.editlineFocused = false
 				fe.editline.Blur()


### PR DESCRIPTION
We don't have many options here that don't conflict with existing terminals or desktop environments.

Initially worried that shift+tab would conflict with tab completion, but it's not bound at the moment. If we want it later, though, maybe we shouldn't do this.