### PR TITLE
Inline dependencies (formerly known as platform modules)

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -43,7 +43,8 @@ var (
 	moduleSourcePath string
 	moduleIncludes   []string
 
-	installName string
+	installName     string
+	installPlatform bool
 
 	developSDK        string
 	developSourcePath string
@@ -135,6 +136,8 @@ func init() {
 	modulePublishCmd.Flags().StringVarP(&moduleURL, "mod", "m", "", "Module reference to publish, remote git repo (defaults to current directory)")
 
 	moduleInstallCmd.Flags().StringVarP(&installName, "name", "n", "", "Name to use for the dependency in the module. Defaults to the name of the module being installed.")
+	moduleInstallCmd.Flags().BoolVarP(&installPlatform, "platform", "p", false, "Install a platform dependency")
+
 	moduleInstallCmd.Flags().StringVar(&compatVersion, "compat", modules.EngineVersionLatest, "Engine API version to target")
 	moduleAddFlags(moduleInstallCmd, moduleInstallCmd.Flags(), false)
 
@@ -330,7 +333,9 @@ var moduleInstallCmd = &cobra.Command{
 				depSrc = depSrc.WithName(installName)
 			}
 
-			modSrc = modSrc.WithDependencies([]*dagger.ModuleSource{depSrc})
+			modSrc = modSrc.WithDependencies([]*dagger.ModuleSource{depSrc}, dagger.ModuleSourceWithDependenciesOpts{
+				Platform: installPlatform,
+			})
 			if engineVersion := getCompatVersion(); engineVersion != "" {
 				modSrc = modSrc.WithEngineVersion(engineVersion)
 			}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -43,8 +43,8 @@ var (
 	moduleSourcePath string
 	moduleIncludes   []string
 
-	installName     string
-	installPlatform bool
+	installName   string
+	installInline bool
 
 	developSDK        string
 	developSourcePath string
@@ -136,7 +136,7 @@ func init() {
 	modulePublishCmd.Flags().StringVarP(&moduleURL, "mod", "m", "", "Module reference to publish, remote git repo (defaults to current directory)")
 
 	moduleInstallCmd.Flags().StringVarP(&installName, "name", "n", "", "Name to use for the dependency in the module. Defaults to the name of the module being installed.")
-	moduleInstallCmd.Flags().BoolVarP(&installPlatform, "platform", "p", false, "Install a platform dependency")
+	moduleInstallCmd.Flags().BoolVarP(&installInline, "inline", "", false, "Install inline (execute in the context of the caller instead of its own)")
 
 	moduleInstallCmd.Flags().StringVar(&compatVersion, "compat", modules.EngineVersionLatest, "Engine API version to target")
 	moduleAddFlags(moduleInstallCmd, moduleInstallCmd.Flags(), false)
@@ -334,7 +334,7 @@ var moduleInstallCmd = &cobra.Command{
 			}
 
 			modSrc = modSrc.WithDependencies([]*dagger.ModuleSource{depSrc}, dagger.ModuleSourceWithDependenciesOpts{
-				Platform: installPlatform,
+				Inline: installInline,
 			})
 			if engineVersion := getCompatVersion(); engineVersion != "" {
 				modSrc = modSrc.WithEngineVersion(engineVersion)

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -191,8 +191,8 @@ type ModuleConfigDependency struct {
 	// The pinned version of the module dependency.
 	Pin string `json:"pin,omitempty"`
 
-	// Load this dependency as a platform module
-	Platform bool `json:"platform,omitempty"`
+	// Inline dependency (executed in the caller's context)
+	Inline bool `json:"inline,omitempty"`
 }
 
 func (depCfg *ModuleConfigDependency) UnmarshalJSON(data []byte) error {

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -190,6 +190,9 @@ type ModuleConfigDependency struct {
 
 	// The pinned version of the module dependency.
 	Pin string `json:"pin,omitempty"`
+
+	// Load this dependency as a platform module
+	Platform bool `json:"platform,omitempty"`
 }
 
 func (depCfg *ModuleConfigDependency) UnmarshalJSON(data []byte) error {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -126,7 +126,8 @@ type ModuleSource struct {
 
 	OriginalSubpath string
 
-	ContextDirectory dagql.Instance[*Directory] `field:"true" name:"contextDirectory" doc:"The full directory loaded for the module source, including the source code as a subdirectory."`
+	ContextDirectory dagql.Instance[*Directory]    `field:"true" name:"contextDirectory" doc:"The full directory loaded for the module source, including the source code as a subdirectory."`
+	ContextModule    dagql.Instance[*ModuleSource] `field:"true" name:"contextModule" doc:"If set, use this module's context directory instead of our own when loading default directory paths"`
 
 	Digest string `field:"true" name:"digest" doc:"A content-hash of the module source. Module sources with the same digest will output the same generated context and convert into the same module instance."`
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -7792,17 +7792,17 @@ func (r *ModuleSource) WithClient(generator string, outputDir string) *ModuleSou
 
 // ModuleSourceWithDependenciesOpts contains options for ModuleSource.WithDependencies
 type ModuleSourceWithDependenciesOpts struct {
-	// Install as platform dependencies (executed in the parent's context directory)
-	Platform bool
+	// Make the dependencies inline (executed in the parent's context)
+	Inline bool
 }
 
 // Append the provided dependencies to the module source's dependency list.
 func (r *ModuleSource) WithDependencies(dependencies []*ModuleSource, opts ...ModuleSourceWithDependenciesOpts) *ModuleSource {
 	q := r.query.Select("withDependencies")
 	for i := len(opts) - 1; i >= 0; i-- {
-		// `platform` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Platform) {
-			q = q.Arg("platform", opts[i].Platform)
+		// `inline` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Inline) {
+			q = q.Arg("inline", opts[i].Inline)
 		}
 	}
 	q = q.Arg("dependencies", dependencies)


### PR DESCRIPTION
*This is a second take on the "platform module" idea, first prototyped in #10442.*

Implement the inline dependency feature described in #10464 

## Usage

```console
$ dagger install --inline github.com/shykes/x/go
$ cat dagger.json
{
  ...
  "dependencies": [
    {
      "name": "go",
      "source": "github.com/shykes/x/go",
      "pin": "c71f1e5edcda371e19f754f0eab1faf31ba2d770",
      "inline": true
    }
  ]
}
```

```console
dagger -c 'go | env | terminal'
```

Note the new `inline` field.

Any dependency can be marked as inline, and will co-exist with other dependencies, and a SDK, normally.

A module can have multiple inline dependencies. Namespacing is unchanged from regular dependencies: each dependency is namespaced under its own name; `dagger call` cannot call dependencies, but dagger shell can. This could be changed, but I don't handle that in the PR yet.
