### PR TITLE
use stable module digest for secrets created in functions

### DIFF
--- a/core/client_resource.go
+++ b/core/client_resource.go
@@ -17,7 +17,7 @@ func GetClientResourceAccessor(ctx context.Context, parent *Query, externalName 
 
 	var scopeDigest digest.Digest
 	if m != nil {
-		scopeDigest = m.Source.ID().Digest()
+		scopeDigest = digest.Digest(m.Source.Self.Digest)
 	}
 
 	// Use an HMAC, which allows us to keep the externalName un-inferrable.

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -710,13 +710,12 @@ import (
 
 type Caller struct {}
 
-func (*Caller) Fn(ctx context.Context, val string) (string, error) {
-	return dag.Secreter().GiveBack(dag.SetSecret("FOO", val)).Plaintext(ctx)
+func (*Caller) Fn(ctx context.Context) (string, error) {
+	return dag.Secreter().GiveBack(dag.SetSecret("FOO", "`+val+`")).Plaintext(ctx)
 }
 `,
 				).
-				WithEnvVariable("CACHEBUSTER", identity.NewID()).
-				With(daggerCall("fn", "--val", val)).
+				With(daggerCall("fn")).
 				Stdout(ctx)
 		}
 


### PR DESCRIPTION
The module digest mixed into the cache key for secrets created in function calls was not stable (per-client), this fixes it to be the stable module source digest. This ensures that secrets created in function calls don't invalidate cache of anything they are included in every call.