### PR TITLE
feat(sdk/elixir): dogfooding Elixir SDK self object

### DIFF
--- a/sdk/elixir/dev/.formatter.exs
+++ b/sdk/elixir/dev/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:dagger],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/sdk/elixir/dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/lib/elixir_sdk_dev.ex
@@ -7,30 +7,88 @@ defmodule ElixirSdkDev do
 
   @base_image "hexpm/elixir:1.18.3-erlang-27.3.3-alpine-3.21.3@sha256:854a84827d9758fcc6a6d7b1b233974c052d767c9929af31ef4b089320caae92"
 
+  object do
+    field :source, Dagger.Directory.t()
+    field :container, Dagger.Container.t()
+  end
+
+  defn init(
+         source:
+           {Dagger.Directory.t() | nil,
+            doc: "The Elixir SDK source",
+            default_path: "..",
+            ignore: [
+              "**/*",
+              "!LICENSE",
+              "!README.md",
+              # sdk source.
+              "!mix.exs",
+              "!mix.lock",
+              "!.formatter.exs",
+              "!.credo.exs",
+              "!lib/**/*.ex",
+              "!test/support/**/*.ex",
+              "!test/**/*.exs",
+              "!runtime/go.mod",
+              "!runtime/go.sum",
+              "!runtime/main.go",
+              "!runtime/templates/*",
+              # codegen source.
+              "!dagger_codegen/mix.exs",
+              "!dagger_codegen/mix.lock",
+              "!dagger_codegen/.formatter.exs",
+              "!dagger_codegen/lib/**/*.ex",
+              "!dagger_codegen/test/support/**/*.ex",
+              "!dagger_codegen/test/**/*.exs",
+              "!dagger_codegen/test/fixtures/**/*.json"
+            ]},
+         container: Dagger.Container.t() | nil
+       ) :: ElixirSdkDev.t() do
+    container =
+      if is_nil(container) do
+        with_base(source)
+      else
+        container
+      end
+
+    %ElixirSdkDev{
+      source: source,
+      container: container
+    }
+  end
+
   @doc """
   Test the SDK.
   """
-  defn test(container: Dagger.Container.t()) :: Dagger.Container.t() do
-    container
-    |> sdk_test()
-    |> codegen_test()
+  defn test(self) :: Dagger.Void.t() do
+    [
+      Task.async(fn -> sdk_test(self) end),
+      Task.async(fn -> codegen_test(self) end)
+    ]
+    |> Task.await_many(:infinity)
+    |> Enum.find(fn result -> match?({:error, _}, result) end)
+    |> case do
+      nil -> :ok
+      error -> error
+    end
   end
 
   @doc """
   Lint the SDK.
   """
-  defn lint(container: Dagger.Container.t()) :: Dagger.Container.t() do
-    container
+  defn lint(self) :: Dagger.Void.t() do
+    self.container
     |> Dagger.Container.with_exec(~w"mix credo")
+    |> sync()
   end
 
   @doc """
   Generate the SDK API.
   """
-  defn generate(container: Dagger.Container.t(), introspection_json: Dagger.File.t()) ::
+  defn generate(self, introspection_json: Dagger.File.t()) ::
          Dagger.Directory.t() do
     gen =
-      container
+      self
       |> with_codegen()
       |> Dagger.Container.with_mounted_file("/schema.json", introspection_json)
       |> Dagger.Container.with_exec(
@@ -47,30 +105,30 @@ defmodule ElixirSdkDev do
   @doc """
   Run the SDK tests.
   """
-  defn sdk_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
-    container
+  defn sdk_test(self) :: Dagger.Void.t() do
+    self.container
     |> Dagger.Container.with_exec(~w"mix test")
+    |> sync()
   end
 
   @doc """
   Run dagger_codegen tests.
   """
-  defn codegen_test(container: Dagger.Container.t()) :: Dagger.Container.t() do
-    container
+  defn codegen_test(self) :: Dagger.Void.t() do
+    self
     |> with_codegen()
     |> Dagger.Container.with_exec(~w"mix test")
+    |> sync()
   end
 
   @doc """
   Sync Elixir image to keep both dev and runtime modules consistent.
   """
-  defn sync_image(
-         source: {Dagger.Directory.t(), doc: "The Elixir SDK source", default_path: ".."}
-       ) :: Dagger.File.t() do
+  defn sync_image(self) :: Dagger.File.t() do
     path = "runtime/main.go"
 
     {:ok, runtime_main_go} =
-      source
+      self.source
       |> with_base()
       |> Dagger.Container.file(path)
       |> Dagger.File.contents()
@@ -90,8 +148,13 @@ defmodule ElixirSdkDev do
     |> Dagger.Container.file(path)
   end
 
-  defn with_base(source: {Dagger.Directory.t(), doc: "The Elixir SDK source"}) ::
-         Dagger.Container.t() do
+  defn with_codegen(self) :: Dagger.Container.t() do
+    self.container
+    |> Dagger.Container.with_workdir("dagger_codegen")
+    |> Dagger.Container.with_exec(~w"mix deps.get")
+  end
+
+  defp with_base(source) do
     dag()
     |> Dagger.Client.container()
     |> Dagger.Container.from(@base_image)
@@ -102,9 +165,12 @@ defmodule ElixirSdkDev do
     |> Dagger.Container.with_exec(~w"mix deps.get")
   end
 
-  defn with_codegen(container: Dagger.Container.t()) :: Dagger.Container.t() do
+  defp sync(container) do
     container
-    |> Dagger.Container.with_workdir("dagger_codegen")
-    |> Dagger.Container.with_exec(~w"mix deps.get")
+    |> Dagger.Container.sync()
+    |> case do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 end


### PR DESCRIPTION
Changes to `elixir-sdk-dev` module:

* Introduce the `init` function that accepts the SDK source directory and the container.
* Convert all functions to accept self object and uses it.
* Add `.formatter.exs` file to add formatting option.

Changes to dagger `ElixirSDK`:

* Modify to uses new `elixir-sdk-dev` module.
* Drop base method since it's moved to `elixir-sdk-dev` module.
* Drop Elixir version matrix. It doesn't uses for a long time.
* Remove unused constant.