### PR TITLE
Docs: missing import in interface example

### DIFF
--- a/docs/current_docs/api/snippets/interfaces/declarations/go/main.go
+++ b/docs/current_docs/api/snippets/interfaces/declarations/go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"dagger/my-module/internal/dagger"
 )
 
 type MyModule struct{}


### PR DESCRIPTION
This import is required to use `DaggerObject` embedded in the interface. The editor likes to automatically remove this if it's not referenced directly as `dagger.DaggerObject` but it's valid as-is