### PR TITLE
chore: cleanup core/util.go

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -34,7 +35,7 @@ func NewCache(keys ...string) *CacheVolume {
 
 func (cache *CacheVolume) Clone() *CacheVolume {
 	cp := *cache
-	cp.Keys = cloneSlice(cp.Keys)
+	cp.Keys = slices.Clone(cp.Keys)
 	return &cp
 }
 

--- a/core/container.go
+++ b/core/container.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -155,18 +156,18 @@ func NewContainer(root *Query, platform Platform) (*Container, error) {
 // WithXXX method.
 func (container *Container) Clone() *Container {
 	cp := *container
-	cp.Config.ExposedPorts = cloneMap(cp.Config.ExposedPorts)
-	cp.Config.Env = cloneSlice(cp.Config.Env)
-	cp.Config.Entrypoint = cloneSlice(cp.Config.Entrypoint)
-	cp.Config.Cmd = cloneSlice(cp.Config.Cmd)
-	cp.Config.Volumes = cloneMap(cp.Config.Volumes)
-	cp.Config.Labels = cloneMap(cp.Config.Labels)
-	cp.Mounts = cloneSlice(cp.Mounts)
-	cp.Secrets = cloneSlice(cp.Secrets)
-	cp.Sockets = cloneSlice(cp.Sockets)
-	cp.Ports = cloneSlice(cp.Ports)
-	cp.Services = cloneSlice(cp.Services)
-	cp.SystemEnvNames = cloneSlice(cp.SystemEnvNames)
+	cp.Config.ExposedPorts = maps.Clone(cp.Config.ExposedPorts)
+	cp.Config.Env = slices.Clone(cp.Config.Env)
+	cp.Config.Entrypoint = slices.Clone(cp.Config.Entrypoint)
+	cp.Config.Cmd = slices.Clone(cp.Config.Cmd)
+	cp.Config.Volumes = maps.Clone(cp.Config.Volumes)
+	cp.Config.Labels = maps.Clone(cp.Config.Labels)
+	cp.Mounts = slices.Clone(cp.Mounts)
+	cp.Secrets = slices.Clone(cp.Secrets)
+	cp.Sockets = slices.Clone(cp.Sockets)
+	cp.Ports = slices.Clone(cp.Ports)
+	cp.Services = slices.Clone(cp.Services)
+	cp.SystemEnvNames = slices.Clone(cp.SystemEnvNames)
 	return &cp
 }
 

--- a/core/directory.go
+++ b/core/directory.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -105,7 +106,7 @@ func NewDirectorySt(ctx context.Context, query *Query, st llb.State, dir string,
 // WithXXX method.
 func (dir *Directory) Clone() *Directory {
 	cp := *dir
-	cp.Services = cloneSlice(cp.Services)
+	cp.Services = slices.Clone(cp.Services)
 	return &cp
 }
 

--- a/core/env.go
+++ b/core/env.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/dagger/dagger/dagql"
@@ -54,11 +55,11 @@ func (env *Env) MCP() *MCP {
 
 func (env *Env) Clone() *Env {
 	cp := *env
-	cp.inputsByName = cloneMap(cp.inputsByName)
-	cp.outputsByName = cloneMap(cp.outputsByName)
-	cp.objsByID = cloneMap(cp.objsByID)
-	cp.typeCounts = cloneMap(cp.typeCounts)
-	cp.idByHash = cloneMap(cp.idByHash)
+	cp.inputsByName = maps.Clone(cp.inputsByName)
+	cp.outputsByName = maps.Clone(cp.outputsByName)
+	cp.objsByID = maps.Clone(cp.objsByID)
+	cp.typeCounts = maps.Clone(cp.typeCounts)
+	cp.idByHash = maps.Clone(cp.idByHash)
 	for name, bnd := range cp.outputsByName {
 		// clone output bindings, since they mutate
 		cp.outputsByName[name] = bnd.Clone()

--- a/core/file.go
+++ b/core/file.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
+	"slices"
 	"time"
 
 	bkcache "github.com/moby/buildkit/cache"
@@ -125,7 +126,7 @@ func NewFileSt(ctx context.Context, query *Query, st llb.State, file string, pla
 // WithXXX method.
 func (file *File) Clone() *File {
 	cp := *file
-	cp.Services = cloneSlice(cp.Services)
+	cp.Services = slices.Clone(cp.Services)
 	return &cp
 }
 

--- a/core/llm.go
+++ b/core/llm.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -479,7 +480,7 @@ func (*LLM) Type() *ast.Type {
 
 func (llm *LLM) Clone() *LLM {
 	cp := *llm
-	cp.messages = cloneSlice(cp.messages)
+	cp.messages = slices.Clone(cp.messages)
 	cp.mcp = cp.mcp.Clone()
 	cp.endpoint = llm.endpoint
 	cp.endpointMtx = &sync.Mutex{}

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -70,7 +70,7 @@ func (m *MCP) DefaultSystemPrompt() string {
 func (m *MCP) Clone() *MCP {
 	cp := *m
 	cp.env = cp.env.Clone()
-	cp.selectedMethods = cloneMap(cp.selectedMethods)
+	cp.selectedMethods = maps.Clone(cp.selectedMethods)
 	cp.returned = false
 	return &cp
 }
@@ -1076,7 +1076,7 @@ NOTE: you must select methods before chaining them`,
 					if call.Args == nil {
 						call.Args = make(map[string]any)
 					}
-					args := cloneMap(call.Args)
+					args := maps.Clone(call.Args)
 					if i > 0 {
 						if obj, ok := dagql.UnwrapAs[dagql.Object](m.LastResult()); ok {
 							// override, since the whole point is to chain from the previous

--- a/core/service.go
+++ b/core/service.go
@@ -77,8 +77,8 @@ func (svc *Service) Clone() *Service {
 	if cp.TunnelUpstream != nil {
 		cp.TunnelUpstream.Self = cp.TunnelUpstream.Self.Clone()
 	}
-	cp.TunnelPorts = cloneSlice(cp.TunnelPorts)
-	cp.HostSockets = cloneSlice(cp.HostSockets)
+	cp.TunnelPorts = slices.Clone(cp.TunnelPorts)
+	cp.HostSockets = slices.Clone(cp.HostSockets)
 	return &cp
 }
 


### PR DESCRIPTION
We can use a lot of the functions from the new slices/maps packages, and a lot of these patterns have other ways of doing them in more modern go.

Some of this is just dead code as well.