### PR TITLE
fix: use correct indentation for magicache.secretName

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -83,11 +83,11 @@ spec:
           {{- if .Values.magicache.enabled }}
           envFrom:
             - secretRef:
-              {{- if .Values.magicache.secretName }}
-              name: {{ .Values.magicache.secretName }}
-              {{- else }}
-              name: {{ include "dagger.fullname" . }}-magicache-token
-              {{- end }}
+                {{- if .Values.magicache.secretName }}
+                name: {{ .Values.magicache.secretName }}
+                {{- else }}
+                name: {{ include "dagger.fullname" . }}-magicache-token
+                {{- end }}
           {{- end }}
           {{- if .Values.engine.port }}
           ports:


### PR DESCRIPTION
Fixed the indentation in `helm/dagger/templates/engine-daemonset.yaml` for the `secretRef` block

Fixes #10065