### PR TITLE
remove llm tool result truncation

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -512,16 +512,6 @@ func (m *MCP) selectionToToolResult(
 				"digest": digest.FromBytes(bytes),
 			})
 		}
-		origSize := len(str)
-		if origSize > maxStr {
-			str = str[:maxStr]
-			return toolStructuredResponse(map[string]any{
-				"result":         str,
-				"truncated":      true,
-				"truncated_size": maxStr,
-				"original_size":  origSize,
-			})
-		}
 		// Return string content directly, without wrapping it in JSON.
 		return str.String(), nil
 	}
@@ -595,8 +585,6 @@ func (m *MCP) toolCallToSelection(
 	}
 	return sel, nil
 }
-
-const maxStr = 80 * 1024
 
 func (m *MCP) Call(ctx context.Context, tools []LLMTool, toolCall LLMToolCall) (string, bool) {
 	var tool *LLMTool


### PR DESCRIPTION
fixes https://github.com/dagger/dagger/issues/10328

in the future we'll probably want to add this back in and make it configurable, but we can wait for user requirements to clarify in the absence of a default truncation, and maybe introduce `.contents(line-number ranges)` or native grep apis in the mean time. 