### PR TITLE
chore: make DagOp helpers return non-instances

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -910,14 +910,8 @@ func (args containerExecArgs) Digest() (digest.Digest, error) {
 func (s *containerSchema) withExec(ctx context.Context, parent dagql.Instance[*core.Container], args containerExecArgs) (inst dagql.Instance[*core.Container], _ error) {
 	parent.Self = parent.Self.Clone()
 	if !args.IsDagOp {
-		st := core.MetaMountState(ctx, args.Stdin)
-		def, err := st.Marshal(ctx, llb.Platform(parent.Self.Platform.Spec()))
-		if err != nil {
-			return inst, err
-		}
-		parent.Self.Meta = def.ToPB()
-
-		inst, err = DagOpContainer(ctx, s.srv, parent, args, s.withExec)
+		parent.Self.Meta = nil
+		inst, err := DagOpContainer(ctx, s.srv, parent, args, s.withExec)
 		if err != nil {
 			return inst, err
 		}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -917,7 +917,7 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.Instance[*c
 		}
 		parent.Self.Meta = def.ToPB()
 
-		inst, err = DagOpContainer(ctx, s.srv, parent, args, nil, s.withExec)
+		inst, err = DagOpContainer(ctx, s.srv, parent, args, s.withExec)
 		if err != nil {
 			return inst, err
 		}

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -595,6 +595,6 @@ func (s *directorySchema) withSymlink(ctx context.Context, parent dagql.Instance
 	return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, dir)
 }
 
-func (s *directorySchema) withSymlinkPath(ctx context.Context, val dagql.Instance[*core.Directory], _ directoryWithSymlinkArgs) (string, error) {
-	return val.Self.Dir, nil
+func (s *directorySchema) withSymlinkPath(ctx context.Context, dir *core.Directory, _ directoryWithSymlinkArgs) (string, error) {
+	return dir.Dir, nil
 }

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -132,9 +132,9 @@ func (s *gitSchema) Install() {
 					View(BeforeVersion("v0.12.0")).
 					Doc("This option should be passed to `git` instead.").Deprecated(),
 			),
-		dagql.NodeFunc("commit", s.fetchCommit).
+		dagql.NodeFunc("commit", DagOpWrapper(s.srv, s.fetchCommit)).
 			Doc(`The resolved commit id at this ref.`),
-		dagql.NodeFunc("ref", s.fetchRef).
+		dagql.NodeFunc("ref", DagOpWrapper(s.srv, s.fetchRef)).
 			Doc(`The resolved ref name at this ref.`),
 	}.Install(s.srv)
 }
@@ -647,10 +647,6 @@ func (s *gitSchema) fetchCommit(
 	parent dagql.Instance[*core.GitRef],
 	args RawDagOpInternalArgs,
 ) (dagql.String, error) {
-	if !args.IsDagOp {
-		return DagOp(ctx, s.srv, parent, args, s.fetchCommit)
-	}
-
 	commit, _, err := parent.Self.Resolve(ctx)
 	if err != nil {
 		return "", err
@@ -663,10 +659,6 @@ func (s *gitSchema) fetchRef(
 	parent dagql.Instance[*core.GitRef],
 	args RawDagOpInternalArgs,
 ) (dagql.String, error) {
-	if !args.IsDagOp {
-		return DagOp(ctx, s.srv, parent, args, s.fetchCommit)
-	}
-
 	_, ref, err := parent.Self.Resolve(ctx)
 	if err != nil {
 		return "", err

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -608,7 +608,11 @@ func (s *gitSchema) tree(ctx context.Context, parent dagql.Instance[*core.GitRef
 		return dagql.NewInstanceForCurrentID(ctx, s.srv, parent, dir)
 	}
 
-	inst, err := DagOpDirectory(ctx, s.srv, parent, args, "", s.tree)
+	dir, err := DagOpDirectory(ctx, s.srv, parent.Self, args, "", s.tree)
+	if err != nil {
+		return inst, err
+	}
+	inst, err = dagql.NewInstanceForCurrentID(ctx, s.srv, parent, dir)
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -188,7 +188,7 @@ func DagOpContainerWrapper[A DagOpInternalArgsIface](
 		if args.InDagOp() {
 			return fn(ctx, self, args)
 		}
-		return DagOpContainer(ctx, srv, self, args, nil, fn)
+		return DagOpContainer(ctx, srv, self, args, fn)
 	}
 }
 
@@ -197,7 +197,6 @@ func DagOpContainer[A any](
 	srv *dagql.Server,
 	self dagql.Instance[*core.Container],
 	args A,
-	data any,
 	fn dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]],
 ) (inst dagql.Instance[*core.Container], _ error) {
 	argDigest, err := core.DigestOf(args)

--- a/core/schema/wrapper.go
+++ b/core/schema/wrapper.go
@@ -44,7 +44,7 @@ func DagOp[T dagql.Typed, A any, R dagql.Typed](
 	}, deps)
 }
 
-type PathFunc[T dagql.Typed, A any] func(ctx context.Context, val dagql.Instance[T], args A) (string, error)
+type PathFunc[T dagql.Typed, A any] func(ctx context.Context, val T, args A) (string, error)
 
 // DagOpFileWrapper caches a file field as a buildkit operation - this is
 // more specialized than DagOpWrapper, since that serializes the value to
@@ -58,7 +58,11 @@ func DagOpFileWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 		if args.InDagOp() {
 			return fn(ctx, self, args)
 		}
-		return DagOpFile(ctx, srv, self, args, "", fn, opts...)
+		file, err := DagOpFile(ctx, srv, self.Self, args, "", fn, opts...)
+		if err != nil {
+			return inst, err
+		}
+		return dagql.NewInstanceForCurrentID(ctx, srv, self, file)
 	}
 }
 
@@ -70,16 +74,16 @@ func DagOpFileWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 func DagOpFile[T dagql.Typed, A any](
 	ctx context.Context,
 	srv *dagql.Server,
-	self dagql.Instance[T],
+	self T,
 	args A,
 	data string,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.File]],
 	opts ...DagOpOptsFn[T, A],
-) (inst dagql.Instance[*core.File], _ error) {
+) (*core.File, error) {
 	o := getOpts(opts...)
-	deps, err := extractLLBDependencies(ctx, self.Self)
+	deps, err := extractLLBDependencies(ctx, self)
 	if err != nil {
-		return inst, err
+		return nil, err
 	}
 
 	filename := "file"
@@ -89,20 +93,15 @@ func DagOpFile[T dagql.Typed, A any](
 		// invalidate the cache
 		filename, err = o.pfn(ctx, self, args)
 		if err != nil {
-			return inst, err
+			return nil, err
 		}
 	}
 
-	file, err := core.NewFileDagOp(ctx, srv, &core.FSDagOp{
+	return core.NewFileDagOp(ctx, srv, &core.FSDagOp{
 		ID:   currentIDForFSDagOp(ctx, filename, data),
 		Path: filename,
 		Data: data,
 	}, deps)
-	if err != nil {
-		return inst, err
-	}
-
-	return dagql.NewInstanceForCurrentID(ctx, srv, self, file)
 }
 
 // DagOpDirectoryWrapper caches a directory field as a buildkit operation,
@@ -116,7 +115,11 @@ func DagOpDirectoryWrapper[T dagql.Typed, A DagOpInternalArgsIface](
 		if args.InDagOp() {
 			return fn(ctx, self, args)
 		}
-		return DagOpDirectory(ctx, srv, self, args, "", fn, opts...)
+		dir, err := DagOpDirectory(ctx, srv, self.Self, args, "", fn, opts...)
+		if err != nil {
+			return inst, err
+		}
+		return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
 	}
 }
 
@@ -146,38 +149,34 @@ func getOpts[T dagql.Typed, A any](opts ...DagOpOptsFn[T, A]) *DagOpOpts[T, A] {
 func DagOpDirectory[T dagql.Typed, A any](
 	ctx context.Context,
 	srv *dagql.Server,
-	self dagql.Instance[T],
+	self T,
 	args A,
 	data string,
 	fn dagql.NodeFuncHandler[T, A, dagql.Instance[*core.Directory]],
 	opts ...DagOpOptsFn[T, A],
-) (inst dagql.Instance[*core.Directory], _ error) {
+) (*core.Directory, error) {
 	o := getOpts(opts...)
 
-	deps, err := extractLLBDependencies(ctx, self.Self)
+	deps, err := extractLLBDependencies(ctx, self)
 	if err != nil {
-		return inst, err
+		return nil, err
 	}
 
 	filename := "/"
 	if o.pfn != nil {
 		filename, err = o.pfn(ctx, self, args)
 		if err != nil {
-			return inst, err
+			return nil, err
 		}
 	}
 
-	dir, err := core.NewDirectoryDagOp(ctx, srv, &core.FSDagOp{
+	return core.NewDirectoryDagOp(ctx, srv, &core.FSDagOp{
 		// FIXME: using this in the cache key means we effectively disable
 		// buildkit content caching
 		ID:   currentIDForFSDagOp(ctx, filename, data),
 		Path: filename,
 		Data: data,
 	}, deps)
-	if err != nil {
-		return inst, err
-	}
-	return dagql.NewInstanceForCurrentID(ctx, srv, self, dir)
 }
 
 func DagOpContainerWrapper[A DagOpInternalArgsIface](
@@ -188,32 +187,31 @@ func DagOpContainerWrapper[A DagOpInternalArgsIface](
 		if args.InDagOp() {
 			return fn(ctx, self, args)
 		}
-		return DagOpContainer(ctx, srv, self, args, fn)
+		ctr, err := DagOpContainer(ctx, srv, self.Self, args, fn)
+		if err != nil {
+			return inst, err
+		}
+		return dagql.NewInstanceForCurrentID(ctx, srv, self, ctr)
 	}
 }
 
 func DagOpContainer[A any](
 	ctx context.Context,
 	srv *dagql.Server,
-	self dagql.Instance[*core.Container],
+	ctr *core.Container,
 	args A,
 	fn dagql.NodeFuncHandler[*core.Container, A, dagql.Instance[*core.Container]],
-) (inst dagql.Instance[*core.Container], _ error) {
+) (*core.Container, error) {
 	argDigest, err := core.DigestOf(args)
 	if err != nil {
-		return inst, err
+		return nil, err
 	}
 
-	deps, err := extractLLBDependencies(ctx, self.Self)
+	deps, err := extractLLBDependencies(ctx, ctr)
 	if err != nil {
-		return inst, err
+		return nil, err
 	}
-
-	ctr, err := core.NewContainerDagOp(ctx, currentIDForContainerDagOp(ctx), argDigest, self.Self, deps)
-	if err != nil {
-		return inst, err
-	}
-	return dagql.NewInstanceForCurrentID(ctx, srv, self, ctr)
+	return core.NewContainerDagOp(ctx, currentIDForContainerDagOp(ctx), argDigest, ctr, deps)
 }
 
 const (

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -27,7 +27,7 @@ Expected stderr:
   ╰─▼ [4/4] RUN echo im failing && false X.Xs ERROR
     ┃ im failing
     ! process "/bin/sh -c echo im failing && false" did not complete successfully: exit code: 1
-● .withExec(args: ["echo", "hey"]): Container! X.Xs
+○ .withExec(args: ["echo", "hey"]): Container! X.Xs
 ✘ .stdout: String! X.Xs ERROR
 ! process "/bin/sh -c echo im failing && false" did not complete successfully: exit code: 1
 

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -556,18 +556,6 @@ func (w *Worker) setupStdio(_ context.Context, state *execState) error {
 		return nil
 	}
 
-	stdinPath := filepath.Join(state.metaMount.Source, MetaMountStdinPath)
-	stdinFile, err := os.Open(stdinPath)
-	switch {
-	case err == nil:
-		state.cleanups.Add("close container stdin file", stdinFile.Close)
-		state.procInfo.Stdin = stdinFile
-	case os.IsNotExist(err):
-		// no stdin to send
-	default:
-		return fmt.Errorf("open stdin file: %w", err)
-	}
-
 	var stdoutWriters []io.Writer
 	if state.procInfo.Stdout != nil {
 		stdoutWriters = append(stdoutWriters, state.procInfo.Stdout)

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -49,7 +49,6 @@ const (
 	// MetaMountDestPath is the special path that the shim writes metadata to.
 	MetaMountDestPath     = "/.dagger_meta_mount"
 	MetaMountExitCodePath = "exitCode"
-	MetaMountStdinPath    = "stdin"
 	MetaMountStdoutPath   = "stdout"
 	MetaMountStderrPath   = "stderr"
 	MetaMountClientIDPath = "clientID"


### PR DESCRIPTION
...and other little fixes.

@sipsma points out that this is a code smell: https://github.com/dagger/dagger/blob/14ff07af8b91c091e1f1e7afbf0e01316142f8ca/core/schema/container.go#L918

Reaching into and modifying the instance isn't a great practice, and will become impossible in https://github.com/dagger/dagger/pull/10620. However, we don't *really* need to be returning instances directly from dagop, there's no hard dependency, so we can simplify some of the code here.

The other little fixes are:
- Removing an unused arg from `DagOpContainer`
- Removing stdin from the meta mount - we don't need to smuggle this through that mount anymore, since we control the call site - this lets us clean up the meta mount init (and just reset it to nil).
- Use the simpler wrappers for git ops where possible.