### PR TITLE
llm: durable to Bedrock API quirks

### DIFF
--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"dagger.io/dagger/telemetry"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/azure"
 	"github.com/openai/openai-go/option"
@@ -272,6 +273,10 @@ func (c *OpenAIClient) queryWithoutStreaming(
 func convertOpenAIToolCalls(calls []openai.ChatCompletionMessageToolCall) ([]LLMToolCall, error) {
 	var toolCalls []LLMToolCall
 	for _, call := range calls {
+		if call.Function.Name == "" {
+			slog.Warn("skipping tool call with empty name", "toolCall", call)
+			continue
+		}
 		args := map[string]any{}
 		if call.Function.Arguments != "" {
 			if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {

--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -272,9 +272,11 @@ func (c *OpenAIClient) queryWithoutStreaming(
 func convertOpenAIToolCalls(calls []openai.ChatCompletionMessageToolCall) ([]LLMToolCall, error) {
 	var toolCalls []LLMToolCall
 	for _, call := range calls {
-		var args map[string]any
-		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal tool call arguments: %w", err)
+		args := map[string]any{}
+		if call.Function.Arguments != "" {
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal tool call arguments: %w", err)
+			}
 		}
 		toolCalls = append(toolCalls, LLMToolCall{
 			ID: call.ID,


### PR DESCRIPTION
Ran into these trying Dagger with behind-the-firewall OpenAI provider. Seems like it generates janky function calls for some reason. Adding these checks fixed everything. :shrug: 

This is two commits but I suspect they both fix one issue, I just happened to hit one error before the other. It's probably generating a fully empty function call struct.