### PR TITLE
ci: Migrate the remaining jobs to an alternative CI runner

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -334,13 +334,12 @@ func (dev *DaggerDev) Scan(ctx context.Context) error {
 	}
 
 	ctr := dag.Container().
-		From("aquasec/trivy:0.56.1@sha256:c42bb3221509b0a9fa2291cd79a3a818b30a172ab87e9aac8a43997a5b56f293").
+		From("aquasec/trivy:0.63.0@sha256:6fb0646988fcd2fdf7bf123f7174945ebc2c9c72d1fa1567c8d7daeeb70f8037").
 		WithMountedDirectory("/mnt/ignores", ignoreFiles).
 		WithMountedCache("/root/.cache/", dag.CacheVolume("trivy-cache")).
 		With(dev.withDockerCfg)
 
 	commonArgs := []string{
-		"--db-repository=public.ecr.aws/aquasecurity/trivy-db",
 		"--format=json",
 		"--exit-code=1",
 		"--severity=CRITICAL,HIGH",
@@ -358,7 +357,7 @@ func (dev *DaggerDev) Scan(ctx context.Context) error {
 			"trivy",
 			"fs",
 			"--scanners=vuln",
-			"--vuln-type=library",
+			"--pkg-types=library",
 		}
 		args = append(args, commonArgs...)
 		args = append(args, "/mnt/src")
@@ -384,7 +383,7 @@ func (dev *DaggerDev) Scan(ctx context.Context) error {
 		args := []string{
 			"trivy",
 			"image",
-			"--vuln-type=os,library",
+			"--pkg-types=os,library",
 		}
 		args = append(args, commonArgs...)
 		engineTarball := "/mnt/engine.tar"

--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
     deploy:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-4c' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: deploy
         steps:
             - name: Checkout

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     docs:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
             - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: docs
         steps:

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -19,7 +19,8 @@ concurrency:
 jobs:
     cli-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-16c-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: cli-test-publish
         steps:
             - name: Checkout
@@ -223,7 +224,8 @@ jobs:
         timeout-minutes: 20
     engine-test-publish:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-16c-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: engine-test-publish
         steps:
             - name: Checkout
@@ -427,7 +429,8 @@ jobs:
         timeout-minutes: 20
     lint:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-16c-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: lint
         steps:
             - name: Checkout
@@ -630,7 +633,8 @@ jobs:
         timeout-minutes: 20
     scan-engine:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-4c' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: scan-engine
         steps:
             - name: Checkout
@@ -833,7 +837,8 @@ jobs:
         timeout-minutes: 20
     scripts:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-4c' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: scripts
         steps:
             - name: Checkout
@@ -2884,7 +2889,7 @@ jobs:
         timeout-minutes: 30
     testdev-llm:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'dagger-g3-v0-18-9-16c-dind-st' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
         name: testdev-LLM
         steps:
             - name: Checkout
@@ -3412,7 +3417,7 @@ jobs:
         timeout-minutes: 30
     testdev-modules:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-16x32' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-32x64' || 'ubuntu-24.04' }}
         name: testdev-modules
         steps:
             - name: Checkout

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     github:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
             - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: Github
         steps:

--- a/.github/workflows/helm.gen.yml
+++ b/.github/workflows/helm.gen.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     helm:
         runs-on:
-            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
             - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: Helm
         steps:

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -20,6 +20,7 @@ jobs:
     dotnet-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: dotnet-dev
         steps:
             - name: Checkout
@@ -265,6 +266,7 @@ jobs:
     elixir-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: elixir-dev
         steps:
             - name: Checkout
@@ -510,6 +512,7 @@ jobs:
     go-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: go-dev
         steps:
             - name: Checkout
@@ -755,6 +758,7 @@ jobs:
     java-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: java-dev
         steps:
             - name: Checkout
@@ -1000,6 +1004,7 @@ jobs:
     php-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: php-dev
         steps:
             - name: Checkout
@@ -1245,6 +1250,7 @@ jobs:
     python-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: python-dev
         steps:
             - name: Checkout
@@ -1490,6 +1496,7 @@ jobs:
     rust-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: rust-dev
         steps:
             - name: Checkout
@@ -1735,6 +1742,7 @@ jobs:
     typescript-dev:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
+            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.18.9' || 'ubuntu-24.04' }}
         name: typescript-dev
         steps:
             - name: Checkout


### PR DESCRIPTION
We have been hitting networking issues in AWS, this should address them and also speed things up. Let's check this before merging.

Also, use the platform cache across the SDK jobs since it seems to speed **each** job up by a good few minutes.

---
Note: wait for these results before merging (approve is fine).