### PR TITLE
cli: Add --cloud flag (EXPERIMENTAL)

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -77,7 +77,9 @@ func withEngine(
 			params.LogLevel = slog.LevelDebug
 		}
 
-		if params.RunnerHost == "" {
+		if useCloudEngine {
+			params.RunnerHost = "dagger-cloud://default-engine-config.dagger.cloud"
+		} else if params.RunnerHost == "" {
 			params.RunnerHost = RunnerHost
 		}
 

--- a/cmd/dagger/functions_cloud_test.go
+++ b/cmd/dagger/functions_cloud_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteEngineFunctions(t *testing.T) {
+	daggerBin := "dagger" // $PATH
+	if bin := os.Getenv("_EXPERIMENTAL_DAGGER_CLI_BIN"); bin != "" {
+		daggerBin = bin
+	}
+	daggerArgs := []string{"--cloud", "functions"}
+	cmd := exec.Command(daggerBin, daggerArgs...)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	require.Error(t, err, "expected to return an error")
+	require.Contains(t, stderr.String(), "please run `dagger login <org>` first")
+}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -65,6 +65,7 @@ var (
 	interactiveCommandParsed []string
 	web                      bool
 	noExit                   bool
+	useCloudEngine           bool
 
 	dotOutputFilePath string
 	dotFocusField     string
@@ -160,6 +161,11 @@ func init() {
 	// we'll add it in the last line of the usage template
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 	rootCmd.PersistentFlags().Lookup("help").Hidden = true
+
+	// this flag changes the behaviour of a few commands, e.g. call, functions, core, shell, etc.
+	// all those functions will run in a remote cloud engine which gets created at execution time
+	rootCmd.PersistentFlags().BoolVar(&useCloudEngine, "cloud", false, "Run in a Dagger Cloud Engine")
+	rootCmd.PersistentFlags().Lookup("cloud").Hidden = true
 
 	disableFlagsInUseLine(rootCmd)
 }

--- a/engine/client/drivers/cloud.go
+++ b/engine/client/drivers/cloud.go
@@ -1,0 +1,99 @@
+package drivers
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/dagger/dagger/internal/cloud"
+	"github.com/dagger/dagger/internal/cloud/auth"
+)
+
+var (
+	TLSHandshakeTimeout = 15 * time.Second
+)
+
+func init() {
+	register("dagger-cloud", &daggerCloudDriver{})
+}
+
+// daggerCloudDriver creates and manages a Cloud Engine, then connects to it
+type daggerCloudDriver struct{}
+
+type daggerCloudConnector struct {
+	EngineSpec cloud.EngineSpec
+}
+
+func (dc *daggerCloudConnector) Connect(ctx context.Context) (net.Conn, error) {
+	serverAddr := dc.EngineSpec.URL
+
+	// Extract hostname for SNI
+	host, _, err := net.SplitHostPort(serverAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port from '%s': %w", serverAddr, err)
+	}
+
+	clientCert, err := dc.EngineSpec.TLSCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("failed to unserialize Cloud Engine cert: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{*clientCert},
+		ServerName:   host,             // Required for SNI and server certificate validation
+		MinVersion:   tls.VersionTLS12, // TLS 1.2 is the oldest version that is still maintained in 2025
+	}
+
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	rawConn, err := dialer.DialContext(ctx, "tcp", serverAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial TCP to '%s': %w", serverAddr, err)
+	}
+
+	// Create TLS Client Connection
+	// tls.Client wraps the rawConn. If Handshake fails, rawConn should be closed.
+	// If Handshake succeeds, closing tlsConn will close rawConn.
+	tlsConn := tls.Client(rawConn, tlsConfig)
+
+	// Use HandshakeContext for better cancellation and timeout control
+	handshakeCtx, cancelHandshake := context.WithTimeout(ctx, TLSHandshakeTimeout)
+	defer cancelHandshake()
+
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		rawConn.Close() // Ensure raw connection is closed if handshake fails
+		return nil, fmt.Errorf("tls handshake failed with '%s': %w", serverAddr, err)
+	}
+
+	return tlsConn, nil
+}
+
+func (d *daggerCloudDriver) Provision(ctx context.Context, _ *url.URL, opts *DriverOpts) (Connector, error) {
+	client, err := cloud.NewClient(ctx)
+	if err != nil {
+		return nil, errors.New("please run `dagger login <org>` first")
+	}
+
+	_, err = client.User(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	org, _ := auth.CurrentOrg()
+	if org == nil {
+		return nil, errors.New("please associate this Engine with an org by running `dagger login <org>")
+	}
+
+	return d.create(ctx, client)
+}
+
+func (d *daggerCloudDriver) create(ctx context.Context, client *cloud.Client) (*daggerCloudConnector, error) {
+	engineSpec, err := client.Engine(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &daggerCloudConnector{EngineSpec: *engineSpec}, nil
+}

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -1,19 +1,31 @@
 package cloud
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/shurcooL/graphql"
 	"golang.org/x/oauth2"
 
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/internal/cloud/auth"
 )
 
 type Client struct {
 	u *url.URL
-	c *graphql.Client
+	g *graphql.Client
+	h *http.Client
+	t *oauth2.Token
 }
 
 func NewClient(ctx context.Context) (*Client, error) {
@@ -32,11 +44,18 @@ func NewClient(ctx context.Context) (*Client, error) {
 		return nil, err
 	}
 
+	token, err := auth.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	httpClient := oauth2.NewClient(ctx, tokenSource)
 
 	return &Client{
 		u: u,
-		c: graphql.NewClient(api+"/query", httpClient),
+		g: graphql.NewClient(u.JoinPath("/query").String(), httpClient),
+		h: httpClient,
+		t: token,
 	}, nil
 }
 
@@ -49,10 +68,116 @@ func (c *Client) User(ctx context.Context) (*UserResponse, error) {
 	var q struct {
 		User UserResponse `graphql:"user"`
 	}
-	err := c.c.Query(ctx, &q, nil)
+	err := c.g.Query(ctx, &q, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return &q.User, nil
+}
+
+type SerializableCertificate struct {
+	CertificateChain [][]byte `json:"certificate_chain"` // DER-encoded certs
+	PrivateKey       []byte   `json:"private_key"`       // PKCS#8 encoded private key
+	OCSPStaple       []byte   `json:"ocsp_staple,omitempty"`
+	SCTs             [][]byte `json:"scts,omitempty"`
+}
+
+type EngineSpec struct {
+	Architecture   string                   `json:"architecture,omitempty"`
+	CacheSizeGb    int                      `json:"cache_size_gb,omitempty"`
+	Continent      string                   `json:"continent,omitempty"`
+	Image          string                   `json:"image,omitempty"`
+	Location       string                   `json:"location,omitempty"`
+	OrgID          string                   `json:"org_id,omitempty"`
+	UserID         string                   `json:"user_id,omitempty"`
+	Size           string                   `json:"size,omitempty"`
+	TTL            string                   `json:"ttl,omitempty"`
+	TTLDuration    time.Duration            `json:"ttl_duration,omitempty"`
+	URL            string                   `json:"url,omitempty"`
+	CertSerialized *SerializableCertificate `json:"cert,omitempty"`
+}
+
+func (es *EngineSpec) TLSCertificate() (*tls.Certificate, error) {
+	if es.CertSerialized == nil {
+		return nil, errors.New("serializable certificate is nil")
+	}
+
+	// Parse the PKCS#8 DER-encoded private key
+	privateKey, err := x509.ParsePKCS8PrivateKey(es.CertSerialized.PrivateKey)
+	if err != nil {
+		// You might want to try x509.ParsePKCS1PrivateKey or x509.ParseECPrivateKey
+		// if PKCS#8 fails, but PKCS#8 should be the most general.
+		return nil, fmt.Errorf("failed to parse PKCS#8 private key: %w", err)
+	}
+
+	// Re-parse the leaf certificate to populate the Leaf field
+	var leaf *x509.Certificate
+	if len(es.CertSerialized.CertificateChain) > 0 && len(es.CertSerialized.CertificateChain[0]) > 0 {
+		leaf, err = x509.ParseCertificate(es.CertSerialized.CertificateChain[0])
+		if err != nil {
+			// Non-fatal for tls.Certificate, but good to have
+			log.Printf("Warning: could not parse leaf certificate: %v", err)
+		}
+	}
+
+	return &tls.Certificate{
+		Certificate:                 es.CertSerialized.CertificateChain,
+		PrivateKey:                  privateKey,
+		OCSPStaple:                  es.CertSerialized.OCSPStaple,
+		SignedCertificateTimestamps: es.CertSerialized.SCTs,
+		Leaf:                        leaf,
+	}, nil
+}
+
+type ErrResponse struct {
+	Message string `json:"message"`
+}
+
+func (c *Client) Engine(ctx context.Context) (*EngineSpec, error) {
+	// Remote Engine version defaults to the CLI version - this guarantees the best compatibility
+	tag := engine.Tag
+	// Default to `main` when the CLI is a development version
+	if tag == "" {
+		tag = "main"
+	}
+
+	// The only property that we can set is the Image tag.
+	// The rest will be handled by engine configs (follow-up).
+	engineSpec := &EngineSpec{
+		Image: "registry.dagger.io/engine:" + tag,
+	}
+	b, err := json.Marshal(engineSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to json marshal the EngineSpec: %w", err)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.u.JoinPath("/v1/engines").String(), bytes.NewBuffer(b))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a remote Engine request: %w", err)
+	}
+	org, err := auth.CurrentOrg()
+	if err != nil {
+		return nil, err
+	}
+	r.Header.Set("X-Dagger-Org", org.ID)
+	resp, err := c.h.Do(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request a remote Engine: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body := json.NewDecoder(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		errResponse := &ErrResponse{}
+		err = body.Decode(errResponse)
+		if err != nil {
+			return nil, fmt.Errorf("response body is not valid JSON: %s", errResponse)
+		}
+		return nil, fmt.Errorf("failed to provision a remote Engine: %s", errResponse.Message)
+	}
+
+	err = body.Decode(engineSpec)
+	return engineSpec, err
 }


### PR DESCRIPTION
> [!WARNING]
> This is a highly **EXPERIMENTAL** feature. One day, all Dagger Cloud users **might** be able to use this. We expect this to change before it becomes available to everyone.

This flag requires that the CLI:
- is connected to Dagger Cloud
- has an org set (e.g. `dagger login <YOUR_CLOUD_ORG>`)
- that org must have the `CLOUD_ENGINES` feature enabled (or be a `Dagger-Internal` org)


This flag provisions a Cloud Engine just-in-time, connects to it and then runs all subsequent operations in it. **ALL** commands will work exactly the same, just that they will run against this Cloud Engine which is configured with:
- `16 vCPUs`
- `32GB RAM`
- `100GB NVMe storage`

> [!NOTE]
> If the CLI is a development version, the Engine provisioned will be `main` (a.k.a. latest development).

By default, the Engine shuts down after `30 minutes` of inactivity (a.k.a. TTL). As soon as another command runs, the TTL resets to `30 minutes`.

State persists across Engines. After 30+ minutes of inactivity, running another command will start a new Engine with the same state that the last running Engine had. While there are a few scenarios which may result in engines starting with no state, this should happen no more than 1 in 10 runs.

The other half of this: https://github.com/dagger/dagger.io/pull/4350 (private repo PR)

---

https://github.com/user-attachments/assets/1553939e-2935-44e5-abb7-84e3a4488886

---

If you are a `Dagger` Cloud Org user, you can test this using the following steps:

1. Build a development version of the `dagger` CLI
2. Point it to a preview Dagger Cloud API
`export DAGGER_CLOUD_URL=https://api-parc-create-engine-api.preview.dagger.cloud` 👈 this part is **essential**
3. Login to Dagger Cloud
4. Run any `dagger` CLI command in an on-demand Dagger Cloud Engine