### PR TITLE
automatically mask fields on user module objects from mcp tools

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -185,6 +185,11 @@ func (m *MCP) tools(srv *dagql.Server, typeName string) ([]LLMTool, error) {
 			// never a reason to call "sync" since we call it automatically
 			continue
 		}
+		if field.Directives.ForName(trivialFieldDirectiveName) != nil {
+			// skip trivial fields on objects, only expose "real" functions
+			// with implementations
+			continue
+		}
 		schema, err := fieldArgsToJSONSchema(schema, field)
 		if err != nil {
 			return nil, fmt.Errorf("field %q: %w", field.Name, err)

--- a/core/object.go
+++ b/core/object.go
@@ -15,6 +15,10 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 )
 
+// indicates an ast field is a "trivial resolver"
+// ref: https://graphql.org/learn/execution/#trivial-resolvers
+const trivialFieldDirectiveName = "trivialResolveField"
+
 type ModuleObjectType struct {
 	typeDef *ObjectTypeDef
 	mod     *Module
@@ -399,6 +403,9 @@ func objField(mod *Module, field *FieldTypeDef) dagql.Field[*ModuleObject] {
 		Type:        field.TypeDef.ToTyped(),
 		Module:      mod.IDModule(),
 	}
+	spec.Directives = append(spec.Directives, &ast.Directive{
+		Name: trivialFieldDirectiveName,
+	})
 	if field.SourceMap != nil {
 		spec.Directives = append(spec.Directives, field.SourceMap.TypeDirective())
 	}


### PR DESCRIPTION
Manual test so far by just asking an LLM what tools it has available when given an object that has a bunch of fields:
```go
type Toy struct {
	Foo *dagger.Container
	Bar *dagger.Directory
	Baz *dagger.File
}

func New() Toy {
	return Toy{
		// Build a base container optimized for Go development
		Foo: dag.Container().
			From("golang").
			WithDefaultTerminalCmd([]string{"/bin/bash"}).
			WithMountedCache("/go/pkg/mod", dag.CacheVolume("go_mod_cache")).
			WithWorkdir("/app"),
		Bar: dag.Directory(),
		Baz: dag.Directory().WithNewFile("hello.txt", "Hello, world!").File("hello.txt"),
	}
}

func (m *Toy) Echo(stringArg string) *dagger.Container {
	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
}
```

When asked what tools it has says:
```
│🤖 I'll explain all the tools available to me:                                                                                   
│ ┃                                                                                                                               
│ ┃ 1.  currentSelection                                                                                                          
│ ┃                                                                                                                               
│ ┃ • This tool shows what Toy is currently selected                                                                              
│ ┃ • Currently shows "Toy#1" is selected                                                                                         
│ ┃ • Takes no parameters                                                                                                         
│ ┃                                                                                                                               
│ ┃ 2.  selectToy                                                                                                                 
│ ┃                                                                                                                               
│ ┃ • This tool allows selecting a different Toy by its ID                                                                        
│ ┃ • Takes one required parameter: "id" which must be in the format "Toy#number"                                                 
│ ┃ • After selecting a Toy, it provides access to Toy-specific tools                                                             
│ ┃                                                                                                                               
│ ┃ 3.  Toy_echo                                                                                                                  
│ ┃                                                                                                                               
│ ┃ • This is a tool available after a Toy is selected                                                                            
│ ┃ • Takes one required parameter: "stringArg" which is a string to echo                                                         
│ ┃ • Appears to echo back the provided string                                                                                    
│ ┃                                                                                                                               
│ ┃ What I can do:                                                                                                                
│ ┃                                                                                                                               
│ ┃ • Check which Toy is currently selected                                                                                       
│ ┃ • Switch between different Toys using their ID numbers                                                                        
│ ┃ • Echo strings using the currently selected Toy                                                                               
```

Before this change, when asked what tools it had it mentioned the (now masked) foo, bar, baz fields.