### PR TITLE
fix current module during initialization

### DIFF
--- a/.changes/unreleased/Fixed-20250421-145534.yaml
+++ b/.changes/unreleased/Fixed-20250421-145534.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix errors using CurrentModule API during SDK module initialization.
+time: 2025-04-21T14:55:34.675123543-07:00
+custom:
+  Author: sipsma
+  PR: "10213"

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -109,6 +109,9 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	mod, err := container.Query.CurrentModule(ctx)
 	if err == nil {
+		if mod.InstanceID == nil {
+			return nil, fmt.Errorf("current module has no instance ID")
+		}
 		// allow the exec to reach services scoped to the module that
 		// installed it
 		execMD.ExtraSearchDomains = append(execMD.ExtraSearchDomains,

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -247,7 +247,6 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		ExecID:            identity.NewID(),
 		CachePerSession:   !opts.Cache,
 		Internal:          true,
-		ModuleName:        mod.NameField,
 		CacheByCall:       !opts.SkipCallDigestCacheKey,
 		ParentIDs:         map[digest.Digest]*resource.ID{},
 		AllowedLLMModules: clientMetadata.AllowedLLMModules,

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -560,7 +561,7 @@ func (s *moduleSchema) currentModuleSource(
 ) (inst dagql.Instance[*core.Directory], err error) {
 	curSrc := curMod.Module.Source
 	if curSrc.Self == nil {
-		return inst, fmt.Errorf("module source not available during initialization")
+		return inst, errors.New("invalid unset current module source")
 	}
 
 	srcSubpath := curSrc.Self.SourceSubpath

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -63,7 +63,6 @@ type ExecutionMetadata struct {
 
 	CallID              *call.ID
 	EncodedModuleID     string
-	ModuleName          string
 	EncodedFunctionCall json.RawMessage
 	CallerClientID      string
 


### PR DESCRIPTION
Module initialization (when we ask the runtime for what type defs it has) previously got just enough data to support checking the current module name, but basically nothing else. This is because the module is not yet fully constructed during initialization.

This update results in as much of the module being available during init as is possible. This should cover various cases like:
1. access to dag.CurrentModule().Source()
2. creating execs during module initialization (which previously panicked because the instance ID was empty)
   * also check for that condition that created a panic and error instead, just in case that codepath can be triggered some other way