### PR TITLE
ci: pin alpine version for aws-cli

### DIFF
--- a/cmd/dagger/.dagger/publish.go
+++ b/cmd/dagger/.dagger/publish.go
@@ -143,6 +143,7 @@ func (cli *DaggerCli) PublishMetadata(
 ) error {
 	ctr := dag.
 		Alpine(dagger.AlpineOpts{
+			Branch:   "3.22",
 			Packages: []string{"aws-cli"},
 		}).
 		Container().


### PR DESCRIPTION
Fixes the failing publish job on `main`.

Seems to be something weird happening in edge with aws-cli, and the version of prompt_toolkit that it's using.
