### PR TITLE
chore: bump minimum engine version to v0.18.6

### DIFF
--- a/engine/version.go
+++ b/engine/version.go
@@ -31,7 +31,7 @@ var (
 
 	// MinimumEngineVersion is used by the client to determine the minimum
 	// allowed engine version that can be used by that client.
-	MinimumEngineVersion = "v0.16.0"
+	MinimumEngineVersion = "v0.18.6"
 
 	// MinimumClientVersion is used by the engine to determine the minimum
 	// allowed client version that can connect to that engine.


### PR DESCRIPTION
We now use the `IncludeDependencies` arg unconditionally in the CLI (see https://github.com/dagger/dagger/pull/10118) - but this arg was only introduced in v0.18.6, so we should error cleanly if there's a mismatch here.