### PR TITLE
connect nested session attachables through http API

### DIFF
--- a/.changes/unreleased/Fixed-20250421-145347.yaml
+++ b/.changes/unreleased/Fixed-20250421-145347.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix "session not found" errors when invoking modules.
+time: 2025-04-21T14:53:47.33409304-07:00
+custom:
+  Author: sipsma
+  PR: "10168"

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -106,6 +106,10 @@ type ExecutionMetadata struct {
 	// list of remote modules allowed to access LLM APIs
 	// any value of "all" bypasses restrictions, a nil slice imposes them
 	AllowedLLMModules []string
+
+	// If set (typically via "_EXPERIMENTAL_DAGGER_VERSION" env var), this forces the client
+	// to be at the specified version. Currently only used for integ testing.
+	ClientVersionOverride string
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -90,18 +90,17 @@ type execState struct {
 
 	cleanups *Cleanups
 
-	spec               *specs.Spec
-	networkNamespace   bknetwork.Namespace
-	rootfsPath         string
-	uid                uint32
-	gid                uint32
-	sgids              []uint32
-	resolvConfPath     string
-	hostsFilePath      string
-	exitCodePath       string
-	metaMount          *specs.Mount
-	origEnvMap         map[string]string
-	sessionClientConnF *os.File
+	spec             *specs.Spec
+	networkNamespace bknetwork.Namespace
+	rootfsPath       string
+	uid              uint32
+	gid              uint32
+	sgids            []uint32
+	resolvConfPath   string
+	hostsFilePath    string
+	exitCodePath     string
+	metaMount        *specs.Mount
+	origEnvMap       map[string]string
 
 	startedOnce *sync.Once
 	startedCh   chan<- struct{}
@@ -947,6 +946,11 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 		} else {
 			w.execMD.SSHAuthSocketPath = sockPath
 		}
+	}
+
+	// include overridden client version if it's set in the exec's env vars
+	if version, ok := state.origEnvMap["_EXPERIMENTAL_DAGGER_VERSION"]; ok {
+		w.execMD.ClientVersionOverride = version
 	}
 
 	srvCtx, srvCancel := context.WithCancelCause(ctx)

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/containerd/containerd/mount"
@@ -950,37 +949,11 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 		}
 	}
 
-	sessionClientConnF, sessionSrvConnF, err := newSocketpair()
-	if err != nil {
-		return fmt.Errorf("create session socket pair: %w", err)
-	}
-	// closing net.FileConn won't close the underlying fd, so do that here
-	state.cleanups.Add("close session client conn", sessionClientConnF.Close)
-	state.cleanups.Add("close session srv conn", sessionSrvConnF.Close)
-	state.sessionClientConnF = sessionClientConnF
-
-	sessionSrvConn, err := net.FileConn(sessionSrvConnF)
-	if err != nil {
-		return fmt.Errorf("convert session srv conn: %w", err)
-	}
-
 	srvCtx, srvCancel := context.WithCancelCause(ctx)
 	state.cleanups.Add("cancel session server", Infallible(func() {
 		srvCancel(errors.New("container cleanup"))
 	}))
 	srvPool := pool.New().WithContext(srvCtx).WithCancelOnError()
-	srvPool.Go(func(ctx context.Context) error {
-		return w.bkSessionManager.HandleConn(ctx, sessionSrvConn, map[string][]string{
-			engine.SessionIDMetaKey:        {w.execMD.ClientID},
-			engine.SessionNameMetaKey:      {w.execMD.ClientID},
-			engine.SessionSharedKeyMetaKey: {""},
-			engine.SessionMethodNameMetaKey: {
-				// buildkit doesn't care about this, except one codepath where it insists on checking
-				// for FileSend/diffcopy, so include that here
-				"/moby.filesync.v1.FileSend/diffcopy",
-			},
-		})
-	})
 
 	httpListener, err := runInNetNS(ctx, state, func() (net.Listener, error) {
 		return net.Listen("tcp", "127.0.0.1:0")
@@ -1023,25 +996,6 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 	}))
 
 	return nil
-}
-
-func newSocketpair() (*os.File, *os.File, error) {
-	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		return nil, nil, fmt.Errorf("socketpair: %w", err)
-	}
-
-	fd0 := fds[0]
-	fd1 := fds[1]
-
-	if err := syscall.SetNonblock(fd0, true); err != nil {
-		return nil, nil, fmt.Errorf("set nonblock fd0: %w", err)
-	}
-	if err := syscall.SetNonblock(fd1, true); err != nil {
-		return nil, nil, fmt.Errorf("set nonblock fd1: %w", err)
-	}
-
-	return os.NewFile(uintptr(fd0), "socketpair0"), os.NewFile(uintptr(fd1), "socketpair1"), nil
 }
 
 func (w *Worker) installCACerts(ctx context.Context, state *execState) error {
@@ -1233,15 +1187,10 @@ func (w *Worker) runContainer(ctx context.Context, state *execState) (rerr error
 	killer := newRunProcKiller(w.runc, state.id)
 
 	runcCall := func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
-		var extraFiles []*os.File
-		if state.sessionClientConnF != nil {
-			extraFiles = append(extraFiles, state.sessionClientConnF)
-		}
 		_, err := w.runc.Run(ctx, state.id, bundle, &runc.CreateOpts{
-			Started:    started,
-			IO:         io,
-			ExtraArgs:  []string{"--keep"},
-			ExtraFiles: extraFiles,
+			Started:   started,
+			IO:        io,
+			ExtraArgs: []string{"--keep"},
 		})
 		return err
 	}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -917,7 +917,10 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // in http headers since it includes arbitrary values from users in the function call metadata, which can exceed max header
 // size.
 func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Request, execMD *buildkit.ExecutionMetadata) {
-	clientVersion := engine.Version
+	clientVersion := execMD.ClientVersionOverride
+	if clientVersion == "" {
+		clientVersion = engine.Version
+	}
 	allowedLLMModules := execMD.AllowedLLMModules
 	if md, _ := engine.ClientMetadataFromHTTPHeaders(r.Header); md != nil {
 		clientVersion = md.ClientVersion


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/10162

Still saw an occurrence of the flake, but this time it's because the healthcheck failed 2 times in a row rather than closed early due to a bug: https://v3.dagger.cloud/dagger/traces/64ca948ee08ce288105b158ab8889321?span=8960846c5fe9627d&logs#8960846c5fe9627d:L245

At first I tried disabling the grpc healthchecks entirely, but that just peeled back another layer and revealed more problems where grpc was calling the dialer multiple times (not good when we are just operating off a single pre-made conn); I suspect that the grpc healthchecks were inadvertently acting as something like a keep-alive and/or otherwise tweaking something about the grpc connection state that resulting in it never being closed.

Either way, all that nonsense is not really worth our time right now, so the fix here just re-arranges how nested session attachables are setup:
1. Previously they worked by creating a `socketpair` and giving one end to the session.Manager and one end to the nested exec init, which was appealing in that it was pretty efficient and low-overhead
2. However it had a side effect of sometimes creating a long-ish period of time between when the session.Manager started trying to connect to the attachables in the exec and when the attachables were actually ready, which caused all the woes we were seeing
3. Now, we connect nested attachable the same way that non-nested clients connect through the HTTP API to /sessionAttachables
   * This improves the situation because it means that `session.Manager` only starts trying to connect to the attachables when they are for sure ready-to-go
5. This theoretically has a little bit more overhead, but doesn't appear to be noticeable at this time. It also is simpler in the code, so overall seems like a good change.