### PR TITLE
fix: highlight shell content based on current theme

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -319,9 +319,9 @@ func (r *renderer) renderSpan(
 
 	switch contentType {
 	case "text/x-shellscript":
-		quick.Highlight(out, name, "bash", "terminal16", "monokai")
+		quick.Highlight(out, name, "bash", "terminal16", highlightStyle())
 	case "text/markdown":
-		quick.Highlight(out, name, "markdown", "terminal16", "monokai")
+		quick.Highlight(out, name, "markdown", "terminal16", highlightStyle())
 	default:
 		label := out.String(name)
 		if span != nil && len(span.Links) > 0 {
@@ -339,6 +339,13 @@ func (r *renderer) renderSpan(
 	}
 
 	return nil
+}
+
+func highlightStyle() string {
+	if HasDarkBackground() {
+		return "monokai"
+	}
+	return "monokailight"
 }
 
 func (r *renderer) renderLiteral(out TermOutput, lit *callpbv1.Literal) {


### PR DESCRIPTION
This was displaying using the dark style when in light mode, which was giving unreadable results.

Before:
![image](https://github.com/user-attachments/assets/d29043e0-93ba-40aa-82b8-a477adf5e4c0)

After:
![image](https://github.com/user-attachments/assets/51b6d123-cc45-4d4a-b7a8-7182e02fe751)

