### PR TITLE
docs: add redirect for features/large-language-models

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -52,6 +52,11 @@
   from = "/ai-agents"
   to = "/features/llm"
   status = 301
+  
+[[redirects]]
+    from = "features/large-language-model/"
+    to = "/features/llm"
+    status = 301
 
 ###### end: specific redirects for ci+agent docs ######
 


### PR DESCRIPTION
Fixes a cached url to redirect to the right page.