### PR TITLE
go: fix parsing of pragma default with `+` in it

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -1178,6 +1178,11 @@ func parsePragmaComment(comment string) (data map[string]any, rest string) {
 	data = map[string]any{}
 	lastEnd := 0
 	for _, v := range pragmaCommentRegexp.FindAllStringSubmatchIndex(comment, -1) {
+		// Skip matches that start before we've finished processing
+		if v[0] < lastEnd {
+			continue
+		}
+
 		var key string
 		if v[2] != -1 {
 			key = comment[v[2]:v[3]]


### PR DESCRIPTION
Fixes a regression from https://github.com/dagger/dagger/pull/10594 where the `+default` value itself has a `+`, which was getting parsed incorrectly and resulting in panics like:
```
9   : ┆ ┆ ┆ [0.5s] | internal error during module code generation: runtime error: slice bounds out of range [50:28]
9   : ┆ ┆ ┆ [0.5s] | goroutine 1 [running]:
9   : ┆ ┆ ┆ [0.5s] | runtime/debug.Stack()
9   : ┆ ┆ ┆ [0.5s] | 	/usr/lib/go/src/runtime/debug/stack.go:26 +0x5e
9   : ┆ ┆ ┆ [0.5s] | runtime/debug.PrintStack()
9   : ┆ ┆ ┆ [0.5s] | 	/usr/lib/go/src/runtime/debug/stack.go:18 +0x13
9   : ┆ ┆ ┆ [0.5s] | github.com/dagger/dagger/cmd/codegen/generator/go/templates.goTemplateFuncs.moduleMainSrc.func1()
9   : ┆ ┆ ┆ [0.5s] | 	/app/cmd/codegen/generator/go/templates/modules.go:88 +0x6a
9   : ┆ ┆ ┆ [0.5s] | panic({0xf713c0?, 0xc000e107c8?})
9   : ┆ ┆ ┆ [0.5s] | 	/usr/lib/go/src/runtime/panic.go:792 +0x132
9   : ┆ ┆ ┆ [0.5s] | github.com/dagger/dagger/cmd/codegen/generator/go/templates.parsePragmaComment({0xc000f8cf80, 0x32})
```