### PR TITLE
feat: support SOURCE_DATE_EPOCH and rewrite-timestamp

### DIFF
--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -99,6 +99,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	execMD.RedirectStderrPath = opts.RedirectStderr
 	execMD.SystemEnvNames = container.SystemEnvNames
 	execMD.EnabledGPUs = container.EnabledGPUs
+	execMD.SourceDateEpoch = clientMetadata.SourceDateEpoch
 
 	if opts.NoInit {
 		execMD.NoInit = true

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -285,6 +285,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		CacheByCall:       !opts.SkipCallDigestCacheKey,
 		ParentIDs:         map[digest.Digest]*resource.ID{},
 		AllowedLLMModules: clientMetadata.AllowedLLMModules,
+		SourceDateEpoch:   clientMetadata.SourceDateEpoch,
 	}
 
 	callInputs, err := fn.setCallInputs(ctx, opts)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -185,6 +185,13 @@ type Container {
     runtimes, but Docker may be needed for older runtimes without OCI support.
     """
     mediaTypes: ImageMediaTypes = OCIMediaTypes
+
+    """
+    Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    
+    Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    """
+    rewriteTimestamp: Boolean = false
   ): File!
 
   """Initializes this container from a Dockerfile build."""
@@ -327,6 +334,13 @@ type Container {
     environment variables defined in the container (e.g. "/$VAR/foo").
     """
     expand: Boolean = false
+
+    """
+    Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    
+    Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    """
+    rewriteTimestamp: Boolean = false
   ): String!
 
   """
@@ -434,6 +448,13 @@ type Container {
     "Docker" may be needed for older registries without OCI support.
     """
     mediaTypes: ImageMediaTypes = OCIMediaTypes
+
+    """
+    Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    
+    Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    """
+    rewriteTimestamp: Boolean = false
   ): String!
 
   """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4198,6 +4198,11 @@
                                 <p>Use the specified media types for the image&#39;s layers.</p>
                                 <p>Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>rewriteTimestamp</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.</p>
+                                <p>Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -4367,6 +4372,11 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>expand</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Replace &quot;${VAR}&quot; or &quot;$VAR&quot; in the value of path according to the current environment variables defined in the container (e.g. &quot;/$VAR/foo&quot;).</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>rewriteTimestamp</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.</p>
+                                <p>Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -4508,6 +4518,11 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaTypes"><code>ImageMediaTypes</code></a></span></h6>
                                 <p>Use the specified media types for the published image&#39;s layers.</p>
                                 <p>Defaults to &quot;OCI&quot;, which is compatible with most recent registries, but &quot;Docker&quot; may be needed for older registries without OCI support.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>rewriteTimestamp</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.</p>
+                                <p>Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.</p>
                               </div>
                             </div>
                           </div>

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -109,6 +109,9 @@ type ExecutionMetadata struct {
 	// If set (typically via "_EXPERIMENTAL_DAGGER_VERSION" env var), this forces the client
 	// to be at the specified version. Currently only used for integ testing.
 	ClientVersionOverride string
+
+	// Rewrite timestamps in layers to match SOURCE_DATE_EPOCH
+	SourceDateEpoch *time.Time
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -929,6 +929,10 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 
 	state.spec.Process.Env = append(state.spec.Process.Env, DaggerSessionTokenEnv+"="+w.execMD.SecretToken)
 
+	if w.execMD.SourceDateEpoch != nil {
+		state.spec.Process.Env = append(state.spec.Process.Env, "SOURCE_DATE_EPOCH="+strconv.FormatInt(w.execMD.SourceDateEpoch.Unix(), 10))
+	}
+
 	w.execMD.ClientStableID = randid.NewID()
 
 	// include SSH_AUTH_SOCK if it's set in the exec's env vars

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1114,6 +1114,16 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		clientVersion = engine.Version
 	}
 
+	var sourceDateEpoch *time.Time = nil
+	sourceDateEpochEnv := os.Getenv("SOURCE_DATE_EPOCH")
+	if sourceDateEpochEnv != "" {
+		sde, err := strconv.ParseInt(sourceDateEpochEnv, 10, 64)
+		if err == nil {
+			var sdePtr = time.Unix(sde, 0)
+			sourceDateEpoch = &sdePtr
+		}
+	}
+
 	return engine.ClientMetadata{
 		ClientID:                  c.ID,
 		ClientVersion:             clientVersion,
@@ -1130,6 +1140,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
 		AllowedLLMModules:         c.AllowedLLMModules,
+		SourceDateEpoch:           sourceDateEpoch,
 	}
 }
 

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 	"unicode"
 
 	controlapi "github.com/moby/buildkit/api/services/control"
@@ -85,6 +86,10 @@ type ClientMetadata struct {
 
 	// Modules permitted to access LLM APIs or "all" to bypass restrictions for any loaded module.
 	AllowedLLMModules []string `json:"allowed_llm_modules"`
+
+	// (Optional) Clamp produced timestamps. For more information, see the SOURCE_DATE_EPOCH specification.
+	// Value: int (number of seconds since Unix epoch)
+	SourceDateEpoch *time.Time `json:"source_date_epoch"`
 }
 
 type clientMetadataCtxKey struct{}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -928,6 +928,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			Labels:            map[string]string{},
 			SSHAuthSocketPath: execMD.SSHAuthSocketPath,
 			AllowedLLMModules: allowedLLMModules,
+			SourceDateEpoch:   execMD.SourceDateEpoch,
 		},
 		CallID:              execMD.CallID,
 		CallerClientID:      execMD.CallerClientID,

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -52,7 +52,8 @@ defmodule Dagger.Container do
   @spec as_tarball(t(), [
           {:platform_variants, [Dagger.ContainerID.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
-          {:media_types, Dagger.ImageMediaTypes.t() | nil}
+          {:media_types, Dagger.ImageMediaTypes.t() | nil},
+          {:rewrite_timestamp, boolean() | nil}
         ]) :: Dagger.File.t()
   def as_tarball(%__MODULE__{} = container, optional_args \\ []) do
     query_builder =
@@ -67,6 +68,7 @@ defmodule Dagger.Container do
       )
       |> QB.maybe_put_arg("forcedCompression", optional_args[:forced_compression])
       |> QB.maybe_put_arg("mediaTypes", optional_args[:media_types])
+      |> QB.maybe_put_arg("rewriteTimestamp", optional_args[:rewrite_timestamp])
 
     %Dagger.File{
       query_builder: query_builder,
@@ -241,7 +243,8 @@ defmodule Dagger.Container do
           {:platform_variants, [Dagger.ContainerID.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
           {:media_types, Dagger.ImageMediaTypes.t() | nil},
-          {:expand, boolean() | nil}
+          {:expand, boolean() | nil},
+          {:rewrite_timestamp, boolean() | nil}
         ]) :: {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
@@ -258,6 +261,7 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg("forcedCompression", optional_args[:forced_compression])
       |> QB.maybe_put_arg("mediaTypes", optional_args[:media_types])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
+      |> QB.maybe_put_arg("rewriteTimestamp", optional_args[:rewrite_timestamp])
 
     Client.execute(container.client, query_builder)
   end
@@ -421,7 +425,8 @@ defmodule Dagger.Container do
   @spec publish(t(), String.t(), [
           {:platform_variants, [Dagger.ContainerID.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
-          {:media_types, Dagger.ImageMediaTypes.t() | nil}
+          {:media_types, Dagger.ImageMediaTypes.t() | nil},
+          {:rewrite_timestamp, boolean() | nil}
         ]) :: {:ok, String.t()} | {:error, term()}
   def publish(%__MODULE__{} = container, address, optional_args \\ []) do
     query_builder =
@@ -437,6 +442,7 @@ defmodule Dagger.Container do
       )
       |> QB.maybe_put_arg("forcedCompression", optional_args[:forced_compression])
       |> QB.maybe_put_arg("mediaTypes", optional_args[:media_types])
+      |> QB.maybe_put_arg("rewriteTimestamp", optional_args[:rewrite_timestamp])
 
     Client.execute(container.client, query_builder)
   end

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -681,6 +681,10 @@ type ContainerAsTarballOpts struct {
 	//
 	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
+	// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+	//
+	// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+	RewriteTimestamp bool
 }
 
 // Package the container state as an OCI image, and return it as a tar archive
@@ -698,6 +702,10 @@ func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
 		// `mediaTypes` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
 			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 
@@ -912,6 +920,10 @@ type ContainerExportOpts struct {
 	MediaTypes ImageMediaTypes
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
+	// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+	//
+	// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+	RewriteTimestamp bool
 }
 
 // Writes the container as an OCI tarball to the destination file path on the host.
@@ -938,6 +950,10 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
 			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 	q = q.Arg("path", path)
@@ -1179,6 +1195,10 @@ type ContainerPublishOpts struct {
 	//
 	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
+	// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+	//
+	// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+	RewriteTimestamp bool
 }
 
 // Package the container state as an OCI image, and publish it to a registry
@@ -1201,6 +1221,10 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 		// `mediaTypes` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
 			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 	q = q.Arg("address", address)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -55,6 +55,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?array $platformVariants = null,
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
+        ?bool $rewriteTimestamp = false,
     ): File {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asTarball');
         if (null !== $platformVariants) {
@@ -65,6 +66,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $mediaTypes) {
         $innerQueryBuilder->setArgument('mediaTypes', $mediaTypes);
+        }
+        if (null !== $rewriteTimestamp) {
+        $innerQueryBuilder->setArgument('rewriteTimestamp', $rewriteTimestamp);
         }
         return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -201,6 +205,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
         ?bool $expand = false,
+        ?bool $rewriteTimestamp = false,
     ): string {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
@@ -215,6 +220,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $expand) {
         $leafQueryBuilder->setArgument('expand', $expand);
+        }
+        if (null !== $rewriteTimestamp) {
+        $leafQueryBuilder->setArgument('rewriteTimestamp', $rewriteTimestamp);
         }
         return (string)$this->queryLeaf($leafQueryBuilder, 'export');
     }
@@ -333,6 +341,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?array $platformVariants = null,
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
+        ?bool $rewriteTimestamp = false,
     ): string {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('publish');
         $leafQueryBuilder->setArgument('address', $address);
@@ -344,6 +353,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $mediaTypes) {
         $leafQueryBuilder->setArgument('mediaTypes', $mediaTypes);
+        }
+        if (null !== $rewriteTimestamp) {
+        $leafQueryBuilder->setArgument('rewriteTimestamp', $rewriteTimestamp);
         }
         return (string)$this->queryLeaf($leafQueryBuilder, 'publish');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -707,6 +707,7 @@ class Container(Type):
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        rewrite_timestamp: bool | None = False,
     ) -> "File":
         """Package the container state as an OCI image, and return it as a tar
         archive
@@ -729,6 +730,10 @@ class Container(Type):
             Defaults to OCI, which is largely compatible with most recent
             container runtimes, but Docker may be needed for older runtimes
             without OCI support.
+        rewrite_timestamp:
+            Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+            Defaults to false. See build reproducibility for how to specify
+            the SOURCE_DATE_EPOCH value.
         """
         _args = [
             Arg(
@@ -738,6 +743,7 @@ class Container(Type):
             ),
             Arg("forcedCompression", forced_compression, None),
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("rewriteTimestamp", rewrite_timestamp, False),
         ]
         _ctx = self._select("asTarball", _args)
         return File(_ctx)
@@ -955,6 +961,7 @@ class Container(Type):
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
         expand: bool | None = False,
+        rewrite_timestamp: bool | None = False,
     ) -> str:
         """Writes the container as an OCI tarball to the destination file path on
         the host.
@@ -986,6 +993,10 @@ class Container(Type):
             Replace "${VAR}" or "$VAR" in the value of path according to the
             current environment variables defined in the container (e.g.
             "/$VAR/foo").
+        rewrite_timestamp:
+            Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+            Defaults to false. See build reproducibility for how to specify
+            the SOURCE_DATE_EPOCH value.
 
         Returns
         -------
@@ -1011,6 +1022,7 @@ class Container(Type):
             Arg("forcedCompression", forced_compression, None),
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
             Arg("expand", expand, False),
+            Arg("rewriteTimestamp", rewrite_timestamp, False),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(str)
@@ -1220,6 +1232,7 @@ class Container(Type):
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        rewrite_timestamp: bool | None = False,
     ) -> str:
         """Package the container state as an OCI image, and publish it to a
         registry
@@ -1249,6 +1262,10 @@ class Container(Type):
             Defaults to "OCI", which is compatible with most recent
             registries, but "Docker" may be needed for older registries
             without OCI support.
+        rewrite_timestamp:
+            Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+            Defaults to false. See build reproducibility for how to specify
+            the SOURCE_DATE_EPOCH value.
 
         Returns
         -------
@@ -1273,6 +1290,7 @@ class Container(Type):
             ),
             Arg("forcedCompression", forced_compression, None),
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("rewriteTimestamp", rewrite_timestamp, False),
         ]
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1802,6 +1802,10 @@ pub struct ContainerAsTarballOpts {
     /// Used for multi-platform images.
     #[builder(setter(into, strip_option), default)]
     pub platform_variants: Option<Vec<ContainerId>>,
+    /// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    /// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    #[builder(setter(into, strip_option), default)]
+    pub rewrite_timestamp: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerBuildOpts<'a> {
@@ -1847,6 +1851,10 @@ pub struct ContainerExportOpts {
     /// Used for multi-platform image.
     #[builder(setter(into, strip_option), default)]
     pub platform_variants: Option<Vec<ContainerId>>,
+    /// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    /// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    #[builder(setter(into, strip_option), default)]
+    pub rewrite_timestamp: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerFileOpts {
@@ -1874,6 +1882,10 @@ pub struct ContainerPublishOpts {
     /// Used for multi-platform image.
     #[builder(setter(into, strip_option), default)]
     pub platform_variants: Option<Vec<ContainerId>>,
+    /// Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+    /// Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+    #[builder(setter(into, strip_option), default)]
+    pub rewrite_timestamp: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerTerminalOpts<'a> {
@@ -2243,6 +2255,9 @@ impl Container {
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
         }
+        if let Some(rewrite_timestamp) = opts.rewrite_timestamp {
+            query = query.arg("rewriteTimestamp", rewrite_timestamp);
+        }
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -2459,6 +2474,9 @@ impl Container {
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
         }
+        if let Some(rewrite_timestamp) = opts.rewrite_timestamp {
+            query = query.arg("rewriteTimestamp", rewrite_timestamp);
+        }
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
@@ -2646,6 +2664,9 @@ impl Container {
         }
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
+        }
+        if let Some(rewrite_timestamp) = opts.rewrite_timestamp {
+            query = query.arg("rewriteTimestamp", rewrite_timestamp);
         }
         query.execute(self.graphql_client.clone()).await
     }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -115,6 +115,13 @@ export type ContainerAsTarballOpts = {
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
    */
   mediaTypes?: ImageMediaTypes
+
+  /**
+   * Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+   */
+  rewriteTimestamp?: boolean
 }
 
 export type ContainerBuildOpts = {
@@ -183,6 +190,13 @@ export type ContainerExportOpts = {
    * Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    */
   expand?: boolean
+
+  /**
+   * Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+   */
+  rewriteTimestamp?: boolean
 }
 
 export type ContainerFileOpts = {
@@ -220,6 +234,13 @@ export type ContainerPublishOpts = {
    * Defaults to "OCI", which is compatible with most recent registries, but "Docker" may be needed for older registries without OCI support.
    */
   mediaTypes?: ImageMediaTypes
+
+  /**
+   * Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
+   */
+  rewriteTimestamp?: boolean
 }
 
 export type ContainerTerminalOpts = {
@@ -1855,6 +1876,9 @@ export class Container extends BaseClient {
    * @param opts.mediaTypes Use the specified media types for the image's layers.
    *
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
+   * @param opts.rewriteTimestamp Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
    */
   asTarball = (opts?: ContainerAsTarballOpts): File => {
     const metadata = {
@@ -2012,6 +2036,9 @@ export class Container extends BaseClient {
    *
    * Defaults to OCI, which is largely compatible with most recent container runtimes, but Docker may be needed for older runtimes without OCI support.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+   * @param opts.rewriteTimestamp Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
    */
   export = async (
     path: string,
@@ -2173,6 +2200,9 @@ export class Container extends BaseClient {
    * @param opts.mediaTypes Use the specified media types for the published image's layers.
    *
    * Defaults to "OCI", which is compatible with most recent registries, but "Docker" may be needed for older registries without OCI support.
+   * @param opts.rewriteTimestamp Rewrite the file timestamps to the SOURCE_DATE_EPOCH value.
+   *
+   * Defaults to false. See build reproducibility for how to specify the SOURCE_DATE_EPOCH value.
    */
   publish = async (
     address: string,


### PR DESCRIPTION
As described on https://github.com/moby/buildkit/blob/master/docs/build-repro.md, buildkit supports the reproducible-builds variable SOURCE_DATE_EPOCH and a rewrite-timestamp build-arg that uses the epoch as timestamp for actions on the filesystem.

This PR follows the idea outlined in #7721 by:
- Reading SOURCE_DATE_EPOCH at the client and propagate it as ClientMetadata
- Propagate SOURCE_DATE_EPOCH from ClientMetadata to ExecutionMetadata
- Propagate the env SOURCE_DATE_EPOCH to nestedClients and Process.Env 
- Add rewriteTimestamp option to terminal publish, export and asTarball operations

According to the builkit-doc, this would affect:
- the created timestamp in the [OCI Image Config](https://github.com/opencontainers/image-spec/blob/main/config.md#properties)
- the created timestamp in the history objects in the [OCI Image Config](https://github.com/opencontainers/image-spec/blob/main/config.md#properties)
- the org.opencontainers.image.created annotation in the [OCI Image Index](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)
- the timestamp of the files exported with the local exporter
- the timestamp of the files exported with the tar exporter

And also:
- The result of every nested build-tool that uses the SOURCE_DATE_EPOCH variable

Ending up in possibly deterministic, binary reproducible images.

As this is mostly compiler driven developed without deep understanding of daggers internals (just best guesses), It would be helpful to get some feedback on this.

closes: #7721 