### PR TITLE
shell: fixed interpreter builtin arguments not being resolved

### DIFF
--- a/.changes/unreleased/Fixed-20250624-133301.yaml
+++ b/.changes/unreleased/Fixed-20250624-133301.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'shell: fixed arguments with pipelines to interpreter builtins not being resolved'
+time: 2025-06-24T13:33:01.431418Z
+custom:
+    Author: helderco
+    PR: "10635"


### PR DESCRIPTION
Reported in:
- https://github.com/dagger/dagger/issues/10538#issuecomment-2997207108

Test was using `echo` but it was not properly testing it, so testing with `exit`.

### Example
```
❯ dagger -M <<'.'
exit_code=$(container | from alpine | with-exec --expect ANY -- sh -c "exit 5" | exit-code)
.echo "Exited with status code $exit_code"
.exit $exit_code
.
▶ connect 0.4s
● loading type definitions 0.4s

● container: Container! 0.0s
$ .from(address: "alpine"): Container! 1.6s CACHED
● .withExec(args: ["sh", "-c", "exit 5"], expect: ANY): Container! 0.2s
▶ .exitCode: Int! 0.3s

Exited with status code 5

✗ echo $?
5
```