### PR TITLE
run publish job on single-tenant engine

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g3-v0-18-3-16c
+    runs-on: dagger-g3-v0-18-3-16c-st
     steps:
       - uses: actions/checkout@v4
       - name: "Publish"


### PR DESCRIPTION
There's currently a bug in v0.18.3 that frequently causes the publish job to error out due to some unhandled cases involving cross-session cache hits and `+private` state.

This will be fixed separately, but in order to avoid this problem during the release of v0.18.4 this change moves the Publish job to run on a single-tenant engine so that it doesn't have any other sessions connected that can cause the bug.

Generally speaking, running the Publish job on a single-tenant engine is probably a safer setup anyways since failures during publish can be particularly painful, so I think this is probably a good change to keep around even after v0.18.4.