### PR TITLE
helm: enable using persistent volume claims in DaemonSet

### DIFF
--- a/helm/dagger/.changes/unreleased/Breaking-20250411-114148.yaml
+++ b/helm/dagger/.changes/unreleased/Breaking-20250411-114148.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: 'helm: Enable using persistent volume claims in DaemonSet'
+time: 2025-04-11T11:41:48.535164+01:00
+custom:
+    Author: vmaffet
+    PR: "10138"

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -122,7 +122,7 @@ spec:
             {{- end }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.engine.hostPath.dataVolume.enabled }}
+            {{- if (or .Values.engine.hostPath.dataVolume.enabled .Values.engine.persistentVolumeClaim.enabled) }}
             - name: varlibdagger
               mountPath: /var/lib/dagger
             {{- end }}
@@ -149,6 +149,16 @@ spec:
         - name: varlibdagger
           hostPath:
             path: /var/lib/dagger-{{ include "dagger.fullname" . }}
+        {{- end }}
+        {{- if .Values.engine.persistentVolumeClaim.enabled }}
+        - name: varlibdagger
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  type: varlibdagger
+              spec:
+                {{- toYaml .Values.engine.persistentVolumeClaim.volumeClaimTemplate | nindent 16 }}
         {{- end }}
         {{- if .Values.engine.hostPath.runVolume.enabled }}
         - name: varrundagger

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -16,10 +16,9 @@ spec:
   selector:
     matchLabels:
       name: {{ include "dagger.fullname" . }}-engine
-  {{- if and .Values.engine.statefulSet.persistentVolumeClaim.enabled .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy }}
+  {{- if and .Values.engine.persistentVolumeClaim.enabled .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
-    whenDeleted: {{ .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy.whenDeleted }}
-    whenScaled: {{ .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy.whenScaled }}
+    {{- toYaml .Values.engine.statefulSet.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -132,8 +131,10 @@ spec:
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}
           volumeMounts:
+            {{- if (or .Values.engine.hostPath.dataVolume.enabled .Values.engine.persistentVolumeClaim.enabled) }}
             - name: data
               mountPath: /var/lib/dagger
+            {{- end }}
             {{- if .Values.engine.hostPath.runVolume.enabled }}
             - name: run
               mountPath: /run/dagger
@@ -180,17 +181,11 @@ spec:
         {{- with .Values.engine.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-  {{- if .Values.engine.statefulSet.persistentVolumeClaim.enabled }}
+  {{- if .Values.engine.persistentVolumeClaim.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      {{- with .Values.engine.statefulSet.persistentVolumeClaim.storageClassName }}
-      storageClassName: {{ . }}
-      {{- end }}
-      accessModes:
-        {{- toYaml .Values.engine.statefulSet.persistentVolumeClaim.accessModes | nindent 8 }}
-      resources:
-        {{- toYaml .Values.engine.statefulSet.persistentVolumeClaim.resources | nindent 8 }}
+      {{- toYaml .Values.engine.persistentVolumeClaim.volumeClaimTemplate | nindent 6 }}
   {{- end }}
 {{- end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -46,17 +46,6 @@ engine:
       # Options: Delete, Retain
       whenScaled: Retain
 
-    # Use PersistentVolumeClaim for data volume
-    persistentVolumeClaim:
-      enabled: false
-      # PVC specifications
-      storageClassName: ""
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 10Gi
-
     # Controls how pods are created during initial scale up,
     # when replacing pods, and when scaling down.
     # Options: OrderedReady, Parallel (default: OrderedReady)
@@ -150,13 +139,28 @@ engine:
   hostPath:
     # Use hostPath for data volume
     dataVolume:
-      # When disabled, PVC will be used if configured above
+      # When disabled, PVC will be used if configured below
       enabled: true
 
     # Use hostPath for run volume
     runVolume:
       # When disabled, no run volume will be mounted
       enabled: true
+
+  ### Persistent Volume Claim configuration
+  #
+  persistentVolumeClaim:
+    # Use PersistentVolumeClaim for data volume
+    enabled: false
+
+    # PVC specification
+    volumeClaimTemplate:
+      # storageClassName: ""
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
 
   ### Additional volumes to mount in the Dagger Engine container
   #


### PR DESCRIPTION
This PR enables using PVCs as ephemeral storage for the cache in DaemonSets

⚠️  This moves the following parameters in the values file as pvc are no longer specific to statefulSets
From:
```yaml
engine:
  statefulSet:
    persistentVolumeClaim:
      enabled: false

      # PVC specifications
      storageClassName: ""
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```

To:
```yaml
engine:
  persistentVolumeClaim:
    enabled: false

    # PVC specifications
    volumeClaimTemplate:
      # storageClassName: ""
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```