### PR TITLE
fix nil dereference issue on LLM type

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -441,6 +441,7 @@ func NewLLM(ctx context.Context, query *Query, model string, maxAPICalls int) (*
 		Endpoint:    endpoint,
 		maxAPICalls: maxAPICalls,
 		mcp:         NewMCP(endpoint),
+		once:        &sync.Once{},
 	}, nil
 }
 


### PR DESCRIPTION
Fixes 10032. Initializes `once` when LLM is created

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
