### PR TITLE
tests: avoid flake from error caching

### DIFF
--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -2673,12 +2673,12 @@ func (CallSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
 				"core", "--silent",
 				"container",
 				"from", "--address", alpineImage,
-				"with-exec", "--args", "ls,wat",
+				"with-exec", "--args", "ls,wat-call1",
 				"stdout",
 			)).
 			Sync(ctx)
 
-		requireErrOut(t, err, "ls: wat: No such file or directory")
+		requireErrOut(t, err, "ls: wat-call1: No such file or directory")
 	})
 
 	t.Run("plain", func(ctx context.Context, t *testctx.T) {
@@ -2689,12 +2689,12 @@ func (CallSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
 				"core", "--progress", "plain",
 				"container",
 				"from", "--address", alpineImage,
-				"with-exec", "--args", "ls,wat",
+				"with-exec", "--args", "ls,wat-call2",
 				"stdout",
 			)).
 			Sync(ctx)
 
-		requireErrOut(t, err, "ls: wat: No such file or directory")
+		requireErrOut(t, err, "ls: wat-call2: No such file or directory")
 	})
 }
 

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -921,11 +921,11 @@ func (ShellSuite) TestCommandStateArgs(ctx context.Context, t *testctx.T) {
 
 func (ShellSuite) TestExecStderr(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
-	script := fmt.Sprintf("container | from %s | with-exec ls wat | stdout", alpineImage)
+	script := fmt.Sprintf("container | from %s | with-exec ls wat-shell | stdout", alpineImage)
 	_, err := daggerCliBase(t, c).
 		With(daggerShell(script)).
 		Sync(ctx)
-	requireErrOut(t, err, "ls: wat: No such file or directory")
+	requireErrOut(t, err, "ls: wat-shell: No such file or directory")
 }
 
 func (ShellSuite) TestInstall(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
As we discovered recently, errors can cache between two sessions when they're active at the same time. This is a pain, and should probably be considered a bug - see #10320.

However, these tests shouldn't be failing - we've had this behavior *forever*, it's not a new failure. It's also not what we're testing, the flakes just add to our CI noise - we're aware it's an issue, and we should fix it (and add a test specifically for it).