### PR TITLE
fix: use the current id view for version compat decisions

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -25,7 +25,6 @@ import (
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 )
 
@@ -938,13 +937,5 @@ func validateFileName(file string) error {
 }
 
 func SupportsDirSlash(ctx context.Context) (bool, error) {
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return false, err
-	}
-	srv, err := query.Server.Server(ctx)
-	if err != nil {
-		return false, err
-	}
-	return engine.CheckVersionCompatibility(string(srv.View), "v0.17.0"), nil
+	return Supports(ctx, "v0.17.0")
 }

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -209,7 +209,7 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.Instance[*cor
 	err := s.srv.Select(ctx, ctr, &svc,
 		dagql.Selector{
 			Field: "asService",
-			View:  s.srv.View,
+			View:  dagql.View(dagql.CurrentID(ctx).View()),
 			Args:  inputs,
 		},
 	)
@@ -227,7 +227,7 @@ func (s *serviceSchema) containerUpLegacy(ctx context.Context, ctr dagql.Instanc
 	err := s.srv.Select(ctx, ctr, &svc,
 		dagql.Selector{
 			Field: "asService",
-			View:  s.srv.View,
+			View:  dagql.View(dagql.CurrentID(ctx).View()),
 		},
 	)
 	if err != nil {

--- a/core/util.go
+++ b/core/util.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dagger/dagger/core/reffs"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/slog"
 )
@@ -292,4 +293,9 @@ func MountRef(ctx context.Context, ref bkcache.Ref, g bksession.Group, f func(st
 		return err
 	}
 	return f(dir)
+}
+
+func Supports(ctx context.Context, minVersion string) (bool, error) {
+	id := dagql.CurrentID(ctx)
+	return engine.CheckVersionCompatibility(id.View(), minVersion), nil
 }

--- a/dagql/introspection/types.go
+++ b/dagql/introspection/types.go
@@ -20,7 +20,7 @@ func Install[T dagql.Typed](srv *dagql.Server) {
 
 		// custom dagger field
 		dagql.Func("__schemaVersion", func(ctx context.Context, self T, args struct{}) (string, error) {
-			return string(srv.View), nil
+			return dagql.CurrentID(ctx).View(), nil
 		}).View(dagql.AllView{}),
 
 		dagql.FuncWithCacheKey("__type", func(ctx context.Context, self T, args struct {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -50,7 +50,10 @@ type Server struct {
 	installLock  *sync.Mutex
 	installHooks []InstallHook
 
-	// View is the view that is applied to all queries on this server
+	// View is the default view that is applied to queries on this server.
+	//
+	// WARNING: this is *not* the view of the current query (for that, inspect
+	// the current id)
 	View View
 
 	// Cache is the inner cache used by the server. It can be replicated to


### PR DESCRIPTION
Importantly! It's *never* correct to use this `View` to determine how to do compat. The view there is used as the default for graphql queries, but everything else uses the `ID.View` or the `Selector.View`.

To understand why, imagine the following scenario:
- In server A (using version A), we call a field and get back an ID which has `ID.View = A`
- Later on, in server B (using version B), we attempt to load this ID.

While we make sure that we select the field+inputs correctly according to view `A` in this case, *if the result is not cached and we need to recompute it*, the actual implementation will see a server that is using version `B`. Previously, it seems like we may have been getting away with this, just because of caching.

However, when I started adding versioning to the typedefs API in #9518, it became quite easy to hit this scenario.

I've just gone through and fixed all the references to the server view that I can find, and have updated the comment there to indicate it shouldn't be used for this (it still needs to be public so it can be manipulated as part of coremod shenanigans).