### PR TITLE
cache llm APIs per session to avoid cross-session reuse of config

### DIFF
--- a/.changes/unreleased/Fixed-20250416-105341.yaml
+++ b/.changes/unreleased/Fixed-20250416-105341.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix re-use of LLM config from other concurrently running dagger sessions.
+time: 2025-04-16T10:53:41.815817556-07:00
+custom:
+  Author: sipsma
+  PR: "10184"

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -804,3 +804,22 @@ func (*Test) Fn(ctx context.Context, secret *dagger.Secret) (*dagger.Container, 
 		require.NoError(t, err)
 	})
 }
+
+func (LLMSuite) TestCrossSessionLLM(ctx context.Context, t *testctx.T) {
+	// verify that llm settings read from clients don't cache across sessions
+	c1 := connect(ctx, t)
+	out, err := goGitBase(t, c1).
+		WithEnvVariable("ANTHROPIC_MODEL", "claude-3-5-sonnet-latest").
+		With(daggerExec("core", "llm", "model")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "claude-3-5-sonnet-latest", out)
+
+	c2 := connect(ctx, t)
+	out, err = goGitBase(t, c2).
+		WithEnvVariable("OPENAI_MODEL", "gpt-4.1").
+		With(daggerExec("core", "llm", "model")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-4.1", out)
+}

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -15,7 +15,7 @@ var _ SchemaResolvers = &llmSchema{}
 
 func (s llmSchema) Install() {
 	dagql.Fields[*core.Query]{
-		dagql.Func("llm", s.llm).
+		dagql.FuncWithCacheKey("llm", s.llm, dagql.CachePerSession).
 			Experimental("LLM support is not yet stabilized").
 			Doc(`Initialize a Large Language Model (LLM)`).
 			ArgDoc("model", "Model to use").

--- a/dagql/cachekey.go
+++ b/dagql/cachekey.go
@@ -46,6 +46,26 @@ func CachePerClientObject[A any](
 	return &cacheCfg, nil
 }
 
+// CachePerSession is a CacheKeyFunc that scopes the cache key to the session by mixing in the session ID to the original digest of the operation.
+// It should be used when the operation should be run for each session, but not more than once for a given session.
+func CachePerSession[P Typed, A any](
+	ctx context.Context,
+	_ Instance[P],
+	_ A,
+	cacheCfg CacheConfig,
+) (*CacheConfig, error) {
+	clientMD, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client metadata: %w", err)
+	}
+	if clientMD.SessionID == "" {
+		return nil, fmt.Errorf("session ID not found in context")
+	}
+
+	cacheCfg.Digest = HashFrom(cacheCfg.Digest.String(), clientMD.SessionID)
+	return &cacheCfg, nil
+}
+
 // CachePerCall results in the API always running when called, but the returned result from that call is cached.
 // For instance, the API may return a snapshot of some live mutating state; in that case the first call to get the snapshot
 // should always run but if the returned object is passed around it should continue to be that snapshot rather than the API


### PR DESCRIPTION
`Query.llm` had no custom cache key, so it was getting cached across sessions after v0.18.3 added the engine-wide dagql cache. This mean that per-session config like `*_MODEL` env vars, model keys, etc. could get re-used if one session was open and another came in and tried to use `llm` too.

This updates the cache key of `llm` to be per-session. Also added integ test coverage for this now.