### PR TITLE
feat: apply git ignore pattern on contextual directory argument

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5082,6 +5082,234 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 	})
 }
 
+func (ModuleSuite) TestDefaultGitIgnore(ctx context.Context, t *testctx.T) {
+	type gitIgnoreFile struct {
+		path    string
+		content string
+	}
+
+	type expectedDir struct {
+		path string
+		want string
+	}
+
+	t.Run("correctly use .gitignore files", func(ctx context.Context, t *testctx.T) {
+		sourceFile := `
+package main
+
+import (
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Repo      *dagger.Directory
+	ModuleDir *dagger.Directory
+}
+
+func New(
+	//+defaultPath="/"
+	repo *dagger.Directory,
+
+	//+defaultPath="."
+	moduleDir *dagger.Directory,
+) *Test {
+	return &Test{
+		Repo:      repo,
+		ModuleDir: moduleDir,
+	}
+}`
+
+		gitIgnore := []gitIgnoreFile{
+			{
+				path: "/work",
+				content: `**.txt
+bar/*.go
+!c.txt
+*.py
+/.git
+**.gitignore
+**.gitattributes
+`,
+			},
+			{
+				path:    "/work/yamlFiles",
+				content: `foo.yaml`,
+			},
+			{
+				path: "/work/mod",
+				content: `/internal
+/dagger.gen.go
+/dagger.json
+/go.mod
+/go.sum
+**.go
+!main.go
+`,
+			},
+		}
+
+		expected := []expectedDir{
+			{
+				path: ".",
+				want: "a.json\nbar/\nc.txt\nfoo.xml\nmod/\nyamlFiles/\n",
+			},
+			{
+				path: "bar",
+				want: "sub.py\n",
+			},
+			{
+				path: "yamlFiles",
+				want: "bar.yaml\n",
+			},
+		}
+
+		expectedModuleDir := "LICENSE\nmain.go\n"
+		c := connect(ctx, t)
+
+		repo := c.Directory().
+			WithNewFile("a.json", "{}").
+			WithNewFile("b.txt", "b").
+			WithNewFile("c.txt", "c").
+			WithNewFile("foo.xml", "<>").
+			WithNewFile("script.py", "print('hello')").
+			WithDirectory("bar", c.Directory().WithNewFile("baz.txt", "baz").WithNewFile("d.go", "package main").WithNewFile("sub.py", "")).
+			WithDirectory("yamlFiles", c.Directory().WithNewFile("foo.yaml", "foo").WithNewFile("bar.yaml", "bar"))
+
+		modGen := c.Container().From(golangImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory("/work", repo).
+			WithWorkdir("/work").
+			// Setup context directory
+			WithExec([]string{"git", "init"}).
+			WithWorkdir("/work/mod").
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
+			WithNewFile("main.go", sourceFile)
+
+		for _, ignore := range gitIgnore {
+			modGen = modGen.WithNewFile(filepath.Join(ignore.path, ".gitignore"), ignore.content)
+		}
+
+		for _, expected := range expected {
+			expectedResult := expected.want
+
+			dir, err := modGen.With(daggerCall("repo", "directory", "--path", expected.path, "entries")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, expectedResult, dir)
+		}
+
+		moduleDir, err := modGen.With(daggerCall("module-dir", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedModuleDir, moduleDir)
+	})
+
+	t.Run("correctly rebase path based on defaultPath", func(ctx context.Context, t *testctx.T) {
+		sourceFile := `
+package main
+
+import (
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Repo      *dagger.Directory
+	ModuleDir *dagger.Directory
+}
+
+func New(
+	//+defaultPath="/bar"
+	repo *dagger.Directory,
+
+	//+defaultPath="./dagger"
+	moduleDir *dagger.Directory,
+) *Test {
+	return &Test{
+		Repo:      repo,
+		ModuleDir: moduleDir,
+	}
+}`
+
+		gitIgnore := []gitIgnoreFile{
+			{
+				path: "/work",
+				content: `**.txt
+bar/*.go
+!c.txt
+*.py
+/.git
+**.gitignore
+**.gitattributes
+`,
+			},
+			{
+				path:    "/work/bar",
+				content: `yamlFiles/foo.yaml`,
+			},
+			{
+				path: "/work/mod",
+				content: `/dagger/internal
+dagger.gen.go
+dagger.json
+/go.mod
+/go.sum
+**.go
+!main.go
+`,
+			},
+		}
+
+		expected := []expectedDir{
+			{
+				path: ".",
+				want: "sub.py\nyamlFiles/\n",
+			},
+			{
+				path: "yamlFiles",
+				want: "bar.yaml\n",
+			},
+		}
+
+		expectedModuleDir := "dagger.gen.go\ngo.mod\ngo.sum\nmain.go\n"
+		c := connect(ctx, t)
+
+		repo := c.Directory().
+			WithNewFile("a.json", "{}").
+			WithNewFile("b.txt", "b").
+			WithNewFile("c.txt", "c").
+			WithNewFile("foo.xml", "<>").
+			WithNewFile("script.py", "print('hello')").
+			WithDirectory("bar", c.Directory().WithNewFile("baz.txt", "baz").WithNewFile("d.go", "package main").WithNewFile("sub.py", "").
+				WithDirectory("yamlFiles", c.Directory().WithNewFile("foo.yaml", "foo").WithNewFile("bar.yaml", "bar")))
+
+		modGen := c.Container().From(golangImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory("/work", repo).
+			WithWorkdir("/work").
+			// Setup context directory
+			WithExec([]string{"git", "init"}).
+			WithWorkdir("/work/mod").
+			With(daggerExec("init", "--source=dagger", "--name=test", "--sdk=go")).
+			WithNewFile("dagger/main.go", sourceFile)
+
+		for _, ignore := range gitIgnore {
+			modGen = modGen.WithNewFile(filepath.Join(ignore.path, ".gitignore"), ignore.content)
+		}
+
+		for _, expected := range expected {
+			expectedResult := expected.want
+
+			dir, err := modGen.With(daggerCall("repo", "directory", "--path", expected.path, "entries")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, expectedResult, dir)
+		}
+
+		moduleDir, err := modGen.With(daggerCall("module-dir", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedModuleDir, moduleDir)
+	})
+}
+
 func (ModuleSuite) TestFloat(ctx context.Context, t *testctx.T) {
 	depSrc := `package main
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -333,6 +333,32 @@ func (src *ModuleSource) LoadContext(
 			return inst, fmt.Errorf("path %q is outside of context directory %q, path should be relative to the context directory", path, ctxPath)
 		}
 
+		// Rebased the ignore patterns to be relative to the mounted path from the context directory.
+		// - If the contextual path is /foo/bar, all /foo/bar/.gitignore patterns must become the root or they'll not be applied correctly
+		// - Recursive patterns are not affected
+		// - Patterns that are outside the contextual path are ignored.
+		// - If relativePathToCtx is "." (meaning the contextual path is the same as the mounted path), then all ignore
+		// patterns are applied.
+		for _, pattern := range src.Local.IgnorePatterns {
+			if !strings.HasPrefix(pattern, "**") &&
+				!strings.HasPrefix(pattern, relativePathToCtx+"/") &&
+				!strings.HasPrefix(pattern, "!"+relativePathToCtx+"/") &&
+				relativePathToCtx != "." {
+				continue
+			}
+
+			// If the pattern is negative, we need to trim the leading "!" before removing the relative path
+			// and add it again after.
+			// !foo/bar/baz -> baz -> !baz
+			if strings.HasPrefix(pattern, "!") {
+				pattern = strings.TrimPrefix(pattern, "!")
+				ignore = append(ignore, "!"+strings.TrimPrefix(pattern, relativePathToCtx+"/"))
+				continue
+			}
+
+			ignore = append(ignore, strings.TrimPrefix(pattern, relativePathToCtx+"/"))
+		}
+
 		err = dag.Select(localSourceCtx, dag.Root(), &inst,
 			dagql.Selector{
 				Field: "host",
@@ -454,6 +480,7 @@ func (src *ModuleSource) LoadContext(
 
 type LocalModuleSource struct {
 	ContextDirectoryPath string
+	IgnorePatterns       []string
 }
 
 func (src LocalModuleSource) Clone() *LocalModuleSource {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/engine/server/resource"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/opencontainers/go-digest"
 	fsutiltypes "github.com/tonistiigi/fsutil/types"
 	"golang.org/x/sync/errgroup"
@@ -410,6 +411,7 @@ func (s *moduleSourceSchema) localModuleSource(
 		Kind:              core.ModuleSourceKindLocal,
 		Local: &core.LocalModuleSource{
 			ContextDirectoryPath: contextDirPath,
+			IgnorePatterns:       nil,
 		},
 	}
 
@@ -444,7 +446,7 @@ func (s *moduleSourceSchema) localModuleSource(
 			return inst, err
 		}
 
-		// load this module source's context directory, sdk and deps in parallel
+		// load this module source's context directory, ignore patterns, sdk and deps in parallel
 		var eg errgroup.Group
 		eg.Go(func() error {
 			if err := s.loadModuleSourceContext(ctx, localSrc); err != nil {
@@ -472,6 +474,10 @@ func (s *moduleSourceSchema) localModuleSource(
 				return nil
 			})
 		}
+
+		eg.Go(func() error {
+			return s.loadLocalModuleIgnorePatterns(ctx, bk, localSrc)
+		})
 		if err := eg.Wait(); err != nil {
 			return inst, err
 		}
@@ -842,6 +848,50 @@ func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.Mod
 	src.RebasedIncludePaths = append(src.RebasedIncludePaths, rebasedIncludes...)
 
 	return nil
+}
+
+// loadModuleIgnorePatterns loads the .gitignore files inside the context directory
+// and returns the list of patterns that should be ignored by the module
+func (s *moduleSourceSchema) loadLocalModuleIgnorePatterns(
+	ctx context.Context,
+	bk *buildkit.Client,
+	src *core.ModuleSource,
+) error {
+	return (func() (rerr error) {
+		ctx, span := core.Tracer(ctx).Start(ctx, fmt.Sprintf("load .gitignore patterns up to %q", src.Local.ContextDirectoryPath), telemetry.Internal())
+		defer telemetry.End(span, func() error { return rerr })
+
+		lg := bklog.G(ctx).WithField("module", src.ModuleName)
+		ctx = bklog.WithLogger(ctx, lg)
+
+		var contextDirectory dagql.ObjectResult[*core.Directory]
+
+		err := s.dag.Select(ctx, s.dag.Root(), &contextDirectory,
+			dagql.Selector{Field: "host"},
+			dagql.Selector{
+				Field: "directory",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String(src.Local.ContextDirectoryPath)},
+					{Name: "include", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray("**.gitignore"))},
+				},
+			},
+		)
+
+		if err != nil {
+			return fmt.Errorf("failed to load context directory with only .gitignore: %w", err)
+		}
+
+		gitIgnorePatterns, err := loadGitIgnoreInDirectory(ctx, contextDirectory.Result.Self(), ".")
+		if err != nil {
+			return fmt.Errorf("failed to load .gitignore in context directory %q: %w", src.Local.ContextDirectoryPath, err)
+		}
+
+		lg.Debugf("pattern ignored by .gitignore %q", strings.Join(gitIgnorePatterns, ", "))
+
+		src.Local.IgnorePatterns = gitIgnorePatterns
+
+		return nil
+	})()
 }
 
 // load (or re-load) the context directory for the given module source


### PR DESCRIPTION
Update local module loading to lookup for all .gitignore files inside the context directory
Add `IgnorePattenrs` in `LocalModuleSource`.
Apply `IgnorePatterns` when loading contextual directory argument.