### PR TITLE
fix(sdk/elixir): fix publish failure on 0.18.6

### DIFF
--- a/sdk/elixir/dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/lib/elixir_sdk_dev.ex
@@ -158,7 +158,7 @@ defmodule ElixirSdkDev do
     dag()
     |> Dagger.Client.container()
     |> Dagger.Container.from(@base_image)
-    |> Dagger.Container.with_workdir("/sdk")
+    |> Dagger.Container.with_workdir("/sdk/elixir")
     |> Dagger.Container.with_directory(".", source)
     |> Dagger.Container.with_exec(~w"mix local.hex --force")
     |> Dagger.Container.with_exec(~w"mix local.rebar --force")


### PR DESCRIPTION
The ElixirSdkDev set the working directory `/sdk` while the `t.Dagger.Source` is `/sdk/elixir` cause a publish function write to incorrect place.

Tested by add a terminal debugger before calling `hex.publish and call `dagger call sdk elixir publish --tag=0.18.6 --dry-run`, then cat the `mix.exs` file, the `@version` must be updated to 0.18.6.