### PR TITLE
docs: fix linting in new python/typescript snippets

### DIFF
--- a/docs/current_docs/cookbook/snippets/mount-dir/python/main.py
+++ b/docs/current_docs/cookbook/snippets/mount-dir/python/main.py
@@ -11,4 +11,8 @@ class MyModule:
         self, source: Annotated[dagger.Directory, Doc("Source directory")]
     ) -> dagger.Container:
         """Return a container with a mounted directory"""
-        return dag.container().from_("alpine:latest").with_mounted_directory("/src", source)
+        return (
+            dag.container()
+            .from_("alpine:latest")
+            .with_mounted_directory("/src", source)
+        )

--- a/docs/current_docs/cookbook/snippets/mount-dir/typescript/index.ts
+++ b/docs/current_docs/cookbook/snippets/mount-dir/typescript/index.ts
@@ -12,6 +12,9 @@ class MyModule {
      */
     source: Directory,
   ): Container {
-    return dag.container().from("alpine:latest").withMountedDirectory("/src", source)
+    return dag
+      .container()
+      .from("alpine:latest")
+      .withMountedDirectory("/src", source)
   }
 }

--- a/docs/current_docs/cookbook/snippets/mount-file/python/main.py
+++ b/docs/current_docs/cookbook/snippets/mount-file/python/main.py
@@ -13,4 +13,6 @@ class MyModule:
     ) -> dagger.Container:
         """Return a container with a mounted file"""
         name = await f.name()
-        return dag.container().from_("alpine:latest").with_mounted_file(f"/src/{name}", f)
+        return (
+            dag.container().from_("alpine:latest").with_mounted_file(f"/src/{name}", f)
+        )

--- a/docs/current_docs/cookbook/snippets/mount-file/typescript/index.ts
+++ b/docs/current_docs/cookbook/snippets/mount-file/typescript/index.ts
@@ -13,6 +13,9 @@ class MyModule {
     f: File,
   ): Promise<Container> {
     const name = await f.name()
-    return dag.container().from("alpine:latest").withMountedFile(`/src/${name}`, f)
+    return dag
+      .container()
+      .from("alpine:latest")
+      .withMountedFile(`/src/${name}`, f)
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/dagger/dagger/pull/10074

This is currently broken on `main`:
- https://v3.dagger.cloud/dagger/traces/978148f6e9e50d1e5eb8b427067a3de5
- https://v3.dagger.cloud/dagger/traces/acb32e58ce53918ea8591cd952ae23c9