### PR TITLE
plain: ignore verbose logs from API responses

### DIFF
--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -325,7 +325,7 @@ func (fe plainLogExporter) Export(ctx context.Context, logs []sdklog.Record) err
 			return true // continue walking
 		})
 
-		// Skip verbose logs in the dots frontend
+		// Skip verbose logs in the plain frontend
 		if isVerbose {
 			continue
 		}


### PR DESCRIPTION
This prevents output from API calls like `Foo.contents` from showing up in the plain output, where the signal:noise ratio is very poor. (Prior art from the `dots` frontend: https://github.com/dagger/dagger/pull/10617)