### PR TITLE
env: fix missing output binding key

### DIFF
--- a/core/env.go
+++ b/core/env.go
@@ -64,6 +64,7 @@ func (env *Env) WithInput(key string, val dagql.Typed, description string) *Env 
 func (env *Env) WithOutput(key string, expectedType dagql.Type, description string) *Env {
 	env = env.Clone()
 	env.outputsByName[key] = &Binding{
+		Key:          key,
 		Value:        nil,
 		expectedType: expectedType,
 		Description:  description,


### PR DESCRIPTION
With this fix, `env | with-file-output foo description | output name` now returns `foo` instead returning an empty result.