### PR TITLE
mcp: show proper description for top-level module

### DIFF
--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -71,7 +71,7 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 	q = q.Root().Select("env").Select("with"+modDef.MainObject.AsObject.Name+"Input").
 		Arg("name", modName).
 		Arg("value", modID).
-		Arg("description", "module to expose as an MCP server").
+		Arg("description", modDef.MainObject.Description()).
 		Select("id")
 
 	var envID string


### PR DESCRIPTION
Fixes #10097

When exposing a module over mcp, dagger didn't expose the module type's actual description to the MCP client. The fix now shows the actual module description

### Open question
- What do we want to show when there is no module description ?

cc @tiborvass 