### PR TITLE
docs: Edit python clone-git-repo shown in code tab

### DIFF
--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -395,7 +395,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 </TabItem>
 <TabItem value="Python">
 
-```python file=./snippets/clone-git-repository-ssh/python/main.py
+```python file=./snippets/clone-git-repository/python/main.py
 ```
 
 </TabItem>


### PR DESCRIPTION
The snippets tab shows Python code for SSH in both cases. This updates the sample code tab to show the correct code.