### PR TITLE
shell: add .printenv builtin command for showing env variables

### DIFF
--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"slices"
 	"strings"
@@ -438,6 +439,35 @@ func (h *shellCallHandler) registerCommands() { //nolint:gocyclo
 
 Writes any specified operands, separated by single blank (' ') characters and followed by a newline ('\n') character, to the standard output. If the -n option is specified, the trailing newline is suppressed.
 `,
+		},
+		&ShellCommand{
+			Use:  ".env [name]",
+			Args: MaximumArgs(1),
+			Description: `Show available environment variables or a specific variable
+
+If no name is provided, all environment variables are printed. If a name is provided, the value of that environment variable is printed.
+			`,
+			State: NoState,
+			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
+				if len(args) == 0 {
+					// Print all environment variables
+					env := os.Environ()
+					if len(env) == 0 {
+						return h.Print(ctx, "No environment variables set")
+					}
+
+					return h.Print(ctx, strings.Join(env, "\n"))
+				}
+
+				// Print a specific environment variable
+				name := args[0]
+				value, ok := os.LookupEnv(name)
+				if !ok {
+					return fmt.Errorf("environment variable %q not set", name)
+				}
+
+				return h.Print(ctx, value)
+			},
 		},
 		&ShellCommand{
 			Use: ".wait",

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -11,7 +11,6 @@ import (
 
 	"dagger.io/dagger/telemetry"
 	"github.com/spf13/cobra"
-	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 )
 
@@ -453,10 +452,9 @@ If no name is provided, all environment variables are printed. If a name is prov
 
 				if len(args) == 0 {
 					// Print all environment variables
-					hc.Env.Each(func(name string, v expand.Variable) bool {
-						fmt.Fprintf(hc.Stdout, "%s=%s\n", name, v.String())
-						return true
-					})
+					for name, vr := range hc.Env.Each {
+						fmt.Fprintf(hc.Stdout, "%s=%s\n", name, vr)
+					}
 
 					return nil
 				}

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -441,7 +441,7 @@ Writes any specified operands, separated by single blank (' ') characters and fo
 `,
 		},
 		&ShellCommand{
-			Use:  ".env [name]",
+			Use:  ".printenv [name]",
 			Args: MaximumArgs(1),
 			Description: `Show available environment variables or a specific variable
 

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -462,10 +462,6 @@ If no name is provided, all environment variables are printed. If a name is prov
 				// Print a specific environment variable
 				name := args[0]
 
-				// if the user prefixed the name with a $ sign, remove it
-				if strings.HasPrefix(name, "$") {
-					name = strings.TrimPrefix(name, "$")
-				}
 
 				value, ok := os.LookupEnv(name)
 				if !ok {

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -461,6 +461,12 @@ If no name is provided, all environment variables are printed. If a name is prov
 
 				// Print a specific environment variable
 				name := args[0]
+
+				// if the user prefixed the name with a $ sign, remove it
+				if strings.HasPrefix(name, "$") {
+					name = strings.TrimPrefix(name, "$")
+				}
+
 				value, ok := os.LookupEnv(name)
 				if !ok {
 					return fmt.Errorf("environment variable %q not set", name)

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"slices"
 	"strings"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/spf13/cobra"
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 )
 
@@ -450,19 +450,19 @@ If no name is provided, all environment variables are printed. If a name is prov
 			State: NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
 				hc := interp.HandlerCtx(ctx)
+
 				if len(args) == 0 {
 					// Print all environment variables
 					hc.Env.Each(func(name string, v expand.Variable) bool {
 						fmt.Fprintf(hc.Stdout, "%s=%s\n", name, v.String())
 						return true
 					})
+
 					return nil
 				}
 
-
 				// Print a specific environment variable
 				name := args[0]
-
 
 				v := hc.Env.Get(name)
 				if !v.IsSet() {
@@ -470,7 +470,6 @@ If no name is provided, all environment variables are printed. If a name is prov
 				}
 
 				return h.Print(ctx, v.String())
-
 			},
 		},
 		&ShellCommand{

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -449,15 +449,16 @@ If no name is provided, all environment variables are printed. If a name is prov
 			`,
 			State: NoState,
 			Run: func(ctx context.Context, cmd *ShellCommand, args []string, _ *ShellState) error {
+				hc := interp.HandlerCtx(ctx)
 				if len(args) == 0 {
 					// Print all environment variables
-					env := os.Environ()
-					if len(env) == 0 {
-						return h.Print(ctx, "No environment variables set")
-					}
-
-					return h.Print(ctx, strings.Join(env, "\n"))
+					hc.Env.Each(func(name string, v expand.Variable) bool {
+						fmt.Fprintf(hc.Stdout, "%s=%s\n", name, v.String())
+						return true
+					})
+					return nil
 				}
+
 
 				// Print a specific environment variable
 				name := args[0]

--- a/cmd/dagger/shell_commands.go
+++ b/cmd/dagger/shell_commands.go
@@ -464,12 +464,13 @@ If no name is provided, all environment variables are printed. If a name is prov
 				name := args[0]
 
 
-				value, ok := os.LookupEnv(name)
-				if !ok {
+				v := hc.Env.Get(name)
+				if !v.IsSet() {
 					return fmt.Errorf("environment variable %q not set", name)
 				}
 
-				return h.Print(ctx, value)
+				return h.Print(ctx, v.String())
+
 			},
 		},
 		&ShellCommand{

--- a/cmd/dagger/shell_env.go
+++ b/cmd/dagger/shell_env.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/dagger/shell_env.go
+++ b/cmd/dagger/shell_env.go
@@ -1,1 +1,0 @@
-package main


### PR DESCRIPTION
Adds a new builtin command for `.printenv` that optional accepts an argument of the specific variable to show. If no argument is provided, it will print all available env vars in the shell using the interpreter.

Resolves #10021