### PR TITLE
engine: use sync log processor for clients

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -643,12 +643,7 @@ func (srv *Server) initializeDaggerClient(
 	}
 	loggerOpts := []sdklog.LoggerProviderOption{
 		sdklog.WithResource(telemetry.Resource),
-		sdklog.WithProcessor(
-			sdklog.NewBatchProcessor(
-				srv.telemetryPubSub.Logs(client),
-				sdklog.WithExportInterval(telemetry.NearlyImmediate),
-			),
-		),
+		sdklog.WithProcessor(clientLogs{client: client}),
 	}
 
 	const metricReaderInterval = 1 * time.Second
@@ -669,10 +664,7 @@ func (srv *Server) initializeDaggerClient(
 			),
 		))
 		loggerOpts = append(loggerOpts, sdklog.WithProcessor(
-			sdklog.NewBatchProcessor(
-				srv.telemetryPubSub.Logs(parent),
-				sdklog.WithExportInterval(telemetry.NearlyImmediate),
-			),
+			clientLogs{client: parent},
 		))
 		meterOpts = append(meterOpts, sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(


### PR DESCRIPTION
The OTel log SDK batch processor consumes an enormous amount of memory when we use it for engine clients. Each client gets its own processor, along with an additional processor for each ancestor. The memory usage really adds up quickly: each processor has a queue, each log batch is written to each parent, and each export does a `slices.Copy` of the batch of records.

Now we'll just write log records to SQLite as soon as they're emitted, synchronously, one at a time. For the evals, this cut the memory usage in half. SQLite seems to take this just fine.

This change brought the heap usage for the evals refactor (#10562) down from 14.38GB to 7.43GB. (Later reduced to 1.38GB via another unrelated optimization, #10579.) Before this fix, the job was OOMing.

![image](https://github.com/user-attachments/assets/41261ac7-5dde-4313-ab2b-4dc55babf4af)

![image](https://github.com/user-attachments/assets/077e8bd1-dae2-4ebc-acd2-9d1df187371d)
