### PR TITLE
fix: correctly escape special characters for elixir docstrings

### DIFF
--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/renderer.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/renderer.ex
@@ -42,7 +42,13 @@ defmodule Dagger.Codegen.ElixirGenerator.Renderer do
         "\"\"\""
       ]
     else
-      [?", s, ?"]
+      [
+        ?",
+        s
+        |> String.replace("\\", "\\\\")
+        |> String.replace("\"", "\\\""),
+        ?",
+      ]
     end
   end
 


### PR DESCRIPTION
Discovered in https://github.com/dagger/dagger/pull/10106#discussion_r2035065993

It was possible to generate bad elixir code if a function had a doc string that included quotes.