### PR TITLE
ci: ensure cni binaries are built with latest go version

### DIFF
--- a/cmd/engine/.dagger/build/builder.go
+++ b/cmd/engine/.dagger/build/builder.go
@@ -129,6 +129,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 			Alpine(dagger.AlpineOpts{
 				Branch: consts.AlpineVersion,
 				Packages: []string{
+					"ca-certificates",
 					// for Buildkit
 					"git", "openssh-client", "pigz", "xz",
 					// for CNI

--- a/cmd/engine/.dagger/build/builder.go
+++ b/cmd/engine/.dagger/build/builder.go
@@ -349,7 +349,7 @@ func (build *Builder) cniPlugins() []*dagger.File {
 		ctr = dag.
 			Alpine(dagger.AlpineOpts{
 				Branch:   consts.AlpineVersion,
-				Packages: []string{"build-base", "go", "git"},
+				Packages: []string{"build-base", "go~" + consts.GolangVersion, "git"},
 			}).
 			Container()
 	case "ubuntu":
@@ -363,7 +363,7 @@ func (build *Builder) cniPlugins() []*dagger.File {
 		ctr = dag.
 			Wolfi().
 			Container(dagger.WolfiContainerOpts{Packages: []string{
-				"build-base", "go", "git",
+				"build-base", "go~" + consts.GolangVersion, "git",
 			}})
 	}
 

--- a/cmd/engine/.dagger/build/builder.go
+++ b/cmd/engine/.dagger/build/builder.go
@@ -140,15 +140,15 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				Arch: build.platformSpec.Architecture,
 			}).
 			Container().
-			WithExec([]string{"sh", "-c", `
-				set -e
-				ln -s /sbin/iptables-legacy /usr/sbin/iptables
-				ln -s /sbin/iptables-legacy-save /usr/sbin/iptables-save
-				ln -s /sbin/iptables-legacy-restore /usr/sbin/iptables-restore
-				ln -s /sbin/ip6tables-legacy /usr/sbin/ip6tables
-				ln -s /sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
-				ln -s /sbin/ip6tables-legacy-restore /usr/sbin/ip6tables-restore
-			`})
+			WithExec([]string{"sh", "-c", strings.Join([]string{
+				"mkdir -p /usr/local/sbin",
+				"ln -s /usr/sbin/iptables-legacy /usr/local/sbin/iptables",
+				"ln -s /usr/sbin/iptables-legacy-save /usr/local/sbin/iptables-save",
+				"ln -s /usr/sbin/iptables-legacy-restore /usr/local/sbin/iptables-restore",
+				"ln -s /usr/sbin/ip6tables-legacy /usr/local/sbin/ip6tables",
+				"ln -s /usr/sbin/ip6tables-legacy-save /usr/local/sbin/ip6tables-save",
+				"ln -s /usr/sbin/ip6tables-legacy-restore /usr/local/sbin/ip6tables-restore",
+			}, " && ")})
 	case "ubuntu":
 		base = dag.Container(dagger.ContainerOpts{Platform: build.platform}).
 			From("ubuntu:"+consts.UbuntuVersion).

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -24,7 +24,7 @@ const (
 )
 
 const (
-	AlpineVersion = "3.20.2"
+	AlpineVersion = "3.22.0"
 	AlpineImage   = "alpine:" + AlpineVersion
 
 	GolangVersion = "1.24.4"


### PR DESCRIPTION
Fixes the failing `scan` check on main, which is detecting that we're building our CNI binaries with an old go version.

To do this, we need to update alpine, since the older version we're on doesn't have a supported version of go.