### PR TITLE
shell: fix errors being hidden by `reveal` attribute

### DIFF
--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -197,7 +197,6 @@ func (h *shellCallHandler) Exec(next interp.ExecHandlerFunc) interp.ExecHandlerF
 				// part of the script triggered it.
 				attrs := []attribute.KeyValue{
 					attribute.Bool(telemetry.UIPassthroughAttr, false),
-					attribute.Bool(telemetry.UIRevealAttr, true),
 				}
 				var he *HandlerError
 				if errors.As(rerr, &he) {


### PR DESCRIPTION
this was causing the deeper error to be hidden, don't think the effect is intended

before:

![image](https://github.com/user-attachments/assets/56182b5a-811c-4c17-832c-5f0d16c7c21e)

after:

![image](https://github.com/user-attachments/assets/9c2a86fa-d27b-40ea-b02c-05051db36383)

not really sure if we need that `passthrough=false` flag either, but leaving that one alone since it's at least not harmful (besides the extra noise) and is probably needed for some edge case I'm not aware of