### PR TITLE
fix: raise up --no-mod flag to same level as --mod

### DIFF
--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -37,7 +37,11 @@ dagger config -m github.com/dagger/hello-dagger
 		return withEngine(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			dag := engineClient.Dagger()
 
-			modSrc := dag.ModuleSource(getModuleSourceRefWithDefault())
+			modRef, err := getModuleSourceRefWithDefault()
+			if err != nil {
+				return err
+			}
+			modSrc := dag.ModuleSource(modRef)
 
 			sourceRootSubpath, err := modSrc.SourceRootSubpath(ctx)
 			if err != nil {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -279,7 +279,7 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 
 	var mod *moduleDef
 	var err error
-	if fc.DisableModuleLoad {
+	if fc.DisableModuleLoad || moduleNoURL {
 		mod, err = initializeCore(ctx, fc.c.Dagger())
 	} else {
 		mod, err = initializeDefaultModule(ctx, fc.c.Dagger())

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -37,6 +37,9 @@ func initializeCore(ctx context.Context, dag *dagger.Client) (rdef *moduleDef, r
 // By default, looks for a module in the current directory, or above.
 // Returns an error if the module is not found or invalid.
 func initializeDefaultModule(ctx context.Context, dag *dagger.Client) (*moduleDef, error) {
+	if moduleNoURL {
+		return nil, fmt.Errorf("cannot load module when --no-module is specified")
+	}
 	modRef, _ := getExplicitModuleSourceRef()
 	if modRef == "" {
 		modRef = moduleURLDefault

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -28,17 +28,14 @@ import (
 
 // shellCode is the code to be executed in the shell command
 var (
-	shellCode         string
-	shellNoLoadModule bool
+	shellCode string
 
 	llmModel string
 )
 
 func shellAddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a dagger shell command")
-	cmd.Flags().BoolVarP(&shellNoLoadModule, "no-mod", "M", false, "Don't load module during shell startup (mutually exclusive with --mod)")
 	cmd.Flags().StringVar(&llmModel, "model", "", "LLM model to use (e.g., 'claude-3-5-sonnet', 'gpt-4o')")
-	cmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
 }
 
 var shellCmd = &cobra.Command{
@@ -189,7 +186,7 @@ func (h *shellCallHandler) Initialize(ctx context.Context) error {
 	var def *moduleDef
 	var cfg *configuredModule
 
-	if !shellNoLoadModule {
+	if !moduleNoURL {
 		def, cfg, err = h.maybeLoadModuleAndDeps(ctx, ref)
 		if err != nil {
 			return err

--- a/cmd/dagger/shell_fs.go
+++ b/cmd/dagger/shell_fs.go
@@ -461,7 +461,7 @@ func (h *shellCallHandler) newWorkdir(ctx context.Context, def *moduleDef, subpa
 			return nil, fmt.Errorf("%q is not a directory", root)
 		}
 
-		if !shellNoLoadModule {
+		if !moduleNoURL {
 			// ask API where the context dir is (.git)
 			ctx, span := Tracer().Start(ctx, "looking for context directory", telemetry.Internal())
 			defer telemetry.End(span, func() error { return rerr })

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -21,10 +21,10 @@ dagger [options] [subcommand | file...]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -m, --mod string                   Path to the module directory. Either local path or a remote git repo
+  -m, --mod string                   Module reference to load, either a local path or a remote git repo (defaults to current directory)
       --model string                 LLM model to use (e.g., 'claude-3-5-sonnet', 'gpt-4o')
   -E, --no-exit                      Leave the TUI running after completion
-  -M, --no-mod                       Don't load module during shell startup (mutually exclusive with --mod)
+  -M, --no-mod                       Don't automatically load a module (mutually exclusive with --mod)
       --progress string              Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
   -s, --silent                       Do not show progress at all
@@ -62,7 +62,8 @@ dagger call [options]
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
   -j, --json                Present result as JSON
-  -m, --mod string          Path to the module directory. Either local path or a remote git repo
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
   -o, --output string       Save the result to a local file or directory
 ```
 
@@ -108,7 +109,8 @@ dagger config -m github.com/dagger/hello-dagger
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --json                output in JSON format
-  -m, --mod string          Path to the module directory. Either local path or a remote git repo
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
 ```
 
 ### Options inherited from parent commands
@@ -196,7 +198,8 @@ dagger develop [options]
       --allow-llm strings        List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string[="skip"]   Engine API version to target (default "latest")
       --license string           License identifier to generate. See https://spdx.org/licenses/ (default "Apache-2.0")
-  -m, --mod string               Path to the module directory. Either local path or a remote git repo
+  -m, --mod string               Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod                   Don't automatically load a module (mutually exclusive with --mod)
   -r, --recursive                Develop recursively into local dependencies
       --sdk string               Install the given Dagger SDK. Can be builtin (go, python, typescript) or a module address
       --source string            Source directory used by the installed SDK. Defaults to module root
@@ -240,7 +243,8 @@ dagger functions [options] [function]...
 
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-  -m, --mod string          Path to the module directory. Either local path or a remote git repo
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
 ```
 
 ### Options inherited from parent commands
@@ -335,8 +339,9 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-  -m, --mod string          Path to the module directory. Either local path or a remote git repo
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -n, --name string         Name to use for the dependency in the module. Defaults to the name of the module being installed.
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
 ```
 
 ### Options inherited from parent commands
@@ -449,7 +454,8 @@ EOF
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --doc string          Read query from file (defaults to reading from stdin)
-  -m, --mod string          Path to the module directory. Either local path or a remote git repo
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
       --var strings         List of query variables, in key=value format
       --var-json string     Query variables in JSON format (overrides --var)
 ```
@@ -552,7 +558,10 @@ dagger uninstall hello
 ### Options
 
 ```
-      --compat string   Engine API version to target (default "latest")
+      --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --compat string       Engine API version to target (default "latest")
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
 ```
 
 ### Options inherited from parent commands
@@ -594,7 +603,10 @@ dagger update [options] <module>
 ### Options
 
 ```
-      --compat string   Engine API version to target (default "latest")
+      --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --compat string       Engine API version to target (default "latest")
+  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
It makes sense that the `--no-mod` flag should be allowed everywhere that the `--mod` flag is.

The main rationale for this was around `dagger query`, where it wasn't possible to run without attempting to load the current directory. But it also extends to other commands.

---

I originally raised this in discord [here](https://discord.com/channels/707636530424053791/1003718839739105300/1354148401280716821):

> @jedevc — 25/03/2025, 17:42
> 
> question around --no-mod - I assume it should be allowed wherever a --mod flag is? it feels weird that it currently isn't.
> for example, i can't attach it to dagger query, if there is a module in the current directory, that command will always attempt to load it 😢

> @shykes — 25/03/2025, 17:52
>
> makes sense to me yeah