### PR TITLE
fix Error ID extraction becoming truncated

### DIFF
--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -567,7 +567,7 @@ func extractError(ctx context.Context, client *buildkit.Client, baseErr error) (
 		return id, false, errors.Join(err, baseErr)
 	}
 
-	idBytes, err := buildkit.ReadSnapshotPath(ctx, client, mntable, modMetaErrorPath)
+	idBytes, err := buildkit.ReadSnapshotPath(ctx, client, mntable, modMetaErrorPath, -1)
 	if err != nil {
 		return id, false, errors.Join(err, baseErr)
 	}

--- a/engine/buildkit/errors.go
+++ b/engine/buildkit/errors.go
@@ -309,5 +309,5 @@ func getExecMeta(ctx context.Context, client *Client, metaMount bksolver.Result)
 }
 
 func getExecMetaFile(ctx context.Context, c *Client, mntable snapshot.Mountable, fileName string) ([]byte, error) {
-	return ReadSnapshotPath(ctx, c, mntable, fileName)
+	return ReadSnapshotPath(ctx, c, mntable, fileName, MaxExecErrorOutputBytes)
 }


### PR DESCRIPTION
We were re-using the same code path for stdout/stderr collection which enforces a 100kb size limit. Applying this to the error extraction resulted in the Error ID also being truncated, which led to errors falling back to the unhelpful `process "/runtime" failed with exit status 2`-esque error.

Example: https://dagger.cloud/dagger/traces/9c9ac34fec07079afbc9b6a737ffacaa

Now we only enforce the limit for stdout/stderr and allow the Error ID to be arbitrarily large.

@sipsma I know you mentioned last time that there's probably a much more elegant way to return errors to avoid the filesystem plumbing, but I didn't quite clock it at the time. This might be a good opportunity to do that instead, but I could use some help with that. If you have a clear idea in mind and it's not too much work feel free to just push on top of this PR. :innocent: 