### PR TITLE
ui: fix error hoisting logic and `UNSET` status handling

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"dagger.io/dagger/telemetry"
@@ -123,11 +122,7 @@ func recordStatus(ctx context.Context, res dagql.Typed, span trace.Span, cached 
 		}
 	}
 
-	if err == nil {
-		// It is important to set an Ok status here so functions can encapsulate
-		// any internal errors.
-		span.SetStatus(codes.Ok, "")
-	} else {
+	if err != nil {
 		// append id.Display() instead of setting it as a field to avoid double
 		// quoting
 		slog.Warn("error resolving "+id.Display(), "error", err)

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -938,21 +938,26 @@ func WalkTree(tree []*TraceTree, f func(*TraceTree, int) WalkDecision) {
 func (db *DB) CollectErrors(rows *RowsView) []*TraceTree {
 	reveal := make(map[*TraceTree]struct{})
 
-	var collect func(row *TraceTree)
-	collect = func(tree *TraceTree) {
+	var collect func(row *TraceTree, ancestorFailed bool)
+	collect = func(tree *TraceTree, ancestorFailed bool) {
 		failed := tree.Span.IsFailedOrCausedFailure()
+		unset := tree.Span.IsUnset()
 		if failed {
 			reveal[tree] = struct{}{}
 		}
-		if failed || tree.Span.IsUnset() {
+		if failed ||
+			// continue through UNSET spans beneath failed parents; these correspond
+			// to basic span.End() calls which intend to just add measurement without
+			// bubbling up or masking failure
+			(unset && ancestorFailed) {
 			for _, child := range tree.Children {
-				collect(child)
+				collect(child, true)
 			}
 		}
 	}
 
 	for _, row := range rows.Body {
-		collect(row)
+		collect(row, false)
 	}
 
 	return collectParents(rows.Body, reveal)

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -71,6 +71,7 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 		{Function: "fail-effect", Fail: true},
 		{Function: "fail-log-native", Fail: true},
 		{Function: "encapsulate"},
+		{Function: "fail-encapsulated", Fail: true},
 		{Function: "pending", Fail: true},
 		{Function: "list", Args: []string{"--dir", "."}},
 		{Function: "object-lists"},

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
@@ -35,8 +35,4 @@ Error logs:
 this should be hoisted - ancestor failed
 ! inner failure
 
-▼ failing inner span X.Xs ERROR
-this should NOT be hoisted - ancestor succeeded
-! inner failure
-
 Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
@@ -1,0 +1,42 @@
+Expected stderr:
+
+▼ connect X.Xs
+├─● starting engine X.Xs
+├─● connecting to engine X.Xs
+╰─● starting session X.Xs
+ 
+▼ load module: ./viztest X.Xs
+├─● finding module configuration X.Xs
+├─● initializing module X.Xs
+├─● inspecting module metadata X.Xs
+╰─● loading type definitions X.Xs
+ 
+● parsing command line arguments X.Xs
+
+● viztest: Viztest! X.Xs
+▼ .failEncapsulated: Void X.Xs ERROR
+! i failed on the outside
+├─▼ failing outer span X.Xs ERROR
+│ ! outer failure
+│ ╰─▼ unset middle span X.Xs
+│   ╰─▼ failing inner span X.Xs ERROR
+│     ┃ this should be hoisted - ancestor failed
+│     ! inner failure
+│    
+╰─▼ succeeding outer span X.Xs
+  ╰─▼ unset middle span X.Xs
+    ╰─▼ failing inner span X.Xs ERROR
+      ┃ this should NOT be hoisted - ancestor succeeded
+      ! inner failure
+
+Error logs:
+
+▼ failing inner span X.Xs ERROR
+this should be hoisted - ancestor failed
+! inner failure
+
+▼ failing inner span X.Xs ERROR
+this should NOT be hoisted - ancestor succeeded
+! inner failure
+
+Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -46,9 +46,9 @@ func (*Viztest) FailEncapsulated(ctx context.Context) error {
 	(func() (rerr error) {
 		ctx, span := Tracer().Start(ctx, "failing outer span")
 		defer telemetry.End(span, func() error { return rerr })
-		(func() (rerr error) {
+		(func() {
 			ctx, span := Tracer().Start(ctx, "unset middle span")
-			defer telemetry.End(span, func() error { return rerr }) // stays UNSET
+			defer span.End() // UNSET
 			(func() (rerr error) {
 				ctx, span := Tracer().Start(ctx, "failing inner span")
 				defer telemetry.End(span, func() error { return rerr })
@@ -56,7 +56,6 @@ func (*Viztest) FailEncapsulated(ctx context.Context) error {
 				fmt.Fprintln(stdio.Stdout, "this should be hoisted - ancestor failed")
 				return errors.New("inner failure")
 			})()
-			return nil // middle span stays UNSET
 		})()
 		return errors.New("outer failure")
 	})()
@@ -65,9 +64,9 @@ func (*Viztest) FailEncapsulated(ctx context.Context) error {
 	(func() (rerr error) {
 		ctx, span := Tracer().Start(ctx, "succeeding outer span")
 		defer telemetry.End(span, func() error { return rerr })
-		(func() (rerr error) {
+		(func() {
 			ctx, span := Tracer().Start(ctx, "unset middle span")
-			defer telemetry.End(span, func() error { return rerr }) // stays UNSET
+			defer span.End() // UNSET
 			(func() (rerr error) {
 				ctx, span := Tracer().Start(ctx, "failing inner span")
 				defer telemetry.End(span, func() error { return rerr })
@@ -75,7 +74,6 @@ func (*Viztest) FailEncapsulated(ctx context.Context) error {
 				fmt.Fprintln(stdio.Stdout, "this should NOT be hoisted - ancestor succeeded")
 				return errors.New("inner failure")
 			})()
-			return nil // middle span stays UNSET
 		})()
 		return nil // outer span succeeds
 	})()

--- a/sdk/go/telemetry/span.go
+++ b/sdk/go/telemetry/span.go
@@ -88,6 +88,8 @@ func End(span trace.Span, fn func() error) {
 		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
 	}
 	span.End()
 }


### PR DESCRIPTION
Currently there are two issues that lead to bubbling up errors beneath the `connect` span:

1. The error hoisting logic should only continue through `UNSET` spans when we're beneath a failed path
1. The `connect` span, and all other spans using `telemetry.End`, has an `UNSET` status - they should have `OK`
  * `UNSET` should only correspond to bare `defer span.End()` usage where the intent is to measure duration without having any impact on success/failure status