### PR TITLE
docs: agent guide: use test func in workspace instead of privileged env

### DIFF
--- a/docs/current_docs/quickstart/agent/inproject.mdx
+++ b/docs/current_docs/quickstart/agent/inproject.mdx
@@ -178,7 +178,6 @@ This code creates a Dagger Function called `develop` that takes an assignment an
 There are a few important points to note here:
 - The variable `environment` is the environment to define inputs and outputs for the agent. Each input and output provides a description which acts as a declarative form of prompting.
 - Other Dagger module dependencies are automatically detected and made available for use in this environment. In this example, Dagger finds the `workspace` sub-module installed and automatically generates bindings for it: `with-workspace-input` and `with-workspace-output`. These bindings can be used to provide (or retrieve) the workspace to the agent.
-- The `environment` is privileged, which means that the environment includes all the Dagger Functions in the existing Daggerized CI pipeline, plus the core Dagger API. This allows the agent to use the existing `test` function to run unit tests.
 - The LLM is supplied with a prompt file instead of an inline prompt. By separating the prompt from the Dagger Function code, it becomes easier to maintain and update the instructions given to the LLM.
 
 The final step is to add the prompt file. Create a file at `.dagger/develop_prompt.md` with the following content:
@@ -191,10 +190,6 @@ Your assignment is: $assignment
 ## Constraints
 - Before writing code, analyze the Workspace to understand the project.
 - Do not make unneccessary changes.
-- Run tests with the HelloDagger Test tool.
-- Read and write files with the Workspace_read_file, Workspace_list_files, and Workspace_write_file tools
-- You must pass the Directory from the Workspace_get_source to the HelloDagger Test tool.
-- Do not select Container or Directory tools. Only use Workspace and HelloDagger tools
 - Always run tests to validate your code changes.
 - Do not stop until you have completed the assignment and the tests pass.
 ```

--- a/docs/current_docs/quickstart/agent/inproject.mdx
+++ b/docs/current_docs/quickstart/agent/inproject.mdx
@@ -8,7 +8,7 @@ import VideoPlayer from '../../../src/components/VideoPlayer';
 
 # Add an AI agent to an Existing Project
 
-Now that you've learned the basics of creating an AI agent with Dagger in [Built an AI agent](./index.mdx), its time to apply those lessons to a more realistic use case. In this guide, you will build an AI agent that builds features for an existing project.
+Now that you've learned the basics of creating an AI agent with Dagger in [Build an AI agent](./index.mdx), its time to apply those lessons to a more realistic use case. In this guide, you will build an AI agent that builds features for an existing project.
 
 For this guide you will start with a Daggerized project. The agent will use the Dagger functions in this project that are already used locally and in CI for testing the project.
 
@@ -112,12 +112,23 @@ In this Dagger module, each Dagger Function performs a different operation:
 - The `read-file` Dagger Function reads a file in the workspace.
 - The `write-file` Dagger Function writes a file to the workspace.
 - The `list-files` Dagger Function lists all the files in the workspace.
-- The `get-source` Dagger Function gets the source code directory from the workspace.
+- The `test` Dagger Function runs the tests on the files in the workspace.
 
 See the functions of the new workspace module:
 
 ```shell
 dagger -m .dagger/workspace functions
+```
+
+This should list the following functions:
+
+```
+Name         Description
+list-files   List all of the files in the Workspace
+read-file    Read a file in the Workspace
+source       the workspace source code
+test         Return the result of running unit tests
+write-file   Write a file to the Workspace
 ```
 
 Now install the new submodule as a dependency to the main module:
@@ -195,8 +206,14 @@ Your assignment is: $assignment
 ```
 
 :::note
-This prompt is longer and more structured than the prompt from the first quickstart. The tasks the agent will be asked to complete will be more complex because its making modifications to an existing codebase and will need to understand more context. To create a reliable agent that can operate with more complexity, the prompt structure and tools are extremely important.
+This prompt is more structured than the prompt from the first quickstart. The tasks the agent will be asked to complete will be more complex because its making modifications to an existing codebase and will need to understand more context. To create a reliable agent that can operate with more complexity, the prompt structure and tools are extremely important.
 :::
+
+To see the new function, run:
+
+```shell
+dagger functions
+```
 
 ## Run the agent
 
@@ -209,7 +226,7 @@ Check the help text for the new Dagger Function:
 
 This should show how to use the `develop` function.
 
-Make sure your LLM provider has been properly configured:
+Make sure your LLM has been properly [configured](../../configuration/llm.mdx):
 
 ```shell
 llm | model
@@ -237,12 +254,24 @@ Since the agent returns a `Directory`, use Dagger Shell to do more with that `Di
 ```shell
 # Save the directory containing the completed assignment to a variable
 completed=$(develop "make the main page blue")
+```
+
+```shell
 # Get a terminal in the build container with the directory
 build-env --source $completed | terminal
+```
+
+```shell
 # Run the app with the updated source code
 build --source $completed | as-service | up --ports 8080:80
+```
+
+```shell
 # Save the changes to your filesystem
 $completed | export .
+```
+
+```shell
 # Exit
 exit
 ```
@@ -318,6 +347,12 @@ The `develop-issue` function connects the dots in the automation flow. It will b
 - Read the title and body from the GitHub issue
 - Use the body as the assignment for the agent
 - Open a pull request with the `Directory` returned by the agent
+
+To see the new function, run:
+
+```shell
+dagger functions
+```
 
 ### Create a GitHub Actions workflow
 

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/go/agent.go.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/go/agent.go.snippet
@@ -7,12 +7,12 @@ func (m *HelloDagger) Develop(
         source *dagger.Directory,
 ) (*dagger.Directory, error) {
         // Environment with agent inputs and outputs
-        environment := dag.Env(dagger.EnvOpts{Privileged: true}).
+        environment := dag.Env().
                 WithStringInput("assignment", assignment, "the assignment to complete").
                 WithWorkspaceInput(
                         "workspace",
                         dag.Workspace(source),
-                        "the workspace with tools to edit code").
+                        "the workspace with tools to edit and test code").
                 WithWorkspaceOutput(
                         "completed",
                         "the workspace with the completed assignment")
@@ -30,7 +30,7 @@ func (m *HelloDagger) Develop(
                 Env().
                 Output("completed").
                 AsWorkspace()
-        completedDirectory := completed.GetSource().WithoutDirectory("node_modules")
+        completedDirectory := completed.Source().WithoutDirectory("node_modules")
 
         // Make sure the tests really pass
         _, err := m.Test(ctx, completedDirectory)

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/java/agent.java.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/java/agent.java.snippet
@@ -9,12 +9,12 @@ public Directory develop(String assignment, @DefaultPath("/") Directory source)
 throws ExecutionException, DaggerQueryException, InterruptedException {
 // Environment with agent inputs and outputs
 Env environment = dag()
-    .env(new Client.EnvArguments().withPrivileged(true))
+    .env()
     .withStringInput("assignment", assignment, "the assignment to complete")
     .withWorkspaceInput(
     "workspace",
     dag().workspace(source),
-    "the workspace with tools to edit code"
+    "the workspace with tools to edit and test code"
     )
     .withWorkspaceOutput("completed", "the workspace with the completed assignment");
 
@@ -26,7 +26,7 @@ LLM work = dag().llm().withEnv(environment).withPromptFile(promptFile);
 
 // Get the output from the agent
 Workspace completed = work.env().output("completed").asWorkspace();
-Directory completedDirectory = completed.getSource().withoutDirectory("node_modules");
+Directory completedDirectory = completed.source().withoutDirectory("node_modules");
 
 // Make sure the tests really pass
 test(completedDirectory);

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/php/agent.php.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/php/agent.php.snippet
@@ -1,4 +1,4 @@
-#[DaggerFunction]
+  #[DaggerFunction]
   #[Doc('A coding agent for developing new features')]
   public function develop(
     #[Doc('Assignment to complete')] string $assignment,
@@ -23,7 +23,7 @@
 
     // Get the output from the agent
     $completed = $work->env()->output('completed')->asWorkspace();
-    $completedDirectory = $completed->source()->withoutDirectory('node_modules');
+    $completedDirectory = $completed->getSource()->withoutDirectory('node_modules');
 
     // Make sure the tests really pass
     $this->test($completedDirectory);

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/php/agent.php.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/php/agent.php.snippet
@@ -6,12 +6,12 @@
   ): Directory {
     // Environment with agent inputs and outputs
     $environment = dag()
-      ->env(privileged: true)
+      ->env()
       ->withStringInput('assignment', $assignment, 'the assignment to complete')
       ->withWorkspaceInput(
         'workspace',
         dag()->workspace($source),
-        'the workspace with tools to edit code'
+        'the workspace with tools to edit and test code'
       )
       ->withWorkspaceOutput('completed', 'the workspace with the completed assignment');
 
@@ -23,7 +23,7 @@
 
     // Get the output from the agent
     $completed = $work->env()->output('completed')->asWorkspace();
-    $completedDirectory = $completed->getSource()->withoutDirectory('node_modules');
+    $completedDirectory = $completed->source()->withoutDirectory('node_modules');
 
     // Make sure the tests really pass
     $this->test($completedDirectory);

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/python/agent.py.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/python/agent.py.snippet
@@ -7,14 +7,14 @@ async def develop(
     """A coding agent for developing new features."""
     # Environment with agent inputs and outputs
     environment = (
-        dag.env(privileged=True)
+        dag.env()
         .with_string_input(
             "assignment", assignment, "the assignment to complete"
         )
         .with_workspace_input(
             "workspace",
             dag.workspace(source),
-            "the workspace with tools to edit code",
+            "the workspace with tools to edit and test code",
         )
         .with_workspace_output(
             "completed", "the workspace with the completed assignment"
@@ -29,7 +29,7 @@ async def develop(
 
     # Get the output from the agent
     completed = work.env().output("completed").as_workspace()
-    completed_directory = completed.get_source().without_directory("node_modules")
+    completed_directory = completed.source().without_directory("node_modules")
 
     # Make sure the tests really pass
     await self.test(completed_directory)

--- a/docs/current_docs/quickstart/agent/snippets/part2/agent/typescript/agent.ts.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part2/agent/typescript/agent.ts.snippet
@@ -11,12 +11,12 @@ async develop(
 ): Promise<Directory> {
     // Environment with agent inputs and outputs
     const environment = dag
-        .env({ privileged: true })
+        .env()
         .withStringInput('assignment', assignment, 'the assignment to complete')
         .withWorkspaceInput(
         'workspace',
         dag.workspace(source),
-        'the workspace with tools to edit code'
+        'the workspace with tools to edit and test code'
         )
         .withWorkspaceOutput('completed', 'the workspace with the completed assignment')
 
@@ -28,7 +28,7 @@ async develop(
 
     // Get the output from the agent
     const completed = work.env().output('completed').asWorkspace()
-    const completedDirectory = completed.getSource().withoutDirectory('node_modules')
+    const completedDirectory = completed.source().withoutDirectory('node_modules')
 
     // Make sure the tests really pass
     await this.test(completedDirectory)

--- a/docs/current_docs/quickstart/agent/snippets/part2/workspace/go/main.go
+++ b/docs/current_docs/quickstart/agent/snippets/part2/workspace/go/main.go
@@ -5,8 +5,6 @@ package main
 import (
 	"context"
 	"dagger/workspace/internal/dagger"
-
-	"dagger.io/dagger/dag"
 )
 
 type Workspace struct {

--- a/docs/current_docs/quickstart/agent/snippets/part2/workspace/php/src/Workspace.php
+++ b/docs/current_docs/quickstart/agent/snippets/part2/workspace/php/src/Workspace.php
@@ -52,9 +52,19 @@ class Workspace
   }
 
   #[DaggerFunction]
-  #[Doc('Get the source code directory from the Workspace')]
-  public function getSource(): Directory
-  {
-    return $this->source;
+  #[Doc('Return the result of running unit tests')]
+  public function test(): string {
+      $nodeCache = dag()
+          ->cacheVolume('node');
+          return dag()
+              ->container()
+              ->from('node:21-slim')
+              ->withDirectory('/src', $this->source)
+              ->withMountedCache('/root/.npm', $nodeCache)
+              ->withWorkdir('/src')
+              ->withExec(['npm', 'install'])
+          ->withExec(['npm', 'run', 'test:unit', 'run'])
+          ->stdout();
   }
+
 }

--- a/docs/current_docs/quickstart/agent/snippets/part2/workspace/php/src/Workspace.php
+++ b/docs/current_docs/quickstart/agent/snippets/part2/workspace/php/src/Workspace.php
@@ -52,19 +52,25 @@ class Workspace
   }
 
   #[DaggerFunction]
-  #[Doc('Return the result of running unit tests')]
-  public function test(): string {
-      $nodeCache = dag()
-          ->cacheVolume('node');
-          return dag()
-              ->container()
-              ->from('node:21-slim')
-              ->withDirectory('/src', $this->source)
-              ->withMountedCache('/root/.npm', $nodeCache)
-              ->withWorkdir('/src')
-              ->withExec(['npm', 'install'])
-          ->withExec(['npm', 'run', 'test:unit', 'run'])
-          ->stdout();
+  #[Doc('Get the source code directory from the Workspace')]
+  public function getSource(): Directory
+  {
+    return $this->source;
   }
 
+  #[DaggerFunction]
+  #[Doc('Return the result of running unit tests')]
+  public function test(): string
+  {
+    $nodeCache = dag()->cacheVolume('node');
+    return dag()
+      ->container()
+      ->from('node:21-slim')
+      ->withDirectory('/src', $this->source)
+      ->withMountedCache('/root/.npm', $nodeCache)
+      ->withWorkdir('/src')
+      ->withExec(['npm', 'install'])
+      ->withExec(['npm', 'run', 'test:unit', 'run'])
+      ->stdout();
+  }
 }

--- a/docs/current_docs/quickstart/agent/snippets/part3/agent/python/agent.py.snippet
+++ b/docs/current_docs/quickstart/agent/snippets/part3/agent/python/agent.py.snippet
@@ -2,7 +2,7 @@
 async def develop_issue(
     self,
     github_token: Annotated[
-        Secret, Doc("Github Token with permissions to write issues and contents")
+        dagger.Secret, Doc("Github Token with permissions to write issues and contents")
     ],
     issue_id: Annotated[int, Doc("Github issue number")],
     repository: Annotated[str, Doc("Github repository url")],

--- a/docs/current_docs/quickstart/ci/index.mdx
+++ b/docs/current_docs/quickstart/ci/index.mdx
@@ -122,9 +122,6 @@ dagger functions
 
 You should see information about two auto-generated Dagger Functions: `container-echo` and `grep-dir`.
 
-:::important
-By default, the Dagger module name is automatically generated from the name of the directory in which `dagger init` runs. In this case, the default name of the cloned application directory is `hello-dagger`, so the module name is `HelloDagger`. If you cloned the application into a different directory, add the `--name=hello-dagger` flag to `dagger init` to correctly set the Dagger module name.
-:::
 
 ## Construct a pipeline
 

--- a/docs/current_docs/quickstart/ci/snippets/python/__init__.py
+++ b/docs/current_docs/quickstart/ci/snippets/python/__init__.py
@@ -2,7 +2,7 @@ import random
 from typing import Annotated
 
 import dagger
-from dagger import DefaultPath, dag, function, object_type
+from dagger import DefaultPath, dag, Doc, function, object_type
 
 
 @object_type
@@ -10,7 +10,7 @@ class HelloDagger:
     @function
     async def publish(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/")],
+        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
     ) -> str:
         """Publish the application container after building and testing it on-the-fly"""
         await self.test(source)
@@ -21,7 +21,7 @@ class HelloDagger:
     @function
     def build(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/")],
+        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
     ) -> dagger.Container:
         """Build the application container"""
         build = (
@@ -39,7 +39,7 @@ class HelloDagger:
     @function
     async def test(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/")],
+        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
     ) -> str:
         """Return the result of running unit tests"""
         return await (
@@ -51,7 +51,7 @@ class HelloDagger:
     @function
     def build_env(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/")],
+        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
     ) -> dagger.Container:
         """Build a ready-to-use development environment"""
         node_cache = dag.cache_volume("node")

--- a/docs/current_docs/quickstart/ci/snippets/python/__init__.py
+++ b/docs/current_docs/quickstart/ci/snippets/python/__init__.py
@@ -2,7 +2,7 @@ import random
 from typing import Annotated
 
 import dagger
-from dagger import DefaultPath, dag, Doc, function, object_type
+from dagger import DefaultPath, Doc, dag, function, object_type
 
 
 @object_type
@@ -10,7 +10,9 @@ class HelloDagger:
     @function
     async def publish(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
+        source: Annotated[
+            dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")
+        ],
     ) -> str:
         """Publish the application container after building and testing it on-the-fly"""
         await self.test(source)
@@ -21,7 +23,9 @@ class HelloDagger:
     @function
     def build(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
+        source: Annotated[
+            dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")
+        ],
     ) -> dagger.Container:
         """Build the application container"""
         build = (
@@ -39,7 +43,9 @@ class HelloDagger:
     @function
     async def test(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
+        source: Annotated[
+            dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")
+        ],
     ) -> str:
         """Return the result of running unit tests"""
         return await (
@@ -51,7 +57,9 @@ class HelloDagger:
     @function
     def build_env(
         self,
-        source: Annotated[dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")],
+        source: Annotated[
+            dagger.Directory, DefaultPath("/"), Doc("hello-dagger source directory")
+        ],
     ) -> dagger.Container:
         """Build a ready-to-use development environment"""
         node_cache = dag.cache_volume("node")


### PR DESCRIPTION
here's the change i'll be pushing to the 'agents in an existing project' guide today https://github.com/kpenfound/hello-dagger-py/pull/3
context:
- we will not have self-calling shipped before the workshop and hack night next week
- agent reliability with privileged env is not great,
- copying the existing test function into the workspace and removing the privileged env greatly increases reliability even though it is not a very clean solution (the agent is no longer using "the same tools" that devs use)