### PR TITLE
mcp: override 'auto' progress mode to 'plain'

### DIFF
--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -25,6 +25,19 @@ func init() {
 var mcpCmd = &cobra.Command{
 	Use:   "mcp [options]",
 	Short: "Expose a dagger module as an MCP server",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if progress == "tty" {
+			return fmt.Errorf("cannot use tty progress output: it interferes with mcp stdio")
+		}
+
+		if progress == "auto" && hasTTY {
+			fmt.Fprintln(os.Stderr, "overriding 'auto' progress mode to 'plain' to avoid interference with mcp stdio")
+
+			Frontend = idtui.NewPlain()
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		cmd.SetContext(idtui.WithPrintTraceLink(ctx, true))


### PR DESCRIPTION
This enables the user to run `dagger mcp` without specifying the progress option -- and adds safeguards on user progress flags mismatch:

- Fails if `progress=tty` in non-tty environment:
```shell
➜  dagger_dev mcp --progress tty -m github.com/shykes/hello | cat
Error: cannot use tty progress output: it interferes with mcp stdio
```

- Enforce progress plain when `tty=auto` 
```shell
➜  dagger_dev mcp -m github.com/shykes/hello                     
overriding 'auto' progress mode to 'plain' to avoid interference with mcp stdio
```

cc @tiborvass 