### PR TITLE
chore: rename sweep option to sweepSize

### DIFF
--- a/docs/static/reference/engine.schema.json
+++ b/docs/static/reference/engine.schema.json
@@ -79,7 +79,7 @@
           "$ref": "#/$defs/DiskSpace",
           "description": "MinFreeSpace is the target amount of free disk space the garbage collector will attempt to leave. However, it will never let the available space fall below ReservedSpace."
         },
-        "sweep": {
+        "sweepSize": {
           "$ref": "#/$defs/DiskSpace",
           "description": "SweepSize is the minimum amount of space to sweep during a single gc pass. Either an absolute number of bytes, or a percentage of the \"allowed space\" between reserved and max."
         },
@@ -123,7 +123,7 @@
           "$ref": "#/$defs/DiskSpace",
           "description": "MinFreeSpace is the target amount of free disk space the garbage collector will attempt to leave. However, it will never let the available space fall below ReservedSpace."
         },
-        "sweep": {
+        "sweepSize": {
           "$ref": "#/$defs/DiskSpace",
           "description": "SweepSize is the minimum amount of space to sweep during a single gc pass. Either an absolute number of bytes, or a percentage of the \"allowed space\" between reserved and max."
         }

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -127,7 +127,7 @@ type GCSpace struct {
 	// SweepSize is the minimum amount of space to sweep during a single gc pass.
 	// Either an absolute number of bytes, or a percentage of the "allowed
 	// space" between reserved and max.
-	SweepSize DiskSpace `json:"sweep,omitempty"`
+	SweepSize DiskSpace `json:"sweepSize,omitempty"`
 }
 
 func (space *GCSpace) IsUnset() bool {


### PR DESCRIPTION
Missed this, woops. Since this is a new option, that very few users are actually using (and the docs referred to it as `sweepSize`), we can just rename this directly.