### PR TITLE
WIP dag.LLM MCP client support

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -560,6 +560,23 @@ func (llm *LLM) WithSystemPrompt(prompt string) *LLM {
 	return llm
 }
 
+// Append a system prompt message to the history
+func (llm *LLM) WithMCP(ctx context.Context, ctr *Container, srv *dagql.Server) (*LLM, error) {
+	llm = llm.Clone()
+	bk, err := llm.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	_, err = bk.MCPClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate MCP Client", err)
+	}
+
+	llm.env.mcpServers = append(llm.env.mcpServers)
+	llm.dirty = true
+	return llm, nil
+}
+
 // Return the last message sent by the agent
 func (llm *LLM) LastReply(ctx context.Context, dag *dagql.Server) (string, error) {
 	if err := llm.Sync(ctx, dag); err != nil {

--- a/core/llm.go
+++ b/core/llm.go
@@ -567,13 +567,12 @@ func (llm *LLM) WithMCP(ctx context.Context, ctr *Container, srv *dagql.Server) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
 	}
-	_, err = bk.MCPClient(ctx)
+	mcpServer, err := bk.MCPClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate MCP Client", err)
 	}
 
-	llm.env.mcpServers = append(llm.env.mcpServers)
-	llm.dirty = true
+	llm.mcp.mcpServers = append(llm.mcp.mcpServers, MCPClient{mcpServer, ctr})
 	return llm, nil
 }
 

--- a/core/llm.go
+++ b/core/llm.go
@@ -564,7 +564,7 @@ func (llm *LLM) WithSystemPrompt(prompt string) *LLM {
 // Add a stdio MCP service to the llm's tool set
 func (llm *LLM) WithMCP(ctx context.Context, ctr *Container, mcpSvcId *call.ID) *LLM {
 	llm = llm.Clone()
-	llm.mcp.mcpServers = append(llm.mcp.mcpServers, MCPClient{container: ctr})
+	llm.mcp.mcpServers = append(llm.mcp.mcpServers, MCPClient{container: ctr, mcpSvcID: mcpSvcId})
 	return llm
 }
 

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -594,6 +594,8 @@ func (ms *MCPClient) Tools(ctx context.Context) ([]LLMTool, error) {
 		ms.Client = client
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	resp, err := ms.Client.ListTools(ctx, mcpc.NewRequest(&mcpc.ListToolsRequest{}))
 	if err != nil {
 		return nil, fmt.Errorf("failed listing tools: %w", err)

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -50,7 +50,7 @@ type MCP struct {
 	// Indicates that the model has returned
 	returned bool
 	// attached MCP Servers... TODO: namespace collision really hurts here
-	mcpServers []*MCPClient
+	mcpServers []MCPClient
 }
 
 func NewMCP(endpoint *LLMEndpoint) *MCP {

--- a/core/mcpserver.go
+++ b/core/mcpserver.go
@@ -156,7 +156,7 @@ func (s mcpServer) genMcpToolHandler(tool LLMTool) mcpserver.ToolHandlerFunc {
 			text = string(b)
 		}
 
-		if err := s.setTools(); err != nil {
+		if err := s.setTools(ctx); err != nil {
 			return nil, err
 		}
 
@@ -181,8 +181,8 @@ func (s mcpServer) convertToMcpTools(llmTools []LLMTool) ([]mcpserver.ServerTool
 	return mcpTools, nil
 }
 
-func (s mcpServer) setTools() error {
-	tools, err := s.env.Tools(s.dag)
+func (s mcpServer) setTools(ctx context.Context) error {
+	tools, err := s.env.Tools(ctx, s.dag)
 	if err != nil {
 		return fmt.Errorf("failed to get tools: %w", err)
 	}
@@ -198,7 +198,7 @@ func (s mcpServer) run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if err := s.setTools(); err != nil {
+	if err := s.setTools(ctx); err != nil {
 		return err
 	}
 

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -211,9 +211,7 @@ func (s *llmSchema) withMCP(ctx context.Context, llm *core.LLM, args struct {
 	if err != nil {
 		return llm, err
 	}
-	llm, err = llm.WithMCP(ctx, inst.Self, s.srv)
-	if err != nil {
-		return llm, err
-	}
-	return llm, nil
+
+	// i suspect inst.ID shouldn't actually wire through here? this is tied up in core.Services prolly
+	return llm.WithMCP(ctx, inst.Self, inst.ID()), nil
 }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2648,6 +2648,12 @@ type LLM {
   """allow the LLM to interact with an environment via MCP"""
   withEnv(env: EnvID!): LLM!
 
+  """attach a stdio MCP server to the LLM"""
+  withMCP(
+    """a container running an MCP server on stdin and stdout"""
+    container: ContainerID!
+  ): LLM!
+
   """swap out the llm model"""
   withModel(
     """The model to use"""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8835,6 +8835,23 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="LLM-withMCP" href="#LLM-withMCP"><code>withMCP</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
+                        <td> attach a stdio MCP server to the LLM </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>container</code></span> - <span class="property-type"><a href="#definition-ContainerID"><code>ContainerID!</code></a></span></h6>
+                                <p>a container running an MCP server on stdin and stdout</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="LLM-withModel" href="#LLM-withModel"><code>withModel</code></a> - <span class="property-type"><a href="#definition-LLM"><code>LLM!</code></a></span> </td>
                         <td> swap out the llm model </td>
                       </tr>

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/mark3labs/mcp-go/client"
 	bkcache "github.com/moby/buildkit/cache"
 	bkcacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/cache/remotecache"
@@ -860,6 +861,10 @@ func (c *Client) OpenPipe(
 	}
 	// io.ReadWriter wrapper
 	return &session.PipeIO{GRPC: pipeIOClient}, nil
+}
+
+func (c *Client) MCPClient(ctx context.Context) (client.MCPClient, error) {
+	return nil, nil
 }
 
 // like sync.OnceValue but accepts an arg

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/mark3labs/mcp-go/client"
 	bkcache "github.com/moby/buildkit/cache"
 	bkcacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/cache/remotecache"
@@ -861,10 +860,6 @@ func (c *Client) OpenPipe(
 	}
 	// io.ReadWriter wrapper
 	return &session.PipeIO{GRPC: pipeIOClient}, nil
-}
-
-func (c *Client) MCPClient(ctx context.Context) (client.MCPClient, error) {
-	return nil, nil
 }
 
 // like sync.OnceValue but accepts an arg

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/dagger/dagger
 
-go 1.23.0
+go 1.23.3
 
-toolchain go1.23.6
+toolchain go1.24.1
 
 require (
 	dagger.io/dagger v0.18.0
@@ -275,7 +275,6 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/goveralls v0.0.12 // indirect
-	github.com/metoro-io/mcp-golang v0.8.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
@@ -297,6 +296,7 @@ require (
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/riza-io/mcp-go v0.4.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -275,6 +275,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/goveralls v0.0.12 // indirect
+	github.com/metoro-io/mcp-golang v0.8.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/goveralls v0.0.12 h1:PEEeF0k1SsTjOBQ8FOmrOAoCu4ytuMaWCnWe94zxbCg=
 github.com/mattn/goveralls v0.0.12/go.mod h1:44ImGEUfmqH8bBtaMrYKsM65LXfNLWmwaxFGjZwgMSQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/metoro-io/mcp-golang v0.8.0 h1:DkigHa3w7WwMFomcEz5wiMDX94DsvVm/3mCV3d1obnc=
+github.com/metoro-io/mcp-golang v0.8.0/go.mod h1:ifLP9ZzKpN1UqFWNTpAHOqSvNkMK6b7d1FSZ5Lu0lN0=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/riza-io/mcp-go v0.4.3 h1:G5MshqEkunmBO6K4g9JS8V/P4dXmmpRbiAWKSi1nXtU=
+github.com/riza-io/mcp-go v0.4.3/go.mod h1:Y49dNydnOfCzgW/4reGneOW/adkC4E06kQkjHHxJ3Qc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=

--- a/sdk/elixir/lib/dagger/gen/llm.ex
+++ b/sdk/elixir/lib/dagger/gen/llm.ex
@@ -164,6 +164,20 @@ defmodule Dagger.LLM do
     }
   end
 
+  @doc "attach a stdio MCP server to the LLM"
+  @spec with_mcp(t(), Dagger.Container.t()) :: Dagger.LLM.t()
+  def with_mcp(%__MODULE__{} = llm, container) do
+    query_builder =
+      llm.query_builder
+      |> QB.select("withMCP")
+      |> QB.put_arg("container", Dagger.ID.id!(container))
+
+    %Dagger.LLM{
+      query_builder: query_builder,
+      client: llm.client
+    }
+  end
+
   @doc "swap out the llm model"
   @spec with_model(t(), String.t()) :: Dagger.LLM.t()
   def with_model(%__MODULE__{} = llm, model) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6217,6 +6217,17 @@ func (r *LLM) WithEnv(env *Env) *LLM {
 	}
 }
 
+// attach a stdio MCP server to the LLM
+func (r *LLM) WithMCP(container *Container) *LLM {
+	assertNotNil("container", container)
+	q := r.query.Select("withMCP")
+	q = q.Arg("container", container)
+
+	return &LLM{
+		query: q,
+	}
+}
+
 // swap out the llm model
 func (r *LLM) WithModel(model string) *LLM {
 	q := r.query.Select("withModel")

--- a/sdk/php/generated/LLM.php
+++ b/sdk/php/generated/LLM.php
@@ -140,6 +140,16 @@ class LLM extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * attach a stdio MCP server to the LLM
+     */
+    public function withMCP(ContainerId|Container $container): LLM
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMCP');
+        $innerQueryBuilder->setArgument('container', $container);
+        return new \Dagger\LLM($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * swap out the llm model
      */
     public function withModel(string $model): LLM

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6556,6 +6556,20 @@ class LLM(Type):
         _ctx = self._select("withEnv", _args)
         return LLM(_ctx)
 
+    def with_mcp(self, container: Container) -> Self:
+        """attach a stdio MCP server to the LLM
+
+        Parameters
+        ----------
+        container:
+            a container running an MCP server on stdin and stdout
+        """
+        _args = [
+            Arg("container", container),
+        ]
+        _ctx = self._select("withMCP", _args)
+        return LLM(_ctx)
+
     def with_model(self, model: str) -> Self:
         """swap out the llm model
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7184,6 +7184,26 @@ impl Llm {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// attach a stdio MCP server to the LLM
+    ///
+    /// # Arguments
+    ///
+    /// * `container` - a container running an MCP server on stdin and stdout
+    pub fn with_mcp(&self, container: impl IntoID<ContainerId>) -> Llm {
+        let mut query = self.selection.select("withMCP");
+        query = query.arg_lazy(
+            "container",
+            Box::new(move || {
+                let container = container.clone();
+                Box::pin(async move { container.into_id().await.unwrap().quote() })
+            }),
+        );
+        Llm {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// swap out the llm model
     ///
     /// # Arguments

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6031,6 +6031,15 @@ export class LLM extends BaseClient {
   }
 
   /**
+   * attach a stdio MCP server to the LLM
+   * @param container a container running an MCP server on stdin and stdout
+   */
+  withMCP = (container: Container): LLM => {
+    const ctx = this._ctx.select("withMCP", { container })
+    return new LLM(ctx)
+  }
+
+  /**
    * swap out the llm model
    * @param model The model to use
    */


### PR DESCRIPTION
this PR intends to allow users to run stdio MCPs within dagger and wire them up to their dagger LLMs.

it's extremely hacky atm, but works with this example:

```sh
with-dev dagger -M -c 'llm |\
  with-mcp $(container |\
             from "mcr.microsoft.com/playwright:v1.51.1-noble" |\
             with-entrypoint -- npx -y g-search-mcp) |\
  with-prompt "search google for hello world. use the us locale. show me the result urls." |\
  last-reply'
```

this is a fairly cool demonstration of the utility here. the g-search MCP uses playwright for browser emulation to search google. playwright's a pretty beefy dependency that can't run on any arbitrary OS... like it's not supported on alpine, but works on ubuntu. it happens to have a nice prepackaged container image that we can abuse.

other cool features of dagger as an MCP server runtime include:
- controlled access to secrets, like run the AWS MCP and only give it 1 specific AWS credential directly from your password manager.
- volume mounts for stitching together different host-filesystem-modifying MCPs 

things that are bad in the current state of this PR:
- the library used for MCP transport uses a bufio.NewScanner that chokes and blocks forever on responses >64kb in size. this is very easy to trigger with many MCP impls, like half of them never make it past tool registration
  - i'm gonna fork mark3labs/mcp-go to make things work for real
- extremely lazy handling of MCP output types. we let the tool return `[]Content{type, text, data, mimetype}` and don't really do anything to square the circle between dagger types and MCP/JSONRPC types.
  - need to see how this might or might not interact with Environment, too.
- Service lifecycle: we're running these services without any particular intent to stop them. uncertain if they hang around after the session ends. 
  - stdout is definitely still printing to OTEL logs even though in this case it's showing responses from the MCP servers.
  - the logs also aren't segregated from the rest of the lastReply sync call. the traces should be made to look more like normal service running.
  - there's a bunch of logspam that indicates we're failing to kill processes because they've already dead
- tcp/SSE MCP transport support. Should be fairly easy, just didn't start here. Likely requires args on WithMCP (stdio bool & port int).