### PR TITLE
refactor(sdk/rust): use introspection.json from codegen binary

### DIFF
--- a/.dagger/sdk_rust.go
+++ b/.dagger/sdk_rust.go
@@ -74,9 +74,10 @@ func (r RustSDK) Test(ctx context.Context) error {
 // Regenerate the Rust SDK API
 func (r RustSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 	installer := r.Dagger.installer("sdk")
+	introspection := r.Dagger.introspection(installer)
 	generated := r.rustBase(rustDockerStable).
-		With(installer).
-		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
+		WithMountedFile("/introspection.json", introspection).
+		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "/introspection.json", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
 		WithExec([]string{"cargo", "fix", "--all", "--allow-no-vcs"}).
 		WithExec([]string{"cargo", "fmt"}).
 		File(strings.TrimPrefix(rustGeneratedAPIPath, "sdk/rust/"))

--- a/sdk/rust/crates/dagger-bootstrap/src/cli_generate.rs
+++ b/sdk/rust/crates/dagger-bootstrap/src/cli_generate.rs
@@ -1,12 +1,11 @@
+use std::fs;
 use std::io::Write;
 use std::sync::Arc;
 
 use clap::{Arg, ArgMatches};
 use dagger_codegen::generate;
 use dagger_codegen::rust::RustGenerator;
-use dagger_sdk::core::config::Config;
-use dagger_sdk::core::engine::Engine;
-use dagger_sdk::core::session::Session;
+use dagger_sdk::core::introspection;
 
 #[allow(dead_code)]
 pub struct GenerateCommand;
@@ -14,15 +13,17 @@ pub struct GenerateCommand;
 #[allow(dead_code)]
 impl GenerateCommand {
     pub fn new_cmd() -> clap::Command {
-        clap::Command::new("generate").arg(Arg::new("output").long("output"))
+        clap::Command::new("generate")
+            .arg(Arg::new("introspection-json").required(true))
+            .arg(Arg::new("output").long("output"))
     }
 
     pub async fn exec(arg_matches: &ArgMatches) -> eyre::Result<()> {
-        let cfg = Config::default();
-        let (conn, _proc) = Engine::new().start(&cfg).await?;
-        let session = Session::new();
-        let req = session.start(&cfg, &conn)?;
-        let schema = session.schema(req).await?;
+        let introspection_json_path = arg_matches.get_one::<String>("introspection-json").unwrap();
+        let introspection_json = fs::read_to_string(introspection_json_path)?;
+        let schema =
+            serde_json::from_str::<introspection::IntrospectionResponse>(&introspection_json)
+                .unwrap();
         let code = generate(
             schema.into_schema().schema.unwrap(),
             Arc::new(RustGenerator {}),


### PR DESCRIPTION
This changeset changes the `dagger-bootstrap` to generate code from `codegen` introspection.json instead of fetch it from Dagger directly.