### PR TITLE
fix: ensure we always import gqlerror

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/sdk/resource"


### PR DESCRIPTION
Fixes #10556

This seems to be missing from https://github.com/dagger/dagger/pull/9033. Since `gqlerror` is imported by `main`, we should make sure it actually ends up in the codegen.

We shouldn't be relying on `go mod tidy` to find it.