### PR TITLE
docs(deno): deno is selected as runtime if deno.lock is present

### DIFF
--- a/docs/current_docs/configuration/modules.mdx
+++ b/docs/current_docs/configuration/modules.mdx
@@ -114,7 +114,7 @@ The module's `source` field must reference the same directory as the `deno.json`
 When a runtime is not explicitly defined within the `package.json` file, Dagger automatically identifies the appropriate runtime by examining the project's files inside the project's `dagger` directory.
 
 - If Dagger finds any of the following lock files : `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`, it automatically selects `node` as the runtime.
-- In the absence of the lock files mentioned above, if a `bun.lock` or `bun.lockb` file is present, Dagger will choose `bun` as the runtime. Alternatively, if a `deno.json` file is present, Dagger will choose `deno` as the runtime.
+- In the absence of the lock files mentioned above, if a `bun.lock` or `bun.lockb` file is present, Dagger will choose `bun` as the runtime. Alternatively, if a `deno.json`, or `deno.lock`, file is present, Dagger will choose `deno` as the runtime.
 - If no or only unknown lock files are present, `node` is chosen.
 
 :::warning


### PR DESCRIPTION
This is implemented [here](https://github.com/dagger/dagger/blob/3af6558837398cd3377013d4a54712441eb080f5/sdk/typescript/runtime/config.go#L333).