### PR TITLE
secret transfer fixes

### DIFF
--- a/.changes/unreleased/Fixed-20250421-163041.yaml
+++ b/.changes/unreleased/Fixed-20250421-163041.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix "client not found" errors when loading cached modules from private repos.
+time: 2025-04-21T16:30:41.36479966-07:00
+custom:
+  Author: sipsma
+  PR: "10223"

--- a/.changes/unreleased/Fixed-20250421-180136.yaml
+++ b/.changes/unreleased/Fixed-20250421-180136.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix "buildkit session not found" errors when calling `.plaintext` on a URI-based secret from a module w/ cache hit.
+time: 2025-04-21T18:01:36.85935517-07:00
+custom:
+  Author: sipsma
+  PR: "10223"

--- a/.changes/unreleased/Fixed-20250421-193832.yaml
+++ b/.changes/unreleased/Fixed-20250421-193832.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fixed error when setSecret provided empty plaintext value and passed between function calls.
+time: 2025-04-21T19:38:32.53903125-07:00
+custom:
+  Author: sipsma
+  PR: "10223"

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -482,7 +482,7 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source da
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call sdk module moduleRuntime: %w", err)
+		return nil, fmt.Errorf("failed to call sdk moduleRuntime: %w", err)
 	}
 	return inst.Self, nil
 }

--- a/core/secret.go
+++ b/core/secret.go
@@ -160,7 +160,7 @@ func (store *SecretStore) GetSecretPlaintext(ctx context.Context, idDgst digest.
 	}
 
 	// If the secret is stored locally (setSecret), return the plaintext.
-	if len(secret.Self.Plaintext) > 0 {
+	if secret.Self.URI == "" {
 		return secret.Self.Plaintext, nil
 	}
 

--- a/engine/server/client_resources.go
+++ b/engine/server/client_resources.go
@@ -81,7 +81,7 @@ func (srv *Server) addClientResourcesFromID(ctx context.Context, destClient *dag
 				// don't attempt to add the secret if it doesn't exist and was optional
 				continue
 			}
-			if err := destClient.secretStore.AddSecret(secret); err != nil {
+			if err := destClient.secretStore.AddSecretFromOtherStore(srcClient.secretStore, secret); err != nil {
 				return fmt.Errorf("failed to add secret from source client %s: %w", srcClient.clientID, err)
 			}
 		}


### PR DESCRIPTION
Bundling together a few tangentially related fixes for secret transfer here:
* Fix for issue brought up in [discord](https://discord.com/channels/707636530424053791/1363438107722125382) where trying to load a module sourced from a private git repo could fail when the cache is hit
* Fix for "buildkit session not found" errors when calling `.Plaintext` on a URI-based secret from a module function call
* Fix for handling of empty plaintext secrets (previously we incorrectly assumed when no plaintext it was a URI-based secret)

I split these up by commit, so see individual commits w/ changelog+tests for more context