### PR TITLE
[#10398] DQE - added methods to improve error messages

### DIFF
--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/DaggerQueryException.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/DaggerQueryException.java
@@ -1,10 +1,23 @@
 package io.dagger.client;
 
-import io.smallrye.graphql.client.GraphQLError;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import io.smallrye.graphql.client.GraphQLError;
 
 public class DaggerQueryException extends Exception {
+
+  private static final String SIMPLE_MESSAGE = "Message: [%s]\nPath: [%s]\nType Code: [%s]\n";
+  private static final String ENANCHED_MESSAGE =
+      "Message: [%s]\nPath: [%s]\nType Code: [%s]\nExit Code: [%s]\nCmd: [%s]\n";
+  private static final String FULL_MESSAGE =
+      "Message: [%s]\nPath: [%s]\nType Code: [%s]\nExit Code: [%s]\nCmd: [%s]\nSTDERR: [%s]\n";
+
+  protected static final String TYPE_KEY = "_type";
+  protected static final String EXIT_CODE_KEY = "exitCode";
+  protected static final String CMD_KEY = "cmd";
+  protected static final String STDERR_KEY = "stderr";
 
   private GraphQLError[] errors;
 
@@ -14,11 +27,34 @@ public class DaggerQueryException extends Exception {
   }
 
   public DaggerQueryException(GraphQLError... errors) {
-    super(Arrays.stream(errors).map(GraphQLError::getMessage).collect(Collectors.joining("\n")));
+    super(Arrays
+        .stream(errors).map(e -> String.format(SIMPLE_MESSAGE, e.getMessage(),
+            StringUtils.join(e.getPath(), ","), e.getExtensions().getOrDefault(TYPE_KEY, null)))
+        .collect(Collectors.joining("\n")));
     this.errors = errors;
   }
 
   public GraphQLError[] getErrors() {
     return errors;
+  }
+
+  public String toEnanchedMessage() {
+    return Arrays.stream(errors).map(e -> String.format(ENANCHED_MESSAGE, e.getMessage(),
+        StringUtils.join(e.getPath(), ","), e.getExtensions().getOrDefault(TYPE_KEY, null),
+        e.getExtensions().getOrDefault(EXIT_CODE_KEY, null),
+        StringUtils.join(
+            ((Object[]) e.getExtensions().getOrDefault(CMD_KEY, Collections.emptyList())), ",")))
+        .collect(Collectors.joining("\n"));
+  }
+
+  public String toFullMessage() {
+    return Arrays.stream(errors)
+        .map(e -> String.format(FULL_MESSAGE, e.getMessage(), StringUtils.join(e.getPath(), ","),
+            e.getExtensions().getOrDefault(TYPE_KEY, null),
+            e.getExtensions().getOrDefault(EXIT_CODE_KEY, null),
+            StringUtils.join(
+                ((Object[]) e.getExtensions().getOrDefault(CMD_KEY, Collections.emptyList())), ","),
+            e.getExtensions().getOrDefault(STDERR_KEY, null)))
+        .collect(Collectors.joining("\n"));
   }
 }

--- a/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/DaggerQueryExceptionTest.java
+++ b/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/DaggerQueryExceptionTest.java
@@ -1,0 +1,92 @@
+package io.dagger.client;
+
+import static io.dagger.client.DaggerQueryException.CMD_KEY;
+import static io.dagger.client.DaggerQueryException.EXIT_CODE_KEY;
+import static io.dagger.client.DaggerQueryException.STDERR_KEY;
+import static io.dagger.client.DaggerQueryException.TYPE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import io.smallrye.graphql.client.GraphQLError;
+
+
+public class DaggerQueryExceptionTest {
+
+    @Test
+    void shouldReturnDefaultMessage() {
+        GraphQLError error =
+                buildError("ERROR", new Object[] {"container", "from", "withExec", "stdout"},
+                        Map.of(TYPE_KEY, "EXEC_ERROR"));
+        GraphQLError error2 = buildError("ERROR2",
+                new Object[] {"container", "from", "withExec", "withExec", "stdout"},
+                Map.of(TYPE_KEY, "EXEC_ERROR"));
+
+        String result = new DaggerQueryException(error, error2).getMessage();
+        String expected =
+                "Message: [ERROR]\nPath: [container,from,withExec,stdout]\nType Code: [EXEC_ERROR]\n\nMessage: [ERROR2]\nPath: [container,from,withExec,withExec,stdout]\nType Code: [EXEC_ERROR]\n";
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnEnanchedMessage() {
+        GraphQLError error = buildError("ERROR",
+                new Object[] {"container", "from", "withExec", "stdout"}, Map.of(TYPE_KEY,
+                        "EXEC_ERROR", EXIT_CODE_KEY, "1", CMD_KEY, new Object[] {"cat", "WRONG"}));
+        GraphQLError error2 = buildError("ERROR2",
+                new Object[] {"container", "from", "withExec", "withExec", "stdout"},
+                Map.of(TYPE_KEY, "EXEC_ERROR", EXIT_CODE_KEY, "2", CMD_KEY,
+                        new Object[] {"cat", "WRONG2"}));
+
+        String result = new DaggerQueryException(error, error2).toEnanchedMessage();
+        String expected =
+                "Message: [ERROR]\nPath: [container,from,withExec,stdout]\nType Code: [EXEC_ERROR]\nExit Code: [1]\nCmd: [cat,WRONG]\n\nMessage: [ERROR2]\nPath: [container,from,withExec,withExec,stdout]\nType Code: [EXEC_ERROR]\nExit Code: [2]\nCmd: [cat,WRONG2]\n";
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnFullMessage() {
+        GraphQLError error =
+                buildError("ERROR", new Object[] {"container", "from", "withExec", "stdout"},
+                        Map.of(TYPE_KEY, "EXEC_ERROR", EXIT_CODE_KEY, "1", CMD_KEY,
+                                new Object[] {"cat", "WRONG"}, STDERR_KEY, "DEEP ERROR DETAILS"));
+        GraphQLError error2 = buildError("ERROR2",
+                new Object[] {"container", "from", "withExec", "withExec", "stdout"},
+                Map.of(TYPE_KEY, "EXEC_ERROR", EXIT_CODE_KEY, "2", CMD_KEY,
+                        new Object[] {"cat", "WRONG2"}, STDERR_KEY, "DEEP ERROR DETAILS2"));
+
+        String result = new DaggerQueryException(error, error2).toFullMessage();
+        String expected =
+                "Message: [ERROR]\nPath: [container,from,withExec,stdout]\nType Code: [EXEC_ERROR]\nExit Code: [1]\nCmd: [cat,WRONG]\nSTDERR: [DEEP ERROR DETAILS]\n\nMessage: [ERROR2]\nPath: [container,from,withExec,withExec,stdout]\nType Code: [EXEC_ERROR]\nExit Code: [2]\nCmd: [cat,WRONG2]\nSTDERR: [DEEP ERROR DETAILS2]\n";
+        assertThat(result).isEqualTo(expected);
+    }
+
+    private GraphQLError buildError(String message, Object[] path, Map<String, Object> extensions) {
+        return new GraphQLError() {
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public List<Map<String, Integer>> getLocations() {
+                return null;
+            }
+
+            @Override
+            public Object[] getPath() {
+                return path;
+            }
+
+            @Override
+            public Map<String, Object> getExtensions() {
+                return extensions;
+            }
+
+            @Override
+            public Map<String, Object> getOtherFields() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Hi @eunomie 
i've added these methods

- default: i add also the `path` and `extension.type` field i think could be useful
- `toEnanchedMessage` which contains `message, path, type code, exit code and cmd`
- `toFullMessage` which contains `message, path, type code, exit code, cmd and STDERR`

Below the patterns of messages
```java
  private static final String SIMPLE_MESSAGE = "Message: [%s]\nPath: [%s]\nType Code: [%s]\n";
  private static final String ENANCHED_MESSAGE =
      "Message: [%s]\nPath: [%s]\nType Code: [%s]\nExit Code: [%s]\nCmd: [%s]\n";
  private static final String FULL_MESSAGE =
      "Message: [%s]\nPath: [%s]\nType Code: [%s]\nExit Code: [%s]\nCmd: [%s]\nSTDERR: [%s]\n";
```

Let me know if is ok or is should review something
Thanks in advance