### PR TITLE
llm: support `-i`/`--interactive`

### DIFF
--- a/.dagger/docker.go
+++ b/.dagger/docker.go
@@ -96,6 +96,9 @@ func (e LoadedEngine) Start(
 
 	// +optional
 	debug bool,
+
+	// +optional
+	extraHosts []string,
 ) error {
 	loader := e.Loader
 
@@ -125,6 +128,10 @@ func (e LoadedEngine) Start(
 	}
 	if debug {
 		args = append(args, "-p", "6060:6060")
+	}
+
+	if len(extraHosts) > 0 {
+		args = append(args, "--add-host", strings.Join(extraHosts, ","))
 	}
 
 	args = append(args, []string{

--- a/core/llm.go
+++ b/core/llm.go
@@ -639,7 +639,17 @@ func (llm *LLM) Interject(ctx context.Context) error {
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
 		log.String(telemetry.ContentTypeAttr, "text/markdown"))
 	defer stdio.Close()
-	msg, err := bk.PromptHumanHelp(ctx, "Provide a message to help the model along:")
+	var lastAssistantMessage string
+	for i := len(llm.messages) - 1; i >= 0; i-- {
+		if llm.messages[i].Role == "assistant" {
+			lastAssistantMessage = llm.messages[i].Content
+			break
+		}
+	}
+	if lastAssistantMessage == "" {
+		return fmt.Errorf("no message from assistant")
+	}
+	msg, err := bk.PromptHumanHelp(ctx, lastAssistantMessage)
 	if err != nil {
 		return err
 	}

--- a/core/llm.go
+++ b/core/llm.go
@@ -649,7 +649,7 @@ func (llm *LLM) Interject(ctx context.Context) error {
 	if lastAssistantMessage == "" {
 		return fmt.Errorf("no message from assistant")
 	}
-	msg, err := bk.PromptHumanHelp(ctx, lastAssistantMessage)
+	msg, err := bk.PromptHumanHelp(ctx, fmt.Sprintf("The LLM was unable to complete its task and needs help. Here is its last message:\n%s", mdQuote(lastAssistantMessage)))
 	if err != nil {
 		return err
 	}
@@ -659,6 +659,14 @@ func (llm *LLM) Interject(ctx context.Context) error {
 		Content: msg,
 	})
 	return nil
+}
+
+func mdQuote(msg string) string {
+	lines := strings.Split(msg, "\n")
+	for i, line := range lines {
+		lines[i] = fmt.Sprintf("> %s", line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // autoInterject keeps the loop going if necessary, by prompting for a new

--- a/core/llm.go
+++ b/core/llm.go
@@ -626,6 +626,51 @@ func (llm *LLM) Sync(ctx context.Context, dag *dagql.Server) error {
 	return err
 }
 
+func (llm *LLM) Interject(ctx context.Context) error {
+	bk, err := llm.Query.Buildkit(ctx)
+	if err != nil {
+		return err
+	}
+	ctx, span := Tracer(ctx).Start(ctx, "LLM prompt", telemetry.Reveal(), trace.WithAttributes(
+		attribute.String(telemetry.UIActorEmojiAttr, "🧑"),
+		attribute.String(telemetry.UIMessageAttr, "sent"),
+	))
+	defer span.End()
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
+		log.String(telemetry.ContentTypeAttr, "text/markdown"))
+	defer stdio.Close()
+	msg, err := bk.PromptHumanHelp(ctx, "Provide a message to help the model along:")
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(stdio.Stdout, msg)
+	llm.messages = append(llm.messages, ModelMessage{
+		Role:    "user",
+		Content: msg,
+	})
+	return nil
+}
+
+// autoInterject keeps the loop going if necessary, by prompting for a new
+// input, adding it to the message history, and returning true
+func (llm *LLM) autoInterject(ctx context.Context) (bool, error) {
+	if llm.mcp.IsDone() {
+		// we either didn't expect a return value, or got one - done!
+		return false, nil
+	}
+	bk, err := llm.Query.Buildkit(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !bk.Opts.Interactive {
+		return false, nil
+	}
+	if err := llm.Interject(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 	if len(llm.messages) == 0 {
 		// dirty but no messages, possibly just a state change, nothing to do
@@ -647,8 +692,16 @@ func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 		if err != nil {
 			var finished *ModelFinishedError
 			if errors.As(err, &finished) {
-				// model finished
-				break
+				if interjected, interjectErr := llm.autoInterject(ctx); interjectErr != nil {
+					// interjecting failed or was interrupted
+					return errors.Join(err, interjectErr)
+				} else if interjected {
+					// interjected - continue
+					continue
+				} else {
+					// no interjection and none needed - we're just done
+					break
+				}
 			}
 			return err
 		}
@@ -663,6 +716,14 @@ func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 		// Handle tool calls
 		// calls := res.Choices[0].Message.ToolCalls
 		if len(res.ToolCalls) == 0 {
+			if interjected, interjectErr := llm.autoInterject(ctx); interjectErr != nil {
+				// interjecting failed or was interrupted
+				return interjectErr
+			} else if interjected {
+				// interjected - continue
+				continue
+			}
+			// no interjection and none needed - we're just done
 			break
 		}
 		for _, toolCall := range res.ToolCalls {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -46,6 +46,8 @@ type MCP struct {
 	needsSystemPrompt bool
 	// Only show these functions, if non-empty
 	functionMask map[string]bool
+	// Indicates that the model has returned
+	returned bool
 }
 
 func NewMCP(endpoint *LLMEndpoint) *MCP {
@@ -543,6 +545,7 @@ Each parameter corresponds to a named result with a specific purpose. Do not cal
 					return nil, fmt.Errorf("undefined output: %q", name)
 				}
 			}
+			m.returned = true
 			return "ok", nil
 		},
 	}
@@ -682,6 +685,10 @@ func (m *MCP) envGetters() []LLMTool {
 		})
 	}
 	return tools
+}
+
+func (m *MCP) IsDone() bool {
+	return len(m.env.outputsByName) == 0 || m.returned
 }
 
 func (m *MCP) toolToID(tool LLMTool, args any) (*call.ID, error) {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1928,7 +1928,7 @@ func (fe *frontendPretty) handlePromptString(ctx context.Context, message string
 	fe.program.Send(tea.Msg(promptString{
 		message: &Markdown{
 			Content: message,
-			Width:   min(max(fe.window.Width/2, 50), 80),
+			Width:   fe.window.Width,
 		},
 		result: result,
 	}))

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -100,7 +100,8 @@ type frontendPretty struct {
 	msgPreFinalRender strings.Builder
 
 	// Add prompt field
-	activePrompt *prompt
+	activeBoolPrompt   *promptBool
+	activeStringPrompt *promptString
 }
 
 func NewPretty() Frontend {
@@ -210,7 +211,7 @@ func (fe *frontendPretty) Run(ctx context.Context, opts dagui.FrontendOpts, run 
 		fe.err = fe.runWithTUI(ctx, run)
 	}
 
-	if fe.editline != nil {
+	if fe.editline != nil && fe.shell != nil {
 		if err := os.MkdirAll(filepath.Dir(historyFile), 0755); err != nil {
 			slog.Error("failed to create history directory", "err", err)
 		}
@@ -234,6 +235,8 @@ func (fe *frontendPretty) HandlePrompt(ctx context.Context, prompt string, dest 
 	switch x := dest.(type) {
 	case *bool:
 		return fe.handlePromptBool(ctx, prompt, x)
+	case *string:
+		return fe.handlePromptString(ctx, prompt, x)
 	default:
 		return fmt.Errorf("unsupported prompt destination type: %T", dest)
 	}
@@ -553,9 +556,13 @@ func (fe *frontendPretty) renderKeymap(out *termenv.Output, style lipgloss.Style
 
 func (fe *frontendPretty) keys(out *termenv.Output) []key.Binding {
 	if fe.editlineFocused {
-		return append([]key.Binding{
+		bnds := []key.Binding{
 			key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "nav mode")),
-		}, fe.shell.KeyBindings()...)
+		}
+		if fe.shell != nil {
+			bnds = append(bnds, fe.shell.KeyBindings()...)
+		}
+		return bnds
 	}
 
 	var quitMsg string
@@ -613,12 +620,17 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 	below := new(strings.Builder)
 	var countOut TermOutput = NewOutput(below, termenv.WithProfile(fe.profile))
 
-	if fe.activePrompt != nil {
-		fmt.Fprint(countOut, fe.viewPrompt(countOut))
+	if fe.activeBoolPrompt != nil {
+		fmt.Fprint(countOut, fe.viewBoolPrompt(countOut))
 		fmt.Fprintln(countOut)
 	}
 
-	if fe.shell == nil {
+	if fe.activeStringPrompt != nil {
+		fmt.Fprintln(countOut)
+		fmt.Fprint(countOut, fe.viewStringPrompt())
+	}
+
+	if fe.editline == nil {
 		fmt.Fprint(countOut, fe.viewKeymap())
 	}
 
@@ -638,8 +650,12 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 	return nil
 }
 
-func (fe *frontendPretty) viewPrompt(out TermOutput) string {
-	message := fe.activePrompt.message.View()
+func (fe *frontendPretty) viewStringPrompt() string {
+	return fe.activeStringPrompt.message.View()
+}
+
+func (fe *frontendPretty) viewBoolPrompt(out TermOutput) string {
+	message := fe.activeBoolPrompt.message.View()
 	width := lipgloss.Width(message)
 
 	// Render Yes/No buttons
@@ -659,7 +675,7 @@ func (fe *frontendPretty) viewPrompt(out TermOutput) string {
 	for i, style := range noStyles {
 		noStyles[i] = style.Foreground(termenv.ANSIRed)
 	}
-	if fe.activePrompt.yessing {
+	if fe.activeBoolPrompt.yessing {
 		for i, style := range yesStyles {
 			yesStyles[i] = style.Bold().Reverse()
 		}
@@ -899,7 +915,7 @@ func (fe *frontendPretty) View() string {
 		// print nothing; make way for the pristine output in the final render
 		return ""
 	}
-	if fe.shell != nil {
+	if fe.editline != nil {
 		prog := ""
 		if fe.scrollback.Len() > 0 {
 			prog += fe.scrollback.String()
@@ -912,7 +928,10 @@ func (fe *frontendPretty) View() string {
 		prog += "\n"
 		if view := strings.TrimSpace(fe.view.String()); view != "" {
 			prog += view
-			prog += "\n\n"
+			prog += "\n"
+			if fe.activeStringPrompt == nil {
+				prog += "\n"
+			}
 		}
 		return prog + fe.editlineView()
 	}
@@ -966,31 +985,23 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		fe.shellCtx = msg.ctx
 		fe.promptFg = termenv.ANSIGreen
 
-		// create the editline
-		fe.editline = editline.New(fe.window.Width, fe.window.Height)
-		fe.editline.HistoryEncoder = msg.handler
-		fe.editline.HideKeyMap = true
-		fe.editlineFocused = true
-
-		// wire up auto completion
-		fe.editline.AutoComplete = msg.handler.AutoComplete
+		fe.initEditline()
 
 		// restore history
 		fe.editline.MaxHistorySize = 1000
 		if history, err := history.LoadHistory(historyFile); err == nil {
 			fe.editline.SetHistory(history)
 		}
+		fe.editline.HistoryEncoder = msg.handler
+
+		// wire up auto completion
+		fe.editline.AutoComplete = msg.handler.AutoComplete
 
 		// if input ends with a pipe, then it's not complete
 		fe.editline.CheckInputComplete = msg.handler.IsComplete
 
 		// put the bowtie on
 		promptCmd := fe.updatePrompt()
-
-		// HACK: for some reason editline's first paint is broken (only shows
-		// first 2 chars of prompt, doesn't show cursor). Sending it a message
-		// - any message - fixes it.
-		fe.editline.Update(nil)
 
 		return fe, tea.Batch(
 			tea.Printf(`Dagger interactive shell. Type ".help" for more information. Press Ctrl+D to exit.`),
@@ -1049,15 +1060,22 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		return fe, nil
 
 	case editline.InputCompleteMsg:
-		if fe.shell != nil && fe.editlineFocused {
-			value := fe.editline.Value()
-			fe.editline.AddHistoryEntry(value)
-			fe.promptFg = termenv.ANSIYellow
-			promptCmd := fe.updatePrompt()
+		if !fe.editlineFocused {
+			return fe, nil
+		}
+		value := fe.editline.Value()
+		fe.editline.AddHistoryEntry(value)
+		fe.promptFg = termenv.ANSIYellow
+		promptCmd := fe.updatePrompt()
 
-			// reset now that we've accepted input
-			fe.editline.Reset()
-
+		// reset now that we've accepted input
+		fe.editline.Reset()
+		if fe.activeStringPrompt != nil {
+			fe.activeStringPrompt.result <- value
+			fe.editline = nil
+			fe.activeStringPrompt = nil
+			fe.editlineFocused = false
+		} else if fe.shell != nil {
 			ctx, cancel := context.WithCancelCause(fe.shellCtx)
 			fe.shellInterrupt = cancel
 			fe.shellRunning = true
@@ -1091,10 +1109,10 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 	case tea.KeyMsg:
 		switch {
 		// Handle prompt input if there's an active prompt
-		case fe.activePrompt != nil:
+		case fe.activeBoolPrompt != nil:
 			return fe, fe.handleBoolPromptKey(msg)
 		// send all input to editline if it's focused
-		case fe.shell != nil && fe.editlineFocused:
+		case fe.editlineFocused:
 			return fe, fe.handleEditlineKey(msg)
 		default:
 			return fe, fe.handleNavKey(msg)
@@ -1112,9 +1130,14 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 		// adjust the outermost layer.
 		return fe, tea.Batch(flushCmd, frame(fe.fps))
 
-	case prompt:
-		fe.activePrompt = &msg
+	case promptBool:
+		fe.activeBoolPrompt = &msg
 		return fe, nil
+
+	case promptString:
+		fe.activeStringPrompt = &msg
+		fe.initEditline()
+		return fe, fe.updatePrompt()
 
 	default:
 		return fe, nil
@@ -1124,27 +1147,27 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 func (fe *frontendPretty) handleBoolPromptKey(msg tea.KeyMsg) tea.Cmd {
 	switch msg.String() {
 	case "left", "h", "right", "l":
-		fe.activePrompt.yessing = !fe.activePrompt.yessing
+		fe.activeBoolPrompt.yessing = !fe.activeBoolPrompt.yessing
 	case "enter":
-		result := fe.activePrompt.result
-		choice := fe.activePrompt.yessing
-		fe.activePrompt = nil
+		result := fe.activeBoolPrompt.result
+		choice := fe.activeBoolPrompt.yessing
+		fe.activeBoolPrompt = nil
 		return func() tea.Msg {
 			result <- choice
 			close(result)
 			return nil
 		}
 	case "n", "N":
-		result := fe.activePrompt.result
-		fe.activePrompt = nil
+		result := fe.activeBoolPrompt.result
+		fe.activeBoolPrompt = nil
 		return func() tea.Msg {
 			result <- false
 			close(result)
 			return nil
 		}
 	case "y", "Y":
-		result := fe.activePrompt.result
-		fe.activePrompt = nil
+		result := fe.activeBoolPrompt.result
+		fe.activeBoolPrompt = nil
 		return func() tea.Msg {
 			result <- true
 			close(result)
@@ -1185,7 +1208,7 @@ func (fe *frontendPretty) handleEditlineKey(msg tea.KeyMsg) (cmd tea.Cmd) {
 		fe.recalculateViewLocked()
 		return nil
 	default:
-		if fe.editline.AtStart() {
+		if fe.shell != nil && fe.editline.AtStart() {
 			cmd := fe.shell.ReactToInput(fe.runCtx, msg)
 			if cmd != nil {
 				return cmd
@@ -1297,12 +1320,28 @@ func (fe *frontendPretty) handleNavKey(msg tea.KeyMsg) tea.Cmd {
 	return nil
 }
 
+func (fe *frontendPretty) initEditline() {
+	// create the editline
+	fe.editline = editline.New(fe.window.Width, fe.window.Height)
+	fe.editline.HideKeyMap = true
+	fe.editlineFocused = true
+	// HACK: for some reason editline's first paint is broken (only shows
+	// first 2 chars of prompt, doesn't show cursor). Sending it a message
+	// - any message - fixes it.
+	fe.editline.Update(nil)
+}
+
 type UpdatePromptMsg struct{}
 
-type prompt struct {
+type promptBool struct {
 	message *Markdown
 	result  chan bool
 	yessing bool
+}
+
+type promptString struct {
+	message *Markdown
+	result  chan string
 }
 
 func (fe *frontendPretty) flushScrollback() (*frontendPretty, tea.Cmd) {
@@ -1411,8 +1450,10 @@ func (fe *frontendPretty) clearScrollback() tea.Cmd {
 }
 
 func (fe *frontendPretty) updatePrompt() tea.Cmd {
-	prompt, cmd := fe.shell.Prompt(fe.runCtx, fe.viewOut, fe.promptFg)
-	fe.editline.Prompt = prompt
+	var cmd tea.Cmd
+	if fe.shell != nil {
+		fe.editline.Prompt, cmd = fe.shell.Prompt(fe.runCtx, fe.viewOut, fe.promptFg)
+	}
 	fe.editline.UpdatePrompt()
 	return cmd
 }
@@ -1517,8 +1558,11 @@ func (fe *frontendPretty) setWindowSizeLocked(msg tea.WindowSizeMsg) {
 	if fe.editline != nil {
 		fe.editline.SetSize(msg.Width, msg.Height)
 	}
-	if fe.activePrompt != nil {
-		fe.activePrompt.message.Width = msg.Width
+	if fe.activeBoolPrompt != nil {
+		fe.activeBoolPrompt.message.Width = msg.Width
+	}
+	if fe.activeStringPrompt != nil {
+		fe.activeStringPrompt.message.Width = msg.Width
 	}
 }
 
@@ -1860,13 +1904,33 @@ type TermOutput interface {
 func (fe *frontendPretty) handlePromptBool(ctx context.Context, message string, dest *bool) error {
 	result := make(chan bool, 1)
 
-	fe.program.Send(tea.Msg(prompt{
+	fe.program.Send(tea.Msg(promptBool{
 		message: &Markdown{
 			Content: message,
 			Width:   min(max(fe.window.Width/2, 50), 80),
 		},
 		result:  result,
 		yessing: *dest,
+	}))
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case val := <-result:
+		*dest = val
+		return nil
+	}
+}
+
+func (fe *frontendPretty) handlePromptString(ctx context.Context, message string, dest *string) error {
+	result := make(chan string, 1)
+
+	fe.program.Send(tea.Msg(promptString{
+		message: &Markdown{
+			Content: message,
+			Width:   min(max(fe.window.Width/2, 50), 80),
+		},
+		result: result,
 	}))
 
 	select {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -678,6 +678,22 @@ func (c *Client) PromptAllowLLM(ctx context.Context, moduleRepoURL string) error
 	return fmt.Errorf("module %s was denied LLM access; pass --allow-llm=%s or --allow-llm=all to allow", moduleRepoURL, moduleRepoURL)
 }
 
+func (c *Client) PromptHumanHelp(ctx context.Context, question string) (string, error) {
+	caller, err := c.GetMainClientCaller()
+	if err != nil {
+		return "", fmt.Errorf("failed to get main client caller to to prompt user for human help: %w", err)
+	}
+
+	response, err := session.NewPromptClient(caller.Conn()).PromptString(ctx, &session.StringRequest{
+		Prompt:  question,
+		Default: "The user did not respond.",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to prompt user for human help: %w", err)
+	}
+	return response.Response, nil
+}
+
 func (c *Client) GetGitConfig(ctx context.Context) ([]*session.GitConfigEntry, error) {
 	md, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {

--- a/engine/session/prompt.pb.go
+++ b/engine/session/prompt.pb.go
@@ -134,15 +134,114 @@ func (m *BoolResponse) GetResponse() bool {
 	return false
 }
 
+type StringRequest struct {
+	// the prompt to display to the user
+	Prompt string `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	// the default value to return if the user doesn't respond
+	Default string `protobuf:"bytes,2,opt,name=default,proto3" json:"default,omitempty"`
+}
+
+func (m *StringRequest) Reset()      { *m = StringRequest{} }
+func (*StringRequest) ProtoMessage() {}
+func (*StringRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2532b5caf780ac64, []int{2}
+}
+func (m *StringRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StringRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StringRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StringRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringRequest.Merge(m, src)
+}
+func (m *StringRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *StringRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_StringRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StringRequest proto.InternalMessageInfo
+
+func (m *StringRequest) GetPrompt() string {
+	if m != nil {
+		return m.Prompt
+	}
+	return ""
+}
+
+func (m *StringRequest) GetDefault() string {
+	if m != nil {
+		return m.Default
+	}
+	return ""
+}
+
+type StringResponse struct {
+	// the response from the user
+	Response string `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+}
+
+func (m *StringResponse) Reset()      { *m = StringResponse{} }
+func (*StringResponse) ProtoMessage() {}
+func (*StringResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2532b5caf780ac64, []int{3}
+}
+func (m *StringResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StringResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StringResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StringResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringResponse.Merge(m, src)
+}
+func (m *StringResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *StringResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_StringResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StringResponse proto.InternalMessageInfo
+
+func (m *StringResponse) GetResponse() string {
+	if m != nil {
+		return m.Response
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*BoolRequest)(nil), "BoolRequest")
 	proto.RegisterType((*BoolResponse)(nil), "BoolResponse")
+	proto.RegisterType((*StringRequest)(nil), "StringRequest")
+	proto.RegisterType((*StringResponse)(nil), "StringResponse")
 }
 
 func init() { proto.RegisterFile("prompt.proto", fileDescriptor_2532b5caf780ac64) }
 
 var fileDescriptor_2532b5caf780ac64 = []byte{
-	// 231 bytes of a gzipped FileDescriptorProto
+	// 279 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x29, 0x28, 0xca, 0xcf,
 	0x2d, 0x28, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x57, 0x4a, 0xe5, 0xe2, 0x76, 0xca, 0xcf, 0xcf,
 	0x09, 0x4a, 0x2d, 0x2c, 0x4d, 0x2d, 0x2e, 0x11, 0x12, 0xe3, 0x62, 0x83, 0x48, 0x4b, 0x30, 0x2a,
@@ -150,14 +249,17 @@ var fileDescriptor_2532b5caf780ac64 = []byte{
 	0x25, 0xa9, 0x79, 0x25, 0xde, 0xa9, 0x95, 0x12, 0x4c, 0x60, 0x69, 0x54, 0x41, 0x21, 0x09, 0x2e,
 	0xf6, 0x94, 0xd4, 0xb4, 0xc4, 0xd2, 0x9c, 0x12, 0x09, 0x66, 0x05, 0x46, 0x0d, 0x8e, 0x20, 0x18,
 	0x57, 0x49, 0x8b, 0x8b, 0x07, 0x62, 0x4d, 0x71, 0x41, 0x7e, 0x5e, 0x71, 0xaa, 0x90, 0x14, 0x17,
-	0x47, 0x11, 0x94, 0x0d, 0xb6, 0x89, 0x23, 0x08, 0xce, 0x37, 0x32, 0xe6, 0x62, 0x0b, 0x80, 0xd8,
-	0xaa, 0xc9, 0xc5, 0x05, 0x61, 0x81, 0xf4, 0x0a, 0xf1, 0xe8, 0x21, 0xb9, 0x54, 0x8a, 0x57, 0x0f,
-	0xd9, 0x40, 0x27, 0xdb, 0x0b, 0x0f, 0xe5, 0x18, 0x6e, 0x3c, 0x94, 0x63, 0xf8, 0xf0, 0x50, 0x8e,
-	0xb1, 0xe1, 0x91, 0x1c, 0xe3, 0x8a, 0x47, 0x72, 0x8c, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24,
-	0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8b, 0x47, 0x72, 0x0c, 0x1f, 0x1e, 0xc9, 0x31, 0x4e, 0x78,
-	0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x51, 0xec, 0xc5, 0xa9, 0xc5,
-	0xc5, 0x99, 0xf9, 0x79, 0x49, 0x6c, 0xe0, 0xd0, 0x30, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xb5,
-	0xab, 0x48, 0x06, 0x1d, 0x01, 0x00, 0x00,
+	0x47, 0x11, 0x94, 0x0d, 0xb6, 0x89, 0x23, 0x08, 0xce, 0x57, 0x72, 0xe4, 0xe2, 0x0d, 0x2e, 0x29,
+	0xca, 0xcc, 0x4b, 0x27, 0xe4, 0x28, 0x24, 0xeb, 0x20, 0xce, 0x81, 0x5b, 0xa7, 0xc3, 0xc5, 0x07,
+	0x33, 0x02, 0x87, 0x85, 0x9c, 0x08, 0x0b, 0x8d, 0x52, 0xb8, 0xd8, 0x02, 0x20, 0x26, 0x6a, 0x72,
+	0x71, 0x41, 0x58, 0x20, 0xc7, 0x0a, 0xf1, 0xe8, 0x21, 0x05, 0x8d, 0x14, 0xaf, 0x1e, 0x8a, 0x0f,
+	0xf4, 0xb9, 0x78, 0x20, 0x4a, 0x21, 0x16, 0x09, 0xf1, 0xe9, 0xa1, 0x38, 0x5a, 0x8a, 0x5f, 0x0f,
+	0xd5, 0x05, 0x4e, 0xb6, 0x17, 0x1e, 0xca, 0x31, 0xdc, 0x78, 0x28, 0xc7, 0xf0, 0xe1, 0xa1, 0x1c,
+	0x63, 0xc3, 0x23, 0x39, 0xc6, 0x15, 0x8f, 0xe4, 0x18, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48,
+	0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x17, 0x8f, 0xe4, 0x18, 0x3e, 0x3c, 0x92, 0x63, 0x9c, 0xf0,
+	0x58, 0x8e, 0xe1, 0xc2, 0x63, 0x39, 0x86, 0x1b, 0x8f, 0xe5, 0x18, 0xa2, 0xd8, 0x8b, 0x53, 0x8b,
+	0x8b, 0x33, 0xf3, 0xf3, 0x92, 0xd8, 0xc0, 0xf1, 0x65, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xf1,
+	0x14, 0xcb, 0x13, 0xbf, 0x01, 0x00, 0x00,
 }
 
 func (this *BoolRequest) Equal(that interface{}) bool {
@@ -214,6 +316,57 @@ func (this *BoolResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *StringRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StringRequest)
+	if !ok {
+		that2, ok := that.(StringRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Prompt != that1.Prompt {
+		return false
+	}
+	if this.Default != that1.Default {
+		return false
+	}
+	return true
+}
+func (this *StringResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StringResponse)
+	if !ok {
+		that2, ok := that.(StringResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Response != that1.Response {
+		return false
+	}
+	return true
+}
 func (this *BoolRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -232,6 +385,27 @@ func (this *BoolResponse) GoString() string {
 	}
 	s := make([]string, 0, 5)
 	s = append(s, "&session.BoolResponse{")
+	s = append(s, "Response: "+fmt.Sprintf("%#v", this.Response)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StringRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&session.StringRequest{")
+	s = append(s, "Prompt: "+fmt.Sprintf("%#v", this.Prompt)+",\n")
+	s = append(s, "Default: "+fmt.Sprintf("%#v", this.Default)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StringResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&session.StringResponse{")
 	s = append(s, "Response: "+fmt.Sprintf("%#v", this.Response)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
@@ -258,6 +432,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type PromptClient interface {
 	PromptBool(ctx context.Context, in *BoolRequest, opts ...grpc.CallOption) (*BoolResponse, error)
+	PromptString(ctx context.Context, in *StringRequest, opts ...grpc.CallOption) (*StringResponse, error)
 }
 
 type promptClient struct {
@@ -277,9 +452,19 @@ func (c *promptClient) PromptBool(ctx context.Context, in *BoolRequest, opts ...
 	return out, nil
 }
 
+func (c *promptClient) PromptString(ctx context.Context, in *StringRequest, opts ...grpc.CallOption) (*StringResponse, error) {
+	out := new(StringResponse)
+	err := c.cc.Invoke(ctx, "/Prompt/PromptString", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PromptServer is the server API for Prompt service.
 type PromptServer interface {
 	PromptBool(context.Context, *BoolRequest) (*BoolResponse, error)
+	PromptString(context.Context, *StringRequest) (*StringResponse, error)
 }
 
 // UnimplementedPromptServer can be embedded to have forward compatible implementations.
@@ -288,6 +473,9 @@ type UnimplementedPromptServer struct {
 
 func (*UnimplementedPromptServer) PromptBool(ctx context.Context, req *BoolRequest) (*BoolResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PromptBool not implemented")
+}
+func (*UnimplementedPromptServer) PromptString(ctx context.Context, req *StringRequest) (*StringResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PromptString not implemented")
 }
 
 func RegisterPromptServer(s *grpc.Server, srv PromptServer) {
@@ -312,6 +500,24 @@ func _Prompt_PromptBool_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Prompt_PromptString_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StringRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PromptServer).PromptString(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/Prompt/PromptString",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PromptServer).PromptString(ctx, req.(*StringRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Prompt_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "Prompt",
 	HandlerType: (*PromptServer)(nil),
@@ -319,6 +525,10 @@ var _Prompt_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PromptBool",
 			Handler:    _Prompt_PromptBool_Handler,
+		},
+		{
+			MethodName: "PromptString",
+			Handler:    _Prompt_PromptString_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -405,6 +615,73 @@ func (m *BoolResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *StringRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StringRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Default) > 0 {
+		i -= len(m.Default)
+		copy(dAtA[i:], m.Default)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Default)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Prompt) > 0 {
+		i -= len(m.Prompt)
+		copy(dAtA[i:], m.Prompt)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Prompt)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StringResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StringResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StringResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Response) > 0 {
+		i -= len(m.Response)
+		copy(dAtA[i:], m.Response)
+		i = encodeVarintPrompt(dAtA, i, uint64(len(m.Response)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintPrompt(dAtA []byte, offset int, v uint64) int {
 	offset -= sovPrompt(v)
 	base := offset
@@ -448,6 +725,36 @@ func (m *BoolResponse) Size() (n int) {
 	return n
 }
 
+func (m *StringRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Prompt)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	l = len(m.Default)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	return n
+}
+
+func (m *StringResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Response)
+	if l > 0 {
+		n += 1 + l + sovPrompt(uint64(l))
+	}
+	return n
+}
+
 func sovPrompt(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -471,6 +778,27 @@ func (this *BoolResponse) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&BoolResponse{`,
+		`Response:` + fmt.Sprintf("%v", this.Response) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StringRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StringRequest{`,
+		`Prompt:` + fmt.Sprintf("%v", this.Prompt) + `,`,
+		`Default:` + fmt.Sprintf("%v", this.Default) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StringResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StringResponse{`,
 		`Response:` + fmt.Sprintf("%v", this.Response) + `,`,
 		`}`,
 	}, "")
@@ -667,6 +995,202 @@ func (m *BoolResponse) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Response = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPrompt(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StringRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPrompt
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StringRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StringRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Prompt", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Prompt = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Default", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Default = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPrompt(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StringResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPrompt
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StringResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StringResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Response", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPrompt
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPrompt
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Response = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipPrompt(dAtA[iNdEx:])

--- a/engine/session/prompt.proto
+++ b/engine/session/prompt.proto
@@ -4,6 +4,7 @@ option go_package = "session";
 
 service Prompt {
   rpc PromptBool(BoolRequest) returns (BoolResponse);
+  rpc PromptString(StringRequest) returns (StringResponse);
 }
 
 message BoolRequest {
@@ -18,4 +19,16 @@ message BoolRequest {
 message BoolResponse {
     // the response from the user
     bool response = 1;
+}
+
+message StringRequest {
+    // the prompt to display to the user
+    string prompt = 1;
+    // the default value to return if the user doesn't respond
+    string default = 2;
+}
+
+message StringResponse {
+    // the response from the user
+    string response = 1;
 }

--- a/hack/build
+++ b/hack/build
@@ -25,8 +25,8 @@ engine |\
         ${_EXPERIMENTAL_DAGGER_GPU_SUPPORT:+--gpu-support} |\
     start \
         --name=$CONTAINER \
+        ${DAGGER_EXTRA_HOSTS:+--extra-hosts=${DAGGER_EXTRA_HOSTS-}} \
         ${DAGGER_CLOUD_TOKEN:+--cloud-token=env://DAGGER_CLOUD_TOKEN} \
         ${DAGGER_CLOUD_URL:+--cloud-url=${DAGGER_CLOUD_URL-}} &
 
 _wait
-


### PR DESCRIPTION
Now when a model ends its turn without returning the requested outputs, and the user has passed `-i`, we'll prompt the user to help the model out.

(Credit to @cwlbraa who started on this in #9978 - preserved a sign-off on the commit!)