### PR TITLE
docs: Use autocapture for video player

### DIFF
--- a/docs/src/components/VideoPlayer.tsx
+++ b/docs/src/components/VideoPlayer.tsx
@@ -29,7 +29,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
     }
   };
 
-  const handleVideoClick = (e: React.MouseEvent<HTMLVideoElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLVideoElement>) => {
     if (e.target === ref.current) {
       window.open(src, '_blank');
     }
@@ -40,7 +40,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
       <video
         ref={ref}
         className={styles.video}
-        onClick={handleVideoClick}
+        onClick={handleClick}
         onEnded={() => setIsPlaying(false)}
         style={{ cursor: 'pointer' }}
       >
@@ -51,7 +51,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
         <button
           onClick={handlePlayPause}
           className={styles.controlButton}
-          data-ph-capture-attribute-video-src={src}
+          data-ph-capture-attribute-video-file={src}
           data-ph-capture-attribute-video-title={alt}
         >
           {isPlaying ? "⏸" : "▶"}
@@ -59,8 +59,6 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
         <button
           onClick={handleStop}
           className={styles.controlButton}
-          data-ph-capture-attribute-video-src={src}
-          data-ph-capture-attribute-video-title={alt}
         >
           ⏹
         </button>

--- a/docs/src/components/VideoPlayer.tsx
+++ b/docs/src/components/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import styles from "../css/videoPlayer.module.scss";
 
 interface VideoPlayerProps {
@@ -7,87 +7,30 @@ interface VideoPlayerProps {
   defaultFrame?: number;
 }
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (eventName: string, properties?: Record<string, any>) => void;
-    };
-  }
-}
-
 const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 }) => {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const ref = useRef<HTMLVideoElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
 
-  useEffect(() => {
-    // Add debug logging
-    // console.log('PostHog available:', !!window.posthog);
-    // console.log('PostHog object:', window.posthog);
-
-    if (videoRef.current) {
-      // Set initial frame when metadata is loaded
-      videoRef.current.addEventListener('loadedmetadata', () => {
-        // Assuming 24fps, calculate time for the default frame
-        videoRef.current.currentTime = (defaultFrame / 24);
-      });
-    }
-  }, [defaultFrame]);
-
-  // Helper function for event capture
-  const captureEvent = (eventName: string, properties: Record<string, any>) => {
-    if (!window.posthog) {
-      // console.warn('PostHog not initialized when capturing:', eventName);
-      return;
-    }
-
-    window.posthog.capture(eventName, properties);
-    // console.log('Event captured:', eventName, properties);
-  };
-
   const handlePlayPause = () => {
-    if (videoRef.current) {
+    if (ref.current) {
       if (isPlaying) {
-        videoRef.current.pause();
-        captureEvent('video_paused', {
-          video_src: src,
-          video_alt: alt,
-          current_time: videoRef.current.currentTime,
-          duration: videoRef.current.duration
-        });
+        ref.current.pause();
       } else {
-        videoRef.current.play();
-        captureEvent('video_played', {
-          video_src: src,
-          video_alt: alt,
-          current_time: videoRef.current.currentTime,
-          duration: videoRef.current.duration
-        });
+        ref.current.play();
       }
       setIsPlaying(!isPlaying);
     }
   };
 
   const handleStop = () => {
-    if (videoRef.current) {
-      videoRef.current.pause();
-      videoRef.current.currentTime = (defaultFrame / 24);
+    if (ref.current) {
+      ref.current.pause();
       setIsPlaying(false);
-      captureEvent('video_stopped', {
-        video_src: src,
-        video_alt: alt,
-        current_time: videoRef.current.currentTime,
-        duration: videoRef.current.duration
-      });
     }
   };
 
   const handleVideoClick = (e: React.MouseEvent<HTMLVideoElement>) => {
-    // Only handle click if it's directly on the video element, not on controls
-    if (e.target === videoRef.current) {
-      captureEvent('video_link_clicked', {
-        video_src: src,
-        video_alt: alt
-      });
+    if (e.target === ref.current) {
       window.open(src, '_blank');
     }
   };
@@ -95,7 +38,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
   return (
     <div className={styles.videoPlayerContainer}>
       <video
-        ref={videoRef}
+        ref={ref}
         className={styles.video}
         onClick={handleVideoClick}
         onEnded={() => setIsPlaying(false)}
@@ -108,14 +51,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, alt, defaultFrame = 5 })
         <button
           onClick={handlePlayPause}
           className={styles.controlButton}
-          aria-label={isPlaying ? "Pause" : "Play"}
+          data-ph-capture-attribute-video-src={src}
+          data-ph-capture-attribute-video-title={alt}
         >
           {isPlaying ? "⏸" : "▶"}
         </button>
         <button
           onClick={handleStop}
           className={styles.controlButton}
-          aria-label="Stop"
+          data-ph-capture-attribute-video-src={src}
+          data-ph-capture-attribute-video-title={alt}
         >
           ⏹
         </button>


### PR DESCRIPTION
Instead of manually capturing events, this commit switches to use PostHog's autocapture to automatically track clicks on the play/pause button, with additional metadata for the video file and title. This also eliminates video click events appearing twice in the PostHog activity log.

https://posthog.com/docs/product-analytics/autocapture