### PR TITLE
docs: remove caution about privileged nesting option

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -74,25 +74,12 @@ Connect to it from a dagger cli:
 
 In core/schema, changes utilizing the dagql package modify the engine's GraphQL API. API documentation and SDK bindings must be generated and committed when modifying the schema. See "Docs" and "SDKs" below for more granular generation functionality. This command also runs go generate for engine code.
 
-    dagger call generate export --path=.
+    dagger call generate -o .
 
 > [!NOTE]
 >
 > For `PHP` and `Elixir` SDKs it's important to manually delete the generated folder before running
 > this command
-
-
-## Docs
-
-Lint the docs:
-
-    dagger call docs lint
-
-Auto-generate docs components:
-
-    dagger call docs generate -o .
-
-    
 
 ## SDKs
 

--- a/core/container.go
+++ b/core/container.go
@@ -41,8 +41,6 @@ type DefaultTerminalCmdOpts struct {
 	Args []string
 
 	// Provide dagger access to the executed command
-	// Do not use this option unless you trust the command being executed.
-	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
 
 	// Grant the process all root capabilities

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -427,10 +427,7 @@ func (s *containerSchema) Install() {
 			"/tmp/stderr").`).
 			ArgDoc("expect", `Exit codes this command is allowed to exit with without error`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -457,10 +454,7 @@ func (s *containerSchema) Install() {
 			"/tmp/stderr").`).
 			ArgDoc("expect", `Exit codes this command is allowed to exit with without error`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -636,10 +630,7 @@ func (s *containerSchema) Install() {
 			Doc(`Set the default command to invoke for the container's terminal API.`).
 			ArgDoc("args", `The args of the command.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -653,10 +644,7 @@ func (s *containerSchema) Install() {
 			Doc(`Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
 			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -668,10 +656,7 @@ func (s *containerSchema) Install() {
 			Doc(`Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
 			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -136,10 +136,7 @@ func (s *directorySchema) Install() {
 			ArgDoc("container", `If set, override the default container used for the terminal.`).
 			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-			the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-			FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 			running a command with "sudo" or executing "docker run" with the

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -33,10 +33,7 @@ func (s *serviceSchema) Install() {
 			ArgDoc("useEntrypoint",
 				`If the container has an entrypoint, prepend it to the args.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -75,10 +72,7 @@ func (s *serviceSchema) Install() {
 			ArgDoc("useEntrypoint",
 				`If the container has an entrypoint, prepend it to the args.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+				`Provides Dagger access to the executed command.`).
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -25,8 +25,6 @@ type TerminalArgs struct {
 	Cmd []string `default:"[]"`
 
 	// Provide dagger access to the executed command
-	// Do not use this option unless you trust the command being executed.
-	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
 
 	// Grant the process all root capabilities

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -122,12 +122,7 @@ type Container {
     """If the container has an entrypoint, prepend it to the args."""
     useEntrypoint: Boolean = false
 
-    """
-    Provides Dagger access to the executed command.
-    
-    Do not use this option unless you trust the command being executed; the
-    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
-    """
+    """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
 
     """
@@ -473,12 +468,7 @@ type Container {
     """
     cmd: [String!] = []
 
-    """
-    Provides Dagger access to the executed command.
-    
-    Do not use this option unless you trust the command being executed; the
-    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
-    """
+    """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
 
     """
@@ -517,12 +507,7 @@ type Container {
     """If the container has an entrypoint, prepend it to the args."""
     useEntrypoint: Boolean = false
 
-    """
-    Provides Dagger access to the executed command.
-    
-    Do not use this option unless you trust the command being executed; the
-    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
-    """
+    """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
 
     """
@@ -577,12 +562,7 @@ type Container {
     """The args of the command."""
     args: [String!]!
 
-    """
-    Provides Dagger access to the executed command.
-    
-    Do not use this option unless you trust the command being executed; the
-    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
-    """
+    """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
 
     """
@@ -1432,12 +1412,7 @@ type Directory {
     """
     cmd: [String!] = []
 
-    """
-    Provides Dagger access to the executed command.
-    
-    Do not use this option unless you trust the command being executed; the
-    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
-    """
+    """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
 
     """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4058,7 +4058,6 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Provides Dagger access to the executed command.</p>
-                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -4457,7 +4456,6 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Provides Dagger access to the executed command.</p>
-                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -4500,7 +4498,6 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Provides Dagger access to the executed command.</p>
-                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -4577,7 +4574,6 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Provides Dagger access to the executed command.</p>
-                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -5841,7 +5837,6 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Provides Dagger access to the executed command.</p>
-                                <p>Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -589,8 +589,6 @@ type ContainerAsServiceOpts struct {
 	// If the container has an entrypoint, prepend it to the args.
 	UseEntrypoint bool
 	// Provides Dagger access to the executed command.
-	//
-	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
@@ -1244,8 +1242,6 @@ type ContainerTerminalOpts struct {
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
 	// Provides Dagger access to the executed command.
-	//
-	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
@@ -1289,8 +1285,6 @@ type ContainerUpOpts struct {
 	// If the container has an entrypoint, prepend it to the args.
 	UseEntrypoint bool
 	// Provides Dagger access to the executed command.
-	//
-	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
@@ -1385,8 +1379,6 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 // ContainerWithDefaultTerminalCmdOpts contains options for Container.WithDefaultTerminalCmd
 type ContainerWithDefaultTerminalCmdOpts struct {
 	// Provides Dagger access to the executed command.
-	//
-	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
@@ -2767,8 +2759,6 @@ type DirectoryTerminalOpts struct {
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
 	// Provides Dagger access to the executed command.
-	//
-	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -632,9 +632,6 @@ class Container(Type):
             If the container has an entrypoint, prepend it to the args.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
-            Do not use this option unless you trust the command being
-            executed; the command being executed WILL BE GRANTED FULL ACCESS
-            TO YOUR HOST FILESYSTEM.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -1381,9 +1378,6 @@ class Container(Type):
             invoke these command arguments instead.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
-            Do not use this option unless you trust the command being
-            executed; the command being executed WILL BE GRANTED FULL ACCESS
-            TO YOUR HOST FILESYSTEM.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -1434,9 +1428,6 @@ class Container(Type):
             If the container has an entrypoint, prepend it to the args.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
-            Do not use this option unless you trust the command being
-            executed; the command being executed WILL BE GRANTED FULL ACCESS
-            TO YOUR HOST FILESYSTEM.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -1550,9 +1541,6 @@ class Container(Type):
             The args of the command.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
-            Do not use this option unless you trust the command being
-            executed; the command being executed WILL BE GRANTED FULL ACCESS
-            TO YOUR HOST FILESYSTEM.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -3034,9 +3022,6 @@ class Directory(Type):
             invoke these command arguments instead.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
-            Do not use this option unless you trust the command being
-            executed; the command being executed WILL BE GRANTED FULL ACCESS
-            TO YOUR HOST FILESYSTEM.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1765,7 +1765,6 @@ pub struct ContainerAsServiceOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
     /// Provides Dagger access to the executed command.
-    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -1872,7 +1871,6 @@ pub struct ContainerTerminalOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
     /// Provides Dagger access to the executed command.
-    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -1889,7 +1887,6 @@ pub struct ContainerUpOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
     /// Provides Dagger access to the executed command.
-    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -1913,7 +1910,6 @@ pub struct ContainerUpOpts<'a> {
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
     /// Provides Dagger access to the executed command.
-    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -4333,7 +4329,6 @@ pub struct DirectoryTerminalOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub container: Option<ContainerId>,
     /// Provides Dagger access to the executed command.
-    /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -73,8 +73,6 @@ export type ContainerAsServiceOpts = {
 
   /**
    * Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
 
@@ -232,8 +230,6 @@ export type ContainerTerminalOpts = {
 
   /**
    * Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
 
@@ -270,8 +266,6 @@ export type ContainerUpOpts = {
 
   /**
    * Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
 
@@ -296,8 +290,6 @@ export type ContainerUpOpts = {
 export type ContainerWithDefaultTerminalCmdOpts = {
   /**
    * Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
 
@@ -755,8 +747,6 @@ export type DirectoryTerminalOpts = {
 
   /**
    * Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
 
@@ -1771,8 +1761,6 @@ export class Container extends BaseClient {
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -2197,8 +2185,6 @@ export class Container extends BaseClient {
    * Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: ContainerTerminalOpts): Container => {
@@ -2219,8 +2205,6 @@ export class Container extends BaseClient {
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -2275,8 +2259,6 @@ export class Container extends BaseClient {
    * Set the default command to invoke for the container's terminal API.
    * @param args The args of the command.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   withDefaultTerminalCmd = (
@@ -3167,8 +3149,6 @@ export class Directory extends BaseClient {
    * Opens an interactive terminal in new container with this directory mounted inside.
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
-   *
-   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.container If set, override the default container used for the terminal.
    */


### PR DESCRIPTION
since we're not mounting the buildkit sock anymore to perform privileged
nesting, there's no security risk in using this option now.

ref: https://discord.com/channels/707636530424053791/1361775263196778496/1361791861475508419

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
