### PR TITLE
docs: add full clone checkout steps to Azure Pipelines snippets

### DIFF
--- a/docs/current_docs/ci/integrations/snippets/azure-pipelines-hello.yml
+++ b/docs/current_docs/ci/integrations/snippets/azure-pipelines-hello.yml
@@ -6,6 +6,13 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
+# full clone checkout required to prevent azure pipeline traces from being orphaned in the Dagger Cloud UI
+- checkout: self
+  fetchDepth: 0
+  displayName: 'Checkout Source Code, fetch full history'
+# branch checkout required to prevent azure pipeline traces from being orphaned in the Dagger Cloud UI
+- script: git checkout $(Build.SourceBranchName)
+  displayName: 'Checkout Source Branch'
 - script: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
   displayName: 'Install Dagger CLI'
 - script: dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting="bonjour" --name="monde"

--- a/docs/current_docs/ci/integrations/snippets/azure-pipelines-test-build.yml
+++ b/docs/current_docs/ci/integrations/snippets/azure-pipelines-test-build.yml
@@ -6,6 +6,13 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
+# full clone checkout required to prevent azure pipeline traces from being orphaned in the Dagger Cloud UI
+- checkout: self
+  fetchDepth: 0
+  displayName: 'Checkout Source Code, fetch full history'
+# branch checkout required to prevent azure pipeline traces from being orphaned in the Dagger Cloud UI
+- script: git checkout $(Build.SourceBranchName)
+  displayName: 'Checkout Source Branch'
 - script: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
   displayName: 'Install Dagger CLI'
 - script: dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call test --source=.


### PR DESCRIPTION
This commit adds the required config to the azure pipelines examples to prevent the traces from being orphaned and allow them to show up in the Dagger Cloud UI. 

You can see a working version of this here: https://dagger.cloud/levlaz/ci?branch=main&ref=42d7d5ab08445c927b5f7e4464c4908db61e183f&repo=levlaz.visualstudio.com%2Fsnippetbox%2F_git%2Fsnippetbox 

<img width="743" alt="Screenshot 2025-06-17 at 2 35 28 PM" src="https://github.com/user-attachments/assets/3f2234e7-9e59-4864-b474-3ebe7a7eed84" />
