### PR TITLE
shell: fix relative arguments in Directory and File flags

### DIFF
--- a/.changes/unreleased/Fixed-20250415-174815.yaml
+++ b/.changes/unreleased/Fixed-20250415-174815.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'shell: fixed relative paths in `Directory` and `File` flags'
+time: 2025-04-15T17:48:15.01366Z
+custom:
+    Author: helderco
+    PR: "10169"

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -632,7 +632,9 @@ func (h *shellCallHandler) parseFlagValue(ctx context.Context, value string, arg
 				// Ignore on git urls since the flag will parse it directly.
 				// We just need to resolve the ref for "local" (contextual) paths.
 				if _, err := parseGitURL(value); err != nil {
-					return h.contextArgRef(value), false, nil //nolint:nilerr
+					if newPath, err := h.contextArgRef(value); err == nil {
+						return newPath, false, nil //nolint:nilerr
+					}
 				}
 			}
 		}

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -633,7 +633,7 @@ func (h *shellCallHandler) parseFlagValue(ctx context.Context, value string, arg
 				// We just need to resolve the ref for "local" (contextual) paths.
 				if _, err := parseGitURL(value); err != nil {
 					if newPath, err := h.contextArgRef(value); err == nil {
-						return newPath, false, nil //nolint:nilerr
+						return newPath, false, nil
 					}
 				}
 			}


### PR DESCRIPTION
Reported by user in [Discord](https://discord.com/channels/707636530424053791/1361372104083378176/1361372104083378176).

`Directory` and `File` arguments weren't resolving relative paths correctly before passing on to the flag.