### PR TITLE
Generic env bindings

### DIFF
--- a/cmd/codegen/generator/go/templates/format.go
+++ b/cmd/codegen/generator/go/templates/format.go
@@ -47,6 +47,9 @@ func (f *FormatTypeFunc) FormatKindScalarBoolean(representation string) string {
 }
 
 func (f *FormatTypeFunc) FormatKindScalarDefault(representation string, refName string, input bool) string {
+	if refName == "ID" {
+		return "Object"
+	}
 	if obj, ok := strings.CutSuffix(refName, "ID"); input && ok {
 		representation += "*" + f.scope + formatName(obj)
 	} else {

--- a/cmd/codegen/generator/go/templates/src/internal/dagger/dagger.gen.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/internal/dagger/dagger.gen.go.tmpl
@@ -5,3 +5,9 @@ package dagger
 
 {{ template "_dagger.gen.go/defs.go.tmpl" . }}
 {{ end }}
+
+// Object is an interface that matches all Dagger object types
+type Object interface {
+    XXX_GraphQLType() string
+    XXX_GraphQLID(context.Context) (string, error)
+}

--- a/core/env.go
+++ b/core/env.go
@@ -111,6 +111,16 @@ func (env *Env) WithInput(key string, val dagql.Typed, description string) *Env 
 	return env
 }
 
+// Add an input (read-only) binding to the environment
+func (env *Env) WithBinding(name string, object dagql.AnyResult, description string) *Env {
+	env = env.Clone()
+	binding := &Binding{Key: name, Value: object, Description: description, env: env}
+	_ = binding.ID() // If val is an object, force its ingestion
+	// FIXME: rename 'inputs' to 'bindings' internally
+	env.inputsByName[name] = binding
+	return env
+}
+
 // Register the desire for a binding in the environment
 func (env *Env) WithOutput(key string, expectedType dagql.Type, description string) *Env {
 	env = env.Clone()
@@ -143,6 +153,11 @@ func (env *Env) Outputs() []*Binding {
 
 // List all inputs in the environment
 func (env *Env) Inputs() []*Binding {
+	return env.Bindings()
+}
+
+// List all bindings
+func (env *Env) Bindings() []*Binding {
 	res := make([]*Binding, 0, len(env.inputsByName))
 	for _, v := range env.inputsByName {
 		res = append(res, v)
@@ -152,22 +167,32 @@ func (env *Env) Inputs() []*Binding {
 
 // Lookup an input binding
 func (env *Env) Input(key string) (*Binding, bool) {
+	return env.Binding(key)
+}
+
+// Lookup a binding
+func (env *Env) Binding(name string) (*Binding, bool) {
 	// next check for values by ID
-	if val, exists := env.objsByID[key]; exists {
+	if val, exists := env.objsByID[name]; exists {
 		return val, true
 	}
 	// next check for values by name
-	if val, exists := env.inputsByName[key]; exists {
+	if val, exists := env.inputsByName[name]; exists {
 		return val, true
 	}
 	return nil, false
 }
 
 // Remove an input
-func (env *Env) WithoutInput(key string) *Env {
+func (env *Env) WithoutBinding(name string) *Env {
 	env = env.Clone()
-	delete(env.inputsByName, key)
+	delete(env.inputsByName, name)
 	return env
+}
+
+// Remove an input
+func (env *Env) WithoutInput(key string) *Env {
+	return env.WithoutBinding(key)
 }
 
 func (env *Env) Ingest(obj dagql.AnyResult, desc string) string {

--- a/core/ids.go
+++ b/core/ids.go
@@ -1,10 +1,69 @@
 package core
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 type JSONValueID = dagql.ID[*JSONValue]
+
+type ID string
+
+func (id ID) Load(ctx context.Context, srv *dagql.Server) (dagql.AnyResult, error) {
+	var callID = new(call.ID)
+	err := callID.Decode(string(id))
+	if err != nil {
+		return nil, err
+	}
+	return srv.Load(ctx, callID)
+}
+
+func (ID) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "ID",
+		NonNull:   true,
+	}
+}
+
+var _ dagql.Typed = ID("")
+
+func (ID) TypeName() string {
+	return "ID"
+}
+
+func (ID) TypeDescription() string {
+	return "A generic object ID"
+}
+
+var _ dagql.ScalarType = ID("")
+
+var _ dagql.Input = ID("")
+
+func (id ID) Decoder() dagql.InputDecoder {
+	return id
+}
+
+func (id ID) ToLiteral() call.Literal {
+	return call.NewLiteralString(string(id))
+}
+
+func (ID) DecodeInput(val any) (res dagql.Input, err error) {
+	switch x := val.(type) {
+	case string:
+		if x == "" {
+			return nil, nil
+		}
+		return ID(x), nil
+	case *call.ID:
+		return ID(x.Display()), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to ID", val)
+	}
+}
 
 type ContainerID = dagql.ID[*Container]
 

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -37,6 +37,7 @@ func (s *querySchema) Install(srv *dagql.Server) {
 
 	srv.InstallScalar(core.JSON{})
 	srv.InstallScalar(core.Void{})
+	srv.InstallScalar(core.ID(""))
 
 	core.NetworkProtocols.Install(srv)
 	core.ImageLayerCompressions.Install(srv)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1886,6 +1886,15 @@ The `EnumValueTypeDefID` scalar type represents an identifier for an object of t
 scalar EnumValueTypeDefID
 
 type Env {
+  """retrieve an object binding"""
+  binding(
+    """The binding name"""
+    name: String!
+  ): Binding!
+
+  """return all object bindings"""
+  bindings: [Binding!]!
+
   """A unique identifier for this Env."""
   id: EnvID!
 
@@ -1900,6 +1909,18 @@ type Env {
 
   """return all output values for the environment"""
   outputs: [Binding!]!
+
+  """bind an object to the env"""
+  withBinding(
+    """Binding name"""
+    name: String!
+
+    """Object to bind"""
+    value: String!
+
+    """Binding description"""
+    description: String
+  ): Env!
 
   """Create or update a binding of type CacheVolume in the environment"""
   withCacheVolumeInput(

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -7176,6 +7176,27 @@
                       </tr>
                     </thead>
                     <tbody>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Env-binding" href="#Env-binding"><code>binding</code></a> - <span class="property-type"><a href="#definition-Binding"><code>Binding!</code></a></span> </td>
+                        <td> retrieve an object binding </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The binding name</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Env-bindings" href="#Env-bindings"><code>bindings</code></a> - <span class="property-type"><a href="#definition-Binding"><code>[Binding!]!</code></a></span> </td>
+                        <td> return all object bindings </td>
+                      </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Env-id" href="#Env-id"><code>id</code></a> - <span class="property-type"><a href="#definition-EnvID"><code>EnvID!</code></a></span> </td>
                         <td> A unique identifier for this Env. </td>
@@ -7219,6 +7240,31 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Env-outputs" href="#Env-outputs"><code>outputs</code></a> - <span class="property-type"><a href="#definition-Binding"><code>[Binding!]!</code></a></span> </td>
                         <td> return all output values for the environment </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Env-withBinding" href="#Env-withBinding"><code>withBinding</code></a> - <span class="property-type"><a href="#definition-Env"><code>Env!</code></a></span> </td>
+                        <td> bind an object to the env </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Binding name</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>value</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Object to bind</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>Binding description</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Env-withCacheVolumeInput" href="#Env-withCacheVolumeInput"><code>withCacheVolumeInput</code></a> - <span class="property-type"><a href="#definition-Env"><code>Env!</code></a></span> </td>

--- a/docs/static/reference/php/Dagger/Env.html
+++ b/docs/static/reference/php/Dagger/Env.html
@@ -80,29 +80,29 @@
         </div>
                 <div id="page-content">
     <div class="page-header">
-        <h1>Env    
+        <h1>Env
             </h1>
     </div>
 
-    
+
     <p>        class
     <strong>Env</strong>        extends <a href="../Dagger/Client/AbstractObject.html"><abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a>        implements        <a href="../Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a>
 </p>
 
-        
-    
-        
 
-            
-        
-    
+
+
+
+
+
+
             <h2>Properties</h2>
 
             <table class="table table-condensed">
                     <tr>
                 <td class="type" id="property_lastQuery">
-                                                                                
-                                                                                
+
+
                                     </td>
                 <td>$lastQuery</td>
                 <td class="last"></td>
@@ -111,17 +111,17 @@
             </tr>
             </table>
 
-    
+
             <h2>Methods</h2>
 
             <div class="container-fluid underlined">
                     <div class="row">
                 <div class="col-md-2 type">
-                    
+
                 </div>
                 <div class="col-md-8">
                     <a href="#method___construct">__construct</a>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method___construct">
@@ -133,7 +133,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_queryLeaf">queryLeaf</a>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method_queryLeaf">
@@ -141,11 +141,31 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_binding">binding</a>(string $name)
+
+                                            <p><p>retrieve an object binding</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    array
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_bindings">bindings</a>()
+
+                                            <p><p>return all object bindings</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
                 </div>
                 <div class="col-md-8">
                     <a href="#method_id">id</a>()
-        
+
                                             <p><p>A unique identifier for this Env.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -155,7 +175,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_input">input</a>(string $name)
-        
+
                                             <p><p>retrieve an input value by name</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -165,7 +185,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_inputs">inputs</a>()
-        
+
                                             <p><p>return all input values for the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -175,7 +195,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_output">output</a>(string $name)
-        
+
                                             <p><p>retrieve an output value by name</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -185,7 +205,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_outputs">outputs</a>()
-        
+
                                             <p><p>return all output values for the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -194,8 +214,18 @@
                     <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withBinding">withBinding</a>(string $name, string $value, string|null $description = null)
+
+                                            <p><p>bind an object to the env</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withCacheVolumeInput">withCacheVolumeInput</a>(string $name, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type CacheVolume in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -205,7 +235,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withCacheVolumeOutput">withCacheVolumeOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired CacheVolume output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -215,7 +245,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withCloudInput">withCloudInput</a>(string $name, <abbr title="Dagger\CloudId|Dagger\Cloud">Cloud</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Cloud in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -225,7 +255,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withCloudOutput">withCloudOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Cloud output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -235,7 +265,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withContainerInput">withContainerInput</a>(string $name, <abbr title="Dagger\ContainerId|Dagger\Container">Container</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Container in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -245,7 +275,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withContainerOutput">withContainerOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Container output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -255,7 +285,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDirectoryInput">withDirectoryInput</a>(string $name, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Directory in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -265,7 +295,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDirectoryOutput">withDirectoryOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Directory output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -275,7 +305,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withEnvInput">withEnvInput</a>(string $name, <abbr title="Dagger\EnvId|Dagger\Env">Env</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Env in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -285,7 +315,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withEnvOutput">withEnvOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Env output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -295,7 +325,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withFileInput">withFileInput</a>(string $name, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type File in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -305,7 +335,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withFileOutput">withFileOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired File output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -315,7 +345,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withGitRefInput">withGitRefInput</a>(string $name, <abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type GitRef in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -325,7 +355,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withGitRefOutput">withGitRefOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired GitRef output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -335,7 +365,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withGitRepositoryInput">withGitRepositoryInput</a>(string $name, <abbr title="Dagger\GitRepositoryId|Dagger\GitRepository">GitRepository</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type GitRepository in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -345,7 +375,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withGitRepositoryOutput">withGitRepositoryOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired GitRepository output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -355,7 +385,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withJSONValueInput">withJSONValueInput</a>(string $name, <abbr title="Dagger\JsonValueId|Dagger\JsonValue">JsonValue</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type JSONValue in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -365,7 +395,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withJSONValueOutput">withJSONValueOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired JSONValue output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -375,7 +405,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withLLMInput">withLLMInput</a>(string $name, <abbr title="Dagger\LLMId|Dagger\LLM">LLM</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type LLM in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -385,7 +415,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withLLMOutput">withLLMOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired LLM output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -395,7 +425,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleConfigClientInput">withModuleConfigClientInput</a>(string $name, <abbr title="Dagger\ModuleConfigClientId|Dagger\ModuleConfigClient">ModuleConfigClient</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type ModuleConfigClient in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -405,7 +435,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleConfigClientOutput">withModuleConfigClientOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired ModuleConfigClient output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -415,7 +445,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleInput">withModuleInput</a>(string $name, <abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Module in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -425,7 +455,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleOutput">withModuleOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Module output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -435,7 +465,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleSourceInput">withModuleSourceInput</a>(string $name, <abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type ModuleSource in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -445,7 +475,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withModuleSourceOutput">withModuleSourceOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired ModuleSource output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -455,7 +485,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSearchResultInput">withSearchResultInput</a>(string $name, <abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type SearchResult in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -465,7 +495,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSearchResultOutput">withSearchResultOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired SearchResult output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -475,7 +505,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSearchSubmatchInput">withSearchSubmatchInput</a>(string $name, <abbr title="Dagger\SearchSubmatchId|Dagger\SearchSubmatch">SearchSubmatch</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type SearchSubmatch in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -485,7 +515,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSearchSubmatchOutput">withSearchSubmatchOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired SearchSubmatch output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -495,7 +525,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSecretInput">withSecretInput</a>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Secret in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -505,7 +535,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSecretOutput">withSecretOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Secret output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -515,7 +545,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withServiceInput">withServiceInput</a>(string $name, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Service in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -525,7 +555,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withServiceOutput">withServiceOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Service output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -535,7 +565,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSocketInput">withSocketInput</a>(string $name, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $value, string $description)
-        
+
                                             <p><p>Create or update a binding of type Socket in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -545,7 +575,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSocketOutput">withSocketOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Declare a desired Socket output to be assigned in the environment</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -555,7 +585,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withStringInput">withStringInput</a>(string $name, string $value, string $description)
-        
+
                                             <p><p>Create or update an input value of type string</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -565,7 +595,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withStringOutput">withStringOutput</a>(string $name, string $description)
-        
+
                                             <p><p>Create or update an input value of type string</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -579,17 +609,17 @@
                     <h3 id="method___construct">
         <div class="location">in <a href="../Dagger/Client/AbstractObject.html#method___construct">
 <abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a> at line 13</div>
-        <code>                    
+        <code>
     <strong>__construct</strong>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -607,10 +637,10 @@
             </tr>
             </table>
 
-            
-            
-            
-            
+
+
+
+
                     </div>
     </div>
 
@@ -623,13 +653,13 @@
     <strong>queryLeaf</strong>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -647,7 +677,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -657,29 +687,103 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_binding">
+        <div class="location">at line 16</div>
+        <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
+    <strong>binding</strong>(string $name)
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>retrieve an object binding</p></p>
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+            </table>
+
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_bindings">
+        <div class="location">at line 26</div>
+        <code>                    array
+    <strong>bindings</strong>()
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>return all object bindings</p></p>
+        </div>
+        <div class="tags">
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>array</td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 16</div>
+        <div class="location">at line 35</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>A unique identifier for this Env.</p></p>                        
+                            <p><p>A unique identifier for this Env.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -689,26 +793,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_input">
-        <div class="location">at line 25</div>
+        <div class="location">at line 44</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>input</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>retrieve an input value by name</p></p>                        
+                            <p><p>retrieve an input value by name</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -721,7 +825,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -731,29 +835,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_inputs">
-        <div class="location">at line 35</div>
+        <div class="location">at line 54</div>
         <code>                    array
     <strong>inputs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>return all input values for the environment</p></p>                        
+                            <p><p>return all input values for the environment</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -763,26 +867,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_output">
-        <div class="location">at line 44</div>
+        <div class="location">at line 63</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>output</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>retrieve an output value by name</p></p>                        
+                            <p><p>retrieve an output value by name</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -795,7 +899,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -805,29 +909,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_outputs">
-        <div class="location">at line 54</div>
+        <div class="location">at line 73</div>
         <code>                    array
     <strong>outputs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>return all output values for the environment</p></p>                        
+                            <p><p>return all output values for the environment</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -837,26 +941,78 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withBinding">
+        <div class="location">at line 82</div>
+        <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
+    <strong>withBinding</strong>(string $name, string $value, string|null $description = null)
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>bind an object to the env</p></p>
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string</td>
+                <td>$value</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$description</td>
+                <td></td>
+            </tr>
+            </table>
+
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withCacheVolumeInput">
-        <div class="location">at line 63</div>
+        <div class="location">at line 96</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCacheVolumeInput</strong>(string $name, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type CacheVolume in the environment</p></p>                        
+                            <p><p>Create or update a binding of type CacheVolume in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -879,7 +1035,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -889,26 +1045,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withCacheVolumeOutput">
-        <div class="location">at line 75</div>
+        <div class="location">at line 108</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCacheVolumeOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired CacheVolume output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired CacheVolume output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -926,7 +1082,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -936,26 +1092,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withCloudInput">
-        <div class="location">at line 86</div>
+        <div class="location">at line 119</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCloudInput</strong>(string $name, <abbr title="Dagger\CloudId|Dagger\Cloud">Cloud</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Cloud in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Cloud in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -978,7 +1134,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -988,26 +1144,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withCloudOutput">
-        <div class="location">at line 98</div>
+        <div class="location">at line 131</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCloudOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Cloud output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Cloud output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1025,7 +1181,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1035,26 +1191,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withContainerInput">
-        <div class="location">at line 109</div>
+        <div class="location">at line 142</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withContainerInput</strong>(string $name, <abbr title="Dagger\ContainerId|Dagger\Container">Container</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Container in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Container in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1077,7 +1233,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1087,26 +1243,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withContainerOutput">
-        <div class="location">at line 121</div>
+        <div class="location">at line 154</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withContainerOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Container output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Container output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1124,7 +1280,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1134,26 +1290,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectoryInput">
-        <div class="location">at line 132</div>
+        <div class="location">at line 165</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDirectoryInput</strong>(string $name, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Directory in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Directory in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1176,7 +1332,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1186,26 +1342,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectoryOutput">
-        <div class="location">at line 144</div>
+        <div class="location">at line 177</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDirectoryOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Directory output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Directory output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1223,7 +1379,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1233,26 +1389,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvInput">
-        <div class="location">at line 155</div>
+        <div class="location">at line 188</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvInput</strong>(string $name, <abbr title="Dagger\EnvId|Dagger\Env">Env</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Env in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Env in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1275,7 +1431,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1285,26 +1441,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvOutput">
-        <div class="location">at line 167</div>
+        <div class="location">at line 200</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Env output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Env output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1322,7 +1478,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1332,26 +1488,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withFileInput">
-        <div class="location">at line 178</div>
+        <div class="location">at line 211</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withFileInput</strong>(string $name, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type File in the environment</p></p>                        
+                            <p><p>Create or update a binding of type File in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1374,7 +1530,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1384,26 +1540,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withFileOutput">
-        <div class="location">at line 190</div>
+        <div class="location">at line 223</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withFileOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired File output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired File output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1421,7 +1577,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1431,26 +1587,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRefInput">
-        <div class="location">at line 201</div>
+        <div class="location">at line 234</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRefInput</strong>(string $name, <abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type GitRef in the environment</p></p>                        
+                            <p><p>Create or update a binding of type GitRef in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1473,7 +1629,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1483,26 +1639,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRefOutput">
-        <div class="location">at line 213</div>
+        <div class="location">at line 246</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRefOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired GitRef output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired GitRef output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1520,7 +1676,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1530,26 +1686,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRepositoryInput">
-        <div class="location">at line 224</div>
+        <div class="location">at line 257</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRepositoryInput</strong>(string $name, <abbr title="Dagger\GitRepositoryId|Dagger\GitRepository">GitRepository</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type GitRepository in the environment</p></p>                        
+                            <p><p>Create or update a binding of type GitRepository in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1572,7 +1728,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1582,26 +1738,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRepositoryOutput">
-        <div class="location">at line 239</div>
+        <div class="location">at line 272</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRepositoryOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired GitRepository output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired GitRepository output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1619,7 +1775,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1629,26 +1785,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withJSONValueInput">
-        <div class="location">at line 250</div>
+        <div class="location">at line 283</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withJSONValueInput</strong>(string $name, <abbr title="Dagger\JsonValueId|Dagger\JsonValue">JsonValue</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type JSONValue in the environment</p></p>                        
+                            <p><p>Create or update a binding of type JSONValue in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1671,7 +1827,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1681,26 +1837,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withJSONValueOutput">
-        <div class="location">at line 262</div>
+        <div class="location">at line 295</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withJSONValueOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired JSONValue output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired JSONValue output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1718,7 +1874,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1728,26 +1884,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withLLMInput">
-        <div class="location">at line 273</div>
+        <div class="location">at line 306</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withLLMInput</strong>(string $name, <abbr title="Dagger\LLMId|Dagger\LLM">LLM</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type LLM in the environment</p></p>                        
+                            <p><p>Create or update a binding of type LLM in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1770,7 +1926,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1780,26 +1936,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withLLMOutput">
-        <div class="location">at line 285</div>
+        <div class="location">at line 318</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withLLMOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired LLM output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired LLM output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1817,7 +1973,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1827,26 +1983,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleConfigClientInput">
-        <div class="location">at line 296</div>
+        <div class="location">at line 329</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleConfigClientInput</strong>(string $name, <abbr title="Dagger\ModuleConfigClientId|Dagger\ModuleConfigClient">ModuleConfigClient</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type ModuleConfigClient in the environment</p></p>                        
+                            <p><p>Create or update a binding of type ModuleConfigClient in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1869,7 +2025,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1879,26 +2035,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleConfigClientOutput">
-        <div class="location">at line 311</div>
+        <div class="location">at line 344</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleConfigClientOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired ModuleConfigClient output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired ModuleConfigClient output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1916,7 +2072,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1926,26 +2082,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleInput">
-        <div class="location">at line 322</div>
+        <div class="location">at line 355</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleInput</strong>(string $name, <abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Module in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Module in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1968,7 +2124,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1978,26 +2134,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleOutput">
-        <div class="location">at line 334</div>
+        <div class="location">at line 367</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Module output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Module output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2015,7 +2171,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2025,26 +2181,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleSourceInput">
-        <div class="location">at line 345</div>
+        <div class="location">at line 378</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleSourceInput</strong>(string $name, <abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type ModuleSource in the environment</p></p>                        
+                            <p><p>Create or update a binding of type ModuleSource in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2067,7 +2223,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2077,26 +2233,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleSourceOutput">
-        <div class="location">at line 357</div>
+        <div class="location">at line 390</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleSourceOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired ModuleSource output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired ModuleSource output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2114,7 +2270,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2124,9 +2280,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2134,16 +2290,18 @@
                     <div class="method-item">
                     <h3 id="method_withSearchResultInput">
         <div class="location">at line 368</div>
+                    <h3 id="method_withSecretInput">
+        <div class="location">at line 401</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchResultInput</strong>(string $name, <abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type SearchResult in the environment</p></p>                        
+                            <p><p>Create or update a binding of type SearchResult in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2166,7 +2324,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2176,9 +2334,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2190,12 +2348,12 @@
     <strong>withSearchResultOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired SearchResult output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired SearchResult output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2213,7 +2371,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2223,9 +2381,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2237,12 +2395,12 @@
     <strong>withSearchSubmatchInput</strong>(string $name, <abbr title="Dagger\SearchSubmatchId|Dagger\SearchSubmatch">SearchSubmatch</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type SearchSubmatch in the environment</p></p>                        
+                            <p><p>Create or update a binding of type SearchSubmatch in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2265,7 +2423,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2275,9 +2433,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2289,12 +2447,12 @@
     <strong>withSearchSubmatchOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired SearchSubmatch output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired SearchSubmatch output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2312,7 +2470,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2322,9 +2480,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2336,12 +2494,12 @@
     <strong>withSecretInput</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Secret in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Secret in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2364,7 +2522,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2374,26 +2532,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretOutput">
+<<<<<<< HEAD
         <div class="location">at line 429</div>
+=======
+        <div class="location">at line 413</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSecretOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Secret output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Secret output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2411,7 +2573,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2421,26 +2583,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceInput">
+<<<<<<< HEAD
         <div class="location">at line 440</div>
+=======
+        <div class="location">at line 424</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceInput</strong>(string $name, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Service in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Service in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2463,7 +2629,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2473,26 +2639,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceOutput">
+<<<<<<< HEAD
         <div class="location">at line 452</div>
+=======
+        <div class="location">at line 436</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Service output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Service output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2510,7 +2680,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2520,26 +2690,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketInput">
+<<<<<<< HEAD
         <div class="location">at line 463</div>
+=======
+        <div class="location">at line 447</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketInput</strong>(string $name, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update a binding of type Socket in the environment</p></p>                        
+                            <p><p>Create or update a binding of type Socket in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2562,7 +2736,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2572,26 +2746,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketOutput">
+<<<<<<< HEAD
         <div class="location">at line 475</div>
+=======
+        <div class="location">at line 459</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Declare a desired Socket output to be assigned in the environment</p></p>                        
+                            <p><p>Declare a desired Socket output to be assigned in the environment</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2609,7 +2787,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2619,26 +2797,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringInput">
+<<<<<<< HEAD
         <div class="location">at line 486</div>
+=======
+        <div class="location">at line 470</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringInput</strong>(string $name, string $value, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update an input value of type string</p></p>                        
+                            <p><p>Create or update an input value of type string</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2661,7 +2843,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2671,26 +2853,30 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringOutput">
+<<<<<<< HEAD
         <div class="location">at line 498</div>
+=======
+        <div class="location">at line 482</div>
+>>>>>>> c27af5a5a (Env: generic object bindings)
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringOutput</strong>(string $name, string $description)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Create or update an input value of type string</p></p>                        
+                            <p><p>Create or update an input value of type string</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2708,7 +2894,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2718,16 +2904,16 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
             </div>
 
-    
+
 </div><div id="footer">
         Generated by <a href="https://github.com/code-lts/doctum">Doctum, a API Documentation generator and fork of Sami</a>.</div></div>
     </div>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -199,7 +199,11 @@
                     <dd><p>The <code>BindingID</code> scalar type represents an identifier for an object of type Binding.</p></dd><dt><a href="Dagger/BuildArg.html"><abbr title="Dagger\BuildArg">BuildArg</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>Key value object that represents a build argument.</p></dd><dt><a href="Dagger/Container.html#method_build">
 <abbr title="Dagger\Container">Container</abbr>::build</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Initializes this container from a Dockerfile build.</p></dd><dt><a href="Dagger/GitRepository.html#method_branch">
+                    <dd><p>Initializes this container from a Dockerfile build.</p></dd><dt><a href="Dagger/Env.html#method_binding">
+<abbr title="Dagger\Env">Env</abbr>::binding</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
+                    <dd><p>retrieve an object binding</p></dd><dt><a href="Dagger/Env.html#method_bindings">
+<abbr title="Dagger\Env">Env</abbr>::bindings</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
+                    <dd><p>return all object bindings</p></dd><dt><a href="Dagger/GitRepository.html#method_branch">
 <abbr title="Dagger\GitRepository">GitRepository</abbr>::branch</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>
                     <dd><p>Returns details of a branch.</p></dd><dt><a href="Dagger/GitRepository.html#method_branches">
 <abbr title="Dagger\GitRepository">GitRepository</abbr>::branches</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>
@@ -1222,7 +1226,9 @@
 <abbr title="Dagger\Directory">Directory</abbr>::withoutFile</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
                     <dd><p>Return a snapshot with a file removed</p></dd><dt><a href="Dagger/Directory.html#method_withoutFiles">
 <abbr title="Dagger\Directory">Directory</abbr>::withoutFiles</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
-                    <dd><p>Return a snapshot with files removed</p></dd><dt><a href="Dagger/Env.html#method_withCacheVolumeInput">
+                    <dd><p>Return a snapshot with files removed</p></dd><dt><a href="Dagger/Env.html#method_withBinding">
+<abbr title="Dagger\Env">Env</abbr>::withBinding</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
+                    <dd><p>bind an object to the env</p></dd><dt><a href="Dagger/Env.html#method_withCacheVolumeInput">
 <abbr title="Dagger\Env">Env</abbr>::withCacheVolumeInput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
                     <dd><p>Create or update a binding of type CacheVolume in the environment</p></dd><dt><a href="Dagger/Env.html#method_withCacheVolumeOutput">
 <abbr title="Dagger\Env">Env</abbr>::withCacheVolumeOutput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2821,6 +2821,18 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Env::binding",
+			"p": "Dagger/Env.html#method_binding",
+			"d": "<p>retrieve an object binding</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::bindings",
+			"p": "Dagger/Env.html#method_bindings",
+			"d": "<p>return all object bindings</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Env::id",
 			"p": "Dagger/Env.html#method_id",
 			"d": "<p>A unique identifier for this Env.</p>"
@@ -2848,6 +2860,12 @@
 			"n": "Dagger\\Env::outputs",
 			"p": "Dagger/Env.html#method_outputs",
 			"d": "<p>return all output values for the environment</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Env::withBinding",
+			"p": "Dagger/Env.html#method_withBinding",
+			"d": "<p>bind an object to the env</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4175,6 +4175,49 @@ func (r *Env) WithGraphQLQuery(q *querybuilder.Selection) *Env {
 	}
 }
 
+// retrieve an object binding
+func (r *Env) Binding(name string) *Binding {
+	q := r.query.Select("binding")
+	q = q.Arg("name", name)
+
+	return &Binding{
+		query: q,
+	}
+}
+
+// return all object bindings
+func (r *Env) Bindings(ctx context.Context) ([]Binding, error) {
+	q := r.query.Select("bindings")
+
+	q = q.Select("id")
+
+	type bindings struct {
+		Id BindingID
+	}
+
+	convert := func(fields []bindings) []Binding {
+		out := []Binding{}
+
+		for i := range fields {
+			val := Binding{id: &fields[i].Id}
+			val.query = q.Root().Select("loadBindingFromID").Arg("id", fields[i].Id)
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []bindings
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
 // A unique identifier for this Env.
 func (r *Env) ID(ctx context.Context) (EnvID, error) {
 	if r.id != nil {
@@ -4299,6 +4342,29 @@ func (r *Env) Outputs(ctx context.Context) ([]Binding, error) {
 	}
 
 	return convert(response), nil
+}
+
+// EnvWithBindingOpts contains options for Env.WithBinding
+type EnvWithBindingOpts struct {
+	// Binding description
+	Description string
+}
+
+// bind an object to the env
+func (r *Env) WithBinding(name string, value string, opts ...EnvWithBindingOpts) *Env {
+	q := r.query.Select("withBinding")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `description` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Description) {
+			q = q.Arg("description", opts[i].Description)
+		}
+	}
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &Env{
+		query: q,
+	}
 }
 
 // Create or update a binding of type CacheVolume in the environment

--- a/sdk/php/generated/Env.php
+++ b/sdk/php/generated/Env.php
@@ -11,6 +11,25 @@ namespace Dagger;
 class Env extends Client\AbstractObject implements Client\IdAble
 {
     /**
+     * retrieve an object binding
+     */
+    public function binding(string $name): Binding
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('binding');
+        $innerQueryBuilder->setArgument('name', $name);
+        return new \Dagger\Binding($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * return all object bindings
+     */
+    public function bindings(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('bindings');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'bindings');
+    }
+
+    /**
      * A unique identifier for this Env.
      */
     public function id(): EnvId
@@ -55,6 +74,20 @@ class Env extends Client\AbstractObject implements Client\IdAble
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('outputs');
         return (array)$this->queryLeaf($leafQueryBuilder, 'outputs');
+    }
+
+    /**
+     * bind an object to the env
+     */
+    public function withBinding(string $name, string $value, ?string $description = null): Env
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withBinding');
+        $innerQueryBuilder->setArgument('name', $name);
+        $innerQueryBuilder->setArgument('value', $value);
+        if (null !== $description) {
+        $innerQueryBuilder->setArgument('description', $description);
+        }
+        return new \Dagger\Env($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4332,6 +4332,26 @@ class EnumValueTypeDef(Type):
 
 @typecheck
 class Env(Type):
+    def binding(self, name: str) -> Binding:
+        """retrieve an object binding
+
+        Parameters
+        ----------
+        name:
+            The binding name
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("binding", _args)
+        return Binding(_ctx)
+
+    async def bindings(self) -> list[Binding]:
+        """return all object bindings"""
+        _args: list[Arg] = []
+        _ctx = self._select("bindings", _args)
+        return await _ctx.execute_object_list(Binding)
+
     async def id(self) -> EnvID:
         """A unique identifier for this Env.
 
@@ -4383,6 +4403,32 @@ class Env(Type):
         _args: list[Arg] = []
         _ctx = self._select("outputs", _args)
         return await _ctx.execute_object_list(Binding)
+
+    def with_binding(
+        self,
+        name: str,
+        value: str,
+        *,
+        description: str | None = None,
+    ) -> Self:
+        """bind an object to the env
+
+        Parameters
+        ----------
+        name:
+            Binding name
+        value:
+            Object to bind
+        description:
+            Binding description
+        """
+        _args = [
+            Arg("name", name),
+            Arg("value", value),
+            Arg("description", description, None),
+        ]
+        _ctx = self._select("withBinding", _args)
+        return Env(_ctx)
 
     def with_cache_volume_input(
         self,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5801,7 +5801,36 @@ pub struct Env {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
+#[derive(Builder, Debug, PartialEq)]
+pub struct EnvWithBindingOpts<'a> {
+    /// Binding description
+    #[builder(setter(into, strip_option), default)]
+    pub description: Option<&'a str>,
+}
 impl Env {
+    /// retrieve an object binding
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The binding name
+    pub fn binding(&self, name: impl Into<String>) -> Binding {
+        let mut query = self.selection.select("binding");
+        query = query.arg("name", name.into());
+        Binding {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// return all object bindings
+    pub fn bindings(&self) -> Vec<Binding> {
+        let query = self.selection.select("bindings");
+        vec![Binding {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }]
+    }
     /// A unique identifier for this Env.
     pub async fn id(&self) -> Result<EnvId, DaggerError> {
         let query = self.selection.select("id");
@@ -5844,6 +5873,48 @@ impl Env {
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }]
+    }
+    /// bind an object to the env
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Binding name
+    /// * `value` - Object to bind
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn with_binding(&self, name: impl Into<String>, value: impl Into<String>) -> Env {
+        let mut query = self.selection.select("withBinding");
+        query = query.arg("name", name.into());
+        query = query.arg("value", value.into());
+        Env {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// bind an object to the env
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Binding name
+    /// * `value` - Object to bind
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn with_binding_opts<'a>(
+        &self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+        opts: EnvWithBindingOpts<'a>,
+    ) -> Env {
+        let mut query = self.selection.select("withBinding");
+        query = query.arg("name", name.into());
+        query = query.arg("value", value.into());
+        if let Some(description) = opts.description {
+            query = query.arg("description", description);
+        }
+        Env {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
     }
     /// Create or update a binding of type CacheVolume in the environment
     ///

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1002,6 +1002,13 @@ export type EnumTypeDefID = string & { __EnumTypeDefID: never }
  */
 export type EnumValueTypeDefID = string & { __EnumValueTypeDefID: never }
 
+export type EnvWithBindingOpts = {
+  /**
+   * Binding description
+   */
+  description?: string
+}
+
 /**
  * The `EnvID` scalar type represents an identifier for an object of type Env.
  */
@@ -4971,6 +4978,30 @@ export class Env extends BaseClient {
   }
 
   /**
+   * retrieve an object binding
+   * @param name The binding name
+   */
+  binding = (name: string): Binding => {
+    const ctx = this._ctx.select("binding", { name })
+    return new Binding(ctx)
+  }
+
+  /**
+   * return all object bindings
+   */
+  bindings = async (): Promise<Binding[]> => {
+    type bindings = {
+      id: BindingID
+    }
+
+    const ctx = this._ctx.select("bindings").select("id")
+
+    const response: Awaited<bindings[]> = await ctx.execute()
+
+    return response.map((r) => new Client(ctx.copy()).loadBindingFromID(r.id))
+  }
+
+  /**
    * retrieve an input value by name
    */
   input = (name: string): Binding => {
@@ -5014,6 +5045,21 @@ export class Env extends BaseClient {
     const response: Awaited<outputs[]> = await ctx.execute()
 
     return response.map((r) => new Client(ctx.copy()).loadBindingFromID(r.id))
+  }
+
+  /**
+   * bind an object to the env
+   * @param name Binding name
+   * @param value Object to bind
+   * @param opts.description Binding description
+   */
+  withBinding = (
+    name: string,
+    value: string,
+    opts?: EnvWithBindingOpts,
+  ): Env => {
+    const ctx = this._ctx.select("withBinding", { name, value, ...opts })
+    return new Env(ctx)
   }
 
   /**


### PR DESCRIPTION
Simplify `Env` with generic bindings. This is part of #10370 

- [ ] New core type: `Object`. A generic type that matches any Dagger object. Must be an interface, supported by all SDKs.
- [x] New core function: `Env.withBinding`. Create a new binding with the given `ID` as value.
- [x] New core function: `Env.binding`. Retrieve a binding.
- [x] New core function: `Env.bindings`. List all bindings.
- [ ] Deprecate `Env.with[XXX]Binding`
- [ ] Deprecate `Env.inputs` and `Env.outputs`
- [ ] Alias `LLM.withBinding`, `LLM.bindings`, `LLM.binding` for convenience

## Generic Object

The current implementation uses a temporary stopgap: a scalar `ID` type. This works, but SDKs won't generate useful bindings for it.

Instead, @vito proposes:

> We could make it take an interface that all objects satisfy (e.g. in Go every object implements XXX_GraphQLID and XXX_GraphQLType
> [...]
> In Go it would probably look like this:
> ```
> type Object interface {
>     XXX_GraphQLType() string
>     XXX_GraphQLID(context.Context) (string, error)
> }
> ```

> The downside to this approach is that it's another box for every SDK maintainer to check. They'll have to special-case an ID argument to take an Object interface (analogous to how ContainerID actually takes a Container), or come up with some other language-specific tactic. Or just leave users to do the boilerplate themselves, but that's no fun.