### PR TITLE
sdk/java: disable transfert progress in output

### DIFF
--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -461,5 +461,6 @@ func (m *JavaSdk) mavenCommand(args ...string) []string {
 	if m.MavenDebugLogging {
 		args = append(args, "-X")
 	}
+	args = append(args, "--no-transfer-progress")
 	return args
 }


### PR DESCRIPTION
Enable by default a maven option to not print any progress when downloading maven artifacts.

This helps to maintain the logs less noisy.