### PR TITLE
ci(alt runners): Bump Dagger Engine version

### DIFF
--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -15,7 +15,7 @@ on:
       dagger:
         description: "Dagger version"
         type: string
-        default: "0.17.1"
+        default: "0.17.2"
         required: false
       ubuntu:
         description: "Ubuntu version"

--- a/.github/workflows/_dagger_on_namespace_remote_engine.yml
+++ b/.github/workflows/_dagger_on_namespace_remote_engine.yml
@@ -20,7 +20,7 @@ on:
       dagger:
         description: "Dagger version"
         type: string
-        default: "0.17.1"
+        default: "0.17.2"
         required: false
       ubuntu:
         description: "Ubuntu version"


### PR DESCRIPTION
I thought this was already handled by the post-release process, specifically this command, but it doesn't seem to be the case 🤷

    find .github/ -type f -exec sed -i 's/0-17-1/0-17-2/g; s/0\.17\.1/0\.17\.2/g' {} +

Follow-up to https://github.com/dagger/dagger/pull/9994