### PR TITLE
ci: Switch back Engine & CLI to initial CI runners

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -182,25 +182,25 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{AltGoldRunner()},
 			}},
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
-				Runner: []string{AltPlatinumRunner()},
+				Runner: []string{PlatinumRunner(true)},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"LLM", []string{"TestLLM"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"cli-engine", []string{"TestCLI", "TestEngine"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"client-generator", []string{"TestClientGenerator"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"everything-else", nil, &dagger.GhaJobOpts{
-				Runner: []string{AltPlatinumRunner()},
+				Runner: []string{PlatinumRunner(true)},
 			}},
 		}))
 

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -1262,7 +1262,7 @@ jobs:
         timeout-minutes: 30
     testdev-cli-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-cli-engine
         steps:
             - name: Checkout
@@ -1520,7 +1520,7 @@ jobs:
         timeout-minutes: 30
     testdev-client-generator:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-client-generator
         steps:
             - name: Checkout
@@ -1778,7 +1778,7 @@ jobs:
         timeout-minutes: 30
     testdev-container:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-container
         steps:
             - name: Checkout
@@ -2036,7 +2036,7 @@ jobs:
         timeout-minutes: 30
     testdev-everything-else:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-everything-else
         steps:
             - name: Checkout
@@ -2294,7 +2294,7 @@ jobs:
         timeout-minutes: 30
     testdev-llm:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-LLM
         steps:
             - name: Checkout
@@ -2552,7 +2552,7 @@ jobs:
         timeout-minutes: 30
     testdev-module-runtimes:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-module-runtimes
         steps:
             - name: Checkout
@@ -2810,7 +2810,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout


### PR DESCRIPTION
So that we see how the initial infrastructure compares to the new runners after a week (or two?).

| Job Name | Before | After |
|---------|-------------------|-------------------|
| testdev-cli-engine | 7m 56s | 8m 45s |
| testdev-client-generator | 8m 29s | 8m 25s |
| testdev-container | 8m 51s | 8m 48s |
| testdev-everything-else | 14m 13s | 14m 51s |
| testdev-LLM | 5m 59s | 6m 47s |
| testdev-module-runtime | 12m 42s | 14m 12s |
| testdev-modules | 11m 34s | 11m 27s |

---

As discussed with @sipsma @jedevc earlier today.