### PR TITLE
Avoid conficts in generated PHP docs

### DIFF
--- a/docs/.dagger/main.go
+++ b/docs/.dagger/main.go
@@ -44,6 +44,12 @@ const (
 	generatedPhpReferencePath     = "docs/static/reference/php/"
 )
 
+const (
+	doctumVersion       = "5.5.4"
+	changieVersion      = "1.21.0"
+	markdownlintVersion = "0.31.1"
+)
+
 const cliZenFrontmatter = `---
 slug: /reference/cli/
 pagination_next: null
@@ -91,7 +97,7 @@ func (d Docs) Lint(ctx context.Context) (rerr error) {
 			span.End()
 		}()
 		_, err := dag.Container().
-			From("tmknom/markdownlint:0.31.1").
+			From("tmknom/markdownlint:"+markdownlintVersion).
 			WithMountedDirectory("/src", d.Source).
 			WithMountedFile("/src/.markdownlint.yaml", d.Source.File(".markdownlint.yaml")).
 			WithWorkdir("/src").
@@ -139,7 +145,7 @@ func (d Docs) Lint(ctx context.Context) (rerr error) {
 		// FIXME: spin out a changie module
 		after := dag.
 			Container().
-			From("ghcr.io/miniscruff/changie").
+			From("ghcr.io/miniscruff/changie:v"+changieVersion).
 			WithMountedDirectory("/src", d.Source).
 			WithWorkdir("/src").
 			WithExec([]string{"/changie", "merge"}).
@@ -189,7 +195,7 @@ func (d Docs) GeneratePhp() *dagger.Directory {
 	dir := dag.PhpSDKDev().Base().
 		WithFile(
 			"/usr/bin/doctum",
-			dag.HTTP("https://doctum.long-term.support/releases/5.5.4/doctum.phar"),
+			dag.HTTP(fmt.Sprintf("https://doctum.long-term.support/releases/%s/doctum.phar", doctumVersion)),
 			dagger.ContainerWithFileOpts{Permissions: 0711},
 		).
 		WithFile("/etc/doctum-config.php", d.DoctumConfig).

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1,1 +1,4252 @@
-{"items":[{"t":"F","n":"Dagger\\dag","p":"Dagger.html#function_dag","d":null},{"t":"C","n":"Dagger\\Attribute\\Argument","p":"Dagger/Attribute/Argument.html","d":"","f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\DaggerFunction","p":"Dagger/Attribute/DaggerFunction.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\DaggerObject","p":"Dagger/Attribute/DaggerObject.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\DefaultPath","p":"Dagger/Attribute/DefaultPath.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\Doc","p":"Dagger/Attribute/Doc.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\Ignore","p":"Dagger/Attribute/Ignore.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\ListOfType","p":"Dagger/Attribute/ListOfType.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Attribute\\ReturnsListOfType","p":"Dagger/Attribute/ReturnsListOfType.html","d":null,"f":{"n":"Dagger\\Attribute","p":"Dagger/Attribute.html"}},{"t":"C","n":"Dagger\\Binding","p":"Dagger/Binding.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\BindingId","p":"Dagger/BindingId.html","d":"<p>The <code>BindingID</code> scalar type represents an identifier for an object of type Binding.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\BuildArg","p":"Dagger/BuildArg.html","d":"<p>Key value object that represents a build argument.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\CacheVolume","p":"Dagger/CacheVolume.html","d":"<p>A directory whose contents persist across runs.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\CacheVolumeId","p":"Dagger/CacheVolumeId.html","d":"<p>The <code>CacheVolumeID</code> scalar type represents an identifier for an object of type CacheVolume.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Client","p":"Dagger/Client.html","d":"<p>The root of the DAG.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Client\\AbstractClient","p":"Dagger/Client/AbstractClient.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\AbstractId","p":"Dagger/Client/AbstractId.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\AbstractInputObject","p":"Dagger/Client/AbstractInputObject.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\AbstractObject","p":"Dagger/Client/AbstractObject.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\AbstractScalar","p":"Dagger/Client/AbstractScalar.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\IdAble","p":"Dagger/Client/IdAble.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Client\\QueryBuilder","p":"Dagger/Client/QueryBuilder.html","d":null,"f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"C","n":"Dagger\\Connection","p":"Dagger/Connection.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Container","p":"Dagger/Container.html","d":"<p>An OCI-compatible container, also known as a Docker container.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ContainerId","p":"Dagger/ContainerId.html","d":"<p>The <code>ContainerID</code> scalar type represents an identifier for an object of type Container.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\CurrentModule","p":"Dagger/CurrentModule.html","d":"<p>Reflective module API provided to functions at runtime.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\CurrentModuleId","p":"Dagger/CurrentModuleId.html","d":"<p>The <code>CurrentModuleID</code> scalar type represents an identifier for an object of type CurrentModule.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Dagger","p":"Dagger/Dagger.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Directory","p":"Dagger/Directory.html","d":"<p>A directory.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\DirectoryId","p":"Dagger/DirectoryId.html","d":"<p>The <code>DirectoryID</code> scalar type represents an identifier for an object of type Directory.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Engine","p":"Dagger/Engine.html","d":"<p>The Dagger engine configuration and state</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCache","p":"Dagger/EngineCache.html","d":"<p>A cache storage for the Dagger engine</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCacheEntry","p":"Dagger/EngineCacheEntry.html","d":"<p>An individual cache entry in a cache entry set</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCacheEntryId","p":"Dagger/EngineCacheEntryId.html","d":"<p>The <code>EngineCacheEntryID</code> scalar type represents an identifier for an object of type EngineCacheEntry.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCacheEntrySet","p":"Dagger/EngineCacheEntrySet.html","d":"<p>A set of cache entries returned by a query to a cache</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCacheEntrySetId","p":"Dagger/EngineCacheEntrySetId.html","d":"<p>The <code>EngineCacheEntrySetID</code> scalar type represents an identifier for an object of type EngineCacheEntrySet.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineCacheId","p":"Dagger/EngineCacheId.html","d":"<p>The <code>EngineCacheID</code> scalar type represents an identifier for an object of type EngineCache.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EngineId","p":"Dagger/EngineId.html","d":"<p>The <code>EngineID</code> scalar type represents an identifier for an object of type Engine.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnumTypeDef","p":"Dagger/EnumTypeDef.html","d":"<p>A definition of a custom enum defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnumTypeDefId","p":"Dagger/EnumTypeDefId.html","d":"<p>The <code>EnumTypeDefID</code> scalar type represents an identifier for an object of type EnumTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnumValueTypeDef","p":"Dagger/EnumValueTypeDef.html","d":"<p>A definition of a value in a custom enum defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnumValueTypeDefId","p":"Dagger/EnumValueTypeDefId.html","d":"<p>The <code>EnumValueTypeDefID</code> scalar type represents an identifier for an object of type EnumValueTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Env","p":"Dagger/Env.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnvId","p":"Dagger/EnvId.html","d":"<p>The <code>EnvID</code> scalar type represents an identifier for an object of type Env.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnvVariable","p":"Dagger/EnvVariable.html","d":"<p>An environment variable name and value.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\EnvVariableId","p":"Dagger/EnvVariableId.html","d":"<p>The <code>EnvVariableID</code> scalar type represents an identifier for an object of type EnvVariable.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Error","p":"Dagger/Error.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ErrorId","p":"Dagger/ErrorId.html","d":"<p>The <code>ErrorID</code> scalar type represents an identifier for an object of type Error.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ErrorValue","p":"Dagger/ErrorValue.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ErrorValueId","p":"Dagger/ErrorValueId.html","d":"<p>The <code>ErrorValueID</code> scalar type represents an identifier for an object of type ErrorValue.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FieldTypeDef","p":"Dagger/FieldTypeDef.html","d":"<p>A definition of a field on a custom object defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FieldTypeDefId","p":"Dagger/FieldTypeDefId.html","d":"<p>The <code>FieldTypeDefID</code> scalar type represents an identifier for an object of type FieldTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\File","p":"Dagger/File.html","d":"<p>A file.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FileId","p":"Dagger/FileId.html","d":"<p>The <code>FileID</code> scalar type represents an identifier for an object of type File.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionArg","p":"Dagger/FunctionArg.html","d":"<p>An argument accepted by a function.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionArgId","p":"Dagger/FunctionArgId.html","d":"<p>The <code>FunctionArgID</code> scalar type represents an identifier for an object of type FunctionArg.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionCall","p":"Dagger/FunctionCall.html","d":"<p>An active function call.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionCallArgValue","p":"Dagger/FunctionCallArgValue.html","d":"<p>A value passed as a named argument to a function call.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionCallArgValueId","p":"Dagger/FunctionCallArgValueId.html","d":"<p>The <code>FunctionCallArgValueID</code> scalar type represents an identifier for an object of type FunctionCallArgValue.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionCallId","p":"Dagger/FunctionCallId.html","d":"<p>The <code>FunctionCallID</code> scalar type represents an identifier for an object of type FunctionCall.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\FunctionId","p":"Dagger/FunctionId.html","d":"<p>The <code>FunctionID</code> scalar type represents an identifier for an object of type Function.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Function_","p":"Dagger/Function_.html","d":"<p>Function represents a resolver provided by a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GeneratedCode","p":"Dagger/GeneratedCode.html","d":"<p>The result of running an SDK's codegen.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GeneratedCodeId","p":"Dagger/GeneratedCodeId.html","d":"<p>The <code>GeneratedCodeID</code> scalar type represents an identifier for an object of type GeneratedCode.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GitRef","p":"Dagger/GitRef.html","d":"<p>A git ref (tag, branch, or commit).</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GitRefId","p":"Dagger/GitRefId.html","d":"<p>The <code>GitRefID</code> scalar type represents an identifier for an object of type GitRef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GitRepository","p":"Dagger/GitRepository.html","d":"<p>A git repository.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\GitRepositoryId","p":"Dagger/GitRepositoryId.html","d":"<p>The <code>GitRepositoryID</code> scalar type represents an identifier for an object of type GitRepository.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Host","p":"Dagger/Host.html","d":"<p>Information about the host environment.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\HostId","p":"Dagger/HostId.html","d":"<p>The <code>HostID</code> scalar type represents an identifier for an object of type Host.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\InputTypeDef","p":"Dagger/InputTypeDef.html","d":"<p>A graphql input type, which is essentially just a group of named args.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\InputTypeDefId","p":"Dagger/InputTypeDefId.html","d":"<p>The <code>InputTypeDefID</code> scalar type represents an identifier for an object of type InputTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\InterfaceTypeDef","p":"Dagger/InterfaceTypeDef.html","d":"<p>A definition of a custom interface defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\InterfaceTypeDefId","p":"Dagger/InterfaceTypeDefId.html","d":"<p>The <code>InterfaceTypeDefID</code> scalar type represents an identifier for an object of type InterfaceTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Json","p":"Dagger/Json.html","d":"<p>An arbitrary JSON-encoded value.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\LLM","p":"Dagger/LLM.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\LLMId","p":"Dagger/LLMId.html","d":"<p>The <code>LLMID</code> scalar type represents an identifier for an object of type LLM.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\LLMTokenUsage","p":"Dagger/LLMTokenUsage.html","d":null,"f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\LLMTokenUsageId","p":"Dagger/LLMTokenUsageId.html","d":"<p>The <code>LLMTokenUsageID</code> scalar type represents an identifier for an object of type LLMTokenUsage.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Label","p":"Dagger/Label.html","d":"<p>A simple key value object that represents a label.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\LabelId","p":"Dagger/LabelId.html","d":"<p>The <code>LabelID</code> scalar type represents an identifier for an object of type Label.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ListTypeDef","p":"Dagger/ListTypeDef.html","d":"<p>A definition of a list type in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ListTypeDefId","p":"Dagger/ListTypeDefId.html","d":"<p>The <code>ListTypeDefID</code> scalar type represents an identifier for an object of type ListTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Module","p":"Dagger/Module.html","d":"<p>A Dagger module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ModuleConfigClient","p":"Dagger/ModuleConfigClient.html","d":"<p>The client generated for the module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ModuleConfigClientId","p":"Dagger/ModuleConfigClientId.html","d":"<p>The <code>ModuleConfigClientID</code> scalar type represents an identifier for an object of type ModuleConfigClient.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ModuleId","p":"Dagger/ModuleId.html","d":"<p>The <code>ModuleID</code> scalar type represents an identifier for an object of type Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ModuleSource","p":"Dagger/ModuleSource.html","d":"<p>The source needed to load and run a module, along with any metadata about the source such as versions/urls/etc.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ModuleSourceId","p":"Dagger/ModuleSourceId.html","d":"<p>The <code>ModuleSourceID</code> scalar type represents an identifier for an object of type ModuleSource.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ObjectTypeDef","p":"Dagger/ObjectTypeDef.html","d":"<p>A definition of a custom object defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ObjectTypeDefId","p":"Dagger/ObjectTypeDefId.html","d":"<p>The <code>ObjectTypeDefID</code> scalar type represents an identifier for an object of type ObjectTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\PipelineLabel","p":"Dagger/PipelineLabel.html","d":"<p>Key value object that represents a pipeline label.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Platform","p":"Dagger/Platform.html","d":"<p>The platform config OS and architecture in a Container.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Port","p":"Dagger/Port.html","d":"<p>A port exposed by a container.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\PortForward","p":"Dagger/PortForward.html","d":"<p>Port forwarding rules for tunneling network traffic.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\PortId","p":"Dagger/PortId.html","d":"<p>The <code>PortID</code> scalar type represents an identifier for an object of type Port.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SDKConfig","p":"Dagger/SDKConfig.html","d":"<p>The SDK config of the module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SDKConfigId","p":"Dagger/SDKConfigId.html","d":"<p>The <code>SDKConfigID</code> scalar type represents an identifier for an object of type SDKConfig.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ScalarTypeDef","p":"Dagger/ScalarTypeDef.html","d":"<p>A definition of a custom scalar defined in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ScalarTypeDefId","p":"Dagger/ScalarTypeDefId.html","d":"<p>The <code>ScalarTypeDefID</code> scalar type represents an identifier for an object of type ScalarTypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Secret","p":"Dagger/Secret.html","d":"<p>A reference to a secret value, which can be handled more safely than the value itself.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SecretId","p":"Dagger/SecretId.html","d":"<p>The <code>SecretID</code> scalar type represents an identifier for an object of type Secret.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Service","p":"Dagger/Service.html","d":"<p>A content-addressed service providing TCP connectivity.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\ServiceId","p":"Dagger/ServiceId.html","d":"<p>The <code>ServiceID</code> scalar type represents an identifier for an object of type Service.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Socket","p":"Dagger/Socket.html","d":"<p>A Unix or TCP/IP socket that can be mounted into a container.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SocketId","p":"Dagger/SocketId.html","d":"<p>The <code>SocketID</code> scalar type represents an identifier for an object of type Socket.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SourceMap","p":"Dagger/SourceMap.html","d":"<p>Source location information.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\SourceMapId","p":"Dagger/SourceMapId.html","d":"<p>The <code>SourceMapID</code> scalar type represents an identifier for an object of type SourceMap.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\Terminal","p":"Dagger/Terminal.html","d":"<p>An interactive terminal that clients can connect to.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\TerminalId","p":"Dagger/TerminalId.html","d":"<p>The <code>TerminalID</code> scalar type represents an identifier for an object of type Terminal.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\TypeDef","p":"Dagger/TypeDef.html","d":"<p>A definition of a parameter or return type in a Module.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"C","n":"Dagger\\TypeDefId","p":"Dagger/TypeDefId.html","d":"<p>The <code>TypeDefID</code> scalar type represents an identifier for an object of type TypeDef.</p>","f":{"n":"Dagger","p":"Dagger.html"}},{"t":"I","n":"Dagger\\Client\\IdAble","p":"Dagger/Client/IdAble.html","f":{"n":"Dagger\\Client","p":"Dagger/Client.html"}},{"t":"M","n":"Dagger\\Attribute\\Argument::__construct","p":"Dagger/Attribute/Argument.html#method___construct","d":null},{"t":"M","n":"Dagger\\Attribute\\DaggerFunction::__construct","p":"Dagger/Attribute/DaggerFunction.html#method___construct","d":""},{"t":"M","n":"Dagger\\Attribute\\DefaultPath::__construct","p":"Dagger/Attribute/DefaultPath.html#method___construct","d":null},{"t":"M","n":"Dagger\\Attribute\\Doc::__construct","p":"Dagger/Attribute/Doc.html#method___construct","d":null},{"t":"M","n":"Dagger\\Attribute\\Ignore::__construct","p":"Dagger/Attribute/Ignore.html#method___construct","d":null},{"t":"M","n":"Dagger\\Attribute\\ListOfType::__construct","p":"Dagger/Attribute/ListOfType.html#method___construct","d":null},{"t":"M","n":"Dagger\\Attribute\\ReturnsListOfType::__construct","p":"Dagger/Attribute/ReturnsListOfType.html#method___construct","d":null},{"t":"M","n":"Dagger\\Binding::asCacheVolume","p":"Dagger/Binding.html#method_asCacheVolume","d":"<p>Retrieve the binding value, as type CacheVolume</p>"},{"t":"M","n":"Dagger\\Binding::asContainer","p":"Dagger/Binding.html#method_asContainer","d":"<p>Retrieve the binding value, as type Container</p>"},{"t":"M","n":"Dagger\\Binding::asDirectory","p":"Dagger/Binding.html#method_asDirectory","d":"<p>Retrieve the binding value, as type Directory</p>"},{"t":"M","n":"Dagger\\Binding::asEnv","p":"Dagger/Binding.html#method_asEnv","d":"<p>Retrieve the binding value, as type Env</p>"},{"t":"M","n":"Dagger\\Binding::asFile","p":"Dagger/Binding.html#method_asFile","d":"<p>Retrieve the binding value, as type File</p>"},{"t":"M","n":"Dagger\\Binding::asGitRef","p":"Dagger/Binding.html#method_asGitRef","d":"<p>Retrieve the binding value, as type GitRef</p>"},{"t":"M","n":"Dagger\\Binding::asGitRepository","p":"Dagger/Binding.html#method_asGitRepository","d":"<p>Retrieve the binding value, as type GitRepository</p>"},{"t":"M","n":"Dagger\\Binding::asLLM","p":"Dagger/Binding.html#method_asLLM","d":"<p>Retrieve the binding value, as type LLM</p>"},{"t":"M","n":"Dagger\\Binding::asModule","p":"Dagger/Binding.html#method_asModule","d":"<p>Retrieve the binding value, as type Module</p>"},{"t":"M","n":"Dagger\\Binding::asModuleConfigClient","p":"Dagger/Binding.html#method_asModuleConfigClient","d":"<p>Retrieve the binding value, as type ModuleConfigClient</p>"},{"t":"M","n":"Dagger\\Binding::asModuleSource","p":"Dagger/Binding.html#method_asModuleSource","d":"<p>Retrieve the binding value, as type ModuleSource</p>"},{"t":"M","n":"Dagger\\Binding::asSecret","p":"Dagger/Binding.html#method_asSecret","d":"<p>Retrieve the binding value, as type Secret</p>"},{"t":"M","n":"Dagger\\Binding::asService","p":"Dagger/Binding.html#method_asService","d":"<p>Retrieve the binding value, as type Service</p>"},{"t":"M","n":"Dagger\\Binding::asSocket","p":"Dagger/Binding.html#method_asSocket","d":"<p>Retrieve the binding value, as type Socket</p>"},{"t":"M","n":"Dagger\\Binding::asString","p":"Dagger/Binding.html#method_asString","d":"<p>The binding's string value</p>"},{"t":"M","n":"Dagger\\Binding::digest","p":"Dagger/Binding.html#method_digest","d":"<p>The digest of the binding value</p>"},{"t":"M","n":"Dagger\\Binding::id","p":"Dagger/Binding.html#method_id","d":"<p>A unique identifier for this Binding.</p>"},{"t":"M","n":"Dagger\\Binding::isNull","p":"Dagger/Binding.html#method_isNull","d":"<p>Returns true if the binding is null</p>"},{"t":"M","n":"Dagger\\Binding::name","p":"Dagger/Binding.html#method_name","d":"<p>The binding name</p>"},{"t":"M","n":"Dagger\\Binding::typeName","p":"Dagger/Binding.html#method_typeName","d":"<p>The binding type</p>"},{"t":"M","n":"Dagger\\BuildArg::__construct","p":"Dagger/BuildArg.html#method___construct","d":null},{"t":"M","n":"Dagger\\CacheVolume::id","p":"Dagger/CacheVolume.html#method_id","d":"<p>A unique identifier for this CacheVolume.</p>"},{"t":"M","n":"Dagger\\Client::cacheVolume","p":"Dagger/Client.html#method_cacheVolume","d":"<p>Constructs a cache volume for a given cache key.</p>"},{"t":"M","n":"Dagger\\Client::container","p":"Dagger/Client.html#method_container","d":"<p>Creates a scratch container, with no image or metadata.</p>"},{"t":"M","n":"Dagger\\Client::currentFunctionCall","p":"Dagger/Client.html#method_currentFunctionCall","d":"<p>The FunctionCall context that the SDK caller is currently executing in.</p>"},{"t":"M","n":"Dagger\\Client::currentModule","p":"Dagger/Client.html#method_currentModule","d":"<p>The module currently being served in the session, if any.</p>"},{"t":"M","n":"Dagger\\Client::currentTypeDefs","p":"Dagger/Client.html#method_currentTypeDefs","d":"<p>The TypeDef representations of the objects currently being served in the session.</p>"},{"t":"M","n":"Dagger\\Client::defaultPlatform","p":"Dagger/Client.html#method_defaultPlatform","d":"<p>The default platform of the engine.</p>"},{"t":"M","n":"Dagger\\Client::directory","p":"Dagger/Client.html#method_directory","d":"<p>Creates an empty directory.</p>"},{"t":"M","n":"Dagger\\Client::engine","p":"Dagger/Client.html#method_engine","d":"<p>The Dagger engine container configuration and state</p>"},{"t":"M","n":"Dagger\\Client::env","p":"Dagger/Client.html#method_env","d":"<p>Initialize a new environment</p>"},{"t":"M","n":"Dagger\\Client::error","p":"Dagger/Client.html#method_error","d":"<p>Create a new error.</p>"},{"t":"M","n":"Dagger\\Client::file","p":"Dagger/Client.html#method_file","d":"<p>Creates a file with the specified contents.</p>"},{"t":"M","n":"Dagger\\Client::function","p":"Dagger/Client.html#method_function","d":"<p>Creates a function.</p>"},{"t":"M","n":"Dagger\\Client::generatedCode","p":"Dagger/Client.html#method_generatedCode","d":"<p>Create a code generation result, given a directory containing the generated code.</p>"},{"t":"M","n":"Dagger\\Client::git","p":"Dagger/Client.html#method_git","d":"<p>Queries a Git repository.</p>"},{"t":"M","n":"Dagger\\Client::host","p":"Dagger/Client.html#method_host","d":"<p>Queries the host environment.</p>"},{"t":"M","n":"Dagger\\Client::http","p":"Dagger/Client.html#method_http","d":"<p>Returns a file containing an http remote url content.</p>"},{"t":"M","n":"Dagger\\Client::llm","p":"Dagger/Client.html#method_llm","d":"<p>Initialize a Large Language Model (LLM)</p>"},{"t":"M","n":"Dagger\\Client::loadBindingFromID","p":"Dagger/Client.html#method_loadBindingFromID","d":"<p>Load a Binding from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadCacheVolumeFromID","p":"Dagger/Client.html#method_loadCacheVolumeFromID","d":"<p>Load a CacheVolume from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadContainerFromID","p":"Dagger/Client.html#method_loadContainerFromID","d":"<p>Load a Container from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadCurrentModuleFromID","p":"Dagger/Client.html#method_loadCurrentModuleFromID","d":"<p>Load a CurrentModule from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadDirectoryFromID","p":"Dagger/Client.html#method_loadDirectoryFromID","d":"<p>Load a Directory from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEngineCacheEntryFromID","p":"Dagger/Client.html#method_loadEngineCacheEntryFromID","d":"<p>Load a EngineCacheEntry from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEngineCacheEntrySetFromID","p":"Dagger/Client.html#method_loadEngineCacheEntrySetFromID","d":"<p>Load a EngineCacheEntrySet from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEngineCacheFromID","p":"Dagger/Client.html#method_loadEngineCacheFromID","d":"<p>Load a EngineCache from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEngineFromID","p":"Dagger/Client.html#method_loadEngineFromID","d":"<p>Load a Engine from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEnumTypeDefFromID","p":"Dagger/Client.html#method_loadEnumTypeDefFromID","d":"<p>Load a EnumTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEnumValueTypeDefFromID","p":"Dagger/Client.html#method_loadEnumValueTypeDefFromID","d":"<p>Load a EnumValueTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEnvFromID","p":"Dagger/Client.html#method_loadEnvFromID","d":"<p>Load a Env from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadEnvVariableFromID","p":"Dagger/Client.html#method_loadEnvVariableFromID","d":"<p>Load a EnvVariable from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadErrorFromID","p":"Dagger/Client.html#method_loadErrorFromID","d":"<p>Load a Error from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadErrorValueFromID","p":"Dagger/Client.html#method_loadErrorValueFromID","d":"<p>Load a ErrorValue from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFieldTypeDefFromID","p":"Dagger/Client.html#method_loadFieldTypeDefFromID","d":"<p>Load a FieldTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFileFromID","p":"Dagger/Client.html#method_loadFileFromID","d":"<p>Load a File from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFunctionArgFromID","p":"Dagger/Client.html#method_loadFunctionArgFromID","d":"<p>Load a FunctionArg from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFunctionCallArgValueFromID","p":"Dagger/Client.html#method_loadFunctionCallArgValueFromID","d":"<p>Load a FunctionCallArgValue from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFunctionCallFromID","p":"Dagger/Client.html#method_loadFunctionCallFromID","d":"<p>Load a FunctionCall from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadFunctionFromID","p":"Dagger/Client.html#method_loadFunctionFromID","d":"<p>Load a Function from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadGeneratedCodeFromID","p":"Dagger/Client.html#method_loadGeneratedCodeFromID","d":"<p>Load a GeneratedCode from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadGitRefFromID","p":"Dagger/Client.html#method_loadGitRefFromID","d":"<p>Load a GitRef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadGitRepositoryFromID","p":"Dagger/Client.html#method_loadGitRepositoryFromID","d":"<p>Load a GitRepository from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadHostFromID","p":"Dagger/Client.html#method_loadHostFromID","d":"<p>Load a Host from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadInputTypeDefFromID","p":"Dagger/Client.html#method_loadInputTypeDefFromID","d":"<p>Load a InputTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadInterfaceTypeDefFromID","p":"Dagger/Client.html#method_loadInterfaceTypeDefFromID","d":"<p>Load a InterfaceTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadLLMFromID","p":"Dagger/Client.html#method_loadLLMFromID","d":"<p>Load a LLM from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadLLMTokenUsageFromID","p":"Dagger/Client.html#method_loadLLMTokenUsageFromID","d":"<p>Load a LLMTokenUsage from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadLabelFromID","p":"Dagger/Client.html#method_loadLabelFromID","d":"<p>Load a Label from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadListTypeDefFromID","p":"Dagger/Client.html#method_loadListTypeDefFromID","d":"<p>Load a ListTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadModuleConfigClientFromID","p":"Dagger/Client.html#method_loadModuleConfigClientFromID","d":"<p>Load a ModuleConfigClient from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadModuleFromID","p":"Dagger/Client.html#method_loadModuleFromID","d":"<p>Load a Module from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadModuleSourceFromID","p":"Dagger/Client.html#method_loadModuleSourceFromID","d":"<p>Load a ModuleSource from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadObjectTypeDefFromID","p":"Dagger/Client.html#method_loadObjectTypeDefFromID","d":"<p>Load a ObjectTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadPortFromID","p":"Dagger/Client.html#method_loadPortFromID","d":"<p>Load a Port from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadSDKConfigFromID","p":"Dagger/Client.html#method_loadSDKConfigFromID","d":"<p>Load a SDKConfig from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadScalarTypeDefFromID","p":"Dagger/Client.html#method_loadScalarTypeDefFromID","d":"<p>Load a ScalarTypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadSecretFromID","p":"Dagger/Client.html#method_loadSecretFromID","d":"<p>Load a Secret from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadServiceFromID","p":"Dagger/Client.html#method_loadServiceFromID","d":"<p>Load a Service from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadSocketFromID","p":"Dagger/Client.html#method_loadSocketFromID","d":"<p>Load a Socket from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadSourceMapFromID","p":"Dagger/Client.html#method_loadSourceMapFromID","d":"<p>Load a SourceMap from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadTerminalFromID","p":"Dagger/Client.html#method_loadTerminalFromID","d":"<p>Load a Terminal from its ID.</p>"},{"t":"M","n":"Dagger\\Client::loadTypeDefFromID","p":"Dagger/Client.html#method_loadTypeDefFromID","d":"<p>Load a TypeDef from its ID.</p>"},{"t":"M","n":"Dagger\\Client::module","p":"Dagger/Client.html#method_module","d":"<p>Create a new module.</p>"},{"t":"M","n":"Dagger\\Client::moduleSource","p":"Dagger/Client.html#method_moduleSource","d":"<p>Create a new module source instance from a source ref string</p>"},{"t":"M","n":"Dagger\\Client::secret","p":"Dagger/Client.html#method_secret","d":"<p>Creates a new secret.</p>"},{"t":"M","n":"Dagger\\Client::setSecret","p":"Dagger/Client.html#method_setSecret","d":"<p>Sets a secret given a user defined name to its plaintext and returns the secret.</p>"},{"t":"M","n":"Dagger\\Client::sourceMap","p":"Dagger/Client.html#method_sourceMap","d":"<p>Creates source map metadata.</p>"},{"t":"M","n":"Dagger\\Client::typeDef","p":"Dagger/Client.html#method_typeDef","d":"<p>Create a new TypeDef.</p>"},{"t":"M","n":"Dagger\\Client::version","p":"Dagger/Client.html#method_version","d":"<p>Get the current Dagger Engine version.</p>"},{"t":"M","n":"Dagger\\Client\\AbstractClient::__construct","p":"Dagger/Client/AbstractClient.html#method___construct","d":null},{"t":"M","n":"Dagger\\Client\\AbstractClient::runQuery","p":"Dagger/Client/AbstractClient.html#method_runQuery","d":null},{"t":"M","n":"Dagger\\Client\\AbstractClient::queryLeaf","p":"Dagger/Client/AbstractClient.html#method_queryLeaf","d":null},{"t":"M","n":"Dagger\\Client\\AbstractInputObject::__toString","p":"Dagger/Client/AbstractInputObject.html#method___toString","d":null},{"t":"M","n":"Dagger\\Client\\AbstractObject::__construct","p":"Dagger/Client/AbstractObject.html#method___construct","d":null},{"t":"M","n":"Dagger\\Client\\AbstractObject::queryLeaf","p":"Dagger/Client/AbstractObject.html#method_queryLeaf","d":null},{"t":"M","n":"Dagger\\Client\\AbstractScalar::__construct","p":"Dagger/Client/AbstractScalar.html#method___construct","d":null},{"t":"M","n":"Dagger\\Client\\AbstractScalar::getValue","p":"Dagger/Client/AbstractScalar.html#method_getValue","d":null},{"t":"M","n":"Dagger\\Client\\AbstractScalar::__toString","p":"Dagger/Client/AbstractScalar.html#method___toString","d":null},{"t":"M","n":"Dagger\\Client\\AbstractScalar::from","p":"Dagger/Client/AbstractScalar.html#method_from","d":null},{"t":"M","n":"Dagger\\Client\\IdAble::id","p":"Dagger/Client/IdAble.html#method_id","d":null},{"t":"M","n":"Dagger\\Client\\QueryBuilder::setArgument","p":"Dagger/Client/QueryBuilder.html#method_setArgument","d":null},{"t":"M","n":"Dagger\\Connection::get","p":"Dagger/Connection.html#method_get","d":null},{"t":"M","n":"Dagger\\Connection::newEnvSession","p":"Dagger/Connection.html#method_newEnvSession","d":null},{"t":"M","n":"Dagger\\Connection::newProcessSession","p":"Dagger/Connection.html#method_newProcessSession","d":""},{"t":"M","n":"Dagger\\Connection::createGraphQlClient","p":"Dagger/Connection.html#method_createGraphQlClient","d":null},{"t":"M","n":"Dagger\\Connection::connect","p":"Dagger/Connection.html#method_connect","d":null},{"t":"M","n":"Dagger\\Connection::close","p":"Dagger/Connection.html#method_close","d":null},{"t":"M","n":"Dagger\\Container::asService","p":"Dagger/Container.html#method_asService","d":"<p>Turn the container into a Service.</p>"},{"t":"M","n":"Dagger\\Container::asTarball","p":"Dagger/Container.html#method_asTarball","d":"<p>Package the container state as an OCI image, and return it as a tar archive</p>"},{"t":"M","n":"Dagger\\Container::build","p":"Dagger/Container.html#method_build","d":"<p>Initializes this container from a Dockerfile build.</p>"},{"t":"M","n":"Dagger\\Container::defaultArgs","p":"Dagger/Container.html#method_defaultArgs","d":"<p>Return the container's default arguments.</p>"},{"t":"M","n":"Dagger\\Container::directory","p":"Dagger/Container.html#method_directory","d":"<p>Retrieve a directory from the container's root filesystem</p>"},{"t":"M","n":"Dagger\\Container::entrypoint","p":"Dagger/Container.html#method_entrypoint","d":"<p>Return the container's OCI entrypoint.</p>"},{"t":"M","n":"Dagger\\Container::envVariable","p":"Dagger/Container.html#method_envVariable","d":"<p>Retrieves the value of the specified environment variable.</p>"},{"t":"M","n":"Dagger\\Container::envVariables","p":"Dagger/Container.html#method_envVariables","d":"<p>Retrieves the list of environment variables passed to commands.</p>"},{"t":"M","n":"Dagger\\Container::exitCode","p":"Dagger/Container.html#method_exitCode","d":"<p>The exit code of the last executed command</p>"},{"t":"M","n":"Dagger\\Container::experimentalWithAllGPUs","p":"Dagger/Container.html#method_experimentalWithAllGPUs","d":"<p>EXPERIMENTAL API! Subject to change/removal at any time.</p>"},{"t":"M","n":"Dagger\\Container::experimentalWithGPU","p":"Dagger/Container.html#method_experimentalWithGPU","d":"<p>EXPERIMENTAL API! Subject to change/removal at any time.</p>"},{"t":"M","n":"Dagger\\Container::export","p":"Dagger/Container.html#method_export","d":"<p>Writes the container as an OCI tarball to the destination file path on the host.</p>"},{"t":"M","n":"Dagger\\Container::exposedPorts","p":"Dagger/Container.html#method_exposedPorts","d":"<p>Retrieves the list of exposed ports.</p>"},{"t":"M","n":"Dagger\\Container::file","p":"Dagger/Container.html#method_file","d":"<p>Retrieves a file at the given path.</p>"},{"t":"M","n":"Dagger\\Container::from","p":"Dagger/Container.html#method_from","d":"<p>Download a container image, and apply it to the container state. All previous state will be lost.</p>"},{"t":"M","n":"Dagger\\Container::id","p":"Dagger/Container.html#method_id","d":"<p>A unique identifier for this Container.</p>"},{"t":"M","n":"Dagger\\Container::imageRef","p":"Dagger/Container.html#method_imageRef","d":"<p>The unique image reference which can only be retrieved immediately after the 'Container.From' call.</p>"},{"t":"M","n":"Dagger\\Container::import","p":"Dagger/Container.html#method_import","d":"<p>Reads the container from an OCI tarball.</p>"},{"t":"M","n":"Dagger\\Container::label","p":"Dagger/Container.html#method_label","d":"<p>Retrieves the value of the specified label.</p>"},{"t":"M","n":"Dagger\\Container::labels","p":"Dagger/Container.html#method_labels","d":"<p>Retrieves the list of labels passed to container.</p>"},{"t":"M","n":"Dagger\\Container::mounts","p":"Dagger/Container.html#method_mounts","d":"<p>Retrieves the list of paths where a directory is mounted.</p>"},{"t":"M","n":"Dagger\\Container::platform","p":"Dagger/Container.html#method_platform","d":"<p>The platform this container executes and publishes as.</p>"},{"t":"M","n":"Dagger\\Container::publish","p":"Dagger/Container.html#method_publish","d":"<p>Package the container state as an OCI image, and publish it to a registry</p>"},{"t":"M","n":"Dagger\\Container::rootfs","p":"Dagger/Container.html#method_rootfs","d":"<p>Return a snapshot of the container's root filesystem. The snapshot can be modified then written back using withRootfs. Use that method for filesystem modifications.</p>"},{"t":"M","n":"Dagger\\Container::stderr","p":"Dagger/Container.html#method_stderr","d":"<p>The buffered standard error stream of the last executed command</p>"},{"t":"M","n":"Dagger\\Container::stdout","p":"Dagger/Container.html#method_stdout","d":"<p>The buffered standard output stream of the last executed command</p>"},{"t":"M","n":"Dagger\\Container::sync","p":"Dagger/Container.html#method_sync","d":"<p>Forces evaluation of the pipeline in the engine.</p>"},{"t":"M","n":"Dagger\\Container::terminal","p":"Dagger/Container.html#method_terminal","d":"<p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p>"},{"t":"M","n":"Dagger\\Container::up","p":"Dagger/Container.html#method_up","d":"<p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p>"},{"t":"M","n":"Dagger\\Container::user","p":"Dagger/Container.html#method_user","d":"<p>Retrieves the user to be set for all commands.</p>"},{"t":"M","n":"Dagger\\Container::withAnnotation","p":"Dagger/Container.html#method_withAnnotation","d":"<p>Retrieves this container plus the given OCI anotation.</p>"},{"t":"M","n":"Dagger\\Container::withDefaultArgs","p":"Dagger/Container.html#method_withDefaultArgs","d":"<p>Configures default arguments for future commands. Like CMD in Dockerfile.</p>"},{"t":"M","n":"Dagger\\Container::withDefaultTerminalCmd","p":"Dagger/Container.html#method_withDefaultTerminalCmd","d":"<p>Set the default command to invoke for the container's terminal API.</p>"},{"t":"M","n":"Dagger\\Container::withDirectory","p":"Dagger/Container.html#method_withDirectory","d":"<p>Return a new container snapshot, with a directory added to its filesystem</p>"},{"t":"M","n":"Dagger\\Container::withEntrypoint","p":"Dagger/Container.html#method_withEntrypoint","d":"<p>Set an OCI-style entrypoint. It will be included in the container's OCI configuration. Note, withExec ignores the entrypoint by default.</p>"},{"t":"M","n":"Dagger\\Container::withEnvVariable","p":"Dagger/Container.html#method_withEnvVariable","d":"<p>Set a new environment variable in the container.</p>"},{"t":"M","n":"Dagger\\Container::withExec","p":"Dagger/Container.html#method_withExec","d":"<p>Execute a command in the container, and return a new snapshot of the container state after execution.</p>"},{"t":"M","n":"Dagger\\Container::withExposedPort","p":"Dagger/Container.html#method_withExposedPort","d":"<p>Expose a network port. Like EXPOSE in Dockerfile (but with healthcheck support)</p>"},{"t":"M","n":"Dagger\\Container::withFile","p":"Dagger/Container.html#method_withFile","d":"<p>Return a container snapshot with a file added</p>"},{"t":"M","n":"Dagger\\Container::withFiles","p":"Dagger/Container.html#method_withFiles","d":"<p>Retrieves this container plus the contents of the given files copied to the given path.</p>"},{"t":"M","n":"Dagger\\Container::withLabel","p":"Dagger/Container.html#method_withLabel","d":"<p>Retrieves this container plus the given label.</p>"},{"t":"M","n":"Dagger\\Container::withMountedCache","p":"Dagger/Container.html#method_withMountedCache","d":"<p>Retrieves this container plus a cache volume mounted at the given path.</p>"},{"t":"M","n":"Dagger\\Container::withMountedDirectory","p":"Dagger/Container.html#method_withMountedDirectory","d":"<p>Retrieves this container plus a directory mounted at the given path.</p>"},{"t":"M","n":"Dagger\\Container::withMountedFile","p":"Dagger/Container.html#method_withMountedFile","d":"<p>Retrieves this container plus a file mounted at the given path.</p>"},{"t":"M","n":"Dagger\\Container::withMountedSecret","p":"Dagger/Container.html#method_withMountedSecret","d":"<p>Retrieves this container plus a secret mounted into a file at the given path.</p>"},{"t":"M","n":"Dagger\\Container::withMountedTemp","p":"Dagger/Container.html#method_withMountedTemp","d":"<p>Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.</p>"},{"t":"M","n":"Dagger\\Container::withNewFile","p":"Dagger/Container.html#method_withNewFile","d":"<p>Return a new container snapshot, with a file added to its filesystem with text content</p>"},{"t":"M","n":"Dagger\\Container::withRegistryAuth","p":"Dagger/Container.html#method_withRegistryAuth","d":"<p>Attach credentials for future publishing to a registry. Use in combination with publish</p>"},{"t":"M","n":"Dagger\\Container::withRootfs","p":"Dagger/Container.html#method_withRootfs","d":"<p>Change the container's root filesystem. The previous root filesystem will be lost.</p>"},{"t":"M","n":"Dagger\\Container::withSecretVariable","p":"Dagger/Container.html#method_withSecretVariable","d":"<p>Set a new environment variable, using a secret value</p>"},{"t":"M","n":"Dagger\\Container::withServiceBinding","p":"Dagger/Container.html#method_withServiceBinding","d":"<p>Establish a runtime dependency on a from a container to a network service.</p>"},{"t":"M","n":"Dagger\\Container::withUnixSocket","p":"Dagger/Container.html#method_withUnixSocket","d":"<p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p>"},{"t":"M","n":"Dagger\\Container::withUser","p":"Dagger/Container.html#method_withUser","d":"<p>Retrieves this container with a different command user.</p>"},{"t":"M","n":"Dagger\\Container::withWorkdir","p":"Dagger/Container.html#method_withWorkdir","d":"<p>Change the container's working directory. Like WORKDIR in Dockerfile.</p>"},{"t":"M","n":"Dagger\\Container::withoutAnnotation","p":"Dagger/Container.html#method_withoutAnnotation","d":"<p>Retrieves this container minus the given OCI annotation.</p>"},{"t":"M","n":"Dagger\\Container::withoutDefaultArgs","p":"Dagger/Container.html#method_withoutDefaultArgs","d":"<p>Remove the container's default arguments.</p>"},{"t":"M","n":"Dagger\\Container::withoutDirectory","p":"Dagger/Container.html#method_withoutDirectory","d":"<p>Return a new container snapshot, with a directory removed from its filesystem</p>"},{"t":"M","n":"Dagger\\Container::withoutEntrypoint","p":"Dagger/Container.html#method_withoutEntrypoint","d":"<p>Reset the container's OCI entrypoint.</p>"},{"t":"M","n":"Dagger\\Container::withoutEnvVariable","p":"Dagger/Container.html#method_withoutEnvVariable","d":"<p>Retrieves this container minus the given environment variable.</p>"},{"t":"M","n":"Dagger\\Container::withoutExposedPort","p":"Dagger/Container.html#method_withoutExposedPort","d":"<p>Unexpose a previously exposed port.</p>"},{"t":"M","n":"Dagger\\Container::withoutFile","p":"Dagger/Container.html#method_withoutFile","d":"<p>Retrieves this container with the file at the given path removed.</p>"},{"t":"M","n":"Dagger\\Container::withoutFiles","p":"Dagger/Container.html#method_withoutFiles","d":"<p>Return a new container spanshot with specified files removed</p>"},{"t":"M","n":"Dagger\\Container::withoutLabel","p":"Dagger/Container.html#method_withoutLabel","d":"<p>Retrieves this container minus the given environment label.</p>"},{"t":"M","n":"Dagger\\Container::withoutMount","p":"Dagger/Container.html#method_withoutMount","d":"<p>Retrieves this container after unmounting everything at the given path.</p>"},{"t":"M","n":"Dagger\\Container::withoutRegistryAuth","p":"Dagger/Container.html#method_withoutRegistryAuth","d":"<p>Retrieves this container without the registry authentication of a given address.</p>"},{"t":"M","n":"Dagger\\Container::withoutSecretVariable","p":"Dagger/Container.html#method_withoutSecretVariable","d":"<p>Retrieves this container minus the given environment variable containing the secret.</p>"},{"t":"M","n":"Dagger\\Container::withoutUnixSocket","p":"Dagger/Container.html#method_withoutUnixSocket","d":"<p>Retrieves this container with a previously added Unix socket removed.</p>"},{"t":"M","n":"Dagger\\Container::withoutUser","p":"Dagger/Container.html#method_withoutUser","d":"<p>Retrieves this container with an unset command user.</p>"},{"t":"M","n":"Dagger\\Container::withoutWorkdir","p":"Dagger/Container.html#method_withoutWorkdir","d":"<p>Unset the container's working directory.</p>"},{"t":"M","n":"Dagger\\Container::workdir","p":"Dagger/Container.html#method_workdir","d":"<p>Retrieves the working directory for all commands.</p>"},{"t":"M","n":"Dagger\\CurrentModule::id","p":"Dagger/CurrentModule.html#method_id","d":"<p>A unique identifier for this CurrentModule.</p>"},{"t":"M","n":"Dagger\\CurrentModule::name","p":"Dagger/CurrentModule.html#method_name","d":"<p>The name of the module being executed in</p>"},{"t":"M","n":"Dagger\\CurrentModule::source","p":"Dagger/CurrentModule.html#method_source","d":"<p>The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).</p>"},{"t":"M","n":"Dagger\\CurrentModule::workdir","p":"Dagger/CurrentModule.html#method_workdir","d":"<p>Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.</p>"},{"t":"M","n":"Dagger\\CurrentModule::workdirFile","p":"Dagger/CurrentModule.html#method_workdirFile","d":"<p>Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.</p>"},{"t":"M","n":"Dagger\\Dagger::getClientInstance","p":"Dagger/Dagger.html#method_getClientInstance","d":null},{"t":"M","n":"Dagger\\Dagger::connect","p":"Dagger/Dagger.html#method_connect","d":null},{"t":"M","n":"Dagger\\Directory::asGit","p":"Dagger/Directory.html#method_asGit","d":"<p>Converts this directory to a local git repository</p>"},{"t":"M","n":"Dagger\\Directory::asModule","p":"Dagger/Directory.html#method_asModule","d":"<p>Load the directory as a Dagger module source</p>"},{"t":"M","n":"Dagger\\Directory::asModuleSource","p":"Dagger/Directory.html#method_asModuleSource","d":"<p>Load the directory as a Dagger module source</p>"},{"t":"M","n":"Dagger\\Directory::diff","p":"Dagger/Directory.html#method_diff","d":"<p>Return the difference between this directory and an another directory. The difference is encoded as a directory.</p>"},{"t":"M","n":"Dagger\\Directory::digest","p":"Dagger/Directory.html#method_digest","d":"<p>Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.</p>"},{"t":"M","n":"Dagger\\Directory::directory","p":"Dagger/Directory.html#method_directory","d":"<p>Retrieves a directory at the given path.</p>"},{"t":"M","n":"Dagger\\Directory::dockerBuild","p":"Dagger/Directory.html#method_dockerBuild","d":"<p>Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.</p>"},{"t":"M","n":"Dagger\\Directory::entries","p":"Dagger/Directory.html#method_entries","d":"<p>Returns a list of files and directories at the given path.</p>"},{"t":"M","n":"Dagger\\Directory::export","p":"Dagger/Directory.html#method_export","d":"<p>Writes the contents of the directory to a path on the host.</p>"},{"t":"M","n":"Dagger\\Directory::file","p":"Dagger/Directory.html#method_file","d":"<p>Retrieve a file at the given path.</p>"},{"t":"M","n":"Dagger\\Directory::filter","p":"Dagger/Directory.html#method_filter","d":"<p>Return a snapshot with some paths included or excluded</p>"},{"t":"M","n":"Dagger\\Directory::glob","p":"Dagger/Directory.html#method_glob","d":"<p>Returns a list of files and directories that matche the given pattern.</p>"},{"t":"M","n":"Dagger\\Directory::id","p":"Dagger/Directory.html#method_id","d":"<p>A unique identifier for this Directory.</p>"},{"t":"M","n":"Dagger\\Directory::name","p":"Dagger/Directory.html#method_name","d":"<p>Returns the name of the directory.</p>"},{"t":"M","n":"Dagger\\Directory::sync","p":"Dagger/Directory.html#method_sync","d":"<p>Force evaluation in the engine.</p>"},{"t":"M","n":"Dagger\\Directory::terminal","p":"Dagger/Directory.html#method_terminal","d":"<p>Opens an interactive terminal in new container with this directory mounted inside.</p>"},{"t":"M","n":"Dagger\\Directory::withDirectory","p":"Dagger/Directory.html#method_withDirectory","d":"<p>Return a snapshot with a directory added</p>"},{"t":"M","n":"Dagger\\Directory::withFile","p":"Dagger/Directory.html#method_withFile","d":"<p>Retrieves this directory plus the contents of the given file copied to the given path.</p>"},{"t":"M","n":"Dagger\\Directory::withFiles","p":"Dagger/Directory.html#method_withFiles","d":"<p>Retrieves this directory plus the contents of the given files copied to the given path.</p>"},{"t":"M","n":"Dagger\\Directory::withNewDirectory","p":"Dagger/Directory.html#method_withNewDirectory","d":"<p>Retrieves this directory plus a new directory created at the given path.</p>"},{"t":"M","n":"Dagger\\Directory::withNewFile","p":"Dagger/Directory.html#method_withNewFile","d":"<p>Return a snapshot with a new file added</p>"},{"t":"M","n":"Dagger\\Directory::withTimestamps","p":"Dagger/Directory.html#method_withTimestamps","d":"<p>Retrieves this directory with all file/dir timestamps set to the given time.</p>"},{"t":"M","n":"Dagger\\Directory::withoutDirectory","p":"Dagger/Directory.html#method_withoutDirectory","d":"<p>Return a snapshot with a subdirectory removed</p>"},{"t":"M","n":"Dagger\\Directory::withoutFile","p":"Dagger/Directory.html#method_withoutFile","d":"<p>Return a snapshot with a file removed</p>"},{"t":"M","n":"Dagger\\Directory::withoutFiles","p":"Dagger/Directory.html#method_withoutFiles","d":"<p>Return a snapshot with files removed</p>"},{"t":"M","n":"Dagger\\Engine::id","p":"Dagger/Engine.html#method_id","d":"<p>A unique identifier for this Engine.</p>"},{"t":"M","n":"Dagger\\Engine::localCache","p":"Dagger/Engine.html#method_localCache","d":"<p>The local (on-disk) cache for the Dagger engine</p>"},{"t":"M","n":"Dagger\\EngineCache::entrySet","p":"Dagger/EngineCache.html#method_entrySet","d":"<p>The current set of entries in the cache</p>"},{"t":"M","n":"Dagger\\EngineCache::id","p":"Dagger/EngineCache.html#method_id","d":"<p>A unique identifier for this EngineCache.</p>"},{"t":"M","n":"Dagger\\EngineCache::keepBytes","p":"Dagger/EngineCache.html#method_keepBytes","d":"<p>The maximum bytes to keep in the cache without pruning, after which automatic pruning may kick in.</p>"},{"t":"M","n":"Dagger\\EngineCache::maxUsedSpace","p":"Dagger/EngineCache.html#method_maxUsedSpace","d":"<p>The maximum bytes to keep in the cache without pruning.</p>"},{"t":"M","n":"Dagger\\EngineCache::minFreeSpace","p":"Dagger/EngineCache.html#method_minFreeSpace","d":"<p>The target amount of free disk space the garbage collector will attempt to leave.</p>"},{"t":"M","n":"Dagger\\EngineCache::prune","p":"Dagger/EngineCache.html#method_prune","d":"<p>Prune the cache of releaseable entries</p>"},{"t":"M","n":"Dagger\\EngineCache::reservedSpace","p":"Dagger/EngineCache.html#method_reservedSpace","d":null},{"t":"M","n":"Dagger\\EngineCacheEntry::activelyUsed","p":"Dagger/EngineCacheEntry.html#method_activelyUsed","d":"<p>Whether the cache entry is actively being used.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntry::createdTimeUnixNano","p":"Dagger/EngineCacheEntry.html#method_createdTimeUnixNano","d":"<p>The time the cache entry was created, in Unix nanoseconds.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntry::description","p":"Dagger/EngineCacheEntry.html#method_description","d":"<p>The description of the cache entry.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntry::diskSpaceBytes","p":"Dagger/EngineCacheEntry.html#method_diskSpaceBytes","d":"<p>The disk space used by the cache entry.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntry::id","p":"Dagger/EngineCacheEntry.html#method_id","d":"<p>A unique identifier for this EngineCacheEntry.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntry::mostRecentUseTimeUnixNano","p":"Dagger/EngineCacheEntry.html#method_mostRecentUseTimeUnixNano","d":"<p>The most recent time the cache entry was used, in Unix nanoseconds.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntrySet::diskSpaceBytes","p":"Dagger/EngineCacheEntrySet.html#method_diskSpaceBytes","d":"<p>The total disk space used by the cache entries in this set.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntrySet::entries","p":"Dagger/EngineCacheEntrySet.html#method_entries","d":"<p>The list of individual cache entries in the set</p>"},{"t":"M","n":"Dagger\\EngineCacheEntrySet::entryCount","p":"Dagger/EngineCacheEntrySet.html#method_entryCount","d":"<p>The number of cache entries in this set.</p>"},{"t":"M","n":"Dagger\\EngineCacheEntrySet::id","p":"Dagger/EngineCacheEntrySet.html#method_id","d":"<p>A unique identifier for this EngineCacheEntrySet.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::description","p":"Dagger/EnumTypeDef.html#method_description","d":"<p>A doc string for the enum, if any.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::id","p":"Dagger/EnumTypeDef.html#method_id","d":"<p>A unique identifier for this EnumTypeDef.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::name","p":"Dagger/EnumTypeDef.html#method_name","d":"<p>The name of the enum.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::sourceMap","p":"Dagger/EnumTypeDef.html#method_sourceMap","d":"<p>The location of this enum declaration.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::sourceModuleName","p":"Dagger/EnumTypeDef.html#method_sourceModuleName","d":"<p>If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"},{"t":"M","n":"Dagger\\EnumTypeDef::values","p":"Dagger/EnumTypeDef.html#method_values","d":"<p>The values of the enum.</p>"},{"t":"M","n":"Dagger\\EnumValueTypeDef::description","p":"Dagger/EnumValueTypeDef.html#method_description","d":"<p>A doc string for the enum value, if any.</p>"},{"t":"M","n":"Dagger\\EnumValueTypeDef::id","p":"Dagger/EnumValueTypeDef.html#method_id","d":"<p>A unique identifier for this EnumValueTypeDef.</p>"},{"t":"M","n":"Dagger\\EnumValueTypeDef::name","p":"Dagger/EnumValueTypeDef.html#method_name","d":"<p>The name of the enum value.</p>"},{"t":"M","n":"Dagger\\EnumValueTypeDef::sourceMap","p":"Dagger/EnumValueTypeDef.html#method_sourceMap","d":"<p>The location of this enum value declaration.</p>"},{"t":"M","n":"Dagger\\Env::id","p":"Dagger/Env.html#method_id","d":"<p>A unique identifier for this Env.</p>"},{"t":"M","n":"Dagger\\Env::input","p":"Dagger/Env.html#method_input","d":"<p>retrieve an input value by name</p>"},{"t":"M","n":"Dagger\\Env::inputs","p":"Dagger/Env.html#method_inputs","d":"<p>return all input values for the environment</p>"},{"t":"M","n":"Dagger\\Env::output","p":"Dagger/Env.html#method_output","d":"<p>retrieve an output value by name</p>"},{"t":"M","n":"Dagger\\Env::outputs","p":"Dagger/Env.html#method_outputs","d":"<p>return all output values for the environment</p>"},{"t":"M","n":"Dagger\\Env::withCacheVolumeInput","p":"Dagger/Env.html#method_withCacheVolumeInput","d":"<p>Create or update a binding of type CacheVolume in the environment</p>"},{"t":"M","n":"Dagger\\Env::withCacheVolumeOutput","p":"Dagger/Env.html#method_withCacheVolumeOutput","d":"<p>Declare a desired CacheVolume output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withContainerInput","p":"Dagger/Env.html#method_withContainerInput","d":"<p>Create or update a binding of type Container in the environment</p>"},{"t":"M","n":"Dagger\\Env::withContainerOutput","p":"Dagger/Env.html#method_withContainerOutput","d":"<p>Declare a desired Container output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withDirectoryInput","p":"Dagger/Env.html#method_withDirectoryInput","d":"<p>Create or update a binding of type Directory in the environment</p>"},{"t":"M","n":"Dagger\\Env::withDirectoryOutput","p":"Dagger/Env.html#method_withDirectoryOutput","d":"<p>Declare a desired Directory output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withEnvInput","p":"Dagger/Env.html#method_withEnvInput","d":"<p>Create or update a binding of type Env in the environment</p>"},{"t":"M","n":"Dagger\\Env::withEnvOutput","p":"Dagger/Env.html#method_withEnvOutput","d":"<p>Declare a desired Env output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withFileInput","p":"Dagger/Env.html#method_withFileInput","d":"<p>Create or update a binding of type File in the environment</p>"},{"t":"M","n":"Dagger\\Env::withFileOutput","p":"Dagger/Env.html#method_withFileOutput","d":"<p>Declare a desired File output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withGitRefInput","p":"Dagger/Env.html#method_withGitRefInput","d":"<p>Create or update a binding of type GitRef in the environment</p>"},{"t":"M","n":"Dagger\\Env::withGitRefOutput","p":"Dagger/Env.html#method_withGitRefOutput","d":"<p>Declare a desired GitRef output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withGitRepositoryInput","p":"Dagger/Env.html#method_withGitRepositoryInput","d":"<p>Create or update a binding of type GitRepository in the environment</p>"},{"t":"M","n":"Dagger\\Env::withGitRepositoryOutput","p":"Dagger/Env.html#method_withGitRepositoryOutput","d":"<p>Declare a desired GitRepository output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withLLMInput","p":"Dagger/Env.html#method_withLLMInput","d":"<p>Create or update a binding of type LLM in the environment</p>"},{"t":"M","n":"Dagger\\Env::withLLMOutput","p":"Dagger/Env.html#method_withLLMOutput","d":"<p>Declare a desired LLM output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleConfigClientInput","p":"Dagger/Env.html#method_withModuleConfigClientInput","d":"<p>Create or update a binding of type ModuleConfigClient in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleConfigClientOutput","p":"Dagger/Env.html#method_withModuleConfigClientOutput","d":"<p>Declare a desired ModuleConfigClient output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleInput","p":"Dagger/Env.html#method_withModuleInput","d":"<p>Create or update a binding of type Module in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleOutput","p":"Dagger/Env.html#method_withModuleOutput","d":"<p>Declare a desired Module output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleSourceInput","p":"Dagger/Env.html#method_withModuleSourceInput","d":"<p>Create or update a binding of type ModuleSource in the environment</p>"},{"t":"M","n":"Dagger\\Env::withModuleSourceOutput","p":"Dagger/Env.html#method_withModuleSourceOutput","d":"<p>Declare a desired ModuleSource output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withSecretInput","p":"Dagger/Env.html#method_withSecretInput","d":"<p>Create or update a binding of type Secret in the environment</p>"},{"t":"M","n":"Dagger\\Env::withSecretOutput","p":"Dagger/Env.html#method_withSecretOutput","d":"<p>Declare a desired Secret output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withServiceInput","p":"Dagger/Env.html#method_withServiceInput","d":"<p>Create or update a binding of type Service in the environment</p>"},{"t":"M","n":"Dagger\\Env::withServiceOutput","p":"Dagger/Env.html#method_withServiceOutput","d":"<p>Declare a desired Service output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withSocketInput","p":"Dagger/Env.html#method_withSocketInput","d":"<p>Create or update a binding of type Socket in the environment</p>"},{"t":"M","n":"Dagger\\Env::withSocketOutput","p":"Dagger/Env.html#method_withSocketOutput","d":"<p>Declare a desired Socket output to be assigned in the environment</p>"},{"t":"M","n":"Dagger\\Env::withStringInput","p":"Dagger/Env.html#method_withStringInput","d":"<p>Create or update an input value of type string</p>"},{"t":"M","n":"Dagger\\Env::withStringOutput","p":"Dagger/Env.html#method_withStringOutput","d":"<p>Create or update an input value of type string</p>"},{"t":"M","n":"Dagger\\EnvVariable::id","p":"Dagger/EnvVariable.html#method_id","d":"<p>A unique identifier for this EnvVariable.</p>"},{"t":"M","n":"Dagger\\EnvVariable::name","p":"Dagger/EnvVariable.html#method_name","d":"<p>The environment variable name.</p>"},{"t":"M","n":"Dagger\\EnvVariable::value","p":"Dagger/EnvVariable.html#method_value","d":"<p>The environment variable value.</p>"},{"t":"M","n":"Dagger\\Error::id","p":"Dagger/Error.html#method_id","d":"<p>A unique identifier for this Error.</p>"},{"t":"M","n":"Dagger\\Error::message","p":"Dagger/Error.html#method_message","d":"<p>A description of the error.</p>"},{"t":"M","n":"Dagger\\Error::values","p":"Dagger/Error.html#method_values","d":"<p>The extensions of the error.</p>"},{"t":"M","n":"Dagger\\Error::withValue","p":"Dagger/Error.html#method_withValue","d":"<p>Add a value to the error.</p>"},{"t":"M","n":"Dagger\\ErrorValue::id","p":"Dagger/ErrorValue.html#method_id","d":"<p>A unique identifier for this ErrorValue.</p>"},{"t":"M","n":"Dagger\\ErrorValue::name","p":"Dagger/ErrorValue.html#method_name","d":"<p>The name of the value.</p>"},{"t":"M","n":"Dagger\\ErrorValue::value","p":"Dagger/ErrorValue.html#method_value","d":"<p>The value.</p>"},{"t":"M","n":"Dagger\\FieldTypeDef::description","p":"Dagger/FieldTypeDef.html#method_description","d":"<p>A doc string for the field, if any.</p>"},{"t":"M","n":"Dagger\\FieldTypeDef::id","p":"Dagger/FieldTypeDef.html#method_id","d":"<p>A unique identifier for this FieldTypeDef.</p>"},{"t":"M","n":"Dagger\\FieldTypeDef::name","p":"Dagger/FieldTypeDef.html#method_name","d":"<p>The name of the field in lowerCamelCase format.</p>"},{"t":"M","n":"Dagger\\FieldTypeDef::sourceMap","p":"Dagger/FieldTypeDef.html#method_sourceMap","d":"<p>The location of this field declaration.</p>"},{"t":"M","n":"Dagger\\FieldTypeDef::typeDef","p":"Dagger/FieldTypeDef.html#method_typeDef","d":"<p>The type of the field.</p>"},{"t":"M","n":"Dagger\\File::contents","p":"Dagger/File.html#method_contents","d":"<p>Retrieves the contents of the file.</p>"},{"t":"M","n":"Dagger\\File::digest","p":"Dagger/File.html#method_digest","d":"<p>Return the file's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.</p>"},{"t":"M","n":"Dagger\\File::export","p":"Dagger/File.html#method_export","d":"<p>Writes the file to a file path on the host.</p>"},{"t":"M","n":"Dagger\\File::id","p":"Dagger/File.html#method_id","d":"<p>A unique identifier for this File.</p>"},{"t":"M","n":"Dagger\\File::name","p":"Dagger/File.html#method_name","d":"<p>Retrieves the name of the file.</p>"},{"t":"M","n":"Dagger\\File::size","p":"Dagger/File.html#method_size","d":"<p>Retrieves the size of the file, in bytes.</p>"},{"t":"M","n":"Dagger\\File::sync","p":"Dagger/File.html#method_sync","d":"<p>Force evaluation in the engine.</p>"},{"t":"M","n":"Dagger\\File::withName","p":"Dagger/File.html#method_withName","d":"<p>Retrieves this file with its name set to the given name.</p>"},{"t":"M","n":"Dagger\\File::withTimestamps","p":"Dagger/File.html#method_withTimestamps","d":"<p>Retrieves this file with its created/modified timestamps set to the given time.</p>"},{"t":"M","n":"Dagger\\FunctionArg::defaultPath","p":"Dagger/FunctionArg.html#method_defaultPath","d":"<p>Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory</p>"},{"t":"M","n":"Dagger\\FunctionArg::defaultValue","p":"Dagger/FunctionArg.html#method_defaultValue","d":"<p>A default value to use for this argument when not explicitly set by the caller, if any.</p>"},{"t":"M","n":"Dagger\\FunctionArg::description","p":"Dagger/FunctionArg.html#method_description","d":"<p>A doc string for the argument, if any.</p>"},{"t":"M","n":"Dagger\\FunctionArg::id","p":"Dagger/FunctionArg.html#method_id","d":"<p>A unique identifier for this FunctionArg.</p>"},{"t":"M","n":"Dagger\\FunctionArg::ignore","p":"Dagger/FunctionArg.html#method_ignore","d":"<p>Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.</p>"},{"t":"M","n":"Dagger\\FunctionArg::name","p":"Dagger/FunctionArg.html#method_name","d":"<p>The name of the argument in lowerCamelCase format.</p>"},{"t":"M","n":"Dagger\\FunctionArg::sourceMap","p":"Dagger/FunctionArg.html#method_sourceMap","d":"<p>The location of this arg declaration.</p>"},{"t":"M","n":"Dagger\\FunctionArg::typeDef","p":"Dagger/FunctionArg.html#method_typeDef","d":"<p>The type of the argument.</p>"},{"t":"M","n":"Dagger\\FunctionCall::id","p":"Dagger/FunctionCall.html#method_id","d":"<p>A unique identifier for this FunctionCall.</p>"},{"t":"M","n":"Dagger\\FunctionCall::inputArgs","p":"Dagger/FunctionCall.html#method_inputArgs","d":"<p>The argument values the function is being invoked with.</p>"},{"t":"M","n":"Dagger\\FunctionCall::name","p":"Dagger/FunctionCall.html#method_name","d":"<p>The name of the function being called.</p>"},{"t":"M","n":"Dagger\\FunctionCall::parent","p":"Dagger/FunctionCall.html#method_parent","d":"<p>The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.</p>"},{"t":"M","n":"Dagger\\FunctionCall::parentName","p":"Dagger/FunctionCall.html#method_parentName","d":"<p>The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.</p>"},{"t":"M","n":"Dagger\\FunctionCall::returnError","p":"Dagger/FunctionCall.html#method_returnError","d":"<p>Return an error from the function.</p>"},{"t":"M","n":"Dagger\\FunctionCall::returnValue","p":"Dagger/FunctionCall.html#method_returnValue","d":"<p>Set the return value of the function call to the provided value.</p>"},{"t":"M","n":"Dagger\\FunctionCallArgValue::id","p":"Dagger/FunctionCallArgValue.html#method_id","d":"<p>A unique identifier for this FunctionCallArgValue.</p>"},{"t":"M","n":"Dagger\\FunctionCallArgValue::name","p":"Dagger/FunctionCallArgValue.html#method_name","d":"<p>The name of the argument.</p>"},{"t":"M","n":"Dagger\\FunctionCallArgValue::value","p":"Dagger/FunctionCallArgValue.html#method_value","d":"<p>The value of the argument represented as a JSON serialized string.</p>"},{"t":"M","n":"Dagger\\Function_::args","p":"Dagger/Function_.html#method_args","d":"<p>Arguments accepted by the function, if any.</p>"},{"t":"M","n":"Dagger\\Function_::description","p":"Dagger/Function_.html#method_description","d":"<p>A doc string for the function, if any.</p>"},{"t":"M","n":"Dagger\\Function_::id","p":"Dagger/Function_.html#method_id","d":"<p>A unique identifier for this Function.</p>"},{"t":"M","n":"Dagger\\Function_::name","p":"Dagger/Function_.html#method_name","d":"<p>The name of the function.</p>"},{"t":"M","n":"Dagger\\Function_::returnType","p":"Dagger/Function_.html#method_returnType","d":"<p>The type returned by the function.</p>"},{"t":"M","n":"Dagger\\Function_::sourceMap","p":"Dagger/Function_.html#method_sourceMap","d":"<p>The location of this function declaration.</p>"},{"t":"M","n":"Dagger\\Function_::withArg","p":"Dagger/Function_.html#method_withArg","d":"<p>Returns the function with the provided argument</p>"},{"t":"M","n":"Dagger\\Function_::withDescription","p":"Dagger/Function_.html#method_withDescription","d":"<p>Returns the function with the given doc string.</p>"},{"t":"M","n":"Dagger\\Function_::withSourceMap","p":"Dagger/Function_.html#method_withSourceMap","d":"<p>Returns the function with the given source map.</p>"},{"t":"M","n":"Dagger\\GeneratedCode::code","p":"Dagger/GeneratedCode.html#method_code","d":"<p>The directory containing the generated code.</p>"},{"t":"M","n":"Dagger\\GeneratedCode::id","p":"Dagger/GeneratedCode.html#method_id","d":"<p>A unique identifier for this GeneratedCode.</p>"},{"t":"M","n":"Dagger\\GeneratedCode::vcsGeneratedPaths","p":"Dagger/GeneratedCode.html#method_vcsGeneratedPaths","d":"<p>List of paths to mark generated in version control (i.e. .gitattributes).</p>"},{"t":"M","n":"Dagger\\GeneratedCode::vcsIgnoredPaths","p":"Dagger/GeneratedCode.html#method_vcsIgnoredPaths","d":"<p>List of paths to ignore in version control (i.e. .gitignore).</p>"},{"t":"M","n":"Dagger\\GeneratedCode::withVCSGeneratedPaths","p":"Dagger/GeneratedCode.html#method_withVCSGeneratedPaths","d":"<p>Set the list of paths to mark generated in version control.</p>"},{"t":"M","n":"Dagger\\GeneratedCode::withVCSIgnoredPaths","p":"Dagger/GeneratedCode.html#method_withVCSIgnoredPaths","d":"<p>Set the list of paths to ignore in version control.</p>"},{"t":"M","n":"Dagger\\GitRef::commit","p":"Dagger/GitRef.html#method_commit","d":"<p>The resolved commit id at this ref.</p>"},{"t":"M","n":"Dagger\\GitRef::id","p":"Dagger/GitRef.html#method_id","d":"<p>A unique identifier for this GitRef.</p>"},{"t":"M","n":"Dagger\\GitRef::ref","p":"Dagger/GitRef.html#method_ref","d":"<p>The resolved ref name at this ref.</p>"},{"t":"M","n":"Dagger\\GitRef::tree","p":"Dagger/GitRef.html#method_tree","d":"<p>The filesystem tree at this ref.</p>"},{"t":"M","n":"Dagger\\GitRepository::branch","p":"Dagger/GitRepository.html#method_branch","d":"<p>Returns details of a branch.</p>"},{"t":"M","n":"Dagger\\GitRepository::branches","p":"Dagger/GitRepository.html#method_branches","d":"<p>branches that match any of the given glob patterns.</p>"},{"t":"M","n":"Dagger\\GitRepository::commit","p":"Dagger/GitRepository.html#method_commit","d":"<p>Returns details of a commit.</p>"},{"t":"M","n":"Dagger\\GitRepository::head","p":"Dagger/GitRepository.html#method_head","d":"<p>Returns details for HEAD.</p>"},{"t":"M","n":"Dagger\\GitRepository::id","p":"Dagger/GitRepository.html#method_id","d":"<p>A unique identifier for this GitRepository.</p>"},{"t":"M","n":"Dagger\\GitRepository::ref","p":"Dagger/GitRepository.html#method_ref","d":"<p>Returns details of a ref.</p>"},{"t":"M","n":"Dagger\\GitRepository::tag","p":"Dagger/GitRepository.html#method_tag","d":"<p>Returns details of a tag.</p>"},{"t":"M","n":"Dagger\\GitRepository::tags","p":"Dagger/GitRepository.html#method_tags","d":"<p>tags that match any of the given glob patterns.</p>"},{"t":"M","n":"Dagger\\GitRepository::withAuthHeader","p":"Dagger/GitRepository.html#method_withAuthHeader","d":"<p>Header to authenticate the remote with.</p>"},{"t":"M","n":"Dagger\\GitRepository::withAuthToken","p":"Dagger/GitRepository.html#method_withAuthToken","d":"<p>Token to authenticate the remote with.</p>"},{"t":"M","n":"Dagger\\Host::directory","p":"Dagger/Host.html#method_directory","d":"<p>Accesses a directory on the host.</p>"},{"t":"M","n":"Dagger\\Host::file","p":"Dagger/Host.html#method_file","d":"<p>Accesses a file on the host.</p>"},{"t":"M","n":"Dagger\\Host::id","p":"Dagger/Host.html#method_id","d":"<p>A unique identifier for this Host.</p>"},{"t":"M","n":"Dagger\\Host::service","p":"Dagger/Host.html#method_service","d":"<p>Creates a service that forwards traffic to a specified address via the host.</p>"},{"t":"M","n":"Dagger\\Host::setSecretFile","p":"Dagger/Host.html#method_setSecretFile","d":"<p>Sets a secret given a user-defined name and the file path on the host, and returns the secret.</p>"},{"t":"M","n":"Dagger\\Host::tunnel","p":"Dagger/Host.html#method_tunnel","d":"<p>Creates a tunnel that forwards traffic from the host to a service.</p>"},{"t":"M","n":"Dagger\\Host::unixSocket","p":"Dagger/Host.html#method_unixSocket","d":"<p>Accesses a Unix socket on the host.</p>"},{"t":"M","n":"Dagger\\InputTypeDef::fields","p":"Dagger/InputTypeDef.html#method_fields","d":"<p>Static fields defined on this input object, if any.</p>"},{"t":"M","n":"Dagger\\InputTypeDef::id","p":"Dagger/InputTypeDef.html#method_id","d":"<p>A unique identifier for this InputTypeDef.</p>"},{"t":"M","n":"Dagger\\InputTypeDef::name","p":"Dagger/InputTypeDef.html#method_name","d":"<p>The name of the input object.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::description","p":"Dagger/InterfaceTypeDef.html#method_description","d":"<p>The doc string for the interface, if any.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::functions","p":"Dagger/InterfaceTypeDef.html#method_functions","d":"<p>Functions defined on this interface, if any.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::id","p":"Dagger/InterfaceTypeDef.html#method_id","d":"<p>A unique identifier for this InterfaceTypeDef.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::name","p":"Dagger/InterfaceTypeDef.html#method_name","d":"<p>The name of the interface.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::sourceMap","p":"Dagger/InterfaceTypeDef.html#method_sourceMap","d":"<p>The location of this interface declaration.</p>"},{"t":"M","n":"Dagger\\InterfaceTypeDef::sourceModuleName","p":"Dagger/InterfaceTypeDef.html#method_sourceModuleName","d":"<p>If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"},{"t":"M","n":"Dagger\\LLM::attempt","p":"Dagger/LLM.html#method_attempt","d":"<p>create a branch in the LLM's history</p>"},{"t":"M","n":"Dagger\\LLM::bindResult","p":"Dagger/LLM.html#method_bindResult","d":"<p>returns the type of the current state</p>"},{"t":"M","n":"Dagger\\LLM::env","p":"Dagger/LLM.html#method_env","d":"<p>return the LLM's current environment</p>"},{"t":"M","n":"Dagger\\LLM::history","p":"Dagger/LLM.html#method_history","d":"<p>return the llm message history</p>"},{"t":"M","n":"Dagger\\LLM::historyJSON","p":"Dagger/LLM.html#method_historyJSON","d":"<p>return the raw llm message history as json</p>"},{"t":"M","n":"Dagger\\LLM::id","p":"Dagger/LLM.html#method_id","d":"<p>A unique identifier for this LLM.</p>"},{"t":"M","n":"Dagger\\LLM::lastReply","p":"Dagger/LLM.html#method_lastReply","d":"<p>return the last llm reply from the history</p>"},{"t":"M","n":"Dagger\\LLM::loop","p":"Dagger/LLM.html#method_loop","d":"<p>synchronize LLM state</p>"},{"t":"M","n":"Dagger\\LLM::model","p":"Dagger/LLM.html#method_model","d":"<p>return the model used by the llm</p>"},{"t":"M","n":"Dagger\\LLM::provider","p":"Dagger/LLM.html#method_provider","d":"<p>return the provider used by the llm</p>"},{"t":"M","n":"Dagger\\LLM::sync","p":"Dagger/LLM.html#method_sync","d":"<p>synchronize LLM state</p>"},{"t":"M","n":"Dagger\\LLM::tokenUsage","p":"Dagger/LLM.html#method_tokenUsage","d":"<p>returns the token usage of the current state</p>"},{"t":"M","n":"Dagger\\LLM::tools","p":"Dagger/LLM.html#method_tools","d":"<p>print documentation for available tools</p>"},{"t":"M","n":"Dagger\\LLM::withEnv","p":"Dagger/LLM.html#method_withEnv","d":"<p>allow the LLM to interact with an environment via MCP</p>"},{"t":"M","n":"Dagger\\LLM::withModel","p":"Dagger/LLM.html#method_withModel","d":"<p>swap out the llm model</p>"},{"t":"M","n":"Dagger\\LLM::withPrompt","p":"Dagger/LLM.html#method_withPrompt","d":"<p>append a prompt to the llm context</p>"},{"t":"M","n":"Dagger\\LLM::withPromptFile","p":"Dagger/LLM.html#method_withPromptFile","d":"<p>append the contents of a file to the llm context</p>"},{"t":"M","n":"Dagger\\LLM::withSystemPrompt","p":"Dagger/LLM.html#method_withSystemPrompt","d":"<p>Add a system prompt to the LLM's environment</p>"},{"t":"M","n":"Dagger\\LLM::withoutDefaultSystemPrompt","p":"Dagger/LLM.html#method_withoutDefaultSystemPrompt","d":"<p>Disable the default system prompt</p>"},{"t":"M","n":"Dagger\\LLMTokenUsage::cachedTokenReads","p":"Dagger/LLMTokenUsage.html#method_cachedTokenReads","d":null},{"t":"M","n":"Dagger\\LLMTokenUsage::cachedTokenWrites","p":"Dagger/LLMTokenUsage.html#method_cachedTokenWrites","d":null},{"t":"M","n":"Dagger\\LLMTokenUsage::id","p":"Dagger/LLMTokenUsage.html#method_id","d":"<p>A unique identifier for this LLMTokenUsage.</p>"},{"t":"M","n":"Dagger\\LLMTokenUsage::inputTokens","p":"Dagger/LLMTokenUsage.html#method_inputTokens","d":null},{"t":"M","n":"Dagger\\LLMTokenUsage::outputTokens","p":"Dagger/LLMTokenUsage.html#method_outputTokens","d":null},{"t":"M","n":"Dagger\\LLMTokenUsage::totalTokens","p":"Dagger/LLMTokenUsage.html#method_totalTokens","d":null},{"t":"M","n":"Dagger\\Label::id","p":"Dagger/Label.html#method_id","d":"<p>A unique identifier for this Label.</p>"},{"t":"M","n":"Dagger\\Label::name","p":"Dagger/Label.html#method_name","d":"<p>The label name.</p>"},{"t":"M","n":"Dagger\\Label::value","p":"Dagger/Label.html#method_value","d":"<p>The label value.</p>"},{"t":"M","n":"Dagger\\ListTypeDef::elementTypeDef","p":"Dagger/ListTypeDef.html#method_elementTypeDef","d":"<p>The type of the elements in the list.</p>"},{"t":"M","n":"Dagger\\ListTypeDef::id","p":"Dagger/ListTypeDef.html#method_id","d":"<p>A unique identifier for this ListTypeDef.</p>"},{"t":"M","n":"Dagger\\Module::dependencies","p":"Dagger/Module.html#method_dependencies","d":"<p>The dependencies of the module.</p>"},{"t":"M","n":"Dagger\\Module::description","p":"Dagger/Module.html#method_description","d":"<p>The doc string of the module, if any</p>"},{"t":"M","n":"Dagger\\Module::enums","p":"Dagger/Module.html#method_enums","d":"<p>Enumerations served by this module.</p>"},{"t":"M","n":"Dagger\\Module::generatedContextDirectory","p":"Dagger/Module.html#method_generatedContextDirectory","d":"<p>The generated files and directories made on top of the module source's context directory.</p>"},{"t":"M","n":"Dagger\\Module::id","p":"Dagger/Module.html#method_id","d":"<p>A unique identifier for this Module.</p>"},{"t":"M","n":"Dagger\\Module::interfaces","p":"Dagger/Module.html#method_interfaces","d":"<p>Interfaces served by this module.</p>"},{"t":"M","n":"Dagger\\Module::name","p":"Dagger/Module.html#method_name","d":"<p>The name of the module</p>"},{"t":"M","n":"Dagger\\Module::objects","p":"Dagger/Module.html#method_objects","d":"<p>Objects served by this module.</p>"},{"t":"M","n":"Dagger\\Module::runtime","p":"Dagger/Module.html#method_runtime","d":"<p>The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.</p>"},{"t":"M","n":"Dagger\\Module::sdk","p":"Dagger/Module.html#method_sdk","d":"<p>The SDK config used by this module.</p>"},{"t":"M","n":"Dagger\\Module::serve","p":"Dagger/Module.html#method_serve","d":"<p>Serve a module's API in the current session.</p>"},{"t":"M","n":"Dagger\\Module::source","p":"Dagger/Module.html#method_source","d":"<p>The source for the module.</p>"},{"t":"M","n":"Dagger\\Module::sync","p":"Dagger/Module.html#method_sync","d":"<p>Forces evaluation of the module, including any loading into the engine and associated validation.</p>"},{"t":"M","n":"Dagger\\Module::withDescription","p":"Dagger/Module.html#method_withDescription","d":"<p>Retrieves the module with the given description</p>"},{"t":"M","n":"Dagger\\Module::withEnum","p":"Dagger/Module.html#method_withEnum","d":"<p>This module plus the given Enum type and associated values</p>"},{"t":"M","n":"Dagger\\Module::withInterface","p":"Dagger/Module.html#method_withInterface","d":"<p>This module plus the given Interface type and associated functions</p>"},{"t":"M","n":"Dagger\\Module::withObject","p":"Dagger/Module.html#method_withObject","d":"<p>This module plus the given Object type and associated functions.</p>"},{"t":"M","n":"Dagger\\ModuleConfigClient::dev","p":"Dagger/ModuleConfigClient.html#method_dev","d":"<p>If true, generate the client in developer mode.</p>"},{"t":"M","n":"Dagger\\ModuleConfigClient::directory","p":"Dagger/ModuleConfigClient.html#method_directory","d":"<p>The directory the client is generated in.</p>"},{"t":"M","n":"Dagger\\ModuleConfigClient::generator","p":"Dagger/ModuleConfigClient.html#method_generator","d":"<p>The generator to use</p>"},{"t":"M","n":"Dagger\\ModuleConfigClient::id","p":"Dagger/ModuleConfigClient.html#method_id","d":"<p>A unique identifier for this ModuleConfigClient.</p>"},{"t":"M","n":"Dagger\\ModuleSource::asModule","p":"Dagger/ModuleSource.html#method_asModule","d":"<p>Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation</p>"},{"t":"M","n":"Dagger\\ModuleSource::asString","p":"Dagger/ModuleSource.html#method_asString","d":"<p>A human readable ref string representation of this module source.</p>"},{"t":"M","n":"Dagger\\ModuleSource::cloneRef","p":"Dagger/ModuleSource.html#method_cloneRef","d":"<p>The ref to clone the root of the git repo from. Only valid for git sources.</p>"},{"t":"M","n":"Dagger\\ModuleSource::commit","p":"Dagger/ModuleSource.html#method_commit","d":"<p>The resolved commit of the git repo this source points to.</p>"},{"t":"M","n":"Dagger\\ModuleSource::configClients","p":"Dagger/ModuleSource.html#method_configClients","d":"<p>The clients generated for the module.</p>"},{"t":"M","n":"Dagger\\ModuleSource::configExists","p":"Dagger/ModuleSource.html#method_configExists","d":"<p>Whether an existing dagger.json for the module was found.</p>"},{"t":"M","n":"Dagger\\ModuleSource::contextDirectory","p":"Dagger/ModuleSource.html#method_contextDirectory","d":"<p>The full directory loaded for the module source, including the source code as a subdirectory.</p>"},{"t":"M","n":"Dagger\\ModuleSource::dependencies","p":"Dagger/ModuleSource.html#method_dependencies","d":"<p>The dependencies of the module source.</p>"},{"t":"M","n":"Dagger\\ModuleSource::digest","p":"Dagger/ModuleSource.html#method_digest","d":"<p>A content-hash of the module source. Module sources with the same digest will output the same generated context and convert into the same module instance.</p>"},{"t":"M","n":"Dagger\\ModuleSource::directory","p":"Dagger/ModuleSource.html#method_directory","d":"<p>The directory containing the module configuration and source code (source code may be in a subdir).</p>"},{"t":"M","n":"Dagger\\ModuleSource::engineVersion","p":"Dagger/ModuleSource.html#method_engineVersion","d":"<p>The engine version of the module.</p>"},{"t":"M","n":"Dagger\\ModuleSource::generatedContextDirectory","p":"Dagger/ModuleSource.html#method_generatedContextDirectory","d":"<p>The generated files and directories made on top of the module source's context directory.</p>"},{"t":"M","n":"Dagger\\ModuleSource::htmlRepoURL","p":"Dagger/ModuleSource.html#method_htmlRepoURL","d":"<p>The URL to access the web view of the repository (e.g., GitHub, GitLab, Bitbucket).</p>"},{"t":"M","n":"Dagger\\ModuleSource::htmlURL","p":"Dagger/ModuleSource.html#method_htmlURL","d":"<p>The URL to the source's git repo in a web browser. Only valid for git sources.</p>"},{"t":"M","n":"Dagger\\ModuleSource::id","p":"Dagger/ModuleSource.html#method_id","d":"<p>A unique identifier for this ModuleSource.</p>"},{"t":"M","n":"Dagger\\ModuleSource::kind","p":"Dagger/ModuleSource.html#method_kind","d":"<p>The kind of module source (currently local, git or dir).</p>"},{"t":"M","n":"Dagger\\ModuleSource::localContextDirectoryPath","p":"Dagger/ModuleSource.html#method_localContextDirectoryPath","d":"<p>The full absolute path to the context directory on the caller's host filesystem that this module source is loaded from. Only valid for local module sources.</p>"},{"t":"M","n":"Dagger\\ModuleSource::moduleName","p":"Dagger/ModuleSource.html#method_moduleName","d":"<p>The name of the module, including any setting via the withName API.</p>"},{"t":"M","n":"Dagger\\ModuleSource::moduleOriginalName","p":"Dagger/ModuleSource.html#method_moduleOriginalName","d":"<p>The original name of the module as read from the module's dagger.json (or set for the first time with the withName API).</p>"},{"t":"M","n":"Dagger\\ModuleSource::originalSubpath","p":"Dagger/ModuleSource.html#method_originalSubpath","d":"<p>The original subpath used when instantiating this module source, relative to the context directory.</p>"},{"t":"M","n":"Dagger\\ModuleSource::pin","p":"Dagger/ModuleSource.html#method_pin","d":"<p>The pinned version of this module source.</p>"},{"t":"M","n":"Dagger\\ModuleSource::repoRootPath","p":"Dagger/ModuleSource.html#method_repoRootPath","d":"<p>The import path corresponding to the root of the git repo this source points to. Only valid for git sources.</p>"},{"t":"M","n":"Dagger\\ModuleSource::sdk","p":"Dagger/ModuleSource.html#method_sdk","d":"<p>The SDK configuration of the module.</p>"},{"t":"M","n":"Dagger\\ModuleSource::sourceRootSubpath","p":"Dagger/ModuleSource.html#method_sourceRootSubpath","d":"<p>The path, relative to the context directory, that contains the module's dagger.json.</p>"},{"t":"M","n":"Dagger\\ModuleSource::sourceSubpath","p":"Dagger/ModuleSource.html#method_sourceSubpath","d":"<p>The path to the directory containing the module's source code, relative to the context directory.</p>"},{"t":"M","n":"Dagger\\ModuleSource::sync","p":"Dagger/ModuleSource.html#method_sync","d":"<p>Forces evaluation of the module source, including any loading into the engine and associated validation.</p>"},{"t":"M","n":"Dagger\\ModuleSource::version","p":"Dagger/ModuleSource.html#method_version","d":"<p>The specified version of the git repo this source points to.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withClient","p":"Dagger/ModuleSource.html#method_withClient","d":"<p>Update the module source with a new client to generate.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withDependencies","p":"Dagger/ModuleSource.html#method_withDependencies","d":"<p>Append the provided dependencies to the module source's dependency list.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withEngineVersion","p":"Dagger/ModuleSource.html#method_withEngineVersion","d":"<p>Upgrade the engine version of the module to the given value.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withIncludes","p":"Dagger/ModuleSource.html#method_withIncludes","d":"<p>Update the module source with additional include patterns for files+directories from its context that are required for building it</p>"},{"t":"M","n":"Dagger\\ModuleSource::withName","p":"Dagger/ModuleSource.html#method_withName","d":"<p>Update the module source with a new name.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withSDK","p":"Dagger/ModuleSource.html#method_withSDK","d":"<p>Update the module source with a new SDK.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withSourceSubpath","p":"Dagger/ModuleSource.html#method_withSourceSubpath","d":"<p>Update the module source with a new source subpath.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withUpdateDependencies","p":"Dagger/ModuleSource.html#method_withUpdateDependencies","d":"<p>Update one or more module dependencies.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withoutClient","p":"Dagger/ModuleSource.html#method_withoutClient","d":"<p>Remove a client from the module source.</p>"},{"t":"M","n":"Dagger\\ModuleSource::withoutDependencies","p":"Dagger/ModuleSource.html#method_withoutDependencies","d":"<p>Remove the provided dependencies from the module source's dependency list.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::constructor","p":"Dagger/ObjectTypeDef.html#method_constructor","d":"<p>The function used to construct new instances of this object, if any</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::description","p":"Dagger/ObjectTypeDef.html#method_description","d":"<p>The doc string for the object, if any.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::fields","p":"Dagger/ObjectTypeDef.html#method_fields","d":"<p>Static fields defined on this object, if any.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::functions","p":"Dagger/ObjectTypeDef.html#method_functions","d":"<p>Functions defined on this object, if any.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::id","p":"Dagger/ObjectTypeDef.html#method_id","d":"<p>A unique identifier for this ObjectTypeDef.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::name","p":"Dagger/ObjectTypeDef.html#method_name","d":"<p>The name of the object.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::sourceMap","p":"Dagger/ObjectTypeDef.html#method_sourceMap","d":"<p>The location of this object declaration.</p>"},{"t":"M","n":"Dagger\\ObjectTypeDef::sourceModuleName","p":"Dagger/ObjectTypeDef.html#method_sourceModuleName","d":"<p>If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"},{"t":"M","n":"Dagger\\PipelineLabel::__construct","p":"Dagger/PipelineLabel.html#method___construct","d":null},{"t":"M","n":"Dagger\\Port::description","p":"Dagger/Port.html#method_description","d":"<p>The port description.</p>"},{"t":"M","n":"Dagger\\Port::experimentalSkipHealthcheck","p":"Dagger/Port.html#method_experimentalSkipHealthcheck","d":"<p>Skip the health check when run as a service.</p>"},{"t":"M","n":"Dagger\\Port::id","p":"Dagger/Port.html#method_id","d":"<p>A unique identifier for this Port.</p>"},{"t":"M","n":"Dagger\\Port::port","p":"Dagger/Port.html#method_port","d":"<p>The port number.</p>"},{"t":"M","n":"Dagger\\Port::protocol","p":"Dagger/Port.html#method_protocol","d":"<p>The transport layer protocol.</p>"},{"t":"M","n":"Dagger\\PortForward::__construct","p":"Dagger/PortForward.html#method___construct","d":null},{"t":"M","n":"Dagger\\SDKConfig::id","p":"Dagger/SDKConfig.html#method_id","d":"<p>A unique identifier for this SDKConfig.</p>"},{"t":"M","n":"Dagger\\SDKConfig::source","p":"Dagger/SDKConfig.html#method_source","d":"<p>Source of the SDK. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation.</p>"},{"t":"M","n":"Dagger\\ScalarTypeDef::description","p":"Dagger/ScalarTypeDef.html#method_description","d":"<p>A doc string for the scalar, if any.</p>"},{"t":"M","n":"Dagger\\ScalarTypeDef::id","p":"Dagger/ScalarTypeDef.html#method_id","d":"<p>A unique identifier for this ScalarTypeDef.</p>"},{"t":"M","n":"Dagger\\ScalarTypeDef::name","p":"Dagger/ScalarTypeDef.html#method_name","d":"<p>The name of the scalar.</p>"},{"t":"M","n":"Dagger\\ScalarTypeDef::sourceModuleName","p":"Dagger/ScalarTypeDef.html#method_sourceModuleName","d":"<p>If this ScalarTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"},{"t":"M","n":"Dagger\\Secret::id","p":"Dagger/Secret.html#method_id","d":"<p>A unique identifier for this Secret.</p>"},{"t":"M","n":"Dagger\\Secret::name","p":"Dagger/Secret.html#method_name","d":"<p>The name of this secret.</p>"},{"t":"M","n":"Dagger\\Secret::plaintext","p":"Dagger/Secret.html#method_plaintext","d":"<p>The value of this secret.</p>"},{"t":"M","n":"Dagger\\Secret::uri","p":"Dagger/Secret.html#method_uri","d":"<p>The URI of this secret.</p>"},{"t":"M","n":"Dagger\\Service::endpoint","p":"Dagger/Service.html#method_endpoint","d":"<p>Retrieves an endpoint that clients can use to reach this container.</p>"},{"t":"M","n":"Dagger\\Service::hostname","p":"Dagger/Service.html#method_hostname","d":"<p>Retrieves a hostname which can be used by clients to reach this container.</p>"},{"t":"M","n":"Dagger\\Service::id","p":"Dagger/Service.html#method_id","d":"<p>A unique identifier for this Service.</p>"},{"t":"M","n":"Dagger\\Service::ports","p":"Dagger/Service.html#method_ports","d":"<p>Retrieves the list of ports provided by the service.</p>"},{"t":"M","n":"Dagger\\Service::start","p":"Dagger/Service.html#method_start","d":"<p>Start the service and wait for its health checks to succeed.</p>"},{"t":"M","n":"Dagger\\Service::stop","p":"Dagger/Service.html#method_stop","d":"<p>Stop the service.</p>"},{"t":"M","n":"Dagger\\Service::up","p":"Dagger/Service.html#method_up","d":"<p>Creates a tunnel that forwards traffic from the caller's network to this service.</p>"},{"t":"M","n":"Dagger\\Service::withHostname","p":"Dagger/Service.html#method_withHostname","d":"<p>Configures a hostname which can be used by clients within the session to reach this container.</p>"},{"t":"M","n":"Dagger\\Socket::id","p":"Dagger/Socket.html#method_id","d":"<p>A unique identifier for this Socket.</p>"},{"t":"M","n":"Dagger\\SourceMap::column","p":"Dagger/SourceMap.html#method_column","d":"<p>The column number within the line.</p>"},{"t":"M","n":"Dagger\\SourceMap::filename","p":"Dagger/SourceMap.html#method_filename","d":"<p>The filename from the module source.</p>"},{"t":"M","n":"Dagger\\SourceMap::id","p":"Dagger/SourceMap.html#method_id","d":"<p>A unique identifier for this SourceMap.</p>"},{"t":"M","n":"Dagger\\SourceMap::line","p":"Dagger/SourceMap.html#method_line","d":"<p>The line number within the filename.</p>"},{"t":"M","n":"Dagger\\SourceMap::module","p":"Dagger/SourceMap.html#method_module","d":"<p>The module dependency this was declared in.</p>"},{"t":"M","n":"Dagger\\Terminal::id","p":"Dagger/Terminal.html#method_id","d":"<p>A unique identifier for this Terminal.</p>"},{"t":"M","n":"Dagger\\Terminal::sync","p":"Dagger/Terminal.html#method_sync","d":"<p>Forces evaluation of the pipeline in the engine.</p>"},{"t":"M","n":"Dagger\\TypeDef::asEnum","p":"Dagger/TypeDef.html#method_asEnum","d":"<p>If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::asInput","p":"Dagger/TypeDef.html#method_asInput","d":"<p>If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::asInterface","p":"Dagger/TypeDef.html#method_asInterface","d":"<p>If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::asList","p":"Dagger/TypeDef.html#method_asList","d":"<p>If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::asObject","p":"Dagger/TypeDef.html#method_asObject","d":"<p>If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::asScalar","p":"Dagger/TypeDef.html#method_asScalar","d":"<p>If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.</p>"},{"t":"M","n":"Dagger\\TypeDef::id","p":"Dagger/TypeDef.html#method_id","d":"<p>A unique identifier for this TypeDef.</p>"},{"t":"M","n":"Dagger\\TypeDef::kind","p":"Dagger/TypeDef.html#method_kind","d":"<p>The kind of type this is (e.g. primitive, list, object).</p>"},{"t":"M","n":"Dagger\\TypeDef::optional","p":"Dagger/TypeDef.html#method_optional","d":"<p>Whether this type can be set to null. Defaults to false.</p>"},{"t":"M","n":"Dagger\\TypeDef::withConstructor","p":"Dagger/TypeDef.html#method_withConstructor","d":"<p>Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.</p>"},{"t":"M","n":"Dagger\\TypeDef::withEnum","p":"Dagger/TypeDef.html#method_withEnum","d":"<p>Returns a TypeDef of kind Enum with the provided name.</p>"},{"t":"M","n":"Dagger\\TypeDef::withEnumValue","p":"Dagger/TypeDef.html#method_withEnumValue","d":"<p>Adds a static value for an Enum TypeDef, failing if the type is not an enum.</p>"},{"t":"M","n":"Dagger\\TypeDef::withField","p":"Dagger/TypeDef.html#method_withField","d":"<p>Adds a static field for an Object TypeDef, failing if the type is not an object.</p>"},{"t":"M","n":"Dagger\\TypeDef::withFunction","p":"Dagger/TypeDef.html#method_withFunction","d":"<p>Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.</p>"},{"t":"M","n":"Dagger\\TypeDef::withInterface","p":"Dagger/TypeDef.html#method_withInterface","d":"<p>Returns a TypeDef of kind Interface with the provided name.</p>"},{"t":"M","n":"Dagger\\TypeDef::withKind","p":"Dagger/TypeDef.html#method_withKind","d":"<p>Sets the kind of the type.</p>"},{"t":"M","n":"Dagger\\TypeDef::withListOf","p":"Dagger/TypeDef.html#method_withListOf","d":"<p>Returns a TypeDef of kind List with the provided type for its elements.</p>"},{"t":"M","n":"Dagger\\TypeDef::withObject","p":"Dagger/TypeDef.html#method_withObject","d":"<p>Returns a TypeDef of kind Object with the provided name.</p>"},{"t":"M","n":"Dagger\\TypeDef::withOptional","p":"Dagger/TypeDef.html#method_withOptional","d":"<p>Sets whether this type can be set to null.</p>"},{"t":"M","n":"Dagger\\TypeDef::withScalar","p":"Dagger/TypeDef.html#method_withScalar","d":"<p>Returns a TypeDef of kind Scalar with the provided name.</p>"},{"t":"M","n":"Dagger\\Client\\IdAble::id","p":"Dagger/Client/IdAble.html#method_id","d":null},{"t":"N","n":"Dagger","p":"Dagger.html"},{"t":"N","n":"Dagger\\Attribute","p":"Dagger/Attribute.html"},{"t":"N","n":"Dagger\\Client","p":"Dagger/Client.html"}]}
+{
+	"items": [
+		{
+			"t": "F",
+			"n": "Dagger\\dag",
+			"p": "Dagger.html#function_dag",
+			"d": null
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\Argument",
+			"p": "Dagger/Attribute/Argument.html",
+			"d": "",
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\DaggerFunction",
+			"p": "Dagger/Attribute/DaggerFunction.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\DaggerObject",
+			"p": "Dagger/Attribute/DaggerObject.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\DefaultPath",
+			"p": "Dagger/Attribute/DefaultPath.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\Doc",
+			"p": "Dagger/Attribute/Doc.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\Ignore",
+			"p": "Dagger/Attribute/Ignore.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\ListOfType",
+			"p": "Dagger/Attribute/ListOfType.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Attribute\\ReturnsListOfType",
+			"p": "Dagger/Attribute/ReturnsListOfType.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Attribute",
+				"p": "Dagger/Attribute.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Binding",
+			"p": "Dagger/Binding.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\BindingId",
+			"p": "Dagger/BindingId.html",
+			"d": "<p>The <code>BindingID</code> scalar type represents an identifier for an object of type Binding.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\BuildArg",
+			"p": "Dagger/BuildArg.html",
+			"d": "<p>Key value object that represents a build argument.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\CacheVolume",
+			"p": "Dagger/CacheVolume.html",
+			"d": "<p>A directory whose contents persist across runs.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\CacheVolumeId",
+			"p": "Dagger/CacheVolumeId.html",
+			"d": "<p>The <code>CacheVolumeID</code> scalar type represents an identifier for an object of type CacheVolume.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client",
+			"p": "Dagger/Client.html",
+			"d": "<p>The root of the DAG.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\AbstractClient",
+			"p": "Dagger/Client/AbstractClient.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\AbstractId",
+			"p": "Dagger/Client/AbstractId.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\AbstractInputObject",
+			"p": "Dagger/Client/AbstractInputObject.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\AbstractObject",
+			"p": "Dagger/Client/AbstractObject.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\AbstractScalar",
+			"p": "Dagger/Client/AbstractScalar.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\IdAble",
+			"p": "Dagger/Client/IdAble.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Client\\QueryBuilder",
+			"p": "Dagger/Client/QueryBuilder.html",
+			"d": null,
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Connection",
+			"p": "Dagger/Connection.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Container",
+			"p": "Dagger/Container.html",
+			"d": "<p>An OCI-compatible container, also known as a Docker container.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ContainerId",
+			"p": "Dagger/ContainerId.html",
+			"d": "<p>The <code>ContainerID</code> scalar type represents an identifier for an object of type Container.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\CurrentModule",
+			"p": "Dagger/CurrentModule.html",
+			"d": "<p>Reflective module API provided to functions at runtime.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\CurrentModuleId",
+			"p": "Dagger/CurrentModuleId.html",
+			"d": "<p>The <code>CurrentModuleID</code> scalar type represents an identifier for an object of type CurrentModule.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Dagger",
+			"p": "Dagger/Dagger.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Directory",
+			"p": "Dagger/Directory.html",
+			"d": "<p>A directory.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\DirectoryId",
+			"p": "Dagger/DirectoryId.html",
+			"d": "<p>The <code>DirectoryID</code> scalar type represents an identifier for an object of type Directory.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Engine",
+			"p": "Dagger/Engine.html",
+			"d": "<p>The Dagger engine configuration and state</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCache",
+			"p": "Dagger/EngineCache.html",
+			"d": "<p>A cache storage for the Dagger engine</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCacheEntry",
+			"p": "Dagger/EngineCacheEntry.html",
+			"d": "<p>An individual cache entry in a cache entry set</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCacheEntryId",
+			"p": "Dagger/EngineCacheEntryId.html",
+			"d": "<p>The <code>EngineCacheEntryID</code> scalar type represents an identifier for an object of type EngineCacheEntry.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCacheEntrySet",
+			"p": "Dagger/EngineCacheEntrySet.html",
+			"d": "<p>A set of cache entries returned by a query to a cache</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCacheEntrySetId",
+			"p": "Dagger/EngineCacheEntrySetId.html",
+			"d": "<p>The <code>EngineCacheEntrySetID</code> scalar type represents an identifier for an object of type EngineCacheEntrySet.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineCacheId",
+			"p": "Dagger/EngineCacheId.html",
+			"d": "<p>The <code>EngineCacheID</code> scalar type represents an identifier for an object of type EngineCache.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EngineId",
+			"p": "Dagger/EngineId.html",
+			"d": "<p>The <code>EngineID</code> scalar type represents an identifier for an object of type Engine.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnumTypeDef",
+			"p": "Dagger/EnumTypeDef.html",
+			"d": "<p>A definition of a custom enum defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnumTypeDefId",
+			"p": "Dagger/EnumTypeDefId.html",
+			"d": "<p>The <code>EnumTypeDefID</code> scalar type represents an identifier for an object of type EnumTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnumValueTypeDef",
+			"p": "Dagger/EnumValueTypeDef.html",
+			"d": "<p>A definition of a value in a custom enum defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnumValueTypeDefId",
+			"p": "Dagger/EnumValueTypeDefId.html",
+			"d": "<p>The <code>EnumValueTypeDefID</code> scalar type represents an identifier for an object of type EnumValueTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Env",
+			"p": "Dagger/Env.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnvId",
+			"p": "Dagger/EnvId.html",
+			"d": "<p>The <code>EnvID</code> scalar type represents an identifier for an object of type Env.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnvVariable",
+			"p": "Dagger/EnvVariable.html",
+			"d": "<p>An environment variable name and value.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\EnvVariableId",
+			"p": "Dagger/EnvVariableId.html",
+			"d": "<p>The <code>EnvVariableID</code> scalar type represents an identifier for an object of type EnvVariable.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Error",
+			"p": "Dagger/Error.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ErrorId",
+			"p": "Dagger/ErrorId.html",
+			"d": "<p>The <code>ErrorID</code> scalar type represents an identifier for an object of type Error.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ErrorValue",
+			"p": "Dagger/ErrorValue.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ErrorValueId",
+			"p": "Dagger/ErrorValueId.html",
+			"d": "<p>The <code>ErrorValueID</code> scalar type represents an identifier for an object of type ErrorValue.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FieldTypeDef",
+			"p": "Dagger/FieldTypeDef.html",
+			"d": "<p>A definition of a field on a custom object defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FieldTypeDefId",
+			"p": "Dagger/FieldTypeDefId.html",
+			"d": "<p>The <code>FieldTypeDefID</code> scalar type represents an identifier for an object of type FieldTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\File",
+			"p": "Dagger/File.html",
+			"d": "<p>A file.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FileId",
+			"p": "Dagger/FileId.html",
+			"d": "<p>The <code>FileID</code> scalar type represents an identifier for an object of type File.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionArg",
+			"p": "Dagger/FunctionArg.html",
+			"d": "<p>An argument accepted by a function.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionArgId",
+			"p": "Dagger/FunctionArgId.html",
+			"d": "<p>The <code>FunctionArgID</code> scalar type represents an identifier for an object of type FunctionArg.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionCall",
+			"p": "Dagger/FunctionCall.html",
+			"d": "<p>An active function call.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionCallArgValue",
+			"p": "Dagger/FunctionCallArgValue.html",
+			"d": "<p>A value passed as a named argument to a function call.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionCallArgValueId",
+			"p": "Dagger/FunctionCallArgValueId.html",
+			"d": "<p>The <code>FunctionCallArgValueID</code> scalar type represents an identifier for an object of type FunctionCallArgValue.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionCallId",
+			"p": "Dagger/FunctionCallId.html",
+			"d": "<p>The <code>FunctionCallID</code> scalar type represents an identifier for an object of type FunctionCall.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\FunctionId",
+			"p": "Dagger/FunctionId.html",
+			"d": "<p>The <code>FunctionID</code> scalar type represents an identifier for an object of type Function.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Function_",
+			"p": "Dagger/Function_.html",
+			"d": "<p>Function represents a resolver provided by a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GeneratedCode",
+			"p": "Dagger/GeneratedCode.html",
+			"d": "<p>The result of running an SDK's codegen.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GeneratedCodeId",
+			"p": "Dagger/GeneratedCodeId.html",
+			"d": "<p>The <code>GeneratedCodeID</code> scalar type represents an identifier for an object of type GeneratedCode.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GitRef",
+			"p": "Dagger/GitRef.html",
+			"d": "<p>A git ref (tag, branch, or commit).</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GitRefId",
+			"p": "Dagger/GitRefId.html",
+			"d": "<p>The <code>GitRefID</code> scalar type represents an identifier for an object of type GitRef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GitRepository",
+			"p": "Dagger/GitRepository.html",
+			"d": "<p>A git repository.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\GitRepositoryId",
+			"p": "Dagger/GitRepositoryId.html",
+			"d": "<p>The <code>GitRepositoryID</code> scalar type represents an identifier for an object of type GitRepository.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Host",
+			"p": "Dagger/Host.html",
+			"d": "<p>Information about the host environment.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\HostId",
+			"p": "Dagger/HostId.html",
+			"d": "<p>The <code>HostID</code> scalar type represents an identifier for an object of type Host.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\InputTypeDef",
+			"p": "Dagger/InputTypeDef.html",
+			"d": "<p>A graphql input type, which is essentially just a group of named args.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\InputTypeDefId",
+			"p": "Dagger/InputTypeDefId.html",
+			"d": "<p>The <code>InputTypeDefID</code> scalar type represents an identifier for an object of type InputTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\InterfaceTypeDef",
+			"p": "Dagger/InterfaceTypeDef.html",
+			"d": "<p>A definition of a custom interface defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\InterfaceTypeDefId",
+			"p": "Dagger/InterfaceTypeDefId.html",
+			"d": "<p>The <code>InterfaceTypeDefID</code> scalar type represents an identifier for an object of type InterfaceTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Json",
+			"p": "Dagger/Json.html",
+			"d": "<p>An arbitrary JSON-encoded value.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\LLM",
+			"p": "Dagger/LLM.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\LLMId",
+			"p": "Dagger/LLMId.html",
+			"d": "<p>The <code>LLMID</code> scalar type represents an identifier for an object of type LLM.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\LLMTokenUsage",
+			"p": "Dagger/LLMTokenUsage.html",
+			"d": null,
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\LLMTokenUsageId",
+			"p": "Dagger/LLMTokenUsageId.html",
+			"d": "<p>The <code>LLMTokenUsageID</code> scalar type represents an identifier for an object of type LLMTokenUsage.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Label",
+			"p": "Dagger/Label.html",
+			"d": "<p>A simple key value object that represents a label.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\LabelId",
+			"p": "Dagger/LabelId.html",
+			"d": "<p>The <code>LabelID</code> scalar type represents an identifier for an object of type Label.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ListTypeDef",
+			"p": "Dagger/ListTypeDef.html",
+			"d": "<p>A definition of a list type in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ListTypeDefId",
+			"p": "Dagger/ListTypeDefId.html",
+			"d": "<p>The <code>ListTypeDefID</code> scalar type represents an identifier for an object of type ListTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Module",
+			"p": "Dagger/Module.html",
+			"d": "<p>A Dagger module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ModuleConfigClient",
+			"p": "Dagger/ModuleConfigClient.html",
+			"d": "<p>The client generated for the module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ModuleConfigClientId",
+			"p": "Dagger/ModuleConfigClientId.html",
+			"d": "<p>The <code>ModuleConfigClientID</code> scalar type represents an identifier for an object of type ModuleConfigClient.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ModuleId",
+			"p": "Dagger/ModuleId.html",
+			"d": "<p>The <code>ModuleID</code> scalar type represents an identifier for an object of type Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ModuleSource",
+			"p": "Dagger/ModuleSource.html",
+			"d": "<p>The source needed to load and run a module, along with any metadata about the source such as versions/urls/etc.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ModuleSourceId",
+			"p": "Dagger/ModuleSourceId.html",
+			"d": "<p>The <code>ModuleSourceID</code> scalar type represents an identifier for an object of type ModuleSource.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ObjectTypeDef",
+			"p": "Dagger/ObjectTypeDef.html",
+			"d": "<p>A definition of a custom object defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ObjectTypeDefId",
+			"p": "Dagger/ObjectTypeDefId.html",
+			"d": "<p>The <code>ObjectTypeDefID</code> scalar type represents an identifier for an object of type ObjectTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\PipelineLabel",
+			"p": "Dagger/PipelineLabel.html",
+			"d": "<p>Key value object that represents a pipeline label.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Platform",
+			"p": "Dagger/Platform.html",
+			"d": "<p>The platform config OS and architecture in a Container.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Port",
+			"p": "Dagger/Port.html",
+			"d": "<p>A port exposed by a container.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\PortForward",
+			"p": "Dagger/PortForward.html",
+			"d": "<p>Port forwarding rules for tunneling network traffic.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\PortId",
+			"p": "Dagger/PortId.html",
+			"d": "<p>The <code>PortID</code> scalar type represents an identifier for an object of type Port.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SDKConfig",
+			"p": "Dagger/SDKConfig.html",
+			"d": "<p>The SDK config of the module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SDKConfigId",
+			"p": "Dagger/SDKConfigId.html",
+			"d": "<p>The <code>SDKConfigID</code> scalar type represents an identifier for an object of type SDKConfig.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ScalarTypeDef",
+			"p": "Dagger/ScalarTypeDef.html",
+			"d": "<p>A definition of a custom scalar defined in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ScalarTypeDefId",
+			"p": "Dagger/ScalarTypeDefId.html",
+			"d": "<p>The <code>ScalarTypeDefID</code> scalar type represents an identifier for an object of type ScalarTypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Secret",
+			"p": "Dagger/Secret.html",
+			"d": "<p>A reference to a secret value, which can be handled more safely than the value itself.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SecretId",
+			"p": "Dagger/SecretId.html",
+			"d": "<p>The <code>SecretID</code> scalar type represents an identifier for an object of type Secret.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Service",
+			"p": "Dagger/Service.html",
+			"d": "<p>A content-addressed service providing TCP connectivity.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\ServiceId",
+			"p": "Dagger/ServiceId.html",
+			"d": "<p>The <code>ServiceID</code> scalar type represents an identifier for an object of type Service.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Socket",
+			"p": "Dagger/Socket.html",
+			"d": "<p>A Unix or TCP/IP socket that can be mounted into a container.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SocketId",
+			"p": "Dagger/SocketId.html",
+			"d": "<p>The <code>SocketID</code> scalar type represents an identifier for an object of type Socket.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SourceMap",
+			"p": "Dagger/SourceMap.html",
+			"d": "<p>Source location information.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\SourceMapId",
+			"p": "Dagger/SourceMapId.html",
+			"d": "<p>The <code>SourceMapID</code> scalar type represents an identifier for an object of type SourceMap.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\Terminal",
+			"p": "Dagger/Terminal.html",
+			"d": "<p>An interactive terminal that clients can connect to.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\TerminalId",
+			"p": "Dagger/TerminalId.html",
+			"d": "<p>The <code>TerminalID</code> scalar type represents an identifier for an object of type Terminal.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\TypeDef",
+			"p": "Dagger/TypeDef.html",
+			"d": "<p>A definition of a parameter or return type in a Module.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "C",
+			"n": "Dagger\\TypeDefId",
+			"p": "Dagger/TypeDefId.html",
+			"d": "<p>The <code>TypeDefID</code> scalar type represents an identifier for an object of type TypeDef.</p>",
+			"f": {
+				"n": "Dagger",
+				"p": "Dagger.html"
+			}
+		},
+		{
+			"t": "I",
+			"n": "Dagger\\Client\\IdAble",
+			"p": "Dagger/Client/IdAble.html",
+			"f": {
+				"n": "Dagger\\Client",
+				"p": "Dagger/Client.html"
+			}
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\Argument::__construct",
+			"p": "Dagger/Attribute/Argument.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\DaggerFunction::__construct",
+			"p": "Dagger/Attribute/DaggerFunction.html#method___construct",
+			"d": ""
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\DefaultPath::__construct",
+			"p": "Dagger/Attribute/DefaultPath.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\Doc::__construct",
+			"p": "Dagger/Attribute/Doc.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\Ignore::__construct",
+			"p": "Dagger/Attribute/Ignore.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\ListOfType::__construct",
+			"p": "Dagger/Attribute/ListOfType.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Attribute\\ReturnsListOfType::__construct",
+			"p": "Dagger/Attribute/ReturnsListOfType.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asCacheVolume",
+			"p": "Dagger/Binding.html#method_asCacheVolume",
+			"d": "<p>Retrieve the binding value, as type CacheVolume</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asContainer",
+			"p": "Dagger/Binding.html#method_asContainer",
+			"d": "<p>Retrieve the binding value, as type Container</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asDirectory",
+			"p": "Dagger/Binding.html#method_asDirectory",
+			"d": "<p>Retrieve the binding value, as type Directory</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asEnv",
+			"p": "Dagger/Binding.html#method_asEnv",
+			"d": "<p>Retrieve the binding value, as type Env</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asFile",
+			"p": "Dagger/Binding.html#method_asFile",
+			"d": "<p>Retrieve the binding value, as type File</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asGitRef",
+			"p": "Dagger/Binding.html#method_asGitRef",
+			"d": "<p>Retrieve the binding value, as type GitRef</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asGitRepository",
+			"p": "Dagger/Binding.html#method_asGitRepository",
+			"d": "<p>Retrieve the binding value, as type GitRepository</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asLLM",
+			"p": "Dagger/Binding.html#method_asLLM",
+			"d": "<p>Retrieve the binding value, as type LLM</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asModule",
+			"p": "Dagger/Binding.html#method_asModule",
+			"d": "<p>Retrieve the binding value, as type Module</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asModuleConfigClient",
+			"p": "Dagger/Binding.html#method_asModuleConfigClient",
+			"d": "<p>Retrieve the binding value, as type ModuleConfigClient</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asModuleSource",
+			"p": "Dagger/Binding.html#method_asModuleSource",
+			"d": "<p>Retrieve the binding value, as type ModuleSource</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asSecret",
+			"p": "Dagger/Binding.html#method_asSecret",
+			"d": "<p>Retrieve the binding value, as type Secret</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asService",
+			"p": "Dagger/Binding.html#method_asService",
+			"d": "<p>Retrieve the binding value, as type Service</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asSocket",
+			"p": "Dagger/Binding.html#method_asSocket",
+			"d": "<p>Retrieve the binding value, as type Socket</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::asString",
+			"p": "Dagger/Binding.html#method_asString",
+			"d": "<p>The binding's string value</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::digest",
+			"p": "Dagger/Binding.html#method_digest",
+			"d": "<p>The digest of the binding value</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::id",
+			"p": "Dagger/Binding.html#method_id",
+			"d": "<p>A unique identifier for this Binding.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::isNull",
+			"p": "Dagger/Binding.html#method_isNull",
+			"d": "<p>Returns true if the binding is null</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::name",
+			"p": "Dagger/Binding.html#method_name",
+			"d": "<p>The binding name</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Binding::typeName",
+			"p": "Dagger/Binding.html#method_typeName",
+			"d": "<p>The binding type</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\BuildArg::__construct",
+			"p": "Dagger/BuildArg.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CacheVolume::id",
+			"p": "Dagger/CacheVolume.html#method_id",
+			"d": "<p>A unique identifier for this CacheVolume.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::cacheVolume",
+			"p": "Dagger/Client.html#method_cacheVolume",
+			"d": "<p>Constructs a cache volume for a given cache key.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::container",
+			"p": "Dagger/Client.html#method_container",
+			"d": "<p>Creates a scratch container, with no image or metadata.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::currentFunctionCall",
+			"p": "Dagger/Client.html#method_currentFunctionCall",
+			"d": "<p>The FunctionCall context that the SDK caller is currently executing in.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::currentModule",
+			"p": "Dagger/Client.html#method_currentModule",
+			"d": "<p>The module currently being served in the session, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::currentTypeDefs",
+			"p": "Dagger/Client.html#method_currentTypeDefs",
+			"d": "<p>The TypeDef representations of the objects currently being served in the session.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::defaultPlatform",
+			"p": "Dagger/Client.html#method_defaultPlatform",
+			"d": "<p>The default platform of the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::directory",
+			"p": "Dagger/Client.html#method_directory",
+			"d": "<p>Creates an empty directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::engine",
+			"p": "Dagger/Client.html#method_engine",
+			"d": "<p>The Dagger engine container configuration and state</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::env",
+			"p": "Dagger/Client.html#method_env",
+			"d": "<p>Initialize a new environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::error",
+			"p": "Dagger/Client.html#method_error",
+			"d": "<p>Create a new error.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::file",
+			"p": "Dagger/Client.html#method_file",
+			"d": "<p>Creates a file with the specified contents.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::function",
+			"p": "Dagger/Client.html#method_function",
+			"d": "<p>Creates a function.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::generatedCode",
+			"p": "Dagger/Client.html#method_generatedCode",
+			"d": "<p>Create a code generation result, given a directory containing the generated code.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::git",
+			"p": "Dagger/Client.html#method_git",
+			"d": "<p>Queries a Git repository.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::host",
+			"p": "Dagger/Client.html#method_host",
+			"d": "<p>Queries the host environment.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::http",
+			"p": "Dagger/Client.html#method_http",
+			"d": "<p>Returns a file containing an http remote url content.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::llm",
+			"p": "Dagger/Client.html#method_llm",
+			"d": "<p>Initialize a Large Language Model (LLM)</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadBindingFromID",
+			"p": "Dagger/Client.html#method_loadBindingFromID",
+			"d": "<p>Load a Binding from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadCacheVolumeFromID",
+			"p": "Dagger/Client.html#method_loadCacheVolumeFromID",
+			"d": "<p>Load a CacheVolume from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadContainerFromID",
+			"p": "Dagger/Client.html#method_loadContainerFromID",
+			"d": "<p>Load a Container from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadCurrentModuleFromID",
+			"p": "Dagger/Client.html#method_loadCurrentModuleFromID",
+			"d": "<p>Load a CurrentModule from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadDirectoryFromID",
+			"p": "Dagger/Client.html#method_loadDirectoryFromID",
+			"d": "<p>Load a Directory from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEngineCacheEntryFromID",
+			"p": "Dagger/Client.html#method_loadEngineCacheEntryFromID",
+			"d": "<p>Load a EngineCacheEntry from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEngineCacheEntrySetFromID",
+			"p": "Dagger/Client.html#method_loadEngineCacheEntrySetFromID",
+			"d": "<p>Load a EngineCacheEntrySet from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEngineCacheFromID",
+			"p": "Dagger/Client.html#method_loadEngineCacheFromID",
+			"d": "<p>Load a EngineCache from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEngineFromID",
+			"p": "Dagger/Client.html#method_loadEngineFromID",
+			"d": "<p>Load a Engine from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEnumTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadEnumTypeDefFromID",
+			"d": "<p>Load a EnumTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEnumValueTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadEnumValueTypeDefFromID",
+			"d": "<p>Load a EnumValueTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEnvFromID",
+			"p": "Dagger/Client.html#method_loadEnvFromID",
+			"d": "<p>Load a Env from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadEnvVariableFromID",
+			"p": "Dagger/Client.html#method_loadEnvVariableFromID",
+			"d": "<p>Load a EnvVariable from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadErrorFromID",
+			"p": "Dagger/Client.html#method_loadErrorFromID",
+			"d": "<p>Load a Error from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadErrorValueFromID",
+			"p": "Dagger/Client.html#method_loadErrorValueFromID",
+			"d": "<p>Load a ErrorValue from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFieldTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadFieldTypeDefFromID",
+			"d": "<p>Load a FieldTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFileFromID",
+			"p": "Dagger/Client.html#method_loadFileFromID",
+			"d": "<p>Load a File from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFunctionArgFromID",
+			"p": "Dagger/Client.html#method_loadFunctionArgFromID",
+			"d": "<p>Load a FunctionArg from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFunctionCallArgValueFromID",
+			"p": "Dagger/Client.html#method_loadFunctionCallArgValueFromID",
+			"d": "<p>Load a FunctionCallArgValue from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFunctionCallFromID",
+			"p": "Dagger/Client.html#method_loadFunctionCallFromID",
+			"d": "<p>Load a FunctionCall from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadFunctionFromID",
+			"p": "Dagger/Client.html#method_loadFunctionFromID",
+			"d": "<p>Load a Function from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadGeneratedCodeFromID",
+			"p": "Dagger/Client.html#method_loadGeneratedCodeFromID",
+			"d": "<p>Load a GeneratedCode from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadGitRefFromID",
+			"p": "Dagger/Client.html#method_loadGitRefFromID",
+			"d": "<p>Load a GitRef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadGitRepositoryFromID",
+			"p": "Dagger/Client.html#method_loadGitRepositoryFromID",
+			"d": "<p>Load a GitRepository from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadHostFromID",
+			"p": "Dagger/Client.html#method_loadHostFromID",
+			"d": "<p>Load a Host from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadInputTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadInputTypeDefFromID",
+			"d": "<p>Load a InputTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadInterfaceTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadInterfaceTypeDefFromID",
+			"d": "<p>Load a InterfaceTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadLLMFromID",
+			"p": "Dagger/Client.html#method_loadLLMFromID",
+			"d": "<p>Load a LLM from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadLLMTokenUsageFromID",
+			"p": "Dagger/Client.html#method_loadLLMTokenUsageFromID",
+			"d": "<p>Load a LLMTokenUsage from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadLabelFromID",
+			"p": "Dagger/Client.html#method_loadLabelFromID",
+			"d": "<p>Load a Label from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadListTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadListTypeDefFromID",
+			"d": "<p>Load a ListTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadModuleConfigClientFromID",
+			"p": "Dagger/Client.html#method_loadModuleConfigClientFromID",
+			"d": "<p>Load a ModuleConfigClient from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadModuleFromID",
+			"p": "Dagger/Client.html#method_loadModuleFromID",
+			"d": "<p>Load a Module from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadModuleSourceFromID",
+			"p": "Dagger/Client.html#method_loadModuleSourceFromID",
+			"d": "<p>Load a ModuleSource from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadObjectTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadObjectTypeDefFromID",
+			"d": "<p>Load a ObjectTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadPortFromID",
+			"p": "Dagger/Client.html#method_loadPortFromID",
+			"d": "<p>Load a Port from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadSDKConfigFromID",
+			"p": "Dagger/Client.html#method_loadSDKConfigFromID",
+			"d": "<p>Load a SDKConfig from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadScalarTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadScalarTypeDefFromID",
+			"d": "<p>Load a ScalarTypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadSecretFromID",
+			"p": "Dagger/Client.html#method_loadSecretFromID",
+			"d": "<p>Load a Secret from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadServiceFromID",
+			"p": "Dagger/Client.html#method_loadServiceFromID",
+			"d": "<p>Load a Service from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadSocketFromID",
+			"p": "Dagger/Client.html#method_loadSocketFromID",
+			"d": "<p>Load a Socket from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadSourceMapFromID",
+			"p": "Dagger/Client.html#method_loadSourceMapFromID",
+			"d": "<p>Load a SourceMap from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadTerminalFromID",
+			"p": "Dagger/Client.html#method_loadTerminalFromID",
+			"d": "<p>Load a Terminal from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::loadTypeDefFromID",
+			"p": "Dagger/Client.html#method_loadTypeDefFromID",
+			"d": "<p>Load a TypeDef from its ID.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::module",
+			"p": "Dagger/Client.html#method_module",
+			"d": "<p>Create a new module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::moduleSource",
+			"p": "Dagger/Client.html#method_moduleSource",
+			"d": "<p>Create a new module source instance from a source ref string</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::secret",
+			"p": "Dagger/Client.html#method_secret",
+			"d": "<p>Creates a new secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::setSecret",
+			"p": "Dagger/Client.html#method_setSecret",
+			"d": "<p>Sets a secret given a user defined name to its plaintext and returns the secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::sourceMap",
+			"p": "Dagger/Client.html#method_sourceMap",
+			"d": "<p>Creates source map metadata.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::typeDef",
+			"p": "Dagger/Client.html#method_typeDef",
+			"d": "<p>Create a new TypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client::version",
+			"p": "Dagger/Client.html#method_version",
+			"d": "<p>Get the current Dagger Engine version.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractClient::__construct",
+			"p": "Dagger/Client/AbstractClient.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractClient::runQuery",
+			"p": "Dagger/Client/AbstractClient.html#method_runQuery",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractClient::queryLeaf",
+			"p": "Dagger/Client/AbstractClient.html#method_queryLeaf",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractInputObject::__toString",
+			"p": "Dagger/Client/AbstractInputObject.html#method___toString",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractObject::__construct",
+			"p": "Dagger/Client/AbstractObject.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractObject::queryLeaf",
+			"p": "Dagger/Client/AbstractObject.html#method_queryLeaf",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractScalar::__construct",
+			"p": "Dagger/Client/AbstractScalar.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractScalar::getValue",
+			"p": "Dagger/Client/AbstractScalar.html#method_getValue",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractScalar::__toString",
+			"p": "Dagger/Client/AbstractScalar.html#method___toString",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\AbstractScalar::from",
+			"p": "Dagger/Client/AbstractScalar.html#method_from",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\IdAble::id",
+			"p": "Dagger/Client/IdAble.html#method_id",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\QueryBuilder::setArgument",
+			"p": "Dagger/Client/QueryBuilder.html#method_setArgument",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::get",
+			"p": "Dagger/Connection.html#method_get",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::newEnvSession",
+			"p": "Dagger/Connection.html#method_newEnvSession",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::newProcessSession",
+			"p": "Dagger/Connection.html#method_newProcessSession",
+			"d": ""
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::createGraphQlClient",
+			"p": "Dagger/Connection.html#method_createGraphQlClient",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::connect",
+			"p": "Dagger/Connection.html#method_connect",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Connection::close",
+			"p": "Dagger/Connection.html#method_close",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::asService",
+			"p": "Dagger/Container.html#method_asService",
+			"d": "<p>Turn the container into a Service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::asTarball",
+			"p": "Dagger/Container.html#method_asTarball",
+			"d": "<p>Package the container state as an OCI image, and return it as a tar archive</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::build",
+			"p": "Dagger/Container.html#method_build",
+			"d": "<p>Initializes this container from a Dockerfile build.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::defaultArgs",
+			"p": "Dagger/Container.html#method_defaultArgs",
+			"d": "<p>Return the container's default arguments.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::directory",
+			"p": "Dagger/Container.html#method_directory",
+			"d": "<p>Retrieve a directory from the container's root filesystem</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::entrypoint",
+			"p": "Dagger/Container.html#method_entrypoint",
+			"d": "<p>Return the container's OCI entrypoint.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::envVariable",
+			"p": "Dagger/Container.html#method_envVariable",
+			"d": "<p>Retrieves the value of the specified environment variable.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::envVariables",
+			"p": "Dagger/Container.html#method_envVariables",
+			"d": "<p>Retrieves the list of environment variables passed to commands.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::exitCode",
+			"p": "Dagger/Container.html#method_exitCode",
+			"d": "<p>The exit code of the last executed command</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::experimentalWithAllGPUs",
+			"p": "Dagger/Container.html#method_experimentalWithAllGPUs",
+			"d": "<p>EXPERIMENTAL API! Subject to change/removal at any time.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::experimentalWithGPU",
+			"p": "Dagger/Container.html#method_experimentalWithGPU",
+			"d": "<p>EXPERIMENTAL API! Subject to change/removal at any time.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::export",
+			"p": "Dagger/Container.html#method_export",
+			"d": "<p>Writes the container as an OCI tarball to the destination file path on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::exposedPorts",
+			"p": "Dagger/Container.html#method_exposedPorts",
+			"d": "<p>Retrieves the list of exposed ports.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::file",
+			"p": "Dagger/Container.html#method_file",
+			"d": "<p>Retrieves a file at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::from",
+			"p": "Dagger/Container.html#method_from",
+			"d": "<p>Download a container image, and apply it to the container state. All previous state will be lost.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::id",
+			"p": "Dagger/Container.html#method_id",
+			"d": "<p>A unique identifier for this Container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::imageRef",
+			"p": "Dagger/Container.html#method_imageRef",
+			"d": "<p>The unique image reference which can only be retrieved immediately after the 'Container.From' call.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::import",
+			"p": "Dagger/Container.html#method_import",
+			"d": "<p>Reads the container from an OCI tarball.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::label",
+			"p": "Dagger/Container.html#method_label",
+			"d": "<p>Retrieves the value of the specified label.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::labels",
+			"p": "Dagger/Container.html#method_labels",
+			"d": "<p>Retrieves the list of labels passed to container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::mounts",
+			"p": "Dagger/Container.html#method_mounts",
+			"d": "<p>Retrieves the list of paths where a directory is mounted.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::platform",
+			"p": "Dagger/Container.html#method_platform",
+			"d": "<p>The platform this container executes and publishes as.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::publish",
+			"p": "Dagger/Container.html#method_publish",
+			"d": "<p>Package the container state as an OCI image, and publish it to a registry</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::rootfs",
+			"p": "Dagger/Container.html#method_rootfs",
+			"d": "<p>Return a snapshot of the container's root filesystem. The snapshot can be modified then written back using withRootfs. Use that method for filesystem modifications.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::stderr",
+			"p": "Dagger/Container.html#method_stderr",
+			"d": "<p>The buffered standard error stream of the last executed command</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::stdout",
+			"p": "Dagger/Container.html#method_stdout",
+			"d": "<p>The buffered standard output stream of the last executed command</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::sync",
+			"p": "Dagger/Container.html#method_sync",
+			"d": "<p>Forces evaluation of the pipeline in the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::terminal",
+			"p": "Dagger/Container.html#method_terminal",
+			"d": "<p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::up",
+			"p": "Dagger/Container.html#method_up",
+			"d": "<p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::user",
+			"p": "Dagger/Container.html#method_user",
+			"d": "<p>Retrieves the user to be set for all commands.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withAnnotation",
+			"p": "Dagger/Container.html#method_withAnnotation",
+			"d": "<p>Retrieves this container plus the given OCI anotation.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withDefaultArgs",
+			"p": "Dagger/Container.html#method_withDefaultArgs",
+			"d": "<p>Configures default arguments for future commands. Like CMD in Dockerfile.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withDefaultTerminalCmd",
+			"p": "Dagger/Container.html#method_withDefaultTerminalCmd",
+			"d": "<p>Set the default command to invoke for the container's terminal API.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withDirectory",
+			"p": "Dagger/Container.html#method_withDirectory",
+			"d": "<p>Return a new container snapshot, with a directory added to its filesystem</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withEntrypoint",
+			"p": "Dagger/Container.html#method_withEntrypoint",
+			"d": "<p>Set an OCI-style entrypoint. It will be included in the container's OCI configuration. Note, withExec ignores the entrypoint by default.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withEnvVariable",
+			"p": "Dagger/Container.html#method_withEnvVariable",
+			"d": "<p>Set a new environment variable in the container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withExec",
+			"p": "Dagger/Container.html#method_withExec",
+			"d": "<p>Execute a command in the container, and return a new snapshot of the container state after execution.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withExposedPort",
+			"p": "Dagger/Container.html#method_withExposedPort",
+			"d": "<p>Expose a network port. Like EXPOSE in Dockerfile (but with healthcheck support)</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withFile",
+			"p": "Dagger/Container.html#method_withFile",
+			"d": "<p>Return a container snapshot with a file added</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withFiles",
+			"p": "Dagger/Container.html#method_withFiles",
+			"d": "<p>Retrieves this container plus the contents of the given files copied to the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withLabel",
+			"p": "Dagger/Container.html#method_withLabel",
+			"d": "<p>Retrieves this container plus the given label.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withMountedCache",
+			"p": "Dagger/Container.html#method_withMountedCache",
+			"d": "<p>Retrieves this container plus a cache volume mounted at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withMountedDirectory",
+			"p": "Dagger/Container.html#method_withMountedDirectory",
+			"d": "<p>Retrieves this container plus a directory mounted at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withMountedFile",
+			"p": "Dagger/Container.html#method_withMountedFile",
+			"d": "<p>Retrieves this container plus a file mounted at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withMountedSecret",
+			"p": "Dagger/Container.html#method_withMountedSecret",
+			"d": "<p>Retrieves this container plus a secret mounted into a file at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withMountedTemp",
+			"p": "Dagger/Container.html#method_withMountedTemp",
+			"d": "<p>Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withNewFile",
+			"p": "Dagger/Container.html#method_withNewFile",
+			"d": "<p>Return a new container snapshot, with a file added to its filesystem with text content</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withRegistryAuth",
+			"p": "Dagger/Container.html#method_withRegistryAuth",
+			"d": "<p>Attach credentials for future publishing to a registry. Use in combination with publish</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withRootfs",
+			"p": "Dagger/Container.html#method_withRootfs",
+			"d": "<p>Change the container's root filesystem. The previous root filesystem will be lost.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withSecretVariable",
+			"p": "Dagger/Container.html#method_withSecretVariable",
+			"d": "<p>Set a new environment variable, using a secret value</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withServiceBinding",
+			"p": "Dagger/Container.html#method_withServiceBinding",
+			"d": "<p>Establish a runtime dependency on a from a container to a network service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withUnixSocket",
+			"p": "Dagger/Container.html#method_withUnixSocket",
+			"d": "<p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withUser",
+			"p": "Dagger/Container.html#method_withUser",
+			"d": "<p>Retrieves this container with a different command user.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withWorkdir",
+			"p": "Dagger/Container.html#method_withWorkdir",
+			"d": "<p>Change the container's working directory. Like WORKDIR in Dockerfile.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutAnnotation",
+			"p": "Dagger/Container.html#method_withoutAnnotation",
+			"d": "<p>Retrieves this container minus the given OCI annotation.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutDefaultArgs",
+			"p": "Dagger/Container.html#method_withoutDefaultArgs",
+			"d": "<p>Remove the container's default arguments.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutDirectory",
+			"p": "Dagger/Container.html#method_withoutDirectory",
+			"d": "<p>Return a new container snapshot, with a directory removed from its filesystem</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutEntrypoint",
+			"p": "Dagger/Container.html#method_withoutEntrypoint",
+			"d": "<p>Reset the container's OCI entrypoint.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutEnvVariable",
+			"p": "Dagger/Container.html#method_withoutEnvVariable",
+			"d": "<p>Retrieves this container minus the given environment variable.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutExposedPort",
+			"p": "Dagger/Container.html#method_withoutExposedPort",
+			"d": "<p>Unexpose a previously exposed port.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutFile",
+			"p": "Dagger/Container.html#method_withoutFile",
+			"d": "<p>Retrieves this container with the file at the given path removed.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutFiles",
+			"p": "Dagger/Container.html#method_withoutFiles",
+			"d": "<p>Return a new container spanshot with specified files removed</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutLabel",
+			"p": "Dagger/Container.html#method_withoutLabel",
+			"d": "<p>Retrieves this container minus the given environment label.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutMount",
+			"p": "Dagger/Container.html#method_withoutMount",
+			"d": "<p>Retrieves this container after unmounting everything at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutRegistryAuth",
+			"p": "Dagger/Container.html#method_withoutRegistryAuth",
+			"d": "<p>Retrieves this container without the registry authentication of a given address.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutSecretVariable",
+			"p": "Dagger/Container.html#method_withoutSecretVariable",
+			"d": "<p>Retrieves this container minus the given environment variable containing the secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutUnixSocket",
+			"p": "Dagger/Container.html#method_withoutUnixSocket",
+			"d": "<p>Retrieves this container with a previously added Unix socket removed.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutUser",
+			"p": "Dagger/Container.html#method_withoutUser",
+			"d": "<p>Retrieves this container with an unset command user.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutWorkdir",
+			"p": "Dagger/Container.html#method_withoutWorkdir",
+			"d": "<p>Unset the container's working directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::workdir",
+			"p": "Dagger/Container.html#method_workdir",
+			"d": "<p>Retrieves the working directory for all commands.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CurrentModule::id",
+			"p": "Dagger/CurrentModule.html#method_id",
+			"d": "<p>A unique identifier for this CurrentModule.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CurrentModule::name",
+			"p": "Dagger/CurrentModule.html#method_name",
+			"d": "<p>The name of the module being executed in</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CurrentModule::source",
+			"p": "Dagger/CurrentModule.html#method_source",
+			"d": "<p>The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CurrentModule::workdir",
+			"p": "Dagger/CurrentModule.html#method_workdir",
+			"d": "<p>Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\CurrentModule::workdirFile",
+			"p": "Dagger/CurrentModule.html#method_workdirFile",
+			"d": "<p>Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Dagger::getClientInstance",
+			"p": "Dagger/Dagger.html#method_getClientInstance",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Dagger::connect",
+			"p": "Dagger/Dagger.html#method_connect",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::asGit",
+			"p": "Dagger/Directory.html#method_asGit",
+			"d": "<p>Converts this directory to a local git repository</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::asModule",
+			"p": "Dagger/Directory.html#method_asModule",
+			"d": "<p>Load the directory as a Dagger module source</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::asModuleSource",
+			"p": "Dagger/Directory.html#method_asModuleSource",
+			"d": "<p>Load the directory as a Dagger module source</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::diff",
+			"p": "Dagger/Directory.html#method_diff",
+			"d": "<p>Return the difference between this directory and an another directory. The difference is encoded as a directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::digest",
+			"p": "Dagger/Directory.html#method_digest",
+			"d": "<p>Return the directory's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::directory",
+			"p": "Dagger/Directory.html#method_directory",
+			"d": "<p>Retrieves a directory at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::dockerBuild",
+			"p": "Dagger/Directory.html#method_dockerBuild",
+			"d": "<p>Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::entries",
+			"p": "Dagger/Directory.html#method_entries",
+			"d": "<p>Returns a list of files and directories at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::export",
+			"p": "Dagger/Directory.html#method_export",
+			"d": "<p>Writes the contents of the directory to a path on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::file",
+			"p": "Dagger/Directory.html#method_file",
+			"d": "<p>Retrieve a file at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::filter",
+			"p": "Dagger/Directory.html#method_filter",
+			"d": "<p>Return a snapshot with some paths included or excluded</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::glob",
+			"p": "Dagger/Directory.html#method_glob",
+			"d": "<p>Returns a list of files and directories that matche the given pattern.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::id",
+			"p": "Dagger/Directory.html#method_id",
+			"d": "<p>A unique identifier for this Directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::name",
+			"p": "Dagger/Directory.html#method_name",
+			"d": "<p>Returns the name of the directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::sync",
+			"p": "Dagger/Directory.html#method_sync",
+			"d": "<p>Force evaluation in the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::terminal",
+			"p": "Dagger/Directory.html#method_terminal",
+			"d": "<p>Opens an interactive terminal in new container with this directory mounted inside.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withDirectory",
+			"p": "Dagger/Directory.html#method_withDirectory",
+			"d": "<p>Return a snapshot with a directory added</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withFile",
+			"p": "Dagger/Directory.html#method_withFile",
+			"d": "<p>Retrieves this directory plus the contents of the given file copied to the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withFiles",
+			"p": "Dagger/Directory.html#method_withFiles",
+			"d": "<p>Retrieves this directory plus the contents of the given files copied to the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withNewDirectory",
+			"p": "Dagger/Directory.html#method_withNewDirectory",
+			"d": "<p>Retrieves this directory plus a new directory created at the given path.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withNewFile",
+			"p": "Dagger/Directory.html#method_withNewFile",
+			"d": "<p>Return a snapshot with a new file added</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withTimestamps",
+			"p": "Dagger/Directory.html#method_withTimestamps",
+			"d": "<p>Retrieves this directory with all file/dir timestamps set to the given time.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withoutDirectory",
+			"p": "Dagger/Directory.html#method_withoutDirectory",
+			"d": "<p>Return a snapshot with a subdirectory removed</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withoutFile",
+			"p": "Dagger/Directory.html#method_withoutFile",
+			"d": "<p>Return a snapshot with a file removed</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Directory::withoutFiles",
+			"p": "Dagger/Directory.html#method_withoutFiles",
+			"d": "<p>Return a snapshot with files removed</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Engine::id",
+			"p": "Dagger/Engine.html#method_id",
+			"d": "<p>A unique identifier for this Engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Engine::localCache",
+			"p": "Dagger/Engine.html#method_localCache",
+			"d": "<p>The local (on-disk) cache for the Dagger engine</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::entrySet",
+			"p": "Dagger/EngineCache.html#method_entrySet",
+			"d": "<p>The current set of entries in the cache</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::id",
+			"p": "Dagger/EngineCache.html#method_id",
+			"d": "<p>A unique identifier for this EngineCache.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::keepBytes",
+			"p": "Dagger/EngineCache.html#method_keepBytes",
+			"d": "<p>The maximum bytes to keep in the cache without pruning, after which automatic pruning may kick in.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::maxUsedSpace",
+			"p": "Dagger/EngineCache.html#method_maxUsedSpace",
+			"d": "<p>The maximum bytes to keep in the cache without pruning.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::minFreeSpace",
+			"p": "Dagger/EngineCache.html#method_minFreeSpace",
+			"d": "<p>The target amount of free disk space the garbage collector will attempt to leave.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::prune",
+			"p": "Dagger/EngineCache.html#method_prune",
+			"d": "<p>Prune the cache of releaseable entries</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCache::reservedSpace",
+			"p": "Dagger/EngineCache.html#method_reservedSpace",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::activelyUsed",
+			"p": "Dagger/EngineCacheEntry.html#method_activelyUsed",
+			"d": "<p>Whether the cache entry is actively being used.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::createdTimeUnixNano",
+			"p": "Dagger/EngineCacheEntry.html#method_createdTimeUnixNano",
+			"d": "<p>The time the cache entry was created, in Unix nanoseconds.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::description",
+			"p": "Dagger/EngineCacheEntry.html#method_description",
+			"d": "<p>The description of the cache entry.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::diskSpaceBytes",
+			"p": "Dagger/EngineCacheEntry.html#method_diskSpaceBytes",
+			"d": "<p>The disk space used by the cache entry.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::id",
+			"p": "Dagger/EngineCacheEntry.html#method_id",
+			"d": "<p>A unique identifier for this EngineCacheEntry.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::mostRecentUseTimeUnixNano",
+			"p": "Dagger/EngineCacheEntry.html#method_mostRecentUseTimeUnixNano",
+			"d": "<p>The most recent time the cache entry was used, in Unix nanoseconds.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntrySet::diskSpaceBytes",
+			"p": "Dagger/EngineCacheEntrySet.html#method_diskSpaceBytes",
+			"d": "<p>The total disk space used by the cache entries in this set.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntrySet::entries",
+			"p": "Dagger/EngineCacheEntrySet.html#method_entries",
+			"d": "<p>The list of individual cache entries in the set</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntrySet::entryCount",
+			"p": "Dagger/EngineCacheEntrySet.html#method_entryCount",
+			"d": "<p>The number of cache entries in this set.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntrySet::id",
+			"p": "Dagger/EngineCacheEntrySet.html#method_id",
+			"d": "<p>A unique identifier for this EngineCacheEntrySet.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::description",
+			"p": "Dagger/EnumTypeDef.html#method_description",
+			"d": "<p>A doc string for the enum, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::id",
+			"p": "Dagger/EnumTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this EnumTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::name",
+			"p": "Dagger/EnumTypeDef.html#method_name",
+			"d": "<p>The name of the enum.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::sourceMap",
+			"p": "Dagger/EnumTypeDef.html#method_sourceMap",
+			"d": "<p>The location of this enum declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::sourceModuleName",
+			"p": "Dagger/EnumTypeDef.html#method_sourceModuleName",
+			"d": "<p>If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumTypeDef::values",
+			"p": "Dagger/EnumTypeDef.html#method_values",
+			"d": "<p>The values of the enum.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumValueTypeDef::description",
+			"p": "Dagger/EnumValueTypeDef.html#method_description",
+			"d": "<p>A doc string for the enum value, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumValueTypeDef::id",
+			"p": "Dagger/EnumValueTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this EnumValueTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumValueTypeDef::name",
+			"p": "Dagger/EnumValueTypeDef.html#method_name",
+			"d": "<p>The name of the enum value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnumValueTypeDef::sourceMap",
+			"p": "Dagger/EnumValueTypeDef.html#method_sourceMap",
+			"d": "<p>The location of this enum value declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::id",
+			"p": "Dagger/Env.html#method_id",
+			"d": "<p>A unique identifier for this Env.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::input",
+			"p": "Dagger/Env.html#method_input",
+			"d": "<p>retrieve an input value by name</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::inputs",
+			"p": "Dagger/Env.html#method_inputs",
+			"d": "<p>return all input values for the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::output",
+			"p": "Dagger/Env.html#method_output",
+			"d": "<p>retrieve an output value by name</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::outputs",
+			"p": "Dagger/Env.html#method_outputs",
+			"d": "<p>return all output values for the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withCacheVolumeInput",
+			"p": "Dagger/Env.html#method_withCacheVolumeInput",
+			"d": "<p>Create or update a binding of type CacheVolume in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withCacheVolumeOutput",
+			"p": "Dagger/Env.html#method_withCacheVolumeOutput",
+			"d": "<p>Declare a desired CacheVolume output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withContainerInput",
+			"p": "Dagger/Env.html#method_withContainerInput",
+			"d": "<p>Create or update a binding of type Container in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withContainerOutput",
+			"p": "Dagger/Env.html#method_withContainerOutput",
+			"d": "<p>Declare a desired Container output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withDirectoryInput",
+			"p": "Dagger/Env.html#method_withDirectoryInput",
+			"d": "<p>Create or update a binding of type Directory in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withDirectoryOutput",
+			"p": "Dagger/Env.html#method_withDirectoryOutput",
+			"d": "<p>Declare a desired Directory output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withEnvInput",
+			"p": "Dagger/Env.html#method_withEnvInput",
+			"d": "<p>Create or update a binding of type Env in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withEnvOutput",
+			"p": "Dagger/Env.html#method_withEnvOutput",
+			"d": "<p>Declare a desired Env output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withFileInput",
+			"p": "Dagger/Env.html#method_withFileInput",
+			"d": "<p>Create or update a binding of type File in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withFileOutput",
+			"p": "Dagger/Env.html#method_withFileOutput",
+			"d": "<p>Declare a desired File output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withGitRefInput",
+			"p": "Dagger/Env.html#method_withGitRefInput",
+			"d": "<p>Create or update a binding of type GitRef in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withGitRefOutput",
+			"p": "Dagger/Env.html#method_withGitRefOutput",
+			"d": "<p>Declare a desired GitRef output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withGitRepositoryInput",
+			"p": "Dagger/Env.html#method_withGitRepositoryInput",
+			"d": "<p>Create or update a binding of type GitRepository in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withGitRepositoryOutput",
+			"p": "Dagger/Env.html#method_withGitRepositoryOutput",
+			"d": "<p>Declare a desired GitRepository output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withLLMInput",
+			"p": "Dagger/Env.html#method_withLLMInput",
+			"d": "<p>Create or update a binding of type LLM in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withLLMOutput",
+			"p": "Dagger/Env.html#method_withLLMOutput",
+			"d": "<p>Declare a desired LLM output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleConfigClientInput",
+			"p": "Dagger/Env.html#method_withModuleConfigClientInput",
+			"d": "<p>Create or update a binding of type ModuleConfigClient in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleConfigClientOutput",
+			"p": "Dagger/Env.html#method_withModuleConfigClientOutput",
+			"d": "<p>Declare a desired ModuleConfigClient output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleInput",
+			"p": "Dagger/Env.html#method_withModuleInput",
+			"d": "<p>Create or update a binding of type Module in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleOutput",
+			"p": "Dagger/Env.html#method_withModuleOutput",
+			"d": "<p>Declare a desired Module output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleSourceInput",
+			"p": "Dagger/Env.html#method_withModuleSourceInput",
+			"d": "<p>Create or update a binding of type ModuleSource in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withModuleSourceOutput",
+			"p": "Dagger/Env.html#method_withModuleSourceOutput",
+			"d": "<p>Declare a desired ModuleSource output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withSecretInput",
+			"p": "Dagger/Env.html#method_withSecretInput",
+			"d": "<p>Create or update a binding of type Secret in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withSecretOutput",
+			"p": "Dagger/Env.html#method_withSecretOutput",
+			"d": "<p>Declare a desired Secret output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withServiceInput",
+			"p": "Dagger/Env.html#method_withServiceInput",
+			"d": "<p>Create or update a binding of type Service in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withServiceOutput",
+			"p": "Dagger/Env.html#method_withServiceOutput",
+			"d": "<p>Declare a desired Service output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withSocketInput",
+			"p": "Dagger/Env.html#method_withSocketInput",
+			"d": "<p>Create or update a binding of type Socket in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withSocketOutput",
+			"p": "Dagger/Env.html#method_withSocketOutput",
+			"d": "<p>Declare a desired Socket output to be assigned in the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withStringInput",
+			"p": "Dagger/Env.html#method_withStringInput",
+			"d": "<p>Create or update an input value of type string</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withStringOutput",
+			"p": "Dagger/Env.html#method_withStringOutput",
+			"d": "<p>Create or update an input value of type string</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnvVariable::id",
+			"p": "Dagger/EnvVariable.html#method_id",
+			"d": "<p>A unique identifier for this EnvVariable.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnvVariable::name",
+			"p": "Dagger/EnvVariable.html#method_name",
+			"d": "<p>The environment variable name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EnvVariable::value",
+			"p": "Dagger/EnvVariable.html#method_value",
+			"d": "<p>The environment variable value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Error::id",
+			"p": "Dagger/Error.html#method_id",
+			"d": "<p>A unique identifier for this Error.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Error::message",
+			"p": "Dagger/Error.html#method_message",
+			"d": "<p>A description of the error.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Error::values",
+			"p": "Dagger/Error.html#method_values",
+			"d": "<p>The extensions of the error.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Error::withValue",
+			"p": "Dagger/Error.html#method_withValue",
+			"d": "<p>Add a value to the error.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ErrorValue::id",
+			"p": "Dagger/ErrorValue.html#method_id",
+			"d": "<p>A unique identifier for this ErrorValue.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ErrorValue::name",
+			"p": "Dagger/ErrorValue.html#method_name",
+			"d": "<p>The name of the value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ErrorValue::value",
+			"p": "Dagger/ErrorValue.html#method_value",
+			"d": "<p>The value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FieldTypeDef::description",
+			"p": "Dagger/FieldTypeDef.html#method_description",
+			"d": "<p>A doc string for the field, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FieldTypeDef::id",
+			"p": "Dagger/FieldTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this FieldTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FieldTypeDef::name",
+			"p": "Dagger/FieldTypeDef.html#method_name",
+			"d": "<p>The name of the field in lowerCamelCase format.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FieldTypeDef::sourceMap",
+			"p": "Dagger/FieldTypeDef.html#method_sourceMap",
+			"d": "<p>The location of this field declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FieldTypeDef::typeDef",
+			"p": "Dagger/FieldTypeDef.html#method_typeDef",
+			"d": "<p>The type of the field.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::contents",
+			"p": "Dagger/File.html#method_contents",
+			"d": "<p>Retrieves the contents of the file.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::digest",
+			"p": "Dagger/File.html#method_digest",
+			"d": "<p>Return the file's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::export",
+			"p": "Dagger/File.html#method_export",
+			"d": "<p>Writes the file to a file path on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::id",
+			"p": "Dagger/File.html#method_id",
+			"d": "<p>A unique identifier for this File.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::name",
+			"p": "Dagger/File.html#method_name",
+			"d": "<p>Retrieves the name of the file.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::size",
+			"p": "Dagger/File.html#method_size",
+			"d": "<p>Retrieves the size of the file, in bytes.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::sync",
+			"p": "Dagger/File.html#method_sync",
+			"d": "<p>Force evaluation in the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::withName",
+			"p": "Dagger/File.html#method_withName",
+			"d": "<p>Retrieves this file with its name set to the given name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\File::withTimestamps",
+			"p": "Dagger/File.html#method_withTimestamps",
+			"d": "<p>Retrieves this file with its created/modified timestamps set to the given time.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::defaultPath",
+			"p": "Dagger/FunctionArg.html#method_defaultPath",
+			"d": "<p>Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::defaultValue",
+			"p": "Dagger/FunctionArg.html#method_defaultValue",
+			"d": "<p>A default value to use for this argument when not explicitly set by the caller, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::description",
+			"p": "Dagger/FunctionArg.html#method_description",
+			"d": "<p>A doc string for the argument, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::id",
+			"p": "Dagger/FunctionArg.html#method_id",
+			"d": "<p>A unique identifier for this FunctionArg.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::ignore",
+			"p": "Dagger/FunctionArg.html#method_ignore",
+			"d": "<p>Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::name",
+			"p": "Dagger/FunctionArg.html#method_name",
+			"d": "<p>The name of the argument in lowerCamelCase format.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::sourceMap",
+			"p": "Dagger/FunctionArg.html#method_sourceMap",
+			"d": "<p>The location of this arg declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionArg::typeDef",
+			"p": "Dagger/FunctionArg.html#method_typeDef",
+			"d": "<p>The type of the argument.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::id",
+			"p": "Dagger/FunctionCall.html#method_id",
+			"d": "<p>A unique identifier for this FunctionCall.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::inputArgs",
+			"p": "Dagger/FunctionCall.html#method_inputArgs",
+			"d": "<p>The argument values the function is being invoked with.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::name",
+			"p": "Dagger/FunctionCall.html#method_name",
+			"d": "<p>The name of the function being called.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::parent",
+			"p": "Dagger/FunctionCall.html#method_parent",
+			"d": "<p>The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::parentName",
+			"p": "Dagger/FunctionCall.html#method_parentName",
+			"d": "<p>The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::returnError",
+			"p": "Dagger/FunctionCall.html#method_returnError",
+			"d": "<p>Return an error from the function.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCall::returnValue",
+			"p": "Dagger/FunctionCall.html#method_returnValue",
+			"d": "<p>Set the return value of the function call to the provided value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCallArgValue::id",
+			"p": "Dagger/FunctionCallArgValue.html#method_id",
+			"d": "<p>A unique identifier for this FunctionCallArgValue.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCallArgValue::name",
+			"p": "Dagger/FunctionCallArgValue.html#method_name",
+			"d": "<p>The name of the argument.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\FunctionCallArgValue::value",
+			"p": "Dagger/FunctionCallArgValue.html#method_value",
+			"d": "<p>The value of the argument represented as a JSON serialized string.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::args",
+			"p": "Dagger/Function_.html#method_args",
+			"d": "<p>Arguments accepted by the function, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::description",
+			"p": "Dagger/Function_.html#method_description",
+			"d": "<p>A doc string for the function, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::id",
+			"p": "Dagger/Function_.html#method_id",
+			"d": "<p>A unique identifier for this Function.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::name",
+			"p": "Dagger/Function_.html#method_name",
+			"d": "<p>The name of the function.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::returnType",
+			"p": "Dagger/Function_.html#method_returnType",
+			"d": "<p>The type returned by the function.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::sourceMap",
+			"p": "Dagger/Function_.html#method_sourceMap",
+			"d": "<p>The location of this function declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::withArg",
+			"p": "Dagger/Function_.html#method_withArg",
+			"d": "<p>Returns the function with the provided argument</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::withDescription",
+			"p": "Dagger/Function_.html#method_withDescription",
+			"d": "<p>Returns the function with the given doc string.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Function_::withSourceMap",
+			"p": "Dagger/Function_.html#method_withSourceMap",
+			"d": "<p>Returns the function with the given source map.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::code",
+			"p": "Dagger/GeneratedCode.html#method_code",
+			"d": "<p>The directory containing the generated code.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::id",
+			"p": "Dagger/GeneratedCode.html#method_id",
+			"d": "<p>A unique identifier for this GeneratedCode.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::vcsGeneratedPaths",
+			"p": "Dagger/GeneratedCode.html#method_vcsGeneratedPaths",
+			"d": "<p>List of paths to mark generated in version control (i.e. .gitattributes).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::vcsIgnoredPaths",
+			"p": "Dagger/GeneratedCode.html#method_vcsIgnoredPaths",
+			"d": "<p>List of paths to ignore in version control (i.e. .gitignore).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::withVCSGeneratedPaths",
+			"p": "Dagger/GeneratedCode.html#method_withVCSGeneratedPaths",
+			"d": "<p>Set the list of paths to mark generated in version control.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GeneratedCode::withVCSIgnoredPaths",
+			"p": "Dagger/GeneratedCode.html#method_withVCSIgnoredPaths",
+			"d": "<p>Set the list of paths to ignore in version control.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRef::commit",
+			"p": "Dagger/GitRef.html#method_commit",
+			"d": "<p>The resolved commit id at this ref.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRef::id",
+			"p": "Dagger/GitRef.html#method_id",
+			"d": "<p>A unique identifier for this GitRef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRef::ref",
+			"p": "Dagger/GitRef.html#method_ref",
+			"d": "<p>The resolved ref name at this ref.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRef::tree",
+			"p": "Dagger/GitRef.html#method_tree",
+			"d": "<p>The filesystem tree at this ref.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::branch",
+			"p": "Dagger/GitRepository.html#method_branch",
+			"d": "<p>Returns details of a branch.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::branches",
+			"p": "Dagger/GitRepository.html#method_branches",
+			"d": "<p>branches that match any of the given glob patterns.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::commit",
+			"p": "Dagger/GitRepository.html#method_commit",
+			"d": "<p>Returns details of a commit.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::head",
+			"p": "Dagger/GitRepository.html#method_head",
+			"d": "<p>Returns details for HEAD.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::id",
+			"p": "Dagger/GitRepository.html#method_id",
+			"d": "<p>A unique identifier for this GitRepository.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::ref",
+			"p": "Dagger/GitRepository.html#method_ref",
+			"d": "<p>Returns details of a ref.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::tag",
+			"p": "Dagger/GitRepository.html#method_tag",
+			"d": "<p>Returns details of a tag.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::tags",
+			"p": "Dagger/GitRepository.html#method_tags",
+			"d": "<p>tags that match any of the given glob patterns.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::withAuthHeader",
+			"p": "Dagger/GitRepository.html#method_withAuthHeader",
+			"d": "<p>Header to authenticate the remote with.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\GitRepository::withAuthToken",
+			"p": "Dagger/GitRepository.html#method_withAuthToken",
+			"d": "<p>Token to authenticate the remote with.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::directory",
+			"p": "Dagger/Host.html#method_directory",
+			"d": "<p>Accesses a directory on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::file",
+			"p": "Dagger/Host.html#method_file",
+			"d": "<p>Accesses a file on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::id",
+			"p": "Dagger/Host.html#method_id",
+			"d": "<p>A unique identifier for this Host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::service",
+			"p": "Dagger/Host.html#method_service",
+			"d": "<p>Creates a service that forwards traffic to a specified address via the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::setSecretFile",
+			"p": "Dagger/Host.html#method_setSecretFile",
+			"d": "<p>Sets a secret given a user-defined name and the file path on the host, and returns the secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::tunnel",
+			"p": "Dagger/Host.html#method_tunnel",
+			"d": "<p>Creates a tunnel that forwards traffic from the host to a service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::unixSocket",
+			"p": "Dagger/Host.html#method_unixSocket",
+			"d": "<p>Accesses a Unix socket on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InputTypeDef::fields",
+			"p": "Dagger/InputTypeDef.html#method_fields",
+			"d": "<p>Static fields defined on this input object, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InputTypeDef::id",
+			"p": "Dagger/InputTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this InputTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InputTypeDef::name",
+			"p": "Dagger/InputTypeDef.html#method_name",
+			"d": "<p>The name of the input object.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::description",
+			"p": "Dagger/InterfaceTypeDef.html#method_description",
+			"d": "<p>The doc string for the interface, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::functions",
+			"p": "Dagger/InterfaceTypeDef.html#method_functions",
+			"d": "<p>Functions defined on this interface, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::id",
+			"p": "Dagger/InterfaceTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this InterfaceTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::name",
+			"p": "Dagger/InterfaceTypeDef.html#method_name",
+			"d": "<p>The name of the interface.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::sourceMap",
+			"p": "Dagger/InterfaceTypeDef.html#method_sourceMap",
+			"d": "<p>The location of this interface declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\InterfaceTypeDef::sourceModuleName",
+			"p": "Dagger/InterfaceTypeDef.html#method_sourceModuleName",
+			"d": "<p>If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::attempt",
+			"p": "Dagger/LLM.html#method_attempt",
+			"d": "<p>create a branch in the LLM's history</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::bindResult",
+			"p": "Dagger/LLM.html#method_bindResult",
+			"d": "<p>returns the type of the current state</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::env",
+			"p": "Dagger/LLM.html#method_env",
+			"d": "<p>return the LLM's current environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::history",
+			"p": "Dagger/LLM.html#method_history",
+			"d": "<p>return the llm message history</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::historyJSON",
+			"p": "Dagger/LLM.html#method_historyJSON",
+			"d": "<p>return the raw llm message history as json</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::id",
+			"p": "Dagger/LLM.html#method_id",
+			"d": "<p>A unique identifier for this LLM.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::lastReply",
+			"p": "Dagger/LLM.html#method_lastReply",
+			"d": "<p>return the last llm reply from the history</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::loop",
+			"p": "Dagger/LLM.html#method_loop",
+			"d": "<p>synchronize LLM state</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::model",
+			"p": "Dagger/LLM.html#method_model",
+			"d": "<p>return the model used by the llm</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::provider",
+			"p": "Dagger/LLM.html#method_provider",
+			"d": "<p>return the provider used by the llm</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::sync",
+			"p": "Dagger/LLM.html#method_sync",
+			"d": "<p>synchronize LLM state</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::tokenUsage",
+			"p": "Dagger/LLM.html#method_tokenUsage",
+			"d": "<p>returns the token usage of the current state</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::tools",
+			"p": "Dagger/LLM.html#method_tools",
+			"d": "<p>print documentation for available tools</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withEnv",
+			"p": "Dagger/LLM.html#method_withEnv",
+			"d": "<p>allow the LLM to interact with an environment via MCP</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withModel",
+			"p": "Dagger/LLM.html#method_withModel",
+			"d": "<p>swap out the llm model</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withPrompt",
+			"p": "Dagger/LLM.html#method_withPrompt",
+			"d": "<p>append a prompt to the llm context</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withPromptFile",
+			"p": "Dagger/LLM.html#method_withPromptFile",
+			"d": "<p>append the contents of a file to the llm context</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withSystemPrompt",
+			"p": "Dagger/LLM.html#method_withSystemPrompt",
+			"d": "<p>Add a system prompt to the LLM's environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withoutDefaultSystemPrompt",
+			"p": "Dagger/LLM.html#method_withoutDefaultSystemPrompt",
+			"d": "<p>Disable the default system prompt</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::cachedTokenReads",
+			"p": "Dagger/LLMTokenUsage.html#method_cachedTokenReads",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::cachedTokenWrites",
+			"p": "Dagger/LLMTokenUsage.html#method_cachedTokenWrites",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::id",
+			"p": "Dagger/LLMTokenUsage.html#method_id",
+			"d": "<p>A unique identifier for this LLMTokenUsage.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::inputTokens",
+			"p": "Dagger/LLMTokenUsage.html#method_inputTokens",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::outputTokens",
+			"p": "Dagger/LLMTokenUsage.html#method_outputTokens",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLMTokenUsage::totalTokens",
+			"p": "Dagger/LLMTokenUsage.html#method_totalTokens",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Label::id",
+			"p": "Dagger/Label.html#method_id",
+			"d": "<p>A unique identifier for this Label.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Label::name",
+			"p": "Dagger/Label.html#method_name",
+			"d": "<p>The label name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Label::value",
+			"p": "Dagger/Label.html#method_value",
+			"d": "<p>The label value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ListTypeDef::elementTypeDef",
+			"p": "Dagger/ListTypeDef.html#method_elementTypeDef",
+			"d": "<p>The type of the elements in the list.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ListTypeDef::id",
+			"p": "Dagger/ListTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this ListTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::dependencies",
+			"p": "Dagger/Module.html#method_dependencies",
+			"d": "<p>The dependencies of the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::description",
+			"p": "Dagger/Module.html#method_description",
+			"d": "<p>The doc string of the module, if any</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::enums",
+			"p": "Dagger/Module.html#method_enums",
+			"d": "<p>Enumerations served by this module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::generatedContextDirectory",
+			"p": "Dagger/Module.html#method_generatedContextDirectory",
+			"d": "<p>The generated files and directories made on top of the module source's context directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::id",
+			"p": "Dagger/Module.html#method_id",
+			"d": "<p>A unique identifier for this Module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::interfaces",
+			"p": "Dagger/Module.html#method_interfaces",
+			"d": "<p>Interfaces served by this module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::name",
+			"p": "Dagger/Module.html#method_name",
+			"d": "<p>The name of the module</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::objects",
+			"p": "Dagger/Module.html#method_objects",
+			"d": "<p>Objects served by this module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::runtime",
+			"p": "Dagger/Module.html#method_runtime",
+			"d": "<p>The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::sdk",
+			"p": "Dagger/Module.html#method_sdk",
+			"d": "<p>The SDK config used by this module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::serve",
+			"p": "Dagger/Module.html#method_serve",
+			"d": "<p>Serve a module's API in the current session.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::source",
+			"p": "Dagger/Module.html#method_source",
+			"d": "<p>The source for the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::sync",
+			"p": "Dagger/Module.html#method_sync",
+			"d": "<p>Forces evaluation of the module, including any loading into the engine and associated validation.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::withDescription",
+			"p": "Dagger/Module.html#method_withDescription",
+			"d": "<p>Retrieves the module with the given description</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::withEnum",
+			"p": "Dagger/Module.html#method_withEnum",
+			"d": "<p>This module plus the given Enum type and associated values</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::withInterface",
+			"p": "Dagger/Module.html#method_withInterface",
+			"d": "<p>This module plus the given Interface type and associated functions</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Module::withObject",
+			"p": "Dagger/Module.html#method_withObject",
+			"d": "<p>This module plus the given Object type and associated functions.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleConfigClient::dev",
+			"p": "Dagger/ModuleConfigClient.html#method_dev",
+			"d": "<p>If true, generate the client in developer mode.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleConfigClient::directory",
+			"p": "Dagger/ModuleConfigClient.html#method_directory",
+			"d": "<p>The directory the client is generated in.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleConfigClient::generator",
+			"p": "Dagger/ModuleConfigClient.html#method_generator",
+			"d": "<p>The generator to use</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleConfigClient::id",
+			"p": "Dagger/ModuleConfigClient.html#method_id",
+			"d": "<p>A unique identifier for this ModuleConfigClient.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::asModule",
+			"p": "Dagger/ModuleSource.html#method_asModule",
+			"d": "<p>Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::asString",
+			"p": "Dagger/ModuleSource.html#method_asString",
+			"d": "<p>A human readable ref string representation of this module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::cloneRef",
+			"p": "Dagger/ModuleSource.html#method_cloneRef",
+			"d": "<p>The ref to clone the root of the git repo from. Only valid for git sources.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::commit",
+			"p": "Dagger/ModuleSource.html#method_commit",
+			"d": "<p>The resolved commit of the git repo this source points to.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::configClients",
+			"p": "Dagger/ModuleSource.html#method_configClients",
+			"d": "<p>The clients generated for the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::configExists",
+			"p": "Dagger/ModuleSource.html#method_configExists",
+			"d": "<p>Whether an existing dagger.json for the module was found.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::contextDirectory",
+			"p": "Dagger/ModuleSource.html#method_contextDirectory",
+			"d": "<p>The full directory loaded for the module source, including the source code as a subdirectory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::dependencies",
+			"p": "Dagger/ModuleSource.html#method_dependencies",
+			"d": "<p>The dependencies of the module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::digest",
+			"p": "Dagger/ModuleSource.html#method_digest",
+			"d": "<p>A content-hash of the module source. Module sources with the same digest will output the same generated context and convert into the same module instance.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::directory",
+			"p": "Dagger/ModuleSource.html#method_directory",
+			"d": "<p>The directory containing the module configuration and source code (source code may be in a subdir).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::engineVersion",
+			"p": "Dagger/ModuleSource.html#method_engineVersion",
+			"d": "<p>The engine version of the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::generatedContextDirectory",
+			"p": "Dagger/ModuleSource.html#method_generatedContextDirectory",
+			"d": "<p>The generated files and directories made on top of the module source's context directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::htmlRepoURL",
+			"p": "Dagger/ModuleSource.html#method_htmlRepoURL",
+			"d": "<p>The URL to access the web view of the repository (e.g., GitHub, GitLab, Bitbucket).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::htmlURL",
+			"p": "Dagger/ModuleSource.html#method_htmlURL",
+			"d": "<p>The URL to the source's git repo in a web browser. Only valid for git sources.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::id",
+			"p": "Dagger/ModuleSource.html#method_id",
+			"d": "<p>A unique identifier for this ModuleSource.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::kind",
+			"p": "Dagger/ModuleSource.html#method_kind",
+			"d": "<p>The kind of module source (currently local, git or dir).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::localContextDirectoryPath",
+			"p": "Dagger/ModuleSource.html#method_localContextDirectoryPath",
+			"d": "<p>The full absolute path to the context directory on the caller's host filesystem that this module source is loaded from. Only valid for local module sources.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::moduleName",
+			"p": "Dagger/ModuleSource.html#method_moduleName",
+			"d": "<p>The name of the module, including any setting via the withName API.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::moduleOriginalName",
+			"p": "Dagger/ModuleSource.html#method_moduleOriginalName",
+			"d": "<p>The original name of the module as read from the module's dagger.json (or set for the first time with the withName API).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::originalSubpath",
+			"p": "Dagger/ModuleSource.html#method_originalSubpath",
+			"d": "<p>The original subpath used when instantiating this module source, relative to the context directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::pin",
+			"p": "Dagger/ModuleSource.html#method_pin",
+			"d": "<p>The pinned version of this module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::repoRootPath",
+			"p": "Dagger/ModuleSource.html#method_repoRootPath",
+			"d": "<p>The import path corresponding to the root of the git repo this source points to. Only valid for git sources.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::sdk",
+			"p": "Dagger/ModuleSource.html#method_sdk",
+			"d": "<p>The SDK configuration of the module.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::sourceRootSubpath",
+			"p": "Dagger/ModuleSource.html#method_sourceRootSubpath",
+			"d": "<p>The path, relative to the context directory, that contains the module's dagger.json.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::sourceSubpath",
+			"p": "Dagger/ModuleSource.html#method_sourceSubpath",
+			"d": "<p>The path to the directory containing the module's source code, relative to the context directory.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::sync",
+			"p": "Dagger/ModuleSource.html#method_sync",
+			"d": "<p>Forces evaluation of the module source, including any loading into the engine and associated validation.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::version",
+			"p": "Dagger/ModuleSource.html#method_version",
+			"d": "<p>The specified version of the git repo this source points to.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withClient",
+			"p": "Dagger/ModuleSource.html#method_withClient",
+			"d": "<p>Update the module source with a new client to generate.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withDependencies",
+			"p": "Dagger/ModuleSource.html#method_withDependencies",
+			"d": "<p>Append the provided dependencies to the module source's dependency list.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withEngineVersion",
+			"p": "Dagger/ModuleSource.html#method_withEngineVersion",
+			"d": "<p>Upgrade the engine version of the module to the given value.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withIncludes",
+			"p": "Dagger/ModuleSource.html#method_withIncludes",
+			"d": "<p>Update the module source with additional include patterns for files+directories from its context that are required for building it</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withName",
+			"p": "Dagger/ModuleSource.html#method_withName",
+			"d": "<p>Update the module source with a new name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withSDK",
+			"p": "Dagger/ModuleSource.html#method_withSDK",
+			"d": "<p>Update the module source with a new SDK.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withSourceSubpath",
+			"p": "Dagger/ModuleSource.html#method_withSourceSubpath",
+			"d": "<p>Update the module source with a new source subpath.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withUpdateDependencies",
+			"p": "Dagger/ModuleSource.html#method_withUpdateDependencies",
+			"d": "<p>Update one or more module dependencies.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withoutClient",
+			"p": "Dagger/ModuleSource.html#method_withoutClient",
+			"d": "<p>Remove a client from the module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::withoutDependencies",
+			"p": "Dagger/ModuleSource.html#method_withoutDependencies",
+			"d": "<p>Remove the provided dependencies from the module source's dependency list.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::constructor",
+			"p": "Dagger/ObjectTypeDef.html#method_constructor",
+			"d": "<p>The function used to construct new instances of this object, if any</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::description",
+			"p": "Dagger/ObjectTypeDef.html#method_description",
+			"d": "<p>The doc string for the object, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::fields",
+			"p": "Dagger/ObjectTypeDef.html#method_fields",
+			"d": "<p>Static fields defined on this object, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::functions",
+			"p": "Dagger/ObjectTypeDef.html#method_functions",
+			"d": "<p>Functions defined on this object, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::id",
+			"p": "Dagger/ObjectTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this ObjectTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::name",
+			"p": "Dagger/ObjectTypeDef.html#method_name",
+			"d": "<p>The name of the object.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::sourceMap",
+			"p": "Dagger/ObjectTypeDef.html#method_sourceMap",
+			"d": "<p>The location of this object declaration.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ObjectTypeDef::sourceModuleName",
+			"p": "Dagger/ObjectTypeDef.html#method_sourceModuleName",
+			"d": "<p>If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\PipelineLabel::__construct",
+			"p": "Dagger/PipelineLabel.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Port::description",
+			"p": "Dagger/Port.html#method_description",
+			"d": "<p>The port description.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Port::experimentalSkipHealthcheck",
+			"p": "Dagger/Port.html#method_experimentalSkipHealthcheck",
+			"d": "<p>Skip the health check when run as a service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Port::id",
+			"p": "Dagger/Port.html#method_id",
+			"d": "<p>A unique identifier for this Port.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Port::port",
+			"p": "Dagger/Port.html#method_port",
+			"d": "<p>The port number.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Port::protocol",
+			"p": "Dagger/Port.html#method_protocol",
+			"d": "<p>The transport layer protocol.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\PortForward::__construct",
+			"p": "Dagger/PortForward.html#method___construct",
+			"d": null
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SDKConfig::id",
+			"p": "Dagger/SDKConfig.html#method_id",
+			"d": "<p>A unique identifier for this SDKConfig.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SDKConfig::source",
+			"p": "Dagger/SDKConfig.html#method_source",
+			"d": "<p>Source of the SDK. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ScalarTypeDef::description",
+			"p": "Dagger/ScalarTypeDef.html#method_description",
+			"d": "<p>A doc string for the scalar, if any.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ScalarTypeDef::id",
+			"p": "Dagger/ScalarTypeDef.html#method_id",
+			"d": "<p>A unique identifier for this ScalarTypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ScalarTypeDef::name",
+			"p": "Dagger/ScalarTypeDef.html#method_name",
+			"d": "<p>The name of the scalar.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ScalarTypeDef::sourceModuleName",
+			"p": "Dagger/ScalarTypeDef.html#method_sourceModuleName",
+			"d": "<p>If this ScalarTypeDef is associated with a Module, the name of the module. Unset otherwise.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Secret::id",
+			"p": "Dagger/Secret.html#method_id",
+			"d": "<p>A unique identifier for this Secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Secret::name",
+			"p": "Dagger/Secret.html#method_name",
+			"d": "<p>The name of this secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Secret::plaintext",
+			"p": "Dagger/Secret.html#method_plaintext",
+			"d": "<p>The value of this secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Secret::uri",
+			"p": "Dagger/Secret.html#method_uri",
+			"d": "<p>The URI of this secret.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::endpoint",
+			"p": "Dagger/Service.html#method_endpoint",
+			"d": "<p>Retrieves an endpoint that clients can use to reach this container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::hostname",
+			"p": "Dagger/Service.html#method_hostname",
+			"d": "<p>Retrieves a hostname which can be used by clients to reach this container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::id",
+			"p": "Dagger/Service.html#method_id",
+			"d": "<p>A unique identifier for this Service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::ports",
+			"p": "Dagger/Service.html#method_ports",
+			"d": "<p>Retrieves the list of ports provided by the service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::start",
+			"p": "Dagger/Service.html#method_start",
+			"d": "<p>Start the service and wait for its health checks to succeed.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::stop",
+			"p": "Dagger/Service.html#method_stop",
+			"d": "<p>Stop the service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::up",
+			"p": "Dagger/Service.html#method_up",
+			"d": "<p>Creates a tunnel that forwards traffic from the caller's network to this service.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::withHostname",
+			"p": "Dagger/Service.html#method_withHostname",
+			"d": "<p>Configures a hostname which can be used by clients within the session to reach this container.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Socket::id",
+			"p": "Dagger/Socket.html#method_id",
+			"d": "<p>A unique identifier for this Socket.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SourceMap::column",
+			"p": "Dagger/SourceMap.html#method_column",
+			"d": "<p>The column number within the line.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SourceMap::filename",
+			"p": "Dagger/SourceMap.html#method_filename",
+			"d": "<p>The filename from the module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SourceMap::id",
+			"p": "Dagger/SourceMap.html#method_id",
+			"d": "<p>A unique identifier for this SourceMap.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SourceMap::line",
+			"p": "Dagger/SourceMap.html#method_line",
+			"d": "<p>The line number within the filename.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\SourceMap::module",
+			"p": "Dagger/SourceMap.html#method_module",
+			"d": "<p>The module dependency this was declared in.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Terminal::id",
+			"p": "Dagger/Terminal.html#method_id",
+			"d": "<p>A unique identifier for this Terminal.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Terminal::sync",
+			"p": "Dagger/Terminal.html#method_sync",
+			"d": "<p>Forces evaluation of the pipeline in the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asEnum",
+			"p": "Dagger/TypeDef.html#method_asEnum",
+			"d": "<p>If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asInput",
+			"p": "Dagger/TypeDef.html#method_asInput",
+			"d": "<p>If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asInterface",
+			"p": "Dagger/TypeDef.html#method_asInterface",
+			"d": "<p>If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asList",
+			"p": "Dagger/TypeDef.html#method_asList",
+			"d": "<p>If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asObject",
+			"p": "Dagger/TypeDef.html#method_asObject",
+			"d": "<p>If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::asScalar",
+			"p": "Dagger/TypeDef.html#method_asScalar",
+			"d": "<p>If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::id",
+			"p": "Dagger/TypeDef.html#method_id",
+			"d": "<p>A unique identifier for this TypeDef.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::kind",
+			"p": "Dagger/TypeDef.html#method_kind",
+			"d": "<p>The kind of type this is (e.g. primitive, list, object).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::optional",
+			"p": "Dagger/TypeDef.html#method_optional",
+			"d": "<p>Whether this type can be set to null. Defaults to false.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withConstructor",
+			"p": "Dagger/TypeDef.html#method_withConstructor",
+			"d": "<p>Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withEnum",
+			"p": "Dagger/TypeDef.html#method_withEnum",
+			"d": "<p>Returns a TypeDef of kind Enum with the provided name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withEnumValue",
+			"p": "Dagger/TypeDef.html#method_withEnumValue",
+			"d": "<p>Adds a static value for an Enum TypeDef, failing if the type is not an enum.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withField",
+			"p": "Dagger/TypeDef.html#method_withField",
+			"d": "<p>Adds a static field for an Object TypeDef, failing if the type is not an object.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withFunction",
+			"p": "Dagger/TypeDef.html#method_withFunction",
+			"d": "<p>Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withInterface",
+			"p": "Dagger/TypeDef.html#method_withInterface",
+			"d": "<p>Returns a TypeDef of kind Interface with the provided name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withKind",
+			"p": "Dagger/TypeDef.html#method_withKind",
+			"d": "<p>Sets the kind of the type.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withListOf",
+			"p": "Dagger/TypeDef.html#method_withListOf",
+			"d": "<p>Returns a TypeDef of kind List with the provided type for its elements.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withObject",
+			"p": "Dagger/TypeDef.html#method_withObject",
+			"d": "<p>Returns a TypeDef of kind Object with the provided name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withOptional",
+			"p": "Dagger/TypeDef.html#method_withOptional",
+			"d": "<p>Sets whether this type can be set to null.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\TypeDef::withScalar",
+			"p": "Dagger/TypeDef.html#method_withScalar",
+			"d": "<p>Returns a TypeDef of kind Scalar with the provided name.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Client\\IdAble::id",
+			"p": "Dagger/Client/IdAble.html#method_id",
+			"d": null
+		},
+		{
+			"t": "N",
+			"n": "Dagger",
+			"p": "Dagger.html"
+		},
+		{
+			"t": "N",
+			"n": "Dagger\\Attribute",
+			"p": "Dagger/Attribute.html"
+		},
+		{
+			"t": "N",
+			"n": "Dagger\\Client",
+			"p": "Dagger/Client.html"
+		}
+	]
+}


### PR DESCRIPTION
This is a quick hack to try and avoid conflicts in these files.

Ideally these just shouldn't be committed to the repo at all, but we're a bit dependent on netlify for our docs builds right now.

(note this doesn't fix the issue in `renderer.index` - I have no idea what format that is, so I can't fix the issue).