### PR TITLE
Add contextual git directories

### DIFF
--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -410,6 +410,7 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 	Description  string    `default:""`
 	DefaultValue core.JSON `default:""`
 	DefaultPath  string    `default:""`
+	DefaultGit   string    `default:""`
 	Ignore       []string  `default:"[]"`
 	SourceMap    dagql.Optional[core.SourceMapID]
 }) (*core.Function, error) {
@@ -446,8 +447,11 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 	if args.DefaultPath != "" {
 		td = td.WithOptional(true)
 	}
+	if args.DefaultGit != "" {
+		td = td.WithOptional(true)
+	}
 
-	return fn.WithArg(args.Name, td, args.Description, args.DefaultValue, args.DefaultPath, args.Ignore, sourceMap), nil
+	return fn.WithArg(args.Name, td, args.Description, args.DefaultValue, args.DefaultPath, args.DefaultGit, args.Ignore, sourceMap), nil
 }
 
 func (s *moduleSchema) functionWithSourceMap(ctx context.Context, fn *core.Function, args struct {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -119,7 +119,7 @@ func (fn *Function) WithDescription(desc string) *Function {
 	return fn
 }
 
-func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, ignore []string, sourceMap *SourceMap) *Function {
+func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, defaultGit string, ignore []string, sourceMap *SourceMap) *Function {
 	fn = fn.Clone()
 	fn.Args = append(fn.Args, &FunctionArg{
 		Name:         strcase.ToLowerCamel(name),
@@ -129,6 +129,7 @@ func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultV
 		DefaultValue: defaultValue,
 		OriginalName: name,
 		DefaultPath:  defaultPath,
+		DefaultGit:   defaultGit,
 		Ignore:       ignore,
 	})
 	return fn
@@ -201,6 +202,7 @@ type FunctionArg struct {
 	TypeDef      *TypeDef   `field:"true" doc:"The type of the argument."`
 	DefaultValue JSON       `field:"true" doc:"A default value to use for this argument when not explicitly set by the caller, if any."`
 	DefaultPath  string     `field:"true" doc:"Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"`
+	DefaultGit   string     `field:"true" doc:"Only applies to arguments of type GitRef or GitRepository. If the argument is not set, load it from the given git ref or repository in the context directory"`
 	Ignore       []string   `field:"true" doc:"Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."`
 
 	// Below are not in public API
@@ -236,6 +238,10 @@ func (*FunctionArg) TypeDescription() string {
 		`An argument accepted by a function.`,
 		`This is a specification for an argument at function definition time, not
 		an argument passed at function call time.`)
+}
+
+func (arg *FunctionArg) isContextual() bool {
+	return arg.DefaultPath != "" || arg.DefaultGit != ""
 }
 
 type DynamicID struct {


### PR DESCRIPTION
Fixes #8520

> [!WARNING]
>
> This PR is under construction! :construction_worker_woman: 

This allows a module to get git information about itself - it can do this through the core `Git` type. Later on, we'll extend the API with more functionality, like in #9968 which will be able to track dirty state, and get diffs.

This was *previously* sort of possible, by using a context dir and calling `.asGit` on it, but:
1. it's not particularly ergonomic, and doesn't convey the user's intention particularly well
2. it has to upload all the files in the local directory to handle this - we should be able to apply optimizations in quite a few cases, which should make it faster.

---

TODO:
- [ ] Ensure we have design consensus
- [ ] Engine plumbing
	- [x] Initial implementation
	- [ ] Fix outstanding comments
- [ ] SDK support
	- [x] Go SDK
	- [ ] Python SDK
	- [ ] Typescript SDK
- [ ] Testing
	- [x] Local source tests
	- [ ] Git source tests through http://github.com/dagger/dagger-test-modules