### PR TITLE
fix: mcp module description regression

### DIFF
--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -88,7 +88,7 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 		q = q.Select("with"+modDef.MainObject.AsObject.Name+"Input").
 			Arg("name", modName).
 			Arg("value", modID).
-			Arg("description", "module to expose as an MCP server").
+			Arg("description", modDef.MainObject.Description()).
 			Select("id")
 
 		logMsg = fmt.Sprintf("Exposing module %q%s as an MCP server on standard input/output", modName, extraCore)


### PR DESCRIPTION
When rebasing #10090 (and fixing the conflicts), I mistakenly removed the fix from #10111.

cc @tiborvass 