### PR TITLE
ci: fix publish job to use v0.18.7

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.18.6"
+    default: "v0.18.7"
     required: false
 
   dev-engine:


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/10395