### PR TITLE
Minor engine build optimizations

### DIFF
--- a/cmd/engine/.dagger/build/builder.go
+++ b/cmd/engine/.dagger/build/builder.go
@@ -36,43 +36,6 @@ type Builder struct {
 }
 
 func NewBuilder(ctx context.Context, source *dagger.Directory) (*Builder, error) {
-	source = dag.Directory().WithDirectory("/", source, dagger.DirectoryWithDirectoryOpts{
-		Exclude: []string{
-			".git",
-			"bin",
-			"**/.DS_Store",
-
-			// node
-			"**/node_modules",
-
-			// python
-			"**/__pycache__",
-			"**/.venv",
-			"**/.mypy_cache",
-			"**/.pytest_cache",
-			"**/.ruff_cache",
-			"sdk/python/dist",
-			"sdk/python/**/sdk",
-
-			// go
-			// go.work is ignored so that you can use ../foo during local dev and let
-			// this exclude rule reflect what the PR would run with, as a reminder to
-			// actually bump dependencies
-			"go.work",
-			"go.work.sum",
-
-			// don't rebuild on test-only-changes
-			"**/*_test.go",
-
-			// rust
-			"**/target",
-
-			// elixir
-			"**/deps",
-			"**/cover",
-			"**/_build",
-		},
-	})
 	v := dag.Version()
 	version, err := v.Version(ctx)
 	if err != nil {

--- a/cmd/engine/.dagger/main.go
+++ b/cmd/engine/.dagger/main.go
@@ -25,6 +25,7 @@ const (
 
 func New(
 	// +defaultPath="/"
+	// +ignore=[".git", "bin", "**/.dagger", "**/.DS_Store", "**/node_modules", "**/__pycache__", "**/.venv", "**/.mypy_cache", "**/.pytest_cache", "**/.ruff_cache", "sdk/python/dist", "sdk/python/**/sdk", "go.work", "go.work.sum", "**/*_test.go", "**/target", "**/deps", "**/cover", "**/_build"]
 	source *dagger.Directory,
 ) *DaggerEngine {
 	return &DaggerEngine{


### PR DESCRIPTION
Was staring a lot at engine build traces today for unrelated reasons and noticed a few pieces of extremely low-hanging fruit in our various modules related to building the engine. Together they trim ~5-10s from an engine build based on some local runs, so not life-changing but enough to send out quick.

See individual commit messages for details.