### PR TITLE
fix plain output being way too verbose

### DIFF
--- a/.changes/unreleased/Fixed-20250624-140402.yaml
+++ b/.changes/unreleased/Fixed-20250624-140402.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed the `plain` progress format being way more verbose than intended.
+time: 2025-06-24T14:04:02.700130241-04:00
+custom:
+    Author: vito
+    PR: "10636"

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -230,7 +230,9 @@ func (fe *frontendPlain) SetVerbosity(n int) {
 
 func (fe *frontendPlain) SetPrimary(spanID dagui.SpanID) {
 	fe.mu.Lock()
-	fe.db.PrimarySpan = spanID
+	fe.db.SetPrimarySpan(spanID)
+	fe.ZoomedSpan = spanID
+	fe.FocusedSpan = spanID
 	fe.mu.Unlock()
 }
 


### PR DESCRIPTION
[Comparison](https://gist.github.com/vito/00947008407bebd6c61c8d23eedb77f3) (213 => 53 lines)

This change simply brings the code in line with the pretty frontend. Not sure if this regressed or was always out of sync. :thinking: 