### PR TITLE
tests: skip source hut tests

### DIFF
--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -120,14 +120,16 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Root: "git.apache.org/package-name_2.x.git",
 			},
 		},
-		{
-			"git.sr.ht/~jacqueline/tangara-fw/lib",
-			&RepoRoot{
-				VCS:  vcsGit,
-				Repo: "https://git.sr.ht/~jacqueline/tangara-fw",
-				Root: "git.sr.ht/~jacqueline/tangara-fw",
-			},
-		},
+		// HACK: temporarily disabled because of go-away (https://drewdevault.com/2025/03/17/2025-03-17-Stop-externalizing-your-costs-on-me.html)
+		// this seems to accidentally catch go-get as well, e.g. `GOPRIVATE=git.sr.ht go get git.sr.ht/~jacqueline/tangara-fw/lib` fails with `403 Forbidden`
+		// {
+		// 	"git.sr.ht/~jacqueline/tangara-fw/lib",
+		// 	&RepoRoot{
+		// 		VCS:  vcsGit,
+		// 		Repo: "https://git.sr.ht/~jacqueline/tangara-fw",
+		// 		Root: "git.sr.ht/~jacqueline/tangara-fw",
+		// 	},
+		// },
 		// { FAILS as returns 404 without tags
 		// 	"git.sr.ht/~jacqueline/tangara-fw.git/lib",
 		// 	&RepoRoot{


### PR DESCRIPTION
This fixes a failing test on `main`, see the first failure on https://github.com/dagger/dagger/commit/9fc751cd479a784828f7ea7a449bb2927997ff13: https://v3.dagger.cloud/dagger/traces/ec1bf6d77b4fdcf9253779adf8b6d5fa?showHidden=5b532095ad9f9342#726a64406e7856a2:L81

```
--- FAIL: TestRepoRootForImportPath (1.56s)
    vcs_test.go:300: RepoRootForImportPath("git.sr.ht/~jacqueline/tangara-fw/lib"): unrecognized import path "git.sr.ht/~jacqueline/tangara-fw/lib"
```

SourceHut looks to have added go-away, which adds a challenge to all pages - including the `?go-get` query pages used by go tooling to determine repos. This seems(?) to have entirely broken access to `git.sr.ht` when using `GOPRIVATE` (to disable the go proxy).

This seems to be a breaking change that prevents all go modules on source hut (and dagger modules since we use the same approach). In the meantime, we disable our tests for this.