### PR TITLE
chore: Enable strict and skipLibCheck settings in tsconfigs

### DIFF
--- a/core/integration/testdata/modules/typescript/ifaces/impl/tsconfig.json
+++ b/core/integration/testdata/modules/typescript/ifaces/impl/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk/src"],
       "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"]

--- a/core/integration/testdata/modules/typescript/ifaces/test/tsconfig.json
+++ b/core/integration/testdata/modules/typescript/ifaces/test/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk/src"],
       "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"]

--- a/dagql/idtui/viztest/typescript/tsconfig.json
+++ b/dagql/idtui/viztest/typescript/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "paths": {

--- a/docs/current_docs/api/snippets/modules/testing/typescript/tsconfig.json
+++ b/docs/current_docs/api/snippets/modules/testing/typescript/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk/src"],
       "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"]

--- a/docs/current_docs/quickstart/agent/snippets/typescript/tsconfig.json
+++ b/docs/current_docs/quickstart/agent/snippets/typescript/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk/src"],
       "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"]

--- a/sdk/typescript/.changes/unreleased/Added-20250418-045435.yaml
+++ b/sdk/typescript/.changes/unreleased/Added-20250418-045435.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Enable strict and skipLibCheck settings in tsconfigs
+time: 2025-04-18T04:54:35.160195-05:00
+custom:
+    Author: "jahands"
+    PR: "10203"

--- a/sdk/typescript/dev/node/tsconfig.json
+++ b/sdk/typescript/dev/node/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": [
         "./sdk/src"

--- a/sdk/typescript/dev/tsconfig.json
+++ b/sdk/typescript/dev/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": [
         "./sdk/src"

--- a/sdk/typescript/runtime/bin/__tsclientconfig.updator.ts
+++ b/sdk/typescript/runtime/bin/__tsclientconfig.updator.ts
@@ -66,6 +66,8 @@ if (!fs.existsSync(tsConfigPath)) {
       target: "ES2022",
       moduleResolution: "Node",
       experimentalDecorators: true,
+      strict: true,
+      skipLibCheck: true,
       paths: {
         "@dagger.io/client": [
           `./${path.join(libraryDir.value, "client.gen.ts")}`,

--- a/sdk/typescript/runtime/bin/__tsconfig.updator.ts
+++ b/sdk/typescript/runtime/bin/__tsconfig.updator.ts
@@ -14,6 +14,8 @@ if (!fs.existsSync(tsConfigPath)) {
       target: "ES2022",
       moduleResolution: "Node",
       experimentalDecorators: true,
+      strict: true,
+      skipLibCheck: true,
       paths: {
         "@dagger.io/dagger": ["./sdk/src"],
         "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"],

--- a/sdk/typescript/runtime/template/tsconfig.json
+++ b/sdk/typescript/runtime/template/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "moduleResolution": "Node",
     "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk/src"],
       "@dagger.io/dagger/telemetry": ["./sdk/src/telemetry"]

--- a/sdk/typescript/src/module/registry.ts
+++ b/sdk/typescript/src/module/registry.ts
@@ -111,10 +111,14 @@ export class Registry {
     opts?: ArgumentOptions,
   ): ((
     target: object,
-    propertyKey: string,
+    propertyKey: string | undefined,
     parameterIndex: number,
   ) => void) => {
-    return (target: object, propertyKey: string, parameterIndex: number) => {}
+    return (
+      target: object,
+      propertyKey: string | undefined,
+      parameterIndex: number,
+    ) => {}
   }
 
   /**


### PR DESCRIPTION
* strict mode prevents a lot of bugs allowed with default typescript settings and is recommended for all typescript projects.
* skipLibCheck is generally recommended to improve typescript speed by not typechecking dependencies
* fixed a type issue in the `@argument` decorator that was caught by strict mode