### PR TITLE
docs: Fix link on 'Day 2' page

### DIFF
--- a/docs/current_docs/ci/adopting.mdx
+++ b/docs/current_docs/ci/adopting.mdx
@@ -66,7 +66,7 @@ When choosing the language to use for your pipeline, follow these principles:
 
 - *Optimize for participation*. The more people on the team are likely to participate in the development of the pipeline, the better.
 
-- *Check SDK availability*. Dagger offers three official SDKs (Python, Go, TypeScript), but there are also several [experimental and community SDKs](https://dagger.io/community-sdks), some of which are actively used in production despite not being officially supported. Take the time to investigate the status of [available SDKs](https://github.com/dagger/dagger/tree/main/sdk), and ask the community for their opinion. Our Discord server is a good place to start - each language has a dedicated channel.
+- *Check SDK availability*. Dagger offers three official SDKs (Python, Go, TypeScript), but there are also several [experimental and community SDKs](https://dagger.io/community-sdk), some of which are actively used in production despite not being officially supported. Take the time to investigate the status of [available SDKs](https://github.com/dagger/dagger/tree/main/sdk), and ask the community for their opinion. Our Discord server is a good place to start - each language has a dedicated channel.
 
 - *Polyglot pipelines for a polyglot stack*. If your team is divided in language siloes, consider writing a different module for each silo, each written in the ideal language. Dagger supports cross-language linking for exactly this reason - take advantage of it!
 


### PR DESCRIPTION
The URL is 'community-sdk' singular.

I hope this is helpful. Dagger looks great!