### PR TITLE
fix: ensure local commit check actually works

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -508,7 +508,9 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 
 		// skip fetch if commit already exists
 		doFetch := true
-		if res, err := git.Run(ctx, "rev-parse", ref.FullRef); err == nil && string(res) == ref.Commit {
+		if res, err := git.New(gitutil.WithIgnoreError()).Run(ctx, "rev-parse", "--verify", ref.FullRef+"^{commit}"); err != nil {
+			return fmt.Errorf("failed to rev-parse: %w", err)
+		} else if strings.TrimSpace(string(res)) == ref.Commit {
 			doFetch = false
 		}
 


### PR DESCRIPTION
This checks wasn't actually working as desired - we weren't actually checking that the commit was local (we need `^{commit}` and `--verify` for that), but the functionality wasn't entirely broken, because we were missing the trailing whitespace (so `skipFetch` was never true, so we lost a little optimization here).

While we're here, we need to make this command non-fatal - a failure here doesn't actually need to be marked as a failure in OTEL, so we can skip past it (as noted by @shykes in discord here: https://discord.com/channels/707636530424053791/1003718839739105300/1365847042353664020) 