### PR TITLE
add `Directory.withPatch`

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"slices"
@@ -25,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	fstypes "github.com/tonistiigi/fsutil/types"
 	"github.com/vektah/gqlparser/v2/ast"
+	"go.opentelemetry.io/otel/trace"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql"
@@ -483,6 +485,68 @@ func (dir *Directory) WithNewFileDagOp(ctx context.Context, dest string, content
 			}
 		}
 
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	snap, err := newRef.Commit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dir.Result = snap
+	return dir, nil
+}
+
+func (dir *Directory) WithPatch(ctx context.Context, patch string) (*Directory, error) {
+	dir = dir.Clone()
+
+	parentRef, err := getRefOrEvaluate(ctx, dir.Result, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	bkSessionGroup, ok := buildkit.CurrentBuildkitSessionGroup(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no buildkit session group in context")
+	}
+
+	opt, ok := buildkit.CurrentOpOpts(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no buildkit opts in context")
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = trace.ContextWithSpanContext(ctx, opt.CauseCtx)
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+	defer stdio.Close()
+
+	newRef, err := query.BuildkitCache().New(ctx, parentRef, bkSessionGroup, bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
+		bkcache.WithDescription("patch"))
+	if err != nil {
+		return nil, err
+	}
+	err = MountRef(ctx, newRef, bkSessionGroup, func(root string) (rerr error) {
+		var stdout, stderr strings.Builder
+		apply := exec.Command("git", "apply", "-")
+		apply.Dir = root
+		apply.Stdin = strings.NewReader(patch)
+		apply.Stdout = io.MultiWriter(&stdout, stdio.Stdout)
+		apply.Stderr = io.MultiWriter(&stderr, stdio.Stderr)
+		if err := apply.Run(); err != nil {
+			return &buildkit.ExecError{
+				Err:      err,
+				Origin:   trace.SpanContextFromContext(ctx),
+				Cmd:      apply.Args,
+				ExitCode: apply.ProcessState.ExitCode(),
+				Stdout:   stdout.String(),
+				Stderr:   stderr.String(),
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1490,6 +1490,118 @@ func (DirectorySuite) TestDirectoryName(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (DirectorySuite) TestPatch(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("basic patch application", func(ctx context.Context, t *testctx.T) {
+		// Create a directory with a simple file
+		dir := c.Directory().
+			WithNewFile("hello.txt", "Hello, World!\n")
+
+		// Create a patch that modifies the file
+		patch := `--- a/hello.txt
++++ b/hello.txt
+@@ -1 +1 @@
+-Hello, World!
++Hello, Dagger!
+`
+
+		// Apply the patch
+		patchedDir := dir.WithPatch(patch)
+
+		// Verify the patch was applied
+		content, err := patchedDir.File("hello.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "Hello, Dagger!\n", content)
+	})
+
+	t.Run("patch adding new file", func(ctx context.Context, t *testctx.T) {
+		// Start with an empty directory
+		dir := c.Directory()
+
+		// Create a patch that adds a new file
+		patch := `--- /dev/null
++++ b/newfile.txt
+@@ -0,0 +1 @@
++This is a new file!
+`
+
+		// Apply the patch
+		patchedDir := dir.WithPatch(patch)
+
+		// Verify the new file was created
+		content, err := patchedDir.File("newfile.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "This is a new file!\n", content)
+	})
+
+	t.Run("patch deleting file", func(ctx context.Context, t *testctx.T) {
+		// Create a directory with a file to delete
+		dir := c.Directory().
+			WithNewFile("delete-me.txt", "This file will be deleted\n").
+			WithNewFile("keep-me.txt", "This file will be kept\n")
+
+		// Create a patch that deletes the file
+		patch := `--- a/delete-me.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-This file will be deleted
+`
+
+		// Apply the patch
+		patchedDir := dir.WithPatch(patch)
+
+		// Verify the file was deleted
+		ents, err := patchedDir.Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"keep-me.txt"}, ents)
+	})
+
+	t.Run("multiple file patch", func(ctx context.Context, t *testctx.T) {
+		// Create a directory with multiple files
+		dir := c.Directory().
+			WithNewFile("file1.txt", "Content 1\n").
+			WithNewFile("file2.txt", "Content 2\n")
+
+		// Create a patch that modifies both files
+		patch := `--- a/file1.txt
++++ b/file1.txt
+@@ -1 +1 @@
+-Content 1
++Modified Content 1
+--- a/file2.txt
++++ b/file2.txt
+@@ -1 +1 @@
+-Content 2
++Modified Content 2
+`
+
+		// Apply the patch
+		patchedDir := dir.WithPatch(patch)
+
+		// Verify both files were modified
+		content1, err := patchedDir.File("file1.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "Modified Content 1\n", content1)
+
+		content2, err := patchedDir.File("file2.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "Modified Content 2\n", content2)
+	})
+
+	t.Run("invalid patch format", func(ctx context.Context, t *testctx.T) {
+		dir := c.Directory().
+			WithNewFile("test.txt", "test content")
+
+		// Create an invalid patch
+		invalidPatch := "this is not a valid patch format"
+
+		// Apply the invalid patch and expect an error
+		_, err := dir.WithPatch(invalidPatch).Sync(ctx)
+		require.Error(t, err)
+	})
+}
+
 func (DirectorySuite) TestSymlink(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -163,6 +163,13 @@ func (s *directorySchema) Install() {
 				dagql.Arg("timestamp").Doc(`Timestamp to set dir/files in.`,
 					`Formatted in seconds following Unix epoch (e.g., 1672531199).`),
 			),
+		dagql.NodeFunc("withPatch",
+			DagOpDirectoryWrapper(s.srv, s.withPatch,
+				WithPathFn(keepParentDir[withPatchArgs]))).
+			Doc(`Retrieves this directory with the given Git-compatible patch applied.`).
+			Args(
+				dagql.Arg("patch").Doc(`Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex 1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-Hello\n+World\n").`),
+			),
 		dagql.Func("asGit", s.asGit).
 			Doc(`Converts this directory to a local git repository`),
 		dagql.NodeFunc("terminal", s.terminal).
@@ -306,6 +313,26 @@ type globArgs struct {
 
 func (s *directorySchema) glob(ctx context.Context, parent *core.Directory, args globArgs) ([]string, error) {
 	return parent.Glob(ctx, args.Pattern)
+}
+
+type withPatchArgs struct {
+	Patch string
+
+	FSDagOpInternalArgs
+}
+
+func (s *directorySchema) withPatch(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args withPatchArgs) (inst dagql.ObjectResult[*core.Directory], _ error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+
+	dir, err := parent.Self().WithPatch(ctx, args.Patch)
+	if err != nil {
+		return inst, err
+	}
+
+	return dagql.NewObjectResultForCurrentID(ctx, srv, dir)
 }
 
 func (s *directorySchema) digest(ctx context.Context, parent *core.Directory, args struct{}) (dagql.String, error) {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1579,6 +1579,16 @@ type Directory {
     permissions: Int = 420
   ): Directory!
 
+  """Retrieves this directory with the given Git-compatible patch applied."""
+  withPatch(
+    """
+    Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex
+    1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1
+    @@\n-Hello\n+World\n").
+    """
+    patch: String!
+  ): Directory!
+
   """Return a snapshot with a symlink"""
   withSymlink(
     """Location of the file or directory to link to (e.g., "/existing/file")."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6294,6 +6294,23 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Directory-withPatch" href="#Directory-withPatch"><code>withPatch</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
+                        <td> Retrieves this directory with the given Git-compatible patch applied. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>patch</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Patch to apply (e.g., &quot;diff --git a/file.txt b/file.txt\nindex 1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-Hello\n+World\n&quot;).</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Directory-withSymlink" href="#Directory-withSymlink"><code>withSymlink</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td> Return a snapshot with a symlink </td>
                       </tr>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -356,6 +356,16 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withPatch">withPatch</a>(string $patch)
+        
+                                            <p><p>Retrieves this directory with the given Git-compatible patch applied.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withSymlink">withSymlink</a>(string $target, string $linkName)
         
                                             <p><p>Return a snapshot with a symlink</p></p>                </div>
@@ -1429,8 +1439,50 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withSymlink">
+                    <h3 id="method_withPatch">
         <div class="location">at line 302</div>
+        <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
+    <strong>withPatch</strong>(string $patch)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Retrieves this directory with the given Git-compatible patch applied.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$patch</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withSymlink">
+        <div class="location">at line 312</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -1477,7 +1529,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 313</div>
+        <div class="location">at line 323</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -1519,7 +1571,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 323</div>
+        <div class="location">at line 333</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -1561,7 +1613,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 333</div>
+        <div class="location">at line 343</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -1603,7 +1655,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 343</div>
+        <div class="location">at line 353</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1126,7 +1126,9 @@
 <abbr title="Dagger\Directory">Directory</abbr>::withNewDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
                     <dd><p>Retrieves this directory plus a new directory created at the given path.</p></dd><dt><a href="Dagger/Directory.html#method_withNewFile">
 <abbr title="Dagger\Directory">Directory</abbr>::withNewFile</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
-                    <dd><p>Return a snapshot with a new file added</p></dd><dt><a href="Dagger/Directory.html#method_withSymlink">
+                    <dd><p>Return a snapshot with a new file added</p></dd><dt><a href="Dagger/Directory.html#method_withPatch">
+<abbr title="Dagger\Directory">Directory</abbr>::withPatch</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
+                    <dd><p>Retrieves this directory with the given Git-compatible patch applied.</p></dd><dt><a href="Dagger/Directory.html#method_withSymlink">
 <abbr title="Dagger\Directory">Directory</abbr>::withSymlink</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
                     <dd><p>Return a snapshot with a symlink</p></dd><dt><a href="Dagger/Directory.html#method_withTimestamps">
 <abbr title="Dagger\Directory">Directory</abbr>::withTimestamps</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2467,6 +2467,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Directory::withPatch",
+			"p": "Dagger/Directory.html#method_withPatch",
+			"d": "<p>Retrieves this directory with the given Git-compatible patch applied.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Directory::withSymlink",
 			"p": "Dagger/Directory.html#method_withSymlink",
 			"d": "<p>Return a snapshot with a symlink</p>"

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -371,6 +371,20 @@ defmodule Dagger.Directory do
   end
 
   @doc """
+  Retrieves this directory with the given Git-compatible patch applied.
+  """
+  @spec with_patch(t(), String.t()) :: Dagger.Directory.t()
+  def with_patch(%__MODULE__{} = directory, patch) do
+    query_builder =
+      directory.query_builder |> QB.select("withPatch") |> QB.put_arg("patch", patch)
+
+    %Dagger.Directory{
+      query_builder: query_builder,
+      client: directory.client
+    }
+  end
+
+  @doc """
   Return a snapshot with a symlink
   """
   @spec with_symlink(t(), String.t(), String.t()) :: Dagger.Directory.t()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3123,6 +3123,16 @@ func (r *Directory) WithNewFile(path string, contents string, opts ...DirectoryW
 	}
 }
 
+// Retrieves this directory with the given Git-compatible patch applied.
+func (r *Directory) WithPatch(patch string) *Directory {
+	q := r.query.Select("withPatch")
+	q = q.Arg("patch", patch)
+
+	return &Directory{
+		query: q,
+	}
+}
+
 // Return a snapshot with a symlink
 func (r *Directory) WithSymlink(target string, linkName string) *Directory {
 	q := r.query.Select("withSymlink")

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -297,6 +297,16 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Retrieves this directory with the given Git-compatible patch applied.
+     */
+    public function withPatch(string $patch): Directory
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withPatch');
+        $innerQueryBuilder->setArgument('patch', $patch);
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Return a snapshot with a symlink
      */
     public function withSymlink(string $target, string $linkName): Directory

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3356,6 +3356,22 @@ class Directory(Type):
         _ctx = self._select("withNewFile", _args)
         return Directory(_ctx)
 
+    def with_patch(self, patch: str) -> Self:
+        """Retrieves this directory with the given Git-compatible patch applied.
+
+        Parameters
+        ----------
+        patch:
+            Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex
+            1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1
+            +1,1 @@\n-Hello\n+World\n").
+        """
+        _args = [
+            Arg("patch", patch),
+        ]
+        _ctx = self._select("withPatch", _args)
+        return Directory(_ctx)
+
     def with_symlink(self, target: str, link_name: str) -> Self:
         """Return a snapshot with a symlink
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5092,6 +5092,20 @@ impl Directory {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Retrieves this directory with the given Git-compatible patch applied.
+    ///
+    /// # Arguments
+    ///
+    /// * `patch` - Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex 1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-Hello\n+World\n").
+    pub fn with_patch(&self, patch: impl Into<String>) -> Directory {
+        let mut query = self.selection.select("withPatch");
+        query = query.arg("patch", patch.into());
+        Directory {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Return a snapshot with a symlink
     ///
     /// # Arguments

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3855,6 +3855,15 @@ export class Directory extends BaseClient {
   }
 
   /**
+   * Retrieves this directory with the given Git-compatible patch applied.
+   * @param patch Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex 1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-Hello\n+World\n").
+   */
+  withPatch = (patch: string): Directory => {
+    const ctx = this._ctx.select("withPatch", { patch })
+    return new Directory(ctx)
+  }
+
+  /**
    * Return a snapshot with a symlink
    * @param target Location of the file or directory to link to (e.g., "/existing/file").
    * @param linkName Location where the symbolic link will be created (e.g., "/new-file-link").


### PR DESCRIPTION
Takes a Git-compatible patch string and applies it to the directory, using `git apply` under the hood.

This way you can make incremental changes to a directory without having to add entire new file contents at a time. Also supports binary diffs, so this is a bit beefier than `patch -p1`.