### PR TITLE
feat: rewrite `Container.withExec` to use DagOp

### DIFF
--- a/cmd/engine/.dagger/main.go
+++ b/cmd/engine/.dagger/main.go
@@ -121,6 +121,7 @@ func (e *DaggerEngine) Container(
 	ctr = ctr.
 		WithFile(cliPath, cli).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", distconsts.DefaultEngineSockAddr)
+	// ctr = ctr.WithEnvVariable("BUILDKIT_SCHEDULER_DEBUG", "1")
 
 	return ctr, nil
 }

--- a/core/container.go
+++ b/core/container.go
@@ -1747,22 +1747,6 @@ type ContainerAsServiceArgs struct {
 	NoInit bool `default:"false"`
 }
 
-func (container *Container) AsServiceLegacy(ctx context.Context) (*Service, error) {
-	if container.Meta == nil {
-		var err error
-		container, err = container.WithExec(ctx, ContainerExecOpts{
-			UseEntrypoint: true,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &Service{
-		Creator:   trace.SpanContextFromContext(ctx),
-		Container: container,
-	}, nil
-}
-
 func (container *Container) AsService(ctx context.Context, args ContainerAsServiceArgs) (*Service, error) {
 	if len(args.Args) == 0 &&
 		len(container.Config.Cmd) == 0 &&

--- a/core/container_emulator.go
+++ b/core/container_emulator.go
@@ -1,0 +1,122 @@
+package core
+
+// originally imported from buildkit's exec_binfmt.go so we can call
+// getEmulator, a private function
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/platforms"
+	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/archutil"
+	"github.com/moby/buildkit/util/bklog"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	copy "github.com/tonistiigi/fsutil/copy"
+)
+
+var qemuArchMap = map[string]string{
+	"arm64":   "aarch64",
+	"amd64":   "x86_64",
+	"riscv64": "riscv64",
+	"arm":     "arm",
+	"s390x":   "s390x",
+	"ppc64":   "ppc64",
+	"ppc64le": "ppc64le",
+	"386":     "i386",
+}
+
+type emulator struct {
+	path  string
+	idmap *idtools.IdentityMapping
+}
+
+func (e *emulator) Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error) {
+	return &staticEmulatorMount{path: e.path, idmap: e.idmap}, nil
+}
+
+type staticEmulatorMount struct {
+	path  string
+	idmap *idtools.IdentityMapping
+}
+
+func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
+	tmpdir, err := os.MkdirTemp("", "buildkit-qemu-emulator")
+	if err != nil {
+		return nil, nil, err
+	}
+	var ret bool
+	defer func() {
+		if !ret {
+			os.RemoveAll(tmpdir)
+		}
+	}()
+
+	var uid, gid int
+	if m.idmap != nil {
+		root := m.idmap.RootPair()
+		uid = root.UID
+		gid = root.GID
+	}
+	if err := copy.Copy(context.TODO(), filepath.Dir(m.path), filepath.Base(m.path), tmpdir, buildkit.BuildkitQemuEmulatorMountPoint, func(ci *copy.CopyInfo) {
+		m := 0555
+		ci.Mode = &m
+	}, copy.WithChown(uid, gid)); err != nil {
+		return nil, nil, err
+	}
+
+	ret = true
+	return []mount.Mount{{
+			Type:    "bind",
+			Source:  filepath.Join(tmpdir, buildkit.BuildkitQemuEmulatorMountPoint),
+			Options: []string{"ro", "bind"},
+		}}, func() error {
+			return os.RemoveAll(tmpdir)
+		}, nil
+}
+
+func (m *staticEmulatorMount) IdentityMapping() *idtools.IdentityMapping {
+	return m.idmap
+}
+
+func getEmulator(ctx context.Context, pp ocispecs.Platform) (*emulator, error) {
+	all := archutil.SupportedPlatforms(false)
+	pp = platforms.Normalize(pp)
+	for _, p := range all {
+		if platforms.Only(p).Match(pp) {
+			return nil, nil
+		}
+	}
+
+	if pp.Architecture == "amd64" {
+		if pp.Variant != "" && pp.Variant != "v2" {
+			var supported []string
+			for _, p := range all {
+				if p.Architecture == "amd64" {
+					supported = append(supported, platforms.Format(p))
+				}
+			}
+			return nil, errors.Errorf("no support for running processes with %s platform, supported: %s", platforms.Format(pp), strings.Join(supported, ", "))
+		}
+	}
+
+	a, ok := qemuArchMap[pp.Architecture]
+	if !ok {
+		a = pp.Architecture
+	}
+
+	fn, err := exec.LookPath("buildkit-qemu-" + a)
+	if err != nil {
+		bklog.G(ctx).Warn(err.Error()) // TODO: remove this with pull support
+		return nil, nil                // no emulator available
+	}
+
+	return &emulator{path: fn}, nil
+}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -1,21 +1,40 @@
 package core
 
 import (
+	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	bkcache "github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/executor"
+	bkcontainer "github.com/moby/buildkit/frontend/gateway/container"
+	"github.com/moby/buildkit/identity"
+	bksession "github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets"
+	bksolver "github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/llbsolver/errdefs"
+	bkmounts "github.com/moby/buildkit/solver/llbsolver/mounts"
+	"github.com/moby/buildkit/solver/pb"
+	utilsystem "github.com/moby/buildkit/util/system"
+	"github.com/moby/buildkit/worker"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/network"
-	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/identity"
-	"github.com/pkg/errors"
 )
 
 var ErrNoCommand = errors.New("no command has been set")
@@ -46,9 +65,6 @@ type ContainerExecOpts struct {
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool `default:"false"`
 
-	// (Internal-only) If this is a nested exec, exec metadata to use for it
-	NestedExecMetadata *buildkit.ExecutionMetadata `name:"-"`
-
 	// Expand the environment variables in args
 	Expand bool `default:"false"`
 
@@ -57,46 +73,48 @@ type ContainerExecOpts struct {
 	NoInit bool `default:"false"`
 }
 
-func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts) (*Container, error) { //nolint:gocyclo
-	container = container.Clone()
-
+func (container *Container) execMeta(ctx context.Context, opts ContainerExecOpts, parent *buildkit.ExecutionMetadata) (*buildkit.ExecutionMetadata, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get current query: %w", err)
 	}
 
-	cfg := container.Config
-	mounts := container.Mounts
-	platform := container.Platform
-	if platform.OS == "" {
-		platform = query.Platform()
-	}
-
-	args, err := container.command(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	runOpts := []llb.RunOption{
-		llb.Args(args),
-		buildkit.WithTracePropagation(ctx),
-		buildkit.WithPassthrough(),
+	execMD := buildkit.ExecutionMetadata{}
+	if parent != nil {
+		execMD = *parent
 	}
 
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	execMD := buildkit.ExecutionMetadata{}
-	if opts.NestedExecMetadata != nil {
-		execMD = *opts.NestedExecMetadata
-	}
-	execMD.CallID = dagql.CurrentID(ctx)
 	execMD.CallerClientID = clientMetadata.ClientID
-	execMD.ExecID = identity.NewID()
 	execMD.SessionID = clientMetadata.SessionID
 	execMD.AllowedLLMModules = clientMetadata.AllowedLLMModules
+
+	if execMD.CallID == nil {
+		execMD.CallID = dagql.CurrentID(ctx)
+	}
+	if execMD.ExecID == "" {
+		execMD.ExecID = identity.NewID()
+	}
+	if execMD.EncodedModuleID == "" {
+		mod, err := query.CurrentModule(ctx)
+		if err != nil {
+			if !errors.Is(err, ErrNoCurrentModule) {
+				return nil, err
+			}
+		} else {
+			if mod.InstanceID == nil {
+				return nil, fmt.Errorf("current module has no instance ID")
+			}
+			execMD.EncodedModuleID, err = mod.InstanceID.Encode()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if execMD.HostAliases == nil {
 		execMD.HostAliases = make(map[string][]string)
 	}
@@ -104,23 +122,18 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	execMD.RedirectStderrPath = opts.RedirectStderr
 	execMD.SystemEnvNames = container.SystemEnvNames
 	execMD.EnabledGPUs = container.EnabledGPUs
-
 	if opts.NoInit {
 		execMD.NoInit = true
-		// include an env var (which will be removed before the exec actually runs) so that execs with
-		// inits disabled will be cached differently than those with them enabled by buildkit
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerNoInitEnv, "true"))
 	}
 
-	mod, err := query.CurrentModule(ctx)
-	if err == nil {
-		if mod.InstanceID == nil {
-			return nil, fmt.Errorf("current module has no instance ID")
+	if execMD.EncodedModuleID != "" {
+		modID := new(call.ID)
+		if err := modID.Decode(execMD.EncodedModuleID); err != nil {
+			return nil, fmt.Errorf("failed to decode module ID: %w", err)
 		}
-		// allow the exec to reach services scoped to the module that
-		// installed it
-		execMD.ExtraSearchDomains = append(execMD.ExtraSearchDomains,
-			network.ModuleDomain(mod.InstanceID, clientMetadata.SessionID))
+
+		// allow the exec to reach services scoped to the module that installed it
+		execMD.ExtraSearchDomains = append(execMD.ExtraSearchDomains, network.ModuleDomain(modID, clientMetadata.SessionID))
 	}
 
 	// if GPU parameters are set for this container pass them over:
@@ -136,222 +149,263 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		if execMD.ClientID == "" {
 			execMD.ClientID = identity.NewID()
 		}
-
-		// include the engine version so that these execs get invalidated if the engine/API change
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerEngineVersionEnv, engine.Version))
 	}
 
-	if execMD.CachePerSession {
-		// include the SessionID here so that we bust cache once-per-session
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerSessionIDEnv, clientMetadata.SessionID))
-	}
-
-	if execMD.CacheByCall {
-		// include a digest of the current call so that we scope of the cache of the ExecOp to this call's args
-		// and receiver values. Currently only used for module function calls.
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerCallDigestEnv, string(dagql.CurrentID(ctx).Digest())))
-	}
-
-	metaSt, metaSourcePath := metaMount(ctx, opts.Stdin)
-
-	// create mount point for the executor to write stdout/stderr/exitcode to
-	runOpts = append(runOpts,
-		llb.AddMount(buildkit.MetaMountDestPath, metaSt, llb.SourcePath(metaSourcePath)))
-
-	if opts.RedirectStdout != "" {
-		// ensure this path is in the cache key
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerRedirectStdoutEnv, opts.RedirectStdout))
-	}
-
-	if opts.RedirectStderr != "" {
-		// ensure this path is in the cache key
-		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerRedirectStderrEnv, opts.RedirectStderr))
-	}
-
-	var aliasStrs []string
 	for _, bnd := range container.Services {
 		for _, alias := range bnd.Aliases {
 			execMD.HostAliases[bnd.Hostname] = append(execMD.HostAliases[bnd.Hostname], alias)
-			aliasStrs = append(aliasStrs, bnd.Hostname+"="+alias)
 		}
-	}
-	if len(aliasStrs) > 0 {
-		// ensure these are in the cache key, sort them for stability
-		slices.Sort(aliasStrs)
-		runOpts = append(runOpts,
-			llb.AddEnv(buildkit.DaggerHostnameAliasesEnv, strings.Join(aliasStrs, ",")))
-	}
-
-	if cfg.User != "" {
-		runOpts = append(runOpts, llb.User(cfg.User))
-	}
-
-	if cfg.WorkingDir != "" {
-		runOpts = append(runOpts, llb.Dir(cfg.WorkingDir))
-	}
-
-	for _, env := range cfg.Env {
-		name, val, ok := strings.Cut(env, "=")
-		if !ok {
-			// it's OK to not be OK
-			// we'll just set an empty env
-			_ = ok
-		}
-
-		runOpts = append(runOpts, llb.AddEnv(name, val))
 	}
 
 	for i, secret := range container.Secrets {
-		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.ID().Digest().String())}
-
-		var secretDest string
 		switch {
 		case secret.EnvName != "":
-			secretDest = secret.EnvName
-			secretOpts = append(secretOpts, llb.SecretAsEnv(true))
 			execMD.SecretEnvNames = append(execMD.SecretEnvNames, secret.EnvName)
 		case secret.MountPath != "":
-			secretDest = secret.MountPath
 			execMD.SecretFilePaths = append(execMD.SecretFilePaths, secret.MountPath)
-			if secret.Owner != nil {
-				secretOpts = append(secretOpts, llb.SecretFileOpt(
-					secret.Owner.UID,
-					secret.Owner.GID,
-					int(secret.Mode),
-				))
-			}
 		default:
 			return nil, fmt.Errorf("malformed secret config at index %d", i)
 		}
-
-		runOpts = append(runOpts, llb.AddSecret(secretDest, secretOpts...))
 	}
 
-	for _, ctrSocket := range container.Sockets {
-		if ctrSocket.ContainerPath == "" {
-			return nil, fmt.Errorf("unsupported socket: only unix paths are implemented")
-		}
+	return &execMD, nil
+}
 
-		socketOpts := []llb.SSHOption{
-			llb.SSHID(ctrSocket.Source.LLBID()),
-			llb.SSHSocketTarget(ctrSocket.ContainerPath),
-		}
-
-		if ctrSocket.Owner != nil {
-			socketOpts = append(socketOpts,
-				llb.SSHSocketOpt(
-					ctrSocket.ContainerPath,
-					ctrSocket.Owner.UID,
-					ctrSocket.Owner.GID,
-					0o600, // preserve default
-				))
-		}
-
-		runOpts = append(runOpts, llb.AddSSHSocket(socketOpts...))
+func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts) (*executor.Meta, error) {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get current query: %w", err)
 	}
 
-	for _, mnt := range mounts {
-		srcSt, err := mnt.SourceState()
-		if err != nil {
-			return nil, fmt.Errorf("mount %s: %w", mnt.Target, err)
-		}
-
-		mountOpts := []llb.MountOption{}
-
-		if mnt.SourcePath != "" {
-			mountOpts = append(mountOpts, llb.SourcePath(mnt.SourcePath))
-		}
-
-		if mnt.CacheVolumeID != "" {
-			var sharingMode llb.CacheMountSharingMode
-			switch mnt.CacheSharingMode {
-			case CacheSharingModeShared:
-				sharingMode = llb.CacheMountShared
-			case CacheSharingModePrivate:
-				sharingMode = llb.CacheMountPrivate
-			case CacheSharingModeLocked:
-				sharingMode = llb.CacheMountLocked
-			default:
-				return nil, errors.Errorf("invalid cache mount sharing mode %q", mnt.CacheSharingMode)
-			}
-
-			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(mnt.CacheVolumeID, sharingMode))
-		}
-
-		if mnt.Tmpfs {
-			mountOpts = append(mountOpts, llb.Tmpfs(llb.TmpfsSize(int64(mnt.Size))))
-		}
-
-		if mnt.Readonly {
-			mountOpts = append(mountOpts, llb.Readonly)
-		}
-
-		runOpts = append(runOpts, llb.AddMount(mnt.Target, srcSt, mountOpts...))
+	cfg := container.Config
+	args, err := container.command(opts)
+	if err != nil {
+		return nil, err
 	}
+	platform := container.Platform
+	if platform.OS == "" {
+		platform = query.Platform()
+	}
+
+	metaSpec := executor.Meta{
+		Args:                      args,
+		Env:                       slices.Clone(cfg.Env),
+		Cwd:                       cmp.Or(cfg.WorkingDir, "/"),
+		User:                      cfg.User,
+		RemoveMountStubsRecursive: true,
+	}
+	if opts.InsecureRootCapabilities {
+		metaSpec.SecurityMode = pb.SecurityMode_INSECURE
+	}
+
+	metaSpec.Env = addDefaultEnvvar(metaSpec.Env, "PATH", utilsystem.DefaultPathEnv(platform.OS))
 
 	if opts.Expect != ReturnSuccess {
-		runOpts = append(runOpts, llb.ValidExitCodes(opts.Expect.ReturnCodes()...))
+		metaSpec.ValidExitCodes = opts.Expect.ReturnCodes()
 	}
 
-	if opts.InsecureRootCapabilities {
-		runOpts = append(runOpts, llb.Security(llb.SecurityModeInsecure))
-	}
+	return &metaSpec, nil
+}
 
-	fsSt, err := container.FSState()
+func (container *Container) secretEnvs() (secretEnvs []*pb.SecretEnv) {
+	for _, secret := range container.Secrets {
+		if secret.EnvName != "" {
+			secretEnvs = append(secretEnvs, &pb.SecretEnv{
+				ID:   secret.Secret.ID().Digest().String(),
+				Name: secret.EnvName,
+			})
+		}
+	}
+	return secretEnvs
+}
+
+func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts, parent *buildkit.ExecutionMetadata) (_ *Container, rerr error) { //nolint:gocyclo
+	container = container.Clone()
+
+	query, err := CurrentQuery(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("fs state: %w", err)
+		return nil, fmt.Errorf("get current query: %w", err)
 	}
 
-	execMDOpt, err := execMD.AsConstraintsOpt()
+	platform := container.Platform
+	if platform.OS == "" {
+		platform = query.Platform()
+	}
+
+	secretEnvs := container.secretEnvs()
+
+	execMD, err := container.execMeta(ctx, opts, parent)
 	if err != nil {
-		return nil, fmt.Errorf("execution metadata: %w", err)
+		return nil, err
 	}
-	runOpts = append(runOpts, execMDOpt)
-	execSt := fsSt.Run(runOpts...)
 
-	marshalOpts := []llb.ConstraintsOpt{
-		llb.Platform(platform.Spec()),
-		execMDOpt,
+	mounts, ok := CurrentMountData(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no dagop here")
 	}
-	if opts.ExperimentalPrivilegedNesting {
-		marshalOpts = append(marshalOpts, llb.SkipEdgeMerge)
+
+	workerRefs := make([]*worker.WorkerRef, 0, len(mounts.Inputs))
+	for _, ref := range mounts.InputRefs() {
+		workerRefs = append(workerRefs, &worker.WorkerRef{ImmutableRef: ref})
 	}
-	execDef, err := execSt.Root().Marshal(ctx, marshalOpts...)
+
+	bk, err := query.Buildkit(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("marshal root: %w", err)
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
 	}
+	cache := query.BuildkitCache()
+	session := query.BuildkitSession()
 
-	container.FS = execDef.ToPB()
-
-	metaDef, err := execSt.GetMount(buildkit.MetaMountDestPath).Marshal(ctx, marshalOpts...)
+	metaSpec, err := container.metaSpec(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("get meta mount: %w", err)
+		return nil, err
 	}
 
-	container.Meta = metaDef.ToPB()
+	bkSessionGroup, ok := buildkit.CurrentBuildkitSessionGroup(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no buildkit session group in context")
+	}
 
-	for i, mnt := range mounts {
-		if mnt.Tmpfs || mnt.CacheVolumeID != "" {
-			continue
+	opt, ok := buildkit.CurrentOpOpts(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no buildkit opts in context")
+	}
+
+	mm := bkmounts.NewMountManager(fmt.Sprintf("exec %s", strings.Join(metaSpec.Args, " ")), cache, session)
+	p, err := bkcontainer.PrepareMounts(ctx, mm, cache, bkSessionGroup, container.Config.WorkingDir, mounts.Mounts, workerRefs, func(m *pb.Mount, ref bkcache.ImmutableRef) (bkcache.MutableRef, error) {
+		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(metaSpec.Args, " "))
+		return cache.New(ctx, ref, bkSessionGroup, bkcache.WithDescription(desc))
+	}, runtime.GOOS)
+	defer func() {
+		if rerr != nil {
+			execInputs := make([]bksolver.Result, len(mounts.Mounts))
+			for i, m := range mounts.Mounts {
+				if m.Input == pb.Empty {
+					continue
+				}
+				execInputs[i] = mounts.Inputs[m.Input].Clone()
+			}
+			execMounts := make([]bksolver.Result, len(mounts.Mounts))
+			copy(execMounts, execInputs)
+			results, err := extractContainerBkOutputs(ctx, container, bk, opt.Worker, mounts)
+			if err != nil {
+				return
+			}
+			for i, res := range results {
+				execMounts[p.OutputRefs[i].MountIndex] = res
+			}
+			for _, active := range p.Actives {
+				if active.NoCommit {
+					active.Ref.Release(context.WithoutCancel(ctx))
+				} else {
+					ref, cerr := active.Ref.Commit(ctx)
+					if cerr != nil {
+						rerr = fmt.Errorf("error committing %s: %w: %w", active.Ref.ID(), cerr, err)
+						continue
+					}
+					execMounts[active.MountIndex] = worker.NewWorkerRefResult(ref, opt.Worker)
+				}
+			}
+
+			rerr = errdefs.WithExecError(rerr, execInputs, execMounts)
+			rerr = buildkit.RichError{
+				ExecError: rerr.(*errdefs.ExecError),
+				Origin:    opt.CauseCtx,
+				Mounts:    mounts.Mounts,
+				ExecMD:    execMD,
+				Meta:      metaSpec,
+				Secretenv: secretEnvs,
+			}
+		} else {
+			// Only release actives if err is nil.
+			for i := len(p.Actives) - 1; i >= 0; i-- { // call in LIFO order
+				p.Actives[i].Ref.Release(context.WithoutCancel(ctx))
+			}
+		}
+		for _, o := range p.OutputRefs {
+			if o.Ref != nil {
+				o.Ref.Release(context.WithoutCancel(ctx))
+			}
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	emu, err := getEmulator(ctx, specs.Platform(container.Platform))
+	if err != nil {
+		return nil, err
+	}
+	if emu != nil {
+		metaSpec.Args = append([]string{buildkit.BuildkitQemuEmulatorMountPoint}, metaSpec.Args...)
+		p.Mounts = append(p.Mounts, executor.Mount{
+			Readonly: true,
+			Src:      emu,
+			Dest:     buildkit.BuildkitQemuEmulatorMountPoint,
+		})
+	}
+
+	meta := *metaSpec
+	meta.Env = slices.Clone(meta.Env)
+	secretEnv, err := loadSecretEnv(ctx, bkSessionGroup, session, secretEnvs)
+	if err != nil {
+		return nil, err
+	}
+	meta.Env = append(meta.Env, secretEnv...)
+
+	worker := opt.Worker.(*buildkit.Worker)
+	worker = worker.ExecWorker(opt.CauseCtx, *execMD)
+	exec := worker.Executor()
+	_, execErr := exec.Run(ctx, "", p.Root, p.Mounts, executor.ProcessInfo{
+		Meta: meta,
+	}, nil)
+
+	for i, ref := range p.OutputRefs {
+		// commit all refs
+		var err error
+		var iref bkcache.ImmutableRef
+		if mutable, ok := ref.Ref.(bkcache.MutableRef); ok {
+			iref, err = mutable.Commit(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error committing %s: %w", mutable.ID(), err)
+			}
+		} else {
+			iref = ref.Ref.(bkcache.ImmutableRef)
 		}
 
-		mountSt := execSt.GetMount(mnt.Target)
-
-		// propagate any changes to regular mounts to subsequent containers
-		execMountDef, err := mountSt.Marshal(ctx, marshalOpts...)
-		if err != nil {
-			return nil, fmt.Errorf("propagate %s: %w", mnt.Target, err)
+		// put the ref to the right mount point
+		switch ref.MountIndex {
+		case 0:
+			container.FSResult = iref
+		case 1:
+			container.MetaResult = iref
+		default:
+			mountIdx := ref.MountIndex - 2
+			if mountIdx >= len(container.Mounts) {
+				// something is disastourously wrong, panic!
+				panic(fmt.Sprintf("index %d escapes number of mounts %d", mountIdx, len(container.Mounts)))
+			}
+			container.Mounts[mountIdx].Result = iref
 		}
 
-		mounts[i].Source = execMountDef.ToPB()
+		// prevent the result from being released by the defer
+		p.OutputRefs[i].Ref = nil
 	}
 
-	container.Mounts = mounts
-
-	// set image ref to empty string
-	container.ImageRef = ""
+	if execErr != nil {
+		return nil, fmt.Errorf("process %q did not complete successfully: %w", strings.Join(metaSpec.Args, " "), execErr)
+	}
 
 	return container, nil
+}
+
+func addDefaultEnvvar(env []string, k, v string) []string {
+	for _, e := range env {
+		if strings.HasPrefix(e, k+"=") {
+			return env
+		}
+	}
+	return append(env, k+"="+v)
 }
 
 func (container *Container) Stdout(ctx context.Context) (string, error) {
@@ -401,16 +455,54 @@ func (container *Container) metaFileContents(ctx context.Context, filePath strin
 	return string(content), nil
 }
 
-func metaMount(ctx context.Context, stdin string) (llb.State, string) {
+func MetaMountState(ctx context.Context, stdin string) llb.State {
 	meta := llb.Mkdir(buildkit.MetaMountDestPath, 0o777)
 	if stdin != "" {
 		meta = meta.Mkfile(path.Join(buildkit.MetaMountDestPath, buildkit.MetaMountStdinPath), 0o666, []byte(stdin))
 	}
 
-	return llb.Scratch().File(
-			meta,
-			buildkit.WithTracePropagation(ctx),
-			buildkit.WithPassthrough(),
-		),
-		buildkit.MetaMountDestPath
+	return llb.Scratch().File(meta,
+		buildkit.WithTracePropagation(ctx),
+		buildkit.WithPassthrough(),
+	)
+}
+
+func loadSecretEnv(ctx context.Context, g bksession.Group, sm *bksession.Manager, secretenv []*pb.SecretEnv) ([]string, error) {
+	if len(secretenv) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(secretenv))
+	eg, gctx := errgroup.WithContext(ctx)
+	var mu sync.Mutex
+	for _, sopt := range secretenv {
+		id := sopt.ID
+		eg.Go(func() error {
+			if id == "" {
+				return fmt.Errorf("secret ID missing for %q environment variable", sopt.Name)
+			}
+			var dt []byte
+			var err error
+			err = sm.Any(gctx, g, func(ctx context.Context, _ string, caller bksession.Caller) error {
+				dt, err = secrets.GetSecret(ctx, caller, id)
+				if err != nil {
+					if errors.Is(err, secrets.ErrNotFound) && sopt.Optional {
+						return nil
+					}
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			out = append(out, fmt.Sprintf("%s=%s", sopt.Name, string(dt)))
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"runtime"
 	"slices"
 	"strconv"
@@ -437,28 +436,25 @@ func (container *Container) usedClientID(ctx context.Context) (string, error) {
 
 func (container *Container) metaFileContents(ctx context.Context, filePath string) (string, error) {
 	if container.Meta == nil {
-		return "", fmt.Errorf("%w: %s requires an exec", ErrNoCommand, filePath)
+		return "", ErrNoCommand
 	}
-
 	file := NewFile(
 		container.Meta,
-		path.Join(buildkit.MetaMountDestPath, filePath),
+		filePath,
 		container.Platform,
 		container.Services,
 	)
-
 	content, err := file.Contents(ctx)
 	if err != nil {
 		return "", err
 	}
-
 	return string(content), nil
 }
 
 func MetaMountState(ctx context.Context, stdin string) llb.State {
 	meta := llb.Mkdir(buildkit.MetaMountDestPath, 0o777)
 	if stdin != "" {
-		meta = meta.Mkfile(path.Join(buildkit.MetaMountDestPath, buildkit.MetaMountStdinPath), 0o666, []byte(stdin))
+		meta = meta.Mkfile(buildkit.MetaMountStdinPath, 0o666, []byte(stdin))
 	}
 
 	return llb.Scratch().File(meta,

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -119,11 +119,12 @@ func (op FSDagOp) Digest() (digest.Digest, error) {
 	}, "+")), nil
 }
 
-func (op FSDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
-	return digest.FromString(strings.Join([]string{
+func (op FSDagOp) CacheMap(ctx context.Context, cm *solver.CacheMap) (*solver.CacheMap, error) {
+	cm.Digest = digest.FromString(strings.Join([]string{
 		op.ID.Digest().String(),
 		op.Path,
-	}, "+")), nil
+	}, "+"))
+	return cm, nil
 }
 
 func (op FSDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, err error) {
@@ -228,11 +229,12 @@ func (op RawDagOp) Digest() (digest.Digest, error) {
 	}, "+")), nil
 }
 
-func (op RawDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
-	return digest.FromString(strings.Join([]string{
+func (op RawDagOp) CacheMap(ctx context.Context, cm *solver.CacheMap) (*solver.CacheMap, error) {
+	cm.Digest = digest.FromString(strings.Join([]string{
 		op.ID.Digest().String(),
 		op.Filename,
-	}, "+")), nil
+	}, "+"))
+	return cm, nil
 }
 
 func (op RawDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, retErr error) {
@@ -425,9 +427,14 @@ func (op ContainerDagOp) Digest() (digest.Digest, error) {
 	}, "+")), nil
 }
 
-func (op ContainerDagOp) CacheKey(ctx context.Context) (key digest.Digest, err error) {
+func (op ContainerDagOp) CacheMap(ctx context.Context, cm *solver.CacheMap) (*solver.CacheMap, error) {
 	// TODO: we need proper cache map control here, to control content digesting
-	return op.Digest()
+	dgst, err := op.Digest()
+	if err != nil {
+		return nil, err
+	}
+	cm.Digest = dgst
+	return cm, nil
 }
 
 func (op ContainerDagOp) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result, opt buildkit.OpOpts) (outputs []solver.Result, retErr error) {

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -653,7 +653,7 @@ func getAllContainerMounts(container *Container) (mounts []*pb.Mount, states []l
 	if err := addMount(ContainerMount{Source: container.FS, Target: "/"}); err != nil {
 		return nil, nil, 0, err
 	}
-	if err := addMount(ContainerMount{Source: container.Meta, Target: buildkit.MetaMountDestPath, SourcePath: buildkit.MetaMountDestPath}); err != nil {
+	if err := addMount(ContainerMount{Source: container.Meta, Target: buildkit.MetaMountDestPath}); err != nil {
 		return nil, nil, 0, err
 	}
 	for _, mount := range container.Mounts {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4373,6 +4373,7 @@ func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
 		// run an exec that has /tmpdir/b/f included
 		output1b := runCtrs(c1, hostDir1, subdirB)
 		// sanity check: those should be different execs, *not* cached
+		// (this happens because content-hashing doesn't occur on the root dir)
 		require.NotEqual(t, output1a, output1b)
 
 		// change /tmpdir/b/f
@@ -4384,6 +4385,7 @@ func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
 		// run an exec that has /tmpdir/b/f included
 		output2b := runCtrs(c2, hostDir2, subdirB)
 		// sanity check: those should be different execs, *not* cached
+		// (this happens because content-hashing doesn't occur on the root dir)
 		require.NotEqual(t, output2a, output2b)
 
 		// we only changed /tmpdir/b/f, so the execs that included /tmpdir/a/f should be cached across clients

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -35,7 +35,7 @@ import (
 type ModuleFunction struct {
 	mod     *Module
 	objDef  *ObjectTypeDef // may be nil for special functions like the module definition function call
-	runtime *Container
+	runtime dagql.Instance[*Container]
 
 	metadata   *Function
 	returnType ModType
@@ -51,7 +51,7 @@ func NewModFunction(
 	ctx context.Context,
 	mod *Module,
 	objDef *ObjectTypeDef,
-	runtime *Container,
+	runtime dagql.Instance[*Container],
 	metadata *Function,
 ) (*ModuleFunction, error) {
 	returnType, ok, err := mod.ModTypeFor(ctx, metadata.ReturnType, true)
@@ -348,7 +348,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		return nil, fmt.Errorf("failed to marshal function call: %w", err)
 	}
 
-	ctr := fn.runtime
+	ctr := fn.runtime.Self
 
 	query, err := CurrentQuery(ctx)
 	if err != nil {

--- a/core/module.go
+++ b/core/module.go
@@ -36,7 +36,7 @@ type Module struct {
 	Deps *ModDeps
 
 	// Runtime is the container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-	Runtime *Container `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
+	Runtime dagql.Instance[*Container] `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
 
 	// The following are populated while initializing the module
 
@@ -710,8 +710,8 @@ func (mod *Module) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) 
 		}
 		defs = append(defs, dirDefs...)
 	}
-	if mod.Runtime != nil {
-		dirDefs, err := mod.Runtime.PBDefinitions(ctx)
+	if mod.Runtime.Self != nil {
+		dirDefs, err := mod.Runtime.Self.PBDefinitions(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -735,8 +735,8 @@ func (mod Module) Clone() *Module {
 		cp.Deps = mod.Deps.Clone()
 	}
 
-	if mod.Runtime != nil {
-		cp.Runtime = mod.Runtime.Clone()
+	if mod.Runtime.Self != nil {
+		cp.Runtime.Self = mod.Runtime.Self.Clone()
 	}
 
 	cp.ObjectDefs = make([]*TypeDef, len(mod.ObjectDefs))

--- a/core/query.go
+++ b/core/query.go
@@ -9,6 +9,7 @@ import (
 	bkcache "github.com/moby/buildkit/cache"
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/executor/oci"
+	bksession "github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/locker"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -108,6 +109,9 @@ type Server interface {
 
 	// Gets the buildkit cache manager
 	BuildkitCache() bkcache.Manager
+
+	// Gets the buildkit session manager
+	BuildkitSession() *bksession.Manager
 
 	// A global lock for the engine, can be used to synchronize access to
 	// shared resources between multiple potentially concurrent calls.

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -601,11 +601,6 @@ func (s *gitSchema) tree(ctx context.Context, parent dagql.Instance[*core.GitRef
 	}
 
 	if args.IsDagOp {
-		query, ok := s.srv.Root().(dagql.Instance[*core.Query])
-		if !ok {
-			return inst, fmt.Errorf("server root was %T", s.srv.Root())
-		}
-		ctx = core.ContextWithQuery(ctx, query.Self)
 		dir, err := parent.Self.Tree(ctx, s.srv, args.DiscardGitDir, args.Depth)
 		if err != nil {
 			return inst, err
@@ -656,12 +651,6 @@ func (s *gitSchema) fetchCommit(
 		return DagOp(ctx, s.srv, parent, args, s.fetchCommit)
 	}
 
-	query, ok := s.srv.Root().(dagql.Instance[*core.Query])
-	if !ok {
-		return "", fmt.Errorf("server root was %T", s.srv.Root())
-	}
-	ctx = core.ContextWithQuery(ctx, query.Self)
-
 	commit, _, err := parent.Self.Resolve(ctx)
 	if err != nil {
 		return "", err
@@ -677,12 +666,6 @@ func (s *gitSchema) fetchRef(
 	if !args.IsDagOp {
 		return DagOp(ctx, s.srv, parent, args, s.fetchCommit)
 	}
-
-	query, ok := s.srv.Root().(dagql.Instance[*core.Query])
-	if !ok {
-		return "", fmt.Errorf("server root was %T", s.srv.Root())
-	}
-	ctx = core.ContextWithQuery(ctx, query.Self)
 
 	_, ref, err := parent.Self.Resolve(ctx)
 	if err != nil {

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -177,12 +177,17 @@ func DagOpContainer[A any](
 	data any,
 	fn dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]],
 ) (inst dagql.Instance[*core.Container], _ error) {
+	argDigest, err := core.DigestOf(args)
+	if err != nil {
+		return inst, err
+	}
+
 	deps, err := extractLLBDependencies(ctx, self.Self)
 	if err != nil {
 		return inst, err
 	}
 
-	ctr, err := core.NewContainerDagOp(ctx, currentIDForContainerDagOp(ctx), self.Self, deps)
+	ctr, err := core.NewContainerDagOp(ctx, currentIDForContainerDagOp(ctx), argDigest, self.Self, deps)
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
@@ -17,11 +16,6 @@ func DagOpWrapper[T dagql.Typed, A DagOpInternalArgsIface, R dagql.Typed](
 ) dagql.NodeFuncHandler[T, A, R] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst R, err error) {
 		if args.InDagOp() {
-			query, ok := srv.Root().(dagql.Instance[*core.Query])
-			if !ok {
-				return inst, fmt.Errorf("server root was %T", srv.Root())
-			}
-			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
 		return DagOp(ctx, srv, self, args, fn)
@@ -62,11 +56,6 @@ func DagOpFileWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.File], err error) {
 		if args.InDagOp() {
-			query, ok := srv.Root().(dagql.Instance[*core.Query])
-			if !ok {
-				return inst, fmt.Errorf("server root was %T", srv.Root())
-			}
-			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
 		return DagOpFile(ctx, srv, self, args, "", fn, pfn)
@@ -124,11 +113,6 @@ func DagOpDirectoryWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.Directory], err error) {
 		if args.InDagOp() {
-			query, ok := srv.Root().(dagql.Instance[*core.Query])
-			if !ok {
-				return inst, fmt.Errorf("server root was %T", srv.Root())
-			}
-			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
 		return DagOpDirectory(ctx, srv, self, args, "", fn, pfn)
@@ -179,11 +163,6 @@ func DagOpContainerWrapper[A DagOpInternalArgsIface](
 ) dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]] {
 	return func(ctx context.Context, self dagql.Instance[*core.Container], args A) (inst dagql.Instance[*core.Container], err error) {
 		if args.InDagOp() {
-			query, ok := srv.Root().(dagql.Instance[*core.Query])
-			if !ok {
-				return inst, fmt.Errorf("server root was %T", srv.Root())
-			}
-			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
 		return DagOpContainer(ctx, srv, self, args, nil, fn)

--- a/core/sdk.go
+++ b/core/sdk.go
@@ -167,7 +167,7 @@ type Runtime interface {
 
 		// Current instance of the module source.
 		dagql.Instance[*ModuleSource],
-	) (*Container, error)
+	) (dagql.Instance[*Container], error)
 }
 
 /*

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -210,10 +210,10 @@ func (sdk *goSDK) Runtime(
 	ctx context.Context,
 	deps *core.ModDeps,
 	source dagql.Instance[*core.ModuleSource],
-) (_ *core.Container, rerr error) {
+) (inst dagql.Instance[*core.Container], rerr error) {
 	ctr, err := sdk.baseWithCodegen(ctx, deps, source)
 	if err != nil {
-		return nil, err
+		return inst, err
 	}
 	if err := sdk.dag.Select(ctx, ctr, &ctr,
 		dagql.Selector{
@@ -271,9 +271,9 @@ func (sdk *goSDK) Runtime(
 			},
 		},
 	); err != nil {
-		return nil, fmt.Errorf("failed to build go runtime binary: %w", err)
+		return inst, fmt.Errorf("failed to build go runtime binary: %w", err)
 	}
-	return ctr.Self, nil
+	return ctr, nil
 }
 
 func (sdk *goSDK) baseWithCodegen(

--- a/core/sdk/module_runtime.go
+++ b/core/sdk/module_runtime.go
@@ -18,15 +18,14 @@ func (sdk *runtimeModule) Runtime(
 	ctx context.Context,
 	deps *core.ModDeps,
 	source dagql.Instance[*core.ModuleSource],
-) (_ *core.Container, rerr error) {
+) (inst dagql.Instance[*core.Container], rerr error) {
 	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: load runtime")
 	defer telemetry.End(span, func() error { return rerr })
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.mod.Self.Name(), err)
+		return inst, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.mod.Self.Name(), err)
 	}
 
-	var inst dagql.Instance[*core.Container]
 	err = sdk.mod.dag.Select(ctx, sdk.mod.sdk, &inst,
 		dagql.Selector{
 			Field: "moduleRuntime",
@@ -52,7 +51,7 @@ func (sdk *runtimeModule) Runtime(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call sdk moduleRuntime: %w", err)
+		return inst, fmt.Errorf("failed to call sdk moduleRuntime: %w", err)
 	}
-	return inst.Self, nil
+	return inst, nil
 }

--- a/core/service.go
+++ b/core/service.go
@@ -362,9 +362,6 @@ func (svc *Service) startContainer(
 		var st *llb.State
 		if pbmount.Input != pb.Empty {
 			st = &states[pbmount.Input]
-		} else if pbmount.Dest == buildkit.MetaMountDestPath {
-			v := MetaMountState(ctx, "")
-			st = &v
 		}
 
 		if st != nil {

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -45,10 +45,9 @@ func AroundFunc(
 	context.Context,
 	func(res dagql.Typed, cached bool, rerr error),
 ) {
-	if isIntrospection(id) || isMeta(id) || isDagOp(id) {
+	if dagql.IsSkipped(ctx) || isIntrospection(id) || isMeta(id) || isDagOp(id) {
 		// introspection+meta are very uninteresting spans
 		// dagops are all self calls, no need to emit additional spans here
-		// FIXME: we lose telemetry.SpanStdio info in dagops from here
 		return ctx, dagql.NoopDone
 	}
 

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -42,7 +42,7 @@ func (container *Container) Terminal(
 	// progress output with the terminal
 	_, err := container.Evaluate(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to evaluate container: %w", err)
 	}
 
 	query, err := CurrentQuery(ctx)

--- a/dagql/cachekey.go
+++ b/dagql/cachekey.go
@@ -167,6 +167,7 @@ func HashFrom(ins ...string) digest.Digest {
 	h := xxh3.New()
 	for _, in := range ins {
 		h.WriteString(in)
+		h.Write([]byte{0}) // separate all inputs with a null byte to help avoid collisions
 	}
 	return digest.NewDigest(XXH3, h)
 }

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -447,7 +447,7 @@ var scrubs = []scrubber{
 	{
 		regexp.MustCompile(`\$ container: Container! X\.Xs CACHED`),
 		"$ container: Container! X.Xs CACHED",
-		"✔ container: Container! X.Xs",
+		"● container: Container! X.Xs",
 	},
 }
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -20,8 +20,7 @@ Expected stderr:
 
 ● viztest: Viztest! X.Xs
 ▼ .dockerBuild: Container! X.Xs
-├─● directory: Directory! X.Xs
-├─● .withNewFile(path: "Dockerfile", contents: "FROM busybox:1.35\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo what is up?\nRUN echo im another layer\n"): Directory! X.Xs
+├─● Directory.withNewFile(path: "Dockerfile", contents: "FROM busybox:1.35\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo what is up?\nRUN echo im another layer\n"): Directory! X.Xs
 ╰─▼ .dockerBuild: Container! X.Xs
   ├─$ [1/5] FROM docker.io/library/busybox:1.35@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX X.Xs CACHED
   ├─▼ [2/5] RUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -16,8 +16,7 @@ Expected stderr:
 ● viztest: Viztest! X.Xs
 ▼ .dockerBuildFail: Container! X.Xs ERROR
 ! process "/bin/sh -c echo im failing && false" did not complete successfully: exit code: 1
-├─● directory: Directory! X.Xs
-├─● .withNewFile(path: "Dockerfile", contents: "FROM busybox:1.34\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo im failing && false\n"): Directory! X.Xs
+├─● Directory.withNewFile(path: "Dockerfile", contents: "FROM busybox:1.34\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo im failing && false\n"): Directory! X.Xs
 ╰─▼ .dockerBuild: Container! X.Xs ERROR
   ! process "/bin/sh -c echo im failing && false" did not complete successfully: exit code: 1
   ├─$ [1/4] FROM docker.io/library/busybox:1.34@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
@@ -23,8 +23,7 @@ Expected stderr:
 ▼ .nestedCalls: [String!]! X.Xs
 ├─$ file(name: "file", contents: "hey"): File! X.Xs CACHED
 │
-├─● directory: Directory! X.Xs
-├─$ .withFile(
+├─$ Directory.withFile(
 │   ┆ path: "file"
 │   ┆ source: file(name: "file", contents: "hey"): File!
 │   ┆ permissions: 420

--- a/dagql/internal.go
+++ b/dagql/internal.go
@@ -4,7 +4,7 @@ import "context"
 
 type internalKey struct{}
 
-// Internal returns a new context with the internal flag set.
+// withInternal returns a new context with the internal flag set.
 //
 // This is used for analytics so that we can distinguish between calls made by
 // an end user and calls made within the engine, for example to SDK modules.
@@ -15,6 +15,19 @@ func withInternal(ctx context.Context) context.Context {
 // IsInternal returns whether the internal flag is set in the context.
 func IsInternal(ctx context.Context) bool {
 	if val := ctx.Value(internalKey{}); val != nil {
+		return val.(bool)
+	}
+	return false
+}
+
+type skipKey struct{}
+
+func WithSkip(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipKey{}, true)
+}
+
+func IsSkipped(ctx context.Context) bool {
+	if val := ctx.Value(skipKey{}); val != nil {
 		return val.(bool)
 	}
 	return false

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -2,6 +2,7 @@ package dagql
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -373,6 +374,10 @@ func (r Instance[T]) GetPostCall() (cache.PostCallFunc, Typed) {
 	return r.postCall, r
 }
 
+func (r Instance[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.ID())
+}
+
 func NoopDone(res Typed, cached bool, rerr error) {}
 
 // Select calls the field on the instance specified by the selector
@@ -541,9 +546,21 @@ func (r Instance[T]) Call(ctx context.Context, s *Server, newID *call.ID) (Typed
 		return nil, nil, fmt.Errorf("Call: %s has no such field: %q", r.Class.TypeName(), fieldName)
 	}
 
-	idArgs := newID.Args()
+	inputArgs, err := ExtractIDArgs(field.Spec.Args, newID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	doNotCache := field.CacheSpec.DoNotCache != ""
+	return r.call(ctx, s, newID, inputArgs, doNotCache)
+}
+
+func ExtractIDArgs(specs InputSpecs, id *call.ID) (map[string]Input, error) {
+	idArgs := id.Args()
+	view := View(id.View())
+
 	inputArgs := make(map[string]Input, len(idArgs))
-	for _, argSpec := range field.Spec.Args.Inputs(view) {
+	for _, argSpec := range specs.Inputs(view) {
 		// just be n^2 since the overhead of a map is likely more expensive
 		// for the expected low value of n
 		var inputLit call.Literal
@@ -558,7 +575,7 @@ func (r Instance[T]) Call(ctx context.Context, s *Server, newID *call.ID) (Typed
 		case inputLit != nil:
 			input, err := argSpec.Type.Decoder().DecodeInput(inputLit.ToInput())
 			if err != nil {
-				return nil, nil, fmt.Errorf("Call: init arg %q value as %T (%s) using %T: %w", argSpec.Name, argSpec.Type, argSpec.Type.Type(), argSpec.Type.Decoder(), err)
+				return nil, fmt.Errorf("Call: init arg %q value as %T (%s) using %T: %w", argSpec.Name, argSpec.Type, argSpec.Type.Type(), argSpec.Type.Decoder(), err)
 			}
 			inputArgs[argSpec.Name] = input
 
@@ -567,12 +584,11 @@ func (r Instance[T]) Call(ctx context.Context, s *Server, newID *call.ID) (Typed
 
 		case argSpec.Type.Type().NonNull:
 			// error out if the arg is missing but required
-			return nil, nil, fmt.Errorf("missing required argument: %q", argSpec.Name)
+			return nil, fmt.Errorf("missing required argument: %q", argSpec.Name)
 		}
 	}
 
-	doNotCache := field.CacheSpec.DoNotCache != ""
-	return r.call(ctx, s, newID, inputArgs, doNotCache)
+	return inputArgs, nil
 }
 
 func (r Instance[T]) call(

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -309,7 +309,7 @@ func (c *Client) NewContainer(ctx context.Context, req NewContainerRequest) (*Co
 	ctr, err := bkcontainer.NewContainer(
 		context.WithoutCancel(ctx),
 		c.Worker.CacheManager(),
-		c.Worker.execWorker(
+		c.Worker.ExecWorker(
 			trace.SpanContextFromContext(ctx),
 			req.ExecutionMetadata,
 		), // also implements Executor

--- a/engine/buildkit/errors.go
+++ b/engine/buildkit/errors.go
@@ -2,12 +2,32 @@ package buildkit
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/dagger/dagger/dagql/idtui"
+	bkexecutor "github.com/moby/buildkit/executor"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	bkgwpb "github.com/moby/buildkit/frontend/gateway/pb"
+	bksession "github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/snapshot"
+	bksolver "github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/llbsolver/errdefs"
+	bksolverpb "github.com/moby/buildkit/solver/pb"
+	bkworker "github.com/moby/buildkit/worker"
+	"github.com/muesli/termenv"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 
 	"dagger.io/dagger/telemetry"
-	"go.opentelemetry.io/otel/trace"
 )
 
-// ExecError is an error that occurred while executing an `Op_Exec`.
+// ExecError is a custom dagger error that occurs during a `withExec` execution.
+//
+// It supports being serialized/deserialized through graphql.
 type ExecError struct {
 	Err      error
 	Origin   trace.SpanContext
@@ -36,4 +56,259 @@ func (e *ExecError) Extensions() map[string]any {
 	ctx := trace.ContextWithSpanContext(context.Background(), e.Origin)
 	telemetry.Propagator.Inject(ctx, telemetry.AnyMapCarrier(ext))
 	return ext
+}
+
+// RichError is an error that can occur while processing a container. It
+// contains functionality to allow launching a debug terminal in it, and
+// unwrapping more interesting metadata.
+//
+// TODO: this should be capable of handling other DagOp errors
+type RichError struct {
+	// HACK: wrap the buildkit exec error, which tracks inputs/mounts. This is
+	// required because buildkit has *special* tracking of this type in the
+	// solver (that handles gc).
+	*errdefs.ExecError
+
+	Origin trace.SpanContext
+
+	// Mounts tracks how the refs are mounted.
+	Mounts []*bksolverpb.Mount
+
+	// optional info about the execution that failed
+	ExecMD    *ExecutionMetadata
+	Meta      *bkexecutor.Meta
+	Secretenv []*bksolverpb.SecretEnv
+}
+
+func (e RichError) Unwrap() error {
+	return e.ExecError
+}
+
+func (e RichError) AsExecErr(ctx context.Context, client *Client) (*ExecError, bool, error) {
+	// This was an exec error, we will retrieve the exec's output and include
+	// it in the error message
+	// get the mnt corresponding to the metadata where stdout/stderr are stored
+	var metaMountResult bksolver.Result
+	for i, mnt := range e.Mounts {
+		if mnt.Dest == MetaMountDestPath {
+			metaMountResult = e.ExecError.Mounts[i]
+			break
+		}
+	}
+	if metaMountResult == nil {
+		return nil, false, nil
+	}
+	stdout, stderr, exitCode, err := getExecMeta(ctx, client, metaMountResult)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Embed the error origin, either from when the op was built, or from the
+	// current context if none is found.
+	spanCtx := e.Origin
+	if !spanCtx.IsValid() {
+		spanCtx = trace.SpanContextFromContext(ctx)
+	}
+
+	execErr := &ExecError{
+		Err:      e,
+		Origin:   spanCtx,
+		Cmd:      e.Meta.Args,
+		ExitCode: exitCode,
+		Stdout:   strings.TrimSpace(string(stdout)),
+		Stderr:   strings.TrimSpace(string(stderr)),
+	}
+	return execErr, true, nil
+}
+
+func (e RichError) DebugTerminal(ctx context.Context, client *Client) error {
+	if !client.Interactive {
+		return nil
+	}
+
+	// Ensure we only spawn one terminal per exec.
+	execMD := e.ExecMD
+	if execMD.ExecID != "" {
+		if _, exists := client.execMap.LoadOrStore(execMD.ExecID, struct{}{}); exists {
+			return nil
+		}
+	}
+
+	// If this is the (internal) exec of the module itself, we don't want to spawn a terminal.
+	if execMD.Internal {
+		return nil
+	}
+
+	// relevant buildkit code we need to contend with here:
+	// https://github.com/moby/buildkit/blob/44504feda1ce39bb8578537a6e6a93f90bdf4220/solver/llbsolver/ops/exec.go#L386-L409
+	mounts := []ContainerMount{}
+	for i, m := range e.Mounts {
+		if m.Input == bksolverpb.Empty {
+			mounts = append(mounts, ContainerMount{
+				Mount: &bkgw.Mount{
+					Dest:      m.Dest,
+					Selector:  m.Selector,
+					Readonly:  m.Readonly,
+					MountType: m.MountType,
+					CacheOpt:  m.CacheOpt,
+					SecretOpt: m.SecretOpt,
+					SSHOpt:    m.SSHOpt,
+				},
+			})
+			continue
+		}
+
+		// sanity check we don't panic
+		if i >= len(e.Mounts) {
+			return fmt.Errorf("exec error mount index out of bounds: %d", i)
+		}
+		errMnt := e.ExecError.Mounts[i]
+		if errMnt == nil {
+			continue
+		}
+		workerRef, ok := errMnt.Sys().(*bkworker.WorkerRef)
+		if !ok {
+			continue
+		}
+
+		mounts = append(mounts, ContainerMount{
+			WorkerRef: workerRef,
+			Mount: &bkgw.Mount{
+				Dest:      m.Dest,
+				Selector:  m.Selector,
+				Readonly:  m.Readonly,
+				MountType: m.MountType,
+				CacheOpt:  m.CacheOpt,
+				SecretOpt: m.SecretOpt,
+				SSHOpt:    m.SSHOpt,
+				ResultID:  errMnt.ID(),
+			},
+		})
+	}
+
+	dbgCtr, err := client.NewContainer(ctx, NewContainerRequest{
+		Hostname: e.Meta.Hostname,
+		Mounts:   mounts,
+	})
+	if err != nil {
+		return err
+	}
+	term, err := client.OpenTerminal(ctx)
+	if err != nil {
+		return err
+	}
+	// always close term; it's wrapped in a once so it won't be called multiple times
+	defer term.Close(bkgwpb.UnknownExitStatus)
+
+	output := idtui.NewOutput(term.Stderr)
+	fmt.Fprint(term.Stderr,
+		output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal: ")
+	dump := idtui.Dump{Newline: "\r\n", Prefix: "    "}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	if err := dump.DumpID(output, execMD.CallID); err != nil {
+		return fmt.Errorf("failed to serialize service ID: %w", err)
+	}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	fmt.Fprintf(term.Stderr,
+		output.String("! %s").Foreground(termenv.ANSIYellow).String(), e.Error())
+	fmt.Fprint(term.Stderr, dump.Newline)
+
+	// We default to "/bin/sh" if the client doesn't provide a command.
+	debugCommand := []string{"/bin/sh"}
+	if len(client.InteractiveCommand) > 0 {
+		debugCommand = client.InteractiveCommand
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	dbgShell, err := dbgCtr.Start(ctx, bkgw.StartRequest{
+		Args: debugCommand,
+
+		Env:          e.Meta.Env,
+		Cwd:          e.Meta.Cwd,
+		User:         e.Meta.User,
+		SecurityMode: e.Meta.SecurityMode,
+		SecretEnv:    e.Secretenv,
+
+		Tty:    true,
+		Stdin:  term.Stdin,
+		Stdout: term.Stdout,
+		Stderr: term.Stderr,
+	})
+	if err != nil {
+		return err
+	}
+
+	eg.Go(func() error {
+		err := <-term.ErrCh
+		if err != nil {
+			return fmt.Errorf("terminal error: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		for resize := range term.ResizeCh {
+			err := dbgShell.Resize(ctx, resize)
+			if err != nil {
+				return fmt.Errorf("failed to resize terminal: %w", err)
+			}
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		waitErr := dbgShell.Wait()
+		termExitCode := 0
+		if waitErr != nil {
+			termExitCode = 1
+			var exitErr *bkgwpb.ExitError
+			if errors.As(waitErr, &exitErr) {
+				termExitCode = int(exitErr.ExitCode)
+			}
+		}
+
+		return term.Close(termExitCode)
+	})
+
+	return eg.Wait()
+}
+
+func getExecMeta(ctx context.Context, client *Client, metaMount bksolver.Result) (stdout []byte, stderr []byte, exitCode int, _ error) {
+	workerRef, ok := metaMount.Sys().(*bkworker.WorkerRef)
+	if !ok {
+		return nil, nil, 0, fmt.Errorf("invalid ref type: %T", metaMount.Sys())
+	}
+	if workerRef.ImmutableRef == nil {
+		return nil, nil, 0, fmt.Errorf("invalid nil ref")
+	}
+	mntable, err := workerRef.ImmutableRef.Mount(ctx, true, bksession.NewGroup(client.ID()))
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	stdout, err = getExecMetaFile(ctx, client, mntable, MetaMountStdoutPath)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	stderr, err = getExecMetaFile(ctx, client, mntable, MetaMountStderrPath)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	exitCodeBytes, err := getExecMetaFile(ctx, client, mntable, MetaMountExitCodePath)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	exitCode = -1
+	if len(exitCodeBytes) > 0 {
+		exitCode, err = strconv.Atoi(string(exitCodeBytes))
+		if err != nil {
+			return nil, nil, 0, err
+		}
+	}
+
+	return stdout, stderr, exitCode, nil
+}
+
+func getExecMetaFile(ctx context.Context, c *Client, mntable snapshot.Mountable, fileName string) ([]byte, error) {
+	return ReadSnapshotPath(ctx, c, mntable, path.Join(MetaMountDestPath, fileName))
 }

--- a/engine/buildkit/errors.go
+++ b/engine/buildkit/errors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"strconv"
 	"strings"
 
@@ -310,5 +309,5 @@ func getExecMeta(ctx context.Context, client *Client, metaMount bksolver.Result)
 }
 
 func getExecMetaFile(ctx context.Context, c *Client, mntable snapshot.Mountable, fileName string) ([]byte, error) {
-	return ReadSnapshotPath(ctx, c, mntable, path.Join(MetaMountDestPath, fileName))
+	return ReadSnapshotPath(ctx, c, mntable, fileName)
 }

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -73,14 +73,8 @@ type ExecutionMetadata struct {
 	// object.
 	ParentIDs map[digest.Digest]*resource.ID
 
-	// If true, scope the exec cache key to the current session ID. It will be cached in the context
-	// of the session but invalidated across different sessions.
-	CachePerSession bool
-
-	// If true, scope the exec cache key to the current dagql call digest. This is needed currently
-	// for module function calls specifically so that their cache key is based on their arguments and
-	// receiver object.
-	CacheByCall bool
+	// Arbitrary to mixin to the cache key for this operation.
+	CacheMixin digest.Digest
 
 	// hostname -> list of aliases
 	HostAliases map[string][]string

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -66,7 +66,7 @@ const (
 	// this is set by buildkit, we cannot change
 	BuildkitSessionIDHeader = "x-docker-expose-session-uuid"
 
-	buildkitQemuEmulatorMountPoint = "/dev/.buildkit_qemu_emulator"
+	BuildkitQemuEmulatorMountPoint = "/dev/.buildkit_qemu_emulator"
 
 	cgroupSampleInterval     = 3 * time.Second
 	finalCgroupSampleTimeout = 3 * time.Second
@@ -435,7 +435,7 @@ func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 		case mnt.Destination == MetaMountDestPath:
 			state.metaMount = &mnt
 
-		case mnt.Destination == buildkitQemuEmulatorMountPoint:
+		case mnt.Destination == BuildkitQemuEmulatorMountPoint:
 			// buildkit puts the qemu emulator under /dev, which we aren't mounting now, so just
 			// leave it be
 			filteredMounts = append(filteredMounts, mnt)

--- a/engine/buildkit/op.go
+++ b/engine/buildkit/op.go
@@ -122,7 +122,7 @@ func (op *CustomOpWrapper) Exec(ctx context.Context, g bksession.Group, inputs [
 	ctx = engine.ContextWithClientMetadata(ctx, &op.ClientMetadata)
 	ctx = ctxWithBkSessionGroup(ctx, g)
 
-	server, err := op.server.DagqlServer(ctx)
+	server, err := op.server.Server(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not find dagql server: %w", err)
 	}

--- a/engine/buildkit/worker.go
+++ b/engine/buildkit/worker.go
@@ -142,7 +142,7 @@ func (w *Worker) ResolveOp(vtx solver.Vertex, s frontend.FrontendLLBBridge, sm *
 				return nil, err
 			}
 			if ok {
-				w = w.execWorker(
+				w = w.ExecWorker(
 					SpanContextFromDescription(vtx.Options().Description),
 					*execMD,
 				)
@@ -164,7 +164,7 @@ func (w *Worker) ResolveOp(vtx solver.Vertex, s frontend.FrontendLLBBridge, sm *
 	return w.Worker.ResolveOp(vtx, s, sm)
 }
 
-func (w *Worker) execWorker(causeCtx trace.SpanContext, execMD ExecutionMetadata) *Worker {
+func (w *Worker) ExecWorker(causeCtx trace.SpanContext, execMD ExecutionMetadata) *Worker {
 	return &Worker{sharedWorkerState: w.sharedWorkerState, causeCtx: causeCtx, execMD: &execMD}
 }
 

--- a/engine/buildkit/worker.go
+++ b/engine/buildkit/worker.go
@@ -70,7 +70,7 @@ type sessionHandler interface {
 }
 
 type dagqlServer interface {
-	DagqlServer(ctx context.Context) (*dagql.Server, error)
+	Server(ctx context.Context) (*dagql.Server, error)
 }
 
 type NewWorkerOpts struct {

--- a/engine/server/client_resources.go
+++ b/engine/server/client_resources.go
@@ -48,8 +48,8 @@ func (srv *Server) addClientResourcesFromID(ctx context.Context, destClient *dag
 	}
 	socketIDs = filteredSocketIDs
 
-	srcClient, ok := srv.clientFromIDs(destClient.daggerSession.sessionID, sourceClientID)
-	if !ok {
+	srcClient, err := srv.clientFromIDs(destClient.daggerSession.sessionID, sourceClientID)
+	if err != nil {
 		if id.Optional {
 			return nil // no errors for this case
 		}

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -591,6 +591,10 @@ func (srv *Server) BuildkitCache() bkcache.Manager {
 	return srv.workerCache
 }
 
+func (srv *Server) BuildkitSession() *bksession.Manager {
+	return srv.bkSessionManager
+}
+
 func (srv *Server) Info(context.Context, *controlapi.InfoRequest) (*controlapi.InfoResponse, error) {
 	return &controlapi.InfoResponse{
 		BuildkitVersion: &apitypes.BuildkitVersion{

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -685,29 +685,29 @@ func (srv *Server) clientFromContext(ctx context.Context) (*daggerClient, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client metadata for session call: %w", err)
 	}
-	client, ok := srv.clientFromIDs(clientMetadata.SessionID, clientMetadata.ClientID)
-	if !ok {
-		return nil, fmt.Errorf("client %q not found", clientMetadata.ClientID)
+	client, err := srv.clientFromIDs(clientMetadata.SessionID, clientMetadata.ClientID)
+	if err != nil {
+		return nil, err
 	}
 	return client, nil
 }
 
-func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, bool) {
+func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error) {
 	srv.daggerSessionsMu.RLock()
 	defer srv.daggerSessionsMu.RUnlock()
 	sess, ok := srv.daggerSessions[sessID]
 	if !ok {
-		return nil, false
+		return nil, fmt.Errorf("session %q not found", sessID)
 	}
 
 	sess.clientMu.RLock()
 	defer sess.clientMu.RUnlock()
 	client, ok := sess.clients[clientID]
 	if !ok {
-		return nil, false
+		return nil, fmt.Errorf("client %q not found", clientID)
 	}
 
-	return client, true
+	return client, nil
 }
 
 // initialize session+client if needed, return:
@@ -1341,9 +1341,9 @@ func (srv *Server) MainClientCallerMetadata(ctx context.Context) (*engine.Client
 	if err != nil {
 		return nil, err
 	}
-	mainClient, ok := srv.clientFromIDs(client.daggerSession.sessionID, client.daggerSession.mainClientCallerID)
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve session main client")
+	mainClient, err := srv.clientFromIDs(client.daggerSession.sessionID, client.daggerSession.mainClientCallerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve session main client: %w", err)
 	}
 	return mainClient.clientMetadata, nil
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -932,18 +932,6 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 
 const InstrumentationLibrary = "dagger.io/engine.server"
 
-func (srv *Server) DagqlServer(ctx context.Context) (*dagql.Server, error) {
-	client, err := srv.clientFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	schema, err := client.deps.Schema(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return schema, nil
-}
-
 func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opts *ClientInitOpts) (rerr error) {
 	ctx := r.Context()
 	ctx, cancel := context.WithCancelCause(ctx)


### PR DESCRIPTION
The continuation of https://github.com/dagger/dagger/issues/10367, converts `withExec` to completely avoid generating LLB, and instead lifting *all* the relevant functionality into dagger.

TODO:
- [x] Something about the `RawDigest` functionality I've added so we can get a form of content-caching for operations doesn't make me super happy.
