### PR TITLE
fix: WithSymlink now returns file exists error for existing symlinks

### DIFF
--- a/.changes/unreleased/Fixed-20250630-111034.yaml
+++ b/.changes/unreleased/Fixed-20250630-111034.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: WithSymlink now returns "file exists" error when attempting to overwrite an existing symlink.
+time: 2025-06-30T11:10:34.880061239-07:00
+custom:
+    Author: alexcb
+    PR: "10664"

--- a/core/directory.go
+++ b/core/directory.go
@@ -863,17 +863,17 @@ func (dir *Directory) WithSymlink(ctx context.Context, srv *dagql.Server, target
 		return nil, err
 	}
 	err = MountRef(ctx, newRef, nil, func(root string) error {
-		fullLinkName, err := containerdfs.RootPath(root, linkName)
+		linkDir, linkBasename := filepath.Split(linkName)
+		resolvedLinkDir, err := containerdfs.RootPath(root, linkDir)
 		if err != nil {
 			return err
 		}
-
-		linkNameDirPath, _ := filepath.Split(fullLinkName)
-		err = os.MkdirAll(filepath.Dir(linkNameDirPath), 0755)
+		err = os.MkdirAll(resolvedLinkDir, 0755)
 		if err != nil {
 			return err
 		}
-		return os.Symlink(target, fullLinkName)
+		resolvedLinkName := path.Join(resolvedLinkDir, linkBasename)
+		return os.Symlink(target, resolvedLinkName)
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If WithSymlink was called on an existing symlink, it would incorrectly
resolve that symlink rather than returning an error.

For example:

    WithSymlink("target", "symlink").
    WithSymlink("newtarget", "symlink").

would incorrectly produce:

    symlink -> target
    target -> newtarget

When the second WithSymlink was called, `containerdfs.RootPath` would
(incorrectly) first resolve `symlink` to `target` prior to making the
the underlying `os.Symlink("target", "newtarget")` syscall.