### PR TITLE
fix: typescript generated client directory issue

### DIFF
--- a/sdk/typescript/runtime/clientgen.go
+++ b/sdk/typescript/runtime/clientgen.go
@@ -42,7 +42,7 @@ func clientGenBaseContainer(cfg *moduleConfig, sdkSourceDir *dagger.Directory) *
 			WithExec([]string{"ln", "-s", "/usr/local/lib/node_modules/tsx/dist/cli.mjs", "/usr/local/bin/tsx"}).
 			// Add dagger codegen binary.
 			WithMountedFile(codegenBinPath, sdkSourceDir.File("/codegen")).
-			WithWorkdir(ModSourceDirPath),
+			WithWorkdir(cfg.moduleRootPath()),
 	}
 
 	return clientGenCtr

--- a/sdk/typescript/runtime/config.go
+++ b/sdk/typescript/runtime/config.go
@@ -82,6 +82,7 @@ type moduleConfig struct {
 	// Module config
 	name    string
 	subPath string
+	modPath string
 	sdk     string
 
 	// Location of the SDK library
@@ -111,6 +112,11 @@ func analyzeModuleConfig(ctx context.Context, modSource *dagger.ModuleSource) (c
 	cfg.subPath, err = modSource.SourceSubpath(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not load module config source subpath: %w", err)
+	}
+
+	cfg.modPath, err = modSource.SourceRootSubpath(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not load module config source root subpath: %w", err)
 	}
 
 	// We retrieve the SDK because if it's set, that means the module is implementing
@@ -409,6 +415,10 @@ func (c *moduleConfig) hasFile(name string) bool {
 // Return the path to the module source.
 func (c *moduleConfig) modulePath() string {
 	return filepath.Join(ModSourceDirPath, c.subPath)
+}
+
+func (c *moduleConfig) moduleRootPath() string {
+	return filepath.Join(ModSourceDirPath, c.modPath)
 }
 
 // Return the path to the SDK directory inside the module source.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2554,8 +2554,11 @@ export class Container extends BaseClient {
     }
 
     const metadata = {
-      forcedCompression: { is_enum: true },
-      mediaTypes: { is_enum: true },
+      forcedCompression: {
+        is_enum: true,
+        value_to_name: ImageLayerCompressionValueToName,
+      },
+      mediaTypes: { is_enum: true, value_to_name: ImageMediaTypesValueToName },
     }
 
     const ctx = this._ctx.select("exportImage", {


### PR DESCRIPTION
Fix for an issue that I noticed while I was testing the TS SDK in a monorepo setup.
Basically, if your context dir is `/root` and your module that generate the client is in `/root/foo/bar`, the generated content would be in `/root` instead of `/root/foo/bar` (only happens in TypeScript).
This PR fixes that behaviour :)