### PR TITLE
Fix ListOfType::getSubType can accept ReturnsListOfTypes

### DIFF
--- a/sdk/php/src/ValueObject/ListOfType.php
+++ b/sdk/php/src/ValueObject/ListOfType.php
@@ -52,7 +52,7 @@ final readonly class ListOfType
     }
 
     private static function getSubtype(
-        Attribute\ListOfType $attribute,
+        Attribute\ListOfType|Attribute\ReturnsListOfType $attribute,
     ): ListOfType|Type {
         if (is_string($attribute->type)) {
             return new Type($attribute->type, $attribute->nullable);

--- a/sdk/php/tests/Unit/ValueObject/ListOfTypeTest.php
+++ b/sdk/php/tests/Unit/ValueObject/ListOfTypeTest.php
@@ -62,7 +62,7 @@ class ListOfTypeTest extends TestCase
     public function itBuildsFromArrayReflections(
         ListOfType $expected,
         ReflectionNamedType $reflection,
-        Attribute\ListOfType $attribute,
+        Attribute\ListOfType|Attribute\ReturnsListOfType $attribute,
     ): void {
         $actual = ListOfType::fromReflection($reflection, $attribute);
 
@@ -184,6 +184,24 @@ class ListOfTypeTest extends TestCase
             ),
             $nullableArrayReflection,
             new Attribute\ListOfType(
+                new Attribute\ListOfType(
+                    new Attribute\ListOfType('string', true),
+                    true
+                ),
+                true,
+            ),
+        ];
+
+        yield 'ReturnsListOfType [[[String]]]' => [
+            new ListOfType(
+                new ListOfType(
+                    new ListOfType(new Type('string', true), true),
+                    true,
+                ),
+                true
+            ),
+            $nullableArrayReflection,
+            new Attribute\ReturnsListOfType(
                 new Attribute\ListOfType(
                     new Attribute\ListOfType('string', true),
                     true


### PR DESCRIPTION
This is a very small fix that allows

```php
#[ReturnsListOfTypes(new ListOfType('string'))]
public function myCustomFunction(): array { }
```