### PR TITLE
fix `err` overwrite causing data race detector failures in integ tests

### DIFF
--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -1192,7 +1192,7 @@ func (*Test) Fn2(ctx context.Context, secret *dagger.Secret) *dagger.Container {
 		c1 := connect(ctx, t, dagger.WithEnvironmentVariable("FOO", "1"))
 		c2 := connect(ctx, t, dagger.WithEnvironmentVariable("FOO", "2"))
 
-		err = c1.ModuleSource(tmpdir).AsModule().Serve(ctx)
+		err := c1.ModuleSource(tmpdir).AsModule().Serve(ctx)
 		require.NoError(t, err)
 
 		err = c2.ModuleSource(tmpdir).AsModule().Serve(ctx)
@@ -1255,7 +1255,7 @@ func (*Test) Fn2(ctx context.Context, secret *dagger.Secret) *dagger.Container {
 		c1 := connect(ctx, t, dagger.WithEnvironmentVariable("FOO", "1"))
 		c2 := connect(ctx, t, dagger.WithEnvironmentVariable("FOO", "2"))
 
-		err = c1.ModuleSource(tmpdir).AsModule().Serve(ctx)
+		err := c1.ModuleSource(tmpdir).AsModule().Serve(ctx)
 		require.NoError(t, err)
 
 		err = c2.ModuleSource(tmpdir).AsModule().Serve(ctx)

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -22,7 +22,7 @@ Expected stderr:
 ✔ .useNoExecService: String! X.Xs
 ┃ PONG
 │ ✔ container: Container! X.Xs
-│ $ .from(address: "redis"): Container! X.Xs CACHED
+│ $ .from(address: "redis:7.4.3"): Container! X.Xs CACHED
 │ ✔ .withExposedPort(port: 6379): Container! X.Xs
 │ ✔ .asService: Service! X.Xs
 │ ┃ X:M XX XXX 20XX XX:XX:XX.XXX * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo

--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -331,14 +331,14 @@ func (v *Viztest) UseExecService(ctx context.Context) error {
 
 func (*Viztest) NoExecService() *dagger.Service {
 	return dag.Container().
-		From("redis").
+		From("redis:7.4.3").
 		WithExposedPort(6379). // TODO: would be great to infer this
 		AsService()
 }
 
 func (v *Viztest) UseNoExecService(ctx context.Context) (string, error) {
 	return dag.Container().
-		From("redis").
+		From("redis:7.4.3").
 		WithServiceBinding("redis", v.NoExecService()).
 		WithEnvVariable("NOW", time.Now().String()).
 		WithExec([]string{"redis-cli", "-h", "redis", "ping"}).


### PR DESCRIPTION
This was causing flakiness in tests when the detector went off (e.g. https://v3.dagger.cloud/dagger/traces/1df689be91b6f1d837af53ff3cd62b41?span=4acfd90e58c43f70&logs)