### PR TITLE
feat(sdk/elixir): add support for constructor function

### DIFF
--- a/.dagger/sdk_elixir.go
+++ b/.dagger/sdk_elixir.go
@@ -127,15 +127,11 @@ func (t ElixirSDK) Bump(ctx context.Context, version string) (*dagger.Directory,
 }
 
 func (t ElixirSDK) sdkDev() *dagger.ElixirSDKDev {
-	return dag.ElixirSDKDev().Init()
+	return dag.ElixirSDKDev()
 }
 
 func (t ElixirSDK) sdkDevWithInstaller(
 	installer func(*dagger.Container) *dagger.Container,
 ) *dagger.ElixirSDKDev {
-	return t.sdkDev().
-		With(func(sdkDev *dagger.ElixirSDKDev) *dagger.ElixirSDKDev {
-			ctr := sdkDev.Container().With(installer)
-			return dag.ElixirSDKDev().Init(dagger.ElixirSDKDevInitOpts{Container: ctr})
-		})
+	return dag.ElixirSDKDev(dagger.ElixirSDKDevOpts{Container: t.sdkDev().Container().With(installer)})
 }

--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -193,6 +193,17 @@ func (ElixirSuite) TestReturnSelf(ctx context.Context, t *testctx.T) {
 	require.Equal(t, "bar", out)
 }
 
+func (ElixirSuite) TestConstructorArg(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	out, err := elixirModule(t, c, "constructor-function").
+		With(daggerCall("--name", "Elixir", "greeting")).
+		Stdout(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Hello, Elixir!", out)
+}
+
 // Ensure the module is working properly with the `Req` adapter.
 func (ElixirSuite) TestReqAdapter(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)

--- a/core/integration/testdata/modules/elixir/constructor-function/.formatter.exs
+++ b/core/integration/testdata/modules/elixir/constructor-function/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:dagger],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/core/integration/testdata/modules/elixir/constructor-function/.gitattributes
+++ b/core/integration/testdata/modules/elixir/constructor-function/.gitattributes
@@ -1,0 +1,1 @@
+/dagger_sdk/** linguist-generated

--- a/core/integration/testdata/modules/elixir/constructor-function/.gitignore
+++ b/core/integration/testdata/modules/elixir/constructor-function/.gitignore
@@ -1,0 +1,9 @@
+/dagger_sdk
+/_build
+/cover
+/deps
+/doc
+/erl_crash.dump
+/*.ez
+/template-*.tar
+/tmp

--- a/core/integration/testdata/modules/elixir/constructor-function/dagger.json
+++ b/core/integration/testdata/modules/elixir/constructor-function/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "constructor-function",
+  "engineVersion": "v0.18.8",
+  "sdk": {
+    "source": "../../sdk/elixir"
+  }
+}

--- a/core/integration/testdata/modules/elixir/constructor-function/lib/constructor_function.ex
+++ b/core/integration/testdata/modules/elixir/constructor-function/lib/constructor_function.ex
@@ -1,0 +1,17 @@
+defmodule ConstructorFunction do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "ConstructorFunction"
+
+  object do
+    field :name, String.t()
+  end
+
+  defn init(name: String.t()) :: ConstructorFunction.t() do
+    %__MODULE__{name: name}
+  end
+
+  defn greeting(self) :: String.t() do
+    "Hello, #{self.name}!"
+  end
+end

--- a/core/integration/testdata/modules/elixir/constructor-function/mix.exs
+++ b/core/integration/testdata/modules/elixir/constructor-function/mix.exs
@@ -1,0 +1,25 @@
+defmodule Template.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :constructor_function,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:dagger, path: "./dagger_sdk"}
+    ]
+  end
+end

--- a/core/integration/testdata/modules/elixir/constructor-function/mix.lock
+++ b/core/integration/testdata/modules/elixir/constructor-function/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nestru": {:hex, :nestru, "1.0.1", "f02321db91b898da3d598c274f2ccba2c41ec5c50c942eabe900474dbfe4bce3", [:mix], [], "hexpm", "e4fbbd6d64b1c8cb37ef590a891f0b6b17b0b880c1c5ce2ac98de02c0ad7417e"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}

--- a/sdk/elixir/.changes/unreleased/Added-20250522-003959.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20250522-003959.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: The `init` function is now convert to a constructor function by the SDK.
+time: 2025-05-22T00:39:59.692634+07:00
+custom:
+    Author: wingyplus
+    PR: "10437"

--- a/sdk/elixir/dev/dagger.json
+++ b/sdk/elixir/dev/dagger.json
@@ -2,6 +2,6 @@
   "name": "elixir-sdk-dev",
   "engineVersion": "v0.18.9",
   "sdk": {
-    "source": "elixir"
+    "source": ".."
   }
 }

--- a/sdk/elixir/lib/dagger/mod/module.ex
+++ b/sdk/elixir/lib/dagger/mod/module.ex
@@ -28,6 +28,20 @@ defmodule Dagger.Mod.Module do
     |> Dagger.TypeDef.with_object(Helper.camelize(mod_name))
     |> then(&define_fields(&1, dag, module))
     |> then(&define_functions(&1, dag, module))
+    |> then(&define_constructor(&1, dag, module))
+  end
+
+  defp define_constructor(type_def, dag, module) do
+    case Enum.find(module.__object__(:functions), &init?/1) do
+      nil ->
+        type_def
+
+      {name, fun_def} ->
+        type_def
+        |> Dagger.TypeDef.with_constructor(
+          FunctionDef.to_dag_function(fun_def, name, module, dag)
+        )
+    end
   end
 
   defp define_fields(type_def, dag, module) do
@@ -39,8 +53,12 @@ defmodule Dagger.Mod.Module do
 
   defp define_functions(type_def, dag, module) do
     module.__object__(:functions)
+    |> Enum.reject(&init?/1)
     |> Enum.reduce(type_def, fn {name, fun_def}, type_def ->
       FunctionDef.define(fun_def, name, module, type_def, dag)
     end)
   end
+
+  defp init?({:init, _}), do: true
+  defp init?({_, _}), do: false
 end

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -11,7 +11,7 @@ defmodule Dagger.Mod.ModuleTest do
   end
 
   describe "define/1" do
-    test "register primitive type arguments", %{dag: dag} do
+    test "primitive type arguments", %{dag: dag} do
       assert {:ok, functions} =
                root_object(dag, PrimitiveTypeArgs) |> Dagger.ObjectTypeDef.functions()
 

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -12,7 +12,147 @@ defmodule Dagger.Mod.ModuleTest do
 
   describe "define/1" do
     test "register module", %{dag: dag} do
-      assert {:ok, _} = Module.define(dag, ObjectMod) |> Dagger.Module.id()
+      module = Module.define(dag, ObjectMod)
+
+      assert {:ok, [root_module]} = Dagger.Module.objects(module)
+
+      assert {:ok, functions} =
+               root_module
+               |> Dagger.TypeDef.as_object()
+               |> Dagger.ObjectTypeDef.functions()
+
+      [accept_string | functions] = functions
+      assert {:ok, "acceptString"} = Dagger.Function.name(accept_string)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_string)
+      assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, :STRING_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+
+      [accept_string2 | functions] = functions
+      assert {:ok, "acceptString2"} = Dagger.Function.name(accept_string2)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_string2)
+      assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, :STRING_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+
+      [accept_integer | functions] = functions
+      assert {:ok, "acceptInteger"} = Dagger.Function.name(accept_integer)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_integer)
+      assert {:ok, "value"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, :INTEGER_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+
+      [accept_float | functions] = functions
+      assert {:ok, "acceptFloat"} = Dagger.Function.name(accept_float)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_float)
+      assert {:ok, "value"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, :FLOAT_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+
+      [accept_boolean | functions] = functions
+      assert {:ok, "acceptBoolean"} = Dagger.Function.name(accept_boolean)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_boolean)
+      assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, :BOOLEAN_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+
+      [empty_args | functions] = functions
+      assert {:ok, "emptyArgs"} = Dagger.Function.name(empty_args)
+      assert {:ok, []} = Dagger.Function.args(empty_args)
+
+      [accept_and_return_module | functions] = functions
+      assert {:ok, "acceptAndReturnModule"} = Dagger.Function.name(accept_and_return_module)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_and_return_module)
+      assert {:ok, "container"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      assert {:ok, "Container"} =
+               arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+
+      [accept_list | functions] = functions
+      assert {:ok, "acceptList"} = Dagger.Function.name(accept_list)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_list)
+      assert {:ok, "alist"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :LIST_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      sub_type_def =
+        arg_type_def |> Dagger.TypeDef.as_list() |> Dagger.ListTypeDef.element_type_def()
+
+      assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
+
+      [accept_list2 | functions] = functions
+      assert {:ok, "acceptList2"} = Dagger.Function.name(accept_list2)
+      assert {:ok, [arg]} = Dagger.Function.args(accept_list2)
+      assert {:ok, "alist"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :LIST_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      sub_type_def =
+        arg_type_def |> Dagger.TypeDef.as_list() |> Dagger.ListTypeDef.element_type_def()
+
+      assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
+
+      [optional_arg | functions] = functions
+      assert {:ok, "optionalArg"} = Dagger.Function.name(optional_arg)
+      assert {:ok, [arg]} = Dagger.Function.args(optional_arg)
+      assert {:ok, "s"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(arg_type_def)
+      assert {:ok, true} = Dagger.TypeDef.optional(arg_type_def)
+
+      [type_option | functions] = functions
+      assert {:ok, "typeOption"} = Dagger.Function.name(type_option)
+      assert {:ok, [arg]} = Dagger.Function.args(type_option)
+      assert {:ok, "dir"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, "/sdk/elixir"} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      assert {:ok, "The directory to run on."} = Dagger.FunctionArg.description(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      assert {:ok, "Directory"} =
+               arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+
+      assert {:ok, true} = Dagger.TypeDef.optional(arg_type_def)
+
+      [return_void | functions] = functions
+      assert {:ok, "returnVoid"} = Dagger.Function.name(return_void)
+      assert {:ok, []} = Dagger.Function.args(return_void)
+      return_type_def = Dagger.Function.return_type(return_void)
+      assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
+
+      [only_self_arg | functions] = functions
+      assert {:ok, "onlySelfArg"} = Dagger.Function.name(only_self_arg)
+      assert {:ok, []} = Dagger.Function.args(only_self_arg)
+      return_type_def = Dagger.Function.return_type(return_void)
+      assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
+
+      [mix_self_and_args | _functions] = functions
+      assert {:ok, "mixSelfAndArgs"} = Dagger.Function.name(mix_self_and_args)
+      assert {:ok, [arg]} = Dagger.Function.args(mix_self_and_args)
+      assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      return_type_def = Dagger.Function.return_type(return_void)
+      assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
     end
   end
 end

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -11,15 +11,9 @@ defmodule Dagger.Mod.ModuleTest do
   end
 
   describe "define/1" do
-    test "register module", %{dag: dag} do
-      module = Module.define(dag, ObjectMod)
-
-      assert {:ok, [root_module]} = Dagger.Module.objects(module)
-
+    test "register primitive type arguments", %{dag: dag} do
       assert {:ok, functions} =
-               root_module
-               |> Dagger.TypeDef.as_object()
-               |> Dagger.ObjectTypeDef.functions()
+               root_object(dag, PrimitiveTypeArgs) |> Dagger.ObjectTypeDef.functions()
 
       [accept_string | functions] = functions
       assert {:ok, "acceptString"} = Dagger.Function.name(accept_string)
@@ -53,19 +47,27 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
       assert {:ok, :FLOAT_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
 
-      [accept_boolean | functions] = functions
+      [accept_boolean | []] = functions
       assert {:ok, "acceptBoolean"} = Dagger.Function.name(accept_boolean)
       assert {:ok, [arg]} = Dagger.Function.args(accept_boolean)
       assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
       assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
       assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
       assert {:ok, :BOOLEAN_KIND} = Dagger.FunctionArg.type_def(arg) |> Dagger.TypeDef.kind()
+    end
 
-      [empty_args | functions] = functions
+    test "empty arguments", %{dag: dag} do
+      assert {:ok, [empty_args]} =
+               root_object(dag, EmptyArgs) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "emptyArgs"} = Dagger.Function.name(empty_args)
       assert {:ok, []} = Dagger.Function.args(empty_args)
+    end
 
-      [accept_and_return_module | functions] = functions
+    test "accept and return object", %{dag: dag} do
+      assert {:ok, [accept_and_return_module]} =
+               root_object(dag, ObjectArgAndReturn) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "acceptAndReturnModule"} = Dagger.Function.name(accept_and_return_module)
       assert {:ok, [arg]} = Dagger.Function.args(accept_and_return_module)
       assert {:ok, "container"} = Dagger.FunctionArg.name(arg)
@@ -76,8 +78,12 @@ defmodule Dagger.Mod.ModuleTest do
 
       assert {:ok, "Container"} =
                arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+    end
 
-      [accept_list | functions] = functions
+    test "list arguments", %{dag: dag} do
+      assert {:ok, [accept_list, accept_list2]} =
+               root_object(dag, ListArgs) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "acceptList"} = Dagger.Function.name(accept_list)
       assert {:ok, [arg]} = Dagger.Function.args(accept_list)
       assert {:ok, "alist"} = Dagger.FunctionArg.name(arg)
@@ -91,7 +97,6 @@ defmodule Dagger.Mod.ModuleTest do
 
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
 
-      [accept_list2 | functions] = functions
       assert {:ok, "acceptList2"} = Dagger.Function.name(accept_list2)
       assert {:ok, [arg]} = Dagger.Function.args(accept_list2)
       assert {:ok, "alist"} = Dagger.FunctionArg.name(arg)
@@ -104,8 +109,12 @@ defmodule Dagger.Mod.ModuleTest do
         arg_type_def |> Dagger.TypeDef.as_list() |> Dagger.ListTypeDef.element_type_def()
 
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
+    end
 
-      [optional_arg | functions] = functions
+    test "optional arguments", %{dag: dag} do
+      assert {:ok, [optional_arg]} =
+               root_object(dag, OptionalArgs) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "optionalArg"} = Dagger.Function.name(optional_arg)
       assert {:ok, [arg]} = Dagger.Function.args(optional_arg)
       assert {:ok, "s"} = Dagger.FunctionArg.name(arg)
@@ -114,8 +123,12 @@ defmodule Dagger.Mod.ModuleTest do
       arg_type_def = Dagger.FunctionArg.type_def(arg)
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(arg_type_def)
       assert {:ok, true} = Dagger.TypeDef.optional(arg_type_def)
+    end
 
-      [type_option | functions] = functions
+    test "argument options", %{dag: dag} do
+      assert {:ok, [type_option]} =
+               root_object(dag, ArgOptions) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "typeOption"} = Dagger.Function.name(type_option)
       assert {:ok, [arg]} = Dagger.Function.args(type_option)
       assert {:ok, "dir"} = Dagger.FunctionArg.name(arg)
@@ -129,20 +142,27 @@ defmodule Dagger.Mod.ModuleTest do
                arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
 
       assert {:ok, true} = Dagger.TypeDef.optional(arg_type_def)
+    end
 
-      [return_void | functions] = functions
+    test "return void type", %{dag: dag} do
+      assert {:ok, [return_void]} =
+               root_object(dag, ReturnVoid) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "returnVoid"} = Dagger.Function.name(return_void)
       assert {:ok, []} = Dagger.Function.args(return_void)
       return_type_def = Dagger.Function.return_type(return_void)
       assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
+    end
 
-      [only_self_arg | functions] = functions
+    test "self object", %{dag: dag} do
+      assert {:ok, [only_self_arg, mix_self_and_args]} =
+               root_object(dag, SelfObject) |> Dagger.ObjectTypeDef.functions()
+
       assert {:ok, "onlySelfArg"} = Dagger.Function.name(only_self_arg)
       assert {:ok, []} = Dagger.Function.args(only_self_arg)
-      return_type_def = Dagger.Function.return_type(return_void)
+      return_type_def = Dagger.Function.return_type(only_self_arg)
       assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
 
-      [mix_self_and_args | _functions] = functions
       assert {:ok, "mixSelfAndArgs"} = Dagger.Function.name(mix_self_and_args)
       assert {:ok, [arg]} = Dagger.Function.args(mix_self_and_args)
       assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
@@ -151,8 +171,36 @@ defmodule Dagger.Mod.ModuleTest do
       arg_type_def = Dagger.FunctionArg.type_def(arg)
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(arg_type_def)
 
-      return_type_def = Dagger.Function.return_type(return_void)
+      return_type_def = Dagger.Function.return_type(mix_self_and_args)
       assert {:ok, :VOID_KIND} = Dagger.TypeDef.kind(return_type_def)
     end
+
+    test "constructor function", %{dag: dag} do
+      root = root_object(dag, ConstructorFunction)
+
+      # No any functions because `init` register as a function.
+      assert {:ok, []} = Dagger.ObjectTypeDef.functions(root)
+
+      init = Dagger.ObjectTypeDef.constructor(root)
+      assert {:ok, ""} = Dagger.Function.name(init)
+      assert {:ok, [arg]} = Dagger.Function.args(init)
+      assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
+      assert {:ok, ""} = Dagger.FunctionArg.default_path(arg)
+      assert {:ok, nil} = Dagger.FunctionArg.default_value(arg)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      return_type_def = Dagger.Function.return_type(init)
+      assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(return_type_def)
+
+      assert {:ok, "ConstructorFunction"} =
+               return_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+    end
+  end
+
+  defp root_object(dag, module) do
+    module = Module.define(dag, module)
+    {:ok, [root_object]} = Dagger.Module.objects(module)
+    Dagger.TypeDef.as_object(root_object)
   end
 end

--- a/sdk/elixir/test/dagger/mod/object_test.exs
+++ b/sdk/elixir/test/dagger/mod/object_test.exs
@@ -5,8 +5,8 @@ defmodule Dagger.Mod.ObjectTest do
   alias Dagger.Mod.Object.FieldDef
 
   describe "defn/2" do
-    test "store function information" do
-      assert ObjectMod.__object__(:functions) == [
+    test "primitive type arguments" do
+      assert PrimitiveTypeArgs.__object__(:functions) == [
                accept_string: %FunctionDef{
                  self: false,
                  args: [
@@ -41,8 +41,18 @@ defmodule Dagger.Mod.ObjectTest do
                    name: [{:ignore, nil}, {:default_path, nil}, {:doc, nil}, {:type, :boolean}]
                  ],
                  return: :string
-               },
-               empty_args: %FunctionDef{self: false, args: [], return: :string},
+               }
+             ]
+    end
+
+    test "empty arguments" do
+      assert EmptyArgs.__object__(:functions) == [
+               empty_args: %FunctionDef{self: false, args: [], return: :string}
+             ]
+    end
+
+    test "accept and return object" do
+      assert ObjectArgAndReturn.__object__(:functions) == [
                accept_and_return_module: %FunctionDef{
                  self: false,
                  args: [
@@ -54,7 +64,12 @@ defmodule Dagger.Mod.ObjectTest do
                    ]
                  ],
                  return: Dagger.Container
-               },
+               }
+             ]
+    end
+
+    test "list arguments" do
+      assert ListArgs.__object__(:functions) == [
                accept_list: %FunctionDef{
                  self: false,
                  args: [
@@ -78,7 +93,12 @@ defmodule Dagger.Mod.ObjectTest do
                    ]
                  ],
                  return: :string
-               },
+               }
+             ]
+    end
+
+    test "optional arguments" do
+      assert OptionalArgs.__object__(:functions) == [
                optional_arg: %FunctionDef{
                  self: false,
                  args: [
@@ -90,7 +110,12 @@ defmodule Dagger.Mod.ObjectTest do
                    ]
                  ],
                  return: :string
-               },
+               }
+             ]
+    end
+
+    test "argument options" do
+      assert ArgOptions.__object__(:functions) == [
                type_option: %FunctionDef{
                  self: false,
                  args: [
@@ -102,8 +127,18 @@ defmodule Dagger.Mod.ObjectTest do
                    ]
                  ],
                  return: :string
-               },
-               return_void: %FunctionDef{self: false, args: [], return: Dagger.Void},
+               }
+             ]
+    end
+
+    test "return void" do
+      assert ReturnVoid.__object__(:functions) == [
+               return_void: %FunctionDef{self: false, args: [], return: Dagger.Void}
+             ]
+    end
+
+    test "self object" do
+      assert SelfObject.__object__(:functions) == [
                only_self_arg: %FunctionDef{self: true, args: [], return: Dagger.Void},
                mix_self_and_args: %FunctionDef{
                  self: true,

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -68,3 +68,112 @@ defmodule ObjectMod do
     name
   end
 end
+
+defmodule PrimitiveTypeArgs do
+  use Dagger.Mod.Object, name: "PrimitiveTypeArgs"
+
+  defn accept_string(name: String.t()) :: String.t() do
+    "Hello, #{name}"
+  end
+
+  defn accept_string2(name: binary()) :: binary() do
+    "Hello, #{name}"
+  end
+
+  defn accept_integer(value: integer()) :: integer() do
+    value
+  end
+
+  defn accept_float(value: float()) :: float() do
+    value
+  end
+
+  defn accept_boolean(name: boolean()) :: String.t() do
+    "Hello, #{name}"
+  end
+end
+
+defmodule EmptyArgs do
+  use Dagger.Mod.Object, name: "EmptyArgs"
+
+  defn empty_args() :: String.t() do
+    "Empty args"
+  end
+end
+
+defmodule ObjectArgAndReturn do
+  use Dagger.Mod.Object, name: "ObjectArgAndReturn"
+
+  defn accept_and_return_module(container: Dagger.Container.t()) :: Dagger.Container.t() do
+    container
+  end
+end
+
+defmodule ListArgs do
+  use Dagger.Mod.Object, name: "ListArg"
+
+  defn accept_list(alist: list(String.t())) :: String.t() do
+    Enum.join(alist, ",")
+  end
+
+  defn accept_list2(alist: [String.t()]) :: String.t() do
+    Enum.join(alist, ",")
+  end
+end
+
+defmodule OptionalArgs do
+  use Dagger.Mod.Object, name: "OptionalArgs"
+
+  defn optional_arg(s: String.t() | nil) :: String.t() do
+    "Hello, #{s}"
+  end
+end
+
+defmodule ArgOptions do
+  use Dagger.Mod.Object, name: "ArgOptions"
+
+  defn type_option(
+         dir:
+           {Dagger.Directory.t() | nil,
+            doc: "The directory to run on.",
+            default_path: "/sdk/elixir",
+            ignore: ["deps", "_build"]}
+       ) :: String.t() do
+    Dagger.Directory.id(dir)
+  end
+end
+
+defmodule ReturnVoid do
+  use Dagger.Mod.Object, name: "ReturnVoid"
+
+  defn return_void() :: Dagger.Void.t() do
+    :ok
+  end
+end
+
+defmodule SelfObject do
+  use Dagger.Mod.Object, name: "SelfObject"
+
+  object do
+  end
+
+  defn only_self_arg(_self) :: Dagger.Void.t() do
+    :ok
+  end
+
+  defn mix_self_and_args(_self, name: String.t()) :: Dagger.Void.t() do
+    name
+  end
+end
+
+defmodule ConstructorFunction do
+  use Dagger.Mod.Object, name: "ConstructorFunction"
+
+  object do
+    field(:name, String.t())
+  end
+
+  defn init(name: String.t()) :: ConstructorFunction.t() do
+    %__MODULE__{name: name}
+  end
+end

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -1,75 +1,5 @@
-defmodule ObjectMod do
-  @moduledoc false
-
-  use Dagger.Mod.Object, name: "ObjectMod"
-
-  defn accept_string(name: String.t()) :: String.t() do
-    "Hello, #{name}"
-  end
-
-  defn accept_string2(name: binary()) :: binary() do
-    "Hello, #{name}"
-  end
-
-  defn accept_integer(value: integer()) :: integer() do
-    value
-  end
-
-  defn accept_float(value: float()) :: float() do
-    value
-  end
-
-  defn accept_boolean(name: boolean()) :: String.t() do
-    "Hello, #{name}"
-  end
-
-  defn empty_args() :: String.t() do
-    "Empty args"
-  end
-
-  defn accept_and_return_module(container: Dagger.Container.t()) :: Dagger.Container.t() do
-    container
-  end
-
-  defn accept_list(alist: list(String.t())) :: String.t() do
-    Enum.join(alist, ",")
-  end
-
-  defn accept_list2(alist: [String.t()]) :: String.t() do
-    Enum.join(alist, ",")
-  end
-
-  defn optional_arg(s: String.t() | nil) :: String.t() do
-    "Hello, #{s}"
-  end
-
-  defn type_option(
-         dir:
-           {Dagger.Directory.t() | nil,
-            doc: "The directory to run on.",
-            default_path: "/sdk/elixir",
-            ignore: ["deps", "_build"]}
-       ) :: String.t() do
-    Dagger.Directory.id(dir)
-  end
-
-  defn return_void() :: Dagger.Void.t() do
-    :ok
-  end
-
-  object do
-  end
-
-  defn only_self_arg(_self) :: Dagger.Void.t() do
-    :ok
-  end
-
-  defn mix_self_and_args(_self, name: String.t()) :: Dagger.Void.t() do
-    name
-  end
-end
-
 defmodule PrimitiveTypeArgs do
+  @moduledoc false
   use Dagger.Mod.Object, name: "PrimitiveTypeArgs"
 
   defn accept_string(name: String.t()) :: String.t() do
@@ -94,6 +24,7 @@ defmodule PrimitiveTypeArgs do
 end
 
 defmodule EmptyArgs do
+  @moduledoc false
   use Dagger.Mod.Object, name: "EmptyArgs"
 
   defn empty_args() :: String.t() do
@@ -102,6 +33,7 @@ defmodule EmptyArgs do
 end
 
 defmodule ObjectArgAndReturn do
+  @moduledoc false
   use Dagger.Mod.Object, name: "ObjectArgAndReturn"
 
   defn accept_and_return_module(container: Dagger.Container.t()) :: Dagger.Container.t() do
@@ -110,6 +42,7 @@ defmodule ObjectArgAndReturn do
 end
 
 defmodule ListArgs do
+  @moduledoc false
   use Dagger.Mod.Object, name: "ListArg"
 
   defn accept_list(alist: list(String.t())) :: String.t() do
@@ -122,6 +55,7 @@ defmodule ListArgs do
 end
 
 defmodule OptionalArgs do
+  @moduledoc false
   use Dagger.Mod.Object, name: "OptionalArgs"
 
   defn optional_arg(s: String.t() | nil) :: String.t() do
@@ -130,6 +64,7 @@ defmodule OptionalArgs do
 end
 
 defmodule ArgOptions do
+  @moduledoc false
   use Dagger.Mod.Object, name: "ArgOptions"
 
   defn type_option(
@@ -144,6 +79,7 @@ defmodule ArgOptions do
 end
 
 defmodule ReturnVoid do
+  @moduledoc false
   use Dagger.Mod.Object, name: "ReturnVoid"
 
   defn return_void() :: Dagger.Void.t() do
@@ -152,6 +88,7 @@ defmodule ReturnVoid do
 end
 
 defmodule SelfObject do
+  @moduledoc false
   use Dagger.Mod.Object, name: "SelfObject"
 
   object do
@@ -167,6 +104,7 @@ defmodule SelfObject do
 end
 
 defmodule ConstructorFunction do
+  @moduledoc false
   use Dagger.Mod.Object, name: "ConstructorFunction"
 
   object do


### PR DESCRIPTION
Once `init` function is define, the SDK turns that function into constructor function.

And also improve test coverage on converting an Elixir module into Dagger module.

Closes #10437