### PR TITLE
fix(sdk/elixir): exdoc source_url now pointing to correct link

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20250603-024039.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20250603-024039.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'sdk/elixir: fix ex_doc source URIs  now pointing to correct link'
+time: 2025-06-03T02:40:39.359634045+02:00
+custom:
+    Author: Nero-F
+    PR: "10524"

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -58,8 +58,7 @@ defmodule Dagger.MixProject do
 
   defp docs do
     [
-      source_ref: "v#{@version}",
-      source_url: @source_url,
+      source_url_pattern: "#{@source_url}/blob/v#{@version}/sdk/elixir/%{path}#L%{line}",
       main: "Dagger"
     ]
   end


### PR DESCRIPTION
ex_doc uses `:source_url` and `:source_ref` for deducing source links but it was not relative to the `sdk/elixir` folder
using `:source_url_pattern` seems to solve this issue #10515 