### PR TITLE
feat: add container dagop

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/pkg/transfer/archive"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
+	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -59,7 +60,8 @@ type Container struct {
 	Query *Query
 
 	// The container's root filesystem.
-	FS *pb.Definition
+	FS       *pb.Definition
+	FSResult bkcache.ImmutableRef // only valid when returned by dagop
 
 	// Image configuration (env, workdir, etc)
 	Config specs.ImageConfig
@@ -71,7 +73,8 @@ type Container struct {
 	Mounts ContainerMounts
 
 	// Meta is the /dagger filesystem. It will be null if nothing has run yet.
-	Meta *pb.Definition
+	Meta       *pb.Definition
+	MetaResult bkcache.ImmutableRef // only valid when returned by dagop
 
 	// The platform of the container's rootfs.
 	Platform Platform
@@ -171,6 +174,32 @@ func (container *Container) Clone() *Container {
 	return &cp
 }
 
+var _ dagql.OnReleaser = (*Container)(nil)
+
+func (container *Container) OnRelease(ctx context.Context) error {
+	if container.FSResult != nil {
+		err := container.FSResult.Release(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	if container.MetaResult != nil {
+		err := container.MetaResult.Release(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	for _, mount := range container.Mounts {
+		if mount.Result != nil {
+			err := mount.Result.Release(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Ownership contains a UID/GID pair resolved from a user/group name or ID pair
 // provided via the API. It primarily exists to distinguish an unspecified
 // ownership from UID/GID 0 (root) ownership.
@@ -230,6 +259,7 @@ func (container *Container) MetaState() (*llb.State, error) {
 type ContainerMount struct {
 	// The source of the mount.
 	Source *pb.Definition
+	Result bkcache.ImmutableRef // only valid when returned by dagop
 
 	// A path beneath the source to scope the mount to.
 	SourcePath string

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -14,9 +14,11 @@ import (
 	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	bksession "github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/worker"
 	"github.com/opencontainers/go-digest"
 )
@@ -24,6 +26,25 @@ import (
 func init() {
 	buildkit.RegisterCustomOp(FSDagOp{})
 	buildkit.RegisterCustomOp(RawDagOp{})
+	buildkit.RegisterCustomOp(ContainerDagOp{})
+}
+
+type dagOpContextKey string
+
+func withDagOpContext(ctx context.Context, op buildkit.CustomOp) context.Context {
+	return context.WithValue(ctx, dagOpContextKey(op.Name()), op)
+}
+
+func DagOpFromContext[T buildkit.CustomOp](ctx context.Context) (t T, ok bool) {
+	if val := ctx.Value(dagOpContextKey(t.Name())); val != nil {
+		t, ok = val.(T)
+	}
+	return t, ok
+}
+
+func DagOpInContext[T buildkit.CustomOp](ctx context.Context) bool {
+	_, ok := DagOpFromContext[T](ctx)
+	return ok
 }
 
 // NewDirectoryDagOp takes a target ID for a Directory, and returns a Directory
@@ -178,10 +199,6 @@ func (op FSDagOp) Group() bksession.Group {
 	return op.g
 }
 
-func (op FSDagOp) Mount(ctx context.Context, ref bkcache.Ref, f func(string) error) error {
-	return MountRef(ctx, ref, op.g, f)
-}
-
 // NewRawDagOp takes a target ID for any JSON-serializable dagql type, and returns
 // it, computing the actual dagql query inside a buildkit operation, which
 // allows for efficiently caching the result.
@@ -321,44 +338,388 @@ func (op RawDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.
 	return []solver.Result{worker.NewWorkerRefResult(snap, opt.Worker)}, nil
 }
 
+func NewContainerDagOp(
+	ctx context.Context,
+	id *call.ID,
+	ctr *Container,
+	extraInputs []llb.State,
+) (*Container, error) {
+	mounts, inputs, outputCount, err := getAllContainerMounts(ctr)
+	if err != nil {
+		return nil, err
+	}
+	inputs = append(inputs, extraInputs...)
+
+	dagop := &ContainerDagOp{
+		ID:          id,
+		Mounts:      mounts,
+		OutputCount: outputCount,
+	}
+
+	st, err := newContainerDagOp(ctx, dagop, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	sts := make([]llb.State, dagop.OutputCount)
+	for _, mount := range mounts {
+		if mount.Output == pb.SkipOutput {
+			continue
+		}
+		out := buildkit.StateIdx(ctx, st, mount.Output, nil)
+		sts[mount.Output] = out
+	}
+
+	ctr = ctr.Clone()
+	err = dagop.setAllContainerMounts(ctx, ctr, sts)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctr, nil
+}
+
+func newContainerDagOp(
+	ctx context.Context,
+	dagop *ContainerDagOp,
+	inputs []llb.State,
+) (llb.State, error) {
+	if dagop.ID == nil {
+		return llb.State{}, fmt.Errorf("dagop ID is nil")
+	}
+
+	var t Container
+	requiredType := t.Type().NamedType
+	if dagop.ID.Type().NamedType() != requiredType {
+		return llb.State{}, fmt.Errorf("expected %s to be selected, instead got %s", requiredType, dagop.ID.Type().NamedType())
+	}
+
+	return newDagOpLLB(ctx, dagop, dagop.ID, inputs)
+}
+
+type ContainerDagOp struct {
+	ID *call.ID
+
+	// all the container mounts - the order here should be guaranteed:
+	// - rootfs is at 0
+	// - meta mount is at 1
+	// - nth container.Mounts is at n+2
+	// - secret/socket mounts are at the very end
+	Mounts []*pb.Mount
+
+	// the number of outputs produced
+	OutputCount int
+
+	// utility values set in the context of an Exec
+	g   bksession.Group
+	opt buildkit.OpOpts
+
+	// inputs are all the inputs provided to the op
+	//
+	// be careful accessing it directly (stable order is not guaranteed, and it
+	// may also contain a bunch of other stuff), ideally access it through a
+	// known pb.Mount.Output index.
+	inputs []solver.Result
+}
+
+func (op ContainerDagOp) Inputs() []bkcache.ImmutableRef {
+	refs := make([]bkcache.ImmutableRef, 0, len(op.inputs))
+	for _, input := range op.inputs {
+		refs = append(refs, input.Sys().(*worker.WorkerRef).ImmutableRef)
+	}
+	return refs
+}
+
+var _ interface{ GetMounts() []*pb.Mount } = ContainerDagOp{}
+
+func (op ContainerDagOp) GetMounts() []*pb.Mount {
+	return op.Mounts
+}
+
+func (op ContainerDagOp) Name() string {
+	return "dagop.ctr"
+}
+
+func (op ContainerDagOp) Backend() buildkit.CustomOpBackend {
+	return &op
+}
+
+func (op ContainerDagOp) Group() bksession.Group {
+	return op.g
+}
+
+func (op ContainerDagOp) Digest() (digest.Digest, error) {
+	mountsData, err := json.Marshal(op.Mounts)
+	if err != nil {
+		return "", err
+	}
+	return digest.FromString(strings.Join([]string{
+		op.ID.Digest().String(),
+		fmt.Sprint(op.OutputCount),
+		string(mountsData),
+	}, "+")), nil
+}
+
+func (op ContainerDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
+	// TODO: we need proper cache map control here, to control content digesting
+	return op.Digest()
+}
+
+func (op ContainerDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, retErr error) {
+	op.g = g
+	op.opt = opt
+	op.inputs = inputs
+
+	obj, err := opt.Server.Load(withDagOpContext(ctx, op), op.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch inst := obj.(type) {
+	case dagql.Instance[*Container]:
+		return op.extractContainerBkOutputs(ctx, inst.Self, opt.Worker)
+	default:
+		// shouldn't happen, should have errored in DagLLB already
+		return nil, fmt.Errorf("expected FS to be selected, instead got %T", obj)
+	}
+}
+
+// getAllContainerMounts gets the list of all mounts for a container, as well as all the
+// inputs that are part of it, and the total number of outputs. Each mount's
+// Input maps to an index in the returned states.
+func getAllContainerMounts(container *Container) (mounts []*pb.Mount, states []llb.State, outputCount int, _ error) {
+	outputIdx := 0
+	inputIdxs := map[digest.Digest]pb.InputIndex{}
+
+	// addMount converts a ContainerMount and creates a corresponding buildkit
+	// mount, creating an input if required
+	addMount := func(mnt ContainerMount) error {
+		st, err := defToState(mnt.Source)
+		if err != nil {
+			return err
+		}
+
+		mount := &pb.Mount{
+			Dest:     mnt.Target,
+			Selector: mnt.SourcePath,
+			Output:   pb.OutputIndex(outputIdx),
+			// ContentCache: nil,
+		}
+		if st.Output() == nil {
+			mount.Input = pb.Empty
+		} else {
+			dag, err := buildkit.DefToDAG(mnt.Source)
+			if err != nil {
+				return err
+			}
+
+			if idx, ok := inputIdxs[*dag.OpDigest]; ok {
+				mount.Input = idx
+			} else {
+				// track and cache this input index, since duplicates are unnecessary
+				// also buildkit's FileOp (which is underlying our DagOp) will
+				// remove them if we don't, which results in significant confusion
+				mount.Input = pb.InputIndex(len(states))
+				inputIdxs[*dag.OpDigest] = mount.Input
+				states = append(states, st)
+			}
+		}
+
+		if mnt.Readonly {
+			mount.Output = pb.SkipOutput
+			mount.Readonly = true
+		}
+
+		if mnt.CacheVolumeID != "" {
+			mount.Output = pb.SkipOutput
+			mount.MountType = pb.MountType_CACHE
+			mount.CacheOpt = &pb.CacheOpt{
+				ID: mnt.CacheVolumeID,
+			}
+			switch mnt.CacheSharingMode {
+			case CacheSharingModeShared:
+				mount.CacheOpt.Sharing = pb.CacheSharingOpt_SHARED
+			case CacheSharingModePrivate:
+				mount.CacheOpt.Sharing = pb.CacheSharingOpt_PRIVATE
+			case CacheSharingModeLocked:
+				mount.CacheOpt.Sharing = pb.CacheSharingOpt_LOCKED
+			}
+		}
+
+		if mnt.Tmpfs {
+			mount.Output = pb.SkipOutput
+			mount.MountType = pb.MountType_TMPFS
+			mount.TmpfsOpt = &pb.TmpfsOpt{
+				Size_: int64(mnt.Size),
+			}
+		}
+
+		mounts = append(mounts, mount)
+		if mount.Output != pb.SkipOutput {
+			outputIdx++
+		}
+
+		return nil
+	}
+
+	// handle our normal mounts
+	if err := addMount(ContainerMount{Source: container.FS, Target: "/"}); err != nil {
+		return nil, nil, 0, err
+	}
+	if err := addMount(ContainerMount{Source: container.Meta, Target: buildkit.MetaMountDestPath, SourcePath: buildkit.MetaMountDestPath}); err != nil {
+		return nil, nil, 0, err
+	}
+	for _, mount := range container.Mounts {
+		if err := addMount(mount); err != nil {
+			return nil, nil, 0, err
+		}
+	}
+
+	// handle secret mounts
+	for _, secret := range container.Secrets {
+		if secret.MountPath == "" {
+			continue
+		}
+		uid, gid := 0, 0
+		if secret.Owner != nil {
+			uid, gid = secret.Owner.UID, secret.Owner.GID
+		}
+		mount := &pb.Mount{
+			Input:     pb.Empty,
+			Output:    pb.SkipOutput,
+			Dest:      secret.MountPath,
+			MountType: pb.MountType_SECRET,
+			SecretOpt: &pb.SecretOpt{
+				ID:   secret.Secret.ID().Digest().String(),
+				Uid:  uint32(uid),
+				Gid:  uint32(gid),
+				Mode: uint32(secret.Mode),
+			},
+		}
+		mounts = append(mounts, mount)
+	}
+
+	// handle socket mounts
+	for _, socket := range container.Sockets {
+		if socket.ContainerPath == "" {
+			return nil, nil, 0, fmt.Errorf("unsupported socket: only unix paths are implemented")
+		}
+		uid, gid := 0, 0
+		if socket.Owner != nil {
+			uid, gid = socket.Owner.UID, socket.Owner.GID
+		}
+		mount := &pb.Mount{
+			Input:     pb.Empty,
+			Output:    pb.SkipOutput,
+			Dest:      socket.ContainerPath,
+			MountType: pb.MountType_SSH,
+			SSHOpt: &pb.SSHOpt{
+				ID:   socket.Source.LLBID(),
+				Uid:  uint32(uid),
+				Gid:  uint32(gid),
+				Mode: 0o600, // preserve default
+			},
+		}
+		mounts = append(mounts, mount)
+	}
+
+	return mounts, states, outputIdx, nil
+}
+
+// setAllContainerMounts is the reverse of getAllContainerMounts, and rewrites
+// the container mounts to the given states.
+func (op *ContainerDagOp) setAllContainerMounts(ctx context.Context, container *Container, outputs []llb.State) error {
+	for mountIdx, mount := range op.Mounts {
+		if mount.Output == pb.SkipOutput {
+			continue
+		}
+		st := outputs[mount.Output]
+		def, err := st.Marshal(ctx, llb.Platform(container.Platform.Spec()))
+		if err != nil {
+			return err
+		}
+
+		switch mountIdx {
+		case 0:
+			container.FS = def.ToPB()
+		case 1:
+			container.Meta = def.ToPB()
+		default:
+			container.Mounts[mountIdx-2].Source = def.ToPB()
+		}
+	}
+
+	return nil
+}
+
+// extractContainerBkOutputs returns a list of outputs suitable to be returned
+// from CustomOp.Exec extracted from the container according to the dagop specification.
+func (op *ContainerDagOp) extractContainerBkOutputs(ctx context.Context, container *Container, wkr worker.Worker) ([]solver.Result, error) {
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+
+	getResult := func(def *pb.Definition, ref bkcache.ImmutableRef) (solver.Result, error) {
+		if ref != nil {
+			return worker.NewWorkerRefResult(ref.Clone(), wkr), nil
+		}
+		if def != nil {
+			res, err := bk.Solve(ctx, bkgw.SolveRequest{
+				Evaluate:   true,
+				Definition: def,
+			})
+			if err != nil {
+				return nil, err
+			}
+			ref, err := res.Ref.Result(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if ref != nil {
+				return worker.NewWorkerRefResult(ref.Sys().(*worker.WorkerRef).ImmutableRef, wkr), nil
+			}
+		}
+		return worker.NewWorkerRefResult(nil, wkr), nil
+	}
+
+	outputs := make([]solver.Result, op.OutputCount)
+	for mountIdx, mount := range op.Mounts {
+		if mount.Output == pb.SkipOutput {
+			continue
+		}
+		var ref solver.Result
+		switch mountIdx {
+		case 0:
+			ref, err = getResult(container.FS, container.FSResult)
+		case 1:
+			ref, err = getResult(container.Meta, container.MetaResult)
+		default:
+			mnt := container.Mounts[mountIdx-2]
+			ref, err = getResult(mnt.Source, mnt.Result)
+		}
+		if err != nil {
+			return nil, err
+		}
+		outputs[mount.Output] = ref
+	}
+	for i, output := range outputs {
+		if output == nil {
+			// this *shouldn't* happen, and means we've got somehow got gaps in
+			// the output araray. the mounts are therefore badly constructed,
+			// so we should error out. otherwise we'll get weird panics deep in
+			// buildkit that are near impossible to debug.
+			return nil, fmt.Errorf("internal: output %d was empty", i)
+		}
+	}
+
+	return outputs, nil
+}
+
 func newDagOpLLB(ctx context.Context, dagOp buildkit.CustomOp, id *call.ID, inputs []llb.State) (llb.State, error) {
 	return buildkit.NewCustomLLB(ctx, dagOp, inputs,
 		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Name()),
 		buildkit.WithTracePropagation(ctx),
 		buildkit.WithPassthrough(),
 	)
-}
-
-type dagOpContextKey string
-
-func withDagOpContext(ctx context.Context, op buildkit.CustomOp) context.Context {
-	return context.WithValue(ctx, dagOpContextKey(op.Name()), op)
-}
-
-func DagOpFromContext[T buildkit.CustomOp](ctx context.Context) (t T, ok bool) {
-	if val := ctx.Value(dagOpContextKey(t.Name())); val != nil {
-		t, ok = val.(T)
-	}
-	return t, ok
-}
-
-func DagOpInContext[T buildkit.CustomOp](ctx context.Context) bool {
-	_, ok := DagOpFromContext[T](ctx)
-	return ok
-}
-
-// MountRef is a utility for easily mounting a ref
-func MountRef(ctx context.Context, ref bkcache.Ref, g bksession.Group, f func(string) error) error {
-	mount, err := ref.Mount(ctx, false, g)
-	if err != nil {
-		return err
-	}
-	lm := snapshot.LocalMounter(mount)
-	defer lm.Unmount()
-
-	dir, err := lm.Mount()
-	if err != nil {
-		return err
-	}
-	return f(dir)
 }

--- a/core/git.go
+++ b/core/git.go
@@ -559,7 +559,7 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 			return err
 		}
 
-		err = op.Mount(ctx, checkoutRef, func(checkoutDir string) error {
+		err = MountRef(ctx, checkoutRef, op.Group(), func(checkoutDir string) error {
 			checkoutDirGit := filepath.Join(checkoutDir, ".git")
 			if err := os.MkdirAll(checkoutDir, 0711); err != nil {
 				return err
@@ -920,7 +920,7 @@ func (ref *LocalGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGitD
 			return fmt.Errorf("could not find git dir: %w", err)
 		}
 
-		return op.Mount(ctx, bkref, func(checkoutDir string) error {
+		return MountRef(ctx, bkref, op.Group(), func(checkoutDir string) error {
 			checkoutDirGit := filepath.Join(checkoutDir, ".git")
 			if err := os.MkdirAll(checkoutDir, 0711); err != nil {
 				return err

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1878,7 +1878,7 @@ func (s *containerSchema) asTarball(
 			bkref.Release(context.WithoutCancel(ctx))
 		}
 	}()
-	err = op.Mount(ctx, bkref, func(out string) error {
+	err = core.MountRef(ctx, bkref, op.Group(), func(out string) error {
 		err = bk.ContainerImageToTarball(ctx, engineHostPlatform.Spec(), filepath.Join(out, op.Path), inputByPlatform, opts)
 		if err != nil {
 			return fmt.Errorf("container image to tarball file conversion failed: %w", err)

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -37,8 +37,9 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 		// very uninteresting spans
 		return ctx, dagql.NoopDone
 	}
-	if DagOpInContext[RawDagOp](ctx) || DagOpInContext[FSDagOp](ctx) {
+	if DagOpInContext[RawDagOp](ctx) || DagOpInContext[FSDagOp](ctx) || DagOpInContext[ContainerDagOp](ctx) {
 		// dagops are all self calls, no need to emit additional spans here
+		// FIXME: we lose telemetry.SpanStdio info from here
 		return ctx, dagql.NoopDone
 	}
 

--- a/core/util.go
+++ b/core/util.go
@@ -9,8 +9,11 @@ import (
 	"strconv"
 	"strings"
 
+	bkcache "github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
+	bksession "github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/sys/user"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -76,7 +79,7 @@ func absPath(workDir string, containerPath string) string {
 }
 
 func defToState(def *pb.Definition) (llb.State, error) {
-	if def.Def == nil {
+	if def == nil || def.Def == nil {
 		// NB(vito): llb.Scratch().Marshal().ToPB() produces an empty
 		// *pb.Definition. If we don't convert it properly back to a llb.Scratch()
 		// we'll hit 'cannot marshal empty definition op' when trying to marshal it
@@ -273,4 +276,20 @@ func mergeImageConfig(dst, src specs.ImageConfig) specs.ImageConfig {
 
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// MountRef is a utility for easily mounting a ref
+func MountRef(ctx context.Context, ref bkcache.Ref, g bksession.Group, f func(string) error) error {
+	mount, err := ref.Mount(ctx, false, g)
+	if err != nil {
+		return err
+	}
+	lm := snapshot.LocalMounter(mount)
+	defer lm.Unmount()
+
+	dir, err := lm.Mount()
+	if err != nil {
+		return err
+	}
+	return f(dir)
 }

--- a/engine/buildkit/op.go
+++ b/engine/buildkit/op.go
@@ -69,13 +69,9 @@ func NewCustomLLB(ctx context.Context, op CustomOp, inputs []llb.State, opts ...
 	}
 
 	// pre-populate a reasonable underlying representation that has some inputs
-	var a *llb.FileAction = llb.Rm("/" + id.Encoded())
+	a := llb.Rm("/" + id.Encoded())
 	for _, input := range inputs {
-		if a == nil {
-			a = llb.Copy(input, "/", "/")
-		} else {
-			a = a.Copy(input, "/", "/")
-		}
+		a = a.Copy(input, "/", "/")
 	}
 	st := llb.Scratch().File(a)
 	customOpOpt, err := opWrapped.AsConstraintsOpt()

--- a/engine/buildkit/output.go
+++ b/engine/buildkit/output.go
@@ -1,0 +1,34 @@
+package buildkit
+
+import (
+	"context"
+
+	"github.com/moby/buildkit/client/llb"
+	solverpb "github.com/moby/buildkit/solver/pb"
+)
+
+type output struct {
+	vertex llb.Vertex
+	idx    solverpb.OutputIndex
+}
+
+func (o *output) ToInput(ctx context.Context, c *llb.Constraints) (*solverpb.Input, error) {
+	//nolint:dogsled
+	dgst, _, _, _, err := o.vertex.Marshal(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	return &solverpb.Input{Digest: dgst, Index: o.idx}, nil
+}
+
+func (o *output) Vertex(context.Context, *llb.Constraints) llb.Vertex {
+	return o.vertex
+}
+
+func StateIdx(ctx context.Context, st llb.State, idx solverpb.OutputIndex, c *llb.Constraints) llb.State {
+	vtx := st.Output().Vertex(ctx, c)
+	return llb.NewState(&output{
+		vertex: vtx,
+		idx:    idx,
+	})
+}


### PR DESCRIPTION
This PR extends the dagop concept introduced in https://github.com/dagger/dagger/pull/9395 to a `ContainerDagOp` which allows using dagops on containers, mapping all mounts correctly :tada:

See example usage in https://github.com/jedevc/dagger/compare/container-dagop...jedevc:dagger:container-dagop-magic?expand=1.

Intended to be used in:
- https://github.com/dagger/dagger/pull/10435
- https://github.com/dagger/dagger/pull/10457