### PR TITLE
[wip] python: improve error reporting in modules

### DIFF
--- a/sdk/python/.changes/unreleased/Added-20250616-113830.yaml
+++ b/sdk/python/.changes/unreleased/Added-20250616-113830.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |-
+    Improved error handling and reporting in Python modules with clearer error messages and
+      better debugging support
+
+    The root logger is now setup with a handler that will ultimately show as stderr output in visualization (TUI/Cloud), for the "warning" log level and above.
+time: 2025-06-16T11:38:30.074492Z
+custom:
+    Author: helderco
+    PR: "10532"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "rich>=10.11.0",
     "opentelemetry-sdk>=1.23.0",
     "opentelemetry-exporter-otlp-proto-http>=1.23.0",
+    "opentelemetry-instrumentation-logging>=0.54b1",
 ]
 
 [project.urls]

--- a/sdk/python/src/dagger/_exceptions.py
+++ b/sdk/python/src/dagger/_exceptions.py
@@ -82,9 +82,16 @@ class QueryError(ClientError):
         if not errors:
             msg = "Errors list is empty"
             raise ValueError(msg)
-        super().__init__(errors[0])
+        super().__init__(*errors)
         self.errors: list[QueryErrorValue] = errors
         self.query = query
+
+    @property
+    def error(self) -> QueryErrorValue:
+        return self.errors[0]
+
+    def __str__(self) -> str:
+        return str(self.error)
 
     def debug_query(self):
         """Return GraphQL query for debugging purposes.
@@ -151,10 +158,9 @@ class ExecError(QueryError):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        error: QueryErrorValue = self.args[0]
-        ext = error.extensions
+        ext = self.error.extensions
         self.command = ext["cmd"]
-        self.message = error.message
+        self.message = self.error.message
         self.exit_code = ext["exitCode"]
         self.stdout = ext["stdout"]
         self.stderr = ext["stderr"]

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -38,9 +38,7 @@ if typing.TYPE_CHECKING:
 
 
 def make_converter():
-    conv = make_json_converter(
-        detailed_validation=True,
-    )
+    conv = make_json_converter()
 
     conv.register_structure_hook_func(
         is_id_type_subclass,
@@ -66,7 +64,7 @@ def dagger_type_structure(id_: str | Scalar, cls: type[Type]):
     cls = strip_annotations(cls)
 
     if not is_id_type_subclass(cls) and not is_dagger_interface_type(cls):
-        msg = f"Unsupported type '{cls.__name__}'"
+        msg = f'Unsupported type "{cls.__name__}"'
         raise TypeError(msg)
 
     return cls(
@@ -82,7 +80,7 @@ def dagger_interface_structure(id_, cls: type[Interface]):
 def dagger_type_unstructure(obj):
     """Get id from dagger object."""
     if not is_id_type(obj) and not isinstance(obj, Interface):
-        msg = f"Expected dagger Type object, got `{type(obj)}`"
+        msg = f'Expected dagger Type object, got "{type(obj)}"'
         raise TypeError(msg)
     return syncify(obj.id)
 
@@ -94,7 +92,7 @@ def to_interface_impl(proto: type) -> type[Interface]:
     mod = get_module(proto)
 
     if typ is None or not typ.interface or mod is None:
-        msg = f"Unexpected interface type `{proto}`"
+        msg = f'Unexpected interface type "{proto}"'
         raise TypeError(msg)
 
     methods = {
@@ -166,17 +164,18 @@ def make_method(name: str, func: Function, proto: type) -> typing.Callable:  # n
 
 
 @functools.cache
-def to_typedef(annotation: typing.Any) -> "TypeDef":  # noqa: C901, PLR0911
+def to_typedef(annotation: typing.Any, context: str = "type") -> "TypeDef":  # noqa: C901, PLR0911
     """Convert Python object to API type."""
     if is_initvar(annotation):
-        return to_typedef(annotation.type)
+        return to_typedef(annotation.type, context)
 
     if is_annotated(annotation):
-        return to_typedef(strip_annotations(annotation))
+        return to_typedef(strip_annotations(annotation), context)
 
     td = dag.type_def()
 
     typ = TypeHint(annotation)
+    error_msg = f"unsupported {context}: {typ.hint!r}"
 
     if is_nullable(typ):
         td = td.with_optional(True)
@@ -185,8 +184,7 @@ def to_typedef(annotation: typing.Any) -> "TypeDef":  # noqa: C901, PLR0911
 
     # Can't represent unions in the API.
     if is_union(typ):
-        msg = f"Unsupported union type: {typ.hint}"
-        raise TypeError(msg)
+        raise TypeError(error_msg)
 
     builtins = {
         str: dagger.TypeDefKind.STRING_KIND,
@@ -221,5 +219,4 @@ def to_typedef(annotation: typing.Any) -> "TypeDef":  # noqa: C901, PLR0911
         if is_id_type_subclass(cls):
             return td.with_object(name)
 
-    msg = f"Unsupported type: {typ.hint!r}"
-    raise TypeError(msg)
+    raise TypeError(error_msg)

--- a/sdk/python/src/dagger/mod/_exceptions.py
+++ b/sdk/python/src/dagger/mod/_exceptions.py
@@ -1,65 +1,79 @@
-import dataclasses
-from functools import partial
+import json
+import logging
+import traceback
+import typing
 from typing import Any
 
 import cattrs
-from rich.console import Console
-from rich.panel import Panel
+from opentelemetry import trace
+from opentelemetry.semconv.attributes.exception_attributes import (
+    EXCEPTION_MESSAGE,
+    EXCEPTION_STACKTRACE,
+    EXCEPTION_TYPE,
+)
 
-from dagger import DaggerError
+import dagger
+from dagger import DaggerError, dag
 
-_console = Console(stderr=True, style="red")
-
-
-class ExtensionError(DaggerError):
-    """Base class for all errors raised by extensions."""
-
-    def rich_print(self):
-        _console.print(
-            Panel(
-                str(self),
-                border_style="red",
-                title="Error",
-                title_align="left",
-            ),
-            markup=False,
-        )
+logger = logging.getLogger(__package__)
 
 
-class FatalError(ExtensionError):
-    """An unrecoverable error."""
+class ModuleError(DaggerError):
+    """Base class for all errors raised by modules."""
+
+    def __init__(
+        self,
+        msg: str = "",
+        exc: Exception | None = None,
+        extra: dict[str, Any] | None = None,
+        notes: tuple[str, ...] = (),
+    ):
+        if exc is not None and msg == "":
+            msg = f"{type(exc).__name__}: {exc}"
+        super().__init__(msg)
+        self.original = exc
+        self.extra = extra
+        if hasattr(self, "add_note"):
+            for note in notes:
+                self.add_note(note)
+
+    def with_log(self, exc_info=False):
+        msg = "".join(traceback.format_exception_only(self))
+        msg = msg.replace(__name__ + ".", "")
+        logger.error(msg, exc_info=exc_info, stacklevel=2, extra=self.extra)
+        return self
 
 
-class InternalError(FatalError):
-    """An error in Dagger itself."""
+class ModuleLoadError(ModuleError):
+    """Error while loading Python module with functions."""
 
 
-class UserError(FatalError):
-    """An error that could be recovered in user code."""
+class InvalidInputError(ModuleError):
+    """Error while deserializing values into Python objects.
+
+    If it happens it's probably a bug in the SDK because the API should
+    validate early if input is not of expected type.
+    """
 
 
-class NameConflictError(UserError):
-    """An error caused by a name conflict."""
+class InvalidResultError(ModuleError):
+    """Error while serializing Python values into JSON."""
 
 
-class FunctionError(UserError):
+class ObjectNotFoundError(ModuleError):
+    """Parent object not found on registry."""
+
+
+class RegistrationError(ModuleError):
+    """An error caused by an invalid type def registration."""
+
+
+class BadUsageError(ModuleError):
+    """A usage error."""
+
+
+class FunctionError(ModuleError):
     """An error while executing a user function."""
-
-
-@dataclasses.dataclass(slots=True)
-class ConversionError(Exception):
-    """An error while converting data."""
-
-    exc: Exception
-    msg: str = ""
-    origin: Any | None = None
-    typ: type | None = None
-
-    def __str__(self):
-        return transform_error(self.exc, self.msg, self.origin, self.typ)
-
-    def as_user(self, msg: str):
-        return UserError(str(dataclasses.replace(self, msg=msg)))
 
 
 def transform_error(
@@ -68,21 +82,71 @@ def transform_error(
     origin: Any | None = None,
     typ: type | None = None,
 ) -> str:
-    """Transform a cattrs error into a list of error messages."""
-    path = "$"
-
+    """Transform an exception raised by cattrs into an error message."""
+    kwargs = {}
     if origin is not None:
         path = getattr(origin, "__qualname__", "")
         if hasattr(origin, "__module__"):
             path = f"{origin.__module__}.{path}"
 
-    fn = partial(cattrs.transform_error, path=path)
+        if path:
+            kwargs["path"] = path
 
-    if typ is not None:
-        fn = partial(
-            fn,
-            format_exception=lambda e, _: cattrs.v.format_exception(e, typ),
+    if msg:
+        msg += ": "
+
+    # cattrs.transform_error sets expected type as None when not a cattrs exception.
+    if typ is not None and not isinstance(exc, cattrs.BaseValidationError):
+        msg += cattrs.v.format_exception(exc, typ)
+        if path := kwargs.get("path"):
+            msg = f"{msg} @ {path}"
+    else:
+        msg += "; ".join(
+            error.removesuffix(" $").removesuffix(" @")
+            for error in cattrs.transform_error(exc, **kwargs)
         )
 
-    errors = "; ".join(error.removesuffix(" @ $") for error in fn(exc))
-    return f"{msg}: {errors}" if msg else errors
+    return msg
+
+
+async def handle_error(exc: Exception):
+    """Convert a Python exception into a `dagger.Error`."""
+    attributes: dict[str, typing.Any] = _exception_attributes(exc)
+
+    if isinstance(exc, ModuleError):
+        if exc.original:
+            attributes.update(_exception_attributes(exc.original))
+        if exc.extra:
+            attributes.update(exc.extra)
+
+    # API error with extensions added last to make sure they're not overwritten.
+    if isinstance(exc, dagger.QueryError):
+        attributes.update(exc.error.extensions)
+
+    dag_err = dag.error(str(exc))
+    for key, value in attributes.items():
+        dag_err.with_value(key, dagger.JSON(json.dumps(value)))
+
+    await dag.current_function_call().return_error(dag_err)
+
+    # This would be automatic if using a custom span, but we're using the parent
+    # span started by the engine for calling this function so just replicating
+    # sending the event with exception details.
+    span = trace.get_current_span()
+    if span.get_span_context().is_valid:
+        span.record_exception(exc)
+
+
+def _exception_attributes(exc: Exception) -> dict[str, str]:
+    message = str(exc)
+    stacktrace = traceback.format_exc()
+    module = type(exc).__module__
+    qualname = type(exc).__qualname__
+    exc_type = f"{module}.{qualname}" if module and module != "builtins" else qualname
+
+    # Reusing OTel attribute names for consistency.
+    return {
+        EXCEPTION_TYPE: exc_type,
+        EXCEPTION_MESSAGE: message,
+        EXCEPTION_STACKTRACE: stacktrace,
+    }

--- a/sdk/python/src/dagger/mod/_exceptions.py
+++ b/sdk/python/src/dagger/mod/_exceptions.py
@@ -29,7 +29,7 @@ class ModuleError(DaggerError):
         notes: tuple[str, ...] = (),
     ):
         if exc is not None and msg == "":
-            msg = f"{type(exc).__name__}: {exc}"
+            msg = str(exc)
         super().__init__(msg)
         self.original = exc
         self.extra = extra
@@ -109,6 +109,15 @@ def transform_error(
     return msg
 
 
+def _safe_json_dumps(value: typing.Any) -> str:
+    """Safely serialize value to JSON, falling back to repr() if not serializable."""
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        # Fall back to string representation for non-serializable values
+        return json.dumps(repr(value))
+
+
 async def handle_error(exc: Exception):
     """Convert a Python exception into a `dagger.Error`."""
     attributes: dict[str, typing.Any] = _exception_attributes(exc)
@@ -125,7 +134,7 @@ async def handle_error(exc: Exception):
 
     dag_err = dag.error(str(exc))
     for key, value in attributes.items():
-        dag_err.with_value(key, dagger.JSON(json.dumps(value)))
+        dag_err.with_value(key, dagger.JSON(_safe_json_dumps(value)))
 
     await dag.current_function_call().return_error(dag_err)
 

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -9,7 +9,6 @@ import typing
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, TypeVar, cast
 
-import anyio
 import cattrs
 import cattrs.gen
 from cattrs.preconf import is_primitive_enum
@@ -22,11 +21,13 @@ from dagger.client._core import configure_converter_enum
 from dagger.mod._arguments import Parameter
 from dagger.mod._converter import make_converter, to_typedef
 from dagger.mod._exceptions import (
-    ConversionError,
-    FatalError,
+    BadUsageError,
     FunctionError,
-    InternalError,
-    UserError,
+    InvalidInputError,
+    InvalidResultError,
+    ObjectNotFoundError,
+    RegistrationError,
+    transform_error,
 )
 from dagger.mod._resolver import (
     Constructor,
@@ -48,7 +49,7 @@ from dagger.mod._utils import (
     to_pascal_case,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__package__)
 
 OBJECT_DEF_KEY: typing.Final[str] = "__dagger_object__"
 FIELD_DEF_KEY: typing.Final[str] = "__dagger_field__"
@@ -66,6 +67,7 @@ class Module:
         self._objects: dict[str, ObjectType] = {}
         self._enums: dict[str, type[enum.Enum]] = {}
         self._main: ObjectType | None = None
+        self.log_exceptions = True
 
     @property
     def main_cls(self) -> type:
@@ -78,33 +80,46 @@ class Module:
 
     def set_module_name(self, name: str):
         self.name = name
-        self._main = self.get_object(to_pascal_case(name))
-
-    def __call__(self) -> None:
-        anyio.run(self._run)
-
-    async def _run(self):
-        async with await dagger.connect():
-            await self.serve()
+        main_name = to_pascal_case(name)
+        try:
+            self._main = self.get_object(main_name)
+        except ObjectNotFoundError as e:
+            # TODO: have the engine provide the main object's name, rather
+            # than the SDK having to convert it.
+            msg = (
+                f"Main object with name '{main_name}' not found or class not "
+                "decorated with `@dagger.object_type`"
+            )
+            note = (
+                "If you believe the name in dagger.json is incorrectly "
+                "being converted into PascalCase, please file a bug report."
+            )
+            raise ObjectNotFoundError(
+                msg,
+                extra=e.extra,
+                notes=(note,),
+            ).with_log() from None
 
     async def serve(self):
         self.set_module_name(await dag.current_module().name())
 
-        try:
-            if parent_name := await dag.current_function_call().parent_name():
-                result = await self._invoke(parent_name)
-            else:
+        if parent_name := await dag.current_function_call().parent_name():
+            result = await self._invoke(parent_name)
+        else:
+            try:
                 result = await self._register()
-        except FunctionError as e:
-            logger.exception("Error while executing function")
-            await dag.current_function_call().return_error(dag.error(str(e)))
-            raise SystemExit(2) from None
+            except TypeError as e:
+                raise RegistrationError(str(e), e) from e
 
         try:
             output = json.dumps(result)
         except (TypeError, ValueError) as e:
-            msg = f"Failed to serialize result: {e}"
-            raise InternalError(msg) from e
+            # Not expected to happen because unstructuring should reduce
+            # Python complex types to primitive values that are easily
+            # serialized to JSON. If not, it's something that should be caught
+            # earlier.
+            msg = f"Failed to serialize final result as JSON: {e}"
+            raise InvalidResultError(msg, e) from e
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
@@ -147,21 +162,33 @@ class Module:
                 types = typing.get_type_hints(obj_type.cls)
 
                 for field_name, field in obj_type.fields.items():
+                    ctx = f"type for field '{field.original_name}' in {obj_type}"
                     type_def = type_def.with_field(
                         field_name,
-                        to_typedef(types[field.original_name]),
+                        to_typedef(types[field.original_name], ctx),
                         description=get_doc(field.return_type),
                     )
 
             # Object/interface functions
             for func_name, func in obj_type.functions.items():
-                func_def = dag.function(func_name, to_typedef(func.return_type))
+                what = f"function '{func_name}'" if func_name else "constructor"
+
+                func_def = dag.function(
+                    func_name,
+                    to_typedef(
+                        func.return_type,
+                        f"return type for {what} in {obj_type}",
+                    ),
+                )
 
                 if doc := func.doc:
                     func_def = func_def.with_description(doc)
 
                 for param in func.parameters.values():
-                    arg_def = to_typedef(param.resolved_type)
+                    arg_def = to_typedef(
+                        param.resolved_type,
+                        f"parameter type for '{param.name}' in {what} and {obj_type}",
+                    )
 
                     if param.is_nullable:
                         arg_def = arg_def.with_optional(True)
@@ -222,8 +249,8 @@ class Module:
             try:
                 parent_state = json.loads(parent_json) or {}
             except ValueError as e:
-                msg = f"Unable to decode parent value `{parent_json}`: {e}"
-                raise FatalError(msg) from e
+                msg = "Unable to decode the parent object's state"
+                raise InvalidInputError(msg, e) from None
 
         inputs = {}
         for arg in input_args:
@@ -236,8 +263,8 @@ class Module:
                 # for more granular control over the error.
                 inputs[arg_name] = json.loads(arg_value)
             except ValueError as e:
-                msg = f"Unable to decode input argument `{arg_name}`: {e}"
-                raise InternalError(msg) from e
+                msg = f"Unable to decode input argument: {arg_name}"
+                raise InvalidInputError(msg) from e
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
@@ -278,18 +305,18 @@ class Module:
         if name == "":
             fn = obj_type.get_constructor(self._converter)
         else:
-            parent = await self._get_parent_instance(obj_type.cls, parent_state)
+            parent = await self._get_parent_instance(obj_type, parent_state)
 
             # NB: fields are not executed by the SDK, they're returned directly by
             # the engine, but this is still useful for testing.
             if name in obj_type.fields:
                 f = obj_type.fields[name]
                 result = getattr(parent, f.original_name)
-                return result, f.return_type
+                return result, f
 
             fn = obj_type.get_bound_function(parent, name)
 
-        inputs = await self._convert_inputs(fn.parameters, raw_inputs)
+        inputs = await self._convert_inputs(fn, raw_inputs)
         bound = fn.bind_arguments(**inputs)
 
         if logger.isEnabledFor(logging.DEBUG):
@@ -297,16 +324,9 @@ class Module:
             logger.debug("input args => %s", repr(raw_inputs))
             logger.debug("bound args => %s", repr(bound.arguments))
 
-        try:
-            result = await self.call(fn.wrapped, *bound.args, **bound.kwargs)
-        except Exception as e:
-            raise FunctionError(e) from e
+        result = await self.call(fn.wrapped, *bound.args, **bound.kwargs)
 
-        if inspect.iscoroutine(result):
-            msg = "Result is a coroutine. Did you forget to add async/await?"
-            raise UserError(msg)
-
-        return result, fn.return_type
+        return result, fn
 
     async def get_result(
         self,
@@ -315,65 +335,109 @@ class Module:
         name: str,
         raw_inputs: Mapping[str, Any],
     ) -> Any:
-        result, return_type = await self.get_structured_result(
+        """Get function result as an unstructured Python primitive."""
+        result, fn = await self.get_structured_result(
             parent_name,
             parent_state,
             name,
             raw_inputs,
         )
-        if return_type is not None:
-            return await self.unstructure(result, return_type)
+        if fn.return_type is not None:
+            try:
+                return await self.unstructure(result, fn.return_type)
+            except Exception as e:
+                msg = transform_error(
+                    e,
+                    "Invalid result from function",
+                    origin=getattr(fn, "wrapped", None),
+                    typ=fn.return_type,
+                )
+                note = (
+                    "Please check if the returned value matches the function "
+                    "signature at runtime."
+                )
+                raise InvalidResultError(msg, e, notes=(note,)).with_log() from e
         return None
 
     async def call(self, func: Func[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         """Call a function and return its result."""
-        return await await_maybe(func(*args, **kwargs))
-
-    async def structure(self, obj: Any, cl: type[T], origin: Any | None = None) -> T:
-        """Convert a primitive value to the expected type."""
         try:
-            return await asyncify(self._converter.structure, obj, cl)
+            result = await await_maybe(func(*args, **kwargs))
         except Exception as e:
-            raise ConversionError(e, origin=origin) from e
+            if self.log_exceptions:
+                logger.exception("Unhandled exception while executing function")
+            raise FunctionError(exc=e) from e
+
+        if inspect.iscoroutine(result):
+            msg = "Function returned a coroutine. Did you forget to add async/await?"
+            raise BadUsageError(msg)
+
+        return result
+
+    async def structure(self, obj: Any, cl: type[T]) -> T:
+        """Convert a primitive value to the expected type."""
+        return await asyncify(self._converter.structure, obj, cl)
 
     async def unstructure(self, obj: Any, unstructure_as: Any) -> Awaitable[Any]:
         """Convert a result to primitive values."""
-        try:
-            return await asyncify(self._converter.unstructure, obj, unstructure_as)
-        except Exception as e:
-            msg = "Failed to convert result to primitive values"
-            raise ConversionError(e).as_user(msg) from e
+        return await asyncify(self._converter.unstructure, obj, unstructure_as)
 
     def get_object(self, name: str) -> ObjectType:
         """Get the object type definition for the given name."""
         try:
             return self._objects[name]
-        except KeyError as e:
-            msg = f"No `@dagger.object_type` decorated class named {name} was found"
-            raise UserError(msg) from e
+        except KeyError:
+            # Not expected to happen during invoke because registration
+            # would fail earlier.
+            msg = f"No '@dagger.object_type' decorated class named '{name}' was found."
+            raise ObjectNotFoundError(
+                msg,
+                extra={"found": self._objects.keys()},
+            ) from None
 
-    async def _get_parent_instance(self, cls: type[T], state: Mapping[str, Any]) -> T:
+    async def _get_parent_instance(
+        self,
+        obj_type: ObjectType[T],
+        state: Mapping[str, Any],
+    ) -> T:
         """Instantiate the parent object from its state."""
         try:
-            return await self.structure(state, cls)
-        except ConversionError as e:
-            msg = f"Failed to instantiate {cls.__name__}"
-            raise e.as_user(msg) from e
+            return await self.structure(state, obj_type.cls)
+        except Exception as e:
+            msg = transform_error(
+                e,
+                f"Failed to instantiate parent {obj_type}",
+                origin=obj_type.cls,
+                typ=obj_type.cls,
+            )
+            notes = (
+                "This could be an error in the Python SDK.",
+                "If so, please file a bug report.",
+            )
+            extra = {
+                "object_state": state,
+            }
+            raise InvalidInputError(
+                msg,
+                e,
+                extra=extra,
+                notes=notes,
+            ).with_log() from e
 
     async def _convert_inputs(
         self,
-        params: Mapping[PythonName, Parameter],
+        fn: Function,
         inputs: Mapping[APIName, Any],
     ) -> Mapping[PythonName, Any]:
         """Convert arguments from lower level primitives to the expected types."""
         kwargs = {}
 
         # Convert arguments to the expected type.
-        for python_name, param in params.items():
+        for python_name, param in fn.parameters.items():
             if param.name not in inputs:
                 if not param.is_optional:
-                    msg = f"Missing required argument: {python_name}"
-                    raise UserError(msg)
+                    msg = f"Missing required function argument: {python_name}"
+                    raise InvalidInputError(msg)
 
                 if param.has_default:
                     continue
@@ -385,9 +449,32 @@ class Module:
 
             try:
                 kwargs[python_name] = await self.structure(value, type_)
-            except ConversionError as e:
-                msg = f"Invalid argument `{param.name}`"
-                raise e.as_user(msg) from e
+            except Exception as e:
+                msg = transform_error(
+                    e,
+                    f"Failed to convert value for argument '{param.name}'",
+                    origin=fn.wrapped,
+                    typ=type_,
+                )
+                notes = (
+                    (
+                        "This could be an error in the Python SDK because the API "
+                        "can't reasonably hold a value that contradicts its type. "
+                    ),
+                    "If so, please file a bug report.",
+                )
+                extra = {
+                    "function": fn.original_name,
+                    "parameter_name": python_name,
+                    "expected_type": repr(type_),
+                    "value": repr(value),
+                }
+                raise InvalidInputError(
+                    msg,
+                    e,
+                    extra=extra,
+                    notes=notes,
+                ).with_log() from e
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("structured args => %s", repr(kwargs))
@@ -540,11 +627,9 @@ class Module:
         def wrapper(cls: T) -> T:
             if not inspect.isclass(cls):
                 msg = f"Expected a class, got {type(cls)}"
-                raise UserError(msg)
+                raise BadUsageError(msg)
 
             # Check for InitVar inside Annotated
-            # TODO: Maybe try to transform field automatically, but check
-            # with community first on how this is usually handled.
             fields = inspect.get_annotations(cls)
             for name, t in fields.items():
                 if is_annotated(t) and isinstance(t.__origin__, dataclasses.InitVar):
@@ -552,10 +637,10 @@ class Module:
                     # in Annotated[init_t.type, *meta]
                     t.__origin__ = t.__origin__.type
                     msg = (
-                        f"Field `{name}` is an InitVar wrapped in Annotated. "
+                        f"Field '{name}' is an InitVar wrapped in Annotated. "
                         f"The correct syntax is: InitVar[{t}]"
                     )
-                    raise UserError(msg)
+                    raise BadUsageError(msg)
 
             wrapped = dataclasses.dataclass(kw_only=True)(cls)
             return self._process_type(wrapped)
@@ -689,12 +774,12 @@ class Module:
 
         def wrapper(cls: T) -> T:
             if not inspect.isclass(cls):
-                msg = f"Expected an enum, got {type(cls)}"
-                raise UserError(msg)
+                msg = f"Expected an enum.Enum subclass, got {type(cls)}"
+                raise BadUsageError(msg)
 
             if not issubclass(cls, enum.Enum):
-                msg = f"Class {cls.__name__} is not an enum.Enum"
-                raise UserError(msg)
+                msg = f"Class '{cls.__name__}' is not an enum.Enum subclass"
+                raise BadUsageError(msg)
 
             cls = cast(T, enum.unique(cls))
             self._enums.setdefault(cls.__name__, cls)

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -4,7 +4,9 @@ import inspect
 import json
 import logging
 import os
+import sys
 import textwrap
+import traceback
 import typing
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, TypeVar, cast
@@ -25,6 +27,7 @@ from dagger.mod._exceptions import (
     FunctionError,
     InvalidInputError,
     InvalidResultError,
+    ModuleError,
     ObjectNotFoundError,
     RegistrationError,
     transform_error,
@@ -67,6 +70,9 @@ class Module:
         self._objects: dict[str, ObjectType] = {}
         self._enums: dict[str, type[enum.Enum]] = {}
         self._main: ObjectType | None = None
+        # Escape hatch if there's too much noise from showing stack traces
+        # from exceptions raised in functions by default. Not documented
+        # intentionally for now.
         self.log_exceptions = True
 
     @property
@@ -362,17 +368,35 @@ class Module:
     async def call(self, func: Func[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         """Call a function and return its result."""
         try:
-            result = await await_maybe(func(*args, **kwargs))
+            # TODO: check from signature if it's an async function warn user if
+            # returning a corouting from a sync function.
+            return await await_maybe(func(*args, **kwargs))
+        except FunctionError:
+            # Escape hatch to fully control logging from user code.
+            raise
+        except dagger.QueryError as e:
+            # Don't show full stack trace for API errors because it's too noisy.
+            # Just return an error for the exception so it shows which part of
+            # user code triggered it.
+            # Just pass through `dag.error()` so they're properly propagated.
+            tb = e.__traceback__
+            f = None
+            if tb:
+                tb = tb.tb_next
+            traceback.print_exception(
+                type(e),
+                value=e,
+                tb=tb,
+                limit=-2,
+                file=sys.stderr,
+            )
+            raise FunctionError(exc=e).with_log() from None
         except Exception as e:
+            # Escape hatch if too noisy.
             if self.log_exceptions:
+                # Logging the exception will show the full stack trace on stderr.
                 logger.exception("Unhandled exception while executing function")
             raise FunctionError(exc=e) from e
-
-        if inspect.iscoroutine(result):
-            msg = "Function returned a coroutine. Did you forget to add async/await?"
-            raise BadUsageError(msg)
-
-        return result
 
     async def structure(self, obj: Any, cl: type[T]) -> T:
         """Convert a primitive value to the expected type."""

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -18,7 +18,11 @@ from cattrs.preconf.json import JsonConverter, make_converter
 from typing_extensions import Self, TypeVar, override
 
 from dagger.mod._arguments import Parameter
-from dagger.mod._exceptions import FatalError, UserError
+from dagger.mod._exceptions import (
+    BadUsageError,
+    InvalidInputError,
+    RegistrationError,
+)
 from dagger.mod._types import APIName, FieldDefinition, FunctionDefinition, PythonName
 from dagger.mod._utils import (
     get_alt_constructor,
@@ -32,7 +36,7 @@ from dagger.mod._utils import (
     normalize_name,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__package__)
 
 T = TypeVar("T")
 R = TypeVar("R", infer_variance=True)
@@ -103,7 +107,7 @@ class Function(Generic[P, R]):
 
             if param.kind is inspect.Parameter.POSITIONAL_ONLY:
                 msg = "Positional-only parameters are not supported"
-                raise TypeError(msg)
+                raise BadUsageError(msg)
 
             mapping[param.name] = self._make_parameter(param)
 
@@ -116,10 +120,7 @@ class Function(Generic[P, R]):
             # resolved forward references and stripped Annotated.
             annotation = self.type_hints[param.name]
         except KeyError:
-            logger.warning(
-                "Missing type annotation for parameter '%s'",
-                param.name,
-            )
+            logger.warning("Missing type annotation for parameter '%s'", param.name)
             annotation = Any
 
         if isinstance(annotation, dataclasses.InitVar):
@@ -167,8 +168,8 @@ class Function(Generic[P, R]):
             bound = self.signature.bind(*args, **kwargs)
             bound.apply_defaults()
         except TypeError as e:
-            msg = f"Unable to bind arguments: {e}"
-            raise UserError(msg) from e
+            msg = "unable to bind input values to arguments"
+            raise InvalidInputError(msg, e) from e
         return bound
 
 
@@ -239,8 +240,12 @@ class ObjectType(Generic[T]):
         assert self.cls is parent.__class__
         try:
             fn = self.functions[name]
-        except KeyError as e:
-            msg = f"No function '{name}' in object '{self.cls.__name__}'"
-            raise FatalError(msg) from e
+        except KeyError:
+            msg = f"No function '{name}' in {self}"
+            raise RegistrationError(msg) from None
 
         return fn.bind_parent(parent)
+
+    def __str__(self):
+        s = "interface" if self.interface else "object"
+        return f"{s} '{self.cls.__module__}.{self.cls.__name__}'"

--- a/sdk/python/src/dagger/mod/cli.py
+++ b/sdk/python/src/dagger/mod/cli.py
@@ -5,16 +5,16 @@ import importlib.metadata
 import importlib.util
 import logging
 import os
-import sys
 import typing
 
-import rich.traceback
-from rich.console import Console
+import anyio
 
+import dagger
 from dagger import telemetry
-from dagger.log import configure_logging
-from dagger.mod._exceptions import FatalError, UserError
+from dagger.mod._exceptions import ModuleError, ModuleLoadError, handle_error
 from dagger.mod._module import Module
+
+logger = logging.getLogger(__package__)
 
 ENTRY_POINT_NAME: typing.Final[str] = "main_object"
 ENTRY_POINT_GROUP: typing.Final[str] = typing.cast(str, __package__)
@@ -22,55 +22,52 @@ ENTRY_POINT_GROUP: typing.Final[str] = typing.cast(str, __package__)
 IMPORT_PKG = os.getenv("DAGGER_DEFAULT_PYTHON_PACKAGE", "main")
 MAIN_OBJECT = os.getenv("DAGGER_MAIN_OBJECT", "Main")
 
-errors = Console(stderr=True, style="red")
-logger = logging.getLogger(__name__)
-
 
 def app():
     """Entrypoint for a Python Dagger module."""
     telemetry.initialize()
-
-    # TODO: Create custom exception hook to control exit code.
-    rich.traceback.install(
-        console=errors,
-        show_locals=logger.isEnabledFor(logging.DEBUG),
-        suppress=[
-            "asyncio",
-            "anyio",
-        ],
-    )
     try:
-        load_module()()
-    except FatalError as e:
-        logger.exception("Fatal error")
-        e.rich_print()
-        sys.exit(1)
+        return anyio.run(main)
     finally:
         telemetry.shutdown()
 
 
+async def main(mod: Module | None = None) -> int | None:
+    """Async entrypoint for a Dagger module."""
+    # Establishing connection early on to allow returning dag.error().
+    async with await dagger.connect():
+        try:
+            if mod is None:
+                mod = load_module()
+            return await mod.serve()
+        except ModuleError as e:
+            await handle_error(e)
+            return 2
+        except Exception as e:
+            logger.exception("Unhandled exception")
+            await handle_error(e)
+            return 1
+
+
 def load_module() -> Module:
     """Load the dagger.Module instance via the main object entry point."""
+    ep = get_entry_point()
     try:
-        cls: type = get_entry_point().load()
-    except (ModuleNotFoundError, AttributeError) as e:
-        # If the main module isn't found the user won't be able to set debug level.
-        # TODO: Allow setting debug level with a pyproject.toml setting.
-        if not logger.isEnabledFor(logging.DEBUG):
-            configure_logging(logging.DEBUG)
-        msg = (
-            "Main object not found. You can configure it explicitly by adding "
-            "an entry point to your pyproject.toml file. For example:\n"
-            "\n"
-            f'[project.entry-points."{ENTRY_POINT_GROUP}"]\n'
-            f"{ENTRY_POINT_NAME} = '{IMPORT_PKG}:{MAIN_OBJECT}'\n"
+        cls = ep.load()
+    except Exception as e:
+        logger.exception(
+            "Error while loading Python module with Dagger functions: %s",
+            ep.module,
         )
-        raise UserError(msg) from e
+        raise ModuleLoadError(exc=e) from e
     try:
         return cls.__dagger_module__
-    except AttributeError as e:
-        msg = "The main object must be a class decorated with @dagger.object_type"
-        raise UserError(msg) from e
+    except AttributeError:
+        msg = (
+            "The main object must be a class decorated with @dagger.object_type, "
+            f"found {type(cls)}"
+        )
+        raise ModuleLoadError(msg) from None
 
 
 def get_entry_point() -> importlib.metadata.EntryPoint:
@@ -87,6 +84,16 @@ def get_entry_point() -> importlib.metadata.EntryPoint:
     # Fallback for modules that still use the "main" package name.
     if not importlib.util.find_spec(import_pkg):
         import_pkg = "main"
+
+        if not importlib.util.find_spec(import_pkg):
+            msg = (
+                "Main object not found. You can configure it explicitly by adding "
+                "an entry point to your pyproject.toml file. For example:\n"
+                "\n"
+                f'[project.entry-points."{ENTRY_POINT_GROUP}"]\n'
+                f"{ENTRY_POINT_NAME} = '{IMPORT_PKG}:{MAIN_OBJECT}'\n"
+            )
+            raise ModuleLoadError(msg)
 
     return importlib.metadata.EntryPoint(
         group=ENTRY_POINT_GROUP,

--- a/sdk/python/src/dagger/telemetry.py
+++ b/sdk/python/src/dagger/telemetry.py
@@ -4,12 +4,21 @@ from collections.abc import Callable
 from typing import Final, Literal
 
 from opentelemetry import context, propagate, trace
+from opentelemetry._logs import get_logger_provider
 from opentelemetry.environment_variables import (
+    _OTEL_PYTHON_LOGGER_PROVIDER,
     OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,
     OTEL_PYTHON_TRACER_PROVIDER,
     OTEL_TRACES_EXPORTER,
 )
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from opentelemetry.instrumentation.logging.environment_variables import (
+    OTEL_PYTHON_LOG_CORRELATION,
+    OTEL_PYTHON_LOG_FORMAT,
+    OTEL_PYTHON_LOG_LEVEL,
+)
+from opentelemetry.sdk import _logs as sdklogs
 from opentelemetry.sdk import trace as sdktrace
 from opentelemetry.sdk._configuration import _BaseConfigurator as _BaseSDKConfigurator
 from opentelemetry.sdk._configuration import (
@@ -47,10 +56,13 @@ SERVICE_NAME: Final = "dagger-python-sdk"
 logger = logging.getLogger(__name__)
 
 
-def initialize():
-    """Configure telemetry."""
+def initialize(*, debug: bool = False):
+    """Configure telemetry.
+
+    If debug is True, enables console exporters.
+    """
     _DaggerPropagationConfigurator().configure()
-    _DaggerOtelConfigurator().configure()
+    _DaggerOtelConfigurator().configure(debug=debug)
 
 
 def get_tracer() -> trace.Tracer:
@@ -64,13 +76,21 @@ def get_tracer() -> trace.Tracer:
 
 def shutdown():
     """Process all spans that have not yet been processed."""
-    provider = get_tracer_provider()
+    # TODO: set a timeout
 
-    if isinstance(provider, sdktrace.TracerProvider):
-        provider.force_flush()
-        # shutdown is called automatically on exit, we just need the forced
-        # flush, but might as well shutdown now too
-        provider.shutdown()
+    tracer_provider = get_tracer_provider()
+    logger_provider = get_logger_provider()
+
+    # Provider shutdown is called automatically on exit, we just need the forced
+    # flush but might as well shutdown now too.
+
+    if isinstance(tracer_provider, sdktrace.TracerProvider):
+        tracer_provider.force_flush()
+        tracer_provider.shutdown()
+
+    if isinstance(logger_provider, sdklogs.LoggerProvider):
+        logger_provider.force_flush()
+        logger_provider.shutdown()
 
 
 def otel_configured() -> bool:
@@ -142,6 +162,8 @@ def _init_tracing(exporters: dict[str, type[SpanExporter]]):
 
 
 class _DaggerOtelConfigurator(_BaseConfigurator):
+    exporters = ("otlp",)
+
     # NB: This is based on opentelemetry.sdk._configuration._OtelSDKConfigurator
     # which is experimental. Instead of importing just the configurator, we're
     # importing several private functions because we need more control over
@@ -157,6 +179,9 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
             logger.debug("Telemetry disabled")
             return
 
+        if kwargs.get("debug"):
+            self.exporters += ("console",)
+
         logger.debug("Initializing telemetry")
         self._prepare_env()
         self._initialize()
@@ -170,15 +195,24 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
 
         # The default is a NoOpProvider.
         os.environ.setdefault(OTEL_PYTHON_TRACER_PROVIDER, "sdk_tracer_provider")
+        os.environ.setdefault(_OTEL_PYTHON_LOGGER_PROVIDER, "sdk_logger_provider")
 
-        # TODO: The following env vars should be set by the shim rather than in the SDK.
+        # Logging instrumentation.
+        os.environ.setdefault(OTEL_PYTHON_LOG_CORRELATION, "true")
+        os.environ.setdefault(OTEL_PYTHON_LOG_LEVEL, "warning")
+        os.environ.setdefault(
+            OTEL_PYTHON_LOG_FORMAT,
+            "%(levelname)s [%(name)s]: %(message)s",
+        )
 
-        for exporter in (
+        # TODO: The rest of the env vars should be set by the shim rather than in the SDK.
+
+        for name in (
             OTEL_TRACES_EXPORTER,
             OTEL_LOGS_EXPORTER,
             OTEL_METRICS_EXPORTER,
         ):
-            os.environ.setdefault(exporter, "otlp")
+            os.environ.setdefault(name, ",".join(self.exporters))
 
         _vars = {
             OTEL_EXPORTER_OTLP_ENDPOINT: OTEL_EXPORTER_OTLP_INSECURE,
@@ -211,3 +245,6 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
             )
 
             init(exporters)
+
+        # The logging instrumentor injects the trace context into logs
+        LoggingInstrumentor().instrument()

--- a/sdk/python/tests/mod/test_interfaces.py
+++ b/sdk/python/tests/mod/test_interfaces.py
@@ -65,8 +65,8 @@ def test_registered_functions(mod: Module):
 async def test_generated_implementation(duck):
     r, t = duck
 
-    assert t.__name__ == "Duck"
-    assert is_dagger_interface_type(t)
+    assert t.return_type.__name__ == "Duck"
+    assert is_dagger_interface_type(t.return_type)
 
     assert type(r).__name__ == "PondDuck"
     assert is_dagger_object_type(type(r))

--- a/sdk/python/tests/mod/test_results.py
+++ b/sdk/python/tests/mod/test_results.py
@@ -9,7 +9,7 @@ import typing_extensions
 import dagger
 from dagger import Doc, Name, dag
 from dagger.mod import Module
-from dagger.mod._exceptions import FatalError
+from dagger.mod._exceptions import RegistrationError
 
 pytestmark = [
     pytest.mark.anyio,
@@ -382,7 +382,7 @@ async def test_constructor_with_init_var():
     assert await mod.get_result("Foo", {}, "", {"foo": "rab", "bar": "oof"}) == {
         "foo": "raboof",
     }
-    with pytest.raises(FatalError):
+    with pytest.raises(RegistrationError):
         await mod.get_result("Foo", {}, "bar", {})
 
 

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -301,6 +301,7 @@ dependencies = [
     { name = "cattrs" },
     { name = "gql", extra = ["httpx"] },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
     { name = "platformdirs" },
     { name = "rich" },
@@ -329,6 +330,7 @@ requires-dist = [
     { name = "cattrs", specifier = ">=25.1.0" },
     { name = "gql", extras = ["httpx"], specifier = ">=3.5.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.23.0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.54b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.23.0" },
     { name = "platformdirs", specifier = ">=2.6.2" },
     { name = "rich", specifier = ">=10.11.0" },
@@ -363,7 +365,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -863,6 +865,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", size = 15351, upload-time = "2025-06-10T08:55:24.657Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/54/b05251c04e30c1ac70cf4a7c5653c085dfcf2c8b98af71661d6a252adc39/opentelemetry_exporter_otlp_proto_http-1.34.1-py3-none-any.whl", hash = "sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8", size = 17744, upload-time = "2025-06-10T08:55:03.802Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fd/5756aea3fdc5651b572d8aef7d94d22a0a36e49c8b12fcb78cb905ba8896/opentelemetry_instrumentation-0.54b1.tar.gz", hash = "sha256:7658bf2ff914b02f246ec14779b66671508125c0e4227361e56b5ebf6cef0aec", size = 28436, upload-time = "2025-05-16T19:03:22.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/89/0790abc5d9c4fc74bd3e03cb87afe2c820b1d1a112a723c1163ef32453ee/opentelemetry_instrumentation-0.54b1-py3-none-any.whl", hash = "sha256:a4ae45f4a90c78d7006c51524f57cd5aa1231aef031eae905ee34d5423f5b198", size = 31019, upload-time = "2025-05-16T19:02:15.611Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/5b/88ed39f22e8c6eb4f6192ab9a62adaa115579fcbcadb3f0241ee645eea56/opentelemetry_instrumentation_logging-0.54b1.tar.gz", hash = "sha256:893a3cbfda893b64ff71b81991894e2fd6a9267ba85bb6c251f51c0419fbe8fa", size = 9976, upload-time = "2025-05-16T19:03:49.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/0c/b441fb30d860f25040eaed61e89d68f4d9ee31873159ed18cbc1b92eba56/opentelemetry_instrumentation_logging-0.54b1-py3-none-any.whl", hash = "sha256:01a4cec54348f13941707d857b850b0febf9d49f45d0fcf0673866e079d7357b", size = 12579, upload-time = "2025-05-16T19:02:49.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow up to:
- https://github.com/dagger/dagger/pull/9628 (added additional values to an API error)
- https://github.com/dagger/dagger/pull/10512 (fixes values not getting unmarshalled in the engine)

Rebased on top of https://github.com/dagger/dagger/pull/10512 for the fix.

Main objective for this was to make sure error extensions are propagated properly (easy), but I'm taking a fresh look at how exceptions are reported, including their stack traces. What's blocking me is that I spent too much time trying to get OTel logging to work. Everything seems to be set up correctly but not showing on TUI/Cloud.

I'll just print stack traces to stderr for now, but need to jump to other things before I have more time to refactor the error handling here. Should probably wait after https://github.com/dagger/dagger/pull/10512 anyway since it changes a few things and I should test against those changes.