### PR TITLE
fix: with-symlink should work on scratch container

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -591,6 +591,9 @@ func getRefOrEvaluate(ctx context.Context, ref bkcache.ImmutableRef, t Evaluatab
 	if err != nil {
 		return nil, err
 	}
+	if res == nil {
+		return nil, nil
+	}
 	cacheRef, err := res.SingleRef()
 	if err != nil {
 		return nil, err

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -5177,6 +5177,13 @@ func (ContainerSuite) TestSymlink(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Contains(t, entries, "bar")
 	})
+
+	t.Run("symlink works with scratch container", func(ctx context.Context, t *testctx.T) {
+		_, err := c.Container().
+			WithSymlink("doesnt-matter", "symlink").
+			Sync(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func (ContainerSuite) TestSymlinkCaching(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
This fixes a bug where with-symlink would panic when attempting to get a reference to a scratch container.