### PR TITLE
feat: add default value comments for go

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -41,11 +41,19 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- range $arg := $field.Args }}
 	{{- if IsArgOptional $arg }}
 	{{ $arg.Description | Comment }}
-	{{- if and (eq $arg.Name "id") (eq $.Name "Query") }}
-	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatOutputType }}
-	{{- else }}
-	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatInputType }}
+	{{- if not $arg.DefaultValueZero }}
+	{{- if $arg.Description }}
+	//
 	{{- end }}
+	// Default: {{ $arg.DefaultValue }}
+	{{- end }}
+	{{- $formattedTypeRef := "" }}
+	{{- if and (eq $arg.Name "id") (eq $.Name "Query") }}
+	{{- $formattedTypeRef = $arg.TypeRef | FormatOutputType }}
+	{{- else }}
+	{{- $formattedTypeRef = $arg.TypeRef | FormatInputType }}
+	{{- end }}
+	{{ $arg.Name | FormatName }} {{ $formattedTypeRef }}
 	{{- with .Directives.SourceMap -}} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
 	{{- end }}
 	{{- end }}

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -268,6 +268,24 @@ func (v InputValue) IsOptional() bool {
 	return v.DefaultValue != nil || (v.TypeRef != nil && v.TypeRef.IsOptional())
 }
 
+func (v InputValue) DefaultValueZero() bool {
+	if v.DefaultValue == nil {
+		return true
+	}
+	// detect zero-ish values in go, and avoid adding them as tags, since they
+	// just add clutter (and look confusing)
+	switch *v.DefaultValue {
+	case
+		`false`, // boolean
+		`0`,     // int
+		`""`,    // string
+		`[]`:    // array
+		return true
+	}
+
+	return false
+}
+
 type EnumValue struct {
 	Name              string     `json:"name"`
 	Description       string     `json:"description"`

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -652,6 +652,8 @@ type ContainerAsTarballOpts struct {
 	// Use the specified media types for the image's layers.
 	//
 	// Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
+	//
+	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
 }
 
@@ -681,6 +683,8 @@ func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
 // ContainerBuildOpts contains options for Container.Build
 type ContainerBuildOpts struct {
 	// Path to the Dockerfile to use.
+	//
+	// Default: "Dockerfile"
 	Dockerfile string
 	// Target build stage to build.
 	Target string
@@ -877,6 +881,8 @@ type ContainerExportOpts struct {
 	// Use the specified media types for the exported image's layers.
 	//
 	// Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
+	//
+	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
@@ -1144,6 +1150,8 @@ type ContainerPublishOpts struct {
 	// Use the specified media types for the published image's layers.
 	//
 	// Defaults to "OCI", which is compatible with most recent registries, but "Docker" may be needed for older registries without OCI support.
+	//
+	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
 }
 
@@ -1506,6 +1514,8 @@ type ContainerWithExecOpts struct {
 	// Like redirectStdout, but for standard error
 	RedirectStderr string
 	// Exit codes this command is allowed to exit with without error
+	//
+	// Default: SUCCESS
 	Expect ReturnType
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
@@ -1572,6 +1582,8 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 // ContainerWithExposedPortOpts contains options for Container.WithExposedPort
 type ContainerWithExposedPortOpts struct {
 	// Network protocol. Example: "tcp"
+	//
+	// Default: TCP
 	Protocol NetworkProtocol
 	// Port description. Example: "payment API endpoint"
 	Description string
@@ -1704,6 +1716,8 @@ type ContainerWithMountedCacheOpts struct {
 	// Identifier of the directory to use as the cache volume's root.
 	Source *Directory
 	// Sharing mode of the cache volume.
+	//
+	// Default: SHARED
 	Sharing CacheSharingMode
 	// A user:group to set for the mounted cache directory.
 	//
@@ -1826,6 +1840,8 @@ type ContainerWithMountedSecretOpts struct {
 	// Permission given to the mounted secret (e.g., 0600).
 	//
 	// This option requires an owner to be set to be active.
+	//
+	// Default: 256
 	Mode int
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
@@ -1888,6 +1904,8 @@ func (r *Container) WithMountedTemp(path string, opts ...ContainerWithMountedTem
 // ContainerWithNewFileOpts contains options for Container.WithNewFile
 type ContainerWithNewFileOpts struct {
 	// Permissions of the new file. Example: 0600
+	//
+	// Default: 420
 	Permissions int
 	// A user:group to set for the file.
 	//
@@ -2119,6 +2137,8 @@ func (r *Container) WithoutEnvVariable(name string) *Container {
 // ContainerWithoutExposedPortOpts contains options for Container.WithoutExposedPort
 type ContainerWithoutExposedPortOpts struct {
 	// Port protocol to unexpose
+	//
+	// Default: TCP
 	Protocol NetworkProtocol
 }
 
@@ -2444,6 +2464,8 @@ type DirectoryAsModuleOpts struct {
 	// An optional subpath of the directory which contains the module's configuration file.
 	//
 	// If not set, the module source code is loaded from the root of the directory.
+	//
+	// Default: "."
 	SourceRootPath string
 }
 
@@ -2467,6 +2489,8 @@ type DirectoryAsModuleSourceOpts struct {
 	// An optional subpath of the directory which contains the module's configuration file.
 	//
 	// If not set, the module source code is loaded from the root of the directory.
+	//
+	// Default: "."
 	SourceRootPath string
 }
 
@@ -2524,6 +2548,8 @@ type DirectoryDockerBuildOpts struct {
 	// The platform to build.
 	Platform Platform
 	// Path to the Dockerfile to use (e.g., "frontend.Dockerfile").
+	//
+	// Default: "Dockerfile"
 	Dockerfile string
 	// Target build stage to build.
 	Target string
@@ -2857,6 +2883,8 @@ func (r *Directory) WithFiles(path string, sources []*File, opts ...DirectoryWit
 // DirectoryWithNewDirectoryOpts contains options for Directory.WithNewDirectory
 type DirectoryWithNewDirectoryOpts struct {
 	// Permission granted to the created directory (e.g., 0777).
+	//
+	// Default: 420
 	Permissions int
 }
 
@@ -2879,6 +2907,8 @@ func (r *Directory) WithNewDirectory(path string, opts ...DirectoryWithNewDirect
 // DirectoryWithNewFileOpts contains options for Directory.WithNewFile
 type DirectoryWithNewFileOpts struct {
 	// Permissions of the new file. Example: 0600
+	//
+	// Default: 420
 	Permissions int
 }
 
@@ -5700,6 +5730,8 @@ func (r *Host) MarshalJSON() ([]byte, error) {
 // HostServiceOpts contains options for Host.Service
 type HostServiceOpts struct {
 	// Upstream host to forward traffic to.
+	//
+	// Default: "localhost"
 	Host string
 }
 
@@ -7949,6 +7981,8 @@ func (r *Client) GeneratedCode(code *Directory) *GeneratedCode {
 // GitOpts contains options for Client.Git
 type GitOpts struct {
 	// DEPRECATED: Set to true to keep .git directory.
+	//
+	// Default: true
 	KeepGitDir bool
 	// A service which must be started before the repo is fetched.
 	ExperimentalServiceHost *Service


### PR DESCRIPTION
Fixes #10084.

Since we do special opts structs for go, this only applies for this special case - we don't need it in typescript or python.