### PR TITLE
chore: fix broken nix install

### DIFF
--- a/cmd/dagger/.dagger/publish.go
+++ b/cmd/dagger/.dagger/publish.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v2.7.0"
+	goReleaserVersion = "v2.11.0"
 	goReleaserImage   = "ghcr.io/goreleaser/goreleaser-pro:" + goReleaserVersion
 )
 
@@ -243,7 +243,7 @@ func publishEnv(ctx context.Context) (*dagger.Container, error) {
 
 	// install nix
 	ctr = ctr.
-		WithExec([]string{"apk", "add", "xz"}).
+		WithExec([]string{"apk", "add", "coreutils", "xz"}).
 		WithDirectory("/nix", dag.Directory()).
 		WithNewFile("/etc/nix/nix.conf", `build-users-group =`).
 		WithExec([]string{"sh", "-c", "curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon"})


### PR DESCRIPTION
And update goreleaser for good measure.

Nix requires cp from coreutils (for reasons, it's annoying). Thankfully, we can just install those. This was added on Friday last week to the nix install script. See an example failure of our pipeline here: https://dagger.cloud/dagger/traces/609f2073c478a1b3e9d3c2fc1787c015#7438f59d4bf0ce5d:EL9