### PR TITLE
Fix caching on `+private` state

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -427,6 +427,12 @@ func renderFile(
 
 	formatted, err := format.Source(source)
 	if err != nil {
+		// TODO:
+		// TODO:
+		// TODO:
+		// TODO:
+		// TODO:
+		os.WriteFile("/broken.gen.go", source, 0600)
 		return nil, fmt.Errorf("error formatting generated code: %w", err)
 	}
 	formatted, err = imports.Process(filepath.Join(cfg.OutputDir, "dummy.go"), formatted, nil)

--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -61,14 +61,14 @@ func (ps *parseState) parseGoFunc(parentType *types.Named, fn *types.Func) (*fun
 			spec.returnsError = true
 			break
 		}
-		spec.returnSpec, err = ps.parseGoTypeReference(result, nil, false)
+		spec.returnSpec, err = ps.parseGoTypeReference(result, nil, false, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse return type: %w", err)
 		}
 	case 2:
 		spec.returnsError = true
 		result := results.At(0).Type()
-		spec.returnSpec, err = ps.parseGoTypeReference(result, nil, false)
+		spec.returnSpec, err = ps.parseGoTypeReference(result, nil, false, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse return type: %w", err)
 		}
@@ -320,7 +320,7 @@ func (ps *parseState) parseParamSpecVar(field *types.Var, astField *ast.Field, d
 	var typeSpec ParsedType
 	if !isContext {
 		var err error
-		typeSpec, err = ps.parseGoTypeReference(baseType, nil, isPtr)
+		typeSpec, err = ps.parseGoTypeReference(baseType, nil, isPtr, false)
 		if err != nil {
 			return paramSpec{}, fmt.Errorf("failed to parse type reference: %w", err)
 		}

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -805,6 +805,8 @@ func (*Test) Fn(ctx context.Context, secret *dagger.Secret) (*dagger.Container, 
 	})
 }
 
+// TODO: variation where there's an object that only ever shows up as a private field
+// TODO: ^^ probably also slices of those objects too, etc.
 func (ModuleSuite) TestCrossSessionContextualDirWithPrivate(ctx context.Context, t *testctx.T) {
 	modDir := t.TempDir()
 

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -166,6 +166,9 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context) (
 	// add any extensions to objects for the interfaces they implement (if any)
 	for _, objType := range objects {
 		obj := objType.typeDef
+		if obj.Private {
+			continue
+		}
 		class, found := dag.ObjectType(obj.Name)
 		if !found {
 			return nil, loadedSchemaJSONFile, fmt.Errorf("failed to find object %q in schema", obj.Name)

--- a/core/module.go
+++ b/core/module.go
@@ -44,7 +44,7 @@ type Module struct {
 	Description string `field:"true" doc:"The doc string of the module, if any"`
 
 	// The module's objects
-	ObjectDefs []*TypeDef `field:"true" name:"objects" doc:"Objects served by this module."`
+	ObjectDefs []*TypeDef
 
 	// The module's interfaces
 	InterfaceDefs []*TypeDef `field:"true" name:"interfaces" doc:"Interfaces served by this module."`

--- a/core/object.go
+++ b/core/object.go
@@ -265,6 +265,9 @@ func (obj *ModuleObject) Install(ctx context.Context, dag *dagql.Server) error {
 	if obj.Module.InstanceID == nil {
 		return fmt.Errorf("installing object %q too early", obj.TypeDef.Name)
 	}
+	if obj.TypeDef.Private {
+		return nil
+	}
 
 	class := dagql.NewClass(dagql.ClassOpts[*ModuleObject]{
 		Typed: obj,
@@ -383,6 +386,9 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 
 func (obj *ModuleObject) fields() (fields []dagql.Field[*ModuleObject]) {
 	for _, field := range obj.TypeDef.Fields {
+		if field.Private {
+			continue
+		}
 		fields = append(fields, objField(obj.Module, field))
 	}
 	return

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2119,7 +2119,7 @@ func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInst
 		mod.Runtime,
 		core.NewFunction("", &core.TypeDef{
 			Kind:     core.TypeDefKindObject,
-			AsObject: dagql.NonNull(core.NewObjectTypeDef("Module", "")),
+			AsObject: dagql.NonNull(core.NewObjectTypeDef("Module", "", false)),
 		}))
 	if err != nil {
 		getModDefSpan.End()

--- a/sdk/python/runtime/dagger.json
+++ b/sdk/python/runtime/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "python-sdk",
-  "engineVersion": "v0.17.0",
+  "engineVersion": "v0.18.4-010101000000-dev-5a572e1c1d93",
   "sdk": {
     "source": "go"
   }


### PR DESCRIPTION
Our publish job has been failing most of the time on main after upgrading to v0.18.3 (but usually passed on a re-run) Was able to repro locally and realized it has to do with getting cache hits on module objects that have private state. The engine doesn't know about private fields so it can't hold cache refs open to them, which opens the door for getting a cache hit on an object with a local dir stored in private state, the original cache ref for that local dir being released, resulting in it being evicted and then getting a cache miss on a dir the caller knows nothing about and fails to load.
* See the newly added integ test for this in action, which is probably easier to follow than my run-on sentence

Similar sort of cases involving private state have bitten us when it comes to caching in the past, so trying to end the nightmare by updating the engine + all SDKs to actually register private fields, so the engine knows about them, but then just hide them from the public api of the module.

Got this working on Go so far. Tricky part was that previously it was possible to use private state to hide types we don't support like `map`, so needed some careful handing of types like that to keep this backwards compatible.

TODO:
- [ ] Rest of SDKs 