### PR TITLE
dagui: fix outdated link logic

### DIFF
--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -614,18 +614,16 @@ func (db *DB) integrateSpan(span *Span) { //nolint: gocyclo
 		db.End = span.EndTime
 	}
 
-	// associate the span to its parents and links
-	if span.ParentID.IsValid() &&
-		// If a span has links, don't bother associating it to its
-		// parent. We might want to use that info someday (the
-		// "unlazying" point), but no use case right now.
-		len(span.Links) == 0 {
+	// associate the span to its parent
+	if span.ParentID.IsValid() {
 		span.ParentSpan = db.initSpan(span.ParentID)
 		if span.ParentSpan.ChildSpans.Add(span) {
 			// if we're a new child, take a new snapshot for ChildCount
 			db.update(span.ParentSpan)
 		}
 	}
+
+	// associate the span to its links
 	for _, linked := range span.Links {
 		linkedCtx := linked.SpanContext
 		switch linked.Purpose {


### PR DESCRIPTION
Previously we used links to represent cause and effect, and we always wanted to see the effect (exec) status/logs represented by the causal span instead (Container.withExec).

Now links are multi-purpose, and we don't want to unilaterally skip showing spans that have links. At this point this check is entirely redundant since all the spans we don't want to see already mark themselves `passthrough`. (following https://github.com/dagger/dagger/pull/8442)