### PR TITLE
fix: WithSymlink didn't store the dir path

### DIFF
--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1524,4 +1524,23 @@ func (DirectorySuite) TestSymlink(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "some-content", s)
 	})
+
+	t.Run("symlink correctly passes dir path", func(ctx context.Context, t *testctx.T) {
+		d := c.Directory().WithNewFile("some-file", "data")
+
+		d2 := c.Directory().
+			WithNewFile("some-other-file", "other-data").
+			WithNewDirectory("dir1").
+			Directory("/dir1").
+			WithDirectory("/", d).
+			WithSymlink("anything", "link")
+
+		// this should no longer be available, since dir.Dir should now be "/dir1"
+		_, err := d2.File("some-other-file").Contents(ctx)
+		require.Error(t, err)
+
+		s, err := d2.File("some-file").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "data", s)
+	})
 }

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -181,7 +181,7 @@ func (s *directorySchema) Install() {
 			guarantees when using this option. It should only be used when
 			absolutely necessary and only with trusted commands.`),
 			),
-		dagql.NodeFunc("withSymlink", DagOpDirectoryWrapper(s.srv, s.withSymlink, nil)).
+		dagql.NodeFunc("withSymlink", DagOpDirectoryWrapper(s.srv, s.withSymlink, s.withSymlinkPath)).
 			Doc(`Return a snapshot with a symlink`).
 			Args(
 				dagql.Arg("target").Doc(`Location of the file or directory to link to (e.g., "/existing/file").`),
@@ -591,4 +591,8 @@ func (s *directorySchema) withSymlink(ctx context.Context, parent dagql.Instance
 		return inst, err
 	}
 	return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, dir)
+}
+
+func (s *directorySchema) withSymlinkPath(ctx context.Context, val dagql.Instance[*core.Directory], _ directoryWithSymlinkArgs) (string, error) {
+	return val.Self.Dir, nil
 }


### PR DESCRIPTION
WithSymlink didn't correctly pass along the directory path which would cause the directory to reset to /