### PR TITLE
chore: use dagql.Instance in service binding

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -129,7 +129,7 @@ func (container *Container) PBDefinitions(ctx context.Context) ([]*pb.Definition
 		}
 	}
 	for _, bnd := range container.Services {
-		ctr := bnd.Service.Container
+		ctr := bnd.Service.Self.Container
 		if ctr == nil {
 			continue
 		}
@@ -1571,10 +1571,10 @@ func (container *Container) WithoutExposedPort(port int, protocol NetworkProtoco
 	return container, nil
 }
 
-func (container *Container) WithServiceBinding(ctx context.Context, id *call.ID, svc *Service, alias string) (*Container, error) {
+func (container *Container) WithServiceBinding(ctx context.Context, svc dagql.Instance[*Service], alias string) (*Container, error) {
 	container = container.Clone()
 
-	host, err := svc.Hostname(ctx, id)
+	host, err := svc.Self.Hostname(ctx, svc.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -1586,7 +1586,6 @@ func (container *Container) WithServiceBinding(ctx context.Context, id *call.ID,
 
 	container.Services.Merge(ServiceBindings{
 		{
-			ID:       id,
 			Service:  svc,
 			Hostname: host,
 			Aliases:  aliases,

--- a/core/directory.go
+++ b/core/directory.go
@@ -60,7 +60,7 @@ func (dir *Directory) PBDefinitions(ctx context.Context) ([]*pb.Definition, erro
 		defs = append(defs, dir.LLB)
 	}
 	for _, bnd := range dir.Services {
-		ctr := bnd.Service.Container
+		ctr := bnd.Service.Self.Container
 		if ctr == nil {
 			continue
 		}

--- a/core/file.go
+++ b/core/file.go
@@ -58,7 +58,7 @@ func (file *File) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 		defs = append(defs, file.LLB)
 	}
 	for _, bnd := range file.Services {
-		ctr := bnd.Service.Container
+		ctr := bnd.Service.Self.Container
 		if ctr == nil {
 			continue
 		}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1988,7 +1988,7 @@ func (s *containerSchema) withServiceBinding(ctx context.Context, parent *core.C
 		return nil, err
 	}
 
-	return parent.WithServiceBinding(ctx, svc.ID(), svc.Self, args.Alias)
+	return parent.WithServiceBinding(ctx, svc, args.Alias)
 }
 
 type containerWithExposedPortArgs struct {

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -176,8 +176,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.Instance[*core.Query],
 			return inst, err
 		}
 		gitServices = append(gitServices, core.ServiceBinding{
-			ID:       svc.ID(),
-			Service:  svc.Self,
+			Service:  svc,
 			Hostname: host,
 		})
 	}

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -105,8 +105,7 @@ func (s *httpSchema) http(ctx context.Context, parent dagql.Instance[*core.Query
 			return inst, err
 		}
 		binding := core.ServiceBinding{
-			ID:       svc.ID(),
-			Service:  svc.Self,
+			Service:  svc,
 			Hostname: host,
 		}
 

--- a/core/service.go
+++ b/core/service.go
@@ -756,8 +756,7 @@ func (svc *Service) startReverseTunnel(ctx context.Context, id *call.ID) (runnin
 type ServiceBindings []ServiceBinding
 
 type ServiceBinding struct {
-	ID       *call.ID
-	Service  *Service
+	Service  dagql.Instance[*Service]
 	Hostname string
 	Aliases  AliasSet
 }

--- a/core/services.go
+++ b/core/services.go
@@ -225,7 +225,7 @@ func (ss *Services) StartBindings(ctx context.Context, bindings ServiceBindings)
 	eg := new(errgroup.Group)
 	for i, bnd := range bindings {
 		eg.Go(func() error {
-			runningSvc, err := ss.Start(ctx, bnd.ID, bnd.Service, false)
+			runningSvc, err := ss.Start(ctx, bnd.Service.ID(), bnd.Service.Self, false)
 			if err != nil {
 				return fmt.Errorf("start %s (%s): %w", bnd.Hostname, bnd.Aliases, err)
 			}


### PR DESCRIPTION
No need to track these separately.