### PR TITLE
docs: Add redirects and fix some URLs

### DIFF
--- a/docs/current_docs/features/llm.mdx
+++ b/docs/current_docs/features/llm.mdx
@@ -1,6 +1,6 @@
 ---
-slug: /features/large-language-model
-description: "Quickly build powerful AI agents"
+slug: /features/llm
+description: "Build powerful AI agents with Large Language Models"
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/current_docs/features/mcp.mdx
+++ b/docs/current_docs/features/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /features/model-context-protocol
+slug: /features/mcp
 description: "Easily give AI agents Environments"
 ---
 import Tabs from '@theme/Tabs';

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -1,12 +1,12 @@
 ---
-slug: /quickstart/basics
+slug: /quickstart/
 title: "Basics"
 ---
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Basics
+# Quickstart
 
 Welcome to Dagger, a general-purpose composition engine for containerized workflows.
 

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /quickstart/
+slug: /quickstart
 title: "Basics"
 ---
 

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -12,6 +12,8 @@ CI pipelines often start simple, but eventually transform into a labyrinth of ar
 
 This quickstart will guide you through building a CI pipeline for an application using Dagger.
 
+
+
 ## Requirements
 
 This quickstart will take you approximately 10 minutes to complete. You should be familiar with programming in Go, Python,  TypeScript, PHP, or Java.

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -12,8 +12,6 @@ CI pipelines often start simple, but eventually transform into a labyrinth of ar
 
 This quickstart will guide you through building a CI pipeline for an application using Dagger.
 
-
-
 ## Requirements
 
 This quickstart will take you approximately 10 minutes to complete. You should be familiar with programming in Go, Python,  TypeScript, PHP, or Java.

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -38,7 +38,7 @@
 [[redirects]]
   # redirect /quickstart/basics pages
   from = "/quickstart/basics"
-  to = "/quickstart/"
+  to = "/quickstart"
   status = 301
 
 [[redirects]]
@@ -50,13 +50,7 @@
 [[redirects]]
   # redirect /ai-agents page to feature page
   from = "/ai-agents"
-  to = "/features/large-language-model"
-  status = 301
-
-[[redirects]]
-  # redirect /features/llm page
-  from = "/features/llm"
-  to = "/features/large-language-model"
+  to = "/features/llm"
   status = 301
 
 ###### end: specific redirects for ci+agent docs ######

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -24,13 +24,25 @@
   status = 301
 
 [[redirects]]
-  # redirect /quickstart pages to CI-specific ones
+  # redirect /integrations pages to CI-specific ones
   from = "/integrations/*"
   to = "/ci/integrations/:splat"
   status = 301
 
 [[redirects]]
-  # redirect /quickstart pages to CI-specific ones
+  # redirect /ci/quickstart pages
+  from = "/ci/quickstart/*"
+  to = "/quickstart/ci"
+  status = 301
+
+[[redirects]]
+  # redirect /quickstart/basics pages
+  from = "/quickstart/basics"
+  to = "/quickstart/"
+  status = 301
+
+[[redirects]]
+  # redirect /adopting page to CI-specific ones
   from = "/adopting"
   to = "/ci/adopting"
   status = 301
@@ -38,7 +50,13 @@
 [[redirects]]
   # redirect /ai-agents page to feature page
   from = "/ai-agents"
-  to = "/features/llm"
+  to = "/features/large-language-model"
+  status = 301
+
+[[redirects]]
+  # redirect /features/llm page
+  from = "/features/llm"
+  to = "/features/large-language-model"
   status = 301
 
 ###### end: specific redirects for ci+agent docs ######
@@ -64,7 +82,7 @@
 [[redirects]]
   # redirect old quickstart index page
   from = "/648215/quickstart"
-  to = "/quickstart/basics"
+  to = "/quickstart/"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
This commit
- changes /quickstart/basics to /quickstart
- adds a redirect for the above
- adds a redirect for all /ci/quickstart/* URLs to /quickstart/ci
- ~~adds a redirect for /features/llm to /features/large-language-model~~ updates existing page URL from /features/large-language-model to previous URL /features/llm