### PR TITLE
docs: sdk language query string support

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -21,7 +21,7 @@
 
   ```html
   <Tabs groupId="language" queryString="sdk">
-  <TabItem value="Go">
+  <TabItem value="go" label="Go">
   ...
   </TabItem>
   <TabItem value="Python">

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -24,7 +24,7 @@
   <TabItem value="go" label="Go">
   ...
   </TabItem>
-  <TabItem value="Python">
+  <TabItem value="python" label="Python">
   ...
   </TabItem>
   <TabItem value="typescript" label="TypeScript">

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -20,7 +20,7 @@
 - By default, provide code snippets for all available SDK languages, with each code snippet in a separate tab. The order of tabs should always be `Go`, `Python` and `TypeScript`. Here is an example:
 
   ```html
-  <Tabs groupId="language">
+  <Tabs groupId="language" queryString="sdk">
   <TabItem value="Go">
   ...
   </TabItem>

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -27,7 +27,7 @@
   <TabItem value="Python">
   ...
   </TabItem>
-  <TabItem value="TypeScript">
+  <TabItem value="typescript" label="TypeScript">
   ...
   </TabItem>
   </Tabs>

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -27,7 +27,7 @@ When passing values to Dagger Functions within Dagger Shell, required arguments 
 Here is an example of a Dagger Function that accepts a string argument:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-string/go/main.go
 ```
 </TabItem>
@@ -151,7 +151,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello --greeting=$GREE
 Here is an example of a Dagger Function that accepts a Boolean argument:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-boolean/go/main.go
 ```
 </TabItem>
@@ -215,7 +215,7 @@ Here is an example of a Dagger function that accepts an integer argument:
 
 <Tabs groupId="language" queryString="sdk">
 
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-return-values-integer/go/main.go
 ```
 </TabItem>
@@ -276,7 +276,7 @@ The result will look like this:
 Here is an example of a Dagger function that accepts a floating-point number as argument:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-return-values-float/go/main.go
 ```
 </TabItem>
@@ -347,7 +347,7 @@ The result will look like this:
 To pass an array argument to a Dagger Function, use a comma-separated list of values.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-array/go/main.go
 ```
 </TabItem>
@@ -415,7 +415,7 @@ Dagger Functions do not have access to the filesystem of the host you invoke the
 Here's an example of a Dagger Function that accepts a `Directory` as argument. The Dagger Function returns a tree representation of the files and directories at that path.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-directory/go/main.go
 ```
 </TabItem>
@@ -561,7 +561,7 @@ File arguments work in the same way as [directory arguments](#directory-argument
 Here's an example of a Dagger Function that accepts a `File` as argument, reads it, and returns its contents:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-file/go/main.go
 ```
 </TabItem>
@@ -638,7 +638,7 @@ Just like directories, you can pass a container to a Dagger Function from the co
 Here is an example of a Dagger Function that accepts a container image reference as an argument. The Dagger Function returns operating system information for the container.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
 </TabItem>
@@ -714,7 +714,7 @@ Dagger allows you to utilize confidential information, such as passwords, API ke
 Secrets can be passed to Dagger Functions as arguments using the `Secret` core type. Here is an example of a Dagger Function which accepts a GitHub personal access token as a secret, and uses the token to authorize a request to the GitHub API:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../cookbook/snippets/secret-variable/go/main.go
 ```
@@ -941,7 +941,7 @@ Function arguments can be marked as optional. In this case, the Dagger CLI will 
 Here's an example of a Dagger Function with an optional argument:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-optional/go/main.go
 ```
 </TabItem>
@@ -1037,7 +1037,7 @@ Function arguments can define a default value if no value is supplied for them.
 Here's an example of a Dagger Function with a default value for a string argument:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-default-string/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -31,7 +31,7 @@ Here is an example of a Dagger Function that accepts a string argument:
 ```go file=./snippets/functions/arguments-string/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-string/python/main.py
 ```
 
@@ -155,7 +155,7 @@ Here is an example of a Dagger Function that accepts a Boolean argument:
 ```go file=./snippets/functions/arguments-boolean/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-boolean/python/main.py
 ```
 </TabItem>
@@ -220,7 +220,7 @@ Here is an example of a Dagger function that accepts an integer argument:
 ```
 </TabItem>
 
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-return-values-integer/python/main.py
 ```
 </TabItem>
@@ -281,7 +281,7 @@ Here is an example of a Dagger function that accepts a floating-point number as 
 ```
 </TabItem>
 
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-return-values-float/python/main.py
 ```
 </TabItem>
@@ -351,7 +351,7 @@ To pass an array argument to a Dagger Function, use a comma-separated list of va
 ```go file=./snippets/functions/arguments-array/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-array/python/main.py
 ```
 </TabItem>
@@ -419,7 +419,7 @@ Here's an example of a Dagger Function that accepts a `Directory` as argument. T
 ```go file=./snippets/functions/arguments-directory/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-directory/python/main.py
 ```
 </TabItem>
@@ -565,7 +565,7 @@ Here's an example of a Dagger Function that accepts a `File` as argument, reads 
 ```go file=./snippets/functions/arguments-file/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-file/python/main.py
 ```
 </TabItem>
@@ -642,7 +642,7 @@ Here is an example of a Dagger Function that accepts a container image reference
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-container/python/main.py
 ```
 </TabItem>
@@ -720,7 +720,7 @@ Secrets can be passed to Dagger Functions as arguments using the `Secret` core t
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../cookbook/snippets/secret-variable/python/main.py
 ```
@@ -945,7 +945,7 @@ Here's an example of a Dagger Function with an optional argument:
 ```go file=./snippets/functions/arguments-optional/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-optional/python/main.py
 ```
 </TabItem>
@@ -1041,7 +1041,7 @@ Here's an example of a Dagger Function with a default value for a string argumen
 ```go file=./snippets/functions/arguments-default-string/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-default-string/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -73,7 +73,7 @@ def hello(self):
 ```typescript file=./snippets/functions/arguments-string/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-string/php/src/MyModule.php
 ```
 
@@ -163,7 +163,7 @@ Here is an example of a Dagger Function that accepts a Boolean argument:
 ```typescript file=./snippets/functions/arguments-boolean/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-boolean/php/src/MyModule.php
 ```
 </TabItem>
@@ -230,7 +230,7 @@ Here is an example of a Dagger function that accepts an integer argument:
 ```
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-return-values-integer/php/src/MyModule.php
 ```
 </TabItem>
@@ -299,7 +299,7 @@ The imported `float` type is a `number` underneath, so you can use it as you wou
 ```
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/functions/arguments-return-values-float/php/src/MyModule.php
 ```
@@ -359,7 +359,7 @@ To pass an array argument to a Dagger Function, use a comma-separated list of va
 ```typescript file=./snippets/functions/arguments-array/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 :::note
 Lists must have their subtype specified by adding the `#[ListOfType]` attribute to the relevant function argument.
 
@@ -427,7 +427,7 @@ Here's an example of a Dagger Function that accepts a `Directory` as argument. T
 ```typescript file=./snippets/functions/arguments-directory/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-directory/php/src/MyModule.php
 ```
 </TabItem>
@@ -573,7 +573,7 @@ Here's an example of a Dagger Function that accepts a `File` as argument, reads 
 ```typescript file=./snippets/functions/arguments-file/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-file/php/src/MyModule.php
 ```
 </TabItem>
@@ -650,7 +650,7 @@ Here is an example of a Dagger Function that accepts a container image reference
 ```typescript file=./snippets/functions/arguments-container/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-container/php/src/MyModule.php
 ```
 </TabItem>
@@ -732,7 +732,7 @@ Secrets can be passed to Dagger Functions as arguments using the `Secret` core t
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=../cookbook/snippets/secret-variable/php/src/MyModule.php
 ```
@@ -953,7 +953,7 @@ Here's an example of a Dagger Function with an optional argument:
 ```typescript file=./snippets/functions/arguments-optional/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 :::note
 The definition of optional varies between Dagger and PHP.
 
@@ -1049,7 +1049,7 @@ Here's an example of a Dagger Function with a default value for a string argumen
 ```typescript file=./snippets/functions/arguments-default-string/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-default-string/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -26,7 +26,7 @@ When passing values to Dagger Functions within Dagger Shell, required arguments 
 
 Here is an example of a Dagger Function that accepts a string argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-string/go/main.go
 ```
@@ -150,7 +150,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello --greeting=$GREE
 
 Here is an example of a Dagger Function that accepts a Boolean argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-boolean/go/main.go
 ```
@@ -213,7 +213,7 @@ When passing optional boolean flags:
 
 Here is an example of a Dagger function that accepts an integer argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-return-values-integer/go/main.go
@@ -275,7 +275,7 @@ The result will look like this:
 
 Here is an example of a Dagger function that accepts a floating-point number as argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-return-values-float/go/main.go
 ```
@@ -346,7 +346,7 @@ The result will look like this:
 
 To pass an array argument to a Dagger Function, use a comma-separated list of values.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-array/go/main.go
 ```
@@ -414,7 +414,7 @@ Dagger Functions do not have access to the filesystem of the host you invoke the
 
 Here's an example of a Dagger Function that accepts a `Directory` as argument. The Dagger Function returns a tree representation of the files and directories at that path.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-directory/go/main.go
 ```
@@ -560,7 +560,7 @@ File arguments work in the same way as [directory arguments](#directory-argument
 
 Here's an example of a Dagger Function that accepts a `File` as argument, reads it, and returns its contents:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-file/go/main.go
 ```
@@ -637,7 +637,7 @@ Just like directories, you can pass a container to a Dagger Function from the co
 
 Here is an example of a Dagger Function that accepts a container image reference as an argument. The Dagger Function returns operating system information for the container.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
@@ -713,7 +713,7 @@ Dagger allows you to utilize confidential information, such as passwords, API ke
 
 Secrets can be passed to Dagger Functions as arguments using the `Secret` core type. Here is an example of a Dagger Function which accepts a GitHub personal access token as a secret, and uses the token to authorize a request to the GitHub API:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../cookbook/snippets/secret-variable/go/main.go
@@ -940,7 +940,7 @@ Function arguments can be marked as optional. In this case, the Dagger CLI will 
 
 Here's an example of a Dagger Function with an optional argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-optional/go/main.go
 ```
@@ -1036,7 +1036,7 @@ Function arguments can define a default value if no value is supplied for them.
 
 Here's an example of a Dagger Function with a default value for a string argument:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-default-string/go/main.go
 ```

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -84,7 +84,7 @@ typing information at runtime to correctly report to the API.
 [typing]: https://www.php.net/manual/en/language.types.type-system.php
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/arguments-string/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -167,7 +167,7 @@ Here is an example of a Dagger Function that accepts a Boolean argument:
 ```php file=./snippets/functions/arguments-boolean/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can either use the primitive `boolean` type or the boxed `java.lang.Boolean` type.
 :::
@@ -235,7 +235,7 @@ Here is an example of a Dagger function that accepts an integer argument:
 ```
 </TabItem>
 
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can either use the primitive `int` type or the boxed `java.lang.Integer` type.
 :::
@@ -305,7 +305,7 @@ The imported `float` type is a `number` underneath, so you can use it as you wou
 ```
 </TabItem>
 
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can either use the primitive `float` type or the boxed `java.lang.Float` type.
 :::
@@ -369,7 +369,7 @@ The PHP SDK needs the typing information at runtime to correctly report to the A
 ```php file=./snippets/functions/arguments-array/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can also use the `java.util.List` interface to represent a list of values.
 For instance instead of the `String[] names` argument in the example, you can have `List<String> names`.
@@ -431,7 +431,7 @@ Here's an example of a Dagger Function that accepts a `Directory` as argument. T
 ```php file=./snippets/functions/arguments-directory/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/arguments-directory/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -577,7 +577,7 @@ Here's an example of a Dagger Function that accepts a `File` as argument, reads 
 ```php file=./snippets/functions/arguments-file/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/arguments-file/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -654,7 +654,7 @@ Here is an example of a Dagger Function that accepts a container image reference
 ```php file=./snippets/functions/arguments-container/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/arguments-container/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -738,7 +738,7 @@ Secrets can be passed to Dagger Functions as arguments using the `Secret` core t
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=../cookbook/snippets/secret-variable/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -966,7 +966,7 @@ To specify a function argument as optional, simply make it nullable. When using 
 ```php file=./snippets/functions/arguments-optional/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 Because of the usage of `Optional`, primitive types can not be marked as optional. You have to use the boxed types like `Integer` or `Boolean`.
 
@@ -1053,7 +1053,7 @@ Here's an example of a Dagger Function with a default value for a string argumen
 ```php file=./snippets/functions/arguments-default-string/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 The default value provided must be a valid JSON string representation of the type.
 

--- a/docs/current_docs/api/arguments.mdx
+++ b/docs/current_docs/api/arguments.mdx
@@ -69,7 +69,7 @@ def hello(self):
 [void]: https://dagger-io.readthedocs.io/en/latest/client.html#dagger.Void
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-string/typescript/index.ts
 ```
 </TabItem>
@@ -159,7 +159,7 @@ Here is an example of a Dagger Function that accepts a Boolean argument:
 ```python file=./snippets/functions/arguments-boolean/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-boolean/typescript/index.ts
 ```
 </TabItem>
@@ -225,7 +225,7 @@ Here is an example of a Dagger function that accepts an integer argument:
 ```
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-return-values-integer/typescript/index.ts
 ```
 </TabItem>
@@ -286,7 +286,7 @@ Here is an example of a Dagger function that accepts a floating-point number as 
 ```
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 :::note
 There's no `float` type keyword in TypeScript because the type keyword `number` already supports floating point numbers.
@@ -355,7 +355,7 @@ To pass an array argument to a Dagger Function, use a comma-separated list of va
 ```python file=./snippets/functions/arguments-array/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-array/typescript/index.ts
 ```
 </TabItem>
@@ -423,7 +423,7 @@ Here's an example of a Dagger Function that accepts a `Directory` as argument. T
 ```python file=./snippets/functions/arguments-directory/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-directory/typescript/index.ts
 ```
 </TabItem>
@@ -569,7 +569,7 @@ Here's an example of a Dagger Function that accepts a `File` as argument, reads 
 ```python file=./snippets/functions/arguments-file/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-file/typescript/index.ts
 ```
 </TabItem>
@@ -646,7 +646,7 @@ Here is an example of a Dagger Function that accepts a container image reference
 ```python file=./snippets/functions/arguments-container/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-container/typescript/index.ts
 ```
 </TabItem>
@@ -726,7 +726,7 @@ Secrets can be passed to Dagger Functions as arguments using the `Secret` core t
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../cookbook/snippets/secret-variable/typescript/index.ts
 ```
@@ -949,7 +949,7 @@ Here's an example of a Dagger Function with an optional argument:
 ```python file=./snippets/functions/arguments-optional/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-optional/typescript/index.ts
 ```
 </TabItem>
@@ -1045,7 +1045,7 @@ Here's an example of a Dagger Function with a default value for a string argumen
 ```python file=./snippets/functions/arguments-default-string/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-default-string/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/cache-volumes.mdx
+++ b/docs/current_docs/api/cache-volumes.mdx
@@ -10,7 +10,7 @@ Volume caching involves caching specific parts of the filesystem and reusing the
 
 Here's an example:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="System shell">
 ```shell
 dagger <<EOF

--- a/docs/current_docs/api/cache-volumes.mdx
+++ b/docs/current_docs/api/cache-volumes.mdx
@@ -55,7 +55,7 @@ dagger core container \
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/cache-volumes/typescript/index.ts
 ```

--- a/docs/current_docs/api/cache-volumes.mdx
+++ b/docs/current_docs/api/cache-volumes.mdx
@@ -49,7 +49,7 @@ dagger core container \
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/cache-volumes/python/main.py
 ```

--- a/docs/current_docs/api/cache-volumes.mdx
+++ b/docs/current_docs/api/cache-volumes.mdx
@@ -43,7 +43,7 @@ dagger core container \
   with-exec --args="npm","install"
 ```
 </TabItem>
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/cache-volumes/go/main.go
 ```

--- a/docs/current_docs/api/clients-http.mdx
+++ b/docs/current_docs/api/clients-http.mdx
@@ -61,7 +61,7 @@ cargo add base64@0.22.1
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```shell
 mkdir my-project
@@ -83,7 +83,7 @@ Add the following code to `src/main.rs`:
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Create a new file named `client.php` and add the following code to it:
 
@@ -103,7 +103,7 @@ Run the Dagger API client using the Dagger CLI as follows:
 dagger run cargo run
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```shell
 dagger run php client.php
 ```

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -28,7 +28,7 @@ Once a module is initialized, `dagger develop --sdk=...` sets up or updates all 
 Here is an example of initializing a Dagger module:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```shell
 dagger init --name=my-module
 dagger develop --sdk=go
@@ -67,7 +67,7 @@ Running `dagger develop` regenerates the module's code based on dependencies, th
 The default template from `dagger develop` creates the following structure:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```
 .
@@ -202,7 +202,7 @@ While you can use the utilities defined in the automatically-generated code abov
 You can now write Dagger Functions using the selected Dagger SDK. Here is an example, which calls a remote API method and returns the result:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/functions-complex/go/main.go
 ```
 
@@ -301,7 +301,7 @@ An alternative approach is to develop a custom application using a Dagger SDK. T
 - executing your application using `dagger run`
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 :::note
 The Dagger Go SDK requires [Go 1.22 or later](https://go.dev/doc/install).

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -27,7 +27,7 @@ Once a module is initialized, `dagger develop --sdk=...` sets up or updates all 
 
 Here is an example of initializing a Dagger module:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```shell
 dagger init --name=my-module
@@ -66,7 +66,7 @@ Running `dagger develop` regenerates the module's code based on dependencies, th
 
 The default template from `dagger develop` creates the following structure:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```
@@ -201,7 +201,7 @@ While you can use the utilities defined in the automatically-generated code abov
 
 You can now write Dagger Functions using the selected Dagger SDK. Here is an example, which calls a remote API method and returns the result:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/functions-complex/go/main.go
 ```
@@ -300,7 +300,7 @@ An alternative approach is to develop a custom application using a Dagger SDK. T
 - calling and combining Dagger API methods from your application to achieve the required result
 - executing your application using `dagger run`
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 :::note

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -52,7 +52,7 @@ dagger init --name=my-module
 dagger develop --sdk=php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```shell
 dagger init --name=my-module
 dagger develop --sdk=java
@@ -165,7 +165,7 @@ In this structure:
 - `sdk/` contains the PHP SDK.
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```
 .
 ├── LICENSE
@@ -233,7 +233,7 @@ the main object needs to be named `MyModule`.
 ```php file=./snippets/functions/functions-complex/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/functions-complex/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -34,7 +34,7 @@ dagger init --name=my-module
 dagger develop --sdk=go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```shell
 dagger init --name=my-module
 dagger develop --sdk=python
@@ -94,7 +94,7 @@ In this structure:
     - `telemetry` has utilities for sending Dagger Engine telemetry.
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```
 .
@@ -208,7 +208,7 @@ You can now write Dagger Functions using the selected Dagger SDK. Here is an exa
 
 This Dagger Function includes the context as input and error as return in its signature.
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/functions-complex/python/main.py
 ```
 
@@ -374,7 +374,7 @@ build
             └── hello
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 :::note
 The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html).

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -46,7 +46,7 @@ dagger init --name=my-module
 dagger develop --sdk=typescript
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```shell
 dagger init --name=my-module
 dagger develop --sdk=php
@@ -142,7 +142,7 @@ In this structure:
 - `sdk/` contains the TypeScript SDK.
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```
 .
@@ -229,7 +229,7 @@ the main object needs to be named `MyModule`.
 ```typescript file=./snippets/functions/functions-complex/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/functions-complex/php/src/MyModule.php
 ```
 </TabItem>
@@ -493,7 +493,7 @@ build-node-20
     └── media
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 :::note
 The Dagger PHP SDK requires [PHP 8.2 or later](https://www.php.net/downloads.php).

--- a/docs/current_docs/api/clients-sdk.mdx
+++ b/docs/current_docs/api/clients-sdk.mdx
@@ -40,7 +40,7 @@ dagger init --name=my-module
 dagger develop --sdk=python
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```shell
 dagger init --name=my-module
 dagger develop --sdk=typescript
@@ -120,7 +120,7 @@ In this structure:
 This structure hosts a Python import package, with a name derived from the project name (in `pyproject.toml`), inside a `src` directory. This follows a [Python convention](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) that requires a project to be installed in order to run its code. This convention prevents accidental usage of development code since the Python interpreter includes the current working directory as the first item on the import path (more information is available in this [blog post on Python packaging](https://blog.ionelmc.ro/2014/05/25/python-packaging/)).
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```
 .
@@ -225,7 +225,7 @@ the main object needs to be named `MyModule`.
 [@function]: https://dagger-io.readthedocs.io/en/latest/module.html#dagger.function
 [@object_type]: https://dagger-io.readthedocs.io/en/latest/module.html#dagger.object_type
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/functions-complex/typescript/index.ts
 ```
 </TabItem>
@@ -435,7 +435,7 @@ All tasks have finished
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 :::note
 The Dagger TypeScript SDK requires [TypeScript 5.0 or later](https://www.typescriptlang.org/download/). This SDK currently only [supports Node.js (stable) and Bun (experimental)](../configuration/modules.mdx). To execute the TypeScript program, you must also have an TypeScript executor like `ts-node` or `tsx`.
 :::

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -29,7 +29,7 @@ Here is an example module with a custom constructor:
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/constructors/python/simple/main.py
 ```
@@ -121,7 +121,7 @@ Here is an example of a Dagger module with a default constructor argument of typ
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/constructors/python/default-object/main.py
 ```

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -22,7 +22,7 @@ Dagger modules have only one constructors. Constructors of [custom types](./cust
 
 Here is an example module with a custom constructor:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/constructors/go/simple/main.go
@@ -114,7 +114,7 @@ Constructors can be passed both simple and complex types (such as `Container`, `
 
 Here is an example of a Dagger module with a default constructor argument of type `Container`:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/constructors/go/default-object/main.go

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -51,7 +51,7 @@ This factory class method must be named `create`.
 ```python file=./snippets/constructors/python/async/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/constructors/typescript/simple/index.ts
 ```
@@ -134,7 +134,7 @@ use a [factory function](https://docs.python.org/3/library/dataclasses.html#defa
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/constructors/typescript/default-object/index.ts
 ```

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -57,7 +57,7 @@ This factory class method must be named `create`.
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/constructors/php/simple/src/MyModule.php
 ```
@@ -149,7 +149,7 @@ When assigning default values to complex types in TypeScript, it is necessary to
 :::
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/constructors/php/default-object/src/MyModule.php
 ```

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -67,7 +67,7 @@ In the PHP SDK the constructor must be the [magic method `__construct`](https://
 As with any method, only public methods with the `#[DaggerFunction]` attribute will be registered with Dagger.
 :::
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/constructors/java/simple/MyModule.java
 ```
@@ -155,7 +155,7 @@ When assigning default values to complex types in TypeScript, it is necessary to
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/constructors/java/default-object/MyModule.java
 ```

--- a/docs/current_docs/api/constructors.mdx
+++ b/docs/current_docs/api/constructors.mdx
@@ -23,7 +23,7 @@ Dagger modules have only one constructors. Constructors of [custom types](./cust
 Here is an example module with a custom constructor:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/constructors/go/simple/main.go
 ```
@@ -115,7 +115,7 @@ Constructors can be passed both simple and complex types (such as `Container`, `
 Here is an example of a Dagger module with a default constructor argument of type `Container`:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/constructors/go/default-object/main.go
 ```

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -65,7 +65,7 @@ Update the `src/MyModule.php` file with the following code:
 ```php file=./snippets/functions/functions-complex/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 Update the `src/main/java/io/dagger/modules/mymodule/MyModule.java` file with the following code:
 

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -22,7 +22,7 @@ When a Dagger module is loaded into a Dagger session, the Dagger API is [dynamic
 Here's an example of a Dagger Function which calls a remote API method and returns the result:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Update the `main.go` file with the following code:
 

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -51,7 +51,7 @@ the main object needs to be named `MyModule`.
 [@function]: https://dagger-io.readthedocs.io/en/latest/module.html#dagger.function
 [@object_type]: https://dagger-io.readthedocs.io/en/latest/module.html#dagger.object_type
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Update the `src/index.ts` file with the following code:
 

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -21,7 +21,7 @@ When a Dagger module is loaded into a Dagger session, the Dagger API is [dynamic
 
 Here's an example of a Dagger Function which calls a remote API method and returns the result:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Update the `main.go` file with the following code:

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -31,7 +31,7 @@ Update the `main.go` file with the following code:
 
 This Dagger Function includes the context as input and error as return in its signature.
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Update the `src/my_module/main.py` file with the following code:
 

--- a/docs/current_docs/api/custom-functions.mdx
+++ b/docs/current_docs/api/custom-functions.mdx
@@ -58,7 +58,7 @@ Update the `src/index.ts` file with the following code:
 ```typescript file=./snippets/functions/functions-complex/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Update the `src/MyModule.php` file with the following code:
 

--- a/docs/current_docs/api/custom-types.mdx
+++ b/docs/current_docs/api/custom-types.mdx
@@ -19,7 +19,7 @@ that returns a custom `Organization` type, itself containing a collection of
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Here is an example of a `github` Dagger module, with a function named `dagger_organization`
 that returns a custom `Organization` type, itself containing a collection of

--- a/docs/current_docs/api/custom-types.mdx
+++ b/docs/current_docs/api/custom-types.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 A Dagger module can have multiple object types defined. It's important to understand that they are only accessible through [chaining](./index.mdx#chaining), starting from a function in the main object.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Here is an example of a `github` Dagger module, with a function named `DaggerOrganization`

--- a/docs/current_docs/api/custom-types.mdx
+++ b/docs/current_docs/api/custom-types.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 A Dagger module can have multiple object types defined. It's important to understand that they are only accessible through [chaining](./index.mdx#chaining), starting from a function in the main object.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Here is an example of a `github` Dagger module, with a function named `DaggerOrganization`
 that returns a custom `Organization` type, itself containing a collection of

--- a/docs/current_docs/api/custom-types.mdx
+++ b/docs/current_docs/api/custom-types.mdx
@@ -31,7 +31,7 @@ that returns a custom `Organization` type, itself containing a collection of
 The [`dagger.field`](https://dagger-io.readthedocs.io/en/latest/module.html#dagger.field) descriptors expose getter functions without arguments, for their [attributes](./state.mdx).
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Here is an example of a `github` Dagger module, with a function named `daggerOrganization`
 that returns a custom `Organization` type, itself containing a collection of

--- a/docs/current_docs/api/daggerverse.mdx
+++ b/docs/current_docs/api/daggerverse.mdx
@@ -28,7 +28,7 @@ Daggerverse will automatically show basic examples for each function in a module
 
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 A Go example must be a Dagger module located at `/examples/go` within the module you're creating examples for.
 

--- a/docs/current_docs/api/daggerverse.mdx
+++ b/docs/current_docs/api/daggerverse.mdx
@@ -41,7 +41,7 @@ If you have a module called `Foo` and a function called `Bar`, you can create th
 1. Functions `FooBar_Baz` will create a Baz example for the function `Bar`.
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 A Python example must be a Dagger module located at `/examples/python` within the module you're creating examples for.
 

--- a/docs/current_docs/api/daggerverse.mdx
+++ b/docs/current_docs/api/daggerverse.mdx
@@ -27,7 +27,7 @@ To make sure your module gets the best possible rank, consider the following for
 Daggerverse will automatically show basic examples for each function in a module. If you would like to provide hand-crafted examples, the following section will describe how to set these up.
 
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 A Go example must be a Dagger module located at `/examples/go` within the module you're creating examples for.

--- a/docs/current_docs/api/daggerverse.mdx
+++ b/docs/current_docs/api/daggerverse.mdx
@@ -58,9 +58,9 @@ Python function names in example modules use double underscores (`__`) as separa
 :::
 
 </TabItem>
-<TabItem value="Typescript">
+<TabItem value="TypeScript">
 
-A Typescript example must be a Dagger module located at `/examples/typescript` within the module you're creating examples for.
+A TypeScript example must be a Dagger module located at `/examples/typescript` within the module you're creating examples for.
 
 If you have a module called `foo` and a function called `bar`, you can create the following functions in your example module:
 

--- a/docs/current_docs/api/daggerverse.mdx
+++ b/docs/current_docs/api/daggerverse.mdx
@@ -58,7 +58,7 @@ Python function names in example modules use double underscores (`__`) as separa
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 A TypeScript example must be a Dagger module located at `/examples/typescript` within the module you're creating examples for.
 

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -29,7 +29,7 @@ The default path is set by adding a `DefaultPath` annotation on the correspondin
 ```python file=./snippets/default-paths/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 The default path is set by adding an `@argument` decorator with a `defaultPath` parameter on the corresponding Dagger Function `source` argument.
 

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -15,7 +15,7 @@ Default paths are only available for `Directory` and `File` arguments. They are 
 Here's an example:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 The default path is set by adding a `defaultPath` pragma on the corresponding Dagger Function `source` argument.
 

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -22,7 +22,7 @@ The default path is set by adding a `defaultPath` pragma on the corresponding Da
 ```go file=./snippets/default-paths/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 The default path is set by adding a `DefaultPath` annotation on the corresponding Dagger Function `source` argument.
 

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -36,7 +36,7 @@ The default path is set by adding an `@argument` decorator with a `defaultPath` 
 ```typescript file=./snippets/default-paths/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 The default path is set by adding a `#[DefaultPath]` Attribute on the corresponding Dagger Function `source` argument.
 

--- a/docs/current_docs/api/default-paths.mdx
+++ b/docs/current_docs/api/default-paths.mdx
@@ -14,7 +14,7 @@ Default paths are only available for `Directory` and `File` arguments. They are 
 
 Here's an example:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 The default path is set by adding a `defaultPath` pragma on the corresponding Dagger Function `source` argument.

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -41,7 +41,7 @@ For function arguments, [annotate](https://peps.python.org/pep-0727/#specificati
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 The following code snippet shows how to add documentation for:
 - The whole module
@@ -129,7 +129,7 @@ The following code snippet shows how to add documentation for an object and its 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/documentation/typescript/object.ts
 ```

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -22,7 +22,7 @@ The following code snippet shows how to add documentation for:
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 The following code snippet shows how to use Python's [documentation string conventions](https://peps.python.org/pep-0008/#documentation-strings) for adding descriptions to:
 - The whole [module](https://docs.python.org/3/tutorial/modules.html) or [package](https://docs.python.org/3/tutorial/modules.html#packages)
@@ -123,7 +123,7 @@ The following code snippet shows how to add documentation for an object and its 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/documentation/python/object.py
 ```

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -64,7 +64,7 @@ The following code snippet shows how to add documentation for:
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 The following code snippet shows how to add documentation for:
 
@@ -141,7 +141,7 @@ The following code snippet shows how to add documentation for an object and its 
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/documentation/java/object/MyModule.java
 ```

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -52,7 +52,7 @@ The following code snippet shows how to add documentation for:
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 The following code snippet shows how to add documentation for:
 
@@ -135,7 +135,7 @@ The following code snippet shows how to add documentation for an object and its 
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/documentation/php/object/src/MyModule.php
 ```

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Dagger modules and Dagger Functions should be documented so that descriptions are shown in the API and the CLI - for example, when calling `dagger functions`, `dagger call ... --help`, or `.help`.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 The following code snippet shows how to add documentation for:
@@ -116,7 +116,7 @@ ARGUMENTS
 
 The following code snippet shows how to add documentation for an object and its fields in your Dagger module:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/documentation/go/object.go

--- a/docs/current_docs/api/documentation.mdx
+++ b/docs/current_docs/api/documentation.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 Dagger modules and Dagger Functions should be documented so that descriptions are shown in the API and the CLI - for example, when calling `dagger functions`, `dagger call ... --help`, or `.help`.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 The following code snippet shows how to add documentation for:
 
@@ -117,7 +117,7 @@ ARGUMENTS
 The following code snippet shows how to add documentation for an object and its fields in your Dagger module:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/documentation/go/object.go
 ```

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -23,7 +23,7 @@ Following the [GraphQL specification](https://spec.graphql.org/October2021/#Name
 
 Here is an example of a Dagger Function that takes two arguments: an image reference and a severity filter. The latter is defined as an enum named `Severity`:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/enums/go/main.go
 ```

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -41,7 +41,7 @@ Here is an example of a Dagger Function that takes two arguments: an image refer
 ```typescript file=./snippets/enums/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/enums/java/Severity.java
 ```
 

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -28,7 +28,7 @@ Here is an example of a Dagger Function that takes two arguments: an image refer
 ```go file=./snippets/enums/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/enums/python/main.py
 ```
 

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -37,7 +37,7 @@ Here is an example of a Dagger Function that takes two arguments: an image refer
 :::
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/enums/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/enumerations.mdx
+++ b/docs/current_docs/api/enumerations.mdx
@@ -24,7 +24,7 @@ Following the [GraphQL specification](https://spec.graphql.org/October2021/#Name
 Here is an example of a Dagger Function that takes two arguments: an image reference and a severity filter. The latter is defined as an enum named `Severity`:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/enums/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -12,7 +12,7 @@ Dagger modules handle errors in the same way as the language they are written in
 Here is an example Dagger Function that performs division and throws an error if the denominator is zero:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/error-handling/go/main.go
 ```

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -38,7 +38,7 @@ Error handling in Go modules follows typical Go error patterns with explicit `er
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/error-handling/java/MyModule.java
 ```

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -11,7 +11,7 @@ Dagger modules handle errors in the same way as the language they are written in
 
 Here is an example Dagger Function that performs division and throws an error if the denominator is zero:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/error-handling/go/main.go

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -26,7 +26,7 @@ Error handling in Go modules follows typical Go error patterns with explicit `er
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/error-handling/typescript/index.ts
 ```

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -20,7 +20,7 @@ Here is an example Dagger Function that performs division and throws an error if
 Error handling in Go modules follows typical Go error patterns with explicit `error` return values and `if err != nil` checks. You can also use error handling to verify user input.
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/error-handling/python/main.py
 ```

--- a/docs/current_docs/api/error-handling.mdx
+++ b/docs/current_docs/api/error-handling.mdx
@@ -32,7 +32,7 @@ Error handling in Go modules follows typical Go error patterns with explicit `er
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/error-handling/php/src/MyModule.php
 ```

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -88,7 +88,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except PHP source code files:
 
@@ -163,7 +163,7 @@ Ignore([".git", "**/.gitignore"])
 @argument({ ignore: [".git", "**/.gitignore"] })
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 // exclude PHPUnit tests and test data
 #[Ignore('tests/', '.phpunit.cache', '.phpunit.result.cache')]
@@ -234,7 +234,7 @@ To implement a post-call filter in your Dagger Function, use the `include` and `
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 To implement a post-call filter in your Dagger Function, use the `include` and `exclude` parameters when working with `Directory` objects. Here's an example:
 
@@ -308,7 +308,7 @@ const dirOpts = { include: ["*.zip"] }
 const dirOpts = { exclude: ["*.git"] }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 // exclude all Markdown files
 $dirOpts = ['exclude' => ['*.md*']];
@@ -407,7 +407,7 @@ debug(
 }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
     #[DaggerFunction]
     public function debug(

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -63,7 +63,7 @@ To implement a pre-call filter in your Dagger Function, add an `ignore` paramete
 - The order of arguments is significant: the pattern `"**", "!**"` includes everything but `"!**", "**"` excludes everything.
 - Prefixing a path with `!` negates a previous ignore: the pattern `"!foo"` has no effect, since nothing is previously ignored, while the pattern `"**", "!foo"` excludes everything except `foo`.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except Go source code files:
@@ -108,7 +108,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 
 Here are a few examples of useful patterns:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 // exclude Go tests and test data
@@ -209,7 +209,7 @@ This is useful when working with directories that are modified "in place" by a D
 
 A good example of this is a multi-stage build. Imagine a Dagger Function that reads and builds an application from source, placing the compiled binaries in a new sub-directory (stage 1). Instead of then transferring everything to the final container image for distribution (stage 2), you could use a post-call filter to transfer only the compiled files.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 To implement a post-call filter in your Dagger Function, use the `DirectoryWithDirectoryOpts` or `ContainerWithDirectoryOpts` structs, which support `Include` and `Exclude` patterns for `Directory` objects. Here's an example:
@@ -254,7 +254,7 @@ To implement a post-call filter in your Dagger Function, use the `Container.With
 
 Here are a few examples of useful patterns:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 // exclude all Markdown files
@@ -373,7 +373,7 @@ Both Dagger Cloud and the Dagger TUI provide detailed information on the pattern
 
 Another way to debug how directories are being filtered is to create a function that receives a `Directory` as input, and returns the same `Directory`:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 func (m *MyModule) Debug(

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -64,7 +64,7 @@ To implement a pre-call filter in your Dagger Function, add an `ignore` paramete
 - Prefixing a path with `!` negates a previous ignore: the pattern `"!foo"` has no effect, since nothing is previously ignored, while the pattern `"**", "!foo"` excludes everything except `foo`.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except Go source code files:
 
@@ -109,7 +109,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 Here are a few examples of useful patterns:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 // exclude Go tests and test data
 +ignore=["**_test.go", "**/testdata/**"]
@@ -210,7 +210,7 @@ This is useful when working with directories that are modified "in place" by a D
 A good example of this is a multi-stage build. Imagine a Dagger Function that reads and builds an application from source, placing the compiled binaries in a new sub-directory (stage 1). Instead of then transferring everything to the final container image for distribution (stage 2), you could use a post-call filter to transfer only the compiled files.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 To implement a post-call filter in your Dagger Function, use the `DirectoryWithDirectoryOpts` or `ContainerWithDirectoryOpts` structs, which support `Include` and `Exclude` patterns for `Directory` objects. Here's an example:
 
@@ -255,7 +255,7 @@ To implement a post-call filter in your Dagger Function, use the `Container.With
 Here are a few examples of useful patterns:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 // exclude all Markdown files
 dirOpts := dagger.ContainerWithDirectoryOpts{
@@ -374,7 +374,7 @@ Both Dagger Cloud and the Dagger TUI provide detailed information on the pattern
 Another way to debug how directories are being filtered is to create a function that receives a `Directory` as input, and returns the same `Directory`:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 func (m *MyModule) Debug(
   ctx context.Context,

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -96,7 +96,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except Java source code files:
 
@@ -181,7 +181,7 @@ Ignore([".git", "**/.gitignore"])
 #[Ignore('.git/', '**/.gitignore')]
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 // exclude Java tests and test data
 @Ignore({"src/test"})
@@ -242,7 +242,7 @@ To implement a post-call filter in your Dagger Function, use the `include` and `
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 To implement a post-call filter in your Dagger Function, use the `Container.WithDirectoryArguments` class which support `withInclude` and `withExclude` functions when working with `Directory` objects. Here's an example:
 
@@ -323,7 +323,7 @@ $dirOpts = ['include' => ['*.zip']];
 $dirOpts = ['exclude' => ['*.git']];
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 // exclude all Markdown files
 var dirOpts = new Container.WithDirectoryArguments()
@@ -418,7 +418,7 @@ debug(
     }
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 @Function
 public Directory debug(@Ignore({"*", "!analytics"}) Directory source) {

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -80,7 +80,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except TypeScript source code files:
 
@@ -145,7 +145,7 @@ Ignore(["**/node_modules"])
 Ignore([".git", "**/.gitignore"])
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 // exclude Mocha tests
 @argument({ ignore: ["**.spec.ts"] })
@@ -226,7 +226,7 @@ To implement a post-call filter in your Dagger Function, use the `include` and `
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 To implement a post-call filter in your Dagger Function, use the `include` and `exclude` parameters when working with `Directory` objects. Here's an example:
 
@@ -293,7 +293,7 @@ dir_opts = {"include": ["*.zip"]}
 dir_opts = {"exclude": ["*.git"]}
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 // exclude all Markdown files
 const dirOpts = { exclude: ["*.md*"] }
@@ -397,7 +397,7 @@ async def foo(
     return source
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 @func()
 debug(

--- a/docs/current_docs/api/fs-filters.mdx
+++ b/docs/current_docs/api/fs-filters.mdx
@@ -72,7 +72,7 @@ Here's an example of a Dagger Function that excludes everything in a given direc
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Here's an example of a Dagger Function that excludes everything in a given directory except Python source code files:
 
@@ -127,7 +127,7 @@ Here are a few examples of useful patterns:
 +ignore=[".git", "**/.gitignore"]
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 # exclude Pytest tests and test data
 Ignore(["tests/", ".pytest_cache"])
@@ -218,7 +218,7 @@ To implement a post-call filter in your Dagger Function, use the `DirectoryWithD
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 To implement a post-call filter in your Dagger Function, use the `include` and `exclude` parameters when working with `Directory` objects. Here's an example:
 
@@ -278,7 +278,7 @@ dirOpts := dagger.DirectoryWithDirectoryOpts{
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 # exclude all Markdown files
 dir_opts = {"exclude": ["*.md*"]}
@@ -385,7 +385,7 @@ func (m *MyModule) Debug(
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 @function
 async def foo(

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -50,7 +50,7 @@ The Go SDK automatically attaches source-maps to the module code. These are a re
 
 Most popular IDEs support source-maps, either natively or with an external plugin, such as the [Open file plugin](https://marketplace.visualstudio.com/items?itemName=Fr43nk.seito-openfile) for Visual Studio Code.
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 To get your IDE to recognize a Dagger Python module and any added Dagger module dependencies in the generated client, all dependencies must be installed in an activated [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) (for example, in `.venv`, next to `pyproject.toml`). This can either be done manually or transparently by a package manager.
 
 For example, to open the Visual Studio Code from the terminal, with functioning autocompletions (assuming the [Python extensions](https://github.com/microsoft/vscode-python) are installed):

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -14,7 +14,7 @@ Dagger uses GraphQL as its low-level language-agnostic API query language, and e
 
 The `dagger develop` command bootstraps a Dagger module template in the selected programming language and sets up or updates all the resources needed to develop a module. After running this command, follow the steps below to have your IDE recognize the Dagger module.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 To get your IDE to recognize a Dagger Go module, [configure your `go.work` file](./custom-functions.mdx#go-workspaces) to include the path to your module.
 

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -15,7 +15,7 @@ Dagger uses GraphQL as its low-level language-agnostic API query language, and e
 The `dagger develop` command bootstraps a Dagger module template in the selected programming language and sets up or updates all the resources needed to develop a module. After running this command, follow the steps below to have your IDE recognize the Dagger module.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 To get your IDE to recognize a Dagger Go module, [configure your `go.work` file](./custom-functions.mdx#go-workspaces) to include the path to your module.
 
 When you generate a Dagger module for the first time, Dagger will create a `go.mod` file just for the module. If the module exists in a sub-directory of an outer Go project (such as `dagger/`, the default), this might confuse the IDE.

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -198,7 +198,7 @@ It can also create and manage the project environment, but may not support `uv.l
 </Tabs>
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 When opening the generated `dagger/src/index.ts` in an IDE, most IDEs will automatically recognize the `@dagger.io/dagger` package, so long as the `tsconfig.json` file has a path configured on it.
 

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -272,7 +272,7 @@ Then open Emacs in any file within the scope of your module's `composer.json` fi
 </TabItem>
 </Tabs>
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 When you generate a Dagger Java module, a `pom.xml` file is created in the module directory. For example, for a module name
 `your-module`, the example source code is created under `src/main/java/io/dagger/modules/yourmodule/YourModule.java`.
 

--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -219,7 +219,7 @@ The TypeScript SDK automatically attaches source-maps to the module code. These 
 
 Most popular IDEs support source-maps, either natively or with an external plugin, such as the [Open file plugin](https://marketplace.visualstudio.com/items?itemName=Fr43nk.seito-openfile) for Visual Studio Code.
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 To get your IDE to recognize a Dagger PHP module, ensure your `composer.json` has a path configured to the generated `dagger/dagger` package. This is located in the `sdk` directory of your module.
 
 For Dagger modules initialized using `dagger init`, the default template is already configured this way:

--- a/docs/current_docs/api/index.mdx
+++ b/docs/current_docs/api/index.mdx
@@ -158,7 +158,7 @@ Functions can be chained with the CLI, or programmatically in a [custom Dagger f
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/chaining/php/src/MyModule.php
 ```

--- a/docs/current_docs/api/index.mdx
+++ b/docs/current_docs/api/index.mdx
@@ -152,7 +152,7 @@ Functions can be chained with the CLI, or programmatically in a [custom Dagger f
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/chaining/typescript/index.ts
 ```

--- a/docs/current_docs/api/index.mdx
+++ b/docs/current_docs/api/index.mdx
@@ -140,7 +140,7 @@ This example chains multiple function calls into a pipeline that builds the Dagg
 Functions can be chained with the CLI, or programmatically in a [custom Dagger function](./custom-functions.mdx) using a Dagger SDK. The following are equivalent:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/chaining/go/main.go
 ```

--- a/docs/current_docs/api/index.mdx
+++ b/docs/current_docs/api/index.mdx
@@ -146,7 +146,7 @@ Functions can be chained with the CLI, or programmatically in a [custom Dagger f
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/chaining/python/main.py
 ```

--- a/docs/current_docs/api/index.mdx
+++ b/docs/current_docs/api/index.mdx
@@ -139,7 +139,7 @@ This example chains multiple function calls into a pipeline that builds the Dagg
 
 Functions can be chained with the CLI, or programmatically in a [custom Dagger function](./custom-functions.mdx) using a Dagger SDK. The following are equivalent:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/chaining/go/main.go

--- a/docs/current_docs/api/interfaces.mdx
+++ b/docs/current_docs/api/interfaces.mdx
@@ -14,7 +14,7 @@ The information on this page is only applicable to Go and TypeScript SDKs. Inter
 ## Declaration
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 The Go SDK supports interfaces, which allow you to define Go-style interface
 definitions so that your module can accept arbitrary values from other modules
@@ -69,7 +69,7 @@ signature style:
 Here is an example of a module `Example` that implements the `Fooer` interface:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/interfaces/implementations/go/main.go
 ```
@@ -97,7 +97,7 @@ Here is an example of a module that uses the `Example` module defined above and
 passes it as argument to the `foo` function of the `MyModule` object:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/interfaces/usages/go/main.go
 ```

--- a/docs/current_docs/api/interfaces.mdx
+++ b/docs/current_docs/api/interfaces.mdx
@@ -39,7 +39,7 @@ to the GraphQL field argument names.
 
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 The TypeScript SDK supports interfaces, which allow you to define a set of functions
 that an object must implement to be considered a valid instance of that interface.
@@ -75,7 +75,7 @@ Here is an example of a module `Example` that implements the `Fooer` interface:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```ts file=./snippets/interfaces/implementations/typescript/index.ts
 ```
@@ -103,7 +103,7 @@ passes it as argument to the `foo` function of the `MyModule` object:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```ts file=./snippets/interfaces/usages/typescript/index.ts
 ```

--- a/docs/current_docs/api/interfaces.mdx
+++ b/docs/current_docs/api/interfaces.mdx
@@ -13,7 +13,7 @@ The information on this page is only applicable to Go and TypeScript SDKs. Inter
 
 ## Declaration
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 The Go SDK supports interfaces, which allow you to define Go-style interface
@@ -68,7 +68,7 @@ signature style:
 
 Here is an example of a module `Example` that implements the `Fooer` interface:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/interfaces/implementations/go/main.go
@@ -96,7 +96,7 @@ so it can be passed as argument.
 Here is an example of a module that uses the `Example` module defined above and
 passes it as argument to the `foo` function of the `MyModule` object:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/interfaces/usages/go/main.go

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -111,7 +111,7 @@ Consider the following Dagger Function:
 ```go file=../quickstart/agent/snippets/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=../quickstart/agent/snippets/python/src/coding_agent/main.py
 ```
 </TabItem>

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -115,7 +115,7 @@ Consider the following Dagger Function:
 ```python file=../quickstart/agent/snippets/python/src/coding_agent/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=../quickstart/agent/snippets/typescript/src/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -123,7 +123,7 @@ Consider the following Dagger Function:
 ```php file=../quickstart/agent/snippets/php/src/CodingAgent.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=../quickstart/agent/snippets/java/src/main/java/io/dagger/modules/codingagent/CodingAgent.java
 ```
 </TabItem>

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -106,7 +106,7 @@ The documentation for the modules are provided to the LLM, so make sure to provi
 
 Consider the following Dagger Function:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=../quickstart/agent/snippets/go/main.go
 ```

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -119,7 +119,7 @@ Consider the following Dagger Function:
 ```typescript file=../quickstart/agent/snippets/typescript/src/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=../quickstart/agent/snippets/php/src/CodingAgent.php
 ```
 </TabItem>

--- a/docs/current_docs/api/llm.mdx
+++ b/docs/current_docs/api/llm.mdx
@@ -107,7 +107,7 @@ The documentation for the modules are provided to the LLM, so make sure to provi
 Consider the following Dagger Function:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=../quickstart/agent/snippets/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -42,7 +42,7 @@ func (m *MyModule) Greeting(ctx context.Context) (string, error) {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python
 @function
@@ -99,7 +99,7 @@ Next, create a new Dagger Function:
 ```go file=./snippets/dependencies/chaining/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/dependencies/chaining/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -72,7 +72,7 @@ public function greeting(): string
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java
 @Function
@@ -111,7 +111,7 @@ Next, create a new Dagger Function:
 ```php file=./snippets/dependencies/chaining/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/dependencies/chaining/java/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -32,7 +32,7 @@ The entrypoint to accessing dependent modules from your own module's code is `da
 
 Here is an example of accessing the installed `hello` module from your own module's code:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go
@@ -94,7 +94,7 @@ dagger install github.com/kpenfound/dagger-modules/golang@v0.2.0
 
 Next, create a new Dagger Function:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/dependencies/chaining/go/main.go
 ```

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -61,7 +61,7 @@ async greeting(): Promise<string> {
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php
 #[DaggerFunction]
@@ -107,7 +107,7 @@ Next, create a new Dagger Function:
 ```typescript file=./snippets/dependencies/chaining/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/dependencies/chaining/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -51,7 +51,7 @@ async def greeting(self) -> str:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript
 @func()
@@ -103,7 +103,7 @@ Next, create a new Dagger Function:
 ```python file=./snippets/dependencies/chaining/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/dependencies/chaining/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/module-dependencies.mdx
+++ b/docs/current_docs/api/module-dependencies.mdx
@@ -33,7 +33,7 @@ The entrypoint to accessing dependent modules from your own module's code is `da
 Here is an example of accessing the installed `hello` module from your own module's code:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go
 func (m *MyModule) Greeting(ctx context.Context) (string, error) {
@@ -95,7 +95,7 @@ dagger install github.com/kpenfound/dagger-modules/golang@v0.2.0
 Next, create a new Dagger Function:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/dependencies/chaining/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -60,7 +60,7 @@ func DoThing(client *dagger.Client) *dagger.Directory {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 The Dagger module's code in Python can be split into multiple files by making a [package](https://docs.python.org/3/tutorial/modules.html#packages) and ensuring the *main object* is imported in `__init__.py`. All the other object types should already be imported from there.
 
 For example given this directory structure:
@@ -360,7 +360,7 @@ Dagger modules run in a runtime container that's bootstrapped by the Dagger Engi
 The runtime container is currently hardcoded to run in Go 1.21  (although this may be configurable in future).
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 The runtime container is based on the [python:3.12-slim](https://hub.docker.com/_/python/tags?name=3.12-slim) base image by default, but it can be overridden by setting [`requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires), or pinned with a `.python-version` file next to your `pyproject.toml`:
 
@@ -461,7 +461,7 @@ use (
 [Go vendor](https://go.dev/ref/mod#go-mod-vendor) directories are not currently supported. See [https://github.com/dagger/dagger/issues/6076](https://github.com/dagger/dagger/issues/6076) for more information.
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Dagger modules in Python are built to be installed, like libraries. At module creation time, a `pyproject.toml` and `uv.lock` file will automatically be created that depend on the locally generated client library (in `./sdk`). This dependency is configured to be editable so that changes in the code don't require a re-install.
 

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -14,7 +14,7 @@ import DaggerModuleInit from '../partials/_dagger_module_init.mdx';
 
 ### Multiple files
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 You can split your Dagger module into multiple files, not just `main.go`. To do this, you can just create another file beside `main.go` (for example, `utils.go`):
@@ -354,7 +354,7 @@ Benefits of this pattern include:
 
 Dagger modules run in a runtime container that's bootstrapped by the Dagger Engine, with the necessary environment to run the Dagger module's code.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 The runtime container is currently hardcoded to run in Go 1.21  (although this may be configurable in future).
@@ -434,7 +434,7 @@ They are currently hardcoded to run in [maven:3.9.9-eclipse-temurin-17](https://
 
 The structure of a Dagger module mimics that of each language's conventional packaging mechanisms and tools.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Dagger modules written for use with the Go SDK are automatically created as [Go modules](https://go.dev/ref/mod). At module creation time, a `go.mod` and `go.sum` file will automatically be created  that import the necessary dependencies. Dependencies can be installed and managed just as for any standard Go environment.

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -203,7 +203,7 @@ Then the import in `__init__.py` is no longer needed since Dagger knows to impor
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Due to TypeScript limitations, it is not possible to split your main class module (`index.ts`) into multiple files. However, it is possible to create sub-classes in different files and access them from your main class module:
 
@@ -387,7 +387,7 @@ This can be useful to add a few requirements to the module's execution environme
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 The runtime container is currently hardcoded to run in Node.js 22.11.0, but it can be overridden by [setting an alternative base image](../configuration/modules.mdx#alternative-base-images).
 
@@ -491,7 +491,7 @@ It will have to be manually kept in sync, though.
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 Dagger modules in Typescript are built to be installed, like libraries. The runtime container installs the module code with:
 
 ```shell

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -15,7 +15,7 @@ import DaggerModuleInit from '../partials/_dagger_module_init.mdx';
 ### Multiple files
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 You can split your Dagger module into multiple files, not just `main.go`. To do this, you can just create another file beside `main.go` (for example, `utils.go`):
 
@@ -355,7 +355,7 @@ Benefits of this pattern include:
 Dagger modules run in a runtime container that's bootstrapped by the Dagger Engine, with the necessary environment to run the Dagger module's code.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 The runtime container is currently hardcoded to run in Go 1.21  (although this may be configurable in future).
 
@@ -435,7 +435,7 @@ They are currently hardcoded to run in [maven:3.9.9-eclipse-temurin-17](https://
 The structure of a Dagger module mimics that of each language's conventional packaging mechanisms and tools.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Dagger modules written for use with the Go SDK are automatically created as [Go modules](https://go.dev/ref/mod). At module creation time, a `go.mod` and `go.sum` file will automatically be created  that import the necessary dependencies. Dependencies can be installed and managed just as for any standard Go environment.
 

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -229,7 +229,7 @@ class MyModule {
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Only functions from your main class (`MyModule.php`) can _initially_ be called by Dagger. However, it is possible to create other classes and access them from your main class:
 
@@ -416,7 +416,7 @@ This is why the initial `package.json` doesn't include any dependencies except a
 
 [^1]:
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 The runtime container is currently hardcoded to run in [php:8.3-cli-alpine](https://hub.docker.com/_/php/tags?name=8.3-cli-alpine) (although this may be configurable in future).
 
@@ -504,7 +504,7 @@ This means that so long as the project has a `package.json` file, it can be used
 Only production dependencies are installed, not packages defined in the `devDependencies` field.
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 Dagger modules in PHP are built to be installed, like libraries. The runtime container installs the module code with:
 
 ```shell

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -265,7 +265,7 @@ class MyModule
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 The Dagger module's code in Java can be split into multiple classes, in multiple files. A few constraints apply:
 
 - The main Dagger object must be represented by a class using the same name as the module, in PascalCase. For instance if the module name is `my-module`, the main object's class must be named `MyModule`.
@@ -421,7 +421,7 @@ This is why the initial `package.json` doesn't include any dependencies except a
 The runtime container is currently hardcoded to run in [php:8.3-cli-alpine](https://hub.docker.com/_/php/tags?name=8.3-cli-alpine) (although this may be configurable in future).
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 Two containers are used by the runtime, one to build the module into a JAR file, one to run it.
 
@@ -515,7 +515,7 @@ composer install
 This means that so long as the project has a `composer.json` file, it can be used as a library.
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 Dagger modules in Java are built as JAR files, using Maven. The runtime container builds the module code with:
 
 ```shell

--- a/docs/current_docs/api/module-tests.mdx
+++ b/docs/current_docs/api/module-tests.mdx
@@ -12,7 +12,7 @@ Like any other piece of software, Dagger Functions and modules should be thoroug
 The following examples rely on a module called `greeter` that provides a function to greet a person:
 
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/modules/testing/go/main.go
@@ -38,7 +38,7 @@ Well-written tests often provide the best documentation for your software, and t
 
 Following these principles leads to writing tests for your Dagger modules using Dagger modules themselves. In practice, this means creating a test module in the same directory as your main module and writing your tests as Dagger Functions, as shown below:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```bash
@@ -132,7 +132,7 @@ In the Daggerverse, [example modules](https://docs.dagger.io/api/daggerverse#exa
 
 You can combine example modules with the test module pattern to turn those examples into executable tests. Often, this approach provides enough coverage to eliminate the need for a separate test module.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```bash
@@ -226,7 +226,7 @@ Another challenge arises when you have multiple test functions with parameters, 
 
 In such cases, it can be helpful to standardize your test function signature. Consider generating inputs from within the function, synchronizing any asynchronous tasks there, and returning a single value or an error. This approach keeps your tests consistent and easier to maintain.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go
@@ -290,7 +290,7 @@ This is where the `all` function comes into the picture. It's basically a single
 
 Depending on the SDK you use, this may be as simple as calling each test function after the other:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go
@@ -342,7 +342,7 @@ export class Tests {
 
 Alternatively, if the SDK/language you use supports this, you can run tests in parallel:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go

--- a/docs/current_docs/api/module-tests.mdx
+++ b/docs/current_docs/api/module-tests.mdx
@@ -24,7 +24,7 @@ The following examples rely on a module called `greeter` that provides a functio
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/modules/testing/typescript/src/index.ts
 ```
@@ -89,7 +89,7 @@ class Tests:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```bash
 mkdir tests
@@ -181,7 +181,7 @@ class Examples:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```bash
 mkdir -p examples/typescript
@@ -256,7 +256,7 @@ class Tests:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript
 @object()
@@ -324,7 +324,7 @@ class Tests:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript
 @object()
@@ -376,7 +376,7 @@ class Tests:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript
 @object()

--- a/docs/current_docs/api/module-tests.mdx
+++ b/docs/current_docs/api/module-tests.mdx
@@ -18,7 +18,7 @@ The following examples rely on a module called `greeter` that provides a functio
 ```go file=./snippets/modules/testing/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/modules/testing/python/src/greeter/main.py
 ```
@@ -66,7 +66,7 @@ func (m *Tests) Hello(ctx context.Context) error {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```bash
 mkdir tests
@@ -159,7 +159,7 @@ func (m *Examples) GreeterHello(ctx context.Context) error {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```bash
 mkdir -p examples/python
@@ -242,7 +242,7 @@ func (m *Tests) YourTest(ctx context.Context) error {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python
 @object_type
@@ -312,7 +312,7 @@ func (m *Tests) All(ctx context.Context) error {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python
 @object_type
@@ -361,7 +361,7 @@ func (m *Tests) All(ctx context.Context) error {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python
 import anyio

--- a/docs/current_docs/api/module-tests.mdx
+++ b/docs/current_docs/api/module-tests.mdx
@@ -13,7 +13,7 @@ The following examples rely on a module called `greeter` that provides a functio
 
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/modules/testing/go/main.go
 ```
@@ -39,7 +39,7 @@ Well-written tests often provide the best documentation for your software, and t
 Following these principles leads to writing tests for your Dagger modules using Dagger modules themselves. In practice, this means creating a test module in the same directory as your main module and writing your tests as Dagger Functions, as shown below:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```bash
 mkdir tests
@@ -133,7 +133,7 @@ In the Daggerverse, [example modules](https://docs.dagger.io/api/daggerverse#exa
 You can combine example modules with the test module pattern to turn those examples into executable tests. Often, this approach provides enough coverage to eliminate the need for a separate test module.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```bash
 mkdir -p examples/go
@@ -227,7 +227,7 @@ Another challenge arises when you have multiple test functions with parameters, 
 In such cases, it can be helpful to standardize your test function signature. Consider generating inputs from within the function, synchronizing any asynchronous tasks there, and returning a single value or an error. This approach keeps your tests consistent and easier to maintain.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go
 func (m *Tests) YourTest(ctx context.Context) error {
@@ -291,7 +291,7 @@ This is where the `all` function comes into the picture. It's basically a single
 Depending on the SDK you use, this may be as simple as calling each test function after the other:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go
 func (m *Tests) All(ctx context.Context) error {
@@ -343,7 +343,7 @@ export class Tests {
 Alternatively, if the SDK/language you use supports this, you can run tests in parallel:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go
 import "github.com/sourcegraph/conc/pool"

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -117,7 +117,7 @@ npm install pm2
 Pinning a specific dependency version or adding local dependencies are supported, in the same way as any Node.js project.
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 To add a PHP package, add it to the `composer.json` file, the same way as any PHP project. For example:
 

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Dagger Functions are just regular code, written in your usual programming language. One of the key advantages of this approach is that it opens up access to your language's existing ecosystem of packages or modules. You can easily import these packages/modules in your Dagger module via your language's package manager.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 To add a Go module, add it to your `go.mod` file using `go get`. For example:

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -34,7 +34,7 @@ Multiple URLs can be specified as comma-separated values. The repository name is
 
 Note that this feature requires a `.gitconfig` file entry to use SSH instead of HTTPS for the host. Use the command `git config --global url."git@github.com:".insteadOf "https://github.com/"` to create the necessary `.gitconfig` entry.
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 To add a Python package, add it to your `pyproject.toml` file using your chosen package manager. For example:
 

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -137,7 +137,7 @@ Use Dagger to [install Dagger modules](./module-dependencies.mdx)
 :::
 
 </TabItem>
-    <TabItem value="Java">
+    <TabItem value="java" label="Java">
 
 To add a Java package, add it to your `pom.xml` file using Maven. For example:
 

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 Dagger Functions are just regular code, written in your usual programming language. One of the key advantages of this approach is that it opens up access to your language's existing ecosystem of packages or modules. You can easily import these packages/modules in your Dagger module via your language's package manager.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 To add a Go module, add it to your `go.mod` file using `go get`. For example:
 

--- a/docs/current_docs/api/packages.mdx
+++ b/docs/current_docs/api/packages.mdx
@@ -106,7 +106,7 @@ Third-party dependencies are managed in the same way as any normal Python projec
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 To add a TypeScript package, add it to the `package.json` file using your favorite package manager. For example:
 

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -37,7 +37,7 @@ Here is an example of a Dagger Function that returns operating system informatio
 ```php file=./snippets/functions/arguments-container/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/arguments-container/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -94,7 +94,7 @@ Here is an example of a Dagger Function that returns the sum of two integers:
 ```
 </TabItem>
 
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can either use the primitive `int` type or the boxed `java.lang.Integer` type.
 :::
@@ -163,7 +163,7 @@ The imported `float` type is a `number` underneath, so you can return it as you 
 ```
 </TabItem>
 
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 :::note
 You can either use the primitive `float` type or the boxed `java.lang.Float` type.
 :::
@@ -228,7 +228,7 @@ Here is an example of a Go builder Dagger Function that accepts a remote Git add
 ```php file=./snippets/functions/return-values-directory/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/return-values-directory/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -292,7 +292,7 @@ Here is an example of a Dagger Function that accepts a filesystem path or remote
 ```php file=./snippets/functions/return-values-file/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/return-values-file/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -362,7 +362,7 @@ Here's an example of a Dagger Function that returns a base `alpine` container im
 ```php file=./snippets/functions/return-values-container/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/return-values-container/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -430,7 +430,7 @@ Here is an example module with support for function chaining:
 ```php file=./snippets/functions/return-values-chaining/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/functions/return-values-chaining/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -33,7 +33,7 @@ Here is an example of a Dagger Function that returns operating system informatio
 ```typescript file=./snippets/functions/arguments-container/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-container/php/src/MyModule.php
 ```
 </TabItem>
@@ -89,7 +89,7 @@ Here is an example of a Dagger Function that returns the sum of two integers:
 ```
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-return-values-integer/php/src/MyModule.php
 ```
 </TabItem>
@@ -158,7 +158,7 @@ The imported `float` type is a `number` underneath, so you can return it as you 
 ```
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/arguments-return-values-float/php/src/MyModule.php
 ```
 </TabItem>
@@ -224,7 +224,7 @@ Here is an example of a Go builder Dagger Function that accepts a remote Git add
 ```typescript file=./snippets/functions/return-values-directory/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/return-values-directory/php/src/MyModule.php
 ```
 </TabItem>
@@ -288,7 +288,7 @@ Here is an example of a Dagger Function that accepts a filesystem path or remote
 ```typescript file=./snippets/functions/return-values-file/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/return-values-file/php/src/MyModule.php
 ```
 </TabItem>
@@ -358,7 +358,7 @@ Here's an example of a Dagger Function that returns a base `alpine` container im
 ```typescript file=./snippets/functions/return-values-container/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/return-values-container/php/src/MyModule.php
 ```
 </TabItem>
@@ -426,7 +426,7 @@ Here is an example module with support for function chaining:
 ```typescript file=./snippets/functions/return-values-chaining/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/functions/return-values-chaining/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -25,7 +25,7 @@ Here is an example of a Dagger Function that returns operating system informatio
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-container/python/main.py
 ```
 </TabItem>
@@ -79,7 +79,7 @@ Here is an example of a Dagger Function that returns the sum of two integers:
 ```
 </TabItem>
 
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-return-values-integer/python/main.py
 ```
 </TabItem>
@@ -140,7 +140,7 @@ Here is an example of a Dagger Function that returns the sum of two floating-poi
 ```
 </TabItem>
 
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/arguments-return-values-float/python/main.py
 ```
 </TabItem>
@@ -216,7 +216,7 @@ Here is an example of a Go builder Dagger Function that accepts a remote Git add
 ```go file=./snippets/functions/return-values-directory/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/return-values-directory/python/main.py
 ```
 </TabItem>
@@ -280,7 +280,7 @@ Here is an example of a Dagger Function that accepts a filesystem path or remote
 ```go file=./snippets/functions/return-values-file/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/return-values-file/python/main.py
 ```
 </TabItem>
@@ -349,7 +349,7 @@ Here's an example of a Dagger Function that returns a base `alpine` container im
 ```go file=./snippets/functions/return-values-container/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/return-values-container/python/main.py
 ```
 </TabItem>
@@ -418,7 +418,7 @@ Here is an example module with support for function chaining:
 ```go file=./snippets/functions/return-values-chaining/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/functions/return-values-chaining/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -20,7 +20,7 @@ If a function doesn't have a return type annotation, it'll be translated to the 
 
 Here is an example of a Dagger Function that returns operating system information for the container as a string:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
@@ -73,7 +73,7 @@ Linux dagger 6.1.0-22-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.94-1 (2024-0
 
 Here is an example of a Dagger Function that returns the sum of two integers:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-return-values-integer/go/main.go
 ```
@@ -134,7 +134,7 @@ The result will look like this:
 
 Here is an example of a Dagger Function that returns the sum of two floating-point numbers:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/arguments-return-values-float/go/main.go
 ```
@@ -211,7 +211,7 @@ Directory return values might be produced by a Dagger Function that:
 
 Here is an example of a Go builder Dagger Function that accepts a remote Git address as a `Directory` argument, builds a Go binary from the source code in that repository, and returns the build directory containing the compiled binary:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/return-values-directory/go/main.go
 ```
@@ -275,7 +275,7 @@ Just-in-time files might be produced by a Dagger Function that:
 
 Here is an example of a Dagger Function that accepts a filesystem path or remote Git address as a `Directory` argument and  returns a ZIP archive of that directory:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/return-values-file/go/main.go
 ```
@@ -344,7 +344,7 @@ You can think of a just-in-time container, and the `Container` type that represe
 
 Here's an example of a Dagger Function that returns a base `alpine` container image with a list of additional specified packages:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/return-values-container/go/main.go
 ```
@@ -413,7 +413,7 @@ So long as a Dagger Function returns an object that can be JSON-serialized, its 
 
 Here is an example module with support for function chaining:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/functions/return-values-chaining/go/main.go
 ```

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -21,7 +21,7 @@ If a function doesn't have a return type annotation, it'll be translated to the 
 Here is an example of a Dagger Function that returns operating system information for the container as a string:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-container/go/main.go
 ```
 </TabItem>
@@ -74,7 +74,7 @@ Linux dagger 6.1.0-22-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.94-1 (2024-0
 Here is an example of a Dagger Function that returns the sum of two integers:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-return-values-integer/go/main.go
 ```
 </TabItem>
@@ -135,7 +135,7 @@ The result will look like this:
 Here is an example of a Dagger Function that returns the sum of two floating-point numbers:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/arguments-return-values-float/go/main.go
 ```
 </TabItem>
@@ -212,7 +212,7 @@ Directory return values might be produced by a Dagger Function that:
 Here is an example of a Go builder Dagger Function that accepts a remote Git address as a `Directory` argument, builds a Go binary from the source code in that repository, and returns the build directory containing the compiled binary:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/return-values-directory/go/main.go
 ```
 </TabItem>
@@ -276,7 +276,7 @@ Just-in-time files might be produced by a Dagger Function that:
 Here is an example of a Dagger Function that accepts a filesystem path or remote Git address as a `Directory` argument and  returns a ZIP archive of that directory:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/return-values-file/go/main.go
 ```
 </TabItem>
@@ -345,7 +345,7 @@ You can think of a just-in-time container, and the `Container` type that represe
 Here's an example of a Dagger Function that returns a base `alpine` container image with a list of additional specified packages:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/return-values-container/go/main.go
 ```
 </TabItem>
@@ -414,7 +414,7 @@ So long as a Dagger Function returns an object that can be JSON-serialized, its 
 Here is an example module with support for function chaining:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/functions/return-values-chaining/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/return-values.mdx
+++ b/docs/current_docs/api/return-values.mdx
@@ -29,7 +29,7 @@ Here is an example of a Dagger Function that returns operating system informatio
 ```python file=./snippets/functions/arguments-container/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-container/typescript/index.ts
 ```
 </TabItem>
@@ -84,7 +84,7 @@ Here is an example of a Dagger Function that returns the sum of two integers:
 ```
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/arguments-return-values-integer/typescript/index.ts
 ```
 </TabItem>
@@ -145,7 +145,7 @@ Here is an example of a Dagger Function that returns the sum of two floating-poi
 ```
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 :::note
 There's no `float` type keyword in TypeScript because the type keyword `number` already supports floating point numbers.
@@ -220,7 +220,7 @@ Here is an example of a Go builder Dagger Function that accepts a remote Git add
 ```python file=./snippets/functions/return-values-directory/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/return-values-directory/typescript/index.ts
 ```
 </TabItem>
@@ -284,7 +284,7 @@ Here is an example of a Dagger Function that accepts a filesystem path or remote
 ```python file=./snippets/functions/return-values-file/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/return-values-file/typescript/index.ts
 ```
 </TabItem>
@@ -354,7 +354,7 @@ Here's an example of a Dagger Function that returns a base `alpine` container im
 ```
 </TabItem>
 
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/return-values-container/typescript/index.ts
 ```
 </TabItem>
@@ -422,7 +422,7 @@ Here is an example module with support for function chaining:
 ```python file=./snippets/functions/return-values-chaining/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/functions/return-values-chaining/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/secrets.mdx
+++ b/docs/current_docs/api/secrets.mdx
@@ -52,7 +52,7 @@ dagger core container \
 ```python file=./snippets/secrets/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/secrets/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/api/secrets.mdx
+++ b/docs/current_docs/api/secrets.mdx
@@ -44,7 +44,7 @@ dagger core container \
   stdout
 ```
 </TabItem>
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/secrets/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/api/secrets.mdx
+++ b/docs/current_docs/api/secrets.mdx
@@ -48,7 +48,7 @@ dagger core container \
 ```go file=./snippets/secrets/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/secrets/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/api/secrets.mdx
+++ b/docs/current_docs/api/secrets.mdx
@@ -14,7 +14,7 @@ Here is an example, which uses a secret in a Dagger function chain:
 export API_TOKEN="guessme"
 ```
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="System shell">
 ```shell
 dagger <<'EOF'

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -61,7 +61,7 @@ Here is an example of a Dagger Function that returns an HTTP service. This servi
 
 </TabItem>
 
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/services/bind-services/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -190,7 +190,7 @@ Here is an example of how a container running in a Dagger Function can access an
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/expose-host-services-to-dagger/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -266,7 +266,7 @@ For example, you can now run two services that depend on each other, each using 
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/create-interdependent-services/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -326,7 +326,7 @@ Dagger cancels each service run after a 10 second grace period to avoid frequent
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/persist-service-state/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -399,7 +399,7 @@ The following example explicitly starts the Redis service and stops it at the en
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/start-stop-services/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -438,7 +438,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/test-against-db-service/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -550,7 +550,7 @@ Here's what happens on the last line:
 1. Dagger runs the `ping` container with the `redis-srv` alias magically added to `/etc/hosts`.
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/service-lifecycle-1/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -605,7 +605,7 @@ Here's a more detailed client-server example of running commands against a Redis
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/service-lifecycle-2/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
@@ -642,7 +642,7 @@ It would be better to chain both commands together, which ensures that the servi
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java file=./snippets/services/service-lifecycle-3/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -42,7 +42,7 @@ Here is an example of a Dagger Function that returns an HTTP service. This servi
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/bind-services/python/main.py
 ```
@@ -172,7 +172,7 @@ Here is an example of how a container running in a Dagger Function can access an
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/expose-host-services-to-dagger/python/main.py
 ```
@@ -248,7 +248,7 @@ For example, you can now run two services that depend on each other, each using 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/create-interdependent-services/python/main.py
 ```
@@ -308,7 +308,7 @@ Dagger cancels each service run after a 10 second grace period to avoid frequent
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/persist-service-state/python/main.py
 ```
@@ -381,7 +381,7 @@ The following example explicitly starts the Redis service and stops it at the en
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/start-stop-services/python/main.py
 ```
@@ -420,7 +420,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/test-against-db-service/python/main.py
 ```
@@ -508,7 +508,7 @@ Here's what happens on the last line:
 1. Dagger runs the `ping` container with the `redis-srv` alias magically added to `/etc/hosts`.
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/service-lifecycle-1/python/main.py
 ```
@@ -587,7 +587,7 @@ Here's a more detailed client-server example of running commands against a Redis
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/service-lifecycle-2/python/main.py
 ```
@@ -624,7 +624,7 @@ It would be better to chain both commands together, which ensures that the servi
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/services/service-lifecycle-3/python/main.py
 ```

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -54,7 +54,7 @@ Here is an example of a Dagger Function that returns an HTTP service. This servi
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/bind-services/php/src/MyModule.php
 ```
@@ -184,7 +184,7 @@ Here is an example of how a container running in a Dagger Function can access an
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/expose-host-services-to-dagger/php/src/MyModule.php
 ```
@@ -260,7 +260,7 @@ For example, you can now run two services that depend on each other, each using 
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/create-interdependent-services/php/src/MyModule.php
 ```
@@ -320,7 +320,7 @@ Dagger cancels each service run after a 10 second grace period to avoid frequent
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/persist-service-state/php/src/MyModule.php
 ```
@@ -393,7 +393,7 @@ The following example explicitly starts the Redis service and stops it at the en
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/start-stop-services/php/src/MyModule.php
 ```
@@ -432,7 +432,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/test-against-db-service/php/src/MyModule.php
 ```
@@ -536,7 +536,7 @@ Here's what happens on the last line:
 1. Dagger runs the `ping` container with the `redis-srv` alias magically added to `/etc/hosts`.
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/service-lifecycle-1/php/src/MyModule.php
 ```
@@ -599,7 +599,7 @@ Here's a more detailed client-server example of running commands against a Redis
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/service-lifecycle-2/php/src/MyModule.php
 ```
@@ -636,7 +636,7 @@ It would be better to chain both commands together, which ensures that the servi
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/services/service-lifecycle-3/php/src/MyModule.php
 ```

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -48,7 +48,7 @@ Here is an example of a Dagger Function that returns an HTTP service. This servi
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/bind-services/typescript/index.ts
 ```
@@ -178,7 +178,7 @@ Here is an example of how a container running in a Dagger Function can access an
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/expose-host-services-to-dagger/typescript/index.ts
 ```
@@ -254,7 +254,7 @@ For example, you can now run two services that depend on each other, each using 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/create-interdependent-services/typescript/index.ts
 ```
@@ -314,7 +314,7 @@ Dagger cancels each service run after a 10 second grace period to avoid frequent
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/persist-service-state/typescript/index.ts
 ```
@@ -387,7 +387,7 @@ The following example explicitly starts the Redis service and stops it at the en
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/start-stop-services/typescript/index.ts
 ```
@@ -426,7 +426,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/test-against-db-service/typescript/index.ts
 ```
@@ -522,7 +522,7 @@ Here's what happens on the last line:
 1. Dagger runs the `ping` container with the `redis-srv` alias magically added to `/etc/hosts`.
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/service-lifecycle-1/typescript/index.ts
 ```
@@ -593,7 +593,7 @@ Here's a more detailed client-server example of running commands against a Redis
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/service-lifecycle-2/typescript/index.ts
 ```
@@ -630,7 +630,7 @@ It would be better to chain both commands together, which ensures that the servi
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/services/service-lifecycle-3/typescript/index.ts
 ```

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -35,7 +35,7 @@ A Dagger Function can create and return a service, which can then be used from a
 
 Here is an example of a Dagger Function that returns an HTTP service. This service is used by another Dagger Function, which creates a service binding using the alias `www` and then accesses the HTTP service using this alias.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/bind-services/go/main.go
@@ -165,7 +165,7 @@ This implies that a service is already listening on a port on the host, out-of-b
 
 Here is an example of how a container running in a Dagger Function can access and query a MariaDB database service (bound using the alias `db`) running on the host.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/expose-host-services-to-dagger/go/main.go
@@ -241,7 +241,7 @@ Custom hostnames follow a structured format (`<host>.<module id>.<session id>.da
 
 For example, you can now run two services that depend on each other, each using a hostname to refer to the other by name:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/create-interdependent-services/go/main.go
@@ -301,7 +301,7 @@ dagger call services up --ports 8080:80
 
 Dagger cancels each service run after a 10 second grace period to avoid frequent restarts. To avoid relying on the grace period, use a cache volume to persist a service's data, as in the following example:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/persist-service-state/go/main.go
@@ -374,7 +374,7 @@ For example, this may be needed if the application in the service has certain be
 
 The following example explicitly starts the Redis service and stops it at the end, ensuring the 10 second grace period doesn't get in the way, without the need for a persistent cache volume:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/start-stop-services/go/main.go
@@ -413,7 +413,7 @@ The following example demonstrates how services can be used in Dagger Functions,
 
 The application used in this example is [Drupal](https://www.drupal.org/), a popular open-source PHP CMS. Drupal includes a large number of unit tests, including tests which require an active database connection. All Drupal 10.x tests are written and executed using the [PHPUnit](https://phpunit.de/) testing framework. Read more about [running PHPUnit tests in Drupal](https://phpunit.de/).
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/test-against-db-service/go/main.go
@@ -493,7 +493,7 @@ If you're not interested in what's happening in the background, you can skip thi
 
 Consider this example:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/service-lifecycle-1/go/main.go
@@ -580,7 +580,7 @@ If you need multiple instances of a service, just attach something unique to eac
 
 Here's a more detailed client-server example of running commands against a Redis service:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/service-lifecycle-2/go/main.go
@@ -617,7 +617,7 @@ This example relies on the 10-second grace period, which you should try to avoid
 
 It would be better to chain both commands together, which ensures that the service stays running for both, as in the revision below:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/services/service-lifecycle-3/go/main.go

--- a/docs/current_docs/api/services.mdx
+++ b/docs/current_docs/api/services.mdx
@@ -36,7 +36,7 @@ A Dagger Function can create and return a service, which can then be used from a
 Here is an example of a Dagger Function that returns an HTTP service. This service is used by another Dagger Function, which creates a service binding using the alias `www` and then accesses the HTTP service using this alias.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/bind-services/go/main.go
 ```
@@ -166,7 +166,7 @@ This implies that a service is already listening on a port on the host, out-of-b
 Here is an example of how a container running in a Dagger Function can access and query a MariaDB database service (bound using the alias `db`) running on the host.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/expose-host-services-to-dagger/go/main.go
 ```
@@ -242,7 +242,7 @@ Custom hostnames follow a structured format (`<host>.<module id>.<session id>.da
 For example, you can now run two services that depend on each other, each using a hostname to refer to the other by name:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/create-interdependent-services/go/main.go
 ```
@@ -302,7 +302,7 @@ dagger call services up --ports 8080:80
 Dagger cancels each service run after a 10 second grace period to avoid frequent restarts. To avoid relying on the grace period, use a cache volume to persist a service's data, as in the following example:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/persist-service-state/go/main.go
 ```
@@ -375,7 +375,7 @@ For example, this may be needed if the application in the service has certain be
 The following example explicitly starts the Redis service and stops it at the end, ensuring the 10 second grace period doesn't get in the way, without the need for a persistent cache volume:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/start-stop-services/go/main.go
 ```
@@ -414,7 +414,7 @@ The following example demonstrates how services can be used in Dagger Functions,
 The application used in this example is [Drupal](https://www.drupal.org/), a popular open-source PHP CMS. Drupal includes a large number of unit tests, including tests which require an active database connection. All Drupal 10.x tests are written and executed using the [PHPUnit](https://phpunit.de/) testing framework. Read more about [running PHPUnit tests in Drupal](https://phpunit.de/).
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/test-against-db-service/go/main.go
 ```
@@ -494,7 +494,7 @@ If you're not interested in what's happening in the background, you can skip thi
 Consider this example:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/service-lifecycle-1/go/main.go
 ```
@@ -581,7 +581,7 @@ If you need multiple instances of a service, just attach something unique to eac
 Here's a more detailed client-server example of running commands against a Redis service:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/service-lifecycle-2/go/main.go
 ```
@@ -618,7 +618,7 @@ This example relies on the 10-second grace period, which you should try to avoid
 It would be better to chain both commands together, which ensures that the service stays running for both, as in the revision below:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/services/service-lifecycle-3/go/main.go
 ```

--- a/docs/current_docs/api/state.mdx
+++ b/docs/current_docs/api/state.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Object state can be exposed as a Dagger Function, without having to create a getter function explicitly. Depending on the language used, this state is exposed using struct fields (Go), object attributes (Python) or object properties (TypeScript).
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 Dagger only exposes a struct's public fields; private fields will not be exposed.
 

--- a/docs/current_docs/api/state.mdx
+++ b/docs/current_docs/api/state.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 Object state can be exposed as a Dagger Function, without having to create a getter function explicitly. Depending on the language used, this state is exposed using struct fields (Go), object attributes (Python) or object properties (TypeScript).
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 Dagger only exposes a struct's public fields; private fields will not be exposed.
 
 Here's an example where one struct field is exposed as a Dagger Function, while the other is not:

--- a/docs/current_docs/api/state.mdx
+++ b/docs/current_docs/api/state.mdx
@@ -46,7 +46,7 @@ Here's an example where one field is exposed as a Dagger Function, while the oth
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 Dagger will automatically expose all public fields of a class as Dagger Functions. It's also possible to expose a package, `protected` or `private` field by annotating it with the `@Function` annotation.
 
 In case of a field that shouldn't be serialized at all, this can be achieved by marking it as `transient` in Java.

--- a/docs/current_docs/api/state.mdx
+++ b/docs/current_docs/api/state.mdx
@@ -37,7 +37,7 @@ In a future version of the Python SDK, the `dagger.function` decorator will be u
 :::
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 TypeScript already offers `private`, `protected` and `public` keywords to handle member visibility in a class. However, Dagger will only expose those members of a Dagger module that are explicitly decorated with the `@func()` decorator. Others will remain private.
 
 Here's an example where one field is exposed as a Dagger Function, while the other is not:

--- a/docs/current_docs/api/state.mdx
+++ b/docs/current_docs/api/state.mdx
@@ -21,7 +21,7 @@ Here's an example where one struct field is exposed as a Dagger Function, while 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 The [`dagger.field`](https://dagger-io.readthedocs.io/en/latest/module.html#dagger.field) descriptor is a wrapper of
 [`dataclasses.field`](https://docs.python.org/3/library/dataclasses.html#mutable-default-values). It creates a getter function for the attribute as well so that it's accessible from the Dagger API.
 

--- a/docs/current_docs/api/terminal.mdx
+++ b/docs/current_docs/api/terminal.mdx
@@ -39,7 +39,7 @@ Here is an example of a Dagger Function which opens an interactive terminal at t
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/debugging/python/terminal-container/main.py
 ```
 
@@ -67,7 +67,7 @@ It's also possible to inspect a directory using the `Container.terminal()` metho
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/debugging/python/terminal-directory-1/main.py
 ```
 
@@ -89,7 +89,7 @@ Under the hood, this creates a new container (defaults to `alpine`) and starts a
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/debugging/python/terminal-directory-2/main.py
 ```
 

--- a/docs/current_docs/api/terminal.mdx
+++ b/docs/current_docs/api/terminal.mdx
@@ -44,7 +44,7 @@ Here is an example of a Dagger Function which opens an interactive terminal at t
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/debugging/typescript/terminal-container/index.ts
 ```
@@ -72,7 +72,7 @@ It's also possible to inspect a directory using the `Container.terminal()` metho
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/debugging/typescript/terminal-directory-1/index.ts
 ```
@@ -94,7 +94,7 @@ Under the hood, this creates a new container (defaults to `alpine`) and starts a
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/debugging/typescript/terminal-directory-2/index.ts
 ```

--- a/docs/current_docs/api/terminal.mdx
+++ b/docs/current_docs/api/terminal.mdx
@@ -32,7 +32,7 @@ dagger core container from --address=alpine terminal
 
 Here is an example of a Dagger Function which opens an interactive terminal at two different points in the Dagger pipeline to inspect the built container:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/debugging/go/terminal-container/main.go
@@ -60,7 +60,7 @@ Multiple terminals are supported in the same Dagger Function; they will open in 
 
 It's also possible to inspect a directory using the `Container.terminal()` method. Here is an example of a Dagger Function which opens an interactive terminal on a directory:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/debugging/go/terminal-directory-1/main.go
@@ -82,7 +82,7 @@ It's also possible to inspect a directory using the `Container.terminal()` metho
 
 Under the hood, this creates a new container (defaults to `alpine`) and starts a shell, mounting the directory inside. This container can be customized using additional options. Here is a more complex example, which produces the same result as the previous one but this time using an `ubuntu` container image and `bash` shell instead of the default `alpine` container image and `sh` shell:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/debugging/go/terminal-directory-2/main.go

--- a/docs/current_docs/api/terminal.mdx
+++ b/docs/current_docs/api/terminal.mdx
@@ -33,7 +33,7 @@ dagger core container from --address=alpine terminal
 Here is an example of a Dagger Function which opens an interactive terminal at two different points in the Dagger pipeline to inspect the built container:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/debugging/go/terminal-container/main.go
 ```
@@ -61,7 +61,7 @@ Multiple terminals are supported in the same Dagger Function; they will open in 
 It's also possible to inspect a directory using the `Container.terminal()` method. Here is an example of a Dagger Function which opens an interactive terminal on a directory:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/debugging/go/terminal-directory-1/main.go
 ```
@@ -83,7 +83,7 @@ It's also possible to inspect a directory using the `Container.terminal()` metho
 Under the hood, this creates a new container (defaults to `alpine`) and starts a shell, mounting the directory inside. This container can be customized using additional options. Here is a more complex example, which produces the same result as the previous one but this time using an `ubuntu` container image and `bash` shell instead of the default `alpine` container image and `sh` shell:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/debugging/go/terminal-directory-2/main.go
 ```

--- a/docs/current_docs/ci/integrations/google-cloud-run.mdx
+++ b/docs/current_docs/ci/integrations/google-cloud-run.mdx
@@ -82,7 +82,7 @@ Update the generated `dagger/src/my_module/main.py` file with the following code
 ```python file=./snippets/google-cloud-run/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 Create a new Dagger module:
 
 ```shell

--- a/docs/current_docs/ci/integrations/google-cloud-run.mdx
+++ b/docs/current_docs/ci/integrations/google-cloud-run.mdx
@@ -64,7 +64,7 @@ Update the generated `dagger/main.go` file with the following code:
 ```go file=./snippets/google-cloud-run/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 Create a new Dagger module:
 
 ```shell

--- a/docs/current_docs/ci/integrations/google-cloud-run.mdx
+++ b/docs/current_docs/ci/integrations/google-cloud-run.mdx
@@ -45,7 +45,7 @@ dagger -m github.com/vvaswani/daggerverse/google-cloud-run@v0.1.5 call create-se
 
 If your requirements are more complex - for example, if you already have one or more Dagger Functions to build, test and containerize your application - you can install the `google-cloud-run` module as a dependency and call it from your existing Dagger Functions using code.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 Create a new Dagger module:
 

--- a/docs/current_docs/ci/integrations/google-cloud-run.mdx
+++ b/docs/current_docs/ci/integrations/google-cloud-run.mdx
@@ -46,7 +46,7 @@ dagger -m github.com/vvaswani/daggerverse/google-cloud-run@v0.1.5 call create-se
 If your requirements are more complex - for example, if you already have one or more Dagger Functions to build, test and containerize your application - you can install the `google-cloud-run` module as a dependency and call it from your existing Dagger Functions using code.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 Create a new Dagger module:
 
 ```shell

--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -18,7 +18,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 :::
 
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/mount-dir/go/main.go
@@ -52,7 +52,7 @@ An alternative option is to copy the target directory in the container. The diff
 Besides helping with the final image size, mounts are more performant and resource-efficient. The rule of thumb should be to always use mounts where possible.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-dir/go/main.go
@@ -260,7 +260,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 When working with private Git repositories, ensure that [SSH authentication is properly configured](../api/remote-modules.mdx#configuring-ssh-authentication) on your Dagger host.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-modify-dir/go/main.go
@@ -380,7 +380,7 @@ The following Dagger Function accepts a Git repository URL and a Git reference. 
 For examples of SSH-based cloning, including private or public Git repositories with an SSH reference format, select the `SSH` tabs below. This approach requires explicitly forwarding the host `SSH_AUTH_SOCK` to the Dagger Function. Learn more about this in Dagger's [security model](../features/security.mdx).
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/clone-git-repository/go/main.go
@@ -501,7 +501,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 
 The following Dagger Function accepts a `File` argument, which could reference either a file from the local filesystem or from a [remote Git repository](../api/arguments.mdx#remote-repositories). It mounts the specified file to a container in the `/src/` directory and returns the modified container.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/mount-file/go/main.go
@@ -528,7 +528,7 @@ An alternative option is to copy the target file to the container. The differenc
 Besides helping with the final image size, mounts are more performant and resource-efficient. The rule of thumb should be to always use mounts where possible.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-file/go/main.go
@@ -721,7 +721,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filtering) with [directory filters](../api/fs-filters.mdx).
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-filter-dir-post/go/main.go
@@ -820,7 +820,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 
 ### Request a file over HTTP/HTTPS and save it in a container
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/read-file-http/go/main.go
@@ -894,7 +894,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 
 The following Dagger Function accepts a `File` argument and copies the specified file to the Dagger module runtime container. This makes it possible to add one or more files to the runtime container and manipulate them using custom logic.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-file-runtime/go/main.go
@@ -949,7 +949,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filtering) with [directory filters](../api/fs-filters.mdx).
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/copy-filter-dir-pre/go/main.go
@@ -1019,7 +1019,7 @@ This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filter
 
 The following Dagger module uses a constructor to set a module-wide `Directory` argument and point it to a default path on the host. This eliminates the need to pass a common `Directory` argument individually to each Dagger Function in the module. If required, the default path can be overridden by specifying a different `Directory` value at call time.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/set-common-default-path/go/main.go
@@ -1094,7 +1094,7 @@ The following Dagger module uses a constructor to set a module-wide `Directory` 
 
 The following Dagger Function performs a multi-stage build.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/multi-stage-build/go/main.go
@@ -1147,7 +1147,7 @@ Perform a multi-stage build of the source code in the `golang/example/hello` rep
 
 The following Dagger Function performs a matrix build.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/matrix-build/go/main.go
@@ -1221,7 +1221,7 @@ Inspect the contents of the exported directory with `tree /tmp/matrix-builds`. T
 
 The following Dagger Function builds a single image for different CPU architectures using native emulation.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/multi-arch/go/main.go
@@ -1273,7 +1273,7 @@ This Dagger Function uses the `containerd` utility module. To run it locally
 install the module first with `dagger install github.com/levlaz/daggerverse/containerd@v0.1.2`
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/multi-arch-cc/go/main.go
@@ -1320,7 +1320,7 @@ Build and publish a multi-platform image with cross compliation:
 
 The following Dagger Function builds an image from a Dockerfile.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/dockerfile/go/main.go
@@ -1372,7 +1372,7 @@ Build and publish an image from an existing Dockerfile
 
 The following function builds an image from a Dockerfile with a build context that is different than the current working directory.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/dockerfile-context/go/main.go
@@ -1421,7 +1421,7 @@ Build an image from the source code in `https://github.com/dockersamples/python-
 
 The following Dagger Function adds [OpenContainer Initiative (OCI) annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to an image.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/oci-annotations/go/main.go
@@ -1468,7 +1468,7 @@ Build and publish an image with OCI annotations:
 
 The following Dagger Function adds [OpenContainer Initiative (OCI) labels](https://github.com/opencontainers/image-spec/blob/main/config.md) to an image.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/oci-labels/go/main.go
@@ -1520,7 +1520,7 @@ The following function demonstrates how to invalidate the Dagger layer cache and
 * Changes in mounted cache volumes or secrets do not invalidate the Dagger layer cache.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/builds/cache/go/main.go
@@ -1575,7 +1575,7 @@ Print the date and time, invalidating the cache on each run. However, if the `CA
 
 The following Dagger Function accepts a GitHub personal access token as a `Secret`, and uses the `Secret` to authorize a request to the GitHub API. The secret may be sourced from the host (via an environment variable, host file, or host command) or from an external secrets manager (1Password or Vault):
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/secret-variable/go/main.go
@@ -1720,7 +1720,7 @@ The following Dagger Function accepts a GitHub personal access token as a `Secre
 
 The following Dagger Function accepts a GitHub hosts configuration file as a `Secret`, and mounts the file as a `Secret` to a container to authorize a request to GitHub.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/secret-file/go/main.go
@@ -1767,7 +1767,7 @@ Use a mounted secret file:
 
 The following code listing demonstrates how to inject a secret into a Dockerfile build. The secret is automatically mounted in the build container at `/run/secrets/SECRET-ID`.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/secret-dockerfile/go/main.go
@@ -1827,7 +1827,7 @@ Build from a Dockerfile with a mounted secret from the host environment:
 
 The first Dagger Function below creates and returns an HTTP service. This service is bound and used from a different Dagger Function, via a service binding using an alias like `www`.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/bind-services/go/main.go
@@ -1874,7 +1874,7 @@ Send a request from one Dagger Function to a bound HTTP service instantiated by 
 
 The Dagger Function below creates and returns an HTTP service. This service can be used from the host.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/expose-dagger-services-to-host/go/main.go
@@ -1957,7 +1957,7 @@ The following Dagger Function accepts a `Service` running on the host, binds it 
 This implies that a service is already listening on a port on the host, out-of-band of Dagger.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/expose-host-services-to-dagger/go/main.go
@@ -2004,7 +2004,7 @@ Send a query to the database service listening on host port 3306 and return the 
 
 The following Dagger Function creates a service and binds it to an application container for unit testing. In this example, the application being tested is Drupal. Drupal includes a large number of unit tests, including tests which depend on an active database service. This database service is created on-the-fly by the Dagger Function.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/test-against-db-service/go/main.go
@@ -2051,7 +2051,7 @@ Run Drupal's unit tests, instantiating a database service during the process:
 
 The following Dagger Function demonstrates how to control a service's lifecycle by explicitly starting and stopping a service. This example uses a Redis service.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/start-stop-services/go/main.go
@@ -2098,7 +2098,7 @@ Start and stop a Redis service:
 
 The following Dagger Function runs two services, service A and service B, that depend on each other. The services are set up with custom hostnames, `svca` and `svcb`, allowing each service to communicate with the other by hostname.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/create-interdependent-services/go/main.go
@@ -2147,7 +2147,7 @@ Start two inter-dependent services:
 
 The following Dagger Function publishes a just-in-time container image to a private registry.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/publish-image/go/main.go
@@ -2214,7 +2214,7 @@ The following Dagger Function publishes a just-in-time container image to a priv
 
 The following Dagger Function tags a just-in-time container image multiple times and publishes it to a private registry.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/tag-publish-image/go/main.go
@@ -2285,7 +2285,7 @@ The following Dagger Functions return a just-in-time directory and file. These o
 When a host directory or file is copied or mounted to a container's filesystem, modifications made to it in the container do not automatically transfer back to the host. Data flows only one way between Dagger operations, because they are connected in a DAG. To transfer modifications back to the local host, you must explicitly export the directory or file back to the host filesystem.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/export-file-dir/go/main.go
@@ -2352,7 +2352,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 
 The following Dagger Function returns a just-in-time container. This can be exported to the host as an OCI tarball.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/export-container/go/main.go
@@ -2401,7 +2401,7 @@ Export the container image returned by the Dagger Function as an OCI tarball to 
 
 The following Dagger Function uses a cache volume for application dependencies. This enables Dagger to reuse the contents of the cache across Dagger Function runs and reduce execution time.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/cache-dependencies/go/main.go
@@ -2458,7 +2458,7 @@ Build an application using cached dependencies:
 
 The following Dagger Function demonstrates how to set a single environment variable in a container.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/set-env-var/go/main.go
@@ -2487,7 +2487,7 @@ The following Dagger Function demonstrates how to set a single environment varia
 
 The following Dagger Function demonstrates how to set multiple environment variables in a container.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/set-env-vars/go/main.go
@@ -2554,7 +2554,7 @@ The following Dagger Function demonstrates how to set multiple environment varia
 
 The following Dagger Function uses a cache volume to persist a Redis service's data across Dagger Function runs.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/services/persist-service-state/go/main.go
@@ -2621,7 +2621,7 @@ The following Dagger Function uses a cache volume to persist a Redis service's d
 
 The following Dagger Function demonstrates how to use native-language concurrency features ([errgroups](https://pkg.go.dev/golang.org/x/sync/errgroup) in Go, [task groups](https://anyio.readthedocs.io/en/stable/tasks.html) in Python), and [promises](https://basarat.gitbook.io/typescript/future-javascript/promise) in TypeScript to execute other Dagger Functions concurrently. If any of the concurrently-running functions fails, the remaining ones will be immediately cancelled.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/execute-concurrently/go/main.go
@@ -2671,7 +2671,7 @@ Execute a Dagger Function which performs different types of tests by executing o
 The following Dagger Function demonstrates how to handle errors in a pipeline.
 
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/handle-errors/go/main.go
@@ -2722,7 +2722,7 @@ The following Dagger Function demonstrates how to continue using a container aft
 The caveat with this approach is that forcing a zero exit code on a failure caches the failure. This may not be desired depending on the use case.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=./snippets/continue-after-errors/go/main.go
@@ -2795,7 +2795,7 @@ Dagger provides two features that can help greatly when trying to debug a pipeli
 
 The following Dagger Function opens an interactive terminal session at different stages in a Dagger pipeline to debug a container build.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-container/main.go
@@ -2841,7 +2841,7 @@ Execute a Dagger Function to build a container, and open an interactive terminal
 
 The following Dagger Function clones Dagger's GitHub repository and opens an interactive terminal session to inspect it. Under the hood, this creates a new container (defaults to `alpine`) and starts a shell, mounting the repository directory inside.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-directory-1/main.go
@@ -2863,7 +2863,7 @@ The following Dagger Function clones Dagger's GitHub repository and opens an int
 
 The container created to mount the directory can be customized using additional options. The following Dagger Function revised the previous example to demonstrate this, using an `ubuntu` container image and `bash` shell instead of the defaults.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-directory-2/main.go

--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -31,7 +31,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/mount-dir/typescript/index.ts
 ```
@@ -65,7 +65,7 @@ Besides helping with the final image size, mounts are more performant and resour
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-dir/typescript/index.ts
 ```
@@ -273,7 +273,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-modify-dir/typescript/index.ts
 ```
@@ -405,7 +405,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/clone-git-repository/typescript/index.ts
 ```
@@ -514,7 +514,7 @@ The following Dagger Function accepts a `File` argument, which could reference e
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/mount-file/typescript/index.ts
 ```
@@ -541,7 +541,7 @@ Besides helping with the final image size, mounts are more performant and resour
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-file/typescript/index.ts
 ```
@@ -734,7 +734,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-filter-dir-post/typescript/index.ts
 ```
@@ -833,7 +833,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/read-file-http/typescript/index.ts
 ```
@@ -907,7 +907,7 @@ The following Dagger Function accepts a `File` argument and copies the specified
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-file-runtime/typescript/index.ts
 ```
@@ -962,7 +962,7 @@ This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filter
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/copy-filter-dir-pre/typescript/index.ts
 ```
@@ -1032,7 +1032,7 @@ The following Dagger module uses a constructor to set a module-wide `Directory` 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/set-common-default-path/typescript/index.ts
 ```
@@ -1107,7 +1107,7 @@ The following Dagger Function performs a multi-stage build.
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/multi-stage-build/typescript/index.ts
 ```
@@ -1160,7 +1160,7 @@ The following Dagger Function performs a matrix build.
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/matrix-build/typescript/index.ts
 ```
@@ -1234,7 +1234,7 @@ The following Dagger Function builds a single image for different CPU architectu
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/multi-arch/typescript/index.ts
 ```
@@ -1286,7 +1286,7 @@ install the module first with `dagger install github.com/levlaz/daggerverse/cont
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/multi-arch-cc/typescript/index.ts
 ```
@@ -1333,7 +1333,7 @@ The following Dagger Function builds an image from a Dockerfile.
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/dockerfile/typescript/index.ts
 ```
@@ -1385,7 +1385,7 @@ The following function builds an image from a Dockerfile with a build context th
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/dockerfile-context/typescript/index.ts
 ```
@@ -1434,7 +1434,7 @@ The following Dagger Function adds [OpenContainer Initiative (OCI) annotations](
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/oci-annotations/typescript/index.ts
 ```
@@ -1481,7 +1481,7 @@ The following Dagger Function adds [OpenContainer Initiative (OCI) labels](https
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/oci-labels/typescript/index.ts
 ```
@@ -1533,7 +1533,7 @@ The following function demonstrates how to invalidate the Dagger layer cache and
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/builds/cache/typescript/index.ts
 ```
@@ -1588,7 +1588,7 @@ The following Dagger Function accepts a GitHub personal access token as a `Secre
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/secret-variable/typescript/index.ts
 ```
@@ -1733,7 +1733,7 @@ The following Dagger Function accepts a GitHub hosts configuration file as a `Se
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/secret-file/typescript/index.ts
 ```
@@ -1780,7 +1780,7 @@ The following code listing demonstrates how to inject a secret into a Dockerfile
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/secret-dockerfile/typescript/index.ts
 ```
@@ -1840,7 +1840,7 @@ The first Dagger Function below creates and returns an HTTP service. This servic
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/bind-services/typescript/index.ts
 ```
@@ -1887,7 +1887,7 @@ The Dagger Function below creates and returns an HTTP service. This service can 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/expose-dagger-services-to-host/typescript/index.ts
 ```
@@ -1970,7 +1970,7 @@ This implies that a service is already listening on a port on the host, out-of-b
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/expose-host-services-to-dagger/typescript/index.ts
 ```
@@ -2017,7 +2017,7 @@ The following Dagger Function creates a service and binds it to an application c
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/test-against-db-service/typescript/index.ts
 ```
@@ -2064,7 +2064,7 @@ The following Dagger Function demonstrates how to control a service's lifecycle 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/start-stop-services/typescript/index.ts
 ```
@@ -2111,7 +2111,7 @@ The following Dagger Function runs two services, service A and service B, that d
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/create-interdependent-services/typescript/index.ts
 ```
@@ -2160,7 +2160,7 @@ The following Dagger Function publishes a just-in-time container image to a priv
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/publish-image/typescript/index.ts
 ```
@@ -2227,7 +2227,7 @@ The following Dagger Function tags a just-in-time container image multiple times
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/tag-publish-image/typescript/index.ts
 ```
@@ -2298,7 +2298,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/export-file-dir/typescript/index.ts
 ```
@@ -2365,7 +2365,7 @@ The following Dagger Function returns a just-in-time container. This can be expo
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/export-container/typescript/index.ts
 ```
@@ -2418,7 +2418,7 @@ The default location for the cache directory depends on the package manager (`~/
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/cache-dependencies/typescript/index.ts
 ```
@@ -2471,7 +2471,7 @@ The following Dagger Function demonstrates how to set a single environment varia
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/set-env-var/typescript/index.ts
 ```
@@ -2500,7 +2500,7 @@ The following Dagger Function demonstrates how to set multiple environment varia
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/set-env-vars/typescript/index.ts
 ```
@@ -2567,7 +2567,7 @@ The following Dagger Function uses a cache volume to persist a Redis service's d
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/services/persist-service-state/typescript/index.ts
 ```
@@ -2634,7 +2634,7 @@ The following Dagger Function demonstrates how to use native-language concurrenc
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/execute-concurrently/typescript/index.ts
 ```
@@ -2684,7 +2684,7 @@ The following Dagger Function demonstrates how to handle errors in a pipeline.
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/handle-errors/typescript/index.ts
 ```
@@ -2735,7 +2735,7 @@ The caveat with this approach is that forcing a zero exit code on a failure cach
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=./snippets/continue-after-errors/typescript/src/index.ts
 ```
@@ -2807,7 +2807,7 @@ The following Dagger Function opens an interactive terminal session at different
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/debugging/typescript/terminal-container/index.ts
 ```
@@ -2853,7 +2853,7 @@ The following Dagger Function clones Dagger's GitHub repository and opens an int
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/debugging/typescript/terminal-directory-1/index.ts
 ```
@@ -2875,7 +2875,7 @@ The container created to mount the directory can be customized using additional 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript file=../api/snippets/debugging/typescript/terminal-directory-2/index.ts
 ```

--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -19,7 +19,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/mount-dir/go/main.go
 ```
@@ -53,7 +53,7 @@ Besides helping with the final image size, mounts are more performant and resour
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-dir/go/main.go
 ```
@@ -261,7 +261,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-modify-dir/go/main.go
 ```
@@ -381,7 +381,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/clone-git-repository/go/main.go
 ```
@@ -502,7 +502,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 The following Dagger Function accepts a `File` argument, which could reference either a file from the local filesystem or from a [remote Git repository](../api/arguments.mdx#remote-repositories). It mounts the specified file to a container in the `/src/` directory and returns the modified container.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/mount-file/go/main.go
 ```
@@ -529,7 +529,7 @@ Besides helping with the final image size, mounts are more performant and resour
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-file/go/main.go
 ```
@@ -722,7 +722,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-filter-dir-post/go/main.go
 ```
@@ -821,7 +821,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 ### Request a file over HTTP/HTTPS and save it in a container
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/read-file-http/go/main.go
 ```
@@ -895,7 +895,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 The following Dagger Function accepts a `File` argument and copies the specified file to the Dagger module runtime container. This makes it possible to add one or more files to the runtime container and manipulate them using custom logic.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-file-runtime/go/main.go
 ```
@@ -950,7 +950,7 @@ This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filter
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/copy-filter-dir-pre/go/main.go
 ```
@@ -1020,7 +1020,7 @@ This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filter
 The following Dagger module uses a constructor to set a module-wide `Directory` argument and point it to a default path on the host. This eliminates the need to pass a common `Directory` argument individually to each Dagger Function in the module. If required, the default path can be overridden by specifying a different `Directory` value at call time.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/set-common-default-path/go/main.go
 ```
@@ -1095,7 +1095,7 @@ The following Dagger module uses a constructor to set a module-wide `Directory` 
 The following Dagger Function performs a multi-stage build.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/multi-stage-build/go/main.go
 ```
@@ -1148,7 +1148,7 @@ Perform a multi-stage build of the source code in the `golang/example/hello` rep
 The following Dagger Function performs a matrix build.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/matrix-build/go/main.go
 ```
@@ -1222,7 +1222,7 @@ Inspect the contents of the exported directory with `tree /tmp/matrix-builds`. T
 The following Dagger Function builds a single image for different CPU architectures using native emulation.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/multi-arch/go/main.go
 ```
@@ -1274,7 +1274,7 @@ install the module first with `dagger install github.com/levlaz/daggerverse/cont
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/multi-arch-cc/go/main.go
 ```
@@ -1321,7 +1321,7 @@ Build and publish a multi-platform image with cross compliation:
 The following Dagger Function builds an image from a Dockerfile.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/dockerfile/go/main.go
 ```
@@ -1373,7 +1373,7 @@ Build and publish an image from an existing Dockerfile
 The following function builds an image from a Dockerfile with a build context that is different than the current working directory.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/dockerfile-context/go/main.go
 ```
@@ -1422,7 +1422,7 @@ Build an image from the source code in `https://github.com/dockersamples/python-
 The following Dagger Function adds [OpenContainer Initiative (OCI) annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to an image.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/oci-annotations/go/main.go
 ```
@@ -1469,7 +1469,7 @@ Build and publish an image with OCI annotations:
 The following Dagger Function adds [OpenContainer Initiative (OCI) labels](https://github.com/opencontainers/image-spec/blob/main/config.md) to an image.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/oci-labels/go/main.go
 ```
@@ -1521,7 +1521,7 @@ The following function demonstrates how to invalidate the Dagger layer cache and
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/builds/cache/go/main.go
 ```
@@ -1576,7 +1576,7 @@ Print the date and time, invalidating the cache on each run. However, if the `CA
 The following Dagger Function accepts a GitHub personal access token as a `Secret`, and uses the `Secret` to authorize a request to the GitHub API. The secret may be sourced from the host (via an environment variable, host file, or host command) or from an external secrets manager (1Password or Vault):
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/secret-variable/go/main.go
 ```
@@ -1721,7 +1721,7 @@ The following Dagger Function accepts a GitHub personal access token as a `Secre
 The following Dagger Function accepts a GitHub hosts configuration file as a `Secret`, and mounts the file as a `Secret` to a container to authorize a request to GitHub.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/secret-file/go/main.go
 ```
@@ -1768,7 +1768,7 @@ Use a mounted secret file:
 The following code listing demonstrates how to inject a secret into a Dockerfile build. The secret is automatically mounted in the build container at `/run/secrets/SECRET-ID`.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/secret-dockerfile/go/main.go
 ```
@@ -1828,7 +1828,7 @@ Build from a Dockerfile with a mounted secret from the host environment:
 The first Dagger Function below creates and returns an HTTP service. This service is bound and used from a different Dagger Function, via a service binding using an alias like `www`.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/bind-services/go/main.go
 ```
@@ -1875,7 +1875,7 @@ Send a request from one Dagger Function to a bound HTTP service instantiated by 
 The Dagger Function below creates and returns an HTTP service. This service can be used from the host.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/expose-dagger-services-to-host/go/main.go
 ```
@@ -1958,7 +1958,7 @@ This implies that a service is already listening on a port on the host, out-of-b
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/expose-host-services-to-dagger/go/main.go
 ```
@@ -2005,7 +2005,7 @@ Send a query to the database service listening on host port 3306 and return the 
 The following Dagger Function creates a service and binds it to an application container for unit testing. In this example, the application being tested is Drupal. Drupal includes a large number of unit tests, including tests which depend on an active database service. This database service is created on-the-fly by the Dagger Function.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/test-against-db-service/go/main.go
 ```
@@ -2052,7 +2052,7 @@ Run Drupal's unit tests, instantiating a database service during the process:
 The following Dagger Function demonstrates how to control a service's lifecycle by explicitly starting and stopping a service. This example uses a Redis service.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/start-stop-services/go/main.go
 ```
@@ -2099,7 +2099,7 @@ Start and stop a Redis service:
 The following Dagger Function runs two services, service A and service B, that depend on each other. The services are set up with custom hostnames, `svca` and `svcb`, allowing each service to communicate with the other by hostname.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/create-interdependent-services/go/main.go
 ```
@@ -2148,7 +2148,7 @@ Start two inter-dependent services:
 The following Dagger Function publishes a just-in-time container image to a private registry.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/publish-image/go/main.go
 ```
@@ -2215,7 +2215,7 @@ The following Dagger Function publishes a just-in-time container image to a priv
 The following Dagger Function tags a just-in-time container image multiple times and publishes it to a private registry.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/tag-publish-image/go/main.go
 ```
@@ -2286,7 +2286,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/export-file-dir/go/main.go
 ```
@@ -2353,7 +2353,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 The following Dagger Function returns a just-in-time container. This can be exported to the host as an OCI tarball.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/export-container/go/main.go
 ```
@@ -2402,7 +2402,7 @@ Export the container image returned by the Dagger Function as an OCI tarball to 
 The following Dagger Function uses a cache volume for application dependencies. This enables Dagger to reuse the contents of the cache across Dagger Function runs and reduce execution time.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/cache-dependencies/go/main.go
 ```
@@ -2459,7 +2459,7 @@ Build an application using cached dependencies:
 The following Dagger Function demonstrates how to set a single environment variable in a container.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/set-env-var/go/main.go
 ```
@@ -2488,7 +2488,7 @@ The following Dagger Function demonstrates how to set a single environment varia
 The following Dagger Function demonstrates how to set multiple environment variables in a container.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/set-env-vars/go/main.go
 ```
@@ -2555,7 +2555,7 @@ The following Dagger Function demonstrates how to set multiple environment varia
 The following Dagger Function uses a cache volume to persist a Redis service's data across Dagger Function runs.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/services/persist-service-state/go/main.go
 ```
@@ -2622,7 +2622,7 @@ The following Dagger Function uses a cache volume to persist a Redis service's d
 The following Dagger Function demonstrates how to use native-language concurrency features ([errgroups](https://pkg.go.dev/golang.org/x/sync/errgroup) in Go, [task groups](https://anyio.readthedocs.io/en/stable/tasks.html) in Python), and [promises](https://basarat.gitbook.io/typescript/future-javascript/promise) in TypeScript to execute other Dagger Functions concurrently. If any of the concurrently-running functions fails, the remaining ones will be immediately cancelled.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/execute-concurrently/go/main.go
 ```
@@ -2672,7 +2672,7 @@ The following Dagger Function demonstrates how to handle errors in a pipeline.
 
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/handle-errors/go/main.go
 ```
@@ -2723,7 +2723,7 @@ The caveat with this approach is that forcing a zero exit code on a failure cach
 :::
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=./snippets/continue-after-errors/go/main.go
 ```
@@ -2796,7 +2796,7 @@ Dagger provides two features that can help greatly when trying to debug a pipeli
 The following Dagger Function opens an interactive terminal session at different stages in a Dagger pipeline to debug a container build.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-container/main.go
 ```
@@ -2842,7 +2842,7 @@ Execute a Dagger Function to build a container, and open an interactive terminal
 The following Dagger Function clones Dagger's GitHub repository and opens an interactive terminal session to inspect it. Under the hood, this creates a new container (defaults to `alpine`) and starts a shell, mounting the repository directory inside.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-directory-1/main.go
 ```
@@ -2864,7 +2864,7 @@ The following Dagger Function clones Dagger's GitHub repository and opens an int
 The container created to mount the directory can be customized using additional options. The following Dagger Function revised the previous example to demonstrate this, using an `ubuntu` container image and `bash` shell instead of the defaults.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go file=../api/snippets/debugging/go/terminal-directory-2/main.go
 ```

--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -38,7 +38,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/mount-dir/php/src/MyModule.php
 ```
@@ -72,7 +72,7 @@ Besides helping with the final image size, mounts are more performant and resour
 
 </TabItem>
 
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/copy-dir/php/src/MyModule.php
 ```
@@ -279,7 +279,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/copy-modify-dir/php/src/MyModule.php
 ```
@@ -417,7 +417,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/clone-git-repository/php/src/MyModule.php
 ```
@@ -1038,7 +1038,7 @@ The following Dagger module uses a constructor to set a module-wide `Directory` 
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/set-common-default-path/php/src/MyModule.php
 ```
@@ -1113,7 +1113,7 @@ The following Dagger Function performs a multi-stage build.
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/builds/multi-stage-build/php/src/MyModule.php
 ```
@@ -1166,7 +1166,7 @@ The following Dagger Function performs a matrix build.
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/builds/matrix-build/php/src/MyModule.php
 ```
@@ -1339,7 +1339,7 @@ The following Dagger Function builds an image from a Dockerfile.
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/builds/dockerfile/php/src/MyModule.php
 ```
@@ -1539,7 +1539,7 @@ The following function demonstrates how to invalidate the Dagger layer cache and
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/builds/cache/php/src/MyModule.php
 ```
@@ -2424,7 +2424,7 @@ The default location for the cache directory depends on the package manager (`~/
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/cache-dependencies/php/src/MyModule.php
 ```
@@ -2477,7 +2477,7 @@ The following Dagger Function demonstrates how to set a single environment varia
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php file=./snippets/set-env-var/php/src/MyModule.php
 ```

--- a/docs/current_docs/cookbook/cookbook.mdx
+++ b/docs/current_docs/cookbook/cookbook.mdx
@@ -25,7 +25,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/mount-dir/python/main.py
 ```
@@ -59,7 +59,7 @@ Besides helping with the final image size, mounts are more performant and resour
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-dir/python/main.py
 ```
@@ -267,7 +267,7 @@ When working with private Git repositories, ensure that [SSH authentication is p
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-modify-dir/python/main.py
 ```
@@ -393,7 +393,7 @@ For examples of SSH-based cloning, including private or public Git repositories 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/clone-git-repository/python/main.py
 ```
@@ -508,7 +508,7 @@ The following Dagger Function accepts a `File` argument, which could reference e
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/mount-file/python/main.py
 ```
@@ -535,7 +535,7 @@ Besides helping with the final image size, mounts are more performant and resour
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-file/python/main.py
 ```
@@ -728,7 +728,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-filter-dir-post/python/main.py
 ```
@@ -827,7 +827,7 @@ This is an example of [post-call filtering](../api/fs-filters.mdx#post-call-filt
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/read-file-http/python/main.py
 ```
@@ -901,7 +901,7 @@ The following Dagger Function accepts a `File` argument and copies the specified
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-file-runtime/python/main.py
 ```
@@ -956,7 +956,7 @@ This is an example of [pre-call filtering](../api/fs-filters.mdx#pre-call-filter
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/copy-filter-dir-pre/python/main.py
 ```
@@ -1026,7 +1026,7 @@ The following Dagger module uses a constructor to set a module-wide `Directory` 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/set-common-default-path/python/main.py
 ```
@@ -1101,7 +1101,7 @@ The following Dagger Function performs a multi-stage build.
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/multi-stage-build/python/main.py
 ```
@@ -1154,7 +1154,7 @@ The following Dagger Function performs a matrix build.
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/matrix-build/python/main.py
 ```
@@ -1228,7 +1228,7 @@ The following Dagger Function builds a single image for different CPU architectu
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/multi-arch/python/main.py
 ```
@@ -1280,7 +1280,7 @@ install the module first with `dagger install github.com/levlaz/daggerverse/cont
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/multi-arch-cc/python/main.py
 ```
@@ -1327,7 +1327,7 @@ The following Dagger Function builds an image from a Dockerfile.
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/dockerfile/python/main.py
 ```
@@ -1379,7 +1379,7 @@ The following function builds an image from a Dockerfile with a build context th
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/dockerfile-context/python/main.py
 ```
@@ -1428,7 +1428,7 @@ The following Dagger Function adds [OpenContainer Initiative (OCI) annotations](
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/oci-annotations/python/main.py
 ```
@@ -1475,7 +1475,7 @@ The following Dagger Function adds [OpenContainer Initiative (OCI) labels](https
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/oci-labels/python/main.py
 ```
@@ -1527,7 +1527,7 @@ The following function demonstrates how to invalidate the Dagger layer cache and
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/builds/cache/python/main.py
 ```
@@ -1582,7 +1582,7 @@ The following Dagger Function accepts a GitHub personal access token as a `Secre
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/secret-variable/python/main.py
 ```
@@ -1727,7 +1727,7 @@ The following Dagger Function accepts a GitHub hosts configuration file as a `Se
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/secret-file/python/main.py
 ```
@@ -1774,7 +1774,7 @@ The following code listing demonstrates how to inject a secret into a Dockerfile
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/secret-dockerfile/python/main.py
 ```
@@ -1834,7 +1834,7 @@ The first Dagger Function below creates and returns an HTTP service. This servic
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/bind-services/python/main.py
 ```
@@ -1881,7 +1881,7 @@ The Dagger Function below creates and returns an HTTP service. This service can 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/expose-dagger-services-to-host/python/main.py
 ```
@@ -1964,7 +1964,7 @@ This implies that a service is already listening on a port on the host, out-of-b
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/expose-host-services-to-dagger/python/main.py
 ```
@@ -2011,7 +2011,7 @@ The following Dagger Function creates a service and binds it to an application c
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/test-against-db-service/python/main.py
 ```
@@ -2058,7 +2058,7 @@ The following Dagger Function demonstrates how to control a service's lifecycle 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/start-stop-services/python/main.py
 ```
@@ -2105,7 +2105,7 @@ The following Dagger Function runs two services, service A and service B, that d
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/create-interdependent-services/python/main.py
 ```
@@ -2154,7 +2154,7 @@ The following Dagger Function publishes a just-in-time container image to a priv
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/publish-image/python/main.py
 ```
@@ -2221,7 +2221,7 @@ The following Dagger Function tags a just-in-time container image multiple times
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/tag-publish-image/python/main.py
 ```
@@ -2292,7 +2292,7 @@ When a host directory or file is copied or mounted to a container's filesystem, 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/export-file-dir/python/main.py
 ```
@@ -2359,7 +2359,7 @@ The following Dagger Function returns a just-in-time container. This can be expo
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/export-container/python/main.py
 ```
@@ -2408,7 +2408,7 @@ The following Dagger Function uses a cache volume for application dependencies. 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 :::note
 The default location for the cache directory depends on the package manager (`~/.cache/pip` for `pip` or `~/.cache/pypoetry` for `poetry`).
@@ -2465,7 +2465,7 @@ The following Dagger Function demonstrates how to set a single environment varia
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/set-env-var/python/main.py
 ```
@@ -2494,7 +2494,7 @@ The following Dagger Function demonstrates how to set multiple environment varia
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/set-env-vars/python/main.py
 ```
@@ -2561,7 +2561,7 @@ The following Dagger Function uses a cache volume to persist a Redis service's d
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=../api/snippets/services/persist-service-state/python/main.py
 ```
@@ -2628,7 +2628,7 @@ The following Dagger Function demonstrates how to use native-language concurrenc
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/execute-concurrently/python/main.py
 ```
@@ -2678,7 +2678,7 @@ The following Dagger Function demonstrates how to handle errors in a pipeline.
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/handle-errors/python/main.py
 ```
@@ -2729,7 +2729,7 @@ The caveat with this approach is that forcing a zero exit code on a failure cach
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python file=./snippets/continue-after-errors/python/main.py
 ```
@@ -2802,7 +2802,7 @@ The following Dagger Function opens an interactive terminal session at different
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=../api/snippets/debugging/python/terminal-container/main.py
 ```
 
@@ -2848,7 +2848,7 @@ The following Dagger Function clones Dagger's GitHub repository and opens an int
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=../api/snippets/debugging/python/terminal-directory-1/main.py
 ```
 
@@ -2870,7 +2870,7 @@ The container created to mount the directory can be customized using additional 
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=../api/snippets/debugging/python/terminal-directory-2/main.py
 ```
 

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -14,7 +14,7 @@ Dagger lets users drop in to an interactive shell when a pipeline run fails, wit
 Here's an example of a pipeline run failing, and Dagger opening an interactive terminal at the point of failure:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/debugging-1/go/main.go
 ```
 </TabItem>
@@ -45,7 +45,7 @@ You can also set one or more explicit breakpoints in your pipeline, which then s
 Here's another example, which opens an interactive terminal at two different points in a pipeline run to inspect the built container:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/debugging-2/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -22,7 +22,7 @@ Here's an example of a pipeline run failing, and Dagger opening an interactive t
 ```python file=./snippets/debugging-1/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/debugging-1/typescript/index.ts
 ```
 </TabItem>
@@ -53,7 +53,7 @@ Here's another example, which opens an interactive terminal at two different poi
 ```python file=./snippets/debugging-2/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/debugging-2/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -30,7 +30,7 @@ Here's an example of a pipeline run failing, and Dagger opening an interactive t
 ```php file=./snippets/debugging-1/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/debugging-1/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -61,7 +61,7 @@ Here's another example, which opens an interactive terminal at two different poi
 ```php file=./snippets/debugging-2/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/debugging-2/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -13,7 +13,7 @@ Dagger lets users drop in to an interactive shell when a pipeline run fails, wit
 
 Here's an example of a pipeline run failing, and Dagger opening an interactive terminal at the point of failure:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/debugging-1/go/main.go
 ```
@@ -44,7 +44,7 @@ You can also set one or more explicit breakpoints in your pipeline, which then s
 
 Here's another example, which opens an interactive terminal at two different points in a pipeline run to inspect the built container:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/debugging-2/go/main.go
 ```

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -18,7 +18,7 @@ Here's an example of a pipeline run failing, and Dagger opening an interactive t
 ```go file=./snippets/debugging-1/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/debugging-1/python/main.py
 ```
 </TabItem>
@@ -49,7 +49,7 @@ Here's another example, which opens an interactive terminal at two different poi
 ```go file=./snippets/debugging-2/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/debugging-2/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/features/debugging.mdx
+++ b/docs/current_docs/features/debugging.mdx
@@ -26,7 +26,7 @@ Here's an example of a pipeline run failing, and Dagger opening an interactive t
 ```typescript file=./snippets/debugging-1/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/debugging-1/php/src/MyModule.php
 ```
 </TabItem>
@@ -57,7 +57,7 @@ Here's another example, which opens an interactive terminal at two different poi
 ```typescript file=./snippets/debugging-2/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/debugging-2/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/features/mcp.mdx
+++ b/docs/current_docs/features/mcp.mdx
@@ -82,7 +82,7 @@ Consider the following Dagger Function:
 ```python file=../quickstart/agent/snippets/python/src/coding_agent/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=../quickstart/agent/snippets/typescript/src/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/features/mcp.mdx
+++ b/docs/current_docs/features/mcp.mdx
@@ -78,7 +78,7 @@ Consider the following Dagger Function:
 ```go file=../quickstart/agent/snippets/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=../quickstart/agent/snippets/python/src/coding_agent/main.py
 ```
 </TabItem>

--- a/docs/current_docs/features/mcp.mdx
+++ b/docs/current_docs/features/mcp.mdx
@@ -73,7 +73,7 @@ EOF
 
 Consider the following Dagger Function:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=../quickstart/agent/snippets/go/main.go
 ```

--- a/docs/current_docs/features/mcp.mdx
+++ b/docs/current_docs/features/mcp.mdx
@@ -74,7 +74,7 @@ EOF
 Consider the following Dagger Function:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=../quickstart/agent/snippets/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -30,7 +30,7 @@ Here's an example of a Dagger Function that builds and containerizes a Go applic
 ```php file=./snippets/programmable-pipelines-1/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/programmable-pipelines-1/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -67,7 +67,7 @@ Here's the same Dagger Function again, modified to return the compiled binary as
 ```php file=./snippets/programmable-pipelines-2/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/programmable-pipelines-2/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -18,7 +18,7 @@ Here's an example of a Dagger Function that builds and containerizes a Go applic
 ```go file=./snippets/programmable-pipelines-1/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/programmable-pipelines-1/python/main.py
 ```
 </TabItem>
@@ -55,7 +55,7 @@ Here's the same Dagger Function again, modified to return the compiled binary as
 ```go file=./snippets/programmable-pipelines-2/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/programmable-pipelines-2/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -22,7 +22,7 @@ Here's an example of a Dagger Function that builds and containerizes a Go applic
 ```python file=./snippets/programmable-pipelines-1/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/programmable-pipelines-1/typescript/index.ts
 ```
 </TabItem>
@@ -59,7 +59,7 @@ Here's the same Dagger Function again, modified to return the compiled binary as
 ```python file=./snippets/programmable-pipelines-2/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/programmable-pipelines-2/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -14,7 +14,7 @@ Dagger Functions are the fundamental unit of computing in Dagger. Dagger Functio
 Here's an example of a Dagger Function that builds and containerizes a Go application:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/programmable-pipelines-1/go/main.go
 ```
 </TabItem>
@@ -51,7 +51,7 @@ Here's an example of calling the same Dagger Function again, but this time chain
 Here's the same Dagger Function again, modified to return the compiled binary as a just-in-time file. The file is then exported to the host via an additional, chained function call:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/programmable-pipelines-2/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -26,7 +26,7 @@ Here's an example of a Dagger Function that builds and containerizes a Go applic
 ```typescript file=./snippets/programmable-pipelines-1/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/programmable-pipelines-1/php/src/MyModule.php
 ```
 </TabItem>
@@ -63,7 +63,7 @@ Here's the same Dagger Function again, modified to return the compiled binary as
 ```typescript file=./snippets/programmable-pipelines-2/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/programmable-pipelines-2/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/features/programmable-pipelines.mdx
+++ b/docs/current_docs/features/programmable-pipelines.mdx
@@ -13,7 +13,7 @@ Dagger Functions are the fundamental unit of computing in Dagger. Dagger Functio
 
 Here's an example of a Dagger Function that builds and containerizes a Go application:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/programmable-pipelines-1/go/main.go
 ```
@@ -50,7 +50,7 @@ Here's an example of calling the same Dagger Function again, but this time chain
 
 Here's the same Dagger Function again, modified to return the compiled binary as a just-in-time file. The file is then exported to the host via an additional, chained function call:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/programmable-pipelines-2/go/main.go
 ```

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -36,7 +36,7 @@ Here's an example of a pipeline that receives and uses a GitHub personal access 
 ```python file=./snippets/secrets/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/secrets/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -28,7 +28,7 @@ Dagger has built-in safeguards to ensure that secrets are used without exposing 
 Here's an example of a pipeline that receives and uses a GitHub personal access token as a secret:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/secrets/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -27,7 +27,7 @@ Dagger has built-in safeguards to ensure that secrets are used without exposing 
 
 Here's an example of a pipeline that receives and uses a GitHub personal access token as a secret:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/secrets/go/main.go
 ```

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -44,7 +44,7 @@ Here's an example of a pipeline that receives and uses a GitHub personal access 
 ```php file=./snippets/secrets/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/secrets/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -32,7 +32,7 @@ Here's an example of a pipeline that receives and uses a GitHub personal access 
 ```go file=./snippets/secrets/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/secrets/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/features/security.mdx
+++ b/docs/current_docs/features/security.mdx
@@ -40,7 +40,7 @@ Here's an example of a pipeline that receives and uses a GitHub personal access 
 ```typescript file=./snippets/secrets/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/secrets/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -42,7 +42,7 @@ Here is an example of a Dagger Function that returns an HTTP service, which can 
 ```typescript file=./snippets/services-1/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/services-1/php/src/MyModule.php
 ```
 </TabItem>
@@ -71,7 +71,7 @@ This also works in the opposite direction: containers in Dagger Functions can co
 ```typescript file=./snippets/services-2/typescript/index.ts
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php file=./snippets/services-2/php/src/MyModule.php
 ```
 </TabItem>

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -29,7 +29,7 @@ Some common scenarios for using services with Dagger Functions are:
 
 Here is an example of a Dagger Function that returns an HTTP service, which can then be accessed from the calling host:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/services-1/go/main.go
 ```
@@ -58,7 +58,7 @@ See it in action:
 
 This also works in the opposite direction: containers in Dagger Functions can communicate with services running on the host. Here's an example of how a pipeline running in a Dagger Function can access and query a MariaDB database service running on the host:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go file=./snippets/services-2/go/main.go
 ```

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -46,7 +46,7 @@ Here is an example of a Dagger Function that returns an HTTP service, which can 
 ```php file=./snippets/services-1/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/services-1/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>
@@ -75,7 +75,7 @@ This also works in the opposite direction: containers in Dagger Functions can co
 ```php file=./snippets/services-2/php/src/MyModule.php
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java file=./snippets/services-2/java/src/main/java/io/dagger/modules/mymodule/MyModule.java
 ```
 </TabItem>

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -30,7 +30,7 @@ Some common scenarios for using services with Dagger Functions are:
 Here is an example of a Dagger Function that returns an HTTP service, which can then be accessed from the calling host:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/services-1/go/main.go
 ```
 </TabItem>
@@ -59,7 +59,7 @@ See it in action:
 This also works in the opposite direction: containers in Dagger Functions can communicate with services running on the host. Here's an example of how a pipeline running in a Dagger Function can access and query a MariaDB database service running on the host:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go file=./snippets/services-2/go/main.go
 ```
 </TabItem>

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -38,7 +38,7 @@ Here is an example of a Dagger Function that returns an HTTP service, which can 
 ```python file=./snippets/services-1/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/services-1/typescript/index.ts
 ```
 </TabItem>
@@ -67,7 +67,7 @@ This also works in the opposite direction: containers in Dagger Functions can co
 ```python file=./snippets/services-2/python/main.py
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript file=./snippets/services-2/typescript/index.ts
 ```
 </TabItem>

--- a/docs/current_docs/features/services.mdx
+++ b/docs/current_docs/features/services.mdx
@@ -34,7 +34,7 @@ Here is an example of a Dagger Function that returns an HTTP service, which can 
 ```go file=./snippets/services-1/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/services-1/python/main.py
 ```
 </TabItem>
@@ -63,7 +63,7 @@ This also works in the opposite direction: containers in Dagger Functions can co
 ```go file=./snippets/services-2/go/main.go
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python file=./snippets/services-2/python/main.py
 ```
 </TabItem>

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -37,7 +37,7 @@ In this structure:
 For examples of modules written in Go, see [Daggerverse Modules in Go](https://daggerverse.dev/search?sdk=go).
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```
 .

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -115,7 +115,7 @@ In this structure:
 For examples of modules written in PHP, see [Daggerverse Modules in PHP](https://daggerverse.dev/search?sdk=php).
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```
 .
 ├── dagger.json

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -8,7 +8,7 @@ Once a module is initialized, `dagger develop --sdk=...` sets up or updates all 
 The default template from `dagger develop` creates the following structure:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```
 .

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -7,7 +7,7 @@ Once a module is initialized, `dagger develop --sdk=...` sets up or updates all 
 
 The default template from `dagger develop` creates the following structure:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -90,7 +90,7 @@ In this structure:
 For examples of modules written in Typescript, see [Daggerverse Modules in Typescript](https://daggerverse.dev/search?sdk=typescript).
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```
 .

--- a/docs/current_docs/partials/_dagger_module_init.mdx
+++ b/docs/current_docs/partials/_dagger_module_init.mdx
@@ -67,7 +67,7 @@ Placing the source code under a `src` directory follows a common Python conventi
 For examples of modules written in Python, see [Daggerverse Modules in Python](https://daggerverse.dev/search?sdk=python).
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```
 .

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -58,7 +58,7 @@ In an empty directory, create a new Dagger module. This module will host your ag
 
 You can write your module in Go, Python, Typescript, PHP, or Java. Choose the SDK you are most comfortable with and run the command below to generate a new Dagger module:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```shell
 dagger init --sdk=go --name=coding-agent
@@ -116,7 +116,7 @@ Learn more about [agent environments](../../api/llm.mdx#environments-and-tools).
 
 Replace the generated Dagger module files as described below.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Edit the agent (`main.go`) and replace the generated code with this code:

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -74,7 +74,7 @@ dagger init --sdk=python --name=coding-agent
 dagger init --sdk=typescript --name=coding-agent
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```shell
 dagger init --sdk=php --name=coding-agent
 ```
@@ -141,7 +141,7 @@ Edit the agent (`src/index.ts`) and replace the generated code with this code:
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Edit the agent (`src/CodingAgent.php`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -79,7 +79,7 @@ dagger init --sdk=typescript --name=coding-agent
 dagger init --sdk=php --name=coding-agent
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```shell
 dagger init --sdk=java --name=coding-agent
 ```
@@ -149,7 +149,7 @@ Edit the agent (`src/CodingAgent.php`) and replace the generated code with this 
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 Edit the agent (`src/main/java/io/dagger/modules/codingagent/CodingAgent.java`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -59,7 +59,7 @@ In an empty directory, create a new Dagger module. This module will host your ag
 You can write your module in Go, Python, TypeScript, PHP, or Java. Choose the SDK you are most comfortable with and run the command below to generate a new Dagger module:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```shell
 dagger init --sdk=go --name=coding-agent
 ```
@@ -117,7 +117,7 @@ Learn more about [agent environments](../../api/llm.mdx#environments-and-tools).
 Replace the generated Dagger module files as described below.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Edit the agent (`main.go`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -69,7 +69,7 @@ dagger init --sdk=go --name=coding-agent
 dagger init --sdk=python --name=coding-agent
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```shell
 dagger init --sdk=typescript --name=coding-agent
 ```
@@ -133,7 +133,7 @@ Edit the agent (`src/coding_agent/main.py`) and replace the generated code with 
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Edit the agent (`src/index.ts`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -56,7 +56,7 @@ After successfully creating your organization, all future Dagger workflows can b
 
 In an empty directory, create a new Dagger module. This module will host your agent functions.
 
-You can write your module in Go, Python, Typescript, PHP, or Java. Choose the SDK you are most comfortable with and run the command below to generate a new Dagger module:
+You can write your module in Go, Python, TypeScript, PHP, or Java. Choose the SDK you are most comfortable with and run the command below to generate a new Dagger module:
 
 <Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
@@ -69,7 +69,7 @@ dagger init --sdk=go --name=coding-agent
 dagger init --sdk=python --name=coding-agent
 ```
 </TabItem>
-<TabItem value="Typescript">
+<TabItem value="TypeScript">
 ```shell
 dagger init --sdk=typescript --name=coding-agent
 ```
@@ -133,7 +133,7 @@ Edit the agent (`src/coding_agent/main.py`) and replace the generated code with 
 ```
 
 </TabItem>
-<TabItem value="Typescript">
+<TabItem value="TypeScript">
 
 Edit the agent (`src/index.ts`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/agent/index.mdx
+++ b/docs/current_docs/quickstart/agent/index.mdx
@@ -64,7 +64,7 @@ You can write your module in Go, Python, TypeScript, PHP, or Java. Choose the SD
 dagger init --sdk=go --name=coding-agent
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```shell
 dagger init --sdk=python --name=coding-agent
 ```
@@ -125,7 +125,7 @@ Edit the agent (`main.go`) and replace the generated code with this code:
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Edit the agent (`src/coding_agent/main.py`) and replace the generated code with this code:
 

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -94,7 +94,7 @@ As your workflows become more complex, you'll start wishing you could make them 
 Here's the previous example, rewritten as a Dagger Function:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 func (m *Basics) Publish(ctx context.Context) (string, error) {
 	return dag.Container().
@@ -170,7 +170,7 @@ When you create a custom Dagger Function and tell Dagger about it (by installing
 Function chaining works the same way, whether you're writing Dagger Function code using a Dagger SDK or using Dagger Shell. The following are equivalent:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```go
 // Returns a base container
@@ -342,7 +342,7 @@ Dagger Functions are just like regular functions: they accept [arguments](../../
 Here's a revision of the previous example which splits it into two smaller functions: one to build the container, and one to publish it. The builder function accepts the container image string as an argument and returns a `Container` type. The publisher function accepts a `Container` type as argument and returns the image identifier as a string.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 func (m *Basics) Build(
 	// +default "alpine:latest"
@@ -460,7 +460,7 @@ Here's an example of installing and using two modules from the Daggerverse: a Wo
 Here's what it looks like in code:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 func (m *Basics) Check(ctx context.Context) (string, error) {
 	ctr := dag.Wolfi().Container()
@@ -530,7 +530,7 @@ One of Dagger's most powerful features is its ability to [cache data across work
 Taken together, these two types of caching significantly reduce execution times. Here's an example: a Dagger Function that creates a cache volume to store the packages installed by `apt`:
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 ```go
 func (m *Basics) Env(ctx context.Context) *dagger.Container {
 	aptCache := dag.CacheVolume("apt-cache")

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -145,7 +145,7 @@ public function publish(): string
 }
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 @Function
 public String publish()
@@ -280,7 +280,7 @@ class Basics
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```java
 @Object
@@ -421,7 +421,7 @@ public function publish2(string $image = 'alpine:latest'): string
 }
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 @Function
 public Container build(@Default("alpine:latest") String image) {
@@ -500,7 +500,7 @@ public function check(): string
 }
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
 @Function
 public String check()
@@ -584,7 +584,7 @@ public function env(): Container
 }
 ```
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 ```java
   @Function
   public Container env() {

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -131,7 +131,7 @@ async publish(): Promise<string> {
 }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 #[DaggerFunction]
 public function publish(): string
@@ -244,7 +244,7 @@ class Basics {
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```php
 #[DaggerObject]
@@ -400,7 +400,7 @@ async publish(image = "alpine:latest"): Promise<string> {
 }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 #[DaggerFunction]
 public function build(string $image = 'alpine:latest'): Container
@@ -486,7 +486,7 @@ check(): string {
 }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 #[DaggerFunction]
 public function check(): string
@@ -569,7 +569,7 @@ env(): Container {
 }
 ```
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 ```php
 #[DaggerFunction]
 public function env(): Container

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -105,7 +105,7 @@ func (m *Basics) Publish(ctx context.Context) (string, error) {
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 @function
 async def publish(self) -> str:
@@ -190,7 +190,7 @@ func (m *Basics) BuildAndPublish(ctx context.Context) (string, error) {
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```python
 @object_type
@@ -364,7 +364,7 @@ func (m *Basics) Publish(
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 @function
 def build(self, image: str = "alpine:latest") -> dagger.Container:
@@ -469,7 +469,7 @@ func (m *Basics) Check(ctx context.Context) (string, error) {
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 @function
 def check(self) -> str:
@@ -542,7 +542,7 @@ func (m *Basics) Env(ctx context.Context) *dagger.Container {
 }
 ```
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 ```python
 @function
 def env(self) -> dagger.Container:

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -118,7 +118,7 @@ async def publish(self) -> str:
     )
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 @func()
 async publish(): Promise<string> {
@@ -212,7 +212,7 @@ class Basics:
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```typescript
 @object()
@@ -381,7 +381,7 @@ async def publish(self, image: str = "alpine:latest") -> str:
     )
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 @func()
 build(image = "alpine:latest"): Container {
@@ -477,7 +477,7 @@ def check(self) -> str:
     return dag.trivy().scan_container(ctr)
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 @func()
 check(): string {
@@ -556,7 +556,7 @@ def env(self) -> dagger.Container:
     )
 ```
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 ```typescript
 @func()
 env(): Container {

--- a/docs/current_docs/quickstart/basics/index.mdx
+++ b/docs/current_docs/quickstart/basics/index.mdx
@@ -93,7 +93,7 @@ As your workflows become more complex, you'll start wishing you could make them 
 
 Here's the previous example, rewritten as a Dagger Function:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 func (m *Basics) Publish(ctx context.Context) (string, error) {
@@ -169,7 +169,7 @@ When you create a custom Dagger Function and tell Dagger about it (by installing
 
 Function chaining works the same way, whether you're writing Dagger Function code using a Dagger SDK or using Dagger Shell. The following are equivalent:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```go
@@ -341,7 +341,7 @@ Dagger Functions are just like regular functions: they accept [arguments](../../
 
 Here's a revision of the previous example which splits it into two smaller functions: one to build the container, and one to publish it. The builder function accepts the container image string as an argument and returns a `Container` type. The publisher function accepts a `Container` type as argument and returns the image identifier as a string.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 func (m *Basics) Build(
@@ -459,7 +459,7 @@ Here's an example of installing and using two modules from the Daggerverse: a Wo
 
 Here's what it looks like in code:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 func (m *Basics) Check(ctx context.Context) (string, error) {
@@ -529,7 +529,7 @@ One of Dagger's most powerful features is its ability to [cache data across work
 
 Taken together, these two types of caching significantly reduce execution times. Here's an example: a Dagger Function that creates a cache volume to store the packages installed by `apt`:
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 ```go
 func (m *Basics) Env(ctx context.Context) *dagger.Container {

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -76,7 +76,7 @@ dagger init --sdk=python
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 ```shell
 dagger init --sdk=typescript
@@ -134,7 +134,7 @@ Replace the generated `.dagger/src/hello_dagger/main.py` file with the following
 ```
 
 </TabItem>
-<TabItem value="TypeScript">
+<TabItem value="typescript" label="TypeScript">
 
 Replace the generated `.dagger/src/index.ts` file with the following code, which adds four Dagger Functions to your Dagger module:
 

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -90,7 +90,7 @@ dagger init --sdk=php
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 ```shell
 dagger init --sdk=java
@@ -150,7 +150,7 @@ Replace the generated `.dagger/src/HelloDagger.php` file with the following code
 ```
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="java" label="Java">
 
 Replace the generated `.dagger/src/main/java/io/dagger/modules/hellodagger/HelloDagger.java` file with the following code, which adds four Dagger Functions to your Dagger module:
 

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -62,7 +62,7 @@ After successfully creating your organization, all future Dagger workflows can b
 Bootstrap a new Dagger module in Go, Python, TypeScript, PHP, or Java by running `dagger init` in the application's root directory.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 ```shell
 dagger init --sdk=go
@@ -118,7 +118,7 @@ By default, the Dagger module name is automatically generated from the name of t
 Replace the generated Dagger module files as described below.
 
 <Tabs groupId="language" queryString="sdk">
-<TabItem value="Go">
+<TabItem value="go" label="Go">
 
 Replace the generated `.dagger/main.go` file with the following code, which adds four Dagger Functions to your Dagger module:
 

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -61,7 +61,7 @@ After successfully creating your organization, all future Dagger workflows can b
 
 Bootstrap a new Dagger module in Go, Python, TypeScript, PHP, or Java by running `dagger init` in the application's root directory.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 ```shell
@@ -117,7 +117,7 @@ By default, the Dagger module name is automatically generated from the name of t
 
 Replace the generated Dagger module files as described below.
 
-<Tabs groupId="language">
+<Tabs groupId="language" queryString="sdk">
 <TabItem value="Go">
 
 Replace the generated `.dagger/main.go` file with the following code, which adds four Dagger Functions to your Dagger module:

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -83,7 +83,7 @@ dagger init --sdk=typescript
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 ```shell
 dagger init --sdk=php
@@ -142,7 +142,7 @@ Replace the generated `.dagger/src/index.ts` file with the following code, which
 ```
 
 </TabItem>
-<TabItem value="PHP">
+<TabItem value="php" label="PHP">
 
 Replace the generated `.dagger/src/HelloDagger.php` file with the following code, which adds four Dagger Functions to your Dagger module:
 

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -69,7 +69,7 @@ dagger init --sdk=go
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 ```shell
 dagger init --sdk=python
@@ -126,7 +126,7 @@ Replace the generated `.dagger/main.go` file with the following code, which adds
 ```
 
 </TabItem>
-<TabItem value="Python">
+<TabItem value="python" label="Python">
 
 Replace the generated `.dagger/src/hello_dagger/main.py` file with the following code, which adds four Dagger Functions to your Dagger module:
 

--- a/docs/src/components/quickstartDoc.js
+++ b/docs/src/components/quickstartDoc.js
@@ -27,7 +27,7 @@ const QuickstartDoc = ({children, embeds}) => {
       <div className={styles.quickstartDoc}>
         <div className={styles.stepContent}>{children}</div>
         <div className={styles.stepEmbed}>
-          <Tabs groupId="language">
+          <Tabs groupId="language" queryString="sdk">
             {Object.keys(embeds).map((x, index) => {
               return (
                 <TabItem key={x} value={x}>


### PR DESCRIPTION
closes [ECO-610](https://linear.app/dagger/issue/ECO-610/docs-way-to-provide-docs-link-that-activates-a-tab-eg-python)

Use case is when I want to send someone a doc for their SDK language like, here's how you use Annotations in Python, I can send `https://docs.dagger.io/api/documentation/?sdk=Python`