### PR TITLE
simplify agent quickstart to not require toy-workspace

### DIFF
--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -129,6 +129,6 @@ Consider the following Dagger Function:
 </TabItem>
 </Tabs>
 
-Here, an instance of the `ToyWorkspace` module is attached as an input to the `Env` environment. The `ToyWorkspace` module contains a number of Dagger Functions for developing code: `Read()`, `Write()`, and `Build()`. When this environment is attached to an `LLM`, the LLM can call any of these Dagger Functions to change the state of the `ToyWorkspace` and complete the assigned task.
+Here, an instance a `Container` is attached as an input to the `Env` environment. The `Container` is a core type with a number of functions useful for a coding environment such as `WithNewFile()`, `File().Contents()`, and `WithExec()`. When this environment is attached to an `LLM`, the LLM can call any of these Dagger Functions to change the state of the `Container` and complete the assigned task.
 
-In the `Env`, a `ToyWorkspace` instance called `after` is specified as a desired output of the LLM. This means that the LLM should return the `ToyWorkspace` module instance as a result of completing its task. The resulting `ToyWorkspace` object is then available for further processing or for use in other Dagger Functions.
+In the `Env`, a `Container` instance called `completed` is specified as a desired output of the LLM. This means that the LLM should return the `Container` instance as a result of completing its task. The resulting `Container` object is then available for further processing or for use in other Dagger Functions.

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -96,21 +96,6 @@ dagger functions
 
 You should see information about two auto-generated Dagger Functions: `container-echo` and `grep-dir`.
 
-## Install a dependency with useful tools
-
-An agent needs tools to complete its tasks. The agent uses this module to solve the assignment given to it. Agents can use any Dagger module as tools, which you can either create yourself or use from elsewhere.
-
-This quickstart uses a pre-created Dagger module, which must be installed as a dependency:
-
-```shell
-dagger install github.com/shykes/toy-programmer/toy-workspace
-```
-
-Here, `toy-workspace` is a Dagger module that provides a simple set of tools for the agent. It has a `Container` object and functions to read, write, and build the code produced by the agent. The `toy-workspace` is provided as an input to the environment of the LLM.
-
-:::tip
-Learn more about [agent environments](../../api/llm.mdx#environments-and-tools).
-:::
 
 ## Create the agent
 
@@ -161,10 +146,15 @@ Edit the agent (`src/main/java/io/dagger/modules/codingagent/CodingAgent.java`) 
 
 This code creates a Dagger Function called `go-program` that takes an assignment as input and returns a `Container` with the result of the assignment.
 
-- The `ToyWorkspace` module is given to the LLM in an environment. It contains various Dagger Functions to write and validate code.
-- A pre-defined prompt is also given to the LLM as input. The description of assigment is a way of providing usage for the input.
-- The LLM will use the Dagger Functions in the `ToyWorkspace` module as tools to write code, validate it, and loop until the code passes validation.
-- Once complete, a `ToyWorkspace` is returned by the LLM with the solution. The container with the LLM's solution can then be obtained by chaining calls to `toy-workspace -> container`.
+- The variable `environment` is the environment to define inputs and outputs for the agent. Each input and output provides a description which acts as a declarative form of prompting.
+- The input `builder` is a `Container`. This provides a workspace for the agent to create files and execute commands like `go build`.
+- The output `completed` signals the agent that it should return a `Container` representing the completed assignment
+- The `environment` is given to an instance of an `LLM` with a prompt describing how it should complete it's work. Prompting can vary depending on which model is being used, and generally requires some experimentation.
+- When the `LLM` decides it is finished, the `Container` `completed` is seleted from the `Env` outputs and returned.
+
+:::tip
+Learn more about [agent environments](../../api/llm.mdx#environments-and-tools).
+:::
 
 ## Run the agent
 
@@ -196,7 +186,7 @@ You'll see the agent receive the prompt, write code, validate it, and return a `
 
 If you signed up for Dagger Cloud, the output of the previous command would have also included a link to visualize the workflow run on Dagger Cloud. Click the link in your browser to see a complete breakdown of the steps performed by the agent.
 
-If the agent fails to write code that passes validation, try adding more helpful guidance to the prompt.
+If the agent fails to write code that passes validation, try adding more helpful guidance to the prompt. If you see an error like "binding value is nil" this means that the `LLM` did not return a value for `completed`. Try adjusting the prompt to make sure the `LLM` completes the assignment and returns a `Container`.
 
 Once the agent has successfully returned a `Container`, open an interactive terminal in the container so that you can inspect its work and run the generated code. Notice that the solution is not recomputed since it is still cached from the previous execution:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -149,11 +149,11 @@ This code creates a Dagger Function called `go-program` that takes an assignment
 - The variable `environment` is the environment to define inputs and outputs for the agent. Each input and output provides a description which acts as a declarative form of prompting.
 - The input `builder` is a `Container`. This provides a workspace for the agent to create files and execute commands like `go build`.
 - The output `completed` signals the agent that it should return a `Container` representing the completed assignment
-- The `environment` is given to an instance of an `LLM` with a prompt describing how it should complete it's work. Prompting can vary depending on which model is being used, and generally requires some experimentation.
-- When the `LLM` decides it is finished, the `Container` `completed` is seleted from the `Env` outputs and returned.
+- The `environment` is given to an instance of an LLM with a prompt describing how it should complete its work. Prompting can vary depending on which model is being used, and generally requires some experimentation.
+- When the LLM decides it is finished, the `completed` container is selected from the `Env` outputs and returned.
 
 :::tip
-Learn more about [agent environments](../../api/llm.mdx#environments-and-tools).
+Learn more about [agent environments](/api/llm#environments).
 :::
 
 ## Run the agent
@@ -186,7 +186,7 @@ You'll see the agent receive the prompt, write code, validate it, and return a `
 
 If you signed up for Dagger Cloud, the output of the previous command would have also included a link to visualize the workflow run on Dagger Cloud. Click the link in your browser to see a complete breakdown of the steps performed by the agent.
 
-If the agent fails to write code that passes validation, try adding more helpful guidance to the prompt. If you see an error like "binding value is nil" this means that the `LLM` did not return a value for `completed`. Try adjusting the prompt to make sure the `LLM` completes the assignment and returns a `Container`.
+If the agent fails to write code that passes validation, try adding more helpful guidance to the prompt. If you see an error like "binding value is nil" this means that the LLM did not return a value for `completed`. Try adjusting the prompt to make sure the LLM completes the assignment and returns a `Container`.
 
 Once the agent has successfully returned a `Container`, open an interactive terminal in the container so that you can inspect its work and run the generated code. Notice that the solution is not recomputed since it is still cached from the previous execution:
 

--- a/docs/current_docs/quickstart/agent/snippets/go/dagger.json
+++ b/docs/current_docs/quickstart/agent/snippets/go/dagger.json
@@ -1,14 +1,7 @@
 {
   "name": "coding-agent",
-  "engineVersion": "v0.18.0",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "go"
-  },
-  "dependencies": [
-    {
-      "name": "toy-workspace",
-      "source": "github.com/shykes/toy-programmer/toy-workspace",
-      "pin": "672f09ff9ad3ba8c709c7d10757cd09d410b9b68"
-    }
-  ]
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/go/main.go
+++ b/docs/current_docs/quickstart/agent/snippets/go/main.go
@@ -11,21 +11,25 @@ func (m *CodingAgent) GoProgram(
 	// The programming assignment, e.g. "write me a curl clone"
 	assignment string,
 ) *dagger.Container {
-	workspace := dag.ToyWorkspace()
 	environment := dag.Env().
-		WithToyWorkspaceInput("before", workspace, "tools to complete the assignment").
 		WithStringInput("assignment", assignment, "the assignment to complete").
-		WithToyWorkspaceOutput("after", "the completed assignment")
+		WithContainerInput("builder",
+			dag.Container().From("golang").WithWorkdir("/app"),
+			"a container to use for building go code").
+		WithContainerOutput("completed", "the completed assignment in the golang container")
 
-	return dag.LLM().
+	work := dag.LLM().
 		WithEnv(environment).
 		WithPrompt(`
-			You are an expert go programmer. You have access to a workspace.
-			Use the default directory in the workspace.
-			Do not stop until the code builds.
-			Your assignment is: $assignment`).
+			You are an expert Go programmer with an assignment to create a go program
+			Create files in the default directory in $builder
+			Always build the code to make sure it is valid
+			Do not stop until your assignment is completed and the code builds
+			Your assignment is: $assignment
+			`)
+
+	return work.
 		Env().
-		Output("after").
-		AsToyWorkspace().
-		Container()
+		Output("completed").
+		AsContainer()
 }

--- a/docs/current_docs/quickstart/agent/snippets/go/main.go
+++ b/docs/current_docs/quickstart/agent/snippets/go/main.go
@@ -15,13 +15,13 @@ func (m *CodingAgent) GoProgram(
 		WithStringInput("assignment", assignment, "the assignment to complete").
 		WithContainerInput("builder",
 			dag.Container().From("golang").WithWorkdir("/app"),
-			"a container to use for building go code").
-		WithContainerOutput("completed", "the completed assignment in the golang container")
+			"a container to use for building Go code").
+		WithContainerOutput("completed", "the completed assignment in the Golang container")
 
 	work := dag.LLM().
 		WithEnv(environment).
 		WithPrompt(`
-			You are an expert Go programmer with an assignment to create a go program
+			You are an expert Go programmer with an assignment to create a Go program
 			Create files in the default directory in $builder
 			Always build the code to make sure it is valid
 			Do not stop until your assignment is completed and the code builds

--- a/docs/current_docs/quickstart/agent/snippets/java/dagger.json
+++ b/docs/current_docs/quickstart/agent/snippets/java/dagger.json
@@ -1,14 +1,7 @@
 {
   "name": "coding-agent",
-  "engineVersion": "v0.18.0",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "java"
-  },
-  "dependencies": [
-    {
-      "name": "toy-workspace",
-      "source": "github.com/shykes/toy-programmer/toy-workspace",
-      "pin": "672f09ff9ad3ba8c709c7d10757cd09d410b9b68"
-    }
-  ]
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
+++ b/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
@@ -15,13 +15,13 @@ public class CodingAgent {
   public Container goProgram(String assignment) {
     Env environment = dag().env()
         .withStringInput("assignment", assignment, "the assignment to complete")
-        .withContainerInput("builder", dag().container().from("golang").withWorkdir("/app"), "a container to use for building go code")
-        .withContainerOutput("completed", "the completed assignment in the golang container");
+        .withContainerInput("builder", dag().container().from("golang").withWorkdir("/app"), "a container to use for building Go code")
+        .withContainerOutput("completed", "the completed assignment in the Golang container");
     return dag()
       .llm()
       .withEnv(environment)
       .withPrompt("""
-        You are an expert Go programmer with an assignment to create a go program
+        You are an expert Go programmer with an assignment to create a Go program
         Create files in the default directory in $builder
         Always build the code to make sure it is valid
         Do not stop until your assignment is completed and the code builds

--- a/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
+++ b/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
@@ -3,7 +3,6 @@ package io.dagger.modules.codingagent;
 import static io.dagger.client.Dagger.dag;
 
 import io.dagger.client.Container;
-import io.dagger.client.ToyWorkspace;
 import io.dagger.client.Env;
 import io.dagger.module.annotation.Function;
 import io.dagger.module.annotation.Object;
@@ -14,23 +13,22 @@ public class CodingAgent {
   /** Write a Go program */
   @Function
   public Container goProgram(String assignment) {
-    ToyWorkspace workspace = dag().toyWorkspace();
     Env environment = dag().env()
-        .withToyWorkspaceInput("before", workspace, "tools to complete the assignment")
         .withStringInput("assignment", assignment, "the assignment to complete")
-        .withToyWorkspaceOutput("after", "the completed assignment");
+        .withContainerInput("builder", dag().container().from("golang").withWorkdir("/app"), "a container to use for building go code")
+        .withContainerOutput("completed", "the completed assignment in the golang container");
     return dag()
       .llm()
       .withEnv(environment)
       .withPrompt("""
-        You are an expert go programmer. You have access to a workspace.
-        Use the default directory in the workspace.
-        Do not stop until the code builds.
-        Your assignment is: $assignment
+        You are an expert Go programmer with an assignment to create a go program
+		Create files in the default directory in $builder
+		Always build the code to make sure it is valid
+		Do not stop until your assignment is completed and the code builds
+		Your assignment is: $assignment
         """)
       .env()
-      .output("after")
-      .asToyWorkspace()
-      .container();
+      .output("completed")
+      .asContainer();
   }
 }

--- a/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
+++ b/docs/current_docs/quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
@@ -22,10 +22,10 @@ public class CodingAgent {
       .withEnv(environment)
       .withPrompt("""
         You are an expert Go programmer with an assignment to create a go program
-		Create files in the default directory in $builder
-		Always build the code to make sure it is valid
-		Do not stop until your assignment is completed and the code builds
-		Your assignment is: $assignment
+        Create files in the default directory in $builder
+        Always build the code to make sure it is valid
+        Do not stop until your assignment is completed and the code builds
+        Your assignment is: $assignment
         """)
       .env()
       .output("completed")

--- a/docs/current_docs/quickstart/agent/snippets/php/dagger.json
+++ b/docs/current_docs/quickstart/agent/snippets/php/dagger.json
@@ -1,14 +1,7 @@
 {
   "name": "coding-agent",
-  "engineVersion": "v0.18.0",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "php"
-  },
-  "dependencies": [
-    {
-      "name": "toy-workspace",
-      "source": "github.com/shykes/toy-programmer/toy-workspace",
-      "pin": "672f09ff9ad3ba8c709c7d10757cd09d410b9b68"
-    }
-  ]
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
+++ b/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
@@ -20,20 +20,20 @@ class CodingAgent
     public function goProgram(string $assignment): Container
     {
         $environment = dag()->env()
-            ->withStringInput("assignment", $assignment, "the assignment to complete")
-            ->withContainerInput("builder", dag()->container()->from("golang")->withWorkdir("/app"), "a container to use for building go code")
-            ->withContainerOutput("completed", "the completed assignment in the golang container");
+            ->withStringInput('assignment', $assignment, 'the assignment to complete')
+            ->withContainerInput('builder', dag()->container()->from('golang')->withWorkdir('/app'), 'a container to use for building Go code')
+            ->withContainerOutput('completed', 'the completed assignment in the Golang container');
         return dag()
             ->llm()
             ->withEnv($environment)
-            ->withPrompt("
-                You are an expert Go programmer with an assignment to create a go program
+            ->withPrompt('
+                You are an expert Go programmer with an assignment to create a Go program
                 Create files in the default directory in $builder
                 Always build the code to make sure it is valid
                 Do not stop until your assignment is completed and the code builds
-                Your assignment is: $assignment")
+                Your assignment is: $assignment')
             ->env()
-            ->output("completed")
+            ->output('completed')
             ->asContainer();
     }
 }

--- a/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
+++ b/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
@@ -27,11 +27,11 @@ class CodingAgent
             ->llm()
             ->withEnv($environment)
             ->withPrompt("
-            You are an expert Go programmer with an assignment to create a go program
-			Create files in the default directory in $builder
-			Always build the code to make sure it is valid
-			Do not stop until your assignment is completed and the code builds
-			Your assignment is: $assignment")
+                You are an expert Go programmer with an assignment to create a go program
+                Create files in the default directory in $builder
+                Always build the code to make sure it is valid
+                Do not stop until your assignment is completed and the code builds
+                Your assignment is: $assignment")
             ->env()
             ->output("completed")
             ->asContainer();

--- a/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
+++ b/docs/current_docs/quickstart/agent/snippets/php/src/CodingAgent.php
@@ -19,22 +19,21 @@ class CodingAgent
     #[Doc('Write a Go program')]
     public function goProgram(string $assignment): Container
     {
-        $workspace = dag()->toyWorkspace();
         $environment = dag()->env()
-            ->withToyWorkspaceInput("before", $workspace, "tools to complete the assignment")
             ->withStringInput("assignment", $assignment, "the assignment to complete")
-            ->withToyWorkspaceOutput("after", "the completed assignment");
+            ->withContainerInput("builder", dag()->container()->from("golang")->withWorkdir("/app"), "a container to use for building go code")
+            ->withContainerOutput("completed", "the completed assignment in the golang container");
         return dag()
             ->llm()
             ->withEnv($environment)
             ->withPrompt("
-            You are an expert go programmer. You have access to a workspace.
-			Use the default directory in the workspace.
-			Do not stop until the code builds.
+            You are an expert Go programmer with an assignment to create a go program
+			Create files in the default directory in $builder
+			Always build the code to make sure it is valid
+			Do not stop until your assignment is completed and the code builds
 			Your assignment is: $assignment")
             ->env()
-            ->output("after")
-            ->asToyWorkspace()
-            ->container();
+            ->output("completed")
+            ->asContainer();
     }
 }

--- a/docs/current_docs/quickstart/agent/snippets/python/dagger.json
+++ b/docs/current_docs/quickstart/agent/snippets/python/dagger.json
@@ -1,14 +1,7 @@
 {
   "name": "coding-agent",
-  "engineVersion": "v0.18.0",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "python"
-  },
-  "dependencies": [
-    {
-      "name": "toy-workspace",
-      "source": "github.com/shykes/toy-programmer/toy-workspace",
-      "pin": "672f09ff9ad3ba8c709c7d10757cd09d410b9b68"
-    }
-  ]
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
+++ b/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
@@ -14,9 +14,13 @@ class CodingAgent:
             dag.env()
             .with_string_input("assignment", assignment, "the assignment to complete")
             .with_container_input(
-                "builder", dag.container().from_("golang").with_workdir("/app"), "a container to use for building go code"
+                "builder",
+                dag.container().from_("golang").with_workdir("/app"),
+                "a container to use for building go code",
             )
-            .with_container_output("completed", "the completed assignment in the golang container")
+            .with_container_output(
+                "completed", "the completed assignment in the golang container"
+            )
         )
 
         work = (
@@ -24,7 +28,8 @@ class CodingAgent:
             .with_env(environment)
             .with_prompt(
                 """
-                You are an expert Go programmer with an assignment to create a go program
+                You are an expert Go programmer
+                with an assignment to create a go program
                 Create files in the default directory in $builder
                 Always build the code to make sure it is valid
                 Do not stop until your assignment is completed and the code builds
@@ -32,9 +37,4 @@ class CodingAgent:
             )
         )
 
-        return (
-            work
-            .env()
-            .output("completed")
-            .as_container()
-        )
+        return work.env().output("completed").as_container()

--- a/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
+++ b/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
@@ -1,6 +1,5 @@
 import dagger
 from dagger import dag, function, object_type
-from pylsp.plugins.signature import GOOGLE
 
 
 @object_type

--- a/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
+++ b/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
@@ -1,5 +1,6 @@
 import dagger
 from dagger import dag, function, object_type
+from pylsp.plugins.signature import GOOGLE
 
 
 @object_type
@@ -16,10 +17,10 @@ class CodingAgent:
             .with_container_input(
                 "builder",
                 dag.container().from_("golang").with_workdir("/app"),
-                "a container to use for building go code",
+                "a container to use for building Go code",
             )
             .with_container_output(
-                "completed", "the completed assignment in the golang container"
+                "completed", "the completed assignment in the Golang container"
             )
         )
 
@@ -29,7 +30,7 @@ class CodingAgent:
             .with_prompt(
                 """
                 You are an expert Go programmer
-                with an assignment to create a go program
+                with an assignment to create a Go program
                 Create files in the default directory in $builder
                 Always build the code to make sure it is valid
                 Do not stop until your assignment is completed and the code builds

--- a/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
+++ b/docs/current_docs/quickstart/agent/snippets/python/src/coding_agent/main.py
@@ -24,11 +24,11 @@ class CodingAgent:
             .with_env(environment)
             .with_prompt(
                 """
-            You are an expert Go programmer with an assignment to create a go program
-			Create files in the default directory in $builder
-			Always build the code to make sure it is valid
-			Do not stop until your assignment is completed and the code builds
-			Your assignment is: $assignment"""
+                You are an expert Go programmer with an assignment to create a go program
+                Create files in the default directory in $builder
+                Always build the code to make sure it is valid
+                Do not stop until your assignment is completed and the code builds
+                Your assignment is: $assignment"""
             )
         )
 

--- a/docs/current_docs/quickstart/agent/snippets/typescript/dagger.json
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/dagger.json
@@ -1,14 +1,7 @@
 {
   "name": "coding-agent",
-  "engineVersion": "v0.17.0",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "typescript"
-  },
-  "dependencies": [
-    {
-      "name": "toy-workspace",
-      "source": "github.com/shykes/toy-programmer/toy-workspace",
-      "pin": "672f09ff9ad3ba8c709c7d10757cd09d410b9b68"
-    }
-  ]
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
@@ -15,8 +15,15 @@ export class CodingAgent {
     const environment = dag
       .env()
       .withStringInput("assignment", assignment, "the assignment to complete")
-      .withContainerInput("builder", dag.container().from("golang").withWorkdir("/app"), "a container to use for building go code")
-      .withContainerOutput("completed", "the completed assignment in the golang container")
+      .withContainerInput(
+        "builder",
+        dag.container().from("golang").withWorkdir("/app"),
+        "a container to use for building go code",
+      )
+      .withContainerOutput(
+        "completed",
+        "the completed assignment in the golang container",
+      )
 
     const work = dag
       .llm()
@@ -29,9 +36,6 @@ export class CodingAgent {
         Your assignment is: $assignment`,
       )
 
-    return work
-      .env()
-      .output("completed")
-      .asContainer()
+    return work.env().output("completed").asContainer()
   }
 }

--- a/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
@@ -18,18 +18,18 @@ export class CodingAgent {
       .withContainerInput(
         "builder",
         dag.container().from("golang").withWorkdir("/app"),
-        "a container to use for building go code",
+        "a container to use for building Go code",
       )
       .withContainerOutput(
         "completed",
-        "the completed assignment in the golang container",
+        "the completed assignment in the Golang container",
       )
 
     const work = dag
       .llm()
       .withEnv(environment)
       .withPrompt(
-        `You are an expert Go programmer with an assignment to create a go program
+        `You are an expert Go programmer with an assignment to create a Go program
         Create files in the default directory in $builder
         Always build the code to make sure it is valid
         Do not stop until your assignment is completed and the code builds

--- a/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
@@ -12,29 +12,26 @@ export class CodingAgent {
      */
     assignment: string,
   ): Container {
-    const workspace = dag.toyWorkspace()
     const environment = dag
       .env()
-      .withToyWorkspaceInput(
-        "before",
-        workspace,
-        "tools to complete the assignment",
-      )
       .withStringInput("assignment", assignment, "the assignment to complete")
-      .withToyWorkspaceOutput("after", "the completed assignment")
+      .withContainerInput("builder", dag.container().from("golang").withWorkdir("/app"), "a container to use for building go code")
+      .withContainerOutput("completed", "the completed assignment in the golang container")
 
-    return dag
+    const work = dag
       .llm()
       .withEnv(environment)
       .withPrompt(
-        `You are an expert go programmer. You have access to a workspace.
-        Use the default directory in the workspace.
-        Do not stop until the code builds.
-        Your assignment is: $assignment`,
+        `You are an expert Go programmer with an assignment to create a go program
+			Create files in the default directory in $builder
+			Always build the code to make sure it is valid
+			Do not stop until your assignment is completed and the code builds
+			Your assignment is: $assignment`,
       )
+
+    return work
       .env()
-      .output("after")
-      .asToyWorkspace()
-      .container()
+      .output("completed")
+      .asContainer()
   }
 }

--- a/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/src/index.ts
@@ -23,10 +23,10 @@ export class CodingAgent {
       .withEnv(environment)
       .withPrompt(
         `You are an expert Go programmer with an assignment to create a go program
-			Create files in the default directory in $builder
-			Always build the code to make sure it is valid
-			Do not stop until your assignment is completed and the code builds
-			Your assignment is: $assignment`,
+        Create files in the default directory in $builder
+        Always build the code to make sure it is valid
+        Do not stop until your assignment is completed and the code builds
+        Your assignment is: $assignment`,
       )
 
     return work


### PR DESCRIPTION
As of 0.18.3 the core types like `Container` are more reliable to use directly. This removes the need to use something like `toy-workspace` for a simple agent like the quickstart.

For more advanced agents a focused tools module is still important. This will come up in the new agent quickstarts part 2 and 3.

Test with:

```
dagger call -m github.com/dagger/dagger/docs@pull/10167/head server up
```