### PR TITLE
feat: expose Host in generated client

### DIFF
--- a/core/env.go
+++ b/core/env.go
@@ -364,8 +364,6 @@ type EnvHook struct {
 // internal usage. So we use this list to scrub them from
 // the introspection JSON that module SDKs use for codegen.
 var TypesHiddenFromModuleSDKs = []dagql.Typed{
-	&Host{},
-
 	&Engine{},
 	&EngineCache{},
 	&EngineCacheEntry{},
@@ -514,7 +512,7 @@ func (s EnvHook) InstallObject(targetType dagql.ObjectType) {
 	// FIXME: in principle LLM should be able to refer to these types, so this should
 	// probably be moved to codegen somehow, i.e. if a field refers to a type that is
 	// hidden, don't codegen the field.
-	for _, hiddenType := range TypesHiddenFromModuleSDKs {
+	for _, hiddenType := range append(TypesHiddenFromModuleSDKs, &Host{}) {
 		if hiddenType.Type().Name() == typename {
 			return
 		}

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1337,5 +1337,4 @@ main()`)
 			require.Equal(t, tc.expected, out)
 		})
 	}
-
 }

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -28,7 +28,10 @@ func (s *querySchema) Install() {
 		// module SDKs and is thus hidden the same way the rest of introspection is hidden
 		// (via the magic __ prefix).
 		dagql.NodeFuncWithCacheKey("__schemaJSONFile", s.schemaJSONFile, dagql.CachePerCall).
-			Doc("Get the current schema as a JSON file."),
+			Doc("Get the current schema as a JSON file.").
+			Args(
+				dagql.Arg("hiddenTypes").Doc("Types to hide from the schema JSON file."),
+			),
 	}.Install(s.srv)
 
 	s.srv.InstallScalar(core.JSON{})
@@ -82,7 +85,13 @@ func (s *querySchema) version(_ context.Context, _ *core.Query, args struct{}) (
 	return engine.Version, nil
 }
 
-func (s *querySchema) schemaJSONFile(ctx context.Context, parent dagql.Instance[*core.Query], args struct{}) (inst dagql.Instance[*core.File], rerr error) {
+func (s *querySchema) schemaJSONFile(
+	ctx context.Context,
+	parent dagql.Instance[*core.Query],
+	args struct {
+		HiddenTypes []string `default:"[]"`
+	},
+) (inst dagql.Instance[*core.File], rerr error) {
 	data, err := s.srv.Query(ctx, codegenintrospection.Query, nil)
 	if err != nil {
 		return inst, fmt.Errorf("introspection query failed: %w", err)
@@ -100,6 +109,12 @@ func (s *querySchema) schemaJSONFile(ctx context.Context, parent dagql.Instance[
 		introspection.Schema.ScrubType(typed.Type().Name())
 		introspection.Schema.ScrubType(dagql.IDTypeNameFor(typed))
 	}
+
+	for _, rawType := range args.HiddenTypes {
+		introspection.Schema.ScrubType(rawType)
+		introspection.Schema.ScrubType(dagql.IDTypeNameForRawType(rawType))
+	}
+
 	moduleSchemaJSON, err := json.Marshal(introspection)
 	if err != nil {
 		return inst, fmt.Errorf("failed to marshal introspection JSON: %w", err)

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -376,7 +376,7 @@ func (sdk *moduleSDK) GenerateClient(
 	outputDir string,
 	dev bool,
 ) (inst dagql.Instance[*core.Directory], err error) {
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{})
 	if err != nil {
 		return inst, fmt.Errorf("failed to get schema introspection json during module client generation: %w", err)
 	}
@@ -423,7 +423,7 @@ func (sdk *moduleSDK) GenerateClient(
 func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (_ *core.GeneratedCode, rerr error) {
 	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: run codegen")
 	defer telemetry.End(span, func() error { return rerr })
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdk.mod.Self.Name(), err)
 	}
@@ -452,7 +452,7 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source da
 func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (_ *core.Container, rerr error) {
 	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: load runtime")
 	defer telemetry.End(span, func() error { return rerr })
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.Self.Name(), err)
 	}
@@ -576,7 +576,7 @@ func (sdk *goSDK) GenerateClient(
 	outputDir string,
 	dev bool,
 ) (inst dagql.Instance[*core.Directory], err error) {
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{})
 	if err != nil {
 		return inst, fmt.Errorf("failed to get schema introspection json during module client generation: %w", err)
 	}
@@ -840,7 +840,7 @@ func (sdk *goSDK) baseWithCodegen(
 ) (dagql.Instance[*core.Container], error) {
 	var ctr dagql.Instance[*core.Container]
 
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {
 		return ctr, fmt.Errorf("failed to get schema introspection json during module sdk codegen: %w", err)
 	}

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -630,6 +630,10 @@ func IDTypeNameFor(t Typed) string {
 	return t.Type().Name() + "ID"
 }
 
+func IDTypeNameForRawType(t string) string {
+	return t + "ID"
+}
+
 // TypeName returns the name of the type with "ID" appended, e.g. `FooID`.
 func (i ID[T]) TypeName() string {
 	return IDTypeNameFor(i.inner)


### PR DESCRIPTION
Update `__schema` to take as argument optional
types thay may be hidden from the API.
Update `schemIntrospectionJSONFile` to hide `Host` when generating for module.
Add host call tests in client generator.