### PR TITLE
cli: fix regression in dagger call when a function argument conflicts with an existing flag

### DIFF
--- a/.changes/unreleased/Fixed-20250430-111645.yaml
+++ b/.changes/unreleased/Fixed-20250430-111645.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Return an error when a function argument conflicts with a persistent flag in `dagger call`
+time: 2025-04-30T11:16:45.32856Z
+custom:
+    Author: helderco
+    PR: "10305"

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -415,6 +415,7 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 				skipped = append(skipped, arg.FlagName())
 				continue
 			}
+			return err
 		}
 		if arg.IsRequired() {
 			cmd.MarkFlagRequired(arg.FlagName())


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/10298 [^1]

This fixes a regression introduced in https://github.com/dagger/dagger/pull/7417 where conflicting flags no longer throw an error in `dagger call`. 

Full explanation in https://github.com/dagger/dagger/issues/10298#issuecomment-2840466435.

[^1]: Fixes the missing error to clear confusion but the underlying problem of supporting a conflicting flag is in another duplicate [issue](https://github.com/dagger/dagger/issues/7032).