### PR TITLE
dagql: fix Server.Schema <-> Class.Extend deadlock

### DIFF
--- a/.changes/unreleased/Fixed-20250625-151600.yaml
+++ b/.changes/unreleased/Fixed-20250625-151600.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed a deadlock caused by concurrent schema introspection and modification
+time: 2025-06-25T15:16:00.098153675-04:00
+custom:
+    Author: vito
+    PR: "10643"


### PR DESCRIPTION
The fact that these are happening concurrently is a little smelly, but we should at least avoid the deadlock.