### PR TITLE
refactor(sdk/elixir): replace :json with JSON in dagger_codegen

### DIFF
--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/field.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/field.ex
@@ -26,7 +26,7 @@ defmodule Dagger.Codegen.Introspection.Types.Field do
     %__MODULE__{
       args: Enum.map(args, &Dagger.Codegen.Introspection.Types.InputValue.from_map/1),
       deprecation_reason:
-        unless deprecation_reason == :null do
+        if not is_nil(deprecation_reason) do
           deprecation_reason
         end,
       description: description,

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type_ref.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type_ref.ex
@@ -12,7 +12,6 @@ defmodule Dagger.Codegen.Introspection.Types.TypeRef do
       of_type:
         case type_ref["ofType"] do
           nil -> nil
-          :null -> nil
           of_type -> Dagger.Codegen.Introspection.Types.TypeRef.from_map(of_type)
         end
     }

--- a/sdk/elixir/dagger_codegen/lib/mix/tasks/dagger.codegen.ex
+++ b/sdk/elixir/dagger_codegen/lib/mix/tasks/dagger.codegen.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Dagger.Codegen do
   end
 
   def handle_generate(%{outdir: outdir, introspection: introspection}) do
-    %{"__schema" => schema} = introspection |> File.read!() |> :json.decode()
+    %{"__schema" => schema} = introspection |> File.read!() |> JSON.decode!()
 
     IO.puts("Generate code to #{outdir}")
 

--- a/sdk/elixir/dagger_codegen/test/support/renderer_case.ex
+++ b/sdk/elixir/dagger_codegen/test/support/renderer_case.ex
@@ -11,7 +11,7 @@ defmodule Dagger.Codegen.RendererCase do
   defp decode_type_from_file(path) do
     path
     |> File.read!()
-    |> :json.decode()
+    |> JSON.decode!()
     |> Dagger.Codegen.Introspection.Types.Type.from_map()
   end
 


### PR DESCRIPTION
Replace all `:json` with Elixir `JSON` standard library and drop `:null` handling because the `JSON` convert to `nil` automatically.

Updates #7444