### PR TITLE
upgrade go 1.23.6->1.23.8

### DIFF
--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -27,7 +27,7 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.23.6"
+	GolangVersion = "1.23.8"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.23.6"
+	// +default="1.23.8"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
A bunch of `TestClientGenerator` tests started consistently failing out of band, turns out this is because:
1. gqlgen did a [release](https://github.com/99designs/gqlgen/releases/tag/v0.17.71) 19h ago where their [go.mod specifies go 1.23.8](https://github.com/99designs/gqlgen/blob/master/go.mod#L3)
2. dagger's go toolchains are on go 1.23.6
3. Some of the `TestClientGenerator` tests init an empty go.mod
4. The custom client generator code doesn't make any attempt to pin to our go sdk dep versions, it runs `go mod tidy` and thus picks up latest releases for everything 
5. We then error out at the point of trying to use the go.mod

We obviously need a fix to the client generator code to handle this better, but wasn't immediately obvious so sending out this quick and easy PR to unblock tests. Moving to the latest go 1.23 is obviously a good thing either way (and can't upgrade to go 1.24 until the upstream go bugs in 1.24 are resolved)