### PR TITLE
rein in evals cost

### DIFF
--- a/.github/dagger.json
+++ b/.github/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ci",
-  "engineVersion": "v0.18.2",
+  "engineVersion": "v0.18.4",
   "sdk": {
     "source": "go"
   },

--- a/.github/main.go
+++ b/.github/main.go
@@ -292,6 +292,7 @@ func (ci *CI) withEvalsWorkflow() *CI {
 			"core/llm_*.md",
 			"core/schema/llm.go",
 			"core/schema/env.go",
+			"modules/evaluator/**",
 		},
 	}).WithJob(gha.Job(
 		"testdev",

--- a/.github/main.go
+++ b/.github/main.go
@@ -285,6 +285,14 @@ func (ci *CI) withEvalsWorkflow() *CI {
 		// NOTE: this will still run for fork branches, so we need the conditional
 		// below to actually skip those.
 		OnPushBranches: []string{"*"},
+		// Only run when LLM-related files are changed
+		OnPushPaths: []string{
+			"core/{llm,mcp,env}.go",
+			"core/llm_*.go",
+			"core/llm_*.md",
+			"core/schema/llm.go",
+			"core/schema/env.go",
+		},
 	}).WithJob(gha.Job(
 		"testdev",
 		"--docs ./core/llm_docs.md evals-across-models --system-prompt ./core/llm_dagger_prompt.md check",

--- a/.github/main.go
+++ b/.github/main.go
@@ -282,9 +282,6 @@ func (ci *CI) withEvalsWorkflow() *CI {
 		}),
 	})
 	w := gha.Workflow("evals", dagger.GhaWorkflowOpts{
-		// NOTE: this will still run for fork branches, so we need the conditional
-		// below to actually skip those.
-		OnPushBranches: []string{"*"},
 		// Only run when LLM-related files are changed
 		OnPushPaths: []string{
 			"core/{llm,mcp,env}.go",
@@ -301,8 +298,9 @@ func (ci *CI) withEvalsWorkflow() *CI {
 			Module:        "modules/evaluator",
 			DaggerVersion: ".", // testdev, so run against local dagger
 			Runner:        []string{GoldRunner(true)},
-			Condition:     fmt.Sprintf(`${{ github.repository == '%s' }}`, upstreamRepository),
-			Secrets:       []string{"OP_SERVICE_ACCOUNT_TOKEN"},
+			// NOTE: avoid running for forks
+			Condition: fmt.Sprintf(`${{ github.repository == '%s' }}`, upstreamRepository),
+			Secrets:   []string{"OP_SERVICE_ACCOUNT_TOKEN"},
 			Env: []string{
 				"ANTHROPIC_API_KEY=op://RelEng/ANTHROPIC/API_KEY",
 				"GEMINI_API_KEY=op://RelEng/GEMINI/API_KEY",

--- a/.github/workflows/evals.gen.yml
+++ b/.github/workflows/evals.gen.yml
@@ -2,8 +2,6 @@
 name: evals
 "on":
     push:
-        branches:
-            - '*'
         paths:
             - core/{llm,mcp,env}.go
             - core/llm_*.go

--- a/.github/workflows/evals.gen.yml
+++ b/.github/workflows/evals.gen.yml
@@ -10,6 +10,7 @@ name: evals
             - core/llm_*.md
             - core/schema/llm.go
             - core/schema/env.go
+            - modules/evaluator/**
     workflow_dispatch: {}
 jobs:
     testdev:

--- a/.github/workflows/evals.gen.yml
+++ b/.github/workflows/evals.gen.yml
@@ -4,6 +4,12 @@ name: evals
     push:
         branches:
             - '*'
+        paths:
+            - core/{llm,mcp,env}.go
+            - core/llm_*.go
+            - core/llm_*.md
+            - core/schema/llm.go
+            - core/schema/env.go
     workflow_dispatch: {}
 jobs:
     testdev:

--- a/modules/evaluator/workspace/main.go
+++ b/modules/evaluator/workspace/main.go
@@ -25,8 +25,8 @@ type Workspace struct {
 	Findings []string
 }
 
-var knownModels = []string{
-	"gpt-4o",
+var testedModels = []string{
+	// "gpt-4o",
 	"gpt-4.1",
 	// "qwen2.5-coder:14b",
 	"gemini-2.0-flash",
@@ -82,7 +82,7 @@ func (w *Workspace) EvalNames() []string {
 
 // The list of models that you can run evaluations against.
 func (w *Workspace) KnownModels() []string {
-	return knownModels
+	return testedModels
 }
 
 // Record an interesting finding after performing evaluations.

--- a/modules/gha/workflow.go
+++ b/modules/gha/workflow.go
@@ -146,6 +146,9 @@ func (gha *Gha) Workflow(
 	// Run the workflow on git push to the specified branches
 	// +optional
 	onPushBranches []string,
+	// Run the workflow only if the paths match
+	// +optional
+	onPushPaths []string,
 	// Run the workflow at a schedule time
 	// +optional
 	onSchedule []string,
@@ -246,13 +249,16 @@ func (gha *Gha) Workflow(
 		w = w.onPullRequest([]string{"auto_merge_disabled"}, nil, nil)
 	}
 	if onPush {
-		w = w.onPush(nil, nil)
+		w = w.onPush(nil, nil, nil)
 	}
 	if onPushBranches != nil {
-		w = w.onPush(onPushBranches, nil)
+		w = w.onPush(onPushBranches, nil, nil)
 	}
 	if onPushTags != nil {
-		w = w.onPush(nil, onPushTags)
+		w = w.onPush(nil, onPushTags, nil)
+	}
+	if onPushPaths != nil {
+		w = w.onPush(nil, nil, onPushPaths)
 	}
 	if onSchedule != nil {
 		w = w.onSchedule(onSchedule)
@@ -304,12 +310,16 @@ func (w *Workflow) onPush(
 	// Run only on push to specific tags
 	// +optional
 	tags []string,
+	// Run only if the paths match
+	// +optional
+	paths []string,
 ) *Workflow {
 	if w.Triggers.Push == nil {
 		w.Triggers.Push = &api.PushEvent{}
 	}
 	w.Triggers.Push.Branches = append(w.Triggers.Push.Branches, branches...)
 	w.Triggers.Push.Tags = append(w.Triggers.Push.Tags, tags...)
+	w.Triggers.Push.Paths = append(w.Triggers.Push.Paths, paths...)
 	return w
 }
 


### PR DESCRIPTION
* only run when relevant files change (currently running on every merge :money_with_wings:)
* stop testing `gpt-4o` (4.1 effectively replaces it, not worth 2x cost)