### PR TITLE
fix: allow serializing/deserializing empty strings as enums

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/enum.go.tmpl
@@ -24,7 +24,14 @@ func (v {{ $enumName }}) Value() string {
 }
 
 func (v *{{ $enumName }}) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *{{ $enumName }}) UnmarshalJSON(dt []byte) error {
@@ -33,6 +40,8 @@ func (v *{{ $enumName }}) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	{{- range $field := .EnumValues | SortEnumFields }}
 	{{- $fieldName := ($field.Name | FormatEnum "") }}
 	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
@@ -40,7 +49,7 @@ func (v *{{ $enumName }}) UnmarshalJSON(dt []byte) error {
 		*v = {{ $fullFieldName }}
 	{{- end }}
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -822,7 +822,7 @@ func (m *Test) ToProto(proto string) dagger.NetworkProtocol {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-proto", "--proto", "INVALID")).Stdout(ctx)
-			requireErrOut(t, err, "invalid enum member")
+			requireErrOut(t, err, "invalid enum")
 		})
 
 		t.Run("choices in help", func(ctx context.Context, t *testctx.T) {
@@ -891,7 +891,7 @@ func (m *Test) ToStatus(status string) Status {
 
 		t.Run("invalid output", func(ctx context.Context, t *testctx.T) {
 			_, err := modGen.With(daggerCall("to-status", "--status", "INVALID")).Stdout(ctx)
-			requireErrOut(t, err, "invalid enum member")
+			requireErrOut(t, err, "invalid enum")
 		})
 
 		t.Run("choices in help", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -1342,6 +1342,60 @@ func (m *Minimal) IsEmpty() bool {
 	require.JSONEq(t, `{"minimal": {"isEmpty": true}}`, out)
 }
 
+func (GoSuite) TestPrivateEnumField(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	ctr := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--sdk=go", "dep")).
+		WithNewFile("dep/main.go", `package main
+
+import (
+	"context"
+	"dagger/dep/internal/dagger"
+)
+
+type Dep struct {
+	Opts []dagger.ContainerPublishOpts // +private
+}
+
+func New() *Dep {
+	return &Dep{
+		Opts: []dagger.ContainerPublishOpts{
+			{PlatformVariants: []*dagger.Container{dag.Container().From("alpine")}},
+		},
+	}
+}
+
+func (m *Dep) Publish(ctx context.Context) (string, error) {
+	// dry run a publish
+	return "registry/repo:latest", nil
+}
+`,
+		).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
+		With(daggerExec("install", "./dep")).
+		WithNewFile("main.go", `package main
+
+import (
+	"context"
+)
+
+type Test struct {}
+
+func (m Test) Publish(ctx context.Context) (string, error) {
+	return dag.Dep().Publish(ctx)
+}
+`,
+		)
+
+	out, err := ctr.With(daggerQuery(`{test{publish}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"test": {"publish": "registry/repo:latest"}}`, out)
+}
+
 func (GoSuite) TestJSONField(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -1114,14 +1114,14 @@ export class Test {
 				require.Equal(t, "TCP", gjson.Get(out, "test.fromProto").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromProto(proto: "INVALID")}}`)).Stdout(ctx)
-				requireErrOut(t, err, "invalid enum member")
+				requireErrOut(t, err, "invalid enum")
 
 				out, err = modGen.With(daggerQuery(`{test{toProto(proto: "TCP")}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "TCP", gjson.Get(out, "test.toProto").String())
 
 				_, err = modGen.With(daggerQuery(`{test{toProto(proto: "INVALID")}}`)).Sync(ctx)
-				requireErrOut(t, err, "invalid enum member")
+				requireErrOut(t, err, "invalid enum")
 
 				out, err = modGen.With(daggerQuery(`{test{fromProtoDefault}}`)).Stdout(ctx)
 				require.NoError(t, err)
@@ -1400,7 +1400,7 @@ export class Test {
 				}
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatus(status: "INVALID")}}`)).Stdout(ctx)
-				requireErrOut(t, err, "invalid enum member")
+				requireErrOut(t, err, "invalid enum")
 
 				// fromStatusOpt
 				out, err = modGen.With(daggerQuery(`{test{fromStatusOpt}}`)).Stdout(ctx)
@@ -1416,7 +1416,7 @@ export class Test {
 				}
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatusOpt(status: "INVALID")}}`)).Stdout(ctx)
-				requireErrOut(t, err, "invalid enum member")
+				requireErrOut(t, err, "invalid enum")
 
 				// toStatus
 				if tc.supportsMembers {
@@ -1428,7 +1428,7 @@ export class Test {
 				require.Equal(t, "INACTIVE", gjson.Get(out, "test.toStatus").String())
 
 				_, err = modGen.With(daggerQuery(`{test{toStatus(status: "INVALID")}}`)).Sync(ctx)
-				requireErrOut(t, err, "invalid enum member")
+				requireErrOut(t, err, "invalid enum")
 
 				// introspection
 				mod := inspectModule(ctx, t, modGen)

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -10321,7 +10321,14 @@ func (v CacheSharingMode) Value() string {
 }
 
 func (v *CacheSharingMode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *CacheSharingMode) UnmarshalJSON(dt []byte) error {
@@ -10330,6 +10337,8 @@ func (v *CacheSharingMode) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "LOCKED":
 		*v = CacheSharingModeLocked
 	case "PRIVATE":
@@ -10337,7 +10346,7 @@ func (v *CacheSharingMode) UnmarshalJSON(dt []byte) error {
 	case "SHARED":
 		*v = CacheSharingModeShared
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10378,7 +10387,14 @@ func (v ImageLayerCompression) Value() string {
 }
 
 func (v *ImageLayerCompression) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *ImageLayerCompression) UnmarshalJSON(dt []byte) error {
@@ -10387,6 +10403,8 @@ func (v *ImageLayerCompression) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "EStarGZ":
 		*v = ImageLayerCompressionEstarGz
 	case "ESTARGZ":
@@ -10398,7 +10416,7 @@ func (v *ImageLayerCompression) UnmarshalJSON(dt []byte) error {
 	case "Zstd":
 		*v = ImageLayerCompressionZstd
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10435,7 +10453,14 @@ func (v ImageMediaTypes) Value() string {
 }
 
 func (v *ImageMediaTypes) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *ImageMediaTypes) UnmarshalJSON(dt []byte) error {
@@ -10444,6 +10469,8 @@ func (v *ImageMediaTypes) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "DOCKER":
 		*v = ImageMediaTypesDocker
 	case "DockerMediaTypes":
@@ -10453,7 +10480,7 @@ func (v *ImageMediaTypes) UnmarshalJSON(dt []byte) error {
 	case "OCIMediaTypes":
 		*v = ImageMediaTypesOcimediaTypes
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10489,7 +10516,14 @@ func (v ModuleSourceKind) Value() string {
 }
 
 func (v *ModuleSourceKind) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *ModuleSourceKind) UnmarshalJSON(dt []byte) error {
@@ -10498,6 +10532,8 @@ func (v *ModuleSourceKind) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "DIR":
 		*v = ModuleSourceKindDir
 	case "DIR_SOURCE":
@@ -10511,7 +10547,7 @@ func (v *ModuleSourceKind) UnmarshalJSON(dt []byte) error {
 	case "LOCAL_SOURCE":
 		*v = ModuleSourceKindLocalSource
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10548,7 +10584,14 @@ func (v NetworkProtocol) Value() string {
 }
 
 func (v *NetworkProtocol) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *NetworkProtocol) UnmarshalJSON(dt []byte) error {
@@ -10557,12 +10600,14 @@ func (v *NetworkProtocol) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "TCP":
 		*v = NetworkProtocolTcp
 	case "UDP":
 		*v = NetworkProtocolUdp
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10596,7 +10641,14 @@ func (v ReturnType) Value() string {
 }
 
 func (v *ReturnType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *ReturnType) UnmarshalJSON(dt []byte) error {
@@ -10605,6 +10657,8 @@ func (v *ReturnType) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "ANY":
 		*v = ReturnTypeAny
 	case "FAILURE":
@@ -10612,7 +10666,7 @@ func (v *ReturnType) UnmarshalJSON(dt []byte) error {
 	case "SUCCESS":
 		*v = ReturnTypeSuccess
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }
@@ -10667,7 +10721,14 @@ func (v TypeDefKind) Value() string {
 }
 
 func (v *TypeDefKind) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Name())
+	if *v == "" {
+		return []byte(`""`), nil
+	}
+	name := v.Name()
+	if name == "" {
+		return nil, fmt.Errorf("invalid enum value %q", *v)
+	}
+	return json.Marshal(name)
 }
 
 func (v *TypeDefKind) UnmarshalJSON(dt []byte) error {
@@ -10676,6 +10737,8 @@ func (v *TypeDefKind) UnmarshalJSON(dt []byte) error {
 		return err
 	}
 	switch s {
+	case "":
+		*v = ""
 	case "BOOLEAN":
 		*v = TypeDefKindBoolean
 	case "BOOLEAN_KIND":
@@ -10721,7 +10784,7 @@ func (v *TypeDefKind) UnmarshalJSON(dt []byte) error {
 	case "VOID_KIND":
 		*v = TypeDefKindVoidKind
 	default:
-		return fmt.Errorf("unknown enum value %q", s)
+		return fmt.Errorf("invalid enum value %q", s)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10715.

This doesn't mean these values have become allowed, the engine will *still* reject them. However, now, they can correctly be used in private fields again, like they used to be.