### PR TITLE
shell: fix executing a script from the root command

### DIFF
--- a/.changes/unreleased/Fixed-20250331-161142.yaml
+++ b/.changes/unreleased/Fixed-20250331-161142.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed executing a dagger shell script from the root command
+time: 2025-03-31T16:11:42.624426Z
+custom:
+    Author: helderco
+    PR: "10020"

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -10,7 +10,7 @@ pagination_prev: null
 A tool to run composable workflows in containers
 
 ```
-dagger [options] [file...]
+dagger [options] [subcommand | file...]
 ```
 
 ### Options


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10009

If the root command has positional arguments we check if it’s an existing file. If it isn’t, return an error before passing it on to `dagger shell`. This way we can still offer suggestions on a subcommand typo:

```
❯ dagger qery
Error: unknown command or file "qery" for "dagger"

Did you mean this?
        query

exit status 1
```

Note that I added “or file” to the error that the root command returned by default.