### PR TITLE
client: bump min connect timeout to 10s

### DIFF
--- a/engine/client/buildkit.go
+++ b/engine/client/buildkit.go
@@ -31,7 +31,7 @@ func newBuildkitClient(ctx context.Context, remote *url.URL, connector drivers.C
 		}),
 		bkclient.WithGRPCDialOption(grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff:           backoffConfig,
-			MinConnectTimeout: 3 * time.Second,
+			MinConnectTimeout: 10 * time.Second,
 		})),
 	}
 


### PR DESCRIPTION
due to what it seems to be a bug in the buildkit client initialization
when using stdio (TBC), bumping the default connect timeout from 3s to 10s
so ssh connections work

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
