### PR TITLE
feat(sdk/elixir): make SDK support Elixir JSON by default

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20250525-231914.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20250525-231914.yaml
@@ -1,0 +1,13 @@
+kind: Added
+body: |-
+    The SDK is now using Elixir `JSON` by default.
+
+    The `Jason` is still support. If want to use it, please adbd `:jason` and put the config belows:
+
+    ```elixir
+    config :dagger, :jason_library, Jason
+    ```
+time: 2025-05-25T23:19:14.203945624+07:00
+custom:
+    Author: wingyplus
+    PR: "10469"

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/object_renderer.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/object_renderer.ex
@@ -71,6 +71,13 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
         Jason.Encode.string(id, opts)
       end
     end
+
+    defimpl JSON.Encoder, for: #{module_name} do
+      def encode(#{module_var}, _encoder) do
+        {:ok, id} = #{module_name}.id(#{module_var})
+        id
+      end
+    end
     """
   end
 

--- a/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
+++ b/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
@@ -649,6 +649,13 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRendererTest do
         end
       end
 
+      defimpl JSON.Encoder, for: Dagger.Module do
+        def encode(module, _encoder) do
+          {:ok, id} = Dagger.Module.id(module)
+          id
+        end
+      end
+
       defimpl Nestru.Decoder, for: Dagger.Module do
         def decode_fields_hint(_struct, _context, id) do
           {:ok, Dagger.Client.load_module_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/core/graphql_client/httpc.ex
+++ b/sdk/elixir/lib/dagger/core/graphql_client/httpc.ex
@@ -14,7 +14,7 @@ defmodule Dagger.Core.GraphQLClient.Httpc do
 
     case :httpc.request(:post, request, http_opts, options) do
       {:ok, {{_, status_code, _}, _, response}} ->
-        {:ok, status_code, response}
+        {:ok, status_code, IO.chardata_to_string(response)}
 
       otherwise ->
         otherwise

--- a/sdk/elixir/lib/dagger/gen/binding.ex
+++ b/sdk/elixir/lib/dagger/gen/binding.ex
@@ -299,6 +299,13 @@ defimpl Jason.Encoder, for: Dagger.Binding do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Binding do
+  def encode(binding, _encoder) do
+    {:ok, id} = Dagger.Binding.id(binding)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Binding do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_binding_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/cache_volume.ex
+++ b/sdk/elixir/lib/dagger/gen/cache_volume.ex
@@ -34,6 +34,13 @@ defimpl Jason.Encoder, for: Dagger.CacheVolume do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.CacheVolume do
+  def encode(cache_volume, _encoder) do
+    {:ok, id} = Dagger.CacheVolume.id(cache_volume)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.CacheVolume do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_cache_volume_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -1370,6 +1370,13 @@ defimpl Jason.Encoder, for: Dagger.Container do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Container do
+  def encode(container, _encoder) do
+    {:ok, id} = Dagger.Container.id(container)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Container do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_container_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/current_module.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module.ex
@@ -92,6 +92,13 @@ defimpl Jason.Encoder, for: Dagger.CurrentModule do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.CurrentModule do
+  def encode(current_module, _encoder) do
+    {:ok, id} = Dagger.CurrentModule.id(current_module)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.CurrentModule do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_current_module_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -451,6 +451,13 @@ defimpl Jason.Encoder, for: Dagger.Directory do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Directory do
+  def encode(directory, _encoder) do
+    {:ok, id} = Dagger.Directory.id(directory)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Directory do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_directory_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/engine.ex
+++ b/sdk/elixir/lib/dagger/gen/engine.ex
@@ -48,6 +48,13 @@ defimpl Jason.Encoder, for: Dagger.Engine do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Engine do
+  def encode(engine, _encoder) do
+    {:ok, id} = Dagger.Engine.id(engine)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Engine do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_engine_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/engine_cache.ex
+++ b/sdk/elixir/lib/dagger/gen/engine_cache.ex
@@ -124,6 +124,13 @@ defimpl Jason.Encoder, for: Dagger.EngineCache do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EngineCache do
+  def encode(engine_cache, _encoder) do
+    {:ok, id} = Dagger.EngineCache.id(engine_cache)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EngineCache do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_engine_cache_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/engine_cache_entry.ex
+++ b/sdk/elixir/lib/dagger/gen/engine_cache_entry.ex
@@ -89,6 +89,13 @@ defimpl Jason.Encoder, for: Dagger.EngineCacheEntry do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EngineCacheEntry do
+  def encode(engine_cache_entry, _encoder) do
+    {:ok, id} = Dagger.EngineCacheEntry.id(engine_cache_entry)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EngineCacheEntry do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_engine_cache_entry_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/engine_cache_entry_set.ex
+++ b/sdk/elixir/lib/dagger/gen/engine_cache_entry_set.ex
@@ -78,6 +78,13 @@ defimpl Jason.Encoder, for: Dagger.EngineCacheEntrySet do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EngineCacheEntrySet do
+  def encode(engine_cache_entry_set, _encoder) do
+    {:ok, id} = Dagger.EngineCacheEntrySet.id(engine_cache_entry_set)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EngineCacheEntrySet do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_engine_cache_entry_set_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/enum_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_type_def.ex
@@ -126,6 +126,13 @@ defimpl Jason.Encoder, for: Dagger.EnumTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EnumTypeDef do
+  def encode(enum_type_def, _encoder) do
+    {:ok, id} = Dagger.EnumTypeDef.id(enum_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EnumTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_enum_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
@@ -81,6 +81,13 @@ defimpl Jason.Encoder, for: Dagger.EnumValueTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EnumValueTypeDef do
+  def encode(enum_value_type_def, _encoder) do
+    {:ok, id} = Dagger.EnumValueTypeDef.id(enum_value_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EnumValueTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_enum_value_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/env.ex
+++ b/sdk/elixir/lib/dagger/gen/env.ex
@@ -674,6 +674,13 @@ defimpl Jason.Encoder, for: Dagger.Env do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Env do
+  def encode(env, _encoder) do
+    {:ok, id} = Dagger.Env.id(env)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Env do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_env_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/env_variable.ex
+++ b/sdk/elixir/lib/dagger/gen/env_variable.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.EnvVariable do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.EnvVariable do
+  def encode(env_variable, _encoder) do
+    {:ok, id} = Dagger.EnvVariable.id(env_variable)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.EnvVariable do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_env_variable_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/error.ex
+++ b/sdk/elixir/lib/dagger/gen/error.ex
@@ -84,6 +84,13 @@ defimpl Jason.Encoder, for: Dagger.Error do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Error do
+  def encode(error, _encoder) do
+    {:ok, id} = Dagger.Error.id(error)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Error do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_error_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/error_value.ex
+++ b/sdk/elixir/lib/dagger/gen/error_value.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.ErrorValue do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ErrorValue do
+  def encode(error_value, _encoder) do
+    {:ok, id} = Dagger.ErrorValue.id(error_value)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ErrorValue do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_error_value_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/field_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/field_type_def.ex
@@ -86,6 +86,13 @@ defimpl Jason.Encoder, for: Dagger.FieldTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.FieldTypeDef do
+  def encode(field_type_def, _encoder) do
+    {:ok, id} = Dagger.FieldTypeDef.id(field_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.FieldTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_field_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/file.ex
+++ b/sdk/elixir/lib/dagger/gen/file.ex
@@ -144,6 +144,13 @@ defimpl Jason.Encoder, for: Dagger.File do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.File do
+  def encode(file, _encoder) do
+    {:ok, id} = Dagger.File.id(file)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.File do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_file_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -168,6 +168,13 @@ defimpl Jason.Encoder, for: Dagger.Function do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Function do
+  def encode(function, _encoder) do
+    {:ok, id} = Dagger.Function.id(function)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Function do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_function_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -119,6 +119,13 @@ defimpl Jason.Encoder, for: Dagger.FunctionArg do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.FunctionArg do
+  def encode(function_arg, _encoder) do
+    {:ok, id} = Dagger.FunctionArg.id(function_arg)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.FunctionArg do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_function_arg_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/function_call.ex
+++ b/sdk/elixir/lib/dagger/gen/function_call.ex
@@ -119,6 +119,13 @@ defimpl Jason.Encoder, for: Dagger.FunctionCall do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.FunctionCall do
+  def encode(function_call, _encoder) do
+    {:ok, id} = Dagger.FunctionCall.id(function_call)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.FunctionCall do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_function_call_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/function_call_arg_value.ex
+++ b/sdk/elixir/lib/dagger/gen/function_call_arg_value.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.FunctionCallArgValue do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.FunctionCallArgValue do
+  def encode(function_call_arg_value, _encoder) do
+    {:ok, id} = Dagger.FunctionCallArgValue.id(function_call_arg_value)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.FunctionCallArgValue do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_function_call_arg_value_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/generated_code.ex
+++ b/sdk/elixir/lib/dagger/gen/generated_code.ex
@@ -102,6 +102,13 @@ defimpl Jason.Encoder, for: Dagger.GeneratedCode do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.GeneratedCode do
+  def encode(generated_code, _encoder) do
+    {:ok, id} = Dagger.GeneratedCode.id(generated_code)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.GeneratedCode do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_generated_code_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/git_ref.ex
+++ b/sdk/elixir/lib/dagger/gen/git_ref.ex
@@ -74,6 +74,13 @@ defimpl Jason.Encoder, for: Dagger.GitRef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.GitRef do
+  def encode(git_ref, _encoder) do
+    {:ok, id} = Dagger.GitRef.id(git_ref)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.GitRef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_git_ref_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -168,6 +168,13 @@ defimpl Jason.Encoder, for: Dagger.GitRepository do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.GitRepository do
+  def encode(git_repository, _encoder) do
+    {:ok, id} = Dagger.GitRepository.id(git_repository)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.GitRepository do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_git_repository_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/host.ex
+++ b/sdk/elixir/lib/dagger/gen/host.ex
@@ -148,6 +148,13 @@ defimpl Jason.Encoder, for: Dagger.Host do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Host do
+  def encode(host, _encoder) do
+    {:ok, id} = Dagger.Host.id(host)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Host do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_host_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/input_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/input_type_def.ex
@@ -70,6 +70,13 @@ defimpl Jason.Encoder, for: Dagger.InputTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.InputTypeDef do
+  def encode(input_type_def, _encoder) do
+    {:ok, id} = Dagger.InputTypeDef.id(input_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.InputTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_input_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/interface_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/interface_type_def.ex
@@ -103,6 +103,13 @@ defimpl Jason.Encoder, for: Dagger.InterfaceTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.InterfaceTypeDef do
+  def encode(interface_type_def, _encoder) do
+    {:ok, id} = Dagger.InterfaceTypeDef.id(interface_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.InterfaceTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_interface_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/label.ex
+++ b/sdk/elixir/lib/dagger/gen/label.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.Label do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Label do
+  def encode(label, _encoder) do
+    {:ok, id} = Dagger.Label.id(label)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Label do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_label_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/list_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/list_type_def.ex
@@ -48,6 +48,13 @@ defimpl Jason.Encoder, for: Dagger.ListTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ListTypeDef do
+  def encode(list_type_def, _encoder) do
+    {:ok, id} = Dagger.ListTypeDef.id(list_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ListTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_list_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/llm.ex
+++ b/sdk/elixir/lib/dagger/gen/llm.ex
@@ -274,6 +274,13 @@ defimpl Jason.Encoder, for: Dagger.LLM do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.LLM do
+  def encode(llm, _encoder) do
+    {:ok, id} = Dagger.LLM.id(llm)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.LLM do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_llm_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/llm_token_usage.ex
+++ b/sdk/elixir/lib/dagger/gen/llm_token_usage.ex
@@ -74,6 +74,13 @@ defimpl Jason.Encoder, for: Dagger.LLMTokenUsage do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.LLMTokenUsage do
+  def encode(llm_token_usage, _encoder) do
+    {:ok, id} = Dagger.LLMTokenUsage.id(llm_token_usage)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.LLMTokenUsage do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_llm_token_usage_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -300,6 +300,13 @@ defimpl Jason.Encoder, for: Dagger.Module do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Module do
+  def encode(module, _encoder) do
+    {:ok, id} = Dagger.Module.id(module)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Module do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_module_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/module_config_client.ex
+++ b/sdk/elixir/lib/dagger/gen/module_config_client.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.ModuleConfigClient do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ModuleConfigClient do
+  def encode(module_config_client, _encoder) do
+    {:ok, id} = Dagger.ModuleConfigClient.id(module_config_client)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ModuleConfigClient do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_module_config_client_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -520,6 +520,13 @@ defimpl Jason.Encoder, for: Dagger.ModuleSource do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ModuleSource do
+  def encode(module_source, _encoder) do
+    {:ok, id} = Dagger.ModuleSource.id(module_source)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ModuleSource do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_module_source_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/object_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/object_type_def.ex
@@ -139,6 +139,13 @@ defimpl Jason.Encoder, for: Dagger.ObjectTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ObjectTypeDef do
+  def encode(object_type_def, _encoder) do
+    {:ok, id} = Dagger.ObjectTypeDef.id(object_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ObjectTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_object_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/port.ex
+++ b/sdk/elixir/lib/dagger/gen/port.ex
@@ -81,6 +81,13 @@ defimpl Jason.Encoder, for: Dagger.Port do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Port do
+  def encode(port, _encoder) do
+    {:ok, id} = Dagger.Port.id(port)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Port do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_port_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/scalar_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/scalar_type_def.ex
@@ -67,6 +67,13 @@ defimpl Jason.Encoder, for: Dagger.ScalarTypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.ScalarTypeDef do
+  def encode(scalar_type_def, _encoder) do
+    {:ok, id} = Dagger.ScalarTypeDef.id(scalar_type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.ScalarTypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_scalar_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/sdk_config.ex
+++ b/sdk/elixir/lib/dagger/gen/sdk_config.ex
@@ -45,6 +45,13 @@ defimpl Jason.Encoder, for: Dagger.SDKConfig do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.SDKConfig do
+  def encode(sdk_config, _encoder) do
+    {:ok, id} = Dagger.SDKConfig.id(sdk_config)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.SDKConfig do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_sdk_config_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/secret.ex
+++ b/sdk/elixir/lib/dagger/gen/secret.ex
@@ -67,6 +67,13 @@ defimpl Jason.Encoder, for: Dagger.Secret do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Secret do
+  def encode(secret, _encoder) do
+    {:ok, id} = Dagger.Secret.id(secret)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Secret do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_secret_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/service.ex
+++ b/sdk/elixir/lib/dagger/gen/service.ex
@@ -160,6 +160,13 @@ defimpl Jason.Encoder, for: Dagger.Service do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Service do
+  def encode(service, _encoder) do
+    {:ok, id} = Dagger.Service.id(service)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Service do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_service_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/socket.ex
+++ b/sdk/elixir/lib/dagger/gen/socket.ex
@@ -34,6 +34,13 @@ defimpl Jason.Encoder, for: Dagger.Socket do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Socket do
+  def encode(socket, _encoder) do
+    {:ok, id} = Dagger.Socket.id(socket)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Socket do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_socket_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/source_map.ex
+++ b/sdk/elixir/lib/dagger/gen/source_map.ex
@@ -78,6 +78,13 @@ defimpl Jason.Encoder, for: Dagger.SourceMap do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.SourceMap do
+  def encode(source_map, _encoder) do
+    {:ok, id} = Dagger.SourceMap.id(source_map)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.SourceMap do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_source_map_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/terminal.ex
+++ b/sdk/elixir/lib/dagger/gen/terminal.ex
@@ -56,6 +56,13 @@ defimpl Jason.Encoder, for: Dagger.Terminal do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.Terminal do
+  def encode(terminal, _encoder) do
+    {:ok, id} = Dagger.Terminal.id(terminal)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.Terminal do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_terminal_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/lib/dagger/gen/type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/type_def.ex
@@ -372,6 +372,13 @@ defimpl Jason.Encoder, for: Dagger.TypeDef do
   end
 end
 
+defimpl JSON.Encoder, for: Dagger.TypeDef do
+  def encode(type_def, _encoder) do
+    {:ok, id} = Dagger.TypeDef.id(type_def)
+    id
+  end
+end
+
 defimpl Nestru.Decoder, for: Dagger.TypeDef do
   def decode_fields_hint(_struct, _context, id) do
     {:ok, Dagger.Client.load_type_def_from_id(Dagger.Global.dag(), id)}

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -26,7 +26,6 @@ defmodule Dagger.MixProject do
 
   defp deps do
     [
-      {:jason, "~> 1.4"},
       {:nimble_options, "~> 1.0"},
       {:nestru, "~> 1.0"},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},

--- a/sdk/elixir/test/dagger/mod/decoder_test.exs
+++ b/sdk/elixir/test/dagger/mod/decoder_test.exs
@@ -47,7 +47,7 @@ defmodule Dagger.Mod.DecoderTest do
     end
   end
 
-  defp json(value), do: Jason.encode!(value)
+  defp json(value), do: JSON.encode!(value)
 
   defp container_id(dag) do
     {:ok, container_id} = dag |> Dagger.Client.container() |> Dagger.Container.id()


### PR DESCRIPTION
* Add `JSON.Encoder` implementation to all generated code.
* Change `:json_library` to `JSON` by default but still allows to configure by set `:json_library` in the config.

Updates #7444 