### PR TITLE
make contextual dir vals count towards cache key

### DIFF
--- a/.changes/unreleased/Fixed-20250421-145654.yaml
+++ b/.changes/unreleased/Fixed-20250421-145654.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix caching of contextual directory args when multiple clients invoking the same function.
+time: 2025-04-21T14:56:54.826667957-07:00
+custom:
+  Author: sipsma
+  PR: "10187"

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/internal/testutil"
@@ -822,4 +823,161 @@ func (LLMSuite) TestCrossSessionLLM(ctx context.Context, t *testctx.T) {
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "gpt-4.1", out)
+}
+
+func (ModuleSuite) TestCrossSessionContextualDirWithPrivate(ctx context.Context, t *testctx.T) {
+	modDir := t.TempDir()
+
+	initCmd := hostDaggerCommand(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
+	initOutput, err := initCmd.CombinedOutput()
+	require.NoError(t, err, string(initOutput))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(modDir, "crap"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "crap", "foo.txt"), []byte(identity.NewID()), 0644))
+
+	err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+type Test struct {
+	Obj *Obj
+}
+func New(
+	// +defaultPath="/crap"
+	dir *dagger.Directory,
+) *Test {
+	return &Test{Obj: &Obj{Dir: dir}}
+}
+func (*Test) Nop(ctx context.Context) (string, error) {
+	return "nop", nil
+}
+func (*Test) Nop2(ctx context.Context) (string, error) {
+	return "nop2", nil
+}
+type Obj struct {
+	// +private
+	Dir *dagger.Directory
+}
+func (o *Obj) Ents(ctx context.Context) ([]string, error) {
+	return o.Dir.Entries(ctx)
+}
+`), 0644)
+	require.NoError(t, err)
+
+	c1 := connect(ctx, t)
+	mod1, err := c1.ModuleSource(modDir).AsModule().Sync(ctx)
+	require.NoError(t, err)
+	err = mod1.Serve(ctx)
+	require.NoError(t, err)
+
+	c2 := connect(ctx, t)
+	mod2, err := c2.ModuleSource(modDir).AsModule().Sync(ctx)
+	require.NoError(t, err)
+	err = mod2.Serve(ctx)
+	require.NoError(t, err)
+
+	res1, err := testutil.QueryWithClient[struct {
+		Test struct {
+			Nop string
+		}
+	}](c1, t, `{test{nop}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "nop", res1.Test.Nop)
+
+	res2, err := testutil.QueryWithClient[struct {
+		Test struct {
+			Nop2 string
+		}
+	}](c2, t, `{test{nop2}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "nop2", res2.Test.Nop2)
+
+	require.NoError(t, c1.Close())
+	time.Sleep(1 * time.Second)
+
+	res3, err := testutil.QueryWithClient[struct {
+		Test struct {
+			Obj struct {
+				Ents []string
+			}
+		}
+	}](c2, t, `{test{obj{ents}}}`, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, res3.Test.Obj.Ents)
+}
+
+func (ModuleSuite) TestCrossSessionContextualDirChange(ctx context.Context, t *testctx.T) {
+	modDir := t.TempDir()
+
+	initCmd := hostDaggerCommand(ctx, t, modDir, "init", "--source=src", "--name=test", "--sdk=go")
+	initOutput, err := initCmd.CombinedOutput()
+	require.NoError(t, err, string(initOutput))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(modDir, "crap"), 0755))
+	rand1 := identity.NewID()
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "crap", "foo.txt"), []byte(rand1), 0644))
+
+	err = os.WriteFile(filepath.Join(modDir, "src", "main.go"), []byte(`package main
+import (
+	"context"
+
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Obj *Obj
+}
+
+func New(
+	// +defaultPath="/crap"
+	dir *dagger.Directory,
+) *Test {
+	return &Test{Obj: &Obj{Dir: dir}}
+}
+
+type Obj struct {
+	Dir *dagger.Directory
+}
+
+func (o *Obj) Foo(ctx context.Context) (string, error) {
+	return o.Dir.File("foo.txt").Contents(ctx)
+}
+`), 0644)
+	require.NoError(t, err)
+
+	c1 := connect(ctx, t)
+	mod1, err := c1.ModuleSource(modDir).AsModule().Sync(ctx)
+	require.NoError(t, err)
+	err = mod1.Serve(ctx)
+	require.NoError(t, err)
+
+	res1, err := testutil.QueryWithClient[struct {
+		Test struct {
+			Obj struct {
+				Foo string
+			}
+		}
+	}](c1, t, `{test{obj{foo}}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, rand1, res1.Test.Obj.Foo)
+
+	rand2 := identity.NewID()
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "crap", "foo.txt"), []byte(rand2), 0644))
+
+	c2 := connect(ctx, t)
+	mod2, err := c2.ModuleSource(modDir).AsModule().Sync(ctx)
+	require.NoError(t, err)
+	err = mod2.Serve(ctx)
+	require.NoError(t, err)
+
+	res2, err := testutil.QueryWithClient[struct {
+		Test struct {
+			Obj struct {
+				Foo string
+			}
+		}
+	}](c2, t, `{test{obj{foo}}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, rand2, res2.Test.Obj.Foo)
 }

--- a/core/interface.go
+++ b/core/interface.go
@@ -168,6 +168,7 @@ func (iface *InterfaceType) TypeDef() *TypeDef {
 	}
 }
 
+//nolint:gocyclo
 func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) error {
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("interface", iface.typeDef.Name))
 	slog.ExtraDebug("installing interface")
@@ -340,7 +341,12 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 						return nil, fmt.Errorf("unexpected underlying type %T for interface resolver %s.%s", runtimeVal.UnderlyingType, ifaceName, fieldDef.Name)
 					}
 
-					return userModObj.mod.CacheConfigForCall(ctx, parentObj, args, cacheCfg)
+					callable, err := userModObj.GetCallable(ctx, fieldDef.Name)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get callable for %s.%s: %w", ifaceName, fieldDef.Name, err)
+					}
+
+					return callable.CacheConfigForCall(ctx, parentObj, args, cacheCfg)
 				},
 			},
 		})

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
@@ -231,6 +232,7 @@ func (fn *ModuleFunction) CacheConfigForCall(
 	}
 	if len(ctxArgs) > 0 {
 		cacheCfg.UpdatedArgs = make(map[string]dagql.Input)
+		var mu sync.Mutex
 		type argInput struct {
 			name string
 			val  dagql.IDType
@@ -248,7 +250,9 @@ func (fn *ModuleFunction) CacheConfigForCall(
 					name: arg.OriginalName,
 					val:  ctxVal,
 				}
+				mu.Lock()
 				cacheCfg.UpdatedArgs[arg.Name] = dagql.Opt(ctxVal)
+				mu.Unlock()
 
 				return nil
 			})

--- a/core/module.go
+++ b/core/module.go
@@ -212,9 +212,6 @@ func (mod *Module) View() (string, bool) {
 	return "", false
 }
 
-// TODO: consolidate this w/ the new the new cacheconfig on modfunc
-// TODO: consolidate this w/ the new the new cacheconfig on modfunc
-// TODO: consolidate this w/ the new the new cacheconfig on modfunc
 func (mod *Module) CacheConfigForCall(
 	ctx context.Context,
 	_ dagql.Object,

--- a/core/module.go
+++ b/core/module.go
@@ -212,6 +212,9 @@ func (mod *Module) View() (string, bool) {
 	return "", false
 }
 
+// TODO: consolidate this w/ the new the new cacheconfig on modfunc
+// TODO: consolidate this w/ the new the new cacheconfig on modfunc
+// TODO: consolidate this w/ the new the new cacheconfig on modfunc
 func (mod *Module) CacheConfigForCall(
 	ctx context.Context,
 	_ dagql.Object,
@@ -236,6 +239,7 @@ func (mod *Module) CacheConfigForCall(
 		mod.Source.Self.Digest,
 		mod.NameField, // the module source content digest only includes the original name
 	)
+
 	return &cacheCfg, nil
 }
 

--- a/core/object.go
+++ b/core/object.go
@@ -377,7 +377,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 			})
 		},
 		dagql.CacheSpec{
-			GetCacheConfig: mod.CacheConfigForCall,
+			GetCacheConfig: fn.CacheConfigForCall,
 		},
 	)
 
@@ -493,7 +493,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 			return modFun.Call(ctx, opts)
 		},
 		CacheSpec: dagql.CacheSpec{
-			GetCacheConfig: mod.CacheConfigForCall,
+			GetCacheConfig: modFun.CacheConfigForCall,
 		},
 	}, nil
 }

--- a/core/object.go
+++ b/core/object.go
@@ -171,6 +171,7 @@ type Callable interface {
 	Call(context.Context, *CallOpts) (dagql.Typed, error)
 	ReturnType() (ModType, error)
 	ArgType(argName string) (ModType, error)
+	CacheConfigForCall(context.Context, dagql.Object, map[string]dagql.Input, dagql.CacheConfig) (*dagql.CacheConfig, error)
 }
 
 func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callable, error) {
@@ -522,4 +523,13 @@ func (f *CallableField) ReturnType() (ModType, error) {
 
 func (f *CallableField) ArgType(argName string) (ModType, error) {
 	return nil, fmt.Errorf("field cannot have argument %q", argName)
+}
+
+func (f *CallableField) CacheConfigForCall(
+	ctx context.Context,
+	parent dagql.Object,
+	args map[string]dagql.Input,
+	inputCfg dagql.CacheConfig,
+) (*dagql.CacheConfig, error) {
+	return f.Module.CacheConfigForCall(ctx, parent, args, inputCfg)
 }

--- a/dagql/call/argument.go
+++ b/dagql/call/argument.go
@@ -34,6 +34,10 @@ func (arg *Argument) Value() Literal {
 	return arg.value
 }
 
+func (arg *Argument) WithValue(value Literal) *Argument {
+	return NewArgument(arg.Name(), value, arg.isSensitive)
+}
+
 func (arg *Argument) gatherCalls(callsByDigest map[string]*callpbv1.Call) {
 	if arg == nil || arg.isSensitive {
 		return

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -632,7 +632,7 @@ func (s *Server) SelectID(ctx context.Context, self Object, sels ...Selector) (*
 	var id *call.ID
 	for i, sel := range sels {
 		var err error
-		res, id, err = self.ReturnType(ctx, sel)
+		res, id, err = self.ReturnType(ctx, s, sel)
 		if err != nil {
 			return nil, fmt.Errorf("select: %w", err)
 		}
@@ -704,6 +704,20 @@ func CurrentID(ctx context.Context) *call.ID {
 		return nil
 	}
 	return val.(*call.ID)
+}
+
+type srvCtx struct{}
+
+func srvToContext(ctx context.Context, srv *Server) context.Context {
+	return context.WithValue(ctx, srvCtx{}, srv)
+}
+
+func CurrentDagqlServer(ctx context.Context) *Server {
+	val := ctx.Value(srvCtx{})
+	if val == nil {
+		return nil
+	}
+	return val.(*Server)
 }
 
 // NewInstanceForCurrentID creates a new Instance that's set to the current ID from

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -103,7 +103,7 @@ type Object interface {
 	// be instantiated with a class for further selection.
 	//
 	// Any Nullable values are automatically unwrapped.
-	ReturnType(context.Context, Selector) (Typed, *call.ID, error)
+	ReturnType(context.Context, *Server, Selector) (Typed, *call.ID, error)
 }
 
 // A type that has a callback attached that needs to always run before returned to a caller


### PR DESCRIPTION
Replacement for https://github.com/dagger/dagger/pull/10175 as this PR solves the problem there plus some more general ones w/ a completely different approach.

New case of contextual dirs causing cache problems was noticed by @cwlbraa where he was hitting old local code when running integ tests w/ `test specific`
* See `TestCrossSessionContextualDirChange` integ test added in this PR for a minimal repro of that situation

The only real fix for this is to tackle the problem of contextual dirs not actually counting towards the cache key of function calls, which turns out to not be a very obscure case after all. Solving this problem also fixes the issue w/ `+private`.

Gist of the problem:
* Contextual dirs+files aren't loaded until the actual implementation of module function invocation
* That comes *after* we calculate the dagql cache key for functions
* Therefore, the cache key of the function invocation doesn't include the actual value of the contextual dir/file, so any time they are used a change in the contextual dir/file doesn't impact the cache
* This allows situations like
   1. run `test | specific` in the `dagger-dev` module, it loads the integ test code via a contextual dir arg. Leave the shell session open
   2. change something in the integ test code
   3. run `test | specific` in a different session, it hits the cache but with the previous value of the contextual dir for the integ test code (since its value doesn't count towards the cache key)
   4. you end up running the tests w/out your changes to integ test code

The fix moves the loading logic for contextual dirs/files to happen in the cache key func for function invocations. This allows their values to be incorporated into the cache key.

This also updates cache key funcs to allow them to modify args, which enables the contextual dir args to just be loaded there once and put into telemetry, etc.