### PR TITLE
fix: incorrect dagop caching of git ops

### DIFF
--- a/core/dagop.go
+++ b/core/dagop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
@@ -101,7 +102,10 @@ func (op FSDagOp) Backend() buildkit.CustomOpBackend {
 }
 
 func (op FSDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
-	return op.ID.Digest(), nil
+	return digest.FromString(strings.Join([]string{
+		op.ID.Digest().String(),
+		op.Path,
+	}, "+")), nil
 }
 
 func (op FSDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, err error) {
@@ -216,7 +220,10 @@ func (op RawDagOp) Backend() buildkit.CustomOpBackend {
 }
 
 func (op RawDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
-	return op.ID.Digest(), nil
+	return digest.FromString(strings.Join([]string{
+		op.ID.Digest().String(),
+		op.Filename,
+	}, "+")), nil
 }
 
 func (op RawDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, retErr error) {

--- a/core/socket.go
+++ b/core/socket.go
@@ -42,6 +42,9 @@ func (*Socket) TypeDescription() string {
 }
 
 func (socket *Socket) LLBID() string {
+	if socket == nil {
+		return ""
+	}
 	return socket.IDDigest.String()
 }
 

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -98,6 +98,10 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 		}, Fail: true},
 		{Function: "revealed-spans"},
 
+		{Function: "git-readme", Args: []string{
+			"--remote", "https://github.com/dagger/dagger",
+		}},
+
 		// tests intended to trigger consistent tui exec metrics output
 		{Function: "disk-metrics", Verbosity: 3, FuzzyTest: func(t *testctx.T, out string) {
 			require.NotEmpty(t, out)

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/disk-metrics
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/disk-metrics
@@ -1,0 +1,120 @@
+Expected stderr:
+
+✔ connect X.Xs
+│ ✔ starting engine X.Xs
+│ ✔ connecting to engine X.Xs
+│ │ ✔ moby.buildkit.v1.Control/Info X.Xs
+│ │ ✔ moby.buildkit.v1.Control/Info X.Xs
+│ ✔ starting session X.Xs
+│ ✔ subscribing to telemetry X.Xs
+│ │ ✔ consuming /v1/traces X.Xs
+│ │ ✔ consuming /v1/logs X.Xs
+│ │ ✔ consuming /v1/metrics X.Xs
+
+✔ load module X.Xs
+│ ✔ finding module configuration X.Xs
+│ │ ✔ moduleSource(refString: "./viztest"): ModuleSource! X.Xs
+│ │ │ ✔ parseRefString: ./viztest X.Xs
+│ │ │
+│ │ │ ✔ host: Host! X.Xs
+│ │ │ ✔ .directory(include: XXXXXXXXXXX): Directory! X.Xs
+│ │ │ │ ✔ upload /XXX/XXX/XXX from XXXXXXXXXXX (client id: XXXXXXXXXXX, session id: XXXXXXXXXXX) (include: XXXXXXXXXXX) X.Xs
+│ │ │ │ │ ✔ filesync X.Xs
+│ │ │ │ │ │ ✔ copy X.Xs
+│ │ │
+│ │ │ ✔ sdkForModule: go X.Xs
+│ │ ✔ .configExists: Boolean! X.Xs
+│ │ ┃ true
+│ ✔ initializing module X.Xs
+│ │ ✔ ModuleSource.asModule: Module! X.Xs
+│ │ │ ✔ load dep modules X.Xs
+│ │ │ ✔ go SDK: load runtime X.Xs
+│ │ │ │ ✔ Container.directory(path: "/go/pkg/mod"): Directory! X.Xs
+│ │ │ │
+│ │ │ │ ✔ Container.directory(path: "/root/.cache/go-build"): Directory! X.Xs
+│ │ │ │
+│ │ │ │ ✔ Container.withMountedCache(
+│ │ │ │ │ │ cache: ✔ cacheVolume(key: "gomod", namespace: "internal"): CacheVolume! X.Xs
+│ │ │ │ │ │ path: "/go/pkg/mod"
+│ │ │ │ │ │ sharing: SHARED
+│ │ │ │ │ │ source: ✔ Container.directory(path: "/go/pkg/mod"): Directory! X.Xs
+│ │ │ │ │ ): Container! X.Xs
+│ │ │ │ ✔ .withMountedCache(
+│ │ │ │ │ │ cache: ✔ cacheVolume(key: "gobuild", namespace: "internal"): CacheVolume! X.Xs
+│ │ │ │ │ │ path: "/root/.cache/go-build"
+│ │ │ │ │ │ sharing: SHARED
+│ │ │ │ │ │ source: ✔ Container.directory(path: "/root/.cache/go-build"): Directory! X.Xs
+│ │ │ │ │ ): Container! X.Xs
+│ │ │ │ ✔ .__withSystemEnvVariable(name: "GOPROXY"): Container! X.Xs
+│ │ │ │ ✔ .__withSystemEnvVariable(name: "GODEBUG"): Container! X.Xs
+│ │ │ │
+│ │ │ │ ✔ Directory.withoutFile(path: "dagger.gen.go"): Directory! X.Xs
+│ │ │ │
+│ │ │ │ $ Container.withMountedFile(
+│ │ │ │ │ │ path: "/schema.json"
+│ │ │ │ │ │ source: no(digest: "sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"): Missing
+│ │ │ │ │ ): Container! X.Xs CACHED
+│ │ │ │ ✔ .withMountedDirectory(
+│ │ │ │ │ │ path: "/src"
+│ │ │ │ │ │ source: ✔ Directory.withoutFile(path: "dagger.gen.go"): Directory! X.Xs
+│ │ │ │ │ ): Container! X.Xs
+│ │ │ │ ✔ .withWorkdir(path: "/src"): Container! X.Xs
+│ │ │ │ ✔ .withEnvVariable(name: "GIT_SSH_COMMAND", value: "ssh -o StrictHostKeyChecking=no "): Container! X.Xs
+│ │ │ │ ✔ .withoutDefaultArgs: Container! X.Xs
+│ │ │ │ $ .withExec(args: ["codegen", "--output", "/src", "--module-source-path", "/src", "--module-name", "viztest", "--introspection-json-path", "/schema.json"]): Container! X.Xs CACHED
+│ │ │ │ ✔ .withoutUnixSocket(path: "/tmp/dagger-ssh-sock"): Container! X.Xs
+│ │ │ │ $ .withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs CACHED
+│ │ │ │ ✔ .withEntrypoint(args: ["/runtime"]): Container! X.Xs
+│ │ │ │ ✔ .withWorkdir(path: "/scratch"): Container! X.Xs
+│ │ │ │ ✔ .withoutMount(path: "/go/pkg/mod"): Container! X.Xs
+│ │ │ │ ✔ .withoutMount(path: "/root/.cache/go-build"): Container! X.Xs
+│ │ │ ✔ asModule getModDef X.Xs
+│ │ │ │ ✔ module: Module! X.Xs
+│ │ ✔ .serve: Void X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ │ ✔ ModuleSource.kind: ModuleSourceKind! X.Xs
+│ │ ┃ LOCAL_SOURCE
+│ │
+│ │ ✔ ModuleSource.digest: String! X.Xs
+│ │ ┃ xxh3:XXXXXXXXXXXXXXXX
+│ │
+│ │ ✔ ModuleSource.asString: String! X.Xs
+│ │ ┃ /app/dagql/idtui/viztest
+│ │
+│ │ ✔ ModuleSource.commit: String! X.Xs
+│ │
+│ │ ✔ ModuleSource.sourceRootSubpath: String! X.Xs
+│ │ ┃ .
+│ │
+│ │ ✔ ModuleSource.version: String! X.Xs
+│ │
+│ │ ✔ ModuleSource.htmlRepoURL: String! X.Xs
+│ │
+│ │ ✔ Module.name: String! X.Xs
+│ │ ┃ viztest
+│ │
+│ │ ✔ Module.description: String! X.Xs
+│ │
+│ │ ✔ Module.dependencies: [Module!]! X.Xs
+│ ✔ loading type definitions X.Xs
+
+✔ parsing command line arguments X.Xs
+
+✔ viztest: Viztest! X.Xs
+✔ .diskMetrics: String! X.Xs ◆ Disk Read: X.X B ◆ Disk Write: X.X B ◆ IO Pressure: X.Xs ◆ CPU Pressure (some): X.Xs ◆ CPU Pressure (full): X.Xs ◆ Memory Bytes (current): X.X B ◆ Memory Bytes (peak): X.X B ◆ Network Rx: X.X B ◆ Network Tx: X.X B
+│ ✔ container: Container! X.Xs
+│ $ .from(address: "alpine"): Container! X.Xs CACHED
+│ │ ✔ resolving docker.io/library/alpine:latest X.Xs
+│ │ │ ✔ remotes.docker.resolver.HTTPRequest X.Xs
+│ │ │ │ ✔ HTTP HEAD X.Xs
+│ │
+│ │ $ Container.from(address: "docker.io/library/alpine:latest@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"): Container! X.Xs CACHED
+│ │ │ ✔ resolving docker.io/library/alpine:latest@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX X.Xs
+│ ✔ .withEnvVariable(name: "cache_bust", value: "20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X"): Container! X.Xs
+│ ✔ .withExec(args: ["sh", "-c", "dd if=/dev/urandom of=random_file bs=1M count=1000 && sync"]): Container! X.Xs ◆ Disk Read: X.X B ◆ Disk Write: X.X B ◆ IO Pressure: X.Xs ◆ CPU Pressure (some): X.Xs ◆ CPU Pressure (full): X.Xs ◆ Memory Bytes (current): X.X B ◆ Memory Bytes (peak): X.X B ◆ Network Rx: X.X B ◆ Network Tx: X.X B
+│ ┃ 1000+0 records in
+│ ┃ 1000+0 records out
+│ ┃ XX bytes (X.X B) copied, X.X seconds, X.X B/s
+│ ✔ .stdout: String! X.Xs
+
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
@@ -1,0 +1,72 @@
+Expected stdout:
+
+## What is Dagger?
+
+Expected stderr:
+
+✔ connect X.Xs
+│ ✔ starting engine X.Xs
+│ ✔ connecting to engine X.Xs
+│ ✔ starting session X.Xs
+
+✔ load module X.Xs
+│ ✔ finding module configuration X.Xs
+│ ✔ initializing module X.Xs
+│ ✔ inspecting module metadata X.Xs
+│ ✔ loading type definitions X.Xs
+
+✔ parsing command line arguments X.Xs
+
+✔ viztest: Viztest! X.Xs
+✔ .gitReadme(remote: "https://github.com/dagger/dagger"): String! X.Xs
+┃ ## What is Dagger?
+│ ✔ git(url: "https://github.com/dagger/dagger"): GitRepository! X.Xs
+│ ✔ .head: GitRef! X.Xs
+│ $ .tree: Directory! X.Xs CACHED
+│ ✔ .file(path: "README.md"): File! X.Xs
+│ ✔ .contents: String! X.Xs
+│ ┃ ## What is Dagger?
+│ ┃
+│ ┃ Dagger is an open-source runtime for composable workflows. It's perfect for systems with many moving parts and a strong need for **repeatability**, **modularity**, **observability** and **cross-platform support**. This makes it a great choice for AI agents and CI/CD workflows.
+│ ┃
+│ ┃ <p align="center"><img src="docs/static/img/current_docs/index/dagger-factory.jpg" width="75%"></p>
+│ ┃
+│ ┃ ## Key Features
+│ ┃
+│ ┃ - **Containerized Workflow Execution:** Transform code into containerized, composable operations. Build reproducible workflows in any language with custom environments, parallel processing, and seamless chaining.
+│ ┃
+│ ┃ - **Universal Type System:** Mix and match components from any language with type-safe connections. Use the best tools from each ecosystem without translation headaches.
+│ ┃
+│ ┃ - **Automatic Artifact Caching:** Operations produce cacheable, immutable artifacts — even for LLMs and API calls. Your workflows run faster and cost less.
+│ ┃
+│ ┃ - **Built-in Observability:** Full visibility into operations with tracing, logs, and metrics. Debug complex workflows and know exactly what's happening.
+│ ┃
+│ ┃ <p align="center"><img src="docs/static/img/current_docs/cloud-trace.gif" width="60%"></a>
+│ ┃
+│ ┃ - **Open Platform:** Works with any compute platform and tech stack — today and tomorrow. Ship faster, experiment freely, and don’t get locked into someone else's choices.
+│ ┃
+│ ┃ - **LLM Augmentation:** Native integration of any LLM that automatically discovers and uses available functions in your workflow. Ship mind-blowing agents in just a few dozen lines of code.
+│ ┃
+│ ┃ - **Interactive Terminal:** Directly interact with your workflow or agents in real-time through your terminal. Prototype, test, debug, and ship even faster.
+│ ┃
+│ ┃ <p align="center"><img src="docs/static/img/current_docs/index/da-robots-white-box.svg" width="60%"></a>
+│ ┃
+│ ┃ ## Getting started
+│ ┃
+│ ┃ - [Dagger for AI Agents](https://docs.dagger.io/ai-agents)
+│ ┃ - [Dagger for CI](https://docs.dagger.io/quickstart)
+│ ┃
+│ ┃ ## Join the community
+│ ┃
+│ ┃ - Join the [Dagger community server](https://discord.gg/NpzVhsGnZu)
+│ ┃ - Follow us on [Twitter](https://twitter.com/dagger_io)
+│ ┃ - Check out our [community activities](https://dagger.io/community)
+│ ┃ - Read more in our [documentation](https://docs.dagger.io)
+│ ┃
+│ ┃ ## Contributing
+│ ┃
+│ ┃ Interested in contributing or building dagger from scratch? See
+│ ┃ [CONTRIBUTING.md](https://github.com/dagger/dagger/tree/main/CONTRIBUTING.md).
+
+
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -431,3 +431,9 @@ func (*Viztest) List(ctx context.Context, dir *dagger.Directory) (string, error)
 	}
 	return strings.Join(ents, "\n"), nil
 }
+
+func (*Viztest) GitReadme(ctx context.Context, remote string) (string, error) {
+	result, err := dag.Git(remote).Head().Tree().File("README.md").Contents(ctx)
+	result, _, _ = strings.Cut(result, "\n")
+	return result, err
+}

--- a/engine/buildkit/op.go
+++ b/engine/buildkit/op.go
@@ -108,7 +108,7 @@ func (op *CustomOpWrapper) CacheMap(ctx context.Context, g bksession.Group, inde
 		if err != nil {
 			return cm, ok, err
 		}
-		cm.Digest = digest.FromString(string(cm.Digest) + "+" + string(key))
+		cm.Digest = digest.FromString("customop+" + string(key))
 	}
 	return cm, ok, err
 }


### PR DESCRIPTION
Woops, #9980 had some issues.

1. I have suddenly remembered why this was important: https://github.com/dagger/dagger/pull/9980#discussion_r2039628759. This *needs* to be lifted up, or the dagql cache key becomes permanently tainted with the client/session ids we used to get here. A ref is "frozen" in time, and so gets detached from these - this was causing us to not cache certain operations.
2. The custom op cache key calculation had a slight bug - we were accidentally including IDs *twice* in the cache key, once with itss ID digest, and again once with its encoding (which *wasn't always the same*) - so we weren't ever caching git checkouts.
3. #9682 added a sanity check condition that means that all SSH urls passed to `git` *must* have a socket passed with them. Effectively this means that we can't pass it directly through to `GitRef.tree` - because we can't get here without the socket. *technically* this is a regression - but #9980 started depending on that behavior, by resolving the ref earlier, before we get to `tree`. I think it makes sense to officially retire this behavior, it's been deprecated for almost a year, and wasn't a widely used feature anyways at the time.
	- I did spend some time attempting to keep it working - it's really not worth the effort IMO, since it prevents us from cleaning up the git code properly here (and would probably introduce weird caching inconsistencies).
	- We don't even have tests for this case, so :shrug:

Finally, I've added a telemetry test for a git clone, which should make sure that `tree` has it's little caching label. We weren't checking this before.

Putting into the v0.18.5 milestone, since by itself #9980 is a perf *regression*.