### PR TITLE
llm: show the model logs generated by tool calls

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -796,7 +796,7 @@ func (llm *LLM) loop(ctx context.Context, dag *dagql.Server) error {
 			break
 		}
 		for _, toolCall := range res.ToolCalls {
-			content, isError := llm.mcp.Call(ctx, tools, toolCall)
+			content, isError := llm.mcp.Call(ctx, dag, tools, toolCall)
 			llm.messages = append(llm.messages, ModelMessage{
 				Role:        "user", // Anthropic only allows tool call results in user messages
 				Content:     content,

--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -68,12 +68,6 @@ func (c *AnthropicClient) IsRetryable(err error) bool {
 
 //nolint:gocyclo
 func (c *AnthropicClient) SendQuery(ctx context.Context, history []ModelMessage, tools []LLMTool) (res *LLMResponse, rerr error) {
-	ctx, span := Tracer(ctx).Start(ctx, "LLM query", telemetry.Reveal(), trace.WithAttributes(
-		attribute.String(telemetry.UIActorEmojiAttr, "🤖"),
-		attribute.String(telemetry.UIMessageAttr, "received"),
-	))
-	defer telemetry.End(span, func() error { return rerr })
-
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
 	defer stdio.Close()
 
@@ -81,9 +75,10 @@ func (c *AnthropicClient) SendQuery(ctx context.Context, history []ModelMessage,
 		log.String(telemetry.ContentTypeAttr, "text/markdown"))
 
 	m := telemetry.Meter(ctx, InstrumentationLibrary)
+	spanCtx := trace.SpanContextFromContext(ctx)
 	attrs := []attribute.KeyValue{
-		attribute.String(telemetry.MetricsTraceIDAttr, span.SpanContext().TraceID().String()),
-		attribute.String(telemetry.MetricsSpanIDAttr, span.SpanContext().SpanID().String()),
+		attribute.String(telemetry.MetricsTraceIDAttr, spanCtx.TraceID().String()),
+		attribute.String(telemetry.MetricsSpanIDAttr, spanCtx.SpanID().String()),
 		attribute.String("model", c.endpoint.Model),
 		attribute.String("provider", string(c.endpoint.Provider)),
 	}

--- a/core/llm_google.go
+++ b/core/llm_google.go
@@ -201,21 +201,15 @@ func (c *GenaiClient) IsRetryable(err error) bool {
 }
 
 func (c *GenaiClient) SendQuery(ctx context.Context, history []ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
-	// setup tracing & telemetry
-	ctx, span := Tracer(ctx).Start(ctx, "LLM query", telemetry.Reveal(), trace.WithAttributes(
-		attribute.String(telemetry.UIActorEmojiAttr, "🤖"),
-		attribute.String(telemetry.UIMessageAttr, "received"),
-	))
-	defer telemetry.End(span, func() error { return rerr })
-
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
 		log.String(telemetry.ContentTypeAttr, "text/markdown"))
 	defer stdio.Close()
 
 	m := telemetry.Meter(ctx, InstrumentationLibrary)
+	spanCtx := trace.SpanContextFromContext(ctx)
 	attrs := []attribute.KeyValue{
-		attribute.String(telemetry.MetricsTraceIDAttr, span.SpanContext().TraceID().String()),
-		attribute.String(telemetry.MetricsSpanIDAttr, span.SpanContext().SpanID().String()),
+		attribute.String(telemetry.MetricsTraceIDAttr, spanCtx.TraceID().String()),
+		attribute.String(telemetry.MetricsSpanIDAttr, spanCtx.SpanID().String()),
 		attribute.String("model", c.endpoint.Model),
 		attribute.String("provider", string(c.endpoint.Provider)),
 	}

--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -52,20 +52,15 @@ func (c *OpenAIClient) IsRetryable(err error) bool {
 }
 
 func (c *OpenAIClient) SendQuery(ctx context.Context, history []ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
-	ctx, span := Tracer(ctx).Start(ctx, "LLM query", telemetry.Reveal(), trace.WithAttributes(
-		attribute.String(telemetry.UIActorEmojiAttr, "🤖"),
-		attribute.String(telemetry.UIMessageAttr, "received"),
-	))
-	defer telemetry.End(span, func() error { return rerr })
-
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
 		log.String(telemetry.ContentTypeAttr, "text/markdown"))
 	defer stdio.Close()
 
 	m := telemetry.Meter(ctx, InstrumentationLibrary)
+	spanCtx := trace.SpanContextFromContext(ctx)
 	attrs := []attribute.KeyValue{
-		attribute.String(telemetry.MetricsTraceIDAttr, span.SpanContext().TraceID().String()),
-		attribute.String(telemetry.MetricsSpanIDAttr, span.SpanContext().SpanID().String()),
+		attribute.String(telemetry.MetricsTraceIDAttr, spanCtx.TraceID().String()),
+		attribute.String(telemetry.MetricsSpanIDAttr, spanCtx.SpanID().String()),
 		attribute.String("model", c.endpoint.Model),
 		attribute.String("provider", string(c.endpoint.Provider)),
 	}

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -612,7 +612,14 @@ func (m *MCP) Call(ctx context.Context, dag *dagql.Server, tools []LLMTool, tool
 					logs[skipped:]...,
 				)
 			}
-			res += fmt.Sprintf(`\n\n<logs>\n%s\n</logs>`, strings.Join(logs, "\n"))
+			if !strings.HasSuffix(res, "\n") {
+				// avoid double trailing linebreak (e.g. pretty JSON)
+				res += "\n"
+			}
+			res += fmt.Sprintf(`\n<logs>\n%s\n</logs>`,
+				// avoid double trailing linebreak
+				strings.TrimSuffix(strings.Join(logs, "\n"), "\n"),
+			)
 		}
 	}()
 
@@ -748,7 +755,8 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 				if err != nil {
 					return nil, err
 				}
-				// linked spans override name (Container.withExec => exec foo bar)
+				var linkSuffix string
+				// linked spans get added to the name (Container.withExec => exec foo bar)
 				for _, link := range base64Links {
 					linkedSpan, err := q.SelectSpan(ctx, clientdb.SelectSpanParams{
 						TraceID: link.TraceID,
@@ -758,10 +766,10 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 						slog.Warn("failed to query linked span", "error", err)
 						continue
 					}
-					prefix += "(" + linkedSpan.Name + ")"
+					linkSuffix = "(" + linkedSpan.Name + ")"
 				}
-
-				prefix += ": "
+				prefix += linkSuffix
+				prefix += ":\n"
 			}
 
 			mpw.SetPrefix(prefix)

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"dagger.io/dagger/telemetry"
+	"github.com/dagger/dagger/core/multiprefixw"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
@@ -387,7 +388,7 @@ func (m *MCP) call(ctx context.Context,
 	var validated bool
 	ctx, span := Tracer(ctx).Start(ctx,
 		fmt.Sprintf("%s%s", fieldDef.Name, displayArgs(args)),
-		trace.WithAttributes(attribute.String(telemetry.DagCallScopeAttr, "llm")),
+		trace.WithAttributes(attribute.Bool("dagger.io/llm", true)),
 		telemetry.ActorEmoji("🤖"),
 		telemetry.Passthrough(),
 		telemetry.Reveal())
@@ -666,7 +667,8 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 	}
 	defer close()
 
-	var formattedLines []string
+	formattedLines := new(strings.Builder)
+	mpw := multiprefixw.New(formattedLines)
 	for {
 		logs, err := q.SelectLogsSince(ctx, clientdb.SelectLogsSinceParams{
 			ID:    m.lastLogID,
@@ -701,31 +703,6 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 				continue
 			}
 
-			var content string
-
-			var bodyPb otlpcommonv1.AnyValue
-			if err := proto.Unmarshal(log.Body, &bodyPb); err != nil {
-				slog.Warn("failed to unmarshal log body", "error", err, "client", mainMeta.ClientID, "log", log.ID)
-				continue
-			}
-			switch x := bodyPb.GetValue().(type) {
-			case *otlpcommonv1.AnyValue_StringValue:
-				if !utf8.ValidString(x.StringValue) {
-					// sanity check
-					continue
-				}
-				content = x.StringValue
-			case *otlpcommonv1.AnyValue_BytesValue:
-				if !utf8.Valid(x.BytesValue) {
-					// sanity check
-					continue
-				}
-				content = string(x.BytesValue)
-			default:
-				// default to something troubleshootable
-				content = fmt.Sprintf("UNHANDLED: %+v", x)
-			}
-
 			var prefix string
 			if log.SpanID.Valid {
 				span, err := q.SelectSpan(ctx, clientdb.SelectSpanParams{
@@ -742,8 +719,8 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 				}
 				var isLLM bool
 				for _, attr := range spanAttrs {
-					if attr.Key == telemetry.DagCallScopeAttr {
-						if attr.Value.GetStringValue() == "llm" {
+					if attr.Key == "dagger.io/llm" {
+						if attr.Value.GetBoolValue() {
 							isLLM = true
 							break
 						}
@@ -755,13 +732,29 @@ func (m *MCP) captureLogs(ctx context.Context, dag *dagql.Server) ([]string, err
 				}
 				prefix = span.Name + " | "
 			}
-			for _, line := range strings.Split(content, "\n") {
-				formattedLines = append(formattedLines, prefix+line)
+
+			mpw.SetPrefix(prefix)
+
+			var bodyPb otlpcommonv1.AnyValue
+			if err := proto.Unmarshal(log.Body, &bodyPb); err != nil {
+				slog.Warn("failed to unmarshal log body", "error", err, "client", mainMeta.ClientID, "log", log.ID)
+				continue
+			}
+			switch x := bodyPb.GetValue().(type) {
+			case *otlpcommonv1.AnyValue_StringValue:
+				fmt.Fprint(mpw, x.StringValue)
+			case *otlpcommonv1.AnyValue_BytesValue:
+				mpw.Write(x.BytesValue)
+			default:
+				// default to something troubleshootable
+				fmt.Fprintf(mpw, "UNHANDLED: %+v", x)
 			}
 		}
 	}
-
-	return formattedLines, nil
+	if formattedLines.Len() == 0 {
+		return []string{}, nil
+	}
+	return strings.Split(formattedLines.String(), "\n"), nil
 }
 
 func toolErrorMessage(err error) string {
@@ -937,6 +930,7 @@ func (m *MCP) Builtins(srv *dagql.Server, tools []LLMTool) ([]LLMTool, error) {
 					trace.WithAttributes(
 						attribute.String(telemetry.UIMessageAttr, "received"),
 						attribute.String(telemetry.UIActorEmojiAttr, "💭"),
+						attribute.Bool("dagger.io/llm", true),
 					),
 				)
 				defer telemetry.End(span, func() error { return rerr })
@@ -1116,7 +1110,7 @@ func (m *MCP) Builtins(srv *dagql.Server, tools []LLMTool) ([]LLMTool, error) {
 				attrs = append(attrs,
 					attribute.String(telemetry.DagDigestAttr, id.Digest().String()),
 					attribute.String(telemetry.DagCallAttr, callAttr),
-					attribute.String(telemetry.DagCallScopeAttr, "llm"),
+					attribute.Bool("dagger.io/llm", true),
 				)
 				return nil
 			}()

--- a/core/multiprefixw/prefixw.go
+++ b/core/multiprefixw/prefixw.go
@@ -1,0 +1,64 @@
+package multiprefixw
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+type Writer struct {
+	w              io.Writer
+	prefix         string
+	lastPrefix     string
+	lineTerminated bool
+}
+
+func New(w io.Writer) *Writer {
+	return &Writer{w: w}
+}
+
+func (pw *Writer) SetPrefix(prefix string) {
+	pw.prefix = prefix
+}
+
+func (pw *Writer) Write(p []byte) (int, error) {
+	for len(p) > 0 {
+		n := bytes.IndexByte(p, '\n')
+		if n < 0 {
+			if err := pw.writePrefix(pw.prefix); err != nil {
+				return 0, err
+			}
+			if _, err := pw.w.Write(p); err != nil {
+				return 0, err
+			}
+			pw.lineTerminated = false
+			break
+		}
+		if err := pw.writePrefix(pw.prefix); err != nil {
+			return 0, err
+		}
+		if _, err := pw.w.Write(p[:n+1]); err != nil {
+			return 0, err
+		}
+		p = p[n+1:]
+		pw.lineTerminated = true
+	}
+	return len(p), nil
+}
+
+func (pw *Writer) writePrefix(prefix string) error {
+	if pw.lastPrefix == prefix && !pw.lineTerminated {
+		// same prefix and we're not a new line, so keep on going
+		return nil
+	}
+	if pw.lastPrefix != "" && pw.lastPrefix != prefix && !pw.lineTerminated {
+		// new prefix and last line was not terminated, so manually add linebreak
+		if _, err := fmt.Fprint(pw.w, "\u23CE\n"); err != nil { // ⏎
+			return err
+		}
+	}
+	// write our prefix and remember it
+	_, err := fmt.Fprint(pw.w, prefix)
+	pw.lastPrefix = prefix
+	return err
+}

--- a/core/multiprefixw/prefixw_test.go
+++ b/core/multiprefixw/prefixw_test.go
@@ -1,0 +1,74 @@
+package multiprefixw
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixedWriter_SingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	pw := New(&buf)
+
+	pw.SetPrefix("[web] ")
+	_, err := pw.Write([]byte("hello world\n"))
+	require.NoError(t, err)
+	require.Equal(t, "[web] hello world\n", buf.String())
+}
+
+func TestPrefixedWriter_PrefixSwitch(t *testing.T) {
+	var buf bytes.Buffer
+	pw := New(&buf)
+
+	pw.SetPrefix("[web] ")
+	_, err := pw.Write([]byte("hello\n"))
+	require.NoError(t, err)
+	pw.SetPrefix("[db] ")
+	_, err = pw.Write([]byte("querying\n"))
+	require.NoError(t, err)
+	expected := "[web] hello\n[db] querying\n"
+	require.Equal(t, expected, buf.String())
+}
+
+func TestPrefixedWriter_MultiLineSinglePrefix(t *testing.T) {
+	var buf bytes.Buffer
+	pw := New(&buf)
+
+	pw.SetPrefix("[worker] ")
+	_, err := pw.Write([]byte("first line\nsecond line\n"))
+	require.NoError(t, err)
+	require.Equal(t, "[worker] first line\n[worker] second line\n", buf.String())
+}
+
+func TestPrefixedWriter_NoNewlineBufferingAndSwitch(t *testing.T) {
+	var buf bytes.Buffer
+	pw := New(&buf)
+
+	pw.SetPrefix("[A] ")
+	_, err := pw.Write([]byte("partial"))
+	require.NoError(t, err)
+	_, err = pw.Write([]byte(" line"))
+	require.NoError(t, err)
+	pw.SetPrefix("[B] ")
+	_, err = pw.Write([]byte("other\n"))
+	require.NoError(t, err)
+
+	expected := "[A] partial line\u23CE\n[B] other\n"
+	require.Equal(t, expected, buf.String())
+}
+
+func TestPrefixedWriter_MultipleSwitches(t *testing.T) {
+	var buf bytes.Buffer
+	pw := New(&buf)
+
+	pw.SetPrefix("[x] ")
+	_, err := pw.Write([]byte("foo\nbar"))
+	require.NoError(t, err)
+	pw.SetPrefix("[y] ")
+	_, err = pw.Write([]byte("baz\nqux"))
+	require.NoError(t, err)
+	expected :=
+		"[x] foo\n[x] bar\u23CE\n[y] baz\n[y] qux"
+	require.Equal(t, expected, buf.String())
+}

--- a/core/query.go
+++ b/core/query.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/clientdb"
 	"github.com/dagger/dagger/engine/server/resource"
 )
 
@@ -110,6 +111,9 @@ type Server interface {
 
 	// A shared engine-wide salt used when creating cache keys for secrets based on their plaintext
 	SecretSalt() []byte
+
+	// Open a client's telemetry database.
+	ClientTelemetry(ctc context.Context, sessID, clientID string) (*clientdb.Queries, func() error, error)
 }
 
 func NewRoot(srv Server) *Query {

--- a/engine/clientdb/generate.go
+++ b/engine/clientdb/generate.go
@@ -1,3 +1,56 @@
 package clientdb
 
+import "context"
+
 //go:generate go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.26.0 generate
+
+// NOTE: this one is done manually since sqlc doesn't support json_each
+const selectLinkedSpans = `-- name: SelectLinkedSpans :many
+;
+
+SELECT DISTINCT
+  s.trace_id AS trace_id,
+  s.span_id AS source_span_id,
+  CAST(l.value->>'$.traceId' AS TEXT) AS target_trace_id,
+  CAST(l.value->>'$.spanId' AS TEXT) AS target_span_id
+FROM
+  spans s,
+  json_each(s.links) l
+WHERE
+  target_span_id = ?
+`
+
+type SelectLinkedSpansRow struct {
+	TraceID       string
+	SourceSpanID  string
+	TargetTraceID string
+	TargetSpanID  string
+}
+
+func (q *Queries) SelectLinkedSpans(ctx context.Context, spanID string) ([]SelectLinkedSpansRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectLinkedSpans, spanID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectLinkedSpansRow
+	for rows.Next() {
+		var i SelectLinkedSpansRow
+		if err := rows.Scan(
+			&i.TraceID,
+			&i.SourceSpanID,
+			&i.TargetTraceID,
+			&i.TargetSpanID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/engine/clientdb/queries.sql
+++ b/engine/clientdb/queries.sql
@@ -1,5 +1,6 @@
 -- name: InsertSpan :one
-INSERT INTO spans (
+INSERT INTO
+  spans (
     trace_id,
     span_id,
     trace_state,
@@ -20,12 +21,34 @@ INSERT INTO spans (
     instrumentation_scope,
     resource,
     resource_schema_url
-) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-) RETURNING id;
+  )
+VALUES
+  (
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?
+  ) RETURNING id;
 
 -- name: InsertLog :one
-INSERT INTO logs (
+INSERT INTO
+  logs (
     trace_id,
     span_id,
     timestamp,
@@ -36,22 +59,70 @@ INSERT INTO logs (
     instrumentation_scope,
     resource,
     resource_schema_url
-) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-) RETURNING id;
+  )
+VALUES
+  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id;
 
 -- name: InsertMetric :one
-INSERT INTO metrics (
-    data
-) VALUES (
-    ?
-) RETURNING id;
+INSERT INTO
+  metrics (data)
+VALUES
+  (?) RETURNING id;
 
 -- name: SelectSpansSince :many
-SELECT * FROM spans WHERE id > ? ORDER BY id ASC LIMIT ?;
+SELECT
+  *
+FROM
+  spans
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?;
 
 -- name: SelectLogsSince :many
-SELECT * FROM logs WHERE id > ? ORDER BY id ASC LIMIT ?;
+SELECT
+  *
+FROM
+  logs
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?;
 
 -- name: SelectMetricsSince :many
-SELECT * FROM metrics WHERE id > ? ORDER BY id ASC LIMIT ?;
+SELECT
+  *
+FROM
+  metrics
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?;
+
+-- name: SelectLogsTimespan :many
+SELECT
+  *
+FROM
+  logs
+WHERE
+  timestamp > @start
+  AND timestamp <= @end
+ORDER BY
+  timestamp ASC
+LIMIT
+  ?;
+
+-- name: SelectSpan :one
+SELECT
+  *
+FROM
+  spans
+WHERE
+  trace_id = ?
+  AND span_id = ?;

--- a/engine/clientdb/queries.sql.go
+++ b/engine/clientdb/queries.sql.go
@@ -11,7 +11,8 @@ import (
 )
 
 const insertLog = `-- name: InsertLog :one
-INSERT INTO logs (
+INSERT INTO
+  logs (
     trace_id,
     span_id,
     timestamp,
@@ -22,9 +23,9 @@ INSERT INTO logs (
     instrumentation_scope,
     resource,
     resource_schema_url
-) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-) RETURNING id
+  )
+VALUES
+  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
 `
 
 type InsertLogParams struct {
@@ -59,11 +60,10 @@ func (q *Queries) InsertLog(ctx context.Context, arg InsertLogParams) (int64, er
 }
 
 const insertMetric = `-- name: InsertMetric :one
-INSERT INTO metrics (
-    data
-) VALUES (
-    ?
-) RETURNING id
+INSERT INTO
+  metrics (data)
+VALUES
+  (?) RETURNING id
 `
 
 func (q *Queries) InsertMetric(ctx context.Context, data []byte) (int64, error) {
@@ -74,7 +74,8 @@ func (q *Queries) InsertMetric(ctx context.Context, data []byte) (int64, error) 
 }
 
 const insertSpan = `-- name: InsertSpan :one
-INSERT INTO spans (
+INSERT INTO
+  spans (
     trace_id,
     span_id,
     trace_state,
@@ -95,9 +96,30 @@ INSERT INTO spans (
     instrumentation_scope,
     resource,
     resource_schema_url
-) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-) RETURNING id
+  )
+VALUES
+  (
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?
+  ) RETURNING id
 `
 
 type InsertSpanParams struct {
@@ -152,7 +174,16 @@ func (q *Queries) InsertSpan(ctx context.Context, arg InsertSpanParams) (int64, 
 }
 
 const selectLogsSince = `-- name: SelectLogsSince :many
-SELECT id, trace_id, span_id, timestamp, severity_number, severity_text, body, attributes, instrumentation_scope, resource, resource_schema_url FROM logs WHERE id > ? ORDER BY id ASC LIMIT ?
+SELECT
+  id, trace_id, span_id, timestamp, severity_number, severity_text, body, attributes, instrumentation_scope, resource, resource_schema_url
+FROM
+  logs
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?
 `
 
 type SelectLogsSinceParams struct {
@@ -195,8 +226,72 @@ func (q *Queries) SelectLogsSince(ctx context.Context, arg SelectLogsSinceParams
 	return items, nil
 }
 
+const selectLogsTimespan = `-- name: SelectLogsTimespan :many
+SELECT
+  id, trace_id, span_id, timestamp, severity_number, severity_text, body, attributes, instrumentation_scope, resource, resource_schema_url
+FROM
+  logs
+WHERE
+  timestamp > ?
+  AND timestamp <= ?
+ORDER BY
+  timestamp ASC
+LIMIT
+  ?
+`
+
+type SelectLogsTimespanParams struct {
+	Start int64
+	End   int64
+	Limit int64
+}
+
+func (q *Queries) SelectLogsTimespan(ctx context.Context, arg SelectLogsTimespanParams) ([]Log, error) {
+	rows, err := q.db.QueryContext(ctx, selectLogsTimespan, arg.Start, arg.End, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Log
+	for rows.Next() {
+		var i Log
+		if err := rows.Scan(
+			&i.ID,
+			&i.TraceID,
+			&i.SpanID,
+			&i.Timestamp,
+			&i.SeverityNumber,
+			&i.SeverityText,
+			&i.Body,
+			&i.Attributes,
+			&i.InstrumentationScope,
+			&i.Resource,
+			&i.ResourceSchemaUrl,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectMetricsSince = `-- name: SelectMetricsSince :many
-SELECT id, data FROM metrics WHERE id > ? ORDER BY id ASC LIMIT ?
+SELECT
+  id, data
+FROM
+  metrics
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?
 `
 
 type SelectMetricsSinceParams struct {
@@ -227,8 +322,61 @@ func (q *Queries) SelectMetricsSince(ctx context.Context, arg SelectMetricsSince
 	return items, nil
 }
 
+const selectSpan = `-- name: SelectSpan :one
+SELECT
+  id, trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time, end_time, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, instrumentation_scope, resource, resource_schema_url
+FROM
+  spans
+WHERE
+  trace_id = ?
+  AND span_id = ?
+`
+
+type SelectSpanParams struct {
+	TraceID string
+	SpanID  string
+}
+
+func (q *Queries) SelectSpan(ctx context.Context, arg SelectSpanParams) (Span, error) {
+	row := q.db.QueryRowContext(ctx, selectSpan, arg.TraceID, arg.SpanID)
+	var i Span
+	err := row.Scan(
+		&i.ID,
+		&i.TraceID,
+		&i.SpanID,
+		&i.TraceState,
+		&i.ParentSpanID,
+		&i.Flags,
+		&i.Name,
+		&i.Kind,
+		&i.StartTime,
+		&i.EndTime,
+		&i.Attributes,
+		&i.DroppedAttributesCount,
+		&i.Events,
+		&i.DroppedEventsCount,
+		&i.Links,
+		&i.DroppedLinksCount,
+		&i.StatusCode,
+		&i.StatusMessage,
+		&i.InstrumentationScope,
+		&i.Resource,
+		&i.ResourceSchemaUrl,
+	)
+	return i, err
+}
+
 const selectSpansSince = `-- name: SelectSpansSince :many
-SELECT id, trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time, end_time, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, instrumentation_scope, resource, resource_schema_url FROM spans WHERE id > ? ORDER BY id ASC LIMIT ?
+SELECT
+  id, trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time, end_time, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, instrumentation_scope, resource, resource_schema_url
+FROM
+  spans
+WHERE
+  id > ?
+ORDER BY
+  id ASC
+LIMIT
+  ?
 `
 
 type SelectSpansSinceParams struct {

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/hack/evals
+++ b/hack/evals
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+# Get number of runs from command line argument, default to 3 if not provided
+RUNS=${1:-3}
+
+# Generate default timestamp-based filename with minute precision
+TIMESTAMP=$(date +"%Y%m%d-%H%M")
+
+# Define output files - allow overriding with environment variables
+NEW_CSV=${NEW_CSV:-"evals/$TIMESTAMP/new.csv"}
+OLD_CSV=${OLD_CSV:-"evals/$TIMESTAMP/old.csv"}
+
+# Ensure parent dir exists
+mkdir -p $(dirname $NEW_CSV)
+
+# Flag to determine if old dagger command should be run
+RUN_OLD=${RUN_OLD:-false}
+
+# Function to determine if header should be included
+function add_header() {
+  local file=$1
+  # Add header if file doesn't exist AND it's the first iteration
+  if [ ! -f "$file" ] && [ $2 -eq 1 ]; then
+    echo " --header"
+  else
+    echo ""
+  fi
+}
+
+echo "Running $RUNS iterations"
+echo "New results will be saved to: $NEW_CSV"
+if [ "$RUN_OLD" = true ]; then
+  echo "Old results will be saved to: $OLD_CSV"
+fi
+
+for i in $(seq $RUNS); do
+  if [ "$RUN_OLD" = true ]; then
+    ./bin/dagger-old call -m \
+      modules/evaluator \
+      evals-across-models csv$(add_header "$OLD_CSV" $i) \
+      >> "$OLD_CSV"
+  fi
+
+  ./bin/dagger call \
+    -m modules/evaluator \
+    evals-across-models \
+    csv$(add_header "$NEW_CSV" $i) \
+    >> "$NEW_CSV"
+done
+
+echo "Evaluation complete"
+echo "Results saved to: $NEW_CSV"


### PR DESCRIPTION
Currently when the model runs something like `withExec("date")` it doesn't see any output - it has to call `stdout` or `stderr` to see it.

[This trace](https://v3.dagger.cloud/dagger/traces/e6564e910d46f6edd5521f8269865e38?listen=3c006823814ca5e7&listen=2d80b1fc091212a2&listen=5e79c32a6e943e80&listen=af3bf6f0883c0ffb&listen=ca8ad84d1e7e1729&span=bb71b07aef15c394) shows the model trying to run various diagnostic commands to check if `go` is installed, but it was never convinced, since it never called `stdout` to check and I guess couldn't tell the container ran and succeeded.[^1]

A human running `withExec` + `sync` would see this output somewhere in the trace, so it's a little unfair that the LLM can't.

---

With this PR we'll capture the logs sent to telemetry, for all spans that descend from the tool call, so the model sees something like this:

```
🧑 💬 run the date command

🤖 🛠️ Container_with_exec {"args":["date"]}
🪙 Tokens Used: 5381 in => 17 out

🛠️ 💬 {
  "result": "Container#8"
}

<logs>
Container.withExec(date):
Thu May  8 14:15:36 UTC 2025
</logs>
```

#### What about cache hits?

This is a caveat worth mentioning - we only see logs when something actually _runs_, so cache hits won't show anything. It's possible that the model in the case linked above would end up in the same confusing path if those were all cache hits.

#### What if the logs are spammy?

Currently it'll show only the last 10 lines, and show `... snipped 123 lines ...` if there were more.

If the model needs more, it can use e.g. `stdout` to get the full result, or we could consider adding a `logs` tool (more on that below).

#### What about line prefixing?

Heroku/Docker Compose-style line prefixes came up, so I implemented it, but ended up down a slightly different path. Instead of prefixing each line, there's a single header (`Container.withExec(date):` above). That way we can save tokens in the common case where there's a bunch of lines printed by one long command (`Container.withExec(cowsay hello world foo bar)`).

The code supports both if we want to use it - it'll "do the right thing" based on the presence of a `\n` in the prefix.

#### What about global logs?

There's an important nuance above: we only show logs for spans descending from the tool call.

An earlier implementation showed _all_ logs, across the entire client, but in testing that felt really problematic. Imagine you're running 10 evals in parallel: now they'll all cross-talk, muddying the results.

There's some upside to be gained there for sure - like it would be amazing to see the logs from a service that a tool call reached - but it seems safer to start tightly scoped and expand more cautiously.

* [ ] Maybe add a `logs` tool? It could support a configurable range (timestamp? offset/limit?) or even grepping. This would be pretty easy to add but we should prove the need first.

[^1]: Maybe that would help too - a stronger indication that the `withExec` succeeded, like showing exit code 0? But the hard part is keeping it generic.