### PR TITLE
mcp: log std{in,out,err} to files specified by DAGGER_LOG_STD{IN,OUT,ERR} envvars

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -97,9 +97,6 @@ func withEngine(
 
 		params.WithTerminal = withTerminal
 
-		params.Stdin = os.Stdin
-		params.Stdout = os.Stdout
-
 		params.Interactive = interactive
 		params.InteractiveCommand = interactiveCommandParsed
 

--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"dagger.io/dagger/querybuilder"
 	"github.com/dagger/dagger/dagql/idtui"
@@ -33,9 +32,9 @@ var mcpCmd = &cobra.Command{
 		}
 
 		if progress == "auto" && hasTTY {
-			fmt.Fprintln(os.Stderr, "overriding 'auto' progress mode to 'plain' to avoid interference with mcp stdio")
+			fmt.Fprintln(stderr, "overriding 'auto' progress mode to 'plain' to avoid interference with mcp stdio")
 
-			Frontend = idtui.NewPlain()
+			Frontend = idtui.NewPlain(stderr)
 		}
 
 		return nil
@@ -43,7 +42,10 @@ var mcpCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		cmd.SetContext(idtui.WithPrintTraceLink(ctx, true))
-		return withEngine(ctx, client.Params{}, mcpStart)
+		return withEngine(ctx, client.Params{
+			Stdin:  stdin,
+			Stdout: stdout,
+		}, mcpStart)
 	},
 	Hidden: true,
 	Annotations: map[string]string{
@@ -102,7 +104,7 @@ func mcpStart(ctx context.Context, engineClient *client.Client) error {
 		return fmt.Errorf("error making environment: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, logMsg)
+	fmt.Fprintln(stderr, logMsg)
 	q = q.Root().
 		Select("llm").
 		Select("withEnv").

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -90,7 +90,7 @@ func Run(cmd *cobra.Command, args []string) error {
 	err := run(cmd, args)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			fmt.Fprintln(os.Stderr, "run canceled")
+			fmt.Fprintln(stderr, "run canceled")
 			return ExitError{Code: 2}
 		}
 		var exitErr *exec.ExitError
@@ -141,7 +141,7 @@ func run(cmd *cobra.Command, args []string) error {
 		subCmd.Env = env
 
 		// allow piping to the command
-		subCmd.Stdin = os.Stdin
+		subCmd.Stdin = stdin
 
 		// NB: go run lets its child process roam free when you interrupt it, so
 		// make sure they all get signalled. (you don't normally notice this in a
@@ -162,19 +162,19 @@ func run(cmd *cobra.Command, args []string) error {
 			if stdoutIsTTY {
 				subCmd.Stdout = cmd.OutOrStdout()
 			} else {
-				subCmd.Stdout = os.Stdout
+				subCmd.Stdout = stdout
 			}
 
 			if stderrIsTTY {
 				subCmd.Stderr = cmd.ErrOrStderr()
 			} else {
-				subCmd.Stderr = os.Stderr
+				subCmd.Stderr = stderr
 			}
 
 			cmdErr = subCmd.Run()
 		} else {
-			subCmd.Stdout = os.Stdout
-			subCmd.Stderr = os.Stderr
+			subCmd.Stdout = stdout
+			subCmd.Stderr = stderr
 			cmdErr = subCmd.Run()
 		}
 

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -3,6 +3,7 @@ package idtui
 import (
 	"context"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"strings"
@@ -622,13 +623,13 @@ func humanizeTokens(v int64) string {
 // 	return nil
 // }
 
-func renderPrimaryOutput(db *dagui.DB) error {
+func renderPrimaryOutput(w io.Writer, db *dagui.DB) error {
 	logs := db.PrimaryLogs[db.PrimarySpan]
 	if len(logs) == 0 {
 		return nil
 	}
 
-	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(w)
 
 	for _, l := range logs {
 		data := l.Body().AsString()
@@ -648,7 +649,7 @@ func renderPrimaryOutput(db *dagui.DB) error {
 		case 2: // stderr
 			fallthrough
 		default:
-			if _, err := fmt.Fprint(os.Stderr, data); err != nil {
+			if _, err := fmt.Fprint(w, data); err != nil {
 				return err
 			}
 		}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -360,8 +360,12 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 		// Git attachable
 		session.NewGitAttachable(ctx),
 		// pipe
-		session.NewPipeAttachable(ctx, c.Params.Stdin, c.Params.Stdout),
 	}
+
+	if c.Params.Stdin != nil && c.Params.Stdout != nil {
+		attachables = append(attachables, session.NewPipeAttachable(ctx, c.Params.Stdin, c.Params.Stdout))
+	}
+
 	// filesync
 	if !c.DisableHostRW {
 		filesyncer, err := NewFilesyncer()


### PR DESCRIPTION


This makes debugging MCP in certain environments easier by providing a way to log the dagger cli's stdin/stdout/stderr.