### PR TITLE
Various enum member followups

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -1047,6 +1047,9 @@ const (
 
 	// Inactive status
 	Inactive Status = "there"
+
+	// Weird status
+	WEIRD Status = "WEIRD"
 )
 
 func New(
@@ -1079,6 +1082,7 @@ class Status(dagger.Enum):
 
     ACTIVE = "here", "Active status"
     INACTIVE = "there", "Inactive status"
+    WEIRD = "WEIRD", "Weird status"
 
 
 @dagger.object_type
@@ -1096,6 +1100,7 @@ class Test:
         class MockEnum(dagger.Enum):
             ACTIVE = "here"
             INACTIVE = "there"
+            WEIRD = "WEIRD"
             INVALID = "INVALID"
 
         return MockEnum(status)
@@ -1144,6 +1149,9 @@ const (
 
 	// Inactive status
 	Inactive Status = "there"
+
+	// Weird status
+	WEIRD Status = "WEIRD"
 )
 
 type Dep struct{}

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -1151,6 +1151,9 @@ const (
 
 	// Inactive status
 	Inactive Status = "INACTIVE value"
+
+	// Weird status
+	WEIRD Status = "WEIRD"
 )
 
 func New(
@@ -1197,6 +1200,9 @@ class Status(enum.Enum):
     INACTIVE = "INACTIVE value"
     """Inactive status"""
 
+    WEIRD = "WEIRD"
+    """Weird status"""
+
 
 @dagger.object_type
 class Test:
@@ -1241,6 +1247,11 @@ export class Status {
    * Inactive status
    */
   static readonly Inactive: string = "INACTIVE"
+
+  /**
+   * Weird status
+   */
+  static readonly WEIRD: string = "WEIRD"
 }
 
 @object()
@@ -1336,18 +1347,22 @@ export class Test {
 				mod := inspectModule(ctx, t, modGen)
 				statusEnum := mod.Get("enums.#.asEnum|#(name=TestStatus)")
 				require.Equal(t, "Enum for Status", statusEnum.Get("description").String())
-				require.Len(t, statusEnum.Get("members").Array(), 2)
+				require.Len(t, statusEnum.Get("members").Array(), 3)
 				require.Equal(t, "ACTIVE", statusEnum.Get("members.0.name").String())
 				require.Equal(t, "INACTIVE", statusEnum.Get("members.1.name").String())
+				require.Equal(t, "WEIRD", statusEnum.Get("members.2.name").String())
 				if tc.supportsMembers {
 					require.Equal(t, "ACTIVE value", statusEnum.Get("members.0.value").String())
 					require.Equal(t, "INACTIVE value", statusEnum.Get("members.1.value").String())
+					require.Equal(t, "WEIRD", statusEnum.Get("members.2.value").String())
 				} else {
 					require.Equal(t, "ACTIVE", statusEnum.Get("members.0.value").String())
 					require.Equal(t, "INACTIVE", statusEnum.Get("members.1.value").String())
+					require.Equal(t, "WEIRD", statusEnum.Get("members.2.value").String())
 				}
 				require.Equal(t, "Active status", statusEnum.Get("members.0.description").String())
 				require.Equal(t, "Inactive status", statusEnum.Get("members.1.description").String())
+				require.Equal(t, "Weird status", statusEnum.Get("members.2.description").String())
 			})
 		}
 	})

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -1363,6 +1363,11 @@ export class Test {
 				require.Equal(t, "Active status", statusEnum.Get("members.0.description").String())
 				require.Equal(t, "Inactive status", statusEnum.Get("members.1.description").String())
 				require.Equal(t, "Weird status", statusEnum.Get("members.2.description").String())
+
+				constructor := mod.Get("objects.#.asObject|#(name=Test).constructor")
+				require.Len(t, constructor.Get("args").Array(), 1)
+				require.Equal(t, "status", constructor.Get("args.0.name").String())
+				require.Equal(t, `"INACTIVE"`, constructor.Get("args.0.defaultValue").String())
 			})
 		}
 	})

--- a/core/interface.go
+++ b/core/interface.go
@@ -309,7 +309,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 				// if the return type of this function is an interface or list of interface, we may need to wrap the
 				// return value of the underlying object's function (due to support for covariant matching on return types)
 
-				underlyingReturnType, ok, _, err := iface.mod.ModTypeFor(ctx, fnTypeDef.ReturnType.Underlying(), true)
+				underlyingReturnType, ok, err := iface.mod.ModTypeFor(ctx, fnTypeDef.ReturnType.Underlying(), true)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get return mod type: %w", err)
 				}
@@ -481,7 +481,7 @@ func (iface *InterfaceAnnotatedValue) PBDefinitions(ctx context.Context) ([]*pb.
 			// missing field
 			continue
 		}
-		fieldType, ok, _, err := iface.UnderlyingType.SourceMod().ModTypeFor(ctx, field.TypeDef, true)
+		fieldType, ok, err := iface.UnderlyingType.SourceMod().ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get mod type for field %q: %w", name, err)
 		}

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -225,7 +225,7 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context, hiddenTypes []string) (
 // deps.
 func (d *ModDeps) ModTypeFor(ctx context.Context, typeDef *TypeDef) (ModType, bool, error) {
 	for _, mod := range d.Mods {
-		modType, ok, _, err := mod.ModTypeFor(ctx, typeDef, false)
+		modType, ok, err := mod.ModTypeFor(ctx, typeDef, false)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to get type from mod %q: %w", mod.Name(), err)
 		}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -54,7 +54,7 @@ func NewModFunction(
 	runtime *Container,
 	metadata *Function,
 ) (*ModuleFunction, error) {
-	returnType, ok, _, err := mod.ModTypeFor(ctx, metadata.ReturnType, true)
+	returnType, ok, err := mod.ModTypeFor(ctx, metadata.ReturnType, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mod type for function %q return type: %w", metadata.Name, err)
 	}
@@ -64,7 +64,7 @@ func NewModFunction(
 
 	argTypes := make(map[string]*UserModFunctionArg, len(metadata.Args))
 	for _, argMetadata := range metadata.Args {
-		argModType, ok, _, err := mod.ModTypeFor(ctx, argMetadata.TypeDef, true)
+		argModType, ok, err := mod.ModTypeFor(ctx, argMetadata.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get mod type for function %q arg %q type: %w", metadata.Name, argMetadata.Name, err)
 		}
@@ -313,7 +313,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 	if opts.ParentTyped != nil {
 		// collect any client resources stored in parent fields (secrets/sockets/etc.) and grant
 		// this function client access
-		parentModType, ok, _, err := mod.ModTypeFor(ctx, &TypeDef{
+		parentModType, ok, err := mod.ModTypeFor(ctx, &TypeDef{
 			Kind:     TypeDefKindObject,
 			AsObject: dagql.NonNull(fn.objDef),
 		}, true)

--- a/core/object.go
+++ b/core/object.go
@@ -119,7 +119,7 @@ func (t *ModuleObjectType) CollectCoreIDs(ctx context.Context, value dagql.Typed
 			unknownCollectIDs(v, ids)
 			continue
 		}
-		modType, ok, _, err := t.mod.ModTypeFor(ctx, fieldTypeDef.TypeDef, true)
+		modType, ok, err := t.mod.ModTypeFor(ctx, fieldTypeDef.TypeDef, true)
 		if err != nil {
 			return fmt.Errorf("failed to get mod type for field %q: %w", k, err)
 		}
@@ -181,7 +181,7 @@ type Callable interface {
 func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callable, error) {
 	mod := t.mod
 	if field, ok := t.typeDef.FieldByName(name); ok {
-		fieldType, ok, _, err := mod.ModTypeFor(ctx, field.TypeDef, true)
+		fieldType, ok, err := mod.ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("get field return type: %w", err)
 		}
@@ -233,7 +233,7 @@ func (obj *ModuleObject) PBDefinitions(ctx context.Context) ([]*pb.Definition, e
 			// missing field
 			continue
 		}
-		fieldType, ok, _, err := obj.Module.ModTypeFor(ctx, field.TypeDef, true)
+		fieldType, ok, err := obj.Module.ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get mod type for field %q: %w", name, err)
 		}
@@ -412,7 +412,7 @@ func objField(mod *Module, field *FieldTypeDef) dagql.Field[*ModuleObject] {
 	return dagql.Field[*ModuleObject]{
 		Spec: spec,
 		Func: func(ctx context.Context, obj dagql.Instance[*ModuleObject], _ map[string]dagql.Input, view dagql.View) (dagql.Typed, error) {
-			modType, ok, _, err := mod.ModTypeFor(ctx, field.TypeDef, true)
+			modType, ok, err := mod.ModTypeFor(ctx, field.TypeDef, true)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get mod type for field %q: %w", field.Name, err)
 			}

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -68,7 +68,7 @@ func (m *CoreMod) Install(ctx context.Context, dag *dagql.Server) error {
 	return nil
 }
 
-func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDirectDeps bool) (core.ModType, bool, bool, error) {
+func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDirectDeps bool) (core.ModType, bool, error) {
 	var modType core.ModType
 
 	switch typeDef.Kind {
@@ -76,12 +76,12 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 		modType = &core.PrimitiveType{Def: typeDef}
 
 	case core.TypeDefKindList:
-		underlyingType, ok, _, err := m.ModTypeFor(ctx, typeDef.AsList.Value.ElementTypeDef, checkDirectDeps)
+		underlyingType, ok, err := m.ModTypeFor(ctx, typeDef.AsList.Value.ElementTypeDef, checkDirectDeps)
 		if err != nil {
-			return nil, false, false, fmt.Errorf("failed to get underlying type: %w", err)
+			return nil, false, fmt.Errorf("failed to get underlying type: %w", err)
 		}
 		if !ok {
-			return nil, false, false, nil
+			return nil, false, nil
 		}
 		modType = &core.ListType{
 			Elem:       typeDef.AsList.Value.ElementTypeDef,
@@ -91,13 +91,13 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 	case core.TypeDefKindScalar:
 		_, ok := m.Dag.ScalarType(typeDef.AsScalar.Value.Name)
 		if !ok {
-			return nil, false, false, nil
+			return nil, false, nil
 		}
 
 		var resolvedDef *core.TypeDef
 		defs, err := m.typedefs(ctx)
 		if err != nil {
-			return nil, false, false, err
+			return nil, false, err
 		}
 		for _, def := range defs {
 			if def.Kind == core.TypeDefKindScalar && def.AsScalar.Value.Name == typeDef.AsScalar.Value.Name {
@@ -106,7 +106,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 			}
 		}
 		if resolvedDef == nil {
-			return nil, false, false, fmt.Errorf("could not resolve scalar def %s", typeDef.AsScalar.Value.Name)
+			return nil, false, fmt.Errorf("could not resolve scalar def %s", typeDef.AsScalar.Value.Name)
 		}
 
 		modType = &CoreModScalar{coreMod: m, name: resolvedDef.AsScalar.Value.Name}
@@ -114,13 +114,13 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 	case core.TypeDefKindObject:
 		_, ok := m.Dag.ObjectType(typeDef.AsObject.Value.Name)
 		if !ok {
-			return nil, false, false, nil
+			return nil, false, nil
 		}
 
 		var resolvedDef *core.TypeDef
 		defs, err := m.typedefs(ctx)
 		if err != nil {
-			return nil, false, false, err
+			return nil, false, err
 		}
 		for _, def := range defs {
 			if def.Kind == core.TypeDefKindObject && def.AsObject.Value.Name == typeDef.AsObject.Value.Name {
@@ -129,7 +129,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 			}
 		}
 		if resolvedDef == nil {
-			return nil, false, false, fmt.Errorf("could not resolve object def %s", typeDef.AsObject.Value.Name)
+			return nil, false, fmt.Errorf("could not resolve object def %s", typeDef.AsObject.Value.Name)
 		}
 
 		modType = &CoreModObject{coreMod: m, name: resolvedDef.AsObject.Value.Name}
@@ -137,13 +137,13 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 	case core.TypeDefKindEnum:
 		_, ok := m.Dag.ScalarType(typeDef.AsEnum.Value.Name)
 		if !ok {
-			return nil, false, false, nil
+			return nil, false, nil
 		}
 
 		var resolvedDef *core.TypeDef
 		defs, err := m.typedefs(ctx)
 		if err != nil {
-			return nil, false, false, err
+			return nil, false, err
 		}
 		for _, def := range defs {
 			if def.Kind == core.TypeDefKindEnum && def.AsEnum.Value.Name == typeDef.AsEnum.Value.Name {
@@ -152,17 +152,17 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 			}
 		}
 		if resolvedDef == nil {
-			return nil, false, false, fmt.Errorf("could not resolve enum def %s", typeDef.AsEnum.Value.Name)
+			return nil, false, fmt.Errorf("could not resolve enum def %s", typeDef.AsEnum.Value.Name)
 		}
 
 		modType = &CoreModEnum{coreMod: m, typeDef: resolvedDef.AsEnum.Value}
 
 	case core.TypeDefKindInterface:
 		// core does not yet define any interfaces
-		return nil, false, false, nil
+		return nil, false, nil
 
 	default:
-		return nil, false, false, fmt.Errorf("unexpected type def kind %s", typeDef.Kind)
+		return nil, false, fmt.Errorf("unexpected type def kind %s", typeDef.Kind)
 	}
 
 	if typeDef.Optional {
@@ -172,7 +172,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 		}
 	}
 
-	return modType, true, true, nil
+	return modType, true, nil
 }
 
 func (m *CoreMod) typedefs(ctx context.Context) ([]*core.TypeDef, error) {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -384,10 +384,6 @@ func (s *moduleSchema) typeDefWithEnumMember(ctx context.Context, def *core.Type
 		return nil, err
 	}
 
-	if args.Value == args.Name {
-		args.Value = ""
-	}
-
 	supports, err := supportEnumMembers(ctx)
 	if err != nil {
 		return nil, err
@@ -395,7 +391,6 @@ func (s *moduleSchema) typeDefWithEnumMember(ctx context.Context, def *core.Type
 	if !supports {
 		return def.WithEnumValue(args.Name, args.Value, args.Description, sourceMap)
 	}
-
 	return def.WithEnumMember(args.Name, args.Value, args.Description, sourceMap)
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2107,8 +2107,12 @@ func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInst
 	for _, enum := range initialized.EnumDefs {
 		mod, err = mod.WithEnum(ctx, enum)
 		if err != nil {
-			return nil, fmt.Errorf("failed to add enum to module %q: %w", mod.Name(), err)
+			return nil, fmt.Errorf("failed to add enum to module %q: %w", modName, err)
 		}
+	}
+	err = mod.Patch()
+	if err != nil {
+		return nil, fmt.Errorf("failed to patch module %q: %w", modName, err)
 	}
 	return mod, nil
 }

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -82,7 +83,7 @@ func (fn *Function) FieldSpec(ctx context.Context, mod *Module) (dagql.FieldSpec
 		spec.Directives = append(spec.Directives, fn.SourceMap.TypeDirective())
 	}
 	for _, arg := range fn.Args {
-		modType, ok, local, err := mod.ModTypeFor(ctx, arg.TypeDef, true)
+		modType, ok, err := mod.ModTypeFor(ctx, arg.TypeDef, true)
 		if err != nil {
 			return spec, fmt.Errorf("failed to get typedef for arg %q: %w", arg.Name, err)
 		}
@@ -101,7 +102,7 @@ func (fn *Function) FieldSpec(ctx context.Context, mod *Module) (dagql.FieldSpec
 			}
 
 			var err error
-			defaultVal, err = modType.TypeDef().ToDefault(val, local)
+			defaultVal, err = input.Decoder().DecodeInput(val)
 			if err != nil {
 				return spec, fmt.Errorf("failed to decode default value for arg %q: %w", arg.Name, err)
 			}
@@ -424,24 +425,6 @@ func (typeDef *TypeDef) ToInput() dagql.Input {
 	return typed
 }
 
-func (typeDef *TypeDef) ToDefault(val any, local bool) (dagql.Input, error) {
-	var typed dagql.Input
-
-	if typeDef.Kind == TypeDefKindEnum {
-		typed = &ModuleEnum{
-			TypeDef: typeDef.AsEnum.Value,
-			Local:   local,
-		}
-		if typeDef.Optional {
-			typed = dagql.DynamicOptional{Elem: typed}
-		}
-	} else {
-		typed = typeDef.ToInput()
-	}
-
-	return typed.Decoder().DecodeInput(val)
-}
-
 func (typeDef *TypeDef) ToType() *ast.Type {
 	return typeDef.ToTyped().Type()
 }
@@ -656,6 +639,21 @@ type ObjectTypeDef struct {
 	// The original name of the object as provided by the SDK that defined it, used
 	// when invoking the SDK so it doesn't need to think as hard about case conversions
 	OriginalName string
+}
+
+func (obj ObjectTypeDef) functions() iter.Seq[*Function] {
+	return func(yield func(*Function) bool) {
+		if obj.Constructor.Valid {
+			if !yield(obj.Constructor.Value) {
+				return
+			}
+		}
+		for _, objFn := range obj.Functions {
+			if !yield(objFn) {
+				return
+			}
+		}
+	}
 }
 
 func (*ObjectTypeDef) Type() *ast.Type {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -547,7 +547,7 @@ func (typeDef *TypeDef) WithEnumValue(name, value, desc string, sourceMap *Sourc
 	if !typeDef.AsEnum.Valid {
 		return nil, fmt.Errorf("cannot add value to non-enum type: %s", typeDef.Kind)
 	}
-	if err := typeDef.validateEnumMember(name, name); err != nil {
+	if err := typeDef.validateEnumMember(value, value); err != nil {
 		return nil, err
 	}
 
@@ -1093,7 +1093,7 @@ func (enumValue EnumMemberTypeDef) Clone() *EnumMemberTypeDef {
 }
 
 func (enumValue *EnumMemberTypeDef) EnumValueDirectives() []*ast.Directive {
-	if enumValue.Value == "" {
+	if enumValue.Value == "" || enumValue.Value == enumValue.Name {
 		return nil
 	}
 


### PR DESCRIPTION
Follow-up to #9518.

- There was an issue where old dagger versions would create an invalid typedef when the enum `name` equaled the enum `value`
  
  Reported by @nipuna-perera in [discord](https://discord.com/channels/707636530424053791/1387452929157632094/1387466805374881863).

- There was an issue where `--help` for enum default values was incorrect.

  Reported in #10644.