### PR TITLE
build: Add e2fsprogs to the dagger image

### DIFF
--- a/.dagger/build/builder.go
+++ b/.dagger/build/builder.go
@@ -170,6 +170,8 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 					"git", "openssh-client", "pigz", "xz",
 					// for CNI
 					"dnsmasq", "iptables", "ip6tables", "iptables-legacy",
+					// for Kata Containers integration
+					"e2fsprogs",
 				},
 				Arch: build.platformSpec.Architecture,
 			}).
@@ -193,6 +195,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				"apt-get", "install", "-y",
 				"iptables", "git", "dnsmasq-base", "network-manager",
 				"gpg", "curl",
+				"e2fsprogs",
 			}).
 			WithExec([]string{
 				"update-alternatives",
@@ -215,6 +218,8 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 			"git", "openssh-client", "pigz", "xz",
 			// for CNI
 			"iptables", "ip6tables", "dnsmasq",
+			// for Kata Containers integration
+			"e2fsprogs",
 		}
 		if build.gpuSupport {
 			pkgs = append(pkgs, "nvidia-driver", "nvidia-tools")


### PR DESCRIPTION
When running Dagger with Kata Containers one will want to avoid using virtio-fs and direct attach a block volume to the container, which will then require `e2fsprogs` in order to properly `mkfs.XYZ ...` the block device before getting it to actually be mounted and used ae `/var/lib/dagger`.

Of course, this is far from a "normal" use-case, but right now there's no way to use the Dagger engine without either modifying Kata Containers itself or re-building the Dagger image ... and both options are less optimal than simply adding `e2fsprogs` to the engine image.