### PR TITLE
docs: improve llms-full.txt with right site path

### DIFF
--- a/docs/plugins/llms-txt-plugin/index.ts
+++ b/docs/plugins/llms-txt-plugin/index.ts
@@ -41,7 +41,7 @@ const llmsTxtPlugin: Plugin = async function pluginLlmsTxt(context) {
               .replace(/\.mdx$/, "");
 
             // Construct the full URL
-            const fullUrl = `https://www.prisma.io/docs/${urlPath}`;
+            const fullUrl = `https://docs.dagger.io/${urlPath}`;
 
             // strip frontmatter
             const contentWithoutFrontmatter = content.replace(/^---\n[\s\S]*?\n---\n/, "");


### PR DESCRIPTION
I found #10089 bring llms-full.txt into doc site. But some link in llms-full.txt not right. So this pr correct it.
![image](https://github.com/user-attachments/assets/47602e0e-3785-41a5-8312-251f66e80769)
