### PR TITLE
fix `llm.withModel` usage from a module

### DIFF
--- a/.changes/unreleased/Fixed-20250421-174513.yaml
+++ b/.changes/unreleased/Fixed-20250421-174513.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix API authentication errors when calling `llm.withModel` from a module function.
+time: 2025-04-21T17:45:13.36105315-07:00
+custom:
+  Author: sipsma
+  PR: "10230"

--- a/core/llm.go
+++ b/core/llm.go
@@ -500,7 +500,7 @@ func (llm *LLM) ToolsDoc(ctx context.Context, srv *dagql.Server) (string, error)
 func (llm *LLM) WithModel(ctx context.Context, model string, srv *dagql.Server) (*LLM, error) {
 	// FIXME: mcp implementation takes hints from endpoint: reconfigure it
 	llm = llm.Clone()
-	router, err := NewLLMRouter(ctx, srv)
+	router, err := loadLLMRouter(ctx, llm.Query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10151

`withModel` was not loading env vars from the main client in the same way that the `llm` constructor was, so calling `withModel` didn't result in any auth being loaded along with the reset model.

This updates `withModel` to load the router in the same way as the constructor so API keys are loaded consistently.

---

Tested manually so far since I don't *believe* our integ tests support any actual calls with real API auth keys.

Tested by repro'ing the original report in discord:
```go
package main

import (
	"context"
	"dagger/test/internal/dagger"
)

type Test struct{}

func (m *Test) Broke(ctx context.Context, model string) (string, error) {
	return dag.LLM().WithModel(model).WithPrompt("testing").LastReply(ctx)
}

func (m *Test) Works(ctx context.Context, model string) (string, error) {
	return dag.LLM(dagger.LLMOpts{Model: model}).WithPrompt("testing").LastReply(ctx)
}
```

Before this change, `dagger call broke --model claude` (with `ANTHROPIC_API_KEY` set in env) would return
```
sipsma@dagger_dev:/tmp/testllm$ dagger call broke --model claude
✔ connect 0.2s
✔ load module 0.6s
✔ parsing command line arguments 0.0s

✔ test: Test! 0.0s
✘ .broke(model: "claude"): String! 0.5s
! not retrying: POST "https://api.anthropic.com/v1/messages": 401 Unauthorized {"type":"error","error":{"type":"authentication_err
│🧑 testing
│ ┃ 0.0s
│ 
│🤖 0.1s
│ ! POST "https://api.anthropic.com/v1/messages": 401 Unauthorized {"type":"error","error":{"type":"authentication_error","message

Full trace at https://dagger.cloud/dagger/traces/8862d6d7b38f5d83e03a6387322a8000
```

Now it returns
```
sipsma@dagger_dev:/tmp/testllm$ dagger call broke --model claude
✔ connect 0.6s
✔ load module 1.1s
✔ parsing command line arguments 0.0s

✔ test: Test! 0.0s
✔ .broke(model: "claude"): String! 7.7s
│🧑 testing
│ ┃ 0.0s
│ 
│🤖 Let me think through what we need to do for this testing request.
│ ┃ 4.0s ◆ Input Tokens: 1,065 ◆ Output Tokens: 125
│ 
│💭 This appears to be a simple test message. Without any specific instructions or objectives, I should acknowledge that we're rea
│ ┃ about what exactly needs to be tested or accomplished.                                                                        
│ ┃                                                                                                                               
│ ┃ The only tool currently available is "think", which I'm using now to reason through the situation.
│ ┃ 0.0s
│ 
│🤖 I understand this is a test message. I can help you with any specific tasks or questions you may have. Currently, I have acces
│ ┃ other tools as they become available based on your needs. What would you like to test or accomplish?
│ ┃ 3.3s ◆ Input Tokens: 1,204 ◆ Output Tokens: 61

I understand this is a test message. I can help you with any specific tasks or questions you may have. Currently, I have access to
tools as they become available based on your needs. What would you like to test or accomplish?

Full trace at https://dagger.cloud/dagger/traces/1be7998fa0a8a941a2ec21488e9a279f
```