### PR TITLE
python: fix issues in v0.18.4

### DIFF
--- a/.dagger/build/sdk.go
+++ b/.dagger/build/sdk.go
@@ -72,7 +72,7 @@ func (build *Builder) pythonSDKContent(ctx context.Context) (*sdkContent, error)
 
 	rootfs = rootfs.
 		// bundle the codegen script and its dependencies into a single executable
-		WithFile("dist/rodegen", base.
+		WithFile("dist/codegen", base.
 			WithWorkdir("/src").
 			WithDirectory("/usr/local/bin", rootfs.Directory("dist")).
 			WithMountedDirectory("", rootfs.Directory("codegen")).

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           # invalidate the cache by modifying the source files
-          [ -f "src/main/__init__.py" ] && echo >> src/main/__init__.py
+          [ -f "src/benchmark/__init__.py" ] && echo >> src/benchmark/__init__.py
 
           dagger functions
         working-directory: ${{ runner.temp }}/benchmark

--- a/sdk/python/.changes/unreleased/Fixed-20250423-175445.yaml
+++ b/sdk/python/.changes/unreleased/Fixed-20250423-175445.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed regression for older modules still using `requirements.lock`, not vendoring the client library appropriately
+time: 2025-04-23T17:54:45.561384Z
+custom:
+    Author: helderco
+    PR: "10252"

--- a/sdk/python/runtime/discovery.go
+++ b/sdk/python/runtime/discovery.go
@@ -408,7 +408,10 @@ func (d *Discovery) loadConfig(ctx context.Context, m *PythonSdk) error {
 		m.PackageName = NormalizePackageName(m.ProjectName)
 	}
 
-	m.VendorPath = d.Config.Tool.Uv.Sources.Dagger.Path
+	// Only look for vendor path when uv.lock is being used
+	if m.UseUvLock() {
+		m.VendorPath = d.Config.Tool.Uv.Sources.Dagger.Path
+	}
 
 	switch {
 	case m.EngineVersion != "":
@@ -431,7 +434,10 @@ func (d *Discovery) loadConfig(ctx context.Context, m *PythonSdk) error {
 		// way users can opt-out when back to a stable build, but also not have
 		// to manually update pyproject.toml in order for it to work.
 		m.VendorPath = GenDir
-		m.AddNewFile("pyproject.toml", VendorConfig(contents, m.VendorPath))
+
+		if m.UseUvLock() {
+			m.AddNewFile("pyproject.toml", VendorConfig(contents, m.VendorPath))
+		}
 	}
 
 	return nil

--- a/sdk/python/runtime/discovery.go
+++ b/sdk/python/runtime/discovery.go
@@ -252,21 +252,6 @@ func (d *Discovery) loadModInfo(ctx context.Context, m *PythonSdk) error {
 		return nil
 	})
 
-	eg.Go(func() error {
-		version, err := dag.Version(ctx)
-		if err != nil {
-			return fmt.Errorf("get engine version: %w", err)
-		}
-		// if it's a custom build, vendor the library
-		if strings.Contains(version, "-") {
-			return nil
-		}
-		d.mu.Lock()
-		m.EngineVersion = strings.TrimPrefix(version, "v")
-		d.mu.Unlock()
-		return nil
-	})
-
 	// TODO: Provide runtime modules with a boolean to indicate whether the
 	// module is new or not. Could be `dagger init --sdk` or `dagger develop --sdk`.
 	//
@@ -411,33 +396,6 @@ func (d *Discovery) loadConfig(ctx context.Context, m *PythonSdk) error {
 	// Only look for vendor path when uv.lock is being used
 	if m.UseUvLock() {
 		m.VendorPath = d.Config.Tool.Uv.Sources.Dagger.Path
-	}
-
-	switch {
-	case m.EngineVersion != "":
-		for _, dep := range d.Config.Project.Dependencies {
-			if strings.HasPrefix(strings.TrimSpace(dep), "dagger-io") {
-				if !strings.HasSuffix(dep, "=="+m.EngineVersion) {
-					m.AddNewFile("pyproject.toml", strings.Replace(
-						contents,
-						fmt.Sprintf("%q", dep),
-						fmt.Sprintf(`"dagger-io ==%s"`, m.EngineVersion),
-						1,
-					))
-				}
-				break
-			}
-		}
-
-	case m.EngineVersion == "" && m.VendorPath == "":
-		// Force vendoring on dev builds even if not already vendoring. This
-		// way users can opt-out when back to a stable build, but also not have
-		// to manually update pyproject.toml in order for it to work.
-		m.VendorPath = GenDir
-
-		if m.UseUvLock() {
-			m.AddNewFile("pyproject.toml", VendorConfig(contents, m.VendorPath))
-		}
 	}
 
 	return nil

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -106,12 +106,6 @@ type PythonSdk struct {
 	// The source needed to load and run a module
 	ModSource *dagger.ModuleSource
 
-	// The current engine version
-	//
-	// Used to pin the same client library version. If a dev build the SDK
-	// should be vendored.
-	EngineVersion string
-
 	// ContextDir is a copy of the context directory from the module source
 	//
 	// We add files to this directory, always joining paths with the source's
@@ -158,7 +152,7 @@ func (m *PythonSdk) Codegen(
 
 	ignorePaths := []string{".venv", "**/__pycache__"}
 	genPaths := []string{
-		// TODO: uncomment when we no longer vendor every time
+		// TODO: uncomment when we start generating client bindings outside the library
 		// UserGenPath,
 	}
 
@@ -326,11 +320,6 @@ func (m *PythonSdk) WithTemplate() *PythonSdk {
 		// this entire branch.
 		if !d.HasFile(ProjectCfg) {
 			projCfg := strings.ReplaceAll(tplToml, "main", m.ProjectName)
-
-			if m.EngineVersion != "" {
-				projCfg = strings.Replace(projCfg, `"dagger-io"`, `"dagger-io ==`+m.EngineVersion+`"`, 1)
-			}
-
 			m.AddNewFile(ProjectCfg, VendorConfig(projCfg, m.VendorPath))
 		}
 		if !d.HasFile("*.py") {


### PR DESCRIPTION
## Fixed regression 🔥 

Fix older modules using `requirements.lock`, not vendoring the client library appropriately. This created a breaking change (sorry about that!).

To mitigate this affected users can **either**:
- Continue on v0.18.3 or older and wait for v0.18.5
- Migrate to uv (`uv add --editable ./sdk`)
- Add the following section to `pyproject.toml`:
  ```toml
  [tool.uv.sources]
  dagger-io = { path = "sdk", editable = true }
  ```

## Other changes

Fixed a typo that prevented the codegen executable to be bundled correctly. It's not a problem because it's a new thing, but it also means no one is taking advantage of it.

Also decided to revert the pinning based on engine version. Need more time to flush it and test it. Shouldn't cause any issue for users because the vendoring ignores the version constraint.

Finally, noticed that the benchmark test doesn't edit the existing file correctly. It has been creating a new one. Shouldn't affect the test because it's enough to trigger a cache miss in the source directory.