### PR TITLE
chore: fix error stutter in contenthash

### DIFF
--- a/core/contenthash.go
+++ b/core/contenthash.go
@@ -32,7 +32,7 @@ func MakeDirectoryContentHashed(
 ) (retInst dagql.Instance[*Directory], err error) {
 	dgst, err := GetContentHashFromDirectory(ctx, bk, dirInst)
 	if err != nil {
-		return retInst, fmt.Errorf("failed to get content hash: %w", err)
+		return retInst, err
 	}
 
 	return dirInst.WithDigest(dgst), nil


### PR DESCRIPTION
We don't need to wrap the error again, we've already got a neat wrapped error at this point.

See the stutter in the message at https://github.com/dagger/dagger/issues/10390.