### PR TITLE
docs: don't mention deprecated exclude field in dagger.json

### DIFF
--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -174,7 +174,7 @@ Poetry manages the project environment in a central location instead of `.venv`.
 </Tabs>
 
 :::tip
-If you place the virtual environment (`.venv`) inside the module, don't forget to add it to `.gitignore` and to `"exclude"` in `dagger.json` to avoid uploading those files to the runtime container unnecessarily.
+If you place the virtual environment (`.venv`) inside the module, don't forget to add it to `.gitignore` and to `"include": ["!.venv"]` in `dagger.json` to avoid uploading those files to the runtime container unnecessarily.
 :::
 
 <Tabs>

--- a/docs/current_docs/configuration/modules.mdx
+++ b/docs/current_docs/configuration/modules.mdx
@@ -13,16 +13,12 @@ For more information, refer to the [JSON schema for the Dagger module configurat
 
 ## File and directory filters
 
-The JSON schema for the Dagger module configuration file `dagger.json` supports `exclude` and `include` fields. These tell the Dagger Engine which files to exclude or include when loading the module itself.
-
-:::important
-Include filters are applied before excludes.
-:::
+The JSON schema for the Dagger module configuration file `dagger.json` supports an `include` field. It tells the Dagger Engine of additional files to include or exclude when loading the module itself. By default, only `dagger.json` and all files under the module's source directory are included.
 
 Notably, these filters only apply to loading the Dagger module. They do not apply to any directories passed as arguments to the Dagger module's functions ([pre- and post-call filtering](../api/fs-filters.mdx) is separately available for directory arguments).
 
 :::tip
-The `exclude` field is particularly useful during local module development, to avoid uploading large cache or generated files that the Dagger Engine doesn't need.
+Adding excluding patterns prefixed with `!` is particularly useful during local module development, to avoid uploading large cache or generated files that the Dagger Engine doesn't need.
 :::
 
 ## TypeScript


### PR DESCRIPTION
Related to:
- https://github.com/dagger/dagger/issues/10531

The `"exclude"` field in `dagger.json` is deprecated in favor of prefixing patterns with `!` under `"include"`.

👀 [Preview](https://deploy-preview-10533--devel-docs-dagger-io.netlify.app/configuration/modules#file-and-directory-filters)