### PR TITLE
fix: ensure dagger develop/publish do not take args

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -500,6 +500,7 @@ This command is idempotent: you can run it at any time, any number of times. It 
 4. Ensure that a module implementation exists, and create a starter template if not
 5. Generate the latest client bindings for the Dagger API and installed dependencies
 `,
+	Args:    cobra.NoArgs,
 	GroupID: moduleGroup.ID,
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
@@ -686,6 +687,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 		daDaggerverse,
 	),
 	GroupID: moduleGroup.ID,
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngine(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {


### PR DESCRIPTION
Running `dagger develop path/to/module` is an easy typo - however, it's not valid, you need to use the `-m` flag. This didn't error out though, we just accepted any additional args and ignored them.

We should explicitly forbid args to these functions if we're not using them, which will help prevent typos.