### PR TITLE
ci: Run SDK jobs in Alternative CI runners

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -152,7 +152,7 @@ func (ci *CI) withSDKWorkflows(runner *dagger.Gha, name string, sdks ...string) 
 		w = w.
 			WithJob(runner.Job(sdk+"-dev", command, dagger.GhaJobOpts{
 				DaggerVersion: ".",
-				Runner:        []string{SilverRunner(true)},
+				Runner:        []string{AltSilverRunner()},
 			}))
 	}
 
@@ -361,6 +361,11 @@ func PlatinumRunner(
 	dind bool,
 ) string {
 	return Runner(3, daggerVersion, 32, true, dind)
+}
+
+// Alternative Silver runner: Single-tenant with Docker, 8 cpu
+func AltSilverRunner() string {
+	return AltRunner(8)
 }
 
 // Alternative Gold runner: Single-tenant with Docker, 16 cpu

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     dotnet-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: dotnet-dev
         steps:
             - name: Checkout
@@ -258,7 +258,7 @@ jobs:
         timeout-minutes: 20
     elixir-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: elixir-dev
         steps:
             - name: Checkout
@@ -497,7 +497,7 @@ jobs:
         timeout-minutes: 20
     go-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: go-dev
         steps:
             - name: Checkout
@@ -736,7 +736,7 @@ jobs:
         timeout-minutes: 20
     java-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: java-dev
         steps:
             - name: Checkout
@@ -975,7 +975,7 @@ jobs:
         timeout-minutes: 20
     php-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: php-dev
         steps:
             - name: Checkout
@@ -1214,7 +1214,7 @@ jobs:
         timeout-minutes: 20
     python-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: python-dev
         steps:
             - name: Checkout
@@ -1453,7 +1453,7 @@ jobs:
         timeout-minutes: 20
     rust-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: rust-dev
         steps:
             - name: Checkout
@@ -1692,7 +1692,7 @@ jobs:
         timeout-minutes: 20
     typescript-dev:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-8c-dind' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
         name: typescript-dev
         steps:
             - name: Checkout


### PR DESCRIPTION
Same as we did for the Engine & CLI tests in https://github.com/dagger/dagger/pull/9887, we want to see what difference this runner type makes.

---
Will update with metrics after the first run.