### PR TITLE
ci: Switch a subset of Engine & CLI jobs to alt CI runners

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -183,13 +183,13 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{AltGoldRunner()},
 			}},
 			{"modules", []string{"TestModule"}, &dagger.GhaJobOpts{
-				Runner: []string{GoldRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"module-runtimes", []string{"TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"}, &dagger.GhaJobOpts{
 				Runner: []string{PlatinumRunner(true)},
 			}},
 			{"container", []string{"TestContainer"}, &dagger.GhaJobOpts{
-				Runner: []string{GoldRunner(true)},
+				Runner: []string{AltGoldRunner()},
 			}},
 			{"LLM", []string{"TestLLM"}, &dagger.GhaJobOpts{
 				Runner: []string{GoldRunner(true)},
@@ -201,7 +201,7 @@ func (ci *CI) withTestWorkflows(runner *dagger.Gha, name string) *CI {
 				Runner: []string{GoldRunner(true)},
 			}},
 			{"everything-else", nil, &dagger.GhaJobOpts{
-				Runner: []string{PlatinumRunner(true)},
+				Runner: []string{AltPlatinumRunner()},
 			}},
 		}))
 	ci.Workflows = ci.Workflows.WithWorkflow(w)

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -1826,7 +1826,7 @@ jobs:
         timeout-minutes: 30
     testdev-container:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-5-16c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-container
         steps:
             - name: Checkout
@@ -2090,7 +2090,7 @@ jobs:
         timeout-minutes: 30
     testdev-everything-else:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-5-32c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
         name: testdev-everything-else
         steps:
             - name: Checkout
@@ -2882,7 +2882,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-5-16c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout


### PR DESCRIPTION
We have seen a speed-up after the initial switch https://github.com/dagger/dagger/pull/9887, and a slow-down after we went back https://github.com/dagger/dagger/pull/10086.

If we still see a speed-up after this switch, we are likely to want to stick with this for more than a few weeks.

As discussed with @sipsma in the last sync.

---

| Job Name | Before (P90 2w) | After (single run) |
|:--------|-------------------|-------------------|
| testdev-everything-else | 1016s (16m 56s) | `TODO` [FYI](https://github.com/dagger/dagger/pull/10248#issuecomment-2839991924) |
| testdev-module-runtimes | 851s (14m 11s) | 817s (13m 37s) |
| testdev-container | 768s (12m 48s) | 459s (7m 39s) |