### PR TITLE
docs: tested kubernetes section

### DIFF
--- a/docs/current_docs/ci/integrations/kubernetes.mdx
+++ b/docs/current_docs/ci/integrations/kubernetes.mdx
@@ -195,6 +195,13 @@ dagger query <<EOF
 EOF
 ```
 
+## Tested Configurations
+
+- Dagger's Helm chart is continuously tested [on K3s via a Dagger pipeline](https://github.com/dagger/dagger/blob/main/helm/.dagger/main.go#L41) in CI
+- Dagger has run CI jobs at significant scale on AWS EKS using the [approach outlined here](https://dagger.io/blog/argo-cd-kubernetes)
+- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in daemonset configuration. Recommend SLE Micro 6.1 with min 100GB SSD.
+- Many other Kubernetes configurations should be compatible.
+
 ## Resources
 
 Below are some resources from the Dagger community that may help as well. If you have any questions about additional ways to use Kubernetes with Dagger, join our [Discord](https://discord.gg/dagger-io) and ask your questions in our [Kubernetes channel](https://discord.com/channels/707636530424053791/1122942037096927353).

--- a/docs/current_docs/ci/integrations/kubernetes.mdx
+++ b/docs/current_docs/ci/integrations/kubernetes.mdx
@@ -199,7 +199,7 @@ EOF
 
 - Dagger's Helm chart is continuously tested [on K3s via a Dagger pipeline](https://github.com/dagger/dagger/blob/main/helm/.dagger/main.go#L41) in CI
 - Dagger has run CI jobs at significant scale on AWS EKS using the [approach outlined here](https://dagger.io/blog/argo-cd-kubernetes)
-- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in daemonset configuration. Recommend SLE Micro 6.1 with min 100GB SSD.
+- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in DaemonSet configuration. The recommended configuration is SUSE Linux Enterprise Micro 6.1 with a 100 GB SSD (minimum).
 - Many other Kubernetes configurations should be compatible.
 
 ## Resources

--- a/docs/current_docs/ci/integrations/kubernetes.mdx
+++ b/docs/current_docs/ci/integrations/kubernetes.mdx
@@ -134,7 +134,7 @@ Although this will obviously vary based on workloads, a minimum of 2 vCPUs and 8
 
 - Dagger's Helm chart is continuously tested [on K3s via a Dagger pipeline](https://github.com/dagger/dagger/blob/main/helm/.dagger/main.go#L41) in CI
 - Dagger has run CI jobs at significant scale on AWS EKS using the [approach outlined here](https://dagger.io/blog/argo-cd-kubernetes)
-- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in DaemonSet configuration. The recommended configuration for RKE2 is SUSE Linux Enterprise (SLE) Micro 6.1 with 100GB storage per node (minimum) for testing, more for production.
+- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in DaemonSet configuration. The recommended configuration for RKE2 is SUSE Linux Enterprise (SLE) Micro 6.1 with 100GB storage per node (minimum).
 - Many other Kubernetes configurations should be compatible.
 
 ## Prerequisites

--- a/docs/current_docs/ci/integrations/kubernetes.mdx
+++ b/docs/current_docs/ci/integrations/kubernetes.mdx
@@ -130,6 +130,13 @@ The Dagger Engine cache is used to store intermediate build artifacts, which can
 
 Although this will obviously vary based on workloads, a minimum of 2 vCPUs and 8GB of RAM is a good place to start. One approach is to set up the CI runners with various sizes so that the Dagger Engine can consume resources from the runners on the same node if needed.
 
+### Tested Configurations
+
+- Dagger's Helm chart is continuously tested [on K3s via a Dagger pipeline](https://github.com/dagger/dagger/blob/main/helm/.dagger/main.go#L41) in CI
+- Dagger has run CI jobs at significant scale on AWS EKS using the [approach outlined here](https://dagger.io/blog/argo-cd-kubernetes)
+- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in DaemonSet configuration. The recommended configuration for RKE2 is SUSE Linux Enterprise (SLE) Micro 6.1 with 100GB storage per node (minimum) for testing, more for production.
+- Many other Kubernetes configurations should be compatible.
+
 ## Prerequisites
 
 - A running Kubernetes cluster with a pre-configured `kubectl` profile.
@@ -194,13 +201,6 @@ dagger query <<EOF
 }
 EOF
 ```
-
-## Tested Configurations
-
-- Dagger's Helm chart is continuously tested [on K3s via a Dagger pipeline](https://github.com/dagger/dagger/blob/main/helm/.dagger/main.go#L41) in CI
-- Dagger has run CI jobs at significant scale on AWS EKS using the [approach outlined here](https://dagger.io/blog/argo-cd-kubernetes)
-- Dagger has tested [SUSE RKE2](https://docs.rke2.io/install/quickstart) and Rancher Desktop Kubernetes using our Helm chart in DaemonSet configuration. The recommended configuration is SUSE Linux Enterprise Micro 6.1 with a 100 GB SSD (minimum).
-- Many other Kubernetes configurations should be compatible.
 
 ## Resources
 


### PR DESCRIPTION
https://deploy-preview-10262--devel-docs-dagger-io.netlify.app/ci/integrations/kubernetes/#tested-configurations

I validated SUSE RKE2 on SLE Micro 6.1 on AWS with our Helm chart in standard daemonset config.
-idempotent `helm upgrade`s
-`helm uninstall` and then re-install
-`dagger` tests including modules, shell, LLM

Previously I had validated Helm install on Rancher Desktops Kubernetes as well

Noted our continuous test of the Helm chart with K3s in CI

Also noted our success with EKS