### PR TITLE
docs: update melvin link

### DIFF
--- a/docs/current_docs/_examples_agents.mdx
+++ b/docs/current_docs/_examples_agents.mdx
@@ -8,7 +8,7 @@ Explore these functional AI agent examples built with Dagger:
 
 - [Toy Programmer](https://github.com/shykes/toy-programmer): A simple programmer micro-agent for demonstration purposes
 
-- [Melvin](https://github.com/dagger/agents/tree/main/melvin): An experimental open-source coding agent made of small composable modules
+- [Melvin](https://github.com/shykes/melvin): An experimental open-source coding agent made of small composable modules
 
 - [Multi-Agent Demo](https://github.com/kpenfound/agents/tree/main/multiagent-demo): A demonstration using multiple LLMs to collaboratively solve a problem
 


### PR DESCRIPTION
Updates the 404 link on Melvin to the right repository.