### PR TITLE
ci: Split all module-runtimes

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -182,25 +182,25 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{AltGoldRunner()},
 			}},
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
-				Runner: []string{AltPlatinumRunner()},
+				Runner: []string{PlatinumRunner(true)},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"LLM", []string{"TestLLM"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"cli-engine", []string{"TestCLI", "TestEngine"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"client-generator", []string{"TestClientGenerator"}, &dagger.GhaJobOpts{
-				Runner: []string{AltGoldRunner()},
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"everything-else", nil, &dagger.GhaJobOpts{
-				Runner: []string{AltPlatinumRunner()},
+				Runner: []string{PlatinumRunner(true)},
 			}},
 		}))
 

--- a/.github/main.go
+++ b/.github/main.go
@@ -184,8 +184,23 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
 				Runner: []string{GoldRunner(true)},
 			}},
-			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+			{"go-module-runtime", []string{"TestGo"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
+			}},
+			{"python-module-runtime", []string{"TestPython"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
+			}},
+			{"typescript-module-runtime", []string{"TestTypescript"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
+			}},
+			{"elixir-module-runtime", []string{"TestElixir"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
+			}},
+			{"php-module-runtime", []string{"TestPHP"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
+			}},
+			{"java-module-runtime", []string{"TestJava"}, &dagger.GhaJobOpts{
+				Runner: []string{GoldRunner(true)},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
 				Runner: []string{GoldRunner(true)},

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -2034,6 +2034,264 @@ jobs:
                 path: /tmp/actions-call-engine.log
               if: always()
         timeout-minutes: 30
+    testdev-elixir-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-elixir-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestElixir'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
     testdev-everything-else:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
@@ -2270,6 +2528,522 @@ jobs:
               env:
                 _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 COMMAND: dagger call -q test specific --race=true --parallel=16 --skip='TestProvision|TestTelemetry|TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava|TestContainer|TestLLM|TestCLI|TestEngine|TestClientGenerator'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-go-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-go-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestGo'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-java-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-java-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestJava'
                 DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 NO_OUTPUT: "true"
               shell: bash
@@ -2550,264 +3324,6 @@ jobs:
                 path: /tmp/actions-call-engine.log
               if: always()
         timeout-minutes: 30
-    testdev-module-runtimes:
-        runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
-        name: testdev-module-runtimes
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: scripts/install-dagger.sh
-              id: install-dagger
-              run: |
-                #!/bin/bash
-
-                set -o pipefail
-                # Fallback to /usr/local for backwards compatability
-                prefix_dir="${RUNNER_TEMP:-/usr/local}"
-
-                # Ensure the dir is writable otherwise fallback to tmpdir
-                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
-                  prefix_dir="$(mktemp -d)"
-                fi
-                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
-
-                if [ -f "$DAGGER_VERSION_FILE" ]; then
-                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
-                fi
-
-                # If the dagger version is 'latest', set the version back to an empty
-                # string. This allows the install script to detect and install the latest
-                # version itself
-                if [[ "$DAGGER_VERSION" == "latest" ]]; then
-                  DAGGER_VERSION=
-                fi
-
-                # The install.sh script creates path ${prefix_dir}/bin
-                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
-              env:
-                DAGGER_VERSION_FILE: dagger.json
-              shell: bash
-            - name: scripts/start-dev-dagger.sh
-              id: start-dev-dagger
-              run: |
-                #!/bin/bash --noprofile --norc -e -o pipefail
-
-                GITHUB_ENV="${GITHUB_ENV:=github.env}"
-                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
-
-                if [ ! -d "$DAGGER_SOURCE" ]; then
-                    dagger core \
-                        directory \
-                        with-directory --path=. --directory="$DAGGER_SOURCE" \
-                        export --path=dagger-source
-                    DAGGER_SOURCE=./dagger-source
-                fi
-
-                echo "::group::Starting dev engine"
-
-                if ! [[ -x "$(command -v docker)" ]]; then
-                    echo "docker is not installed"
-                    exit 1
-                fi
-                if ! [[ -x "$(command -v dagger)" ]]; then
-                    echo "dagger is not installed"
-                    exit 1
-                fi
-
-                $DAGGER_SOURCE/hack/build
-                export PATH=$(realpath ./bin):$PATH
-                echo "PATH=$PATH" >>"${GITHUB_ENV}"
-
-                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
-                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
-
-                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
-
-                echo "::endgroup::"
-              env:
-                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
-                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
-                DAGGER_SOURCE: .
-              shell: bash
-            - name: scripts/warm-engine.sh
-              id: warm-engine
-              run: |
-                #!/bin/bash
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-                if [[ -n "$USE_DEV_ENGINE" ]]; then
-                  # use runner host baked into the cli for dev jobs
-                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
-                fi
-
-                # Run a simple query to "warm up" the engine
-                dagger version
-                dagger core version
-              shell: bash
-            - name: scripts/exec.sh
-              id: exec
-              run: |
-                #!/bin/bash --noprofile --norc -e -o pipefail
-
-                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
-                    set -x
-                    env
-                    which dagger
-                    pwd
-                    ls -l
-                    ps aux
-                fi
-
-                # Detect if a dev engine is available, if so: use that
-                # We don't rely on PATH because the GHA runner messes with that
-                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
-                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
-                fi
-                # use runner host baked into the cli for dev jobs
-                if [[ -n "$USE_DEV_ENGINE" ]]; then
-                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
-                fi
-
-                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
-                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
-
-                # Ensure the command is provided as an environment variable
-                if [ -z "$COMMAND" ]; then
-                  echo "Error: Please set the COMMAND environment variable."
-                  exit 1
-                fi
-
-                tmp=$(mktemp -d)
-                (
-                    cd $tmp
-
-                    # Create named pipes (FIFOs) for stdout and stderr
-                    mkfifo stdout.fifo stderr.fifo
-
-                    # Set up tee to capture and display stdout and stderr
-                    if [ -n "$NO_OUTPUT" ]; then
-                        tee stdout.txt < stdout.fifo > /dev/null &
-                        tee stderr.txt < stderr.fifo > /dev/null &
-                    else
-                        tee stdout.txt < stdout.fifo &
-                        tee stderr.txt < stderr.fifo >&2 &
-                    fi
-                )
-
-                # Run the command, capturing stdout and stderr in the FIFOs
-                set +e
-                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
-                EXIT_CODE=$?
-                set -e
-                # Wait for all background jobs to finish
-                wait
-
-                # Extra trace URL
-                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
-
-                {
-                cat <<'.'
-                ## Dagger trace
-
-                .
-
-                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
-                    cat <<.
-                Cloud token must be rotated. Please follow these steps:
-
-                1. Go to [Dagger Cloud](https://dagger.cloud)
-                2. Click on your profile icon in the bottom left corner
-                3. Click on "Organization Settings"
-                4. Click on "Regenerate token"
-                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
-                .
-                elif [ -n "$TRACE_URL" ]; then
-                    echo "[$TRACE_URL]($TRACE_URL)"
-                else
-                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
-                fi
-
-                cat <<'.'
-
-                ## Dagger version
-
-                ```
-                .
-
-                dagger version
-
-                cat <<'.'
-                ```
-
-                ## Pipeline command
-
-                ```bash
-                .
-
-                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
-                echo " $COMMAND"
-
-                cat <<'.'
-                ```
-
-                ## Pipeline output
-
-                ```
-                .
-
-                cat $tmp/stdout.txt
-
-                cat <<'.'
-                ```
-
-                ## Pipeline logs
-
-                ```
-                .
-
-                tail -n 1000 $tmp/stderr.txt
-
-                cat <<'.'
-                ```
-                .
-
-                } >"${GITHUB_STEP_SUMMARY}"
-
-                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
-                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
-
-                exit $EXIT_CODE
-              env:
-                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava'
-                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
-                NO_OUTPUT: "true"
-              shell: bash
-            - name: Upload call logs
-              uses: actions/upload-artifact@v4
-              with:
-                name: call-logs-${{ runner.name }}-${{ github.job }}exec
-                overwrite: "true"
-                path: ${{ steps.exec.outputs.stderr_file }}
-              if: always()
-            - name: Capture dev engine logs
-              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
-              shell: bash
-              if: always()
-            - name: Upload dev engine logs
-              uses: actions/upload-artifact@v4
-              with:
-                name: engine-logs-${{ runner.name }}-${{ github.job }}
-                overwrite: "true"
-                path: /tmp/actions-call-engine.log
-              if: always()
-        timeout-minutes: 30
     testdev-modules:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
@@ -3044,6 +3560,780 @@ jobs:
               env:
                 _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestModule'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-php-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-php-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestPHP'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-python-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-python-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestPython'
+                DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                NO_OUTPUT: "true"
+              shell: bash
+            - name: Upload call logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: call-logs-${{ runner.name }}-${{ github.job }}exec
+                overwrite: "true"
+                path: ${{ steps.exec.outputs.stderr_file }}
+              if: always()
+            - name: Capture dev engine logs
+              run: docker logs "dagger-engine.dev-${{ github.run_id }}-${{ github.job }}" &> /tmp/actions-call-engine.log
+              shell: bash
+              if: always()
+            - name: Upload dev engine logs
+              uses: actions/upload-artifact@v4
+              with:
+                name: engine-logs-${{ runner.name }}-${{ github.job }}
+                overwrite: "true"
+                path: /tmp/actions-call-engine.log
+              if: always()
+        timeout-minutes: 30
+    testdev-typescript-module-runtime:
+        runs-on:
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
+        name: testdev-typescript-module-runtime
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: scripts/install-dagger.sh
+              id: install-dagger
+              run: |
+                #!/bin/bash
+
+                set -o pipefail
+                # Fallback to /usr/local for backwards compatability
+                prefix_dir="${RUNNER_TEMP:-/usr/local}"
+
+                # Ensure the dir is writable otherwise fallback to tmpdir
+                if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+                  prefix_dir="$(mktemp -d)"
+                fi
+                printf '%s/bin' "$prefix_dir" >>$GITHUB_PATH
+
+                if [ -f "$DAGGER_VERSION_FILE" ]; then
+                  DAGGER_VERSION=$(cat "$DAGGER_VERSION_FILE" | jq -r .engineVersion)
+                fi
+
+                # If the dagger version is 'latest', set the version back to an empty
+                # string. This allows the install script to detect and install the latest
+                # version itself
+                if [[ "$DAGGER_VERSION" == "latest" ]]; then
+                  DAGGER_VERSION=
+                fi
+
+                # The install.sh script creates path ${prefix_dir}/bin
+                curl -fsS https://dl.dagger.io/dagger/install.sh | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$DAGGER_VERSION sh
+              env:
+                DAGGER_VERSION_FILE: dagger.json
+              shell: bash
+            - name: scripts/start-dev-dagger.sh
+              id: start-dev-dagger
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                GITHUB_ENV="${GITHUB_ENV:=github.env}"
+                DAGGER_SOURCE="${DAGGER_SOURCE:=.}"
+
+                if [ ! -d "$DAGGER_SOURCE" ]; then
+                    dagger core \
+                        directory \
+                        with-directory --path=. --directory="$DAGGER_SOURCE" \
+                        export --path=dagger-source
+                    DAGGER_SOURCE=./dagger-source
+                fi
+
+                echo "::group::Starting dev engine"
+
+                if ! [[ -x "$(command -v docker)" ]]; then
+                    echo "docker is not installed"
+                    exit 1
+                fi
+                if ! [[ -x "$(command -v dagger)" ]]; then
+                    echo "dagger is not installed"
+                    exit 1
+                fi
+
+                $DAGGER_SOURCE/hack/build
+                export PATH=$(realpath ./bin):$PATH
+                echo "PATH=$PATH" >>"${GITHUB_ENV}"
+
+                export _EXPERIMENTAL_DAGGER_CLI_BIN=$(which dagger)
+                echo "_EXPERIMENTAL_DAGGER_CLI_BIN=$_EXPERIMENTAL_DAGGER_CLI_BIN" >>"${GITHUB_ENV}"
+
+                echo "USE_DEV_ENGINE=y" >> "${GITHUB_ENV}"
+
+                echo "::endgroup::"
+              env:
+                _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.job }}
+                _EXPERIMENTAL_DAGGER_DEV_IMAGE: localhost/dagger-engine.dev:${{ github.run_id }}-${{ github.job }}
+                DAGGER_SOURCE: .
+              shell: bash
+            - name: scripts/warm-engine.sh
+              id: warm-engine
+              run: |
+                #!/bin/bash
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    ls -lh $(dirname $_EXPERIMENTAL_DAGGER_CLI_BIN)
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  # use runner host baked into the cli for dev jobs
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                # Run a simple query to "warm up" the engine
+                dagger version
+                dagger core version
+              shell: bash
+            - name: scripts/exec.sh
+              id: exec
+              run: |
+                #!/bin/bash --noprofile --norc -e -o pipefail
+
+                if [[ -n "$DEBUG" && "$DEBUG" != "0" ]]; then
+                    set -x
+                    env
+                    which dagger
+                    pwd
+                    ls -l
+                    ps aux
+                fi
+
+                # Detect if a dev engine is available, if so: use that
+                # We don't rely on PATH because the GHA runner messes with that
+                if [[ -n "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]]; then
+                    export PATH=$(dirname "$_EXPERIMENTAL_DAGGER_CLI_BIN"):$PATH
+                fi
+                # use runner host baked into the cli for dev jobs
+                if [[ -n "$USE_DEV_ENGINE" ]]; then
+                  unset _EXPERIMENTAL_DAGGER_RUNNER_HOST
+                fi
+
+                GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:=github-summary.md}"
+                export NO_COLOR="${NO_COLOR:=1}" # Disable colors in dagger logs
+
+                # Ensure the command is provided as an environment variable
+                if [ -z "$COMMAND" ]; then
+                  echo "Error: Please set the COMMAND environment variable."
+                  exit 1
+                fi
+
+                tmp=$(mktemp -d)
+                (
+                    cd $tmp
+
+                    # Create named pipes (FIFOs) for stdout and stderr
+                    mkfifo stdout.fifo stderr.fifo
+
+                    # Set up tee to capture and display stdout and stderr
+                    if [ -n "$NO_OUTPUT" ]; then
+                        tee stdout.txt < stdout.fifo > /dev/null &
+                        tee stderr.txt < stderr.fifo > /dev/null &
+                    else
+                        tee stdout.txt < stdout.fifo &
+                        tee stderr.txt < stderr.fifo >&2 &
+                    fi
+                )
+
+                # Run the command, capturing stdout and stderr in the FIFOs
+                set +e
+                eval "$COMMAND" > $tmp/stdout.fifo 2> $tmp/stderr.fifo
+                EXIT_CODE=$?
+                set -e
+                # Wait for all background jobs to finish
+                wait
+
+                # Extra trace URL
+                TRACE_URL=$(sed -En 's/^Full trace at (.*)/\1/p' < $tmp/stderr.txt)
+
+                {
+                cat <<'.'
+                ## Dagger trace
+
+                .
+
+                if [[ "$TRACE_URL" == *"rotate dagger.cloud token for full url"* ]]; then
+                    cat <<.
+                Cloud token must be rotated. Please follow these steps:
+
+                1. Go to [Dagger Cloud](https://dagger.cloud)
+                2. Click on your profile icon in the bottom left corner
+                3. Click on "Organization Settings"
+                4. Click on "Regenerate token"
+                5. Update the [\`DAGGER_CLOUD_TOKEN\` secret in your GitHub repository settings](https://github.com/${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY is not set}/settings/secrets/actions/DAGGER_CLOUD_TOKEN)
+                .
+                elif [ -n "$TRACE_URL" ]; then
+                    echo "[$TRACE_URL]($TRACE_URL)"
+                else
+                    echo "No trace available. To setup: [https://dagger.cloud/traces/setup](https://dagger.cloud/traces/setup)"
+                fi
+
+                cat <<'.'
+
+                ## Dagger version
+
+                ```
+                .
+
+                dagger version
+
+                cat <<'.'
+                ```
+
+                ## Pipeline command
+
+                ```bash
+                .
+
+                echo "DAGGER_MODULE=$DAGGER_MODULE \\"
+                echo " $COMMAND"
+
+                cat <<'.'
+                ```
+
+                ## Pipeline output
+
+                ```
+                .
+
+                cat $tmp/stdout.txt
+
+                cat <<'.'
+                ```
+
+                ## Pipeline logs
+
+                ```
+                .
+
+                tail -n 1000 $tmp/stderr.txt
+
+                cat <<'.'
+                ```
+                .
+
+                } >"${GITHUB_STEP_SUMMARY}"
+
+                echo "stdout_file=$tmp/stdout.txt" >>"$GITHUB_OUTPUT"
+                echo "stderr_file=$tmp/stderr.txt" >>"$GITHUB_OUTPUT"
+
+                exit $EXIT_CODE
+              env:
+                _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
+                COMMAND: dagger call -q test specific --race=true --parallel=16 --run='TestTypescript'
                 DAGGER_CLOUD_TOKEN: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
                 NO_OUTPUT: "true"
               shell: bash

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -1262,7 +1262,7 @@ jobs:
         timeout-minutes: 30
     testdev-cli-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-cli-engine
         steps:
             - name: Checkout
@@ -1520,7 +1520,7 @@ jobs:
         timeout-minutes: 30
     testdev-client-generator:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-client-generator
         steps:
             - name: Checkout
@@ -1778,7 +1778,7 @@ jobs:
         timeout-minutes: 30
     testdev-container:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-container
         steps:
             - name: Checkout
@@ -2036,7 +2036,7 @@ jobs:
         timeout-minutes: 30
     testdev-everything-else:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-everything-else
         steps:
             - name: Checkout
@@ -2294,7 +2294,7 @@ jobs:
         timeout-minutes: 30
     testdev-llm:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-LLM
         steps:
             - name: Checkout
@@ -2552,7 +2552,7 @@ jobs:
         timeout-minutes: 30
     testdev-module-runtimes:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-32c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-module-runtimes
         steps:
             - name: Checkout
@@ -2810,7 +2810,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-0-16c-dind-st' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout


### PR DESCRIPTION
As this is our second slowest test suite - `13m 20s` P90 for the last 2 weeks - and also most likely to flake, we (@sipsma  @jedevc) were curious to see how this behaves when everything is split.

FWIW, this provided some surprising results, so we want to dig a little bit more into the behaviour of this particular split:
- https://github.com/dagger/dagger/pull/9953

Builds on top of:
- https://github.com/dagger/dagger/pull/10086

---
We **may** not want to merge this, the primary reason for this PR is to inform.