### PR TITLE
shell: skip CSV flag parsing when spreading `with-exec` positional arguments

### DIFF
--- a/.changes/unreleased/Changed-20250403-130048.yaml
+++ b/.changes/unreleased/Changed-20250403-130048.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'shell: skip CSV flag parsing when spreading `with-exec` positional arguments'
+time: 2025-04-03T13:00:48.074591Z
+custom:
+    Author: helderco
+    PR: "10063"

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -143,7 +143,7 @@ func (h *shellCallHandler) Exec(next interp.ExecHandlerFunc) interp.ExecHandlerF
 		}
 		if err != nil {
 			if h.debug {
-				shellDebug(ctx, "Error", err, args)
+				shellDebug(ctx, "Error", args[0], args[1:], err)
 			}
 
 			if st == nil {
@@ -385,7 +385,14 @@ func (h *shellCallHandler) functionCall(ctx context.Context, st *ShellState, nam
 //
 // Additionally, if there's only one required argument that is a list of strings,
 // all positional arguments are used as elements of that list.
-func shellPreprocessArgs(ctx context.Context, fn *modFunction, args []string) ([]string, error) {
+func (h *shellCallHandler) shellPreprocessArgs(
+	ctx context.Context,
+	fn *modFunction,
+	args []string,
+) (map[string]any, []string, error) {
+	// Final map of resolved argument values
+	values := make(map[string]any, len(fn.Args))
+
 	flags := pflag.NewFlagSet(fn.CmdName(), pflag.ContinueOnError)
 	flags.SetOutput(io.MultiWriter(
 		interp.HandlerCtx(ctx).Stderr,
@@ -416,7 +423,7 @@ func shellPreprocessArgs(ctx context.Context, fn *modFunction, args []string) ([
 	}
 
 	if err := flags.Parse(args); err != nil {
-		return args, checkErrHelp(err, args)
+		return values, args, checkErrHelp(err, args)
 	}
 
 	reqs := fn.RequiredArgs()
@@ -438,17 +445,17 @@ func shellPreprocessArgs(ctx context.Context, fn *modFunction, args []string) ([
 	// All positional arguments become elements in the list.
 	if len(reqs) == 1 && len(pos) > 1 && reqs[0].TypeDef.String() == "[]string" {
 		name := reqs[0].FlagName()
-		a = make([]string, 0, len(opts)+len(pos))
 
-		for _, value := range pos {
-			// Instead of creating a CSV value here, repeat the flag for each
-			// one so that pflags is the only one dealing with CSVs.
-			a = append(a, fmt.Sprintf("--%s=%v", name, value))
+		// bypass additional flag parsing, but make sure state values are resolved
+		results, err := h.resolveResults(ctx, pos)
+		if err != nil {
+			return values, pos, err
 		}
+		values[name] = results
 	} else {
 		// Normal use case. Positional arguments should match number of required function arguments
 		if err := ExactArgs(len(reqs))(pos); err != nil {
-			return args, err
+			return values, args, err
 		}
 		a = make([]string, 0, len(fn.Args))
 		// Use the `=` syntax so that each element in the args list corresponds
@@ -474,7 +481,7 @@ func shellPreprocessArgs(ctx context.Context, fn *modFunction, args []string) ([
 		}
 	})
 
-	return a, nil
+	return values, a, nil
 }
 
 // checkErrHelp circumvents pflag's special cases for -h and --help
@@ -509,19 +516,21 @@ func (h *shellCallHandler) parseArgumentValues(
 		}
 	}()
 
-	newArgs, err := shellPreprocessArgs(ctx, fn, args)
+	values, newArgs, err := h.shellPreprocessArgs(ctx, fn, args)
+	if h.debug {
+		shellDebug(ctx, "Preprocess arguments", fn.CmdName(), struct {
+			Args    []string
+			NewArgs []string
+			Values  map[string]any
+		}{args, newArgs, values}, err)
+	}
 	if err != nil {
 		return nil, err
 	}
 
+	// no further processing needed
 	if len(newArgs) == 0 {
-		return nil, nil
-	}
-
-	if h.debug {
-		defer func() {
-			shellDebug(ctx, "Arguments", fn.CmdName(), args, newArgs, rargs)
-		}()
+		return values, nil
 	}
 
 	flags := pflag.NewFlagSet(fn.CmdName(), pflag.ContinueOnError)
@@ -553,9 +562,6 @@ func (h *shellCallHandler) parseArgumentValues(
 			return nil, fmt.Errorf("error addding flag: %w", err)
 		}
 	}
-
-	// Final map of resolved argument values
-	values := make(map[string]any, len(fn.Args))
 
 	// Parse arguments using flags to get the values matched with the right
 	// argument definition. Bypass the flag if the argument value comes from

--- a/cmd/dagger/shell_state.go
+++ b/cmd/dagger/shell_state.go
@@ -376,10 +376,6 @@ func (h *shellCallHandler) resolveResults(ctx context.Context, args []string) ([
 
 	err := eg.Wait()
 
-	if h.debug {
-		shellDebug(ctx, "resolve results", args, results)
-	}
-
 	return results, err
 }
 

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -733,6 +733,26 @@ func (ShellSuite) TestArgsSpread(ctx context.Context, t *testctx.T) {
 			command:  `with-exec --redirect-stdout /out -- echo -n git checkout -- file | file /out | contents`,
 			expected: "git checkout -- file",
 		},
+		{
+			command:  `with-exec -- sh -c 'echo hello something,with,commas' | stdout`,
+			expected: "hello something,with,commas\n",
+		},
+		{
+			command:  `with-exec -- sh -c 'echo "with double quotes"' | stdout`,
+			expected: "with double quotes\n",
+		},
+		{
+			command:  `with-exec -- sh -c "echo 'with single quotes'" | stdout`,
+			expected: "with single quotes\n",
+		},
+		{
+			command:  `with-exec -- sh -c "echo $(directory | with-new-file foo "with state" | file foo | contents)" | stdout`,
+			expected: "with state\n",
+		},
+		{
+			command:  `with-exec echo,with,csv,support | stdout`,
+			expected: "with csv support\n",
+		},
 	} {
 		t.Run(strings.TrimSpace(tc.expected), func(ctx context.Context, t *testctx.T) {
 			script := fmt.Sprintf("container | from %s | %s", alpineImage, tc.command)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7678
Also allows nested quotes, as reported in [Discord](https://discord.com/channels/707636530424053791/1356989954676363557).

## Before

**Spread commas**
```
✔ container | from alpine | with-exec -- echo trivy fs --scanners vuln,misconfig,secret | stdout 2.4s
trivy fs --scanners vuln misconfig secret
```

**Nested quotes**
```
✘ container | from alpine | with-exec -- sh -c 'echo "hello world"' | stdout
! function "with-exec": invalid argument "echo \"hello world\"" for "--args" flag: parse error on line 1, column 6: bare " in non-quoted-field
```

## After

```
✔ container | from alpine | with-exec -- echo trivy fs --scanners vuln,misconfig,secret | stdout 1.2s
trivy fs --scanners vuln,misconfig,secret
✔ container | from alpine | with-exec -- sh -c 'echo "hello world"' | stdout
hello world
```

## How?

There's a convenience where:
- if the function has only one required argument and it's a `[]string`
- and if **more than 1** positional argument has been provided
- then we use the positional arguments as values for the function argument

This is the case with `with-exec`.  Previously, each of the arguments were prefixed with the same flag in order to pass it on to pflag, like `dagger call`. So `with-exec echo "hello world"` became `with-exec --args echo --args "hello world"`.

This change **skips the additional flag parsing** and saves the list of positional arguments as the final value directly.

Note that a single positional argument still undergoes additional parsing in order to support a comma separated value (CSV).

For more context:
- https://github.com/dagger/dagger/issues/7678#issuecomment-2757728320
