### PR TITLE
fix: handle empty argument case in shell completion

### DIFF
--- a/cmd/dagger/shell_completion.go
+++ b/cmd/dagger/shell_completion.go
@@ -156,6 +156,9 @@ func (h *shellAutoComplete) dispatchCall(previous *CompletionContext, call *synt
 	for _, arg := range call.Args {
 		args = append(args, arg.Lit())
 	}
+	if len(args) == 0 {
+		return previous
+	}
 	return previous.lookupField(args[0], args[1:])
 }
 

--- a/cmd/dagger/shell_completion_test.go
+++ b/cmd/dagger/shell_completion_test.go
@@ -73,6 +73,15 @@ func (DaggerCMDSuite) TestShellAutocomplete(ctx context.Context, t *testctx.T) {
 		`container | with-directory $(container | <dir$ectory >`,
 
 		// args
+		// FIXME: should not have any completions
+		// `container <$>`,
+		`container <$container>`,
+		`container | with-directory $(container <$>`,
+		// FIXME: should not have any completions
+		// `dir=$(container <$>`,
+		`dir=$(container <$container>`,
+
+		// flags
 		`container <--$packages >`,
 		`container <--$packages > | directory`,
 		`container | directory <--$expand >`,
@@ -142,15 +151,19 @@ func (DaggerCMDSuite) TestShellAutocomplete(ctx context.Context, t *testctx.T) {
 			cursor := start + len(inprogress)
 
 			_, comp := autoComplete.Do([][]rune{[]rune(cmdline)}, 0, cursor)
-			require.NotNil(t, comp)
-			require.Equal(t, 1, comp.NumCategories())
-			candidates := make([]string, 0, comp.NumEntries(0))
-			for i := 0; i < comp.NumEntries(0); i++ {
-				entry := comp.Entry(0, i)
-				t.Logf("entry %d: %s (%q)", i, entry.Title(), entry.Description())
-				candidates = append(candidates, entry.Title())
+			if expected == "" {
+				require.Nil(t, comp)
+			} else {
+				require.NotNil(t, comp)
+				require.Equal(t, 1, comp.NumCategories())
+				candidates := make([]string, 0, comp.NumEntries(0))
+				for i := range comp.NumEntries(0) {
+					entry := comp.Entry(0, i)
+					t.Logf("entry %d: %s (%q)", i, entry.Title(), entry.Description())
+					candidates = append(candidates, entry.Title())
+				}
+				require.Contains(t, candidates, expected)
 			}
-			require.Contains(t, candidates, expected)
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10107.

This is my first PR, please let me know if I am missing something. 

This PR addresses bug where the shell was crashing due to a slice bounds out of range [1:0] error in `dispatchCall`, caused by accessing `args[0]` when `call.Args` is empty.