### PR TITLE
sdk/java: lock concurrent access to maven cache

### DIFF
--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -33,6 +33,7 @@ type JavaSdk struct {
 type moduleConfig struct {
 	name    string
 	subPath string
+	dirPath string
 }
 
 func (c *moduleConfig) modulePath() string {
@@ -141,7 +142,7 @@ func (m *JavaSdk) buildJavaDependencies(
 	}
 	return ctr.
 		// Cache maven dependencies
-		WithMountedCache("/root/.m2", dag.CacheVolume("sdk-java-maven-m2")).
+		WithMountedCache("/root/.m2", dag.CacheVolume("sdk-java-maven-m2"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.CacheSharingModeLocked}).
 		// Mount the introspection JSON file used to generate the SDK
 		WithMountedFile("/schema.json", introspectionJSON).
 		// Copy the SDK source directory, so all the files needed to build the dependencies
@@ -386,9 +387,14 @@ func (m *JavaSdk) setModuleConfig(ctx context.Context, modSource *dagger.ModuleS
 	if err != nil {
 		return err
 	}
+	dirPath, err := modSource.LocalContextDirectoryPath(ctx)
+	if err != nil {
+		return err
+	}
 	m.moduleConfig = moduleConfig{
 		name:    modName,
 		subPath: subPath,
+		dirPath: dirPath,
 	}
 
 	return nil


### PR DESCRIPTION
Set the sharing mode of the maven cache volume to lock.
This ensure there's no concurrent write to the cache that should limit
the risk of corruption of maven files, as concurrent access to the maven
local repository is not supported.

Error looks like:

    [ERROR] Failed to execute goal
    org.apache.maven.plugins:maven-install-plugin:3.1.2:install
    (default-install) on project dagger-sdk-parent: Failed to install
    metadata io.dagger:dagger-sdk-parent/maven-metadata.xml:
    Could not parse metadata
    /root/.m2/repository/io/dagger/dagger-sdk-parent/maven-metadata-local.xml:
    in epilog non whitespace content is not allowed but got 0 (position:
    END_TAG seen ...</metadata>\n0... @13:2)

To lock the cache might have an impact in term of performances in case
of concurrent access, but it will keep good performances on single
access and ensure there's no corruption anymore.

This should help to solve #10156 