### PR TITLE
refactor: client install CLI DX

### DIFF
--- a/cmd/dagger/client.go
+++ b/cmd/dagger/client.go
@@ -45,25 +45,27 @@ var clientCmd = &cobra.Command{
 }
 
 var clientInstallCmd = &cobra.Command{
-	Use:     "install [options] [path]",
+	Use:     "install [options] generator [path]",
 	Aliases: []string{"use"},
 	Short:   "Generate a new Dagger client from the Dagger module",
-	Example: "dagger client install --generator=go ./dagger",
+	Example: "dagger client install go ./dagger",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
-			if generator == "" {
-				return fmt.Errorf("generator must set (ts, go, python or custom generator)")
-			}
-
 			// default the output to the current working directory if it doesn't exist yet
 			cwd, err := pathutil.Getwd()
 			if err != nil {
 				return fmt.Errorf("failed to get current working directory: %w", err)
 			}
 
-			outputPath := filepath.Join(cwd, "dagger")
-			if len(args) > 0 {
-				outputPath = args[0]
+			switch len(args) {
+			case 0:
+				return fmt.Errorf("generator must set (ts, go, python or custom generator)")
+			case 1:
+				generator = args[0]
+				outputPath = filepath.Join(cwd, "dagger")
+			case 2:
+				generator = args[0]
+				outputPath = args[1]
 			}
 
 			if filepath.IsAbs(outputPath) {

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1099,7 +1099,7 @@ export class Generator {
 				With(sdkSource(tc.generatorSDK, tc.generatorSource)).
 				WithWorkdir("/work").
 				With(daggerExec("init")).
-				With(daggerExec("client", "install", "--generator=./generator"))
+				With(daggerExec("client", "install", "./generator"))
 
 			out, err := moduleSrc.File("hello.txt").Contents(ctx)
 			require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5729,11 +5729,11 @@ func daggerNonNestedRun(args ...string) dagger.WithContainerFunc {
 }
 
 func daggerClientInstall(generator string) dagger.WithContainerFunc {
-	return daggerExec("client", "install", "--generator="+generator, "--dev")
+	return daggerExec("client", "install", "--dev", generator)
 }
 
 func daggerClientInstallAt(generator string, outputDirPath string) dagger.WithContainerFunc {
-	return daggerExec("client", "install", "--generator="+generator, "--dev", outputDirPath)
+	return daggerExec("client", "install", "--dev", generator, outputDirPath)
 }
 
 func daggerQuery(query string, args ...any) dagger.WithContainerFunc {


### PR DESCRIPTION
@shykes [mentioned](https://discord.com/channels/707636530424053791/1120503349599543376/1367677268033409188) that the current `dagger client install` CLI doesn't completely follows the spec described in #9582.

This PR aims to fix that difference:
Before: `dagger client install --generator=<generator> <output-path>` 
Now: `dagger client install <generator> <output-path>`