### PR TITLE
chore: tidy up engine startup and connection telemetry

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -95,17 +95,12 @@ func withEngine(
 			if err != nil {
 				return err
 			}
-			loader, err := backend.Loader(ctx)
-			if err != nil {
-				return err
-			}
-			params.ImageLoader = loader
+			params.ImageLoaderBackend = backend
 		}
 
 		params.DisableHostRW = disableHostRW
 		params.AllowedLLMModules = allowedLLMModules
 
-		params.EngineCallback = Frontend.ConnectedToEngine
 		params.CloudURLCallback = Frontend.SetCloudURL
 
 		params.EngineTrace = telemetry.SpanForwarder{

--- a/cmd/dagger/span_name.go
+++ b/cmd/dagger/span_name.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -93,7 +95,8 @@ func spanName(args []string) string {
 	}
 	if !isCall {
 		// if we're not a call, just use the original command
-		keep = args
+		keep = slices.Clone(args)
+		keep[0] = filepath.Base(keep[0])
 	} else if len(keep) == 0 {
 		// we're a call, but failed to parse the chain, probably confused by a
 		// boolean flag, so just show the full call

--- a/cmd/dagger/span_name_test.go
+++ b/cmd/dagger/span_name_test.go
@@ -34,6 +34,7 @@ func TestSpanName(t *testing.T) {
 			// like `--bool foo`, so we want to fall back to the full command
 			want: "--bool foo --fizz",
 		},
+		{args: []string{"/path/to/dagger", "session", "--label", "dagger.io/sdk.name:go"}, want: "dagger session --label dagger.io/sdk.name:go"},
 	} {
 		t.Run(fmt.Sprintf("%v", test.args), func(t *testing.T) {
 			require.Equal(t, test.want, spanName(test.args))

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -83,8 +83,6 @@ type Frontend interface {
 	LogExporter() sdklog.Exporter
 	MetricExporter() sdkmetric.Exporter
 
-	// ConnectedToEngine is called when the CLI connects to an engine.
-	ConnectedToEngine(ctx context.Context, name string, version string, clientID string)
 	// SetCloudURL is called after the CLI checks auth and sets the cloud URL.
 	SetCloudURL(ctx context.Context, url string, msg string, logged bool)
 

--- a/dagql/idtui/frontend_dots.go
+++ b/dagql/idtui/frontend_dots.go
@@ -122,10 +122,6 @@ func (fe *frontendDots) MetricExporter() sdkmetric.Exporter {
 	return &dotsMetricExporter{fe: fe}
 }
 
-func (fe *frontendDots) ConnectedToEngine(ctx context.Context, name string, version string, clientID string) {
-	fe.reporter.ConnectedToEngine(ctx, name, version, clientID)
-}
-
 func (fe *frontendDots) SetCloudURL(ctx context.Context, url string, msg string, logged bool) {
 	fe.reporter.SetCloudURL(ctx, url, msg, logged)
 }

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -125,13 +125,6 @@ func (fe *frontendPlain) Shell(ctx context.Context, handler ShellHandler) {
 	fmt.Fprintln(fe.output.Writer(), "Shell not supported in plain mode")
 }
 
-func (fe *frontendPlain) ConnectedToEngine(ctx context.Context, name string, version string, clientID string) {
-	if fe.Silent {
-		return
-	}
-	fe.addVirtualLog(trace.SpanFromContext(ctx), "engine", "name", name, "version", version, "client", clientID)
-}
-
 func (fe *frontendPlain) SetCloudURL(ctx context.Context, url string, msg string, logged bool) {
 	if fe.OpenWeb {
 		if err := browser.OpenURL(url); err != nil {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -158,10 +158,6 @@ func (fe *frontendPretty) Shell(ctx context.Context, handler ShellHandler) {
 	<-ctx.Done()
 }
 
-func (fe *frontendPretty) ConnectedToEngine(ctx context.Context, name string, version string, clientID string) {
-	// noisy, so suppress this for now
-}
-
 func (fe *frontendPretty) SetCloudURL(ctx context.Context, url string, msg string, logged bool) {
 	if fe.OpenWeb {
 		if err := browser.OpenURL(url); err != nil {

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -450,6 +450,18 @@ var scrubs = []scrubber{
 		"12:34:56",
 		"XX:XX:XX",
 	},
+	// *.dagger.local
+	{
+		regexp.MustCompile(`[a-z0-9]+\.[a-z0-9]+\.dagger\.local`),
+		"iujpijlqnc7me.tun3vdbg35c6q.dagger.local",
+		"xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local",
+	},
+	// version=
+	{
+		regexp.MustCompile(`version=v[a-f0-9.-]+`),
+		"version=v0.18.13-250710134709-7edd4496ecc1",
+		"version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx",
+	},
 	// Trailing whitespace
 	{
 		regexp.MustCompile(`\s*` + regexp.QuoteMeta(midterm.Reset.Render())),

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/broken-dep X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/broken-dep/broken X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/call-bubbling-dep
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/call-bubbling-dep
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/call-failing-dep
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/call-failing-dep
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875/fn
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875/fn
@@ -6,7 +6,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: github.com/dagger/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-encapsulated
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log-native
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
@@ -6,7 +6,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/hello-world
@@ -6,7 +6,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/httpreadme
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/httpreadme
@@ -6,7 +6,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/list
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/list
@@ -23,7 +23,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
@@ -8,7 +8,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/object-lists
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/object-lists
@@ -6,7 +6,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/python X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/python X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/revealed-spans
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/revealed-spans
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/trace-function-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/trace-function-calls
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/trace-remote-function-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/trace-remote-function-calls
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/typescript X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/typescript X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/typescript X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log-native
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log-native
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/typescript X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/typescript X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
@@ -2,7 +2,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -7,7 +7,8 @@ Expected stderr:
 
 ▼ connect X.Xs
 ├─● starting engine X.Xs
-├─● connecting to engine X.Xs
+├─▼ connecting to engine X.Xs
+│ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest X.Xs

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -86,7 +86,7 @@ const InstrumentationLibrary = "dagger.io/client.drivers"
 // are identified by looking for containers with the prefix
 // "dagger-engine-").
 func (d *dockerDriver) create(ctx context.Context, imageRef string, containerName string, volumeName string, cleanup bool, port int, opts *DriverOpts) (helper *connh.ConnectionHelper, rerr error) {
-	ctx, span := otel.Tracer("").Start(ctx, "create")
+	ctx, span := otel.Tracer("").Start(ctx, "create container")
 	defer telemetry.End(span, func() error { return rerr })
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
@@ -124,7 +124,7 @@ func (d *dockerDriver) create(ctx context.Context, imageRef string, containerNam
 	}
 
 	// ensure the image is pulled
-	if _, err := traceexec.Exec(ctx, exec.CommandContext(ctx, "docker", "inspect", "--type=image", imageRef), telemetry.Encapsulated()); err != nil {
+	if _, err := traceexec.Exec(ctx, exec.CommandContext(ctx, "docker", "inspect", "--type=image", imageRef, "--format", "{{ .ID }}"), telemetry.Encapsulated()); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, fmt.Errorf("failed to inspect image: %w", err)
 		}

--- a/engine/client/imageload/containerd.go
+++ b/engine/client/imageload/containerd.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"os"
 
+	"dagger.io/dagger/telemetry"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/defaults"
 	"github.com/dagger/dagger/util/ctrns"
+	"go.opentelemetry.io/otel"
 )
 
 type Containerd struct{}
@@ -20,6 +22,9 @@ func (Containerd) ID() string {
 }
 
 func (loader Containerd) Loader(ctx context.Context) (_ *Loader, rerr error) {
+	_, span := otel.Tracer("").Start(ctx, "dial containerd")
+	defer telemetry.End(span, func() error { return rerr })
+
 	addr := defaults.DefaultAddress
 	if v, ok := os.LookupEnv("CONTAINERD_ADDRESS"); ok {
 		addr = v

--- a/engine/client/imageload/docker.go
+++ b/engine/client/imageload/docker.go
@@ -23,16 +23,6 @@ func (Docker) ID() string {
 }
 
 func (loader Docker) Loader(ctx context.Context) (_ *Loader, rerr error) {
-	ctx, span := otel.Tracer("").Start(ctx, "check for docker daemon")
-	defer telemetry.End(span, func() error { return rerr })
-
-	// check docker is running
-	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
-	_, err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated())
-	if err != nil {
-		return nil, err
-	}
-
 	return &Loader{
 		TarballLoader: loader.loadTarball,
 	}, nil

--- a/engine/client/imageload/docker.go
+++ b/engine/client/imageload/docker.go
@@ -22,9 +22,12 @@ func (Docker) ID() string {
 	return "docker"
 }
 
-func (loader Docker) Loader(ctx context.Context) (*Loader, error) {
+func (loader Docker) Loader(ctx context.Context) (_ *Loader, rerr error) {
+	ctx, span := otel.Tracer("").Start(ctx, "check for docker daemon")
+	defer telemetry.End(span, func() error { return rerr })
+
 	// check docker is running
-	cmd := exec.CommandContext(ctx, "docker", "info")
+	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
 	_, err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This patch improves the telemetry at client startup in a few ways:
- Earlier notification of cloud telemetry info - this ensures we can open the web view *before* the engine is provisioned.
- Adds logging info as a __real__ OTEL span, instead of a virtual log. This means that we can get metadata about the versions we're actually connecting to in cloud (previously missing).
- Correctly nests the image store configuration under the "connecting to engine" span (which requires defering the load operation a little bit).