### PR TITLE
for prompt mode: selectroot and module scoping

### DIFF
--- a/cmd/dagger/llm.go
+++ b/cmd/dagger/llm.go
@@ -97,6 +97,7 @@ func (s *LLMSession) reset() {
 	s.llm = s.dag.LLM(dagger.LLMOpts{Model: s.model}).
 		WithEnv(s.dag.Env(dagger.EnvOpts{
 			Privileged: true,
+			Module:     s.dag.CurrentModule().Source().AsModule(),
 		}))
 }
 

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -240,6 +240,7 @@ func (h *shellCallHandler) llmBuiltins() []*ShellCommand {
 				if h.llmSession == nil {
 					return fmt.Errorf("LLM not initialized")
 				}
+
 				h.llmSession = h.llmSession.Clear()
 				return nil
 			},

--- a/core/env.go
+++ b/core/env.go
@@ -26,6 +26,8 @@ type Env struct {
 	// Can be used to give the environment ambient access to the
 	// dagger core API, possibly extended by a module
 	root dagql.Object
+	// Initial selection for LLM
+	initialSelection dagql.Object
 }
 
 func (*Env) Type() *ast.Type {
@@ -72,6 +74,18 @@ func (env *Env) WithRoot(root dagql.Object) *Env {
 // Return the root object, or nil if no root object is set
 func (env *Env) Root() dagql.Object {
 	return env.root
+}
+
+// Set an initial selection for LLM
+func (env *Env) WithInitialSelection(selection dagql.Object) *Env {
+	env = env.Clone()
+	env.initialSelection = selection
+	return env
+}
+
+// Return the initial selection object, if any
+func (env *Env) InitialSelection() dagql.Object {
+	return env.initialSelection
 }
 
 // Add an input (read-only) binding to the environment

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -494,6 +494,27 @@ func (m *MCP) Call(ctx context.Context, tools []LLMTool, toolCall ToolCall) (str
 	}
 }
 
+func (m *MCP) selectRootBuiltin() LLMTool {
+	return LLMTool{
+		Name:        "selectRoot",
+		Description: "Return to the root Query or toplevel loaded module. Use this to back out from a selected object.",
+		Schema: map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{},
+			"strict":               true,
+			"additionalProperties": false,
+		},
+		Call: ToolFunc(func(ctx context.Context, args struct{}) (any, error) {
+			if m.env.Root() == nil {
+				return nil, fmt.Errorf("no root object available")
+			}
+			prev := m.Current()
+			m.Select(m.env.Root())
+			return m.currentState(prev)
+		}),
+	}
+}
+
 func (m *MCP) returnBuiltin() LLMTool {
 	props := map[string]any{}
 	required := []string{}
@@ -563,6 +584,9 @@ func (m *MCP) Builtins(srv *dagql.Server) ([]LLMTool, error) {
 	if len(m.env.outputsByName) > 0 {
 		builtins = append(builtins, m.returnBuiltin())
 	}
+
+	// Add the selectRoot tool
+	builtins = append(builtins, m.selectRootBuiltin())
 
 	for _, typeName := range m.env.Types() {
 		tools, err := m.tools(srv, typeName)

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -55,9 +55,14 @@ func newMCP(env *Env, endpoint *LLMEndpoint) *MCP {
 		env:          env,
 		functionMask: map[string]bool{},
 	}
-	if env.Root() != nil {
+	
+	// Set initial selection if available, otherwise use root
+	if env.initialSelection != nil {
+		m.Select(env.initialSelection)
+	} else if env.Root() != nil {
 		m.Select(env.Root())
 	}
+	
 	if endpoint != nil {
 		m.needsSystemPrompt = (endpoint.Provider == Google)
 	}

--- a/core/schema/env.go
+++ b/core/schema/env.go
@@ -18,6 +18,7 @@ func (s environmentSchema) Install() {
 	dagql.Fields[*core.Query]{
 		dagql.Func("env", s.environment).
 			ArgDoc("privileged", "Give the environment the same privileges as the caller: core API including host access, current module, and dependencies").
+			ArgDoc("module", "Set this module as the initial selection and fallback root").
 			Doc(`Initialize a new environment`),
 	}.Install(s.srv)
 	dagql.Fields[*core.Env]{
@@ -53,11 +54,35 @@ func (s environmentSchema) Install() {
 
 func (s environmentSchema) environment(ctx context.Context, parent *core.Query, args struct {
 	Privileged bool `default:"false"`
+	Module     dagql.Optional[core.ModuleID]
 }) (*core.Env, error) {
 	env := core.NewEnv()
+
+	// If module is provided, load it once
+	var moduleObj dagql.Object
+	if args.Module.Valid {
+		obj, err := s.srv.Load(ctx, args.Module.Value.ID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load module: %w", err)
+		}
+
+		module, ok := obj.(dagql.Object)
+		if !ok {
+			return nil, fmt.Errorf("unexpected module type: %T", obj)
+		}
+
+		moduleObj = module
+
+		// Set as initial selection
+		env = env.WithInitialSelection(moduleObj)
+	}
+
+	// Set the root based on privileged flag and module availability
 	if args.Privileged {
+		// In privileged mode, set the global root
 		env = env.WithRoot(s.srv.Root())
 	}
+
 	return env, nil
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3142,6 +3142,9 @@ type Query {
 
   """Initialize a new environment"""
   env(
+    """Set this module as the initial selection and fallback root"""
+    module: ModuleID
+
     """
     Give the environment the same privileges as the caller: core API including host access, current module, and dependencies
     """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -601,6 +601,12 @@
                     <tbody>
                       <tr>
                         <td>
+                          <span class="property-name"><code>module</code></span> - <span class="property-type"><a href="#definition-ModuleID"><code>ModuleID</code></a></span>
+                        </td>
+                        <td> Set this module as the initial selection and fallback root </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <span class="property-name"><code>privileged</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
                         </td>
                         <td> Give the environment the same privileges as the caller: core API including host access, current module, and dependencies. Default = <code>false</code> </td>

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -124,12 +124,14 @@ defmodule Dagger.Client do
   end
 
   @doc "Initialize a new environment"
-  @spec env(t(), [{:privileged, boolean() | nil}]) :: Dagger.Env.t()
+  @spec env(t(), [{:privileged, boolean() | nil}, {:module, Dagger.ModuleID.t() | nil}]) ::
+          Dagger.Env.t()
   def env(%__MODULE__{} = client, optional_args \\ []) do
     query_builder =
       client.query_builder
       |> QB.select("env")
       |> QB.maybe_put_arg("privileged", optional_args[:privileged])
+      |> QB.maybe_put_arg("module", optional_args[:module])
 
     %Dagger.Env{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -7898,6 +7898,8 @@ func (r *Client) Engine() *Engine {
 type EnvOpts struct {
 	// Give the environment the same privileges as the caller: core API including host access, current module, and dependencies
 	Privileged bool
+	// Set this module as the initial selection and fallback root
+	Module *Module
 }
 
 // Initialize a new environment
@@ -7907,6 +7909,10 @@ func (r *Client) Env(opts ...EnvOpts) *Env {
 		// `privileged` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Privileged) {
 			q = q.Arg("privileged", opts[i].Privileged)
+		}
+		// `module` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Module) {
+			q = q.Arg("module", opts[i].Module)
 		}
 	}
 

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -99,11 +99,14 @@ class Client extends Client\AbstractClient
     /**
      * Initialize a new environment
      */
-    public function env(?bool $privileged = false): Env
+    public function env(?bool $privileged = false, ModuleId|Module|null $module = null): Env
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('env');
         if (null !== $privileged) {
         $innerQueryBuilder->setArgument('privileged', $privileged);
+        }
+        if (null !== $module) {
+        $innerQueryBuilder->setArgument('module', $module);
         }
         return new \Dagger\Env($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -8247,7 +8247,12 @@ class Client(Root):
         _ctx = self._select("engine", _args)
         return Engine(_ctx)
 
-    def env(self, *, privileged: bool | None = False) -> Env:
+    def env(
+        self,
+        *,
+        privileged: bool | None = False,
+        module: Module | None = None,
+    ) -> Env:
         """Initialize a new environment
 
         Parameters
@@ -8255,9 +8260,12 @@ class Client(Root):
         privileged:
             Give the environment the same privileges as the caller: core API
             including host access, current module, and dependencies
+        module:
+            Set this module as the initial selection and fallback root
         """
         _args = [
             Arg("privileged", privileged, False),
+            Arg("module", module, None),
         ]
         _ctx = self._select("env", _args)
         return Env(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8001,6 +8001,9 @@ pub struct QueryContainerOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryEnvOpts {
+    /// Set this module as the initial selection and fallback root
+    #[builder(setter(into, strip_option), default)]
+    pub module: Option<ModuleId>,
     /// Give the environment the same privileges as the caller: core API including host access, current module, and dependencies
     #[builder(setter(into, strip_option), default)]
     pub privileged: Option<bool>,
@@ -8192,6 +8195,9 @@ impl Query {
         let mut query = self.selection.select("env");
         if let Some(privileged) = opts.privileged {
             query = query.arg("privileged", privileged);
+        }
+        if let Some(module) = opts.module {
+            query = query.arg("module", module);
         }
         Env {
             proc: self.proc.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1171,6 +1171,11 @@ export type ClientEnvOpts = {
    * Give the environment the same privileges as the caller: core API including host access, current module, and dependencies
    */
   privileged?: boolean
+
+  /**
+   * Set this module as the initial selection and fallback root
+   */
+  module?: Module_
 }
 
 export type ClientGitOpts = {
@@ -7499,6 +7504,7 @@ export class Client extends BaseClient {
   /**
    * Initialize a new environment
    * @param opts.privileged Give the environment the same privileges as the caller: core API including host access, current module, and dependencies
+   * @param opts.module Set this module as the initial selection and fallback root
    */
   env = (opts?: ClientEnvOpts): Env => {
     const ctx = this._ctx.select("env", { ...opts })


### PR DESCRIPTION
this PR adds a selectRoot tool and the ability for Environments to specify an initial selection for an LLM. The idea here is that the default behavior for the dagger shell should be to drop the llm into the module, but also give the llm the ability to back out to the core API. 

this is currently broken because i'm trying to pass a module to dagql to construct an environment, but trying to get a module in the shell context via dag.CurrentModule() chokes- presumably that function is intended to run in an SDK module container?