### PR TITLE
shell: fix state getting deleted when using a var in the same run

### DIFF
--- a/.changes/unreleased/Fixed-20250331-125002.yaml
+++ b/.changes/unreleased/Fixed-20250331-125002.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed an issue when reusing a variable with a pipeline, in the same run
+time: 2025-03-31T12:50:02.16152Z
+custom:
+    Author: helderco
+    PR: "10018"

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -367,7 +367,7 @@ func (h *shellCallHandler) Handle(ctx context.Context, line string) (rerr error)
 	// when last used. We should only have orphans at this point if
 	// there's a variable that gets reset with a different value and
 	// that should hardly cause memory issues.
-	defer h.state.Prune()
+	defer h.state.Prune(ctx)
 	if h.debug {
 		defer h.state.debug(ctx)
 	}

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -644,7 +644,7 @@ func (h *shellCallHandler) parseFlagValue(ctx context.Context, value string, arg
 	}
 
 	// Otherwise it may be an object that we want to bypass (for its ID)
-	st, err := h.state.Extract(GetStateKey(value))
+	st, err := h.state.Extract(ctx, GetStateKey(value))
 	if err != nil {
 		return nil, false, err
 	}
@@ -868,4 +868,16 @@ func (h *shellCallHandler) loadedModules(yield func(*moduleDef) bool) {
 		}
 		return true
 	})
+}
+
+// HandlerCtx returns interp.HandlerContext value stored in ctx, or nil if
+// it doesn't have one.
+func HandlerCtx(ctx context.Context) (ret *interp.HandlerContext) {
+	defer func() {
+		if err := recover(); err != nil {
+			ret = nil
+		}
+	}()
+	hc := interp.HandlerCtx(ctx)
+	return &hc
 }

--- a/cmd/dagger/shell_state.go
+++ b/cmd/dagger/shell_state.go
@@ -14,6 +14,7 @@ import (
 	"dagger.io/dagger/querybuilder"
 	"github.com/dagger/dagger/core/rand"
 	"golang.org/x/sync/errgroup"
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 )
 
@@ -97,8 +98,8 @@ func (s *ShellStateStore) Get(key string) (ShellState, bool) {
 // Delete removes a state instance by key.
 //
 // The state won't be deleted if in use by a variable.
-func (s *ShellStateStore) Delete(key string) {
-	if s.isUsed(key) {
+func (s *ShellStateStore) Delete(ctx context.Context, key string) {
+	if s.isUsed(ctx, key) {
 		return
 	}
 	s.mu.Lock()
@@ -123,44 +124,54 @@ func (s *ShellStateStore) Load(key string) (*ShellState, error) {
 //
 // This is expected to be used when the state is being resolved rather than
 // just passed around.
-func (s *ShellStateStore) Extract(key string) (*ShellState, error) {
-	defer s.Delete(key)
+func (s *ShellStateStore) Extract(ctx context.Context, key string) (*ShellState, error) {
+	defer s.Delete(ctx, key)
 	return s.Load(key)
 }
 
 // isUsed returns true if a state key is being used in a variable.
-func (s *ShellStateStore) isUsed(key string) bool {
-	if s.runner == nil {
-		return false
+func (s *ShellStateStore) isUsed(ctx context.Context, key string) bool {
+	hctx := HandlerCtx(ctx)
+	if hctx == nil {
+		return true
 	}
-	for _, v := range s.runner.Vars {
-		if strings.Contains(v.String(), newStateToken(key)) {
-			return true
+
+	var used bool
+	token := newStateToken(key)
+
+	hctx.Env.Each(func(name string, v expand.Variable) bool {
+		if strings.Contains(v.String(), token) {
+			used = true
+			return false
 		}
-	}
-	return false
+		return true
+	})
+
+	return used
 }
 
 // Prune removes all state instances that are not in use by a variable.
-//
-// This can be used at the end of a run to avoid
-func (s *ShellStateStore) Prune() int {
+func (s *ShellStateStore) Prune(ctx context.Context) int {
+	hctx := HandlerCtx(ctx)
+	if hctx == nil {
+		return 0
+	}
+
 	used := make(map[string]struct{})
 
-	if s.runner != nil {
-		for _, v := range s.runner.Vars {
-			for key := range FindStateKeys(v.String()) {
-				used[key] = struct{}{}
-			}
+	hctx.Env.Each(func(_ string, v expand.Variable) bool {
+		for key := range FindStateKeys(v.String()) {
+			used[key] = struct{}{}
 		}
-	}
+		return true
+	})
 
 	count := 0
 	s.mu.Lock()
 	for key := range s.data {
 		if _, exists := used[key]; !exists {
-			count++
 			delete(s.data, key)
+			count++
 		}
 	}
 	s.mu.Unlock()
@@ -249,7 +260,7 @@ func (h *shellCallHandler) Save(ctx context.Context, st ShellState) error {
 	if st.Key != "" {
 		// Replace instead of mutate otherwise it's harder to manage
 		// when it's saved in a var.
-		defer h.state.Delete(st.Key)
+		defer h.state.Delete(ctx, st.Key)
 	}
 	nkey := h.state.Store(st)
 	w := interp.HandlerCtx(ctx).Stdout
@@ -404,7 +415,7 @@ func (h *shellCallHandler) resolveResult(ctx context.Context, in string) (res st
 
 // resolveState returns the resolved value of a state instance given its key
 func (h *shellCallHandler) resolveState(ctx context.Context, key string) (string, error) {
-	st, err := h.state.Extract(key)
+	st, err := h.state.Extract(ctx, key)
 	if err != nil {
 		return "", err
 	}

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -616,6 +616,20 @@ func (ShellSuite) TestStateCommand(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ShellSuite) TestStateInVarUsage(ctx context.Context, t *testctx.T) {
+	script := `
+dir=$(directory | with-new-file foo bar)
+$dir | name
+$dir | entries
+`
+	c := connect(ctx, t)
+	out, err := daggerCliBase(t, c).With(daggerShellNoMod(script)).Stdout(ctx)
+
+	require.NoError(t, err)
+	require.Contains(t, out, "/")
+	require.Contains(t, out, "foo")
+}
+
 func (ShellSuite) TestArgsSpread(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen := daggerCliBase(t, c)


### PR DESCRIPTION
Reported in [Discord](https://discord.com/channels/707636530424053791/1354863326907334736/1355202111171985558).

This fixes an issue where state was getting deleted when using a variable in the same run (same prompt or in non-interactive mode):

```console
❯ dagger -c 'dir=$(directory); $dir | entries; $dir | name'
Error: tried to access non-existent state "R2MDGQFTJ74TAAXBA26SBGHZXF"
```
