### PR TITLE
fix: typescript clien gen conflict with module

### DIFF
--- a/sdk/typescript/runtime/bundled_static_export/module/index.ts
+++ b/sdk/typescript/runtime/bundled_static_export/module/index.ts
@@ -10,4 +10,6 @@ export {
   entrypoint,
 } from "./core.js"
 
+export type { ConnectOpts, CallbackFct } from "./core.js"
+
 export * from "./client.gen.js"

--- a/sdk/typescript/runtime/config.go
+++ b/sdk/typescript/runtime/config.go
@@ -82,6 +82,7 @@ type moduleConfig struct {
 	// Module config
 	name    string
 	subPath string
+	sdk     string
 
 	// Location of the SDK library
 	sdkLibOrigin SDKLibOrigin
@@ -110,6 +111,13 @@ func analyzeModuleConfig(ctx context.Context, modSource *dagger.ModuleSource) (c
 	cfg.subPath, err = modSource.SourceSubpath(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not load module config source subpath: %w", err)
+	}
+
+	// We retrieve the SDK because if it's set, that means the module is implementing
+	// logic and is not just for a standalone client.
+	cfg.sdk, err = modSource.SDK().Source(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not load module config sdk: %w", err)
 	}
 
 	// If a first init, there will be no directory, so we ignore the error here.

--- a/sdk/typescript/runtime/sdk_module_fs.go
+++ b/sdk/typescript/runtime/sdk_module_fs.go
@@ -26,6 +26,6 @@ func bundledStaticDirectoryForModule() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("bundled_static_export/module")
 }
 
-func bundledStaticDirectoryForClient() *dagger.Directory {
+func bundledStaticDirectoryForClientOnly() *dagger.Directory {
 	return dag.CurrentModule().Source().Directory("bundled_static_export/client")
 }


### PR DESCRIPTION
I noticed during a demo that if a module source is `.` and  implements functions and also generate a client, the `sdk/index.ts` file will not expose the generated client in the `sdk` folder because it doesn't expect it to be there.

I changes the logic in the runtime to handle this specific edge case and updated integrations tests.

This behaviour could be handled in the codegen binary ideally but it's a quick fixes for now.