### PR TITLE
tui: fix yes/no prompt linebreak location

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -614,8 +614,8 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 	var countOut TermOutput = NewOutput(below, termenv.WithProfile(fe.profile))
 
 	if fe.activePrompt != nil {
-		fmt.Fprintln(countOut)
 		fmt.Fprint(countOut, fe.viewPrompt(countOut))
+		fmt.Fprintln(countOut)
 	}
 
 	if fe.shell == nil {


### PR DESCRIPTION
Currently the prompt has a blank line above it and then the keymap to the right of it. So this fixes that. (Tested locally.)