### PR TITLE
ci: Add alternative CI Runners 4

### DIFF
--- a/.github/workflows/_dagger_on_northflank_remote_engine.yml
+++ b/.github/workflows/_dagger_on_northflank_remote_engine.yml
@@ -1,0 +1,36 @@
+name: Dagger on Northflank - Remote Engine
+
+on:
+  workflow_call:
+    inputs:
+      function:
+        description: "Dagger function"
+        type: string
+        required: true
+      timeout:
+        description: "Timeout if not finished after this many minutes"
+        type: number
+        default: 10
+        required: false
+      machine:
+        description: "Machine type - runner & Engine are limited to 16 vCPUs & 32GB RAM"
+        type: string
+        required: true
+
+jobs:
+  remote-dagger-engine:
+    if: ${{ github.repository == 'dagger/dagger' }}
+    runs-on:
+      - ${{ inputs.machine }}
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: ${{ inputs.function }}
+        uses: ./.github/actions/call-ci-alt-runner
+        with:
+          function: ${{ inputs.function }}
+      - name: ${{ inputs.function }} (CACHE TEST)
+        uses: ./.github/actions/call-ci-alt-runner
+        with:
+          function: ${{ inputs.function }}

--- a/.github/workflows/alternative-ci-runners-4.yml
+++ b/.github/workflows/alternative-ci-runners-4.yml
@@ -1,0 +1,85 @@
+name: Alternative CI Runners 4
+
+on:
+  # Run the workflow every day TWICE:
+  # 1. 9:06AM UTC (low activity)
+  # 2. 9:36AM UTC (cache test - high chance of no code changes)
+  schedule:
+    - cron: "6,36 9 * * *"
+  # Enable manual trigger for on-demand runs - helps when debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-lint-on-northflank-c3-remote-engine:
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-c3-highcpu-44-kata-qemu
+      function: check --targets=docs
+
+  sdk-go-on-northflank-c3-remote-engine:
+    needs: docs-lint-on-northflank-c3-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-c3-highcpu-44-kata-qemu
+      function: check --targets=sdk/go
+
+  sdk-python-on-northflank-c3-remote-engine:
+    needs: docs-lint-on-northflank-c3-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-c3-highcpu-44-kata-qemu
+      function: check --targets=sdk/python
+
+  sdk-typescript-on-northflank-c3-remote-engine:
+    needs: docs-lint-on-northflank-c3-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-c3-highcpu-44-kata-qemu
+      function: check --targets=sdk/typescript
+
+  test-cli-engine-on-northflank-c3-remote-engine:
+    needs: docs-lint-on-northflank-c3-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-c3-highcpu-44-kata-qemu
+      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
+      timeout: 20
+
+  # We are running the same tests on a different machine type to see how they compare
+  docs-lint-on-northflank-n4-remote-engine:
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-n4-highcpu-32-kata-qemu
+      function: check --targets=docs
+
+  sdk-go-on-northflank-n4-remote-engine:
+    needs: docs-lint-on-northflank-n4-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-n4-highcpu-32-kata-qemu
+      function: check --targets=sdk/go
+
+  sdk-python-on-northflank-n4-remote-engine:
+    needs: docs-lint-on-northflank-n4-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-n4-highcpu-32-kata-qemu
+      function: check --targets=sdk/python
+
+  sdk-typescript-on-northflank-n4-remote-engine:
+    needs: docs-lint-on-northflank-n4-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-n4-highcpu-32-kata-qemu
+      function: check --targets=sdk/typescript
+
+  test-cli-engine-on-northflank-n4-remote-engine:
+    needs: docs-lint-on-northflank-n4-remote-engine
+    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
+    with:
+      machine: nf-n4-highcpu-32-kata-qemu
+      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
+      timeout: 20

--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -6,6 +6,7 @@ on:
       - "Alternative CI Runners 1"
       - "Alternative CI Runners 2"
       - "Alternative CI Runners 3"
+      - "Alternative CI Runners 4"
       - "Benchmark"
       - "daggerverse-preview"
       - "docs"


### PR DESCRIPTION
This sets up an Alternative CI Runner that runs a subset of our tests in an Engine wrapped in kata-containers (GKE).

The goal is to let this run for a week or two, and see how the metrics compare to the other runtimes. We are especially interested in:
- queue times
- Engine warm-up
- cache test (the second run)
- total duration over `>=20` runs expressed as `P90` `P95` `P99`

Power pair @fidencio 💪

---
Starting point: https://github.com/dagger/dagger/actions/runs/14738033762
![image](https://github.com/user-attachments/assets/c99adeb4-86ed-47e3-8b5c-52a89c040527)