### PR TITLE
scrub whether container constructor is cached from telemetry tests

### DIFF
--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -424,6 +424,14 @@ var scrubs = []scrubber{
 		"# WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.\n",
 		"",
 	},
+	// Container constructor CACHED label; this is cached on the dagql level and can easily show up
+	// as either CACHED or not depending on anything else concurrently running against the engine.
+	// It's not something we particularly care about, so we just scrub it.
+	{
+		regexp.MustCompile(`\$ container: Container! X\.Xs CACHED`),
+		"$ container: Container! X.Xs CACHED",
+		"✔ container: Container! X.Xs",
+	},
 }
 
 func TestScrubbers(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10233

The `CACHED` label for container constructor calls are extremely uninteresting and can easily be CACHED or not based on whether anything else connected to the engine is using `Container`s (these are dagql in memory cache hits), so just attempting to scrub it.