### PR TITLE
python: fix incorrectly generated "sync" function in codegen

### DIFF
--- a/sdk/python/.changes/unreleased/Fixed-20250512-152354.yaml
+++ b/sdk/python/.changes/unreleased/Fixed-20250512-152354.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed regression where Dagger module functions named "sync" would generate an incorrect client binding
+time: 2025-05-12T15:23:54.509983Z
+custom:
+    Author: helderco
+    PR: "10381"

--- a/sdk/python/codegen/src/codegen/generator.py
+++ b/sdk/python/codegen/src/codegen/generator.py
@@ -537,7 +537,6 @@ class _ObjectField:
         self.is_list = is_list_of_objects_type(field.type)
         self.is_exec = self.is_leaf or self.is_list
         self.is_void = self.is_leaf and self.named_type.name == "Void"
-        self.is_sync = self.is_leaf and self.name == "sync"
         self.type = format_output_type(field.type).replace("Query", "Client")
 
         # Currently, `sync` is the only field where the error is all we
@@ -552,6 +551,7 @@ class _ObjectField:
                 self.type = converted
                 self.convert_id = True
 
+        self.is_sync = self.convert_id and self.name == "sync"
         self.id_query_field = id_query_field(self.named_type)
 
     @joiner


### PR DESCRIPTION
This fixes a regression, reported in [Discord](https://discord.com/channels/707636530424053791/1369680570917060740).

If user had a function named "sync" returning a leaf value in a dependency, it was getting generated as the special case "sync" functions we have in core.

## Example

Dependency:
```python
from dagger import function, object_type


@object_type
class Dep:
    @function
    def sync(self) -> str:
        return "hello world"
```

Caller module:
```python
from dagger import dag, function, object_type


@object_type
class MyModule:
    @function
    async def test(self) -> str:
        return await dag.dep().sync()
```

Calling:
```
 ❯ dagger -c test
```
Result:
```diff
- ! Coroutine factory method dagger.client.gen.Dep.sync() return <dagger.Dep object at 0xffff6ff73610> was expected to be of type <class 'str'>.
+ hello world
```