### PR TITLE
docs: fix engine image tag

### DIFF
--- a/docs/current_docs/configuration/engine.mdx
+++ b/docs/current_docs/configuration/engine.mdx
@@ -55,7 +55,7 @@ at `/etc/dagger/engine.json`. For example:
 {`    -v $HOME/.config/dagger/engine.json:/etc/dagger/engine.json \\\n`}
 {`    --name dagger-engine-custom \\\n`}
 {`    --privileged \\\n`}
-{`    registry.dagger.io/engine:${daggerVersion}`}
+{`    registry.dagger.io/engine:v${daggerVersion}`}
 </CodeBlock>
 
 </TabItem>
@@ -73,7 +73,7 @@ mounted to `/etc/dagger/engine.toml`. For example:
 {`    -v $PWD/engine.toml:/etc/dagger/engine.toml \\\n`}
 {`    --name dagger-engine-custom \\\n`}
 {`    --privileged \\\n`}
-{`    registry.dagger.io/engine:${daggerVersion}`}
+{`    registry.dagger.io/engine:v${daggerVersion}`}
 </CodeBlock>
 
 </TabItem>


### PR DESCRIPTION
The page about engine configuration currently gives the engine container image as `registry.dagger.io/engine:0.18.4`.

This PR changes it to `registry.dagger.io/engine:v0.18.4`

See the snippet:
```bash
docker run --rm \
    -v /var/lib/dagger \
    -v $HOME/.config/dagger/engine.json:/etc/dagger/engine.json \
    --name dagger-engine-custom \
    --privileged \
    registry.dagger.io/engine:0.18.4
```
From: https://docs.dagger.io/configuration/engine/