### PR TITLE
docs: fix ts linting

### DIFF
--- a/docs/current_docs/api/snippets/services/use-endpoint/typescript/index.ts
+++ b/docs/current_docs/api/snippets/services/use-endpoint/typescript/index.ts
@@ -9,7 +9,7 @@ export class MyModule {
     service = await service.start()
 
     // wait for service to be ready
-    let endpoint = await service.endpoint({"port": 80, "scheme": "http"})
+    const endpoint = await service.endpoint({ port: 80, scheme: "http" })
 
     // send HTTP request to service endpoint
     return await dag.http(endpoint).contents()


### PR DESCRIPTION
Failures came from https://github.com/dagger/dagger/pull/10492.

See https://dagger.cloud/dagger/traces/9f28b4b977d3ee22b55842681c312e13#578a2f8af50a3c52.

```
/docs/current_docs/api/snippets/services/use-endpoint/typescript/index.ts
  12:9   error  'endpoint' is never reassigned. Use 'const' instead                       prefer-const
  12:44  error  Replace `"port":·80,·"scheme":·"http"` with `·port:·80,·scheme:·"http"·`  prettier/prettier

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```