### PR TITLE
mcp: add ability to expose core API as tools

### DIFF
--- a/.changes/unreleased/Added-20250410-180705.yaml
+++ b/.changes/unreleased/Added-20250410-180705.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'experimental: expose Dagger Core API as MCP tools'
+time: 2025-04-10T18:07:05.8265558Z
+custom:
+    Author: grouville, tiborvass
+    PR: "10090"

--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -13,14 +13,14 @@ import (
 )
 
 var (
-	mcpStdio   bool
-	mcpSseAddr string
-	core       bool
+	mcpStdio      bool
+	mcpSseAddr    string
+	envPrivileged bool
 )
 
 func init() {
 	mcpCmd.PersistentFlags().BoolVar(&mcpStdio, "stdio", true, "Use standard input/output for communicating with the MCP server")
-	mcpCmd.PersistentFlags().BoolVar(&core, "core", false, "Expose the core API as tools")
+	mcpCmd.PersistentFlags().BoolVar(&envPrivileged, "env-privileged", false, "Expose the core API as tools")
 	mcpCmd.PersistentFlags().StringVar(&mcpSseAddr, "sse-addr", "", "Address of the MCP SSE server (no SSE server if empty)")
 }
 
@@ -61,7 +61,7 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 		return err
 	}
 
-	if err == errModuleNotFound && !core {
+	if err == errModuleNotFound && !envPrivileged {
 		return fmt.Errorf("%w and --core not specified", errModuleNotFound)
 	}
 
@@ -80,8 +80,8 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 		q = q.Root().Select("env")
 
 		extraCore := ""
-		if core {
-			q = q.Arg("privileged", core)
+		if envPrivileged {
+			q = q.Arg("privileged", envPrivileged)
 			extraCore = " and Dagger core"
 		}
 
@@ -93,7 +93,7 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 
 		logMsg = fmt.Sprintf("Exposing module %q%s as an MCP server on standard input/output", modName, extraCore)
 	} else {
-		q = q.Root().Select("env").Arg("privileged", core).Select("id")
+		q = q.Root().Select("env").Arg("privileged", envPrivileged).Select("id")
 		logMsg = "Exposing Dagger core as an MCP server"
 	}
 

--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -15,10 +15,12 @@ import (
 var (
 	mcpStdio   bool
 	mcpSseAddr string
+	core       bool
 )
 
 func init() {
 	mcpCmd.PersistentFlags().BoolVar(&mcpStdio, "stdio", true, "Use standard input/output for communicating with the MCP server")
+	mcpCmd.PersistentFlags().BoolVar(&core, "core", false, "Expose the core API as tools")
 	mcpCmd.PersistentFlags().StringVar(&mcpSseAddr, "sse-addr", "", "Address of the MCP SSE server (no SSE server if empty)")
 }
 
@@ -55,31 +57,52 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 		return errors.New("currently MCP only works with stdio")
 	}
 	modDef, err := initializeDefaultModule(ctx, engineClient.Dagger())
-	if err != nil {
+	if err != nil && err != errModuleNotFound {
 		return err
 	}
-	q := querybuilder.Query().Client(engineClient.Dagger().GraphQLClient())
-	// TODO: parse user args and pass them to constructor
-	modName := modDef.MainObject.AsObject.Constructor.Name
-	q = q.Root().Select(modName).Select("id")
 
-	var modID string
-	if err := makeRequest(ctx, q, &modID); err != nil {
-		return fmt.Errorf("error instantiating module: %w", err)
+	if err == errModuleNotFound && !core {
+		return fmt.Errorf("%w and --core not specified", errModuleNotFound)
 	}
 
-	q = q.Root().Select("env").Select("with"+modDef.MainObject.AsObject.Name+"Input").
-		Arg("name", modName).
-		Arg("value", modID).
-		Arg("description", modDef.MainObject.Description()).
-		Select("id")
+	q := querybuilder.Query().Client(engineClient.Dagger().GraphQLClient())
+	var logMsg string
+	if modDef != nil {
+		// TODO: parse user args and pass them to constructor
+		modName := modDef.MainObject.AsObject.Constructor.Name
+		q = q.Root().Select(modName).Select("id")
+
+		var modID string
+		if err := makeRequest(ctx, q, &modID); err != nil {
+			return fmt.Errorf("error instantiating module: %w", err)
+		}
+
+		q = q.Root().Select("env")
+
+		extraCore := ""
+		if core {
+			q = q.Arg("privileged", core)
+			extraCore = " and Dagger core"
+		}
+
+		q = q.Select("with"+modDef.MainObject.AsObject.Name+"Input").
+			Arg("name", modName).
+			Arg("value", modID).
+			Arg("description", "module to expose as an MCP server").
+			Select("id")
+
+		logMsg = fmt.Sprintf("Exposing module %q%s as an MCP server on standard input/output", modName, extraCore)
+	} else {
+		q = q.Root().Select("env").Arg("privileged", core).Select("id")
+		logMsg = "Exposing Dagger core as an MCP server"
+	}
 
 	var envID string
 	if err := makeRequest(ctx, q, &envID); err != nil {
 		return fmt.Errorf("error making environment: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Exposing module %q as an MCP server on standard input/output\n", modName)
+	fmt.Fprintln(os.Stderr, logMsg)
 	q = q.Root().
 		Select("llm").
 		Select("withEnv").

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -19,6 +19,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+var errModuleNotFound = errors.New("module not found")
+
 // initializeCore loads the core type definitions only
 func initializeCore(ctx context.Context, dag *dagger.Client) (rdef *moduleDef, rerr error) {
 	def := &moduleDef{}
@@ -61,7 +63,7 @@ func initializeModule(
 		return nil, fmt.Errorf("failed to get configured module: %w", err)
 	}
 	if !configExists {
-		return nil, fmt.Errorf("module not found")
+		return nil, errModuleNotFound
 	}
 
 	serveCtx, serveSpan := Tracer().Start(ctx, "initializing module", telemetry.Encapsulate())


### PR DESCRIPTION
This adds a `--core` flag to the MCP command, allowing the env to optionally expose the core API as an MCP server

#### Usage

| Module Present | Core Present | Exposed Tools     | Outcome       |
|----------------|--------------|------------------------|----------------|
| ✅             | ✅           | SDK + Core             | ✅ Success      |
| ✅             | ❌           | SDK only               | ✅ Success      |
| ❌             | ✅           | Core only              | ✅ Success      |
| ❌             | ❌           | None                   | ❌ Error        |

Co-authored-by: @tiborvass 

#### How to test

`dagger_dev mcp --core`

cc @jpadams 