### PR TITLE
docs: Add automatic labels for docs PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 # Add 'area/documentation' label to any PR where
 # - any file in the `docs` directory is changed
-# - the head branch name starts with `docs` or has a `docs:` section in the name
+# - the head branch name starts with `docs` or has a `docs` section in the name
 area/documentation:
 - any:
   - changed-files:
     - any-glob-to-any-file: 'docs/*'
-  - head-branch: ['^docs', 'docs:']
+  - head-branch: ['^docs', 'docs']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+# Add 'area/documentation' label to any PR where
+# - any file in the `docs` directory is changed
+# - the head branch name starts with `docs` or has a `docs:` section in the name
+area/documentation:
+- any:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/*'
+  - head-branch: ['^docs', 'docs:']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
I noticed @jedevc manually applying labels to docs PRs and was wondering if this could be a solution: https://github.com/actions/labeler

Note: I'm not quite sure how to test it without first merging it