### PR TITLE
fix: ensure that we use views with trailing slash methods

### DIFF
--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -38,11 +38,14 @@ func (s *directorySchema) Install() {
 			ArgDoc("description", "Description of the sub-pipeline.").
 			ArgDoc("labels", "Labels to apply to the sub-pipeline."),
 		dagql.Func("name", s.name).
+			View(AllVersion). // name returns different results in different versions
 			Doc(`Returns the name of the directory.`),
 		dagql.Func("entries", s.entries).
+			View(AllVersion). // entries returns different results in different versions
 			Doc(`Returns a list of files and directories at the given path.`).
 			ArgDoc("path", `Location of the directory to look at (e.g., "/src").`),
 		dagql.Func("glob", s.glob).
+			View(AllVersion). // glob returns different results in different versions
 			Doc(`Returns a list of files and directories that matche the given pattern.`).
 			ArgDoc("pattern", `Pattern to match (e.g., "*.md").`),
 		dagql.Func("digest", s.digest).


### PR DESCRIPTION
Follow-up from https://github.com/dagger/dagger/pull/9118.

When we mixed in slashes here, we *should* have ensured that we updated the view. Otherwise, we could encounter the following scenario:
- Module A uses v0.16.0 (no trailing slashes), and calls `Directory.entries` on a directory.
- Module B uses v0.17.0 (has trailing slashes), and calls `Directory.entries` on the same directory.

If this all occurs within the same session (or across the whole engine once https://github.com/dagger/dagger/pull/9682 is merged), then these calls will generate the same ID - and the wrong result will leak between these (in a racy way).

The correct way to solve this problem is to ensure that these generate different IDs (which we can do by manually using `dagql.AllVersion`).