### PR TITLE
shell: fix usage of `_` prefix not being reserved for interpreter builtins

### DIFF
--- a/.changes/unreleased/Fixed-20250521-235914.yaml
+++ b/.changes/unreleased/Fixed-20250521-235914.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'shell: fixed `_` prefix not being reserved for interpreter builtins'
+time: 2025-05-21T23:59:14.55937Z
+custom:
+    Author: helderco
+    PR: "10452"

--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -85,7 +85,7 @@ func (h *shellCallHandler) Call(ctx context.Context, args []string) ([]string, e
 	// with an interpreter builtin, the Dagger function is favored.
 	// To force the builtin to execute instead, prefix the command
 	// with "_". For example: "container | from $(_echo alpine)".
-	if after, ok := strings.CutPrefix(args[0], shellInterpBuiltinPrefix); ok {
+	if after, found := strings.CutPrefix(args[0], shellInterpBuiltinPrefix); found && isInterpBuiltin(after) {
 		args[0] = after
 		return args, nil
 	}
@@ -94,9 +94,9 @@ func (h *shellCallHandler) Call(ctx context.Context, args []string) ([]string, e
 	// builtins, but there's no way to directly call the interpreter
 	// command from there so we use ShellCommand just for the documentation
 	// (.help) but strip the builtin prefix here ('.') when executing.
-	if cmd, _ := h.BuiltinCommand(args[0]); cmd != nil && cmd.Run == nil {
-		if name := strings.TrimPrefix(args[0], "."); isInterpBuiltin(name) {
-			args[0] = name
+	if after, ok := strings.CutPrefix(args[0], "."); ok && isInterpBuiltin(after) {
+		if cmd, _ := h.BuiltinCommand(args[0]); cmd != nil && cmd.Run == nil {
+			args[0] = after
 			return args, nil
 		}
 	}

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -997,4 +997,12 @@ func (ShellSuite) TestInterpreterBuiltins(ctx context.Context, t *testctx.T) {
 			Sync(ctx)
 		requireErrOut(t, err, "reserved for internal use")
 	})
+
+	t.Run("unknown", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		_, err := daggerCliBase(t, c).
+			With(daggerShell(`_container`)).
+			Sync(ctx)
+		requireErrOut(t, err, "does not exist")
+	})
 }


### PR DESCRIPTION
You could previously prefix anything with an underscore and it would just be stripped out. So `_container` would execute `container`. However this was only intended to give access to the interpreter's own builtins, like `_echo`. Now `_container` should error since it doesn't exist.