### PR TITLE
python: try new uv.lock support in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,7 +61,7 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/sdk/python"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Docs: https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependabot

It's GA but there's quite a few open issues:
- https://github.com/dependabot/dependabot-core/issues/10478
- https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/
- https://github.com/astral-sh/uv/issues/2512
- https://github.com/dependabot/dependabot-core/issues?q=is%3Aissue%20state%3Aopen%20uv