### PR TITLE
Add support for environment variables to function args

### DIFF
--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -97,6 +97,14 @@ func TestParsePragmaComment(t *testing.T) {
 			},
 			rest: "line 1\r\nline 2\r\nline 3",
 		},
+		{
+			name:    "default environment variable",
+			comment: "+defaultEnv=MY_VAR",
+			expected: map[string]string{
+				"defaultEnv": "MY_VAR",
+			},
+			rest: "",
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -1,112 +1,113 @@
 fragment TypeDefRefParts on TypeDef {
-	kind
-	optional
-	asObject {
-		name
-	}
-	asInterface {
-		name
-	}
-	asInput {
-		name
-	}
-	asScalar {
-		name
-	}
-	asEnum {
-		name
-	}
-	asList {
-		elementTypeDef {
-			kind
-			asObject {
-				name
-			}
-			asInterface {
-				name
-			}
-			asInput {
-				name
-			}
-			asScalar {
-				name
-			}
-			asEnum {
-				name
-			}
-		}
-	}
+    kind
+    optional
+    asObject {
+        name
+    }
+    asInterface {
+        name
+    }
+    asInput {
+        name
+    }
+    asScalar {
+        name
+    }
+    asEnum {
+        name
+    }
+    asList {
+        elementTypeDef {
+            kind
+            asObject {
+                name
+            }
+            asInterface {
+                name
+            }
+            asInput {
+                name
+            }
+            asScalar {
+                name
+            }
+            asEnum {
+                name
+            }
+        }
+    }
 }
 
 fragment FunctionParts on Function {
-	name
-	description
-	returnType {
-		...TypeDefRefParts
-	}
-	args {
-		name
-		description
-		defaultValue
+    name
+    description
+    returnType {
+        ...TypeDefRefParts
+    }
+    args {
+        name
+        description
+        defaultValue
         defaultPath
-		ignore
-		typeDef {
-			...TypeDefRefParts
-		}
-	}
+        defaultEnv
+        ignore
+        typeDef {
+            ...TypeDefRefParts
+        }
+    }
 }
 
 fragment FieldParts on FieldTypeDef {
-	name
-	description
-	typeDef {
-		...TypeDefRefParts
-	}
+    name
+    description
+    typeDef {
+        ...TypeDefRefParts
+    }
 }
 
 query TypeDefs {
-	typeDefs: currentTypeDefs {
-		kind
-		optional
-		asObject {
-			name
-			description
-			sourceModuleName
-			constructor {
-				...FunctionParts
-			}
-			functions {
-				...FunctionParts
-			}
-			fields {
-				...FieldParts
-			}
-		}
-		asScalar {
-			name
-			description
-		}
-		asEnum {
-			name
-			description
-			values {
-				name
-			    description
-			}
-		}
-		asInterface {
-			name
-			description
-			sourceModuleName
-			functions {
-				...FunctionParts
-			}
-		}
-		asInput {
-			name
-			fields {
-				...FieldParts
-			}
-		}
-	}
+    typeDefs: currentTypeDefs {
+        kind
+        optional
+        asObject {
+            name
+            description
+            sourceModuleName
+            constructor {
+                ...FunctionParts
+            }
+            functions {
+                ...FunctionParts
+            }
+            fields {
+                ...FieldParts
+            }
+        }
+        asScalar {
+            name
+            description
+        }
+        asEnum {
+            name
+            description
+            values {
+                name
+                description
+            }
+        }
+        asInterface {
+            name
+            description
+            sourceModuleName
+            functions {
+                ...FunctionParts
+            }
+        }
+        asInput {
+            name
+            fields {
+                ...FieldParts
+            }
+        }
+    }
 }

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -119,7 +119,7 @@ func (fn *Function) WithDescription(desc string) *Function {
 	return fn
 }
 
-func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, ignore []string, sourceMap *SourceMap) *Function {
+func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, defaultEnv string, ignore []string, sourceMap *SourceMap) *Function {
 	fn = fn.Clone()
 	fn.Args = append(fn.Args, &FunctionArg{
 		Name:         strcase.ToLowerCamel(name),
@@ -129,6 +129,7 @@ func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultV
 		DefaultValue: defaultValue,
 		OriginalName: name,
 		DefaultPath:  defaultPath,
+		DefaultEnv:   defaultEnv,
 		Ignore:       ignore,
 	})
 	return fn
@@ -201,6 +202,7 @@ type FunctionArg struct {
 	TypeDef      *TypeDef   `field:"true" doc:"The type of the argument."`
 	DefaultValue JSON       `field:"true" doc:"A default value to use for this argument when not explicitly set by the caller, if any."`
 	DefaultPath  string     `field:"true" doc:"Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"`
+	DefaultEnv   string     `field:"true" doc:"If the argument is not set, load it from the given environment variable"`
 	Ignore       []string   `field:"true" doc:"Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."`
 
 	// Below are not in public API


### PR DESCRIPTION
This PR adds the ability to define `+defaultEnv="FOO"` to function arguments to reduce verbosity and improve developer experience.

There are a few things we need to discuss in terms of implementation but I wanted to get the ball rolling.