### PR TITLE
chore: bump go to 1.24.3

### DIFF
--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.23.6-alpine").
+		From("golang:1.24.3-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -27,7 +27,7 @@ const (
 	AlpineVersion = "3.20.2"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.23.8"
+	GolangVersion = "1.24.3"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/dagger/dagger
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24.3
 
 require (
 	dagger.io/dagger v0.18.5

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.23.8"
+	// +default="1.24.3"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
Take 2! go 1.24.3 has the fix for SIGSEGV in `vgetrandomPutState`.

Fixes https://github.com/dagger/dagger/issues/9759.

Related:
- first take to 1.24.0: https://github.com/dagger/dagger/pull/9673
- reversion back to 1.23: https://github.com/dagger/dagger/pull/9766
