### PR TITLE
feat(sdk/elixir): enum support

### DIFF
--- a/sdk/elixir/lib/dagger/mod/decoder.ex
+++ b/sdk/elixir/lib/dagger/mod/decoder.ex
@@ -50,10 +50,19 @@ defmodule Dagger.Mod.Decoder do
   defp cast(value, module, dag) when (is_map(value) or is_binary(value)) and is_atom(module) do
     Code.ensure_loaded!(module)
 
-    if function_exported?(module, :__struct__, 0) do
-      Nestru.decode(value, module, dag)
-    else
-      {:ok, value}
+    case module.__kind__() do
+      :object ->
+        Nestru.decode(value, module, dag)
+
+      :enum ->
+        if function_exported?(module, :__enum__, 2) do
+          {:ok, module.__enum__(:key, value)}
+        else
+          {:ok, value}
+        end
+
+      :scalar ->
+        {:ok, value}
     end
   end
 

--- a/sdk/elixir/lib/dagger/mod/enum.ex
+++ b/sdk/elixir/lib/dagger/mod/enum.ex
@@ -1,0 +1,64 @@
+defmodule Dagger.Mod.Enum do
+  @moduledoc """
+  Declare a module as an enum type.
+  """
+
+  defmacro __using__(opts) do
+    values = opts[:values]
+    name = opts[:name]
+
+    if is_nil(values) do
+      raise "The option `:values` need to be set."
+    end
+
+    functions = Enum.map(values, &defenum/1)
+
+    quote do
+      use Dagger.Core.Base, kind: :enum, name: unquote(name)
+
+      def __enum__(:keys), do: unquote(values)
+
+      unquote(functions)
+    end
+  end
+
+  defp defenum(key) when is_atom(key) do
+    value = Atom.to_string(key)
+
+    quote do
+      def __enum__(:value, unquote(key)), do: unquote(value)
+      def __enum__(:key, unquote(value)), do: unquote(key)
+      def __enum__(:doc, unquote(key)), do: nil
+    end
+  end
+
+  defp defenum({key, options}) when is_atom(key) and is_list(options) do
+    value = Atom.to_string(key)
+    doc = options[:doc]
+
+    quote do
+      def __enum__(:value, unquote(key)), do: unquote(value)
+      def __enum__(:key, unquote(value)), do: unquote(key)
+      def __enum__(:doc, unquote(key)), do: unquote(doc)
+    end
+  end
+
+  defp defenum({key, value}) when is_atom(key) and is_binary(value) do
+    quote do
+      def __enum__(:value, unquote(key)), do: unquote(value)
+      def __enum__(:key, unquote(value)), do: unquote(key)
+      def __enum__(:doc, unquote(key)), do: nil
+    end
+  end
+
+  defp defenum({key, {value, options}})
+       when is_atom(key) and is_binary(value) and is_list(options) do
+    doc = options[:doc]
+
+    quote do
+      def __enum__(:value, unquote(key)), do: unquote(value)
+      def __enum__(:key, unquote(value)), do: unquote(key)
+      def __enum__(:doc, unquote(key)), do: unquote(doc)
+    end
+  end
+end

--- a/sdk/elixir/test/dagger/mod/decoder_test.exs
+++ b/sdk/elixir/test/dagger/mod/decoder_test.exs
@@ -45,6 +45,10 @@ defmodule Dagger.Mod.DecoderTest do
     test "decode error", %{dag: dag} do
       assert {:error, _} = Decoder.decode(json(1), :string, dag)
     end
+
+    test "decode enum", %{dag: dag} do
+      assert {:ok, :unknown} = Decoder.decode(json("unknown"), SimpleEnum, dag)
+    end
   end
 
   defp json(value), do: Jason.encode!(value)

--- a/sdk/elixir/test/dagger/mod/enum_test.exs
+++ b/sdk/elixir/test/dagger/mod/enum_test.exs
@@ -1,0 +1,25 @@
+defmodule Dagger.Mod.EnumTest do
+  use ExUnit.Case, async: true
+
+  test "get possible values" do
+    assert SimpleEnum.__enum__(:keys) == [:unknown, :low, :high]
+  end
+
+  test "get value of the enum" do
+    assert_enum = fn module ->
+      assert Enum.map([:unknown, :low, :high], &module.__enum__(:value, &1)) == [
+               "unknown",
+               "low",
+               "high"
+             ]
+    end
+
+    assert_enum.(SimpleEnum)
+    assert_enum.(EnumWithOption)
+  end
+
+  test "alias key with value" do
+    assert EnumAliasValue.__enum__(:value, :UNKNOWN) == "unknown"
+    assert EnumAliasValue.__enum__(:value, :LOW) == "low"
+  end
+end

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -279,6 +279,35 @@ defmodule Dagger.Mod.ModuleTest do
                |> Dagger.TypeDef.as_enum()
                |> Dagger.EnumTypeDef.name()
     end
+
+    test "accept and return custom enum", %{dag: dag} do
+      assert {:ok, [simple, enum_opt]} =
+               root_object(dag, CustomEnum) |> Dagger.ObjectTypeDef.functions()
+
+      assert {:ok, [arg]} = Dagger.Function.args(simple)
+      arg_type_def = Dagger.FunctionArg.type_def(arg)
+      assert {:ok, :ENUM_KIND} = Dagger.TypeDef.kind(arg_type_def)
+
+      assert {:ok, "SimpleEnum"} =
+               arg_type_def
+               |> Dagger.TypeDef.as_enum()
+               |> Dagger.EnumTypeDef.name()
+
+      return_type_def = Dagger.Function.return_type(simple)
+      assert {:ok, :ENUM_KIND} = Dagger.TypeDef.kind(return_type_def)
+
+      assert {:ok, "SimpleEnum"} =
+               return_type_def
+               |> Dagger.TypeDef.as_enum()
+               |> Dagger.EnumTypeDef.name()
+
+      assert {:ok, [arg]} = Dagger.Function.args(enum_opt)
+      enum_type_def = arg |> Dagger.FunctionArg.type_def() |> Dagger.TypeDef.as_enum()
+      [low, high, unknown] = Dagger.EnumTypeDef.values(enum_type_def)
+      assert {:ok, "low"} = Dagger.EnumValueTypeDef.name(low)
+      assert {:ok, "high"} = Dagger.EnumValueTypeDef.name(high)
+      assert {:ok, "unknown"} = Dagger.EnumValueTypeDef.name(unknown)
+    end
   end
 
   defp root_object(dag, module) do

--- a/sdk/elixir/test/support/enum_mod.ex
+++ b/sdk/elixir/test/support/enum_mod.ex
@@ -1,0 +1,18 @@
+defmodule SimpleEnum do
+  @moduledoc false
+  use Dagger.Mod.Enum, name: "SimpleEnum", values: [:unknown, :low, :high]
+end
+
+defmodule EnumWithOption do
+  @moduledoc false
+  use Dagger.Mod.Enum,
+    name: "EnumWithOption",
+    values: [:low, :high, unknown: [doc: "Unknown severity"]]
+end
+
+defmodule EnumAliasValue do
+  @moduledoc false
+  use Dagger.Mod.Enum,
+    name: "EnumAliasValue",
+    values: [UNKNOWN: "unknown", LOW: {"low", doc: "Low severity"}]
+end

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -212,3 +212,18 @@ defmodule Deps do
     %Deps.A{}
   end
 end
+
+defmodule CustomEnum do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "CustomEnum"
+
+  defn scan(severity: SimpleEnum.t()) :: SimpleEnum.t() do
+    severity
+  end
+
+  defn enum_opt(opt: EnumWithOption.t()) :: Dagger.Void.t() do
+    _ = opt
+    :ok
+  end
+end


### PR DESCRIPTION
Needs #10544

- [x] Add `use Dagger.Mod.Enum`
- [ ] Converting enum module into Dagger `with_enum` call during the register of a module.
- [ ] Ensure function can accept and return enum
- [ ] Integration test

Closes #10514 