### PR TITLE
ignore CA cert automatically installed by OrbStack

### DIFF
--- a/.changes/unreleased/Changed-20250626-161512.yaml
+++ b/.changes/unreleased/Changed-20250626-161512.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |
+  Ignore default OrbStack CA cert for automatic installation.
+
+  OrbStack users were by default ending up with a custom CA in their engine and automatically installed in each container, adding overhead. We now ignore that CA cert by default to improve performance in the default case.
+time: 2025-06-26T16:15:12.022089779-07:00
+custom:
+  Author: sipsma
+  PR: "10648"

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -257,14 +257,22 @@ func main() { //nolint:gocyclo
 		if os.Geteuid() > 0 {
 			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
 		}
+
 		// install CA certs in case the user has a custom engine w/ extra certs installed to
 		// /usr/local/share/ca-certificates
-		if out, err := exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput(); err != nil {
-			bklog.G(ctx).WithError(err).Warnf("failed to update ca-certificates: %s", out)
-		} else {
-			//nolint:gosec // it thinks we're using untrusted input even though we're only using consts here...?
-			if out, err := exec.CommandContext(ctx, "c_rehash", cacerts.EngineCustomCACertsDir).CombinedOutput(); err != nil {
-				bklog.G(ctx).WithError(err).Warnf("failed to rehash ca-certificates: %s", out)
+		// Ignore if there's only an OrbStack CA, which we don't care about
+		dirEnts, err := os.ReadDir(cacerts.EngineCustomCACertsDir)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to read %s: %w", cacerts.EngineCustomCACertsDir, err)
+		}
+		if len(dirEnts) > 1 || (len(dirEnts) == 1 && dirEnts[0].Name() != cacerts.OrbstackCACertName) {
+			if out, err := exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput(); err != nil {
+				bklog.G(ctx).WithError(err).Warnf("failed to update ca-certificates: %s", out)
+			} else {
+				//nolint:gosec // it thinks we're using untrusted input even though we're only using consts here...?
+				if out, err := exec.CommandContext(ctx, "c_rehash", cacerts.EngineCustomCACertsDir).CombinedOutput(); err != nil {
+					bklog.G(ctx).WithError(err).Warnf("failed to rehash ca-certificates: %s", out)
+				}
 			}
 		}
 

--- a/engine/buildkit/cacerts/cacerts.go
+++ b/engine/buildkit/cacerts/cacerts.go
@@ -13,6 +13,11 @@ import (
 
 const (
 	EngineCustomCACertsDir = "/usr/local/share/ca-certificates"
+
+	// OrbStack automatically installs this custom CA cert, but we don't want to automatically
+	// install it in every Dagger container, so we ignore it if found.
+	// https://docs.orbstack.dev/features/https#between-containers
+	OrbstackCACertName = "orbstack-root.crt"
 )
 
 // Installer is an implementation of installing+uninstalling custom CA certs for a container,
@@ -38,6 +43,10 @@ func NewInstaller(
 	dirEnts, err := os.ReadDir(EngineCustomCACertsDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
+	}
+
+	if len(dirEnts) == 1 && dirEnts[0].Name() == OrbstackCACertName {
+		return noopInstaller{}, nil
 	}
 	if len(dirEnts) == 0 {
 		return noopInstaller{}, nil


### PR DESCRIPTION
[OrbStack will by default automatically put a CA cert in containers](https://docs.orbstack.dev/features/https#between-containers),
including the dagger engine if the user is running on MacOS w/ OrbStack.

This results in the engine seeing a custom CA cert and deciding to
automatically install it in every container. While this works it
introduces performance overhead for a case that is unlikely to be of any
utility.

This therefore disables automatic CA cert installation when the only CA
cert found is the OrbStack one, keeping the default path case for
OrbStack users simpler and more performant.

---

@TomChv noticed this after pulling down [this change](https://github.com/dagger/dagger/pull/10645), so the first commit here also improves some busybox symlink handling in the alpine module.

Discord thread for context: https://discord.com/channels/707636530424053791/1387901998283624654