### PR TITLE
feat(sdk/elixir): bump Elixir image to 1.18.3

### DIFF
--- a/sdk/elixir/dagger.json
+++ b/sdk/elixir/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-sdk",
-  "engineVersion": "v0.16.2",
+  "engineVersion": "v0.18.3",
   "sdk": {
     "source": "go"
   },

--- a/sdk/elixir/dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/lib/elixir_sdk_dev.ex
@@ -5,7 +5,7 @@ defmodule ElixirSdkDev do
 
   use Dagger.Mod.Object, name: "ElixirSdkDev"
 
-  @base_image "hexpm/elixir:1.17.3-erlang-27.2-alpine-3.20.3@sha256:557156f12d23b0d2aa12d8955668cc3b9a981563690bb9ecabd7a5a951702afe"
+  @base_image "hexpm/elixir:1.18.3-erlang-27.3.3-alpine-3.21.3@sha256:854a84827d9758fcc6a6d7b1b233974c052d767c9929af31ef4b089320caae92"
 
   @doc """
   Test the SDK.
@@ -76,7 +76,11 @@ defmodule ElixirSdkDev do
       |> Dagger.File.contents()
 
     new_runtime_main_go =
-      Regex.replace(~r/elixirImage\s*=.*\n/, runtime_main_go, "elixirImage = \"#{@base_image}\"\n")
+      Regex.replace(
+        ~r/elixirImage\s*=.*\n/,
+        runtime_main_go,
+        "elixirImage = \"#{@base_image}\"\n"
+      )
 
     dag()
     |> Dagger.Client.container()

--- a/sdk/elixir/dev/mix.lock
+++ b/sdk/elixir/dev/mix.lock
@@ -1,4 +1,5 @@
 %{
   "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nestru": {:hex, :nestru, "1.0.1", "f02321db91b898da3d598c274f2ccba2c41ec5c50c942eabe900474dbfe4bce3", [:mix], [], "hexpm", "e4fbbd6d64b1c8cb37ef590a891f0b6b17b0b880c1c5ce2ac98de02c0ad7417e"},
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
 }

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -18,7 +18,7 @@ const (
 	sdkSrc           = "/sdk"
 	genDir           = "dagger_sdk"
 	schemaPath       = "/schema.json"
-	elixirImage      = "hexpm/elixir:1.17.3-erlang-27.2-alpine-3.20.3@sha256:557156f12d23b0d2aa12d8955668cc3b9a981563690bb9ecabd7a5a951702afe"
+	elixirImage      = "hexpm/elixir:1.18.3-erlang-27.3.3-alpine-3.21.3@sha256:854a84827d9758fcc6a6d7b1b233974c052d767c9929af31ef4b089320caae92"
 )
 
 //go:embed template/mix.exs


### PR DESCRIPTION
Changes to `elixir-sdk` module:

* Bump Elixir to 1.18.3 with Erlang/OTP 27.3.3.
* Run `dagger develop`.

Changes to `elixir-sdk-dev` module:

* Bump Elixir to 0.18.3 with Erlang/OTP 27.3.3
* Reformat code in `elixir-sdk-dev` module.
* Run `dagger develop`.