### PR TITLE
add .env to .gitignore for all sdks codegen

### DIFF
--- a/core/codegen.go
+++ b/core/codegen.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"slices"
 
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -49,6 +50,12 @@ func (code *GeneratedCode) WithVCSGeneratedPaths(paths []string) *GeneratedCode 
 func (code *GeneratedCode) WithVCSIgnoredPaths(paths []string) *GeneratedCode {
 	code = code.Clone()
 	code.VCSIgnoredPaths = paths
+
+	// if the paths does not have a .env file we need to add it
+	if !slices.Contains(code.VCSIgnoredPaths, ".env") {
+		code.VCSIgnoredPaths = append(code.VCSIgnoredPaths, ".env")
+	}
+
 	return code
 }
 

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -203,6 +203,7 @@ func (sdk *goSDK) Codegen(
 			"internal/dagger",
 			"internal/querybuilder",
 			"internal/telemetry",
+			".env", // this is here because the Go SDK does not use WithVCSIgnoredPaths on core/codegen/GeneratedCode
 		},
 	}, nil
 }


### PR DESCRIPTION
When generating code for SDKs we need to add the `.env` to the `.gitignore` that is generated. This prevents users from accidentally committed secrets into their repositories.

Resolves #9729

