### PR TITLE
fix: don't panic in cmd/init

### DIFF
--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -332,7 +332,7 @@ defmodule Dagger.ClientTest do
              |> Sync.sync()
 
     assert Exception.message(error) ==
-             "input: container.from.withExec.sync process \"foobar\" did not complete successfully: exit code: 2"
+             "input: container.from.withExec.sync process \"foobar\" did not complete successfully: exit code: 1"
   end
 
   test "iss 8601 - Dagger.Directory.with_directory/4 should not crash", %{dag: dag} do


### PR DESCRIPTION
Technically, we *are* error handling, we should take these errors and print them nicely, and exit correctly.

We've had bug reports that mention the `panic`, and interpret it as being a dagger internal error. This seems fair, `panic` should be reserved for exceptional + unrecoverable scenarios (not ones that can be caused by users by passing bad input, like trying to execute a program that's not in the `PATH`).