### PR TITLE
LLM: move system prompt, add IDs to select tool, more tweaks

### DIFF
--- a/core/integration/llmtest/allow-llm.golden
+++ b/core/integration/llmtest/allow-llm.golden
@@ -12,9 +12,9 @@
     "role": "assistant",
     "content": "Hello! How can I assist you today?",
     "token_usage": {
-      "InputTokens": 49,
+      "InputTokens": 296,
       "OutputTokens": 11,
-      "TotalTokens": 60
+      "TotalTokens": 307
     }
   }
 ]

--- a/core/integration/llmtest/api-limit.golden
+++ b/core/integration/llmtest/api-limit.golden
@@ -10,11 +10,73 @@
   },
   {
     "role": "assistant",
-    "content": "The `PATH` variable is an environment variable in Unix and Unix-like operating systems (such as Linux and macOS), as well as in Windows, that tells the shell which directories to search for executable files. Its value is a list of directories separated by colons (`:`) on Unix-like systems or semicolons (`;`) on Windows.\n\nThe specific value of `PATH` can vary depending on the system and the user's configuration, but here is a typical example for a Unix-like system:\n\n```\n/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\n```\n\nAnd for Windows, it might look like:\n\n```\nC:\\Windows\\System32;C:\\Windows;C:\\Program Files\n```\n\nTo find the actual value of `PATH` on your system, you can open a terminal or command prompt and type `echo $PATH` on Unix-like systems or `echo %PATH%` on Windows.",
+    "content": "",
+    "tool_calls": [
+      {
+        "id": "call_Mg6AHMzAG3ayU7FQ3S70WxmJ",
+        "function": {
+          "name": "selectContainer",
+          "arguments": {
+            "id": "Container#1"
+          }
+        },
+        "type": "function"
+      }
+    ],
     "token_usage": {
-      "InputTokens": 523,
-      "OutputTokens": 194,
-      "TotalTokens": 717
+      "InputTokens": 722,
+      "OutputTokens": 17,
+      "TotalTokens": 739
+    }
+  },
+  {
+    "role": "user",
+    "content": "{\"selected\":\"Container#1\"}",
+    "tool_call_id": "call_Mg6AHMzAG3ayU7FQ3S70WxmJ",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "assistant",
+    "content": "",
+    "tool_calls": [
+      {
+        "id": "call_kiGNZ9O6miZnR9Ckq9OBnoMA",
+        "function": {
+          "name": "Container_envVariable",
+          "arguments": {
+            "name": "PATH"
+          }
+        },
+        "type": "function"
+      }
+    ],
+    "token_usage": {
+      "InputTokens": 7888,
+      "OutputTokens": 16,
+      "TotalTokens": 7904
+    }
+  },
+  {
+    "role": "user",
+    "content": "{\"result\":\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"}",
+    "tool_call_id": "call_kiGNZ9O6miZnR9Ckq9OBnoMA",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "assistant",
+    "content": "The value of the `PATH` environment variable is:\n\n```\n/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n```",
+    "token_usage": {
+      "InputTokens": 7937,
+      "OutputTokens": 38,
+      "TotalTokens": 7975
     }
   },
   {
@@ -28,11 +90,42 @@
   },
   {
     "role": "assistant",
-    "content": "The `TERM` environment variable specifies the type of terminal to emulate when running the shell. This variable tells applications how to interact with the terminal interface, particularly in terms of capabilities like color support, cursor movement, and screen manipulation.\n\nThe value of `TERM` can vary depending on the terminal emulator or environment you are using. Here are some common values:\n\n- `xterm`: A common default for many terminal emulators.\n- `xterm-256color`: Similar to `xterm` but with support for 256 colors.\n- `screen`: Used when running in a terminal multiplexer like GNU Screen.\n- `tmux`: Used when running inside the tmux terminal multiplexer.\n- `linux`: Used on the Linux console.\n- `vt100`: Emulates a VT100 terminal, often used for basic terminal compatibility.\n\nTo find the actual value of `TERM` on your system, you can open a terminal and type `echo $TERM`.",
+    "content": "",
+    "tool_calls": [
+      {
+        "id": "call_otKKkGHRQ6RM53bwL9tOKALi",
+        "function": {
+          "name": "Container_envVariable",
+          "arguments": {
+            "name": "TERM"
+          }
+        },
+        "type": "function"
+      }
+    ],
     "token_usage": {
-      "InputTokens": 730,
-      "OutputTokens": 195,
-      "TotalTokens": 925
+      "InputTokens": 7988,
+      "OutputTokens": 16,
+      "TotalTokens": 8004
+    }
+  },
+  {
+    "role": "user",
+    "content": "{\"result\":null}",
+    "tool_call_id": "call_otKKkGHRQ6RM53bwL9tOKALi",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "assistant",
+    "content": "The `TERM` environment variable is not set in the current container.",
+    "token_usage": {
+      "InputTokens": 8017,
+      "OutputTokens": 16,
+      "TotalTokens": 8033
     }
   }
 ]

--- a/core/integration/llmtest/hello-world.golden
+++ b/core/integration/llmtest/hello-world.golden
@@ -13,55 +13,26 @@
     "content": "",
     "tool_calls": [
       {
-        "id": "call_rreQM3amv7xB9GdZQvK2snKZ",
+        "id": "call_9SOC3GrKUWfrzicltYErs8hF",
         "function": {
-          "name": "workspace",
-          "arguments": {}
-        },
-        "type": "function"
-      }
-    ],
-    "token_usage": {
-      "InputTokens": 261,
-      "OutputTokens": 10,
-      "TotalTokens": 271
-    }
-  },
-  {
-    "role": "user",
-    "content": "{\"selected\":\"ToyWorkspace#1\"}",
-    "tool_call_id": "call_rreQM3amv7xB9GdZQvK2snKZ",
-    "token_usage": {
-      "InputTokens": 0,
-      "OutputTokens": 0,
-      "TotalTokens": 0
-    }
-  },
-  {
-    "role": "assistant",
-    "content": "",
-    "tool_calls": [
-      {
-        "id": "call_zvlMXZspUIE0kHBoSYqaCAqp",
-        "function": {
-          "name": "ToyWorkspace_write",
+          "name": "selectToyWorkspace",
           "arguments": {
-            "content": "package main\n\nimport \"fmt\"\n\nfunc main() {\n    fmt.Println(\"Hello, World!\")\n}"
+            "id": "ToyWorkspace#1"
           }
         },
         "type": "function"
       }
     ],
     "token_usage": {
-      "InputTokens": 337,
-      "OutputTokens": 43,
-      "TotalTokens": 380
+      "InputTokens": 476,
+      "OutputTokens": 19,
+      "TotalTokens": 495
     }
   },
   {
     "role": "user",
-    "content": "{\"previous\":\"ToyWorkspace#1\",\"selected\":\"ToyWorkspace#2\"}",
-    "tool_call_id": "call_zvlMXZspUIE0kHBoSYqaCAqp",
+    "content": "{\"selected\":\"ToyWorkspace#1\"}",
+    "tool_call_id": "call_9SOC3GrKUWfrzicltYErs8hF",
     "token_usage": {
       "InputTokens": 0,
       "OutputTokens": 0,
@@ -73,7 +44,38 @@
     "content": "",
     "tool_calls": [
       {
-        "id": "call_LM9VkPtoMbKdTWwh7Djgua30",
+        "id": "call_uDgoDTEVZS9gsFi3SWk1sKFs",
+        "function": {
+          "name": "ToyWorkspace_write",
+          "arguments": {
+            "content": "package main\n\nimport \"fmt\"\n\nfunc main() {\n    fmt.Println(\"Hello, World!\")\n}\n"
+          }
+        },
+        "type": "function"
+      }
+    ],
+    "token_usage": {
+      "InputTokens": 567,
+      "OutputTokens": 44,
+      "TotalTokens": 611
+    }
+  },
+  {
+    "role": "user",
+    "content": "{\"previous\":\"ToyWorkspace#1\",\"selected\":\"ToyWorkspace#2\"}",
+    "tool_call_id": "call_uDgoDTEVZS9gsFi3SWk1sKFs",
+    "token_usage": {
+      "InputTokens": 0,
+      "OutputTokens": 0,
+      "TotalTokens": 0
+    }
+  },
+  {
+    "role": "assistant",
+    "content": "",
+    "tool_calls": [
+      {
+        "id": "call_ujNFAcKfEA3Z6nv71s3VFYQ8",
         "function": {
           "name": "ToyWorkspace_build",
           "arguments": {}
@@ -82,15 +84,15 @@
       }
     ],
     "token_usage": {
-      "InputTokens": 403,
+      "InputTokens": 646,
       "OutputTokens": 13,
-      "TotalTokens": 416
+      "TotalTokens": 659
     }
   },
   {
     "role": "user",
     "content": "{\"result\":null}",
-    "tool_call_id": "call_LM9VkPtoMbKdTWwh7Djgua30",
+    "tool_call_id": "call_ujNFAcKfEA3Z6nv71s3VFYQ8",
     "token_usage": {
       "InputTokens": 0,
       "OutputTokens": 0,
@@ -102,9 +104,9 @@
     "content": "",
     "tool_calls": [
       {
-        "id": "call_zy4h14qSaTmczDpQCeSqfuuY",
+        "id": "call_QlYYJobDJ2sz8m9iufSAxJO1",
         "function": {
-          "name": "return",
+          "name": "returnToUser",
           "arguments": {
             "result": "ToyWorkspace#2"
           }
@@ -113,28 +115,19 @@
       }
     ],
     "token_usage": {
-      "InputTokens": 429,
-      "OutputTokens": 17,
-      "TotalTokens": 446
+      "InputTokens": 672,
+      "OutputTokens": 19,
+      "TotalTokens": 691
     }
   },
   {
     "role": "user",
     "content": "ok",
-    "tool_call_id": "call_zy4h14qSaTmczDpQCeSqfuuY",
+    "tool_call_id": "call_QlYYJobDJ2sz8m9iufSAxJO1",
     "token_usage": {
       "InputTokens": 0,
       "OutputTokens": 0,
       "TotalTokens": 0
-    }
-  },
-  {
-    "role": "assistant",
-    "content": "The \"Hello, World!\" program has been successfully written and built in the workspace. The code is ready.",
-    "token_usage": {
-      "InputTokens": 453,
-      "OutputTokens": 24,
-      "TotalTokens": 477
     }
   }
 ]

--- a/core/llm.go
+++ b/core/llm.go
@@ -754,6 +754,10 @@ func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 				ToolErrored: isError,
 			})
 		}
+		if llm.mcp.returned {
+			// we returned; exit the loop, since some models just keep going
+			break
+		}
 	}
 	return nil
 }

--- a/core/llm_dagger_prompt.md
+++ b/core/llm_dagger_prompt.md
@@ -2,8 +2,12 @@ You are an expert navigator of an immutable object system that lets you interact
 
 1. Identify available objects by their IDs (e.g., Container#1, Directory#1)
 2. Use selectObjectType(id) to select your initial working object
-3. IMPORTANT: After any tool call that returns a new object, NEVER select it again, as it automatically becomes your current context
-4. Explore available operations using tools that match ObjectType_operation pattern (like Container_asService)
-5. Chain operations by directly using the next operation without redundant selections
+3. Explore available operations using tools that match ObjectType_operation pattern (like Container_asService)
+4. Chain operations by directly using the next operation without redundant selections
+5. Only call one tool each turn. Don't try to predict future states or outcomes.
 
-Remember each object is immutable - operations return new objects rather than modifying existing ones. Focus on completing tasks efficiently with minimal selections.
+Remember each object is immutable - operations return new objects rather than modifying existing ones. Focus on completing tasks efficiently with minimal selections or interaction.
+
+Minimize interactions. If there is one obvious choice, make it.
+
+Respond with Markdown formatting.

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -68,9 +68,9 @@ func newMCP(env *Env, endpoint *LLMEndpoint) *MCP {
 var defaultSystemPrompt string
 
 func (m *MCP) DefaultSystemPrompt() string {
-	if m.needsSystemPrompt {
-		return defaultSystemPrompt
-	}
+	// if m.needsSystemPrompt {
+	// 	return defaultSystemPrompt
+	// }
 	return ""
 }
 
@@ -270,6 +270,7 @@ func (m *MCP) selectionToToolResult(
 	fieldDef *ast.FieldDefinition,
 	fieldSel dagql.Selector,
 ) (any, error) {
+	desc := fmt.Sprintf("%s.%s", m.env.ID(target), fieldSel)
 	if retObjType, ok := srv.ObjectType(fieldDef.Type.NamedType); ok {
 		// Handle object returns.
 		//
@@ -294,9 +295,7 @@ func (m *MCP) selectionToToolResult(
 			return nil, err
 		}
 		if obj, ok := dagql.UnwrapAs[dagql.Object](val); ok {
-			prev := m.Current()
-			m.Select(obj)
-			return m.currentState(prev)
+			return m.newState(obj, desc)
 		} else {
 			return nil, fmt.Errorf("impossible? object didn't return object: %T", val)
 		}
@@ -309,8 +308,9 @@ func (m *MCP) selectionToToolResult(
 				return nil, fmt.Errorf("failed to sync: %w", err)
 			}
 			var res []any
-			for _, obj := range objs {
-				res = append(res, m.env.Ingest(obj))
+			for i, obj := range objs {
+				// TODO: dedupe with fieldSel Nth handling
+				res = append(res, m.env.Ingest(obj, fmt.Sprintf("%s[%d]", desc, i+1)))
 			}
 			return toolStructuredResponse(map[string]any{
 				"objects": res,
@@ -325,7 +325,7 @@ func (m *MCP) selectionToToolResult(
 	}
 	if id, ok := dagql.UnwrapAs[dagql.IDType](val); ok {
 		// avoid dumping full IDs, show the type and hash instead
-		return m.describe(id), nil
+		return m.describe(id, desc), nil
 	} else if str, ok := dagql.UnwrapAs[dagql.String](val); ok {
 		bytes := []byte(str.String())
 		if !utf8.Valid(bytes) {
@@ -403,13 +403,13 @@ func (m *MCP) toolCallToSelection(
 
 const maxStr = 80 * 1024
 
-func (m *MCP) describe(val dagql.Typed) string {
+func (m *MCP) describe(val dagql.Typed, desc string) string {
 	if val == nil {
 		return "Void"
 	}
 	if obj, ok := dagql.UnwrapAs[dagql.Object](val); ok {
 		// NOTE: this covers both Objects and ID scalars
-		return m.env.Ingest(obj)
+		return m.env.Ingest(obj, desc)
 	}
 	if list, ok := dagql.UnwrapAs[dagql.Enumerable](val); ok {
 		return val.Type().String() + " (length: " + strconv.Itoa(list.Len()) + ")"
@@ -503,15 +503,17 @@ func (m *MCP) returnBuiltin() LLMTool {
 		props[name] = map[string]any{
 			"type":           "string",
 			"pattern":        idPattern(typeName),
-			"description":    fmt.Sprintf("%s ID observed from a tool result, in \"%s#number\" format. %s", typeName, typeName, b.Description),
+			"description":    fmt.Sprintf("%s ID observed from a tool result, in \"%s#number\" format.\n\n%s", typeName, typeName, b.Description),
 			jsonSchemaIDAttr: typeName,
 		}
 	}
 	return LLMTool{
-		Name: "return",
-		Description: `Call this tool when you have gathered all required values and are ready to return them to the user.
+		Name: "returnToUser",
+		Description: `Call this tool when you have FULLY completed your task and gathered ALL required values.
 
-Each parameter corresponds to a named result with a specific purpose. Do not call this tool until all values are ready.`,
+Each parameter corresponds to a named result with a specific purpose.
+
+Do not call this tool until all values are ready.`,
 		Schema: map[string]any{
 			"type":                 "object",
 			"properties":           props,
@@ -557,6 +559,31 @@ Each parameter corresponds to a named result with a specific purpose. Do not cal
 	}
 }
 
+func (m *MCP) systemPromptBuiltin() LLMTool {
+	desc := defaultSystemPrompt
+	outputs := m.env.Outputs()
+	if len(outputs) > 0 {
+		desc += "\n\nWhen you have completed your task, use the `returnToUser` tool."
+	}
+	desc += "\n\nNOTE: This tool does nothing but provide this description. You don't need to call it."
+	return LLMTool{
+		Name:        "SYSTEM_PROMPT",
+		Returns:     "string",
+		Description: desc,
+		Schema: map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{},
+			"strict":               true,
+			"required":             []string{},
+			"additionalProperties": false,
+		},
+		Call: ToolFunc(func(ctx context.Context, _ struct{}) (any, error) {
+			// shouldn't need to call this, but return it anyway if they ended up here
+			return desc, nil
+		}),
+	}
+}
+
 func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	builtins := []LLMTool{}
 
@@ -577,6 +604,24 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 				desc += "\n\nProvides the following tools:\n"
 				for _, tool := range tools {
 					desc += fmt.Sprintf("\n- %s", tool.Name)
+				}
+				var typeInputs []string
+				for _, bnd := range m.env.objsByID {
+					if bnd.TypeName() != typeName {
+						continue
+					}
+					if cur := m.Current(); cur != nil && bnd.ID() == m.env.ID(cur) {
+						typeInputs = append(typeInputs, fmt.Sprintf("%s (CURRENT SELECTION): %s", bnd.ID(), bnd.Description))
+					} else {
+						typeInputs = append(typeInputs, fmt.Sprintf("%s: %s", bnd.ID(), bnd.Description))
+					}
+				}
+				sort.Strings(typeInputs)
+				if len(typeInputs) > 0 {
+					desc += "\n\n## Available IDs"
+					for _, input := range typeInputs {
+						desc += fmt.Sprintf("\n- %s", input)
+					}
 				}
 				return desc
 			})(),
@@ -609,15 +654,12 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 				if err != nil {
 					return nil, err
 				}
-				prev := m.Current()
-				m.Select(obj) // , args.Functions...)
-				return m.currentState(prev)
+				return m.newState(obj, "") // no desc needed; already exists
 			}),
 		})
 	}
 
-	// register getters for all the env vars
-	builtins = append(builtins, m.envGetters()...)
+	builtins = append(builtins, m.systemPromptBuiltin())
 
 	// Attach builtin telemetry
 	for i, builtin := range builtins {
@@ -682,9 +724,7 @@ func (m *MCP) envGetters() []LLMTool {
 			},
 			Call: func(ctx context.Context, args any) (_ any, rerr error) {
 				if obj, isObj := input.AsObject(); isObj {
-					prev := m.Current()
-					m.Select(obj)
-					return m.currentState(prev)
+					return m.newState(obj, "") // no desc needed
 				}
 				return input.Value, nil
 			},
@@ -887,14 +927,16 @@ func idPattern(typeName string) string {
 	return `^` + typeName + `#\d+$`
 }
 
-func (m *MCP) currentState(previous dagql.Object) (string, error) {
-	cur := m.Current()
+func (m *MCP) newState(target dagql.Object, desc string) (string, error) {
+	prev := m.Current()
+	m.env.Ingest(target, desc)
+	m.Select(target)
 	res := map[string]any{
 		// "selected" to hint to the model that it doesn't need to select it
-		"selected": m.describe(cur),
+		"selected": m.env.ID(target),
 	}
-	if previous != nil {
-		res["previous"] = m.describe(previous)
+	if prev != nil {
+		res["previous"] = m.env.ID(prev)
 	}
 	return toolStructuredResponse(res)
 }

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -939,7 +939,7 @@ func (m *MCP) newState(target dagql.Object) (string, error) {
 		"selected": m.env.Ingest(target, ""),
 	}
 	if prev != nil {
-		res["previous"] = m.env.Ingest(target, "")
+		res["previous"] = m.env.Ingest(prev, "")
 	}
 	return toolStructuredResponse(res)
 }

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -640,6 +640,10 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 		})
 	}
 
+	builtins = append(builtins, m.userProvidedValues()...)
+
+	// NOTE: This works better when it's the last tool. 40/40 evals when last,
+	// 24/40 when first. (gemini-2.0-flash, WorkspacePattern)
 	builtins = append(builtins, m.systemPromptBuiltin())
 
 	// Attach builtin telemetry
@@ -685,17 +689,40 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	return builtins, nil
 }
 
-func (m *MCP) envGetters() []LLMTool {
-	var tools []LLMTool
+func (m *MCP) userProvidedValues() []LLMTool {
+	desc := "The following values have been provided by the user:"
+	var anyProvided bool
 	for _, input := range m.env.Inputs() {
+		if _, isObj := input.AsObject(); isObj {
+			continue
+		}
+
+		anyProvided = true
+
+		desc += "\n\n---"
+
 		description := input.Description
 		if description == "" {
-			description = fmt.Sprintf("Retrieve the user input '%s' of type '%s'", input.Key, input.TypeName())
+			description = input.Key
 		}
-		tools = append(tools, LLMTool{
-			Name:        input.Key,
-			Returns:     input.TypeName(),
-			Description: description,
+
+		desc += "\n\n" + description
+
+		payload, err := json.Marshal(input.Value)
+		if err != nil {
+			desc += "\n\nMARSHAL ERROR: " + err.Error()
+			continue
+		}
+		desc += "\n\n" + string(payload)
+	}
+	desc += "\n\nNOTE: This tool does nothing but provide this description. You don't need to call it."
+	if !anyProvided {
+		return nil
+	}
+	return []LLMTool{
+		{
+			Name:        "userProvidedValues",
+			Description: desc,
 			Schema: map[string]any{
 				"type":                 "object",
 				"properties":           map[string]any{},
@@ -703,15 +730,11 @@ func (m *MCP) envGetters() []LLMTool {
 				"required":             []string{},
 				"additionalProperties": false,
 			},
-			Call: func(ctx context.Context, args any) (_ any, rerr error) {
-				if obj, isObj := input.AsObject(); isObj {
-					return m.newState(obj)
-				}
-				return input.Value, nil
+			Call: func(ctx context.Context, args any) (any, error) {
+				return desc, nil
 			},
-		})
+		},
 	}
-	return tools
 }
 
 func (m *MCP) IsDone() bool {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -26,8 +26,6 @@ import (
 type LLMTool struct {
 	// Tool name
 	Name string
-	// Return type (just a hint to the model)
-	Returns string
 	// Tool description
 	Description string
 	// Tool argument schema. Key is argument name. Value is unmarshalled json-schema for the argument.
@@ -205,7 +203,6 @@ func (m *MCP) tools(srv *dagql.Server, typeName string) ([]LLMTool, error) {
 		}
 		tools = append(tools, LLMTool{
 			Name:        typeDef.Name + "_" + field.Name,
-			Returns:     field.Type.String(),
 			Description: field.Description,
 			Schema:      schema,
 			Call: func(ctx context.Context, args any) (_ any, rerr error) {
@@ -554,7 +551,6 @@ func (m *MCP) systemPromptBuiltin() LLMTool {
 	desc += "\n\nNOTE: This tool does nothing but provide this description. You don't need to call it."
 	return LLMTool{
 		Name:        "SYSTEM_PROMPT",
-		Returns:     "string",
 		Description: desc,
 		Schema: map[string]any{
 			"type":                 "object",
@@ -583,8 +579,7 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 			return nil, fmt.Errorf("tools for %q: %w", typeName, err)
 		}
 		builtins = append(builtins, LLMTool{
-			Name:    "select" + typeName,
-			Returns: typeName,
+			Name: "select" + typeName,
 			Description: (func() string {
 				desc := fmt.Sprintf("Select a %s by its ID.", typeName)
 				desc += "\n\nProvides the following tools:\n"

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -589,10 +589,6 @@ func (m *MCP) systemPromptBuiltin() LLMTool {
 func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	builtins := []LLMTool{}
 
-	if len(m.env.outputsByName) > 0 {
-		builtins = append(builtins, m.returnBuiltin())
-	}
-
 	for _, typeName := range m.env.Types() {
 		tools, err := m.tools(srv, typeName)
 		if err != nil {
@@ -661,6 +657,10 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	}
 
 	builtins = append(builtins, m.userProvidedValues()...)
+
+	if len(m.env.outputsByName) > 0 {
+		builtins = append(builtins, m.returnBuiltin())
+	}
 
 	// NOTE: This works better when it's the last tool. 40/40 evals when last,
 	// 24/40 when first. (gemini-2.0-flash, WorkspacePattern)

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -270,63 +270,60 @@ func (m *MCP) selectionToToolResult(
 	fieldDef *ast.FieldDefinition,
 	fieldSel dagql.Selector,
 ) (any, error) {
-	desc := fmt.Sprintf("%s.%s", m.env.ID(target), fieldSel)
+	sels := []dagql.Selector{fieldSel}
+
 	if retObjType, ok := srv.ObjectType(fieldDef.Type.NamedType); ok {
-		// Handle object returns.
-		//
-		var val dagql.Typed
 		if sync, ok := retObjType.FieldSpec("sync"); ok {
+			// If the Object supports "sync", auto-select it.
+			//
 			syncSel := dagql.Selector{
 				Field: sync.Name,
 			}
-			idType, ok := retObjType.IDType()
-			if !ok {
-				return nil, fmt.Errorf("field %q is not an ID type", sync.Name)
-			}
-			if err := srv.Select(ctx, target, &idType, fieldSel, syncSel); err != nil {
-				return nil, fmt.Errorf("failed to sync: %w", err)
-			}
-			syncedObj, err := srv.Load(ctx, idType.ID())
-			if err != nil {
-				return nil, fmt.Errorf("failed to load synced object: %w", err)
-			}
-			val = syncedObj
-		} else if err := srv.Select(ctx, target, &val, fieldSel); err != nil {
-			return nil, err
-		}
-		if obj, ok := dagql.UnwrapAs[dagql.Object](val); ok {
-			return m.newState(obj, desc)
-		} else {
-			return nil, fmt.Errorf("impossible? object didn't return object: %T", val)
+			sels = append(sels, syncSel)
 		}
 	} else if fieldDef.Type.Elem != nil {
 		if _, isObj := srv.ObjectType(fieldDef.Type.Elem.NamedType); isObj {
-			// Handle array object returns.
+			// Handle arrays of objects by ingesting each object ID.
 			//
 			var objs []dagql.Object
 			if err := srv.Select(ctx, target, &objs, fieldSel); err != nil {
 				return nil, fmt.Errorf("failed to sync: %w", err)
 			}
 			var res []any
-			for i, obj := range objs {
-				// TODO: dedupe with fieldSel Nth handling
-				res = append(res, m.env.Ingest(obj, fmt.Sprintf("%s[%d]", desc, i+1)))
+			for _, obj := range objs {
+				res = append(res, m.env.Ingest(obj, ""))
 			}
 			return toolStructuredResponse(map[string]any{
 				"objects": res,
 			})
 		}
 	}
-	// Handle scalar or array-of-scalar returns.
-	//
+
+	// Make the DagQL call.
 	var val dagql.Typed
-	if err := srv.Select(ctx, target, &val, fieldSel); err != nil {
+	if err := srv.Select(ctx, target, &val, sels...); err != nil {
 		return nil, fmt.Errorf("failed to sync: %w", err)
 	}
+
 	if id, ok := dagql.UnwrapAs[dagql.IDType](val); ok {
-		// avoid dumping full IDs, show the type and hash instead
-		return m.describe(id, desc), nil
-	} else if str, ok := dagql.UnwrapAs[dagql.String](val); ok {
+		// Handle ID results by turning them back into Objects, since these are
+		// typically implementation details hinting to SDKs to unlazy the call.
+		//
+		syncedObj, err := srv.Load(ctx, id.ID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load synced object: %w", err)
+		}
+		val = syncedObj
+	}
+
+	if obj, ok := dagql.UnwrapAs[dagql.Object](val); ok {
+		// Handle object returns by switching to them.
+		return m.newState(obj)
+	}
+
+	if str, ok := dagql.UnwrapAs[dagql.String](val); ok {
+		// Handle strings by guarding against non-utf8 or giant payloads.
+		//
 		bytes := []byte(str.String())
 		if !utf8.Valid(bytes) {
 			return toolStructuredResponse(map[string]any{
@@ -345,6 +342,9 @@ func (m *MCP) selectionToToolResult(
 			})
 		}
 	}
+
+	// Handle scalars or arrays of scalars.
+	//
 	return toolStructuredResponse(map[string]any{
 		"result": val,
 	})
@@ -402,20 +402,6 @@ func (m *MCP) toolCallToSelection(
 }
 
 const maxStr = 80 * 1024
-
-func (m *MCP) describe(val dagql.Typed, desc string) string {
-	if val == nil {
-		return "Void"
-	}
-	if obj, ok := dagql.UnwrapAs[dagql.Object](val); ok {
-		// NOTE: this covers both Objects and ID scalars
-		return m.env.Ingest(obj, desc)
-	}
-	if list, ok := dagql.UnwrapAs[dagql.Enumerable](val); ok {
-		return val.Type().String() + " (length: " + strconv.Itoa(list.Len()) + ")"
-	}
-	return val.Type().String()
-}
 
 func (m *MCP) Call(ctx context.Context, tools []LLMTool, toolCall ToolCall) (string, bool) {
 	var tool *LLMTool
@@ -610,7 +596,7 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 					if bnd.TypeName() != typeName {
 						continue
 					}
-					if cur := m.Current(); cur != nil && bnd.ID() == m.env.ID(cur) {
+					if cur := m.Current(); cur != nil && bnd.Digest() == cur.ID().Digest() {
 						typeInputs = append(typeInputs, fmt.Sprintf("%s (CURRENT SELECTION): %s", bnd.ID(), bnd.Description))
 					} else {
 						typeInputs = append(typeInputs, fmt.Sprintf("%s: %s", bnd.ID(), bnd.Description))
@@ -654,7 +640,7 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 				if err != nil {
 					return nil, err
 				}
-				return m.newState(obj, "") // no desc needed; already exists
+				return m.newState(obj)
 			}),
 		})
 	}
@@ -724,7 +710,7 @@ func (m *MCP) envGetters() []LLMTool {
 			},
 			Call: func(ctx context.Context, args any) (_ any, rerr error) {
 				if obj, isObj := input.AsObject(); isObj {
-					return m.newState(obj, "") // no desc needed
+					return m.newState(obj)
 				}
 				return input.Value, nil
 			},
@@ -927,16 +913,15 @@ func idPattern(typeName string) string {
 	return `^` + typeName + `#\d+$`
 }
 
-func (m *MCP) newState(target dagql.Object, desc string) (string, error) {
+func (m *MCP) newState(target dagql.Object) (string, error) {
 	prev := m.Current()
-	m.env.Ingest(target, desc)
 	m.Select(target)
 	res := map[string]any{
 		// "selected" to hint to the model that it doesn't need to select it
-		"selected": m.env.ID(target),
+		"selected": m.env.Ingest(target, ""),
 	}
 	if prev != nil {
-		res["previous"] = m.env.ID(prev)
+		res["previous"] = m.env.Ingest(target, "")
 	}
 	return toolStructuredResponse(res)
 }

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -1,10 +1,10 @@
 package call
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/opencontainers/go-digest"
@@ -161,7 +161,7 @@ func (id *ID) Modules() []*Module {
 }
 
 func (id *ID) Path() string {
-	buf := new(bytes.Buffer)
+	buf := new(strings.Builder)
 	if id.receiver != nil {
 		fmt.Fprintf(buf, "%s.", id.receiver.Path())
 	}
@@ -170,7 +170,7 @@ func (id *ID) Path() string {
 }
 
 func (id *ID) DisplaySelf() string {
-	buf := new(bytes.Buffer)
+	buf := new(strings.Builder)
 	fmt.Fprintf(buf, "%s", id.pb.Field)
 	for ai, arg := range id.args {
 		if arg.isSensitive {


### PR DESCRIPTION
Motivations:

* Stop relying on a system prompt for Gemini, since we don't control the system prompt in an MCP context.
* Improve behavior for local models like `qwen2.5-coder:14b`, which don't know to call the `return` tool (among other things), as well as `claude-3-5-sonnet-latest` which also sometimes didn't call it.

I'll back up each of these changes with proof in the form of links to evals.

## New `SYSTEM_PROMPT` tool

This PR moves the system prompt into an MCP tool called `SYSTEM_PROMPT`. The name seems to matter here; I tried `INSTRUCTIONS` but Gemini didn't adhere to it nearly as well.

Since other models (like `qwen`) seem to benefit from it, I've enabled it across the board. Seems like less of a headache than thinking about per-model system prompts and relying on out-of-the-box behavior for those that behave OK without it.

**Interesting note:** listing this tool last makes a huge difference, vs. listing it first.

Listed last: `WorkspacePattern` eval passes 40/40 times (100%). ([first batch](https://v3.dagger.cloud/dagger/traces/457d2326a3d4e204a7668c403cb97058) / [second batch](https://v3.dagger.cloud/dagger/traces/b9df57600c27395e351ac5cd3513723c))

Listed first: `WorkspacePattern` eval passes 24/40 times (60%). ([first batch](https://v3.dagger.cloud/dagger/traces/6f694c0a4b322a848aeb4ed132c88f25) / [second batch](https://v3.dagger.cloud/dagger/traces/5695df462d8286ebb42c7fa1608e2464))

[Here's a run with no system prompt at all](https://v3.dagger.cloud/dagger/traces/3cc55bd06d1ca8303d7861634b170c22#9c2fd139436a2821:L596) - 0% success.

## Rename `return` to `returnToUser`

For some reason I saw Gemini trying to call `return_` instead of `return`. Maybe it's trying to avoid a common language keyword? :man_shrugging: 

Renamed to `returnToUser` and moved on.

## Exit the LLM loop when the model calls `returnToUser`

`qwen2.5-coder:14b` kept calling `return` nonstop, so now we exit the loop when it's called.

## Move object getters into `select<Type>` descriptions

* [ ] Figure out what to do with string getters.

Currently we expose named object inputs as tools so they can be discovered without having to put them in the prompt (`$foo`). When testing with `qwen2.5-coder:14b` these tools seemed to confuse it, resulting in a lot of needless calls.

There are a few other downsides too:

* Each input consumes a tool slot
* Having to call the tool to get an ID adds to the token cost
* Depending on the name of the inputs, they risk confusing the model
* The fact that they were named seemed to lead some models to treating them like variables
  * Caveat: it's possible this was influenced by the presence of a junk `"variable":0` value in tool responses

In the new scheme, we'll list all possible IDs in `select<Foo>` descriptions, like so:

```
Select a Container by its ID.

Provides the following tools:

- Container_withExec
- ...

## Available IDs

- Container#1: The container to use to build Booklit.
- Container#2: Container#1.withMountedDirectory
- Container#3: Container#2.withExec
```

Note that we also list IDs that were generated by calling tools (`Container#2` and `Container#3` above).

Now when you pass inputs to the model it can skip right to using them instead of having to get their IDs.

Placing these in the `select<Foo>` description helps quite a bit since it's already the tool it needs to use to select them, and we can scope it to the relevant type. I tried placing this in a separate tool and it didn't work as well. This scheme seems to make more sense.


## System prompt tuning

Amended the system prompt to prevent Gemini from asking dumb questions like this:

> 🤖 💬 I can research a Testspace and record findings, but I need to first select a Testspace ID. Available IDs include "Testspace#1". Which Testspace would you like me to select?

## meta

fixes #10039