### PR TITLE
add support for internal-only args; use for dag-op

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -531,6 +531,9 @@ func (m *MCP) toolCallToSelection(
 	remainingArgs := make(map[string]any)
 	maps.Copy(remainingArgs, argsMap)
 	for _, arg := range field.Args.Inputs(srv.View) {
+		if arg.Internal {
+			continue // skip internal args
+		}
 		val, ok := argsMap[arg.Name]
 		if !ok {
 			continue

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -583,6 +583,8 @@ func (s *directorySchema) asGit(
 type directoryWithSymlinkArgs struct {
 	Target   string
 	LinkName string
+
+	FSDagOpInternalArgs
 }
 
 func (s *directorySchema) withSymlink(ctx context.Context, parent dagql.Instance[*core.Directory], args directoryWithSymlinkArgs) (inst dagql.Instance[*core.Directory], _ error) {

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -11,12 +11,12 @@ import (
 )
 
 // DagOpWrapper caches an arbitrary dagql field as a buildkit operation
-func DagOpWrapper[T dagql.Typed, A any, R dagql.Typed](
+func DagOpWrapper[T dagql.Typed, A DagOpInternalArgsIface, R dagql.Typed](
 	srv *dagql.Server,
 	fn dagql.NodeFuncHandler[T, A, R],
 ) dagql.NodeFuncHandler[T, A, R] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst R, err error) {
-		if core.DagOpInContext[core.RawDagOp](ctx) {
+		if args.InDagOp() {
 			query, ok := srv.Root().(dagql.Instance[*core.Query])
 			if !ok {
 				return inst, fmt.Errorf("server root was %T", srv.Root())
@@ -43,9 +43,10 @@ func DagOp[T dagql.Typed, A any, R dagql.Typed](
 	if err != nil {
 		return inst, err
 	}
+	filename := "output.json"
 	return core.NewRawDagOp[R](ctx, srv, &core.RawDagOp{
-		ID:       currentIDForDagOp(ctx),
-		Filename: "output.json",
+		ID:       currentIDForRawDagOp(ctx, filename),
+		Filename: filename,
 	}, deps)
 }
 
@@ -54,13 +55,13 @@ type PathFunc[T dagql.Typed, A any] func(ctx context.Context, val dagql.Instance
 // DagOpFileWrapper caches a file field as a buildkit operation - this is
 // more specialized than DagOpWrapper, since that serializes the value to
 // JSON, so we'd just end up with a cached ID instead of the actual content.
-func DagOpFileWrapper[T dagql.Typed, A any](
+func DagOpFileWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 	srv *dagql.Server,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]],
 	pfn PathFunc[T, A],
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.File], err error) {
-		if core.DagOpInContext[core.FSDagOp](ctx) {
+		if args.InDagOp() {
 			query, ok := srv.Root().(dagql.Instance[*core.Query])
 			if !ok {
 				return inst, fmt.Errorf("server root was %T", srv.Root())
@@ -68,7 +69,7 @@ func DagOpFileWrapper[T dagql.Typed, A any](
 			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
-		return DagOpFile(ctx, srv, self, args, nil, fn, pfn)
+		return DagOpFile(ctx, srv, self, args, "", fn, pfn)
 	}
 }
 
@@ -82,7 +83,7 @@ func DagOpFile[T dagql.Typed, A any](
 	srv *dagql.Server,
 	self dagql.Instance[T],
 	args A,
-	data any,
+	data string,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]],
 	pfn PathFunc[T, A],
 ) (inst dagql.Instance[*core.File], _ error) {
@@ -103,25 +104,26 @@ func DagOpFile[T dagql.Typed, A any](
 	}
 
 	file, err := core.NewFileDagOp(ctx, srv, &core.FSDagOp{
-		ID:   currentIDForDagOp(ctx),
+		ID:   currentIDForFSDagOp(ctx, filename, data),
 		Path: filename,
 		Data: data,
 	}, deps)
 	if err != nil {
 		return inst, err
 	}
+
 	return dagql.NewInstanceForCurrentID(ctx, srv, self, file)
 }
 
 // DagOpDirectoryWrapper caches a directory field as a buildkit operation,
 // similar to DagOpFileWrapper.
-func DagOpDirectoryWrapper[T dagql.Typed, A any](
+func DagOpDirectoryWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 	srv *dagql.Server,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]],
 	pfn PathFunc[T, A],
 ) dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]] {
 	return func(ctx context.Context, self dagql.Instance[T], args A) (inst dagql.Instance[*core.Directory], err error) {
-		if core.DagOpInContext[core.FSDagOp](ctx) {
+		if args.InDagOp() {
 			query, ok := srv.Root().(dagql.Instance[*core.Query])
 			if !ok {
 				return inst, fmt.Errorf("server root was %T", srv.Root())
@@ -129,7 +131,7 @@ func DagOpDirectoryWrapper[T dagql.Typed, A any](
 			ctx = core.ContextWithQuery(ctx, query.Self)
 			return fn(ctx, self, args)
 		}
-		return DagOpDirectory(ctx, srv, self, args, nil, fn, pfn)
+		return DagOpDirectory(ctx, srv, self, args, "", fn, pfn)
 	}
 }
 
@@ -141,7 +143,7 @@ func DagOpDirectory[T dagql.Typed, A any](
 	srv *dagql.Server,
 	self dagql.Instance[T],
 	args A,
-	data any,
+	data string,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]],
 	pfn PathFunc[T, A],
 ) (inst dagql.Instance[*core.Directory], _ error) {
@@ -161,7 +163,7 @@ func DagOpDirectory[T dagql.Typed, A any](
 	dir, err := core.NewDirectoryDagOp(ctx, srv, &core.FSDagOp{
 		// FIXME: using this in the cache key means we effectively disable
 		// buildkit content caching
-		ID:   currentIDForDagOp(ctx),
+		ID:   currentIDForFSDagOp(ctx, filename, data),
 		Path: filename,
 		Data: data,
 	}, deps)
@@ -171,12 +173,12 @@ func DagOpDirectory[T dagql.Typed, A any](
 	return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
 }
 
-func DagOpContainerWrapper[A any](
+func DagOpContainerWrapper[A DagOpInternalArgsIface](
 	srv *dagql.Server,
 	fn dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]],
 ) dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]] {
 	return func(ctx context.Context, self dagql.Instance[*core.Container], args A) (inst dagql.Instance[*core.Container], err error) {
-		if core.DagOpInContext[core.ContainerDagOp](ctx) {
+		if args.InDagOp() {
 			query, ok := srv.Root().(dagql.Instance[*core.Query])
 			if !ok {
 				return inst, fmt.Errorf("server root was %T", srv.Root())
@@ -201,23 +203,115 @@ func DagOpContainer[A any](
 		return inst, err
 	}
 
-	ctr, err := core.NewContainerDagOp(ctx, currentIDForDagOp(ctx), self.Self, deps)
+	ctr, err := core.NewContainerDagOp(ctx, currentIDForContainerDagOp(ctx), self.Self, deps)
 	if err != nil {
 		return inst, err
 	}
 	return dagql.NewInstanceForCurrentID(ctx, srv, self, ctr)
 }
 
-const runDagOpDigestMixin = "runDagOpDigestMixin"
+const (
+	// defined in core package to support telemetry code accessing it too
+	IsDagOpArgName = core.IsDagOpArgName
+)
 
-// Return an ID that can be used to force execution of the current ID as a DagOp.
-// It works by mixing in a constant value into the current ID's digest.
-func currentIDForDagOp(ctx context.Context) *call.ID {
+type DagOpInternalArgsIface interface {
+	InDagOp() bool
+}
+
+type DagOpInternalArgs struct {
+	IsDagOp bool `internal:"true" default:"false" name:"isDagOp"`
+}
+
+func (d DagOpInternalArgs) InDagOp() bool {
+	return d.IsDagOp
+}
+
+const (
+	RawDagOpFilenameArgName = "dagOpFilename"
+)
+
+type RawDagOpInternalArgs struct {
+	DagOpInternalArgs
+
+	DagOpFilename string `internal:"true" default:"" name:"dagOpFilename"`
+}
+
+func currentIDForRawDagOp(
+	ctx context.Context,
+	filename string,
+) *call.ID {
 	currentID := dagql.CurrentID(ctx)
-	return currentID.WithDigest(dagql.HashFrom(
-		currentID.Digest().String(),
-		runDagOpDigestMixin,
-	))
+
+	return currentID.
+		WithArgument(call.NewArgument(
+			IsDagOpArgName,
+			call.NewLiteralBool(true),
+			false,
+		)).
+		WithArgument(call.NewArgument(
+			RawDagOpFilenameArgName,
+			call.NewLiteralString(filename),
+			false,
+		))
+}
+
+const (
+	FSDagOpPathArgName = "dagOpPath"
+	FSDagOpDataArgName = "dagOpData"
+)
+
+type FSDagOpInternalArgs struct {
+	DagOpInternalArgs
+
+	DagOpPath string `internal:"true" default:"" name:"dagOpPath"`
+	DagOpData string `internal:"true" default:"" name:"dagOpData"`
+}
+
+func currentIDForFSDagOp(
+	ctx context.Context,
+	path string,
+	data string,
+) *call.ID {
+	currentID := dagql.CurrentID(ctx)
+
+	return currentID.
+		WithArgument(call.NewArgument(
+			IsDagOpArgName,
+			call.NewLiteralBool(true),
+			false,
+		)).
+		WithArgument(call.NewArgument(
+			FSDagOpPathArgName,
+			call.NewLiteralString(path),
+			false,
+		)).
+		WithArgument(call.NewArgument(
+			FSDagOpDataArgName,
+			call.NewLiteralString(data),
+			false,
+		))
+}
+
+const (
+	ContainerDagOpOutputCountArgName = "dagOpOutputCount"
+)
+
+type ContainerDagOpInternalArgs struct {
+	DagOpInternalArgs
+}
+
+func currentIDForContainerDagOp(
+	ctx context.Context,
+) *call.ID {
+	currentID := dagql.CurrentID(ctx)
+
+	return currentID.
+		WithArgument(call.NewArgument(
+			IsDagOpArgName,
+			call.NewLiteralBool(true),
+			false,
+		))
 }
 
 func extractLLBDependencies(ctx context.Context, val any) ([]llb.State, error) {

--- a/core/sdk/module.go
+++ b/core/sdk/module.go
@@ -128,7 +128,7 @@ func (sdk *module) withConfig(
 
 		// override if the argument with same name exists in dagger.json -> sdk.config
 		val, ok := rawConfig[input.Name]
-		if ok {
+		if ok && !input.Internal {
 			valInput, err = input.Type.Decoder().DecodeInput(val)
 			if err != nil {
 				return nil, fmt.Errorf("parsing value for arg %q: %w", input.Name, err)

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -289,6 +289,42 @@ func (id *ID) WithDigest(customDigest digest.Digest) *ID {
 	)
 }
 
+// WithArgument returns a new ID that's the same as before except with the
+// given argument added to the ID's arguments. If an argument with the same
+// name already exists, it will be replaced with the new one. The digest will
+// reset to the default "recipe-based" value, so any custom one needs to be
+// set after this call via WithDigest.
+func (id *ID) WithArgument(arg *Argument) *ID {
+	if id == nil {
+		return nil
+	}
+
+	newArgs := make([]*Argument, len(id.args))
+	copy(newArgs, id.args)
+	var replaced bool
+	for i, existingArg := range newArgs {
+		if existingArg.pb.Name == arg.pb.Name {
+			// replace existing argument with the new one
+			newArgs[i] = arg
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		newArgs = append(newArgs, arg)
+	}
+
+	return id.receiver.Append(
+		id.pb.Type.ToAST(),
+		id.pb.Field,
+		id.pb.View,
+		id.module,
+		int(id.pb.Nth),
+		"", // reset to default digest
+		newArgs...,
+	)
+}
+
 func (id *ID) Encode() (string, error) {
 	dagPB, err := id.ToProto()
 	if err != nil {

--- a/dagql/directives.go
+++ b/dagql/directives.go
@@ -99,3 +99,9 @@ func experimental(reason string) *ast.Directive {
 		},
 	}
 }
+
+func internal() *ast.Directive {
+	return &ast.Directive{
+		Name: "internal",
+	}
+}

--- a/dagql/introspection/types.go
+++ b/dagql/introspection/types.go
@@ -176,7 +176,14 @@ func Install[T dagql.Typed](srv *dagql.Server) {
 			return self.Description(), nil
 		}).DoNotCache("simple field selection"),
 		dagql.Func("args", func(ctx context.Context, self *Field, _ struct{}) (dagql.Array[*InputValue], error) {
-			return self.Args, nil
+			args := make([]*InputValue, 0, len(self.Args))
+			for _, arg := range self.Args {
+				if arg.internal {
+					continue // skip internal args
+				}
+				args = append(args, arg)
+			}
+			return args, nil
 		}).DoNotCache("simple field selection"),
 		dagql.Func("type", func(ctx context.Context, self *Field, args struct{}) (*Type, error) {
 			return self.Type_, nil
@@ -339,6 +346,7 @@ func (s *Schema) directiveFromDef(d *ast.DirectiveDefinition) Directive {
 			DefaultValue: defaultValue(arg.DefaultValue),
 			Type_:        WrapTypeFromType(s.schema, arg.Type),
 			deprecation:  arg.Directives.ForName("deprecated"),
+			internal:     arg.Directives.ForName("internal") != nil,
 		}
 	}
 
@@ -592,6 +600,7 @@ func (t *Type) Fields(includeDeprecated bool) []*Field {
 				description:  arg.Description,
 				DefaultValue: defaultValue(arg.DefaultValue),
 				deprecation:  arg.Directives.ForName("deprecated"),
+				internal:     arg.Directives.ForName("internal") != nil,
 				directives:   arg.Directives,
 			})
 		}
@@ -622,6 +631,7 @@ func (t *Type) InputFields() []*InputValue {
 			DefaultValue: defaultValue(f.DefaultValue),
 			directives:   f.Directives,
 			deprecation:  f.Directives.ForName("deprecated"),
+			internal:     f.Directives.ForName("internal") != nil,
 		})
 	}
 	return res
@@ -754,6 +764,7 @@ type (
 		Type_        *Type
 		directives   []*ast.Directive
 		deprecation  *ast.Directive
+		internal     bool
 	}
 )
 

--- a/engine/buildkit/op.go
+++ b/engine/buildkit/op.go
@@ -107,8 +107,20 @@ func (op *CustomOpWrapper) CacheMap(ctx context.Context, g bksession.Group, inde
 	return cm, ok, err
 }
 
+type bkSessionGroupContextKey struct{}
+
+func ctxWithBkSessionGroup(ctx context.Context, g bksession.Group) context.Context {
+	return context.WithValue(ctx, bkSessionGroupContextKey{}, g)
+}
+
+func CurrentBuildkitSessionGroup(ctx context.Context) (bksession.Group, bool) {
+	g, ok := ctx.Value(bkSessionGroupContextKey{}).(bksession.Group)
+	return g, ok
+}
+
 func (op *CustomOpWrapper) Exec(ctx context.Context, g bksession.Group, inputs []solver.Result) (outputs []solver.Result, err error) {
 	ctx = engine.ContextWithClientMetadata(ctx, &op.ClientMetadata)
+	ctx = ctxWithBkSessionGroup(ctx, g)
 
 	server, err := op.server.DagqlServer(ctx)
 	if err != nil {


### PR DESCRIPTION
Another spin-off from the [persistent dagql cache work](https://github.com/dagger/dagger/pull/10497)

---

This adds support for marking arguments to fields as internal, in which case they can only be set by internal server-side self calls and never by external clients in graphql requests. They won't show up in introspection schema requests either, so they never make it to SDKs or docs.

We have wanted this in a variety of situations for a while, but the immediate motivation here is to update DagOp to use it to distinguish the "outer" lazy implementation and the "inner" call that actually triggers the execution of the operation.

Previously we have accomplished that by plumbing things through context, but this no longer worked with the persistent dagql cache. That new caching implementation has logic such that even when digests of a call don't match, you can still get cache hits based on the inputs all being equivalent. Since inner/outer DagOp calls had the exact same inputs to the exact same field, they started incorrectly hitting cache for each other.

Now, DagOps have internal args that indicate whether the real/inner operation should be executed unlazily and other metadata previously plumbed just through the LLB op. This fixes the persistent cache use case since now there are actual inputs to the call that distinguish the outer+inner calls.

Besides the need from the persistent cache, this approach feels like a good step in that it moves just a bit more logic/data away from LLB and into "dagger-native" code (i.e. into our actual API schema).

This should be generally useful too for other situations where we have been forced to add args that really shouldn't be public in the interest of supporting internal server self calls, though this commit only updates DagOp-ified APIs for now.

---

TODO:
- [ ] I'll give a quick shot at updating the `namespace` arg to `CacheVolume` to use this too since it's one of those APIs we didn't actually want to be public