### PR TITLE
fix: typescript telemetry correctly flush spans on failure

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20250702-222014.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20250702-222014.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Correctly flush custom span on execution failure so it's properly displayed
+  on Dagger Cloud.
+time: 2025-07-02T22:20:14.226107+02:00
+custom:
+  Author: TomChv
+  PR: "10677"

--- a/sdk/typescript/src/telemetry/init.ts
+++ b/sdk/typescript/src/telemetry/init.ts
@@ -54,7 +54,7 @@ export class DaggerOtelConfigurator {
    */
   async close() {
     if (this.sdk) {
-      this.sdk.shutdown()
+      await this.sdk.shutdown()
     }
   }
 


### PR DESCRIPTION
Raised by @marcosnils on Discord: https://discord.com/channels/707636530424053791/708371226174685314/1389235734166114424

Fixed by correctly awaiting `sdk.shutdown` and closing telemetry when an error is thrown since the process is exiting early meaning it's not properly closed by the `connection` finaly logic.