### PR TITLE
don't spam the output when sending telemetry upload fails

### DIFF
--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -51,6 +51,9 @@ type FrontendOpts struct {
 
 	// Filter is applied while constructing the tree.
 	Filter func(*Span) WalkDecision
+
+	// TelemetryError indicates if an error has occurred while sending telemetry
+	TelemetryError error
 }
 
 const (

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -408,6 +408,9 @@ func (fe *frontendPlain) finalRender() {
 		// if we rendered anything, leave a newline
 		fmt.Fprintln(os.Stderr)
 	}
+
+	handleTelemetryErrorOutput(os.Stderr, fe.output, fe.TelemetryError)
+
 	if fe.msgPreFinalRender.Len() > 0 {
 		fmt.Fprintln(os.Stderr, "\n"+fe.msgPreFinalRender.String()+"\n")
 	}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1945,7 +1945,7 @@ func (fe *frontendPretty) handlePromptString(ctx context.Context, message string
 
 func handleTelemetryErrorOutput(w io.Writer, to *termenv.Output, err error) {
 	if err != nil {
-		fmt.Fprintf(w, "%s - %s\n(%s)\n", to.String("WARN").Foreground(termenv.ANSIYellow), "failures detected while emitting telemetry. trace information inocomplete", err.Error())
+		fmt.Fprintf(w, "%s - %s\n(%s)\n", to.String("WARN").Foreground(termenv.ANSIYellow), "failures detected while emitting telemetry. trace information incomplete", err.Error())
 		fmt.Fprintln(w)
 	}
 }

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -391,6 +391,7 @@ func (fe *frontendPretty) FinalRender(w io.Writer) error {
 		if fe.msgPreFinalRender.Len() > 0 {
 			defer func() {
 				fmt.Fprintln(os.Stderr)
+				handleTelemetryErrorOutput(os.Stderr, out, fe.TelemetryError)
 				fmt.Fprintln(os.Stderr, fe.msgPreFinalRender.String())
 			}()
 		}
@@ -1939,6 +1940,13 @@ func (fe *frontendPretty) handlePromptString(ctx context.Context, message string
 	case val := <-result:
 		*dest = val
 		return nil
+	}
+}
+
+func handleTelemetryErrorOutput(w io.Writer, to *termenv.Output, err error) {
+	if err != nil {
+		fmt.Fprintf(w, "%s - %s\n(%s)\n", to.String("WARN").Foreground(termenv.ANSIYellow), "failures detected while emitting telemetry. trace information inocomplete", err.Error())
+		fmt.Fprintln(w)
 	}
 }
 


### PR DESCRIPTION
handles better the case where the client gets an error when sending
telemetry. If the --debug flag is supplied, all errors are displayed as
they were before this change

before:

![image](https://github.com/user-attachments/assets/eafb8e0d-717d-4ccc-87ab-38db5cac8e3b)

after:

![image](https://github.com/user-attachments/assets/51b8a346-3d20-4488-93a3-fc5cc6eef012)


Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
