### PR TITLE
cli: don't serve transitive dependencies

### DIFF
--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -68,7 +68,7 @@ func initializeModule(
 	}
 
 	serveCtx, serveSpan := Tracer().Start(ctx, "initializing module", telemetry.Encapsulate())
-	err = modSrc.AsModule().Serve(serveCtx, dagger.ModuleServeOpts{IncludeDependencies: true})
+	err = modSrc.AsModule().Serve(serveCtx)
 	telemetry.End(serveSpan, func() error { return err })
 	if err != nil {
 		return nil, fmt.Errorf("failed to serve module: %w", err)


### PR DESCRIPTION
when loading a module by ref, only serve that module, otherwise it's easy to hit name conflicts (e.g. `evaluator/workspace`, `evals/workspace`)