### PR TITLE
ci: alt-runners-4: Update the runner

### DIFF
--- a/.github/workflows/alternative-ci-runners-4.yml
+++ b/.github/workflows/alternative-ci-runners-4.yml
@@ -13,73 +13,37 @@ permissions:
   contents: read
 
 jobs:
-  docs-lint-on-northflank-c3-remote-engine:
+  docs-lint-on-northflank-kata-remote-engine:
     uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
     with:
-      machine: nf-c3-highcpu-44-kata-qemu
+      machine: nf-kata-az-amd-qemu
       function: check --targets=docs
 
-  sdk-go-on-northflank-c3-remote-engine:
-    needs: docs-lint-on-northflank-c3-remote-engine
+  sdk-go-on-northflank-kata-remote-engine:
+    needs: docs-lint-on-northflank-kata-remote-engine
     uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
     with:
-      machine: nf-c3-highcpu-44-kata-qemu
+      machine: nf-kata-az-amd-qemu
       function: check --targets=sdk/go
 
-  sdk-python-on-northflank-c3-remote-engine:
-    needs: docs-lint-on-northflank-c3-remote-engine
+  sdk-python-on-northflank-kata-remote-engine:
+    needs: docs-lint-on-northflank-kata-remote-engine
     uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
     with:
-      machine: nf-c3-highcpu-44-kata-qemu
+      machine: nf-kata-az-amd-qemu
       function: check --targets=sdk/python
 
-  sdk-typescript-on-northflank-c3-remote-engine:
-    needs: docs-lint-on-northflank-c3-remote-engine
+  sdk-typescript-on-northflank-kata-remote-engine:
+    needs: docs-lint-on-northflank-kata-remote-engine
     uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
     with:
-      machine: nf-c3-highcpu-44-kata-qemu
+      machine: nf-kata-az-amd-qemu
       function: check --targets=sdk/typescript
 
-  test-cli-engine-on-northflank-c3-remote-engine:
-    needs: docs-lint-on-northflank-c3-remote-engine
+  test-cli-engine-on-northflank-kata-remote-engine:
+    needs: docs-lint-on-northflank-kata-remote-engine
     uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
     with:
-      machine: nf-c3-highcpu-44-kata-qemu
-      function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
-      timeout: 20
-
-  # We are running the same tests on a different machine type to see how they compare
-  docs-lint-on-northflank-n4-remote-engine:
-    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
-    with:
-      machine: nf-n4-highcpu-32-kata-qemu
-      function: check --targets=docs
-
-  sdk-go-on-northflank-n4-remote-engine:
-    needs: docs-lint-on-northflank-n4-remote-engine
-    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
-    with:
-      machine: nf-n4-highcpu-32-kata-qemu
-      function: check --targets=sdk/go
-
-  sdk-python-on-northflank-n4-remote-engine:
-    needs: docs-lint-on-northflank-n4-remote-engine
-    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
-    with:
-      machine: nf-n4-highcpu-32-kata-qemu
-      function: check --targets=sdk/python
-
-  sdk-typescript-on-northflank-n4-remote-engine:
-    needs: docs-lint-on-northflank-n4-remote-engine
-    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
-    with:
-      machine: nf-n4-highcpu-32-kata-qemu
-      function: check --targets=sdk/typescript
-
-  test-cli-engine-on-northflank-n4-remote-engine:
-    needs: docs-lint-on-northflank-n4-remote-engine
-    uses: ./.github/workflows/_dagger_on_northflank_remote_engine.yml
-    with:
-      machine: nf-n4-highcpu-32-kata-qemu
+      machine: nf-kata-az-amd-qemu
       function: test specific --run='TestCLI|TestEngine' --race=true --parallel=16
       timeout: 20


### PR DESCRIPTION
The current runners are giving us results around 4 minutes for the first job.  Those specific runners are using nested virt atop of Intel SPR or EMR.

We're now switching to using nested virt atop of AMD CPUs, as we're getting results closer to 3m30s with those, instead of the Intel ones.

Let's switch the runners for now to use the AMD ones, while we keep working on shaving the time down more and more with different approaches. :-).

cc @gerhard 