### PR TITLE
lazy LLM api key loading/model selection

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -190,32 +190,32 @@ func (dev *DaggerDev) Test() *Test {
 	return &Test{Dagger: dev}
 }
 
-// TODO: these depend on unreleased APIs
-func (dev *DaggerDev) Evals(
-	ctx context.Context,
-	// +defaultPath=./core/llm_docs.md
-	docs *dagger.File,
-	// +defaultPath=./core/llm_dagger_prompt.md
-	systemPrompt *dagger.File,
-) error {
-	return dag.Evaluator(dagger.EvaluatorOpts{
-		Docs:          docs,
-		InitialPrompt: systemPrompt,
-	}).EvalsAcrossModels().Check(ctx)
-}
+// // TODO: these depend on unreleased APIs
+// func (dev *DaggerDev) Evals(
+// 	ctx context.Context,
+// 	// +defaultPath=./core/llm_docs.md
+// 	docs *dagger.File,
+// 	// +defaultPath=./core/llm_dagger_prompt.md
+// 	systemPrompt *dagger.File,
+// ) error {
+// 	return dag.Evaluator(dagger.EvaluatorOpts{
+// 		Docs:          docs,
+// 		InitialPrompt: systemPrompt,
+// 	}).EvalsAcrossModels().Check(ctx)
+// }
 
-func (dev *DaggerDev) GenerateSystemPrompt(
-	ctx context.Context,
-	// +defaultPath=./core/llm_docs.md
-	docs *dagger.File,
-	// +defaultPath=./core/llm_dagger_prompt.md
-	systemPrompt *dagger.File,
-) (string, error) {
-	return dag.Evaluator(dagger.EvaluatorOpts{
-		Docs:          docs,
-		InitialPrompt: systemPrompt,
-	}).GenerateSystemPrompt(ctx)
-}
+// func (dev *DaggerDev) GenerateSystemPrompt(
+// 	ctx context.Context,
+// 	// +defaultPath=./core/llm_docs.md
+// 	docs *dagger.File,
+// 	// +defaultPath=./core/llm_dagger_prompt.md
+// 	systemPrompt *dagger.File,
+// ) (string, error) {
+// 	return dag.Evaluator(dagger.EvaluatorOpts{
+// 		Docs:          docs,
+// 		InitialPrompt: systemPrompt,
+// 	}).GenerateSystemPrompt(ctx)
+// }
 
 // Find benchmark suites to run
 func (dev *DaggerDev) Bench() *Bench {

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -191,31 +191,31 @@ func (dev *DaggerDev) Test() *Test {
 }
 
 // TODO: these depend on unreleased APIs
-// func (dev *DaggerDev) Evals(
-// 	ctx context.Context,
-// 	// +defaultPath=./core/llm_docs.md
-// 	docs *dagger.File,
-// 	// +defaultPath=./core/llm_dagger_prompt.md
-// 	systemPrompt *dagger.File,
-// ) error {
-// 	return dag.Evaluator(dagger.EvaluatorOpts{
-// 		Docs:          docs,
-// 		InitialPrompt: systemPrompt,
-// 	}).EvalsAcrossModels().Check(ctx)
-// }
+func (dev *DaggerDev) Evals(
+	ctx context.Context,
+	// +defaultPath=./core/llm_docs.md
+	docs *dagger.File,
+	// +defaultPath=./core/llm_dagger_prompt.md
+	systemPrompt *dagger.File,
+) error {
+	return dag.Evaluator(dagger.EvaluatorOpts{
+		Docs:          docs,
+		InitialPrompt: systemPrompt,
+	}).EvalsAcrossModels().Check(ctx)
+}
 
-// func (dev *DaggerDev) GenerateSystemPrompt(
-// 	ctx context.Context,
-// 	// +defaultPath=./core/llm_docs.md
-// 	docs *dagger.File,
-// 	// +defaultPath=./core/llm_dagger_prompt.md
-// 	systemPrompt *dagger.File,
-// ) (string, error) {
-// 	return dag.Evaluator(dagger.EvaluatorOpts{
-// 		Docs:          docs,
-// 		InitialPrompt: systemPrompt,
-// 	}).GenerateSystemPrompt(ctx)
-// }
+func (dev *DaggerDev) GenerateSystemPrompt(
+	ctx context.Context,
+	// +defaultPath=./core/llm_docs.md
+	docs *dagger.File,
+	// +defaultPath=./core/llm_dagger_prompt.md
+	systemPrompt *dagger.File,
+) (string, error) {
+	return dag.Evaluator(dagger.EvaluatorOpts{
+		Docs:          docs,
+		InitialPrompt: systemPrompt,
+	}).GenerateSystemPrompt(ctx)
+}
 
 // Find benchmark suites to run
 func (dev *DaggerDev) Bench() *Bench {

--- a/cmd/dagger/llm.go
+++ b/cmd/dagger/llm.go
@@ -76,10 +76,6 @@ func NewLLMSession(ctx context.Context, dag *dagger.Client, llmModel string, she
 		shell: shellHandler,
 	}
 
-	if llmModel != "" {
-		s.llm = s.llm.WithModel(llmModel)
-	}
-
 	// don't sync the initial env vars
 	for k := range shellHandler.runner.Env.Each {
 		s.skipEnv[k] = true

--- a/core/llm.go
+++ b/core/llm.go
@@ -64,8 +64,7 @@ type LLM struct {
 	maxAPICalls int
 	apiCalls    int
 
-	model string
-	// todo: sync once this
+	model    string
 	endpoint *LLMEndpoint
 
 	once *sync.Once
@@ -506,7 +505,6 @@ func (llm *LLM) ToolsDoc(ctx context.Context, srv *dagql.Server) (string, error)
 }
 
 func (llm *LLM) WithModel(ctx context.Context, model string, srv *dagql.Server) (*LLM, error) {
-	// FIXME: mcp implementation takes hints from endpoint: reconfigure it
 	llm = llm.Clone()
 	llm.model = model
 	return llm, nil

--- a/core/llm.go
+++ b/core/llm.go
@@ -63,7 +63,10 @@ type LLM struct {
 
 	maxAPICalls int
 	apiCalls    int
-	Endpoint    *LLMEndpoint
+
+	model string
+	// todo: sync once this
+	endpoint *LLMEndpoint
 
 	once *sync.Once
 
@@ -427,24 +430,9 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 }
 
 func NewLLM(ctx context.Context, query *Query, model string, maxAPICalls int) (*LLM, error) {
-	router, err := loadLLMRouter(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-
-	if model == "" {
-		model = router.DefaultModel()
-	}
-	endpoint, err := router.Route(model)
-	if err != nil {
-		return nil, err
-	}
-	if endpoint.Model == "" {
-		return nil, fmt.Errorf("no valid LLM endpoint configuration")
-	}
 	return &LLM{
 		Query:       query,
-		Endpoint:    endpoint,
+		model:       model,
 		maxAPICalls: maxAPICalls,
 		mcp:         NewEnv().MCP(),
 		once:        &sync.Once{},
@@ -480,6 +468,26 @@ func (llm *LLM) Clone() *LLM {
 	return &cp
 }
 
+func (llm *LLM) Endpoint(ctx context.Context) (*LLMEndpoint, error) {
+	if llm.endpoint != nil {
+		return llm.endpoint, nil
+	}
+	router, err := loadLLMRouter(ctx, llm.Query)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := router.Route(llm.model)
+	if err != nil {
+		return nil, err
+	}
+	if endpoint.Model == "" {
+		return nil, fmt.Errorf("no valid LLM endpoint configuration")
+	}
+
+	llm.endpoint = endpoint
+	return llm.endpoint, nil
+}
+
 // Generate a human-readable documentation of tools available to the model
 func (llm *LLM) ToolsDoc(ctx context.Context, srv *dagql.Server) (string, error) {
 	tools, err := llm.mcp.Tools(srv)
@@ -500,18 +508,7 @@ func (llm *LLM) ToolsDoc(ctx context.Context, srv *dagql.Server) (string, error)
 func (llm *LLM) WithModel(ctx context.Context, model string, srv *dagql.Server) (*LLM, error) {
 	// FIXME: mcp implementation takes hints from endpoint: reconfigure it
 	llm = llm.Clone()
-	router, err := loadLLMRouter(ctx, llm.Query)
-	if err != nil {
-		return nil, err
-	}
-	endpoint, err := router.Route(model)
-	if err != nil {
-		return nil, err
-	}
-	if endpoint.Model == "" {
-		return nil, fmt.Errorf("no valid LLM endpoint configuration")
-	}
-	llm.Endpoint = endpoint
+	llm.model = model
 	return llm, nil
 }
 
@@ -734,7 +731,11 @@ func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 		var res *LLMResponse
 
 		// Retry operation
-		client := llm.Endpoint.Client
+		ep, err := llm.Endpoint(ctx)
+		if err != nil {
+			return err
+		}
+		client := ep.Client
 		err = backoff.Retry(func() error {
 			var sendErr error
 			res, sendErr = client.SendQuery(ctx, messagesToSend, tools)

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -111,11 +111,19 @@ func (s *llmSchema) env(ctx context.Context, llm *core.LLM, args struct{}) (*cor
 }
 
 func (s *llmSchema) model(ctx context.Context, llm *core.LLM, args struct{}) (string, error) {
-	return llm.Endpoint.Model, nil
+	ep, err := llm.Endpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	return ep.Model, nil
 }
 
 func (s *llmSchema) provider(ctx context.Context, llm *core.LLM, args struct{}) (string, error) {
-	return string(llm.Endpoint.Provider), nil
+	ep, err := llm.Endpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(ep.Provider), nil
 }
 
 func (s *llmSchema) lastReply(ctx context.Context, llm *core.LLM, args struct{}) (dagql.String, error) {

--- a/dagger.json
+++ b/dagger.json
@@ -38,6 +38,10 @@
       "source": "sdk/elixir/dev"
     },
     {
+      "name": "evaluator",
+      "source": "modules/evaluator"
+    },
+    {
       "name": "go",
       "source": "modules/go"
     },

--- a/dagger.json
+++ b/dagger.json
@@ -38,10 +38,6 @@
       "source": "sdk/elixir/dev"
     },
     {
-      "name": "evaluator",
-      "source": "modules/evaluator"
-    },
-    {
       "name": "go",
       "source": "modules/go"
     },


### PR DESCRIPTION
fixes https://github.com/dagger/dagger/issues/10356

~this also uncomments the evals so we can run `dagger call evals` now that the appropriate APIs are released. note these don't build a dagger-in-dagger dev engine so you usually wanna use em with `./hack/dev`.~ commented again because we keep changing the api :)

TODO:
- [x] run evals
- [x] manually test the secret prompting thing at the core of 10356
   - [x] fix: still prompting- client needs some changes too 
- [x] ~refactor llm.endpoint init to use sync.Once~ bad idea, not doing this, err handling gets weird.
- [ ] ??? very open to suggestions as to what else to test here, there shouldn't be behavior changes outside fixing the issue we're trying to fix, but i also don't entire trust our test coverage here (hence running evals)