### PR TITLE
replace integ test Query usage w/ QueryWithClient

### DIFF
--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -149,15 +149,9 @@ func (ClientSuite) TestClientStableID(ctx context.Context, t *testctx.T) {
 // We use this in tests to do quick-and-easy checks against the schemas served
 // (without needing to do fancy module manipulation).
 func (ClientSuite) TestQuerySchemaVersion(ctx context.Context, t *testctx.T) {
-	v := struct {
+	v, err := testutil.Query[struct {
 		SchemaVersion string `json:"__schemaVersion"`
-	}{}
-	err := testutil.Query(t,
-		`{
-			__schemaVersion
-		}`, &v, &testutil.QueryOptions{
-			Version: "v123.456.789",
-		})
+	}](t, `{ __schemaVersion }`, nil, dagger.WithVersionOverride("v123.456.789"))
 	require.NoError(t, err)
 	require.Equal(t, "v123.456.789", v.SchemaVersion)
 }

--- a/core/integration/dind_test.go
+++ b/core/integration/dind_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (ContainerSuite) TestDIND(ctx context.Context, t *testctx.T) {
-	var res struct {
+	res, err := testutil.Query[struct {
 		Container struct {
 			From struct {
 				WithExec struct {
@@ -20,9 +20,7 @@ func (ContainerSuite) TestDIND(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}
-	}
-
-	err := testutil.Query(t,
+	}](t,
 		`
 {
   container {
@@ -46,7 +44,7 @@ curl \
 }
 
 
-                `, &res, nil)
+                `, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Container.From.WithExec.WithExec.Stdout)
 	require.Equal(t, "{\"data\":{\"host\":{\"directory\":{\"entries\":[\"1\",\"2\"]}}}}", res.Container.From.WithExec.WithExec.Stdout)

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -29,7 +29,7 @@ func TestFile(t *testing.T) {
 }
 
 func (FileSuite) TestFile(ctx context.Context, t *testctx.T) {
-	var res struct {
+	res, err := testutil.Query[struct {
 		Directory struct {
 			WithNewFile struct {
 				File struct {
@@ -38,9 +38,7 @@ func (FileSuite) TestFile(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}
-	}
-
-	err := testutil.Query(t,
+	}](t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -50,14 +48,14 @@ func (FileSuite) TestFile(ctx context.Context, t *testctx.T) {
 					}
 				}
 			}
-		}`, &res, nil)
+		}`, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Directory.WithNewFile.File.ID)
 	require.Equal(t, "some-content", res.Directory.WithNewFile.File.Contents)
 }
 
 func (FileSuite) TestDirectoryFile(ctx context.Context, t *testctx.T) {
-	var res struct {
+	res, err := testutil.Query[struct {
 		Directory struct {
 			WithNewFile struct {
 				Directory struct {
@@ -68,9 +66,7 @@ func (FileSuite) TestDirectoryFile(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}
-	}
-
-	err := testutil.Query(t,
+	}](t,
 		`{
 			directory {
 				withNewFile(path: "some-dir/some-file", contents: "some-content") {
@@ -82,14 +78,14 @@ func (FileSuite) TestDirectoryFile(ctx context.Context, t *testctx.T) {
 					}
 				}
 			}
-		}`, &res, nil)
+		}`, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Directory.WithNewFile.Directory.File.ID)
 	require.Equal(t, "some-content", res.Directory.WithNewFile.Directory.File.Contents)
 }
 
 func (FileSuite) TestSize(ctx context.Context, t *testctx.T) {
-	var res struct {
+	res, err := testutil.Query[struct {
 		Directory struct {
 			WithNewFile struct {
 				File struct {
@@ -98,9 +94,7 @@ func (FileSuite) TestSize(ctx context.Context, t *testctx.T) {
 				}
 			}
 		}
-	}
-
-	err := testutil.Query(t,
+	}](t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -110,7 +104,7 @@ func (FileSuite) TestSize(ctx context.Context, t *testctx.T) {
 					}
 				}
 			}
-		}`, &res, nil)
+		}`, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Directory.WithNewFile.File.ID)
 	require.Equal(t, len("some-content"), res.Directory.WithNewFile.File.Size)


### PR DESCRIPTION
The new util is a bit more ergonomic in many situations by using generics to return results directly.

This was mostly done by Claude, with human touch-ups.

Follow-up from here: https://github.com/dagger/dagger/pull/9682#discussion_r2021729577