### PR TITLE
dagql: fix case where session cache refs are never closed

### DIFF
--- a/.changes/unreleased/Fixed-20250709-184653.yaml
+++ b/.changes/unreleased/Fixed-20250709-184653.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix memory leak in engine
+time: 2025-07-09T18:46:53.359054779-07:00
+custom:
+  Author: sipsma
+  PR: "10708"

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -793,6 +793,5 @@ func newDagOpLLB(ctx context.Context, dagOp buildkit.CustomOp, id *call.ID, inpu
 		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Name()),
 		buildkit.WithTracePropagation(ctx),
 		buildkit.WithPassthrough(),
-		llb.SkipEdgeMerge,
 	)
 }

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -793,5 +793,6 @@ func newDagOpLLB(ctx context.Context, dagOp buildkit.CustomOp, id *call.ID, inpu
 		llb.WithCustomNamef("%s %s", dagOp.Name(), id.Name()),
 		buildkit.WithTracePropagation(ctx),
 		buildkit.WithPassthrough(),
+		llb.SkipEdgeMerge,
 	)
 }

--- a/core/query.go
+++ b/core/query.go
@@ -135,6 +135,30 @@ func CurrentQuery(ctx context.Context) (*Query, error) {
 	return q, nil
 }
 
+func CurrentDagqlServer(ctx context.Context) (*dagql.Server, error) {
+	q, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("current query: %w", err)
+	}
+	srv, err := q.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query server: %w", err)
+	}
+	return srv, nil
+}
+
+func CurrentDagqlCache(ctx context.Context) (*dagql.SessionCache, error) {
+	q, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("current query: %w", err)
+	}
+	cache, err := q.Cache(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query cache: %w", err)
+	}
+	return cache, nil
+}
+
 func NewRoot(srv Server) *Query {
 	return &Query{Server: srv}
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -815,7 +815,11 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		return inst, fmt.Errorf("failed to set digest on image %s: %w", refName.String(), err)
 	}
 
-	err = s.srv.Select(ctx, parent, &inst,
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+	err = srv.Select(ctx, parent, &inst,
 		dagql.Selector{
 			Field: "from",
 			Args: []dagql.NamedInput{
@@ -840,15 +844,20 @@ type containerBuildArgs struct {
 }
 
 func (s *containerSchema) build(ctx context.Context, parent *core.Container, args containerBuildArgs) (*core.Container, error) {
-	dir, err := args.Context.Load(ctx, s.srv)
-	if err != nil {
-		return nil, err
-	}
-	secrets, err := dagql.LoadIDResults(ctx, s.srv, args.Secrets)
-	if err != nil {
-		return nil, err
-	}
 	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	dir, err := args.Context.Load(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+	secrets, err := dagql.LoadIDResults(ctx, srv, args.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +866,7 @@ func (s *containerSchema) build(ctx context.Context, parent *core.Container, arg
 		return nil, err
 	}
 
-	buildctxDir, err := applyDockerIgnore(ctx, s.srv, dir, args.Dockerfile)
+	buildctxDir, err := applyDockerIgnore(ctx, srv, dir, args.Dockerfile)
 	if err != nil {
 		return nil, err
 	}
@@ -880,7 +889,16 @@ type containerWithRootFSArgs struct {
 }
 
 func (s *containerSchema) withRootfs(ctx context.Context, parent *core.Container, args containerWithRootFSArgs) (*core.Container, error) {
-	dir, err := args.Directory.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	dir, err := args.Directory.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -936,15 +954,25 @@ func (args containerExecArgs) Digest() (digest.Digest, error) {
 
 func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerExecArgs) (inst dagql.ObjectResult[*core.Container], _ error) {
 	ctr := parent.Self().Clone()
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	if !args.IsDagOp {
 		ctr.Meta = nil
-		ctr, err := DagOpContainer(ctx, s.srv, ctr, args, s.withExec)
+		ctr, err := DagOpContainer(ctx, srv, ctr, args, s.withExec)
 		if err != nil {
 			return inst, err
 		}
 
 		ctr.ImageRef = ""
-		return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+		return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 	}
 
 	if args.SkipEntrypoint != nil {
@@ -968,11 +996,11 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 		md = args.ExecMD.Self
 	}
 
-	ctr, err := parent.Self().WithExec(ctx, args.ContainerExecOpts, md)
+	ctr, err = parent.Self().WithExec(ctx, args.ContainerExecOpts, md)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 func (s *containerSchema) withExecCacheKey(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerExecArgs, cacheCfg dagql.CacheConfig) (*dagql.CacheConfig, error) {
@@ -992,10 +1020,19 @@ func (s *containerSchema) stdout(ctx context.Context, parent *core.Container, _ 
 }
 
 func (s *containerSchema) stdoutLegacy(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (string, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return "", err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get server: %w", err)
+	}
+
 	out, err := parent.Self().Stdout(ctx)
 	if errors.Is(err, core.ErrNoCommand) {
 		var ctr dagql.ObjectResult[*core.Container]
-		if err := s.srv.Select(ctx, parent, &ctr, dagql.Selector{
+		if err := srv.Select(ctx, parent, &ctr, dagql.Selector{
 			Field: "withExec",
 			Args: []dagql.NamedInput{
 				{
@@ -1020,10 +1057,19 @@ func (s *containerSchema) stderr(ctx context.Context, parent *core.Container, _ 
 }
 
 func (s *containerSchema) stderrLegacy(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (string, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return "", err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get server: %w", err)
+	}
+
 	out, err := parent.Self().Stderr(ctx)
 	if errors.Is(err, core.ErrNoCommand) {
 		var ctr dagql.ObjectResult[*core.Container]
-		if err := s.srv.Select(ctx, parent, &ctr, dagql.Selector{
+		if err := srv.Select(ctx, parent, &ctr, dagql.Selector{
 			Field: "withExec",
 			Args: []dagql.NamedInput{
 				{
@@ -1056,6 +1102,15 @@ type containerWithSymlinkArgs struct {
 }
 
 func (s *containerSchema) withSymlink(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithSymlinkArgs) (inst dagql.ObjectResult[*core.Container], _ error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	target, err := expandEnvVar(ctx, parent.Self(), args.Target, args.Expand)
 	if err != nil {
 		return inst, err
@@ -1066,11 +1121,11 @@ func (s *containerSchema) withSymlink(ctx context.Context, parent dagql.ObjectRe
 		return inst, err
 	}
 
-	ctr, err := parent.Self().WithSymlink(ctx, s.srv, target, linkName)
+	ctr, err := parent.Self().WithSymlink(ctx, srv, target, linkName)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerGpuArgs struct {
@@ -1390,7 +1445,16 @@ type containerWithMountedDirectoryArgs struct {
 }
 
 func (s *containerSchema) withMountedDirectory(ctx context.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
-	dir, err := args.Source.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	dir, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1428,7 +1492,16 @@ type containerPublishArgs struct {
 }
 
 func (s *containerSchema) publish(ctx context.Context, parent *core.Container, args containerPublishArgs) (dagql.String, error) {
-	variants, err := dagql.LoadIDs(ctx, s.srv, args.PlatformVariants)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return "", err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get server: %w", err)
+	}
+
+	variants, err := dagql.LoadIDs(ctx, srv, args.PlatformVariants)
 	if err != nil {
 		return "", err
 	}
@@ -1453,7 +1526,16 @@ type containerWithMountedFileArgs struct {
 }
 
 func (s *containerSchema) withMountedFile(ctx context.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
-	file, err := args.Source.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	file, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,16 +1558,25 @@ type containerWithMountedCacheArgs struct {
 }
 
 func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Container, args containerWithMountedCacheArgs) (*core.Container, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	var dir *core.Directory
 	if args.Source.Valid {
-		inst, err := args.Source.Value.Load(ctx, s.srv)
+		inst, err := args.Source.Value.Load(ctx, srv)
 		if err != nil {
 			return nil, err
 		}
 		dir = inst.Self()
 	}
 
-	cache, err := args.Cache.Load(ctx, s.srv)
+	cache, err := args.Cache.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1648,7 +1739,16 @@ type containerWithSecretVariableArgs struct {
 }
 
 func (s *containerSchema) withSecretVariable(ctx context.Context, parent *core.Container, args containerWithSecretVariableArgs) (*core.Container, error) {
-	secret, err := args.Secret.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	secret, err := args.Secret.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1672,7 +1772,16 @@ type containerWithMountedSecretArgs struct {
 }
 
 func (s *containerSchema) withMountedSecret(ctx context.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
-	secret, err := args.Source.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	secret, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1692,7 +1801,16 @@ type containerWithDirectoryArgs struct {
 }
 
 func (s *containerSchema) withDirectory(ctx context.Context, parent *core.Container, args containerWithDirectoryArgs) (*core.Container, error) {
-	dir, err := args.Directory.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	dir, err := args.Directory.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1714,7 +1832,16 @@ type containerWithFileArgs struct {
 }
 
 func (s *containerSchema) withFile(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithFileArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	file, err := args.Source.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	file, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return inst, err
 	}
@@ -1724,12 +1851,12 @@ func (s *containerSchema) withFile(ctx context.Context, parent dagql.ObjectResul
 		return inst, err
 	}
 
-	ctr, err := parent.Self().WithFile(ctx, s.srv, path, file.Self(), args.Permissions, args.Owner)
+	ctr, err := parent.Self().WithFile(ctx, srv, path, file.Self(), args.Permissions, args.Owner)
 	if err != nil {
 		return inst, err
 	}
 
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerWithFilesArgs struct {
@@ -1741,9 +1868,18 @@ type containerWithFilesArgs struct {
 }
 
 func (s *containerSchema) withFiles(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithFilesArgs) (inst dagql.ObjectResult[*core.Container], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	files := []*core.File{}
 	for _, id := range args.Sources {
-		file, err := id.Load(ctx, s.srv)
+		file, err := id.Load(ctx, srv)
 		if err != nil {
 			return inst, err
 		}
@@ -1755,11 +1891,11 @@ func (s *containerSchema) withFiles(ctx context.Context, parent dagql.ObjectResu
 		return inst, err
 	}
 
-	ctr, err := parent.Self().WithFiles(ctx, s.srv, path, files, args.Permissions, args.Owner)
+	ctr, err := parent.Self().WithFiles(ctx, srv, path, files, args.Permissions, args.Owner)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerWithoutDirectoryArgs struct {
@@ -1770,16 +1906,25 @@ type containerWithoutDirectoryArgs struct {
 }
 
 func (s *containerSchema) withoutDirectory(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutDirectoryArgs) (inst dagql.ObjectResult[*core.Container], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	path, err := expandEnvVar(ctx, parent.Self(), args.Path, args.Expand)
 	if err != nil {
 		return inst, err
 	}
 
-	ctr, err := parent.Self().WithoutPaths(ctx, s.srv, path)
+	ctr, err := parent.Self().WithoutPaths(ctx, srv, path)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerWithoutFileArgs struct {
@@ -1790,16 +1935,25 @@ type containerWithoutFileArgs struct {
 }
 
 func (s *containerSchema) withoutFile(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutFileArgs) (inst dagql.ObjectResult[*core.Container], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	path, err := expandEnvVar(ctx, parent.Self(), args.Path, args.Expand)
 	if err != nil {
 		return inst, err
 	}
 
-	ctr, err := parent.Self().WithoutPaths(ctx, s.srv, path)
+	ctr, err := parent.Self().WithoutPaths(ctx, srv, path)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerWithoutFilesArgs struct {
@@ -1810,6 +1964,15 @@ type containerWithoutFilesArgs struct {
 }
 
 func (s *containerSchema) withoutFiles(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutFilesArgs) (inst dagql.ObjectResult[*core.Container], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	paths := args.Paths
 	for i, p := range args.Paths {
 		paths[i], err = expandEnvVar(ctx, parent.Self(), p, args.Expand)
@@ -1818,11 +1981,11 @@ func (s *containerSchema) withoutFiles(ctx context.Context, parent dagql.ObjectR
 		}
 	}
 
-	ctr, err := parent.Self().WithoutPaths(ctx, s.srv, paths...)
+	ctr, err := parent.Self().WithoutPaths(ctx, srv, paths...)
 	if err != nil {
 		return inst, err
 	}
-	return dagql.NewObjectResultForCurrentID(ctx, s.srv, ctr)
+	return dagql.NewObjectResultForCurrentID(ctx, srv, ctr)
 }
 
 type containerWithNewFileArgs struct {
@@ -1861,7 +2024,16 @@ type containerWithUnixSocketArgs struct {
 }
 
 func (s *containerSchema) withUnixSocket(ctx context.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
-	socket, err := args.Source.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	socket, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -1901,7 +2073,16 @@ type containerExportArgs struct {
 }
 
 func (s *containerSchema) export(ctx context.Context, parent *core.Container, args containerExportArgs) (dagql.String, error) {
-	variants, err := dagql.LoadIDs(ctx, s.srv, args.PlatformVariants)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return "", err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get server: %w", err)
+	}
+
+	variants, err := dagql.LoadIDs(ctx, srv, args.PlatformVariants)
 	if err != nil {
 		return "", err
 	}
@@ -1921,10 +2102,6 @@ func (s *containerSchema) export(ctx context.Context, parent *core.Container, ar
 			Tar:               true,
 		},
 	)
-	if err != nil {
-		return "", err
-	}
-	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -1960,15 +2137,20 @@ func (s *containerSchema) asTarball(
 	parent dagql.ObjectResult[*core.Container],
 	args containerAsTarballArgs,
 ) (inst dagql.ObjectResult[*core.File], rerr error) {
-	platformVariants, err := dagql.LoadIDs(ctx, s.srv, args.PlatformVariants)
-	if err != nil {
-		return inst, err
-	}
-
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return inst, err
 	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	platformVariants, err := dagql.LoadIDs(ctx, srv, args.PlatformVariants)
+	if err != nil {
+		return inst, err
+	}
+
 	bk, err := query.Buildkit(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get buildkit client: %w", err)
@@ -2084,7 +2266,7 @@ func (s *containerSchema) asTarball(
 	}
 	bkref = nil
 	f.Result = snap
-	fileInst, err := dagql.NewObjectResultForCurrentID(ctx, s.srv, f)
+	fileInst, err := dagql.NewObjectResultForCurrentID(ctx, srv, f)
 	if err != nil {
 		return inst, err
 	}
@@ -2243,7 +2425,17 @@ func (s *containerSchema) import_(ctx context.Context, parent *core.Container, a
 	defer func() {
 		slog.ExtraDebug("done importing container", "source", args.Source.Display(), "tag", args.Tag, "took", start)
 	}()
-	source, err := args.Source.Load(ctx, s.srv)
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	source, err := args.Source.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -2261,15 +2453,20 @@ type containerWithRegistryAuthArgs struct {
 }
 
 func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Container, args containerWithRegistryAuthArgs) (*core.Container, error) {
-	secret, err := args.Secret.Load(ctx, s.srv)
-	if err != nil {
-		return nil, err
-	}
-
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return nil, err
 	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	secret, err := args.Secret.Load(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+
 	secretStore, err := query.Secrets(ctx)
 	if err != nil {
 		return nil, err
@@ -2320,7 +2517,16 @@ type containerWithServiceBindingArgs struct {
 }
 
 func (s *containerSchema) withServiceBinding(ctx context.Context, parent *core.Container, args containerWithServiceBindingArgs) (*core.Container, error) {
-	svc, err := args.Service.Load(ctx, s.srv)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	svc, err := args.Service.Load(ctx, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -2451,6 +2657,15 @@ func (s *containerSchema) terminalLegacy(
 	ctr dagql.ObjectResult[*core.Container],
 	args containerTerminalArgs,
 ) (*core.TerminalLegacy, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
 	// HACK: when attempting to construct a legacy terminal, just spin up a new
 	// terminal attachable. The returned terminal is definitely invalid, but,
 	// the intention was probably to debug it anyways, so we're probably okay.
@@ -2474,7 +2689,7 @@ func (s *containerSchema) terminalLegacy(
 		})
 	}
 
-	err := s.srv.Select(ctx, ctr, new(dagql.Result[*core.Container]),
+	err = srv.Select(ctx, ctr, new(dagql.Result[*core.Container]),
 		dagql.Selector{
 			Field: "terminal",
 			Args:  inputs,

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1019,12 +1019,9 @@ func (s *containerSchema) stdout(ctx context.Context, parent *core.Container, _ 
 	return parent.Stdout(ctx)
 }
 
+//nolint:dupl
 func (s *containerSchema) stdoutLegacy(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (string, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return "", err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1056,12 +1053,9 @@ func (s *containerSchema) stderr(ctx context.Context, parent *core.Container, _ 
 	return parent.Stderr(ctx)
 }
 
+//nolint:dupl
 func (s *containerSchema) stderrLegacy(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (string, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return "", err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get server: %w", err)
 	}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -889,11 +889,7 @@ type containerWithRootFSArgs struct {
 }
 
 func (s *containerSchema) withRootfs(ctx context.Context, parent *core.Container, args containerWithRootFSArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -955,11 +951,7 @@ func (args containerExecArgs) Digest() (digest.Digest, error) {
 func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerExecArgs) (inst dagql.ObjectResult[*core.Container], _ error) {
 	ctr := parent.Self().Clone()
 
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1096,11 +1088,7 @@ type containerWithSymlinkArgs struct {
 }
 
 func (s *containerSchema) withSymlink(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithSymlinkArgs) (inst dagql.ObjectResult[*core.Container], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1439,11 +1427,7 @@ type containerWithMountedDirectoryArgs struct {
 }
 
 func (s *containerSchema) withMountedDirectory(ctx context.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1486,11 +1470,7 @@ type containerPublishArgs struct {
 }
 
 func (s *containerSchema) publish(ctx context.Context, parent *core.Container, args containerPublishArgs) (dagql.String, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return "", err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1520,11 +1500,7 @@ type containerWithMountedFileArgs struct {
 }
 
 func (s *containerSchema) withMountedFile(ctx context.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1552,11 +1528,7 @@ type containerWithMountedCacheArgs struct {
 }
 
 func (s *containerSchema) withMountedCache(ctx context.Context, parent *core.Container, args containerWithMountedCacheArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1733,11 +1705,7 @@ type containerWithSecretVariableArgs struct {
 }
 
 func (s *containerSchema) withSecretVariable(ctx context.Context, parent *core.Container, args containerWithSecretVariableArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1766,11 +1734,7 @@ type containerWithMountedSecretArgs struct {
 }
 
 func (s *containerSchema) withMountedSecret(ctx context.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1795,11 +1759,7 @@ type containerWithDirectoryArgs struct {
 }
 
 func (s *containerSchema) withDirectory(ctx context.Context, parent *core.Container, args containerWithDirectoryArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1826,11 +1786,7 @@ type containerWithFileArgs struct {
 }
 
 func (s *containerSchema) withFile(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithFileArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1862,11 +1818,7 @@ type containerWithFilesArgs struct {
 }
 
 func (s *containerSchema) withFiles(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithFilesArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1900,11 +1852,7 @@ type containerWithoutDirectoryArgs struct {
 }
 
 func (s *containerSchema) withoutDirectory(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutDirectoryArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1929,11 +1877,7 @@ type containerWithoutFileArgs struct {
 }
 
 func (s *containerSchema) withoutFile(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutFileArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -1958,11 +1902,7 @@ type containerWithoutFilesArgs struct {
 }
 
 func (s *containerSchema) withoutFiles(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutFilesArgs) (inst dagql.ObjectResult[*core.Container], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -2018,11 +1958,7 @@ type containerWithUnixSocketArgs struct {
 }
 
 func (s *containerSchema) withUnixSocket(ctx context.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -2420,11 +2356,7 @@ func (s *containerSchema) import_(ctx context.Context, parent *core.Container, a
 		slog.ExtraDebug("done importing container", "source", args.Source.Display(), "tag", args.Tag, "took", start)
 	}()
 
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -2511,11 +2443,7 @@ type containerWithServiceBindingArgs struct {
 }
 
 func (s *containerSchema) withServiceBinding(ctx context.Context, parent *core.Container, args containerWithServiceBindingArgs) (*core.Container, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
@@ -2651,11 +2579,7 @@ func (s *containerSchema) terminalLegacy(
 	ctr dagql.ObjectResult[*core.Container],
 	args containerTerminalArgs,
 ) (*core.TerminalLegacy, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -408,14 +408,15 @@ func (obj *CoreModObject) ConvertFromSDKResult(ctx context.Context, value any) (
 		return nil, err
 	}
 
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO: not efficient/correct
-	c := dagql.NewSessionCache(obj.coreMod.Dag.Cache.BaseCache())
-	x := *obj.coreMod.Dag
-	dag := &x
-	dag.Cache = c
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("CoreModObject.ConvertFromSDKResult: failed to get current query: %w", err)
+	}
+	c, err := query.Cache(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("CoreModObject.ConvertFromSDKResult: failed to get query cache: %w", err)
+	}
+	dag := obj.coreMod.Dag.WithCache(c)
 
 	val, err := dag.Load(ctx, &idp)
 	if err != nil {

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -408,7 +408,16 @@ func (obj *CoreModObject) ConvertFromSDKResult(ctx context.Context, value any) (
 		return nil, err
 	}
 
-	val, err := obj.coreMod.Dag.Load(ctx, &idp)
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO: not efficient/correct
+	c := dagql.NewSessionCache(obj.coreMod.Dag.Cache.BaseCache())
+	x := *obj.coreMod.Dag
+	dag := &x
+	dag.Cache = c
+
+	val, err := dag.Load(ctx, &idp)
 	if err != nil {
 		return nil, fmt.Errorf("CoreModObject.load %s: %w", idp.Display(), err)
 	}

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -231,11 +231,7 @@ type WithDirectoryArgs struct {
 }
 
 func (s *directorySchema) withDirectory(ctx context.Context, parent *core.Directory, args WithDirectoryArgs) (*core.Directory, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -338,11 +334,7 @@ type WithFileArgs struct {
 }
 
 func (s *directorySchema) withFile(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args WithFileArgs) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}
@@ -372,11 +364,7 @@ type WithFilesArgs struct {
 }
 
 func (s *directorySchema) withFiles(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args WithFilesArgs) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}
@@ -404,11 +392,7 @@ type withoutDirectoryArgs struct {
 }
 
 func (s *directorySchema) withoutDirectory(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args withoutDirectoryArgs) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}
@@ -427,11 +411,7 @@ type withoutFileArgs struct {
 }
 
 func (s *directorySchema) withoutFile(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args withoutFileArgs) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}
@@ -450,11 +430,7 @@ type withoutFilesArgs struct {
 }
 
 func (s *directorySchema) withoutFiles(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args withoutFilesArgs) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}
@@ -471,11 +447,7 @@ type diffArgs struct {
 }
 
 func (s *directorySchema) diff(ctx context.Context, parent *core.Directory, args diffArgs) (*core.Directory, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -649,11 +621,7 @@ func (s *directorySchema) terminal(
 	dir dagql.ObjectResult[*core.Directory],
 	args directoryTerminalArgs,
 ) (res dagql.ObjectResult[*core.Directory], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return res, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return res, err
 	}
@@ -700,11 +668,7 @@ type directoryWithSymlinkArgs struct {
 }
 
 func (s *directorySchema) withSymlink(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args directoryWithSymlinkArgs) (inst dagql.ObjectResult[*core.Directory], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	srv, err := query.Server.Server(ctx)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -267,11 +267,7 @@ func (s *moduleSchema) typeDefWithScalar(ctx context.Context, def *core.TypeDef,
 func (s *moduleSchema) typeDefWithListOf(ctx context.Context, def *core.TypeDef, args struct {
 	ElementType core.TypeDefID
 }) (*core.TypeDef, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -319,11 +315,7 @@ func (s *moduleSchema) typeDefWithObjectField(ctx context.Context, def *core.Typ
 	Description string `default:""`
 	SourceMap   dagql.Optional[core.SourceMapID]
 }) (*core.TypeDef, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -342,11 +334,7 @@ func (s *moduleSchema) typeDefWithObjectField(ctx context.Context, def *core.Typ
 func (s *moduleSchema) typeDefWithFunction(ctx context.Context, def *core.TypeDef, args struct {
 	Function core.FunctionID
 }) (*core.TypeDef, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -361,11 +349,7 @@ func (s *moduleSchema) typeDefWithFunction(ctx context.Context, def *core.TypeDe
 func (s *moduleSchema) typeDefWithObjectConstructor(ctx context.Context, def *core.TypeDef, args struct {
 	Function core.FunctionID
 }) (*core.TypeDef, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -437,11 +421,7 @@ func supportEnumMembers(ctx context.Context) (bool, error) {
 func (s *moduleSchema) generatedCode(ctx context.Context, _ *core.Query, args struct {
 	Code core.DirectoryID
 }) (*core.GeneratedCode, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -461,11 +441,7 @@ func (s *moduleSchema) function(ctx context.Context, _ *core.Query, args struct 
 	Name       string
 	ReturnType core.TypeDefID
 }) (*core.Function, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -504,11 +480,7 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 	Ignore       []string  `default:"[]"`
 	SourceMap    dagql.Optional[core.SourceMapID]
 }) (*core.Function, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -553,11 +525,7 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 func (s *moduleSchema) functionWithSourceMap(ctx context.Context, fn *core.Function, args struct {
 	SourceMap core.SourceMapID
 }) (*core.Function, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -632,11 +600,7 @@ func (s *moduleSchema) moduleGeneratedContextDirectory(
 	mod dagql.ObjectResult[*core.Module],
 	args struct{},
 ) (inst dagql.Result[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -677,11 +641,7 @@ func (s *moduleSchema) moduleWithDescription(ctx context.Context, mod *core.Modu
 func (s *moduleSchema) moduleWithObject(ctx context.Context, mod *core.Module, args struct {
 	Object core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -696,11 +656,7 @@ func (s *moduleSchema) moduleWithObject(ctx context.Context, mod *core.Module, a
 func (s *moduleSchema) moduleWithInterface(ctx context.Context, mod *core.Module, args struct {
 	Iface core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -715,11 +671,7 @@ func (s *moduleSchema) moduleWithInterface(ctx context.Context, mod *core.Module
 func (s *moduleSchema) moduleWithEnum(ctx context.Context, mod *core.Module, args struct {
 	Enum core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -745,11 +697,7 @@ func (s *moduleSchema) currentModuleSource(
 	curMod dagql.ObjectResult[*core.CurrentModule],
 	args struct{},
 ) (inst dagql.Result[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -802,11 +750,7 @@ func (s *moduleSchema) currentModuleWorkdir(
 		core.CopyFilter
 	},
 ) (inst dagql.Result[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -839,11 +783,7 @@ func (s *moduleSchema) currentModuleWorkdirFile(
 		Path string
 	},
 ) (inst dagql.Result[*core.File], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -868,11 +808,7 @@ func (s *moduleSchema) currentModuleWorkdirFile(
 }
 
 func (s *moduleSchema) loadSourceMap(ctx context.Context, sourceMap dagql.Optional[core.SourceMapID]) (*core.SourceMap, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -267,7 +267,16 @@ func (s *moduleSchema) typeDefWithScalar(ctx context.Context, def *core.TypeDef,
 func (s *moduleSchema) typeDefWithListOf(ctx context.Context, def *core.TypeDef, args struct {
 	ElementType core.TypeDefID
 }) (*core.TypeDef, error) {
-	elemType, err := args.ElementType.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	elemType, err := args.ElementType.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode element type: %w", err)
 	}
@@ -310,7 +319,16 @@ func (s *moduleSchema) typeDefWithObjectField(ctx context.Context, def *core.Typ
 	Description string `default:""`
 	SourceMap   dagql.Optional[core.SourceMapID]
 }) (*core.TypeDef, error) {
-	fieldType, err := args.TypeDef.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	fieldType, err := args.TypeDef.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode element type: %w", err)
 	}
@@ -324,7 +342,16 @@ func (s *moduleSchema) typeDefWithObjectField(ctx context.Context, def *core.Typ
 func (s *moduleSchema) typeDefWithFunction(ctx context.Context, def *core.TypeDef, args struct {
 	Function core.FunctionID
 }) (*core.TypeDef, error) {
-	fn, err := args.Function.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	fn, err := args.Function.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode element type: %w", err)
 	}
@@ -334,7 +361,16 @@ func (s *moduleSchema) typeDefWithFunction(ctx context.Context, def *core.TypeDe
 func (s *moduleSchema) typeDefWithObjectConstructor(ctx context.Context, def *core.TypeDef, args struct {
 	Function core.FunctionID
 }) (*core.TypeDef, error) {
-	inst, err := args.Function.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	inst, err := args.Function.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode element type: %w", err)
 	}
@@ -401,7 +437,16 @@ func supportEnumMembers(ctx context.Context) (bool, error) {
 func (s *moduleSchema) generatedCode(ctx context.Context, _ *core.Query, args struct {
 	Code core.DirectoryID
 }) (*core.GeneratedCode, error) {
-	dir, err := args.Code.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	dir, err := args.Code.Load(ctx, dag)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +461,16 @@ func (s *moduleSchema) function(ctx context.Context, _ *core.Query, args struct 
 	Name       string
 	ReturnType core.TypeDefID
 }) (*core.Function, error) {
-	returnType, err := args.ReturnType.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	returnType, err := args.ReturnType.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode return type: %w", err)
 	}
@@ -450,7 +504,16 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 	Ignore       []string  `default:"[]"`
 	SourceMap    dagql.Optional[core.SourceMapID]
 }) (*core.Function, error) {
-	argType, err := args.TypeDef.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	argType, err := args.TypeDef.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode arg type: %w", err)
 	}
@@ -490,7 +553,16 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 func (s *moduleSchema) functionWithSourceMap(ctx context.Context, fn *core.Function, args struct {
 	SourceMap core.SourceMapID
 }) (*core.Function, error) {
-	sourceMap, err := args.SourceMap.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	sourceMap, err := args.SourceMap.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode source map: %w", err)
 	}
@@ -560,7 +632,16 @@ func (s *moduleSchema) moduleGeneratedContextDirectory(
 	mod dagql.ObjectResult[*core.Module],
 	args struct{},
 ) (inst dagql.Result[*core.Directory], err error) {
-	err = s.dag.Select(ctx, mod.Self().Source, &inst,
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	err = dag.Select(ctx, mod.Self().Source, &inst,
 		dagql.Selector{
 			Field: "generatedContextDirectory",
 		},
@@ -596,17 +677,35 @@ func (s *moduleSchema) moduleWithDescription(ctx context.Context, mod *core.Modu
 func (s *moduleSchema) moduleWithObject(ctx context.Context, mod *core.Module, args struct {
 	Object core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	def, err := args.Object.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return core.EnvHook{Server: s.dag}.ModuleWithObject(ctx, mod, def.Self())
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	def, err := args.Object.Load(ctx, dag)
+	if err != nil {
+		return nil, err
+	}
+	return core.EnvHook{Server: dag}.ModuleWithObject(ctx, mod, def.Self())
 }
 
 func (s *moduleSchema) moduleWithInterface(ctx context.Context, mod *core.Module, args struct {
 	Iface core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	def, err := args.Iface.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	def, err := args.Iface.Load(ctx, dag)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +715,16 @@ func (s *moduleSchema) moduleWithInterface(ctx context.Context, mod *core.Module
 func (s *moduleSchema) moduleWithEnum(ctx context.Context, mod *core.Module, args struct {
 	Enum core.TypeDefID
 }) (_ *core.Module, rerr error) {
-	def, err := args.Enum.Load(ctx, s.dag)
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	def, err := args.Enum.Load(ctx, dag)
 	if err != nil {
 		return nil, err
 	}
@@ -637,6 +745,15 @@ func (s *moduleSchema) currentModuleSource(
 	curMod dagql.ObjectResult[*core.CurrentModule],
 	args struct{},
 ) (inst dagql.Result[*core.Directory], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
 	curSrc := curMod.Self().Module.Source
 	if curSrc.Self() == nil {
 		return inst, errors.New("invalid unset current module source")
@@ -648,14 +765,14 @@ func (s *moduleSchema) currentModuleSource(
 	}
 
 	var generatedDiff dagql.Result[*core.Directory]
-	err = s.dag.Select(ctx, curSrc, &generatedDiff,
+	err = dag.Select(ctx, curSrc, &generatedDiff,
 		dagql.Selector{Field: "generatedContextDirectory"},
 	)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get generated context directory: %w", err)
 	}
 
-	err = s.dag.Select(ctx, curSrc.Self().ContextDirectory, &inst,
+	err = dag.Select(ctx, curSrc.Self().ContextDirectory, &inst,
 		dagql.Selector{
 			Field: "withDirectory",
 			Args: []dagql.NamedInput{
@@ -685,12 +802,21 @@ func (s *moduleSchema) currentModuleWorkdir(
 		core.CopyFilter
 	},
 ) (inst dagql.Result[*core.Directory], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
 	if !filepath.IsLocal(args.Path) {
 		return inst, fmt.Errorf("workdir path %q escapes workdir", args.Path)
 	}
 	args.Path = filepath.Join(sdk.RuntimeWorkdirPath, args.Path)
 
-	err = s.dag.Select(ctx, s.dag.Root(), &inst,
+	err = dag.Select(ctx, dag.Root(), &inst,
 		dagql.Selector{
 			Field: "host",
 		},
@@ -713,12 +839,21 @@ func (s *moduleSchema) currentModuleWorkdirFile(
 		Path string
 	},
 ) (inst dagql.Result[*core.File], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
 	if !filepath.IsLocal(args.Path) {
 		return inst, fmt.Errorf("workdir path %q escapes workdir", args.Path)
 	}
 	args.Path = filepath.Join(sdk.RuntimeWorkdirPath, args.Path)
 
-	err = s.dag.Select(ctx, s.dag.Root(), &inst,
+	err = dag.Select(ctx, dag.Root(), &inst,
 		dagql.Selector{
 			Field: "host",
 		},
@@ -733,10 +868,19 @@ func (s *moduleSchema) currentModuleWorkdirFile(
 }
 
 func (s *moduleSchema) loadSourceMap(ctx context.Context, sourceMap dagql.Optional[core.SourceMapID]) (*core.SourceMap, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
 	if !sourceMap.Valid {
 		return nil, nil
 	}
-	sourceMapI, err := sourceMap.Value.Load(ctx, s.dag)
+	sourceMapI, err := sourceMap.Value.Load(ctx, dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode source map: %w", err)
 	}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -677,11 +677,7 @@ func (s *moduleSourceSchema) directoryAsModule(
 	contextDir dagql.ObjectResult[*core.Directory],
 	args directoryAsModuleArgs,
 ) (inst dagql.Result[*core.Module], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -873,11 +869,7 @@ func (s *moduleSourceSchema) loadModuleSourceContext(
 	ctx context.Context,
 	src *core.ModuleSource,
 ) error {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -1106,11 +1098,7 @@ func (s *moduleSourceSchema) moduleSourceDirectory(
 		Path string
 	},
 ) (inst dagql.Result[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -1271,11 +1259,7 @@ func (s *moduleSourceSchema) moduleSourceWithDependencies(
 ) (*core.ModuleSource, error) {
 	parentSrc = parentSrc.Clone()
 
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -1392,11 +1376,7 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateDependencies(
 		Dependencies []string
 	},
 ) (inst dagql.Result[*core.ModuleSource], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -1777,11 +1757,7 @@ func (s *moduleSourceSchema) runCodegen(
 	ctx context.Context,
 	srcInst dagql.ObjectResult[*core.ModuleSource],
 ) (res dagql.ObjectResult[*core.Directory], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return res, fmt.Errorf("failed to get current query: %w", err)
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return res, fmt.Errorf("failed to get current dag: %w", err)
 	}
@@ -2016,11 +1992,7 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
 	srcInst dagql.ObjectResult[*core.ModuleSource],
 	args struct{},
 ) (res dagql.ObjectResult[*core.Directory], _ error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return res, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return res, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -2089,11 +2061,7 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
 }
 
 func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInstContentHashed dagql.ObjectResult[*core.ModuleSource], mod *core.Module) (*core.Module, error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
@@ -2213,11 +2181,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	src dagql.ObjectResult[*core.ModuleSource],
 	args struct{},
 ) (inst dagql.Result[*core.Module], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
+	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}

--- a/core/sdk/module.go
+++ b/core/sdk/module.go
@@ -14,11 +14,11 @@ type module struct {
 	// The module implementing the SDK.
 	mod dagql.ObjectResult[*core.Module]
 
-	// A server that the SDK module has been installed to.
-	dag *dagql.Server
-
 	// The SDK object retrieved from the server, for calling functions against.
 	sdk dagql.AnyObjectResult
+
+	// A server that the SDK module has been installed to.
+	dag *dagql.Server
 
 	funcs map[string]*core.Function
 }
@@ -30,10 +30,21 @@ func newModuleSDK(
 	optionalFullSDKSourceDir dagql.ObjectResult[*core.Directory],
 	rawConfig map[string]any,
 ) (*module, error) {
-	dagqlCache, err := root.Cache(ctx)
+	// TODO: THIS WILL LEAK IF NEVER RELEASED
+	// TODO: THIS WILL LEAK IF NEVER RELEASED
+	// TODO: THIS WILL LEAK IF NEVER RELEASED
+	// TODO: THIS WILL LEAK IF NEVER RELEASED
+	/*
+		dagqlCache, err := root.Cache(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cache for sdk module %s: %w", sdkModMeta.Self().Name(), err)
+		}
+	*/
+	parentDag, err := root.Server.Server(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cache for sdk module %s: %w", sdkModMeta.Self().Name(), err)
+		return nil, fmt.Errorf("failed to get dag for sdk module %s: %w", sdkModMeta.Self().Name(), err)
 	}
+	dagqlCache := dagql.NewSessionCache(parentDag.Cache.BaseCache())
 	dag := dagql.NewServer(root, dagqlCache)
 	dag.Around(core.AroundFunc)
 

--- a/core/sdk/module_client_generator.go
+++ b/core/sdk/module_client_generator.go
@@ -18,15 +18,10 @@ type clientGeneratorModule struct {
 func (sdk *clientGeneratorModule) RequiredClientGenerationFiles(
 	ctx context.Context,
 ) (res dagql.Array[dagql.String], err error) {
-	query, err := core.CurrentQuery(ctx)
+	dag, err := sdk.mod.dag(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get dag for sdk module %s: %w", sdk.mod.mod.Self().Name(), err)
 	}
-	dagqlCache, err := query.Cache(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag := sdk.mod.dag.WithCache(dagqlCache)
 
 	// Return an empty array if the SDK doesn't implement the
 	// `requiredClientGenerationFiles` function.
@@ -51,15 +46,10 @@ func (sdk *clientGeneratorModule) GenerateClient(
 	deps *core.ModDeps,
 	outputDir string,
 ) (inst dagql.ObjectResult[*core.Directory], err error) {
-	query, err := core.CurrentQuery(ctx)
+	dag, err := sdk.mod.dag(ctx)
 	if err != nil {
-		return inst, err
+		return inst, fmt.Errorf("failed to get dag for sdk module %s: %w", sdk.mod.mod.Self().Name(), err)
 	}
-	dagqlCache, err := query.Cache(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag := sdk.mod.dag.WithCache(dagqlCache)
 
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{})
 	if err != nil {

--- a/core/sdk/module_code_generator.go
+++ b/core/sdk/module_code_generator.go
@@ -22,15 +22,10 @@ func (sdk *codeGeneratorModule) Codegen(
 	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: run codegen")
 	defer telemetry.End(span, func() error { return rerr })
 
-	query, err := core.CurrentQuery(ctx)
+	dag, err := sdk.mod.dag(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get dag for sdk module %s: %w", sdk.mod.mod.Self().Name(), err)
 	}
-	dagqlCache, err := query.Cache(ctx)
-	if err != nil {
-		return nil, err
-	}
-	dag := sdk.mod.dag.WithCache(dagqlCache)
 
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {

--- a/core/sdk/module_runtime.go
+++ b/core/sdk/module_runtime.go
@@ -22,15 +22,10 @@ func (sdk *runtimeModule) Runtime(
 	ctx, span := core.Tracer(ctx).Start(ctx, "module SDK: load runtime")
 	defer telemetry.End(span, func() error { return rerr })
 
-	query, err := core.CurrentQuery(ctx)
+	dag, err := sdk.mod.dag(ctx)
 	if err != nil {
-		return inst, err
+		return inst, fmt.Errorf("failed to get dag for sdk module %s: %w", sdk.mod.mod.Self().Name(), err)
 	}
-	dagqlCache, err := query.Cache(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag := sdk.mod.dag.WithCache(dagqlCache)
 
 	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, []string{"Host"})
 	if err != nil {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -71,6 +71,30 @@ type Server struct {
 	Cache *SessionCache
 }
 
+type ServerSchema struct {
+	inner Server
+}
+
+func (s *ServerSchema) WithCache(c *SessionCache) *Server {
+	inner := s.inner
+	inner.Cache = c
+	return &inner
+}
+
+func (s *ServerSchema) View() View {
+	return s.inner.View
+}
+
+func (s *Server) AsSchema() *ServerSchema {
+	return &ServerSchema{
+		inner: *s,
+	}
+}
+
+func (s *Server) WithCache(c *SessionCache) *Server {
+	return s.AsSchema().WithCache(c)
+}
+
 type InstallHook interface {
 	InstallObject(ObjectType)
 	// FIXME: add support for other install functions

--- a/dagql/session_cache.go
+++ b/dagql/session_cache.go
@@ -64,14 +64,6 @@ func WithTelemetry(telemetry TelemetryFunc) CacheCallOpt {
 	})
 }
 
-// TODO:
-// TODO:
-// TODO:
-// TODO:
-func (c *SessionCache) BaseCache() cache.Cache[CacheKeyType, CacheValueType] {
-	return c.cache
-}
-
 func (c *SessionCache) GetOrInitializeValue(
 	ctx context.Context,
 	key CacheKeyType,

--- a/dagql/session_cache.go
+++ b/dagql/session_cache.go
@@ -64,6 +64,14 @@ func WithTelemetry(telemetry TelemetryFunc) CacheCallOpt {
 	})
 }
 
+// TODO:
+// TODO:
+// TODO:
+// TODO:
+func (c *SessionCache) BaseCache() cache.Cache[CacheKeyType, CacheValueType] {
+	return c.cache
+}
+
 func (c *SessionCache) GetOrInitializeValue(
 	ctx context.Context,
 	key CacheKeyType,

--- a/dagql/session_cache_test.go
+++ b/dagql/session_cache_test.go
@@ -1,0 +1,92 @@
+package dagql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagger/dagger/engine/cache"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestSessionCacheReleaseAndClose(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		ctx := t.Context()
+
+		c := cache.NewCache[digest.Digest, AnyResult]()
+		sc1 := NewSessionCache(c)
+		sc2 := NewSessionCache(c)
+
+		_, err := sc1.GetOrInitializeValue(ctx, "1", nil)
+		require.NoError(t, err)
+
+		_, err = sc1.GetOrInitializeValue(ctx, "2", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, c.Size())
+
+		_, err = sc2.GetOrInitializeValue(ctx, "2", nil)
+		require.NoError(t, err)
+
+		_, err = sc2.GetOrInitializeValue(ctx, "3", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, 3, c.Size())
+
+		err = sc1.ReleaseAndClose(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, c.Size())
+
+		_, err = sc1.GetOrInitializeValue(ctx, "x", nil)
+		require.Error(t, err)
+
+		require.Equal(t, 2, c.Size())
+
+		err = sc2.ReleaseAndClose(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, 0, c.Size())
+	})
+
+	t.Run("close while running", func(t *testing.T) {
+		ctx := t.Context()
+
+		c := cache.NewCache[digest.Digest, AnyResult]()
+		sc := NewSessionCache(c)
+
+		_, err := sc.GetOrInitializeValue(ctx, "1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, c.Size())
+
+		var eg errgroup.Group
+		startCh := make(chan struct{})
+		stopCh := make(chan struct{})
+		eg.Go(func() error {
+			_, err := sc.GetOrInitialize(ctx, "2", func(ctx context.Context) (AnyResult, error) {
+				close(startCh)
+				<-stopCh
+				return nil, nil
+			})
+			return err
+		})
+
+		select {
+		case <-startCh:
+		case <-time.After(10 * time.Second): // just don't block forever if there's a bug
+			t.Fatal("timeout waiting for goroutine to start")
+			return
+		}
+
+		err = sc.ReleaseAndClose(ctx)
+		require.NoError(t, err)
+		close(stopCh)
+
+		err = eg.Wait()
+		require.Error(t, err, "expected error when closing session cache while a call is running")
+
+		require.Equal(t, 0, c.Size())
+	})
+}


### PR DESCRIPTION
If the session cache Release method was called while some calls were still running, it was possible for them to only be appended to the list of results after Release was already done, in which case they'd stay in the underlying cache and leak forever.

This adds handling to track when the session cache is closed and release any results that show up after that.

---

This seemed to be resulting in memory leaks. It wasn't perfectly repro-able, but was able to see leaks fairly often just after running tests and canceling them in the middle. I suspect that dag-op refs were more prone to it, likely just due to the timing of their execution in the bk solver, which is extra bad since that also results in leaks of on-disk cache refs.

After this change I can't repro that anymore. Also added some unit test coverage.

---

This change expanded in size quite a bit since adding error checks for use of session caches after they were closed resulted in error popping up all over the place in integ tests.

I ended up having to fix this by removing quite a few of our uses of `dagql.Server` stored on various structs.
* I took this quite a bit further but started getting mystery new errors. Wouldn't be surprised if I just made a typo somewhere in the very large diff, but I couldn't find it and want to get this merged ASAP, so there's files in `schema/` that probably should have similar updates but don't. The current ones are the ones that were strictly necessary for now.