### PR TITLE
infra: Add hostNetwork, dnsPolicy and dnsConfig to Helm chart

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -143,6 +143,16 @@ spec:
             {{- with .Values.engine.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- if .Values.engine.hostNetwork }}
+      hostNetwork: {{ .Values.engine.hostNetwork }}
+      {{- end }}
+      {{- if .Values.engine.dnsPolicy }}
+      dnsPolicy: {{ .Values.engine.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.engine.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.engine.terminationGracePeriodSeconds }}
       volumes:
         {{- if .Values.engine.hostPath.dataVolume.enabled }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -151,6 +151,16 @@ spec:
             {{- with .Values.engine.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- if .Values.engine.hostNetwork }}
+      hostNetwork: {{ .Values.engine.hostNetwork }}
+      {{- end }}
+      {{- if .Values.engine.dnsPolicy }}
+      dnsPolicy: {{ .Values.engine.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.engine.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.engine.terminationGracePeriodSeconds }}
       volumes:
         {{- if .Values.engine.hostPath.dataVolume.enabled }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -178,6 +178,43 @@ engine:
   #   persistentVolumeClaim:
   #     claimName: my-pvc
 
+  ## Host networking requested for this pod. 
+  ##   Use the host's network namespace. If this option is set, the ports 
+  ##   that will be used must be specified. Default to false.
+  hostNetwork:
+
+  ## Set DNS policy and config for the pod
+  ##   Possible enum values:
+  ##    - "ClusterFirst" indicates that the pod should use cluster DNS first
+  ##       unless hostNetwork is true, if it is available, then fall back on the
+  ##       default (as determined by kubelet) DNS settings.
+  ##    - "ClusterFirstWithHostNet" indicates that the pod should use cluster DNS
+  ##      first, if it is available, then fall back on the default (as determined by
+  ##      kubelet) DNS settings.
+  ##    - "Default" indicates that the pod should use the default (as determined
+  ##      by kubelet) DNS settings.
+  ##    - "None" indicates that the pod should use empty DNS settings. DNS
+  ##      parameters such as nameservers and search paths should be defined via
+  ##      DNSConfig.
+  dnsPolicy:
+
+  ## Specifies the DNS parameters of a pod. 
+  ##   Parameters specified here will be
+  ##   merged to the generated DNS configuration based on DNSPolicy.
+  ##   PodDNSConfig defines the DNS parameters of a pod in addition to those
+  ##   generated from DNSPolicy.
+  dnsConfig: {}
+    # nameservers:
+    # - 8.8.8.8
+    # - 8.8.4.4
+    # searches:
+    # - ns1.svc.cluster-domain.example
+    # - my.dns.search.suffix
+    # options:
+    # - name: ndots
+    #   value: "2"
+    # - name: edns0
+
 magicache:
   enabled: false
   url: https://api.dagger.cloud/magicache


### PR DESCRIPTION
Added hostNetwork, dnsPolicy and dnsConfig as optional fields to the Helm chart.  

This is needed in some cases when using `kube-pod` to access the dagger engine running in a Kubernetes cluster.  In my case I installed RKE2, deployed the dagger helm chart and got `failed to resolve image "docker.io/library/alpine:latest"` errors.  After digging into it a bit I found that if I set `hostNetwork: true` it started working

```
export _EXPERIMENTAL_DAGGER_RUNNER_HOST="kube-pod://...
...

$ dagger query <<EOF
> {
>   container {
>     from(address:"alpine") {
>     withExec(args: ["uname", "-a"]) { stdout }
>     }
>   }
> }
> EOF
...
Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1
Error: make request: input: container.from failed to resolve image "docker.io/library/alpine:latest" (platform: "linux/amd64"): failed to resolve source metadata for docker.io/library/alpine:latest: failed to do request: Head "https://registry-1.docker.io/v2/library/alpine/manifests/latest": dial tcp: lookup registry-1.docker.io on 10.87.0.1:53: read udp 10.87.0.1:47496->10.87.0.1:53: i/o timeout
```
