### PR TITLE
fix: correctly propagate depth arg to remote clone

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -537,7 +537,7 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 
 			if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
 				// if shallow, check we have enough depth
-				if depth == 0 {
+				if depth <= 0 {
 					doFetch = true
 				} else {
 					res, err := git.New().Run(ctx, "rev-list", "--count", ref.Commit)
@@ -649,7 +649,7 @@ func (ref *RemoteGitRef) fetchRemote(ctx context.Context, git *gitutil.GitCLI, d
 		"--update-head-ok",
 		"--force",
 	}
-	if depth == 0 {
+	if depth <= 0 {
 		if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
 			args = append(args, "--unshallow")
 		}
@@ -704,7 +704,7 @@ func doGitCheckout(
 	}
 
 	args := []string{"fetch", "-u"}
-	if depth != 0 {
+	if depth > 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", depth))
 	}
 	args = append(args, "origin", pullref)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -280,21 +280,43 @@ func (GitSuite) TestGitDepth(ctx context.Context, t *testctx.T) {
 		return strings.TrimSpace(res), err
 	}
 
-	t.Run("default depth", func(ctx context.Context, t *testctx.T) {
-		dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree()
-		res, err := log(ctx, dir)
-		require.NoError(t, err)
-		lines := strings.Split(res, "\n")
-		require.Len(t, lines, 1)
-	})
+	// default depth = 1
+	dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree()
+	res, err := log(ctx, dir)
+	require.NoError(t, err)
+	lines := strings.Split(res, "\n")
+	require.Len(t, lines, 1)
 
-	t.Run("depth 5", func(ctx context.Context, t *testctx.T) {
-		dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{Depth: 5})
-		res, err := log(ctx, dir)
-		require.NoError(t, err)
-		lines := strings.Split(res, "\n")
-		require.Len(t, lines, 5)
-	})
+	// depth = 5
+	dir = c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{Depth: 5})
+	res, err = log(ctx, dir)
+	require.NoError(t, err)
+	lines = strings.Split(res, "\n")
+	require.Len(t, lines, 5)
+
+	// depth = 1000 (big depth)
+	dir = c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{Depth: 1000})
+	res, err = log(ctx, dir)
+	require.NoError(t, err)
+	lines = strings.Split(res, "\n")
+	require.Len(t, lines, 1000)
+
+	// depth = 20 (back down)
+	dir = c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{Depth: 20})
+	res, err = log(ctx, dir)
+	require.NoError(t, err)
+	lines = strings.Split(res, "\n")
+	require.Len(t, lines, 20)
+
+	// depth = -1 (max depth)
+	dir = c.Git("https://github.com/dagger/dagger").Branch("main").Tree(dagger.GitRefTreeOpts{Depth: -1})
+	res, err = log(ctx, dir)
+	require.NoError(t, err)
+	lines = strings.Split(res, "\n")
+	last := lines[len(lines)-1]
+	require.Greater(t, len(lines), 2000)
+	require.True(t, strings.HasPrefix(last, "30f75"), last)
+	require.Contains(t, last, "Move prototype 69-dagger-archon to top-level")
 }
 
 func (GitSuite) TestSSHAuthSock(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
Looks like this was a "simple" case of the conditional being the wrong way round. I missed this when working on the conversion to dagop in #9980.

Fixing that though means we need a better way of ensuring that we `doFetch` correctly.

Also realized, we couldn't actually *send* a `depth=0` value using the go sdk :cry: so actually, that entire functionality was just broken (woops, no tests). So instead, we'll also allow negative values here.

TODO:
- [x] Fix `depth` arg
- [x] Tests