### PR TITLE
add missing backquote around write

### DIFF
--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -151,7 +151,7 @@ Consider the following Dagger Function:
 </TabItem>
 </Tabs>
 
-Here, the `ToyWorkspace` is the `Environment` module. It contains a number of Dagger Functions: `Read()`, `Write(), and `Build()`. When an instance of this module is attached to the `LLM` core type, the LLM can call any of these Dagger Functions to change the state of the environment and complete the assigned task.
+Here, the `ToyWorkspace` is the `Environment` module. It contains a number of Dagger Functions: `Read()`, `Write()`, and `Build()`. When an instance of this module is attached to the `LLM` core type, the LLM can call any of these Dagger Functions to change the state of the environment and complete the assigned task.
 
 :::tip
 Dagger's core types, like `Directory` and `Container`, have extensive APIs, and an LLM can easily get lost or provide inconsistent results when working with these objects. To resolve this, we recommend using a Dagger module with limited functionality as an environment and confining the LLM to that module. With this, the LLM has fewer degrees of freedom when interacting with its environment and this, in turn, helps produce more consistent results.


### PR DESCRIPTION
Add the missing end backquote around `Write()` in LLM environments

Before:
<img width="938" alt="image" src="https://github.com/user-attachments/assets/02480816-103f-464e-b0a3-6100cf32b211" />
