### PR TITLE
fix: make various module fields nullable

### DIFF
--- a/core/client_resource.go
+++ b/core/client_resource.go
@@ -17,7 +17,7 @@ func GetClientResourceAccessor(ctx context.Context, parent *Query, externalName 
 
 	var scopeDigest digest.Digest
 	if m != nil {
-		scopeDigest = digest.Digest(m.Source.Self().Digest)
+		scopeDigest = digest.Digest(m.Source.Value.Self().Digest)
 	}
 
 	// Use an HMAC, which allows us to keep the externalName un-inferrable.

--- a/core/container.go
+++ b/core/container.go
@@ -199,6 +199,9 @@ func (container *Container) WithoutInputs() *Container {
 var _ dagql.OnReleaser = (*Container)(nil)
 
 func (container *Container) OnRelease(ctx context.Context) error {
+	if container == nil {
+		return nil
+	}
 	if container.FSResult != nil {
 		err := container.FSResult.Release(ctx)
 		if err != nil {

--- a/core/llm.go
+++ b/core/llm.go
@@ -882,7 +882,7 @@ func (llm *LLM) allowed(ctx context.Context) error {
 		return fmt.Errorf("failed to figure out module while deciding if llm is allowed: %w", err)
 	}
 
-	src := module.ContextSource.Self()
+	src := module.ContextSource.Value.Self()
 	if src.Kind != ModuleSourceKindGit {
 		return nil
 	}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -594,7 +594,7 @@ func (fn *ModuleFunction) ArgType(argName string) (ModType, error) {
 func moduleAnalyticsProps(mod *Module, prefix string, props map[string]string) {
 	props[prefix+"module_name"] = mod.Name()
 
-	source := mod.ContextSource.Self()
+	source := mod.ContextSource.Value.Self()
 	switch source.Kind {
 	case ModuleSourceKindLocal:
 		props[prefix+"source_kind"] = "local"
@@ -635,7 +635,7 @@ func (fn *ModuleFunction) loadContextualArg(
 	case "Directory":
 		slog.Debug("moduleFunction.loadContextualArg: loading contextual directory", "fn", arg.Name, "dir", arg.DefaultPath)
 
-		dir, err := fn.mod.ContextSource.Self().LoadContext(ctx, dag, arg.DefaultPath, arg.Ignore)
+		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, arg.DefaultPath, arg.Ignore)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load contextual directory %q: %w", arg.DefaultPath, err)
 		}
@@ -649,7 +649,7 @@ func (fn *ModuleFunction) loadContextualArg(
 		filePath := filepath.Base(arg.DefaultPath)
 
 		// Load the directory containing the file.
-		dir, err := fn.mod.ContextSource.Self().LoadContext(ctx, dag, dirPath, nil)
+		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, dirPath, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load contextual directory %q: %w", dirPath, err)
 		}

--- a/core/module.go
+++ b/core/module.go
@@ -20,10 +20,10 @@ import (
 
 type Module struct {
 	// The source of the module
-	Source dagql.ObjectResult[*ModuleSource] `field:"true" name:"source" doc:"The source for the module."`
+	Source dagql.Nullable[dagql.ObjectResult[*ModuleSource]] `field:"true" name:"source" doc:"The source for the module."`
 
 	// The source to load contextual dirs/files from, which may be different than Source for blueprints
-	ContextSource dagql.ObjectResult[*ModuleSource]
+	ContextSource dagql.Nullable[dagql.ObjectResult[*ModuleSource]]
 
 	// The name of the module
 	NameField string `field:"true" name:"name" doc:"The name of the module"`
@@ -39,7 +39,7 @@ type Module struct {
 	Deps *ModDeps
 
 	// Runtime is the container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-	Runtime dagql.ObjectResult[*Container] `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
+	Runtime dagql.Nullable[dagql.ObjectResult[*Container]] `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
 
 	// The following are populated while initializing the module
 
@@ -77,36 +77,44 @@ func (mod *Module) Name() string {
 }
 
 func (mod *Module) GetSource() *ModuleSource {
-	return mod.Source.Self()
+	if !mod.Source.Valid {
+		return nil
+	}
+	return mod.Source.Value.Self()
 }
 
 func (mod *Module) IDModule() *call.Module {
+	if !mod.Source.Valid {
+		panic("no module source")
+	}
+	src := mod.Source.Value.Self()
+
 	var ref, pin string
-	switch mod.Source.Self().Kind {
+	switch src.Kind {
 	case ModuleSourceKindLocal:
-		ref = filepath.Join(mod.Source.Self().Local.ContextDirectoryPath, mod.Source.Self().SourceRootSubpath)
+		ref = filepath.Join(src.Local.ContextDirectoryPath, src.SourceRootSubpath)
 
 	case ModuleSourceKindGit:
-		ref = mod.Source.Self().Git.CloneRef
-		if mod.Source.Self().SourceRootSubpath != "" {
-			ref += "/" + strings.TrimPrefix(mod.Source.Self().SourceRootSubpath, "/")
+		ref = src.Git.CloneRef
+		if src.SourceRootSubpath != "" {
+			ref += "/" + strings.TrimPrefix(src.SourceRootSubpath, "/")
 		}
-		if mod.Source.Self().Git.Version != "" {
-			ref += "@" + mod.Source.Self().Git.Version
+		if src.Git.Version != "" {
+			ref += "@" + src.Git.Version
 		}
-		pin = mod.Source.Self().Git.Commit
+		pin = src.Git.Commit
 
 	case ModuleSourceKindDir:
 		// FIXME: this is better than nothing, but no other code handles refs that
 		// are an encoded ID right now
 		var err error
-		ref, err = mod.Source.Self().ContextDirectory.ID().Encode()
+		ref, err = src.ContextDirectory.ID().Encode()
 		if err != nil {
 			panic(fmt.Sprintf("failed to encode context directory ID: %v", err))
 		}
 
 	default:
-		panic(fmt.Sprintf("unexpected module source kind %q", mod.Source.Self().Kind))
+		panic(fmt.Sprintf("unexpected module source kind %q", src.Kind))
 	}
 
 	return call.NewModule(mod.ResultID, mod.Name(), ref, pin)
@@ -237,7 +245,7 @@ func (mod *Module) CacheConfigForCall(
 	)
 	cacheCfg.Digest = dagql.HashFrom(
 		curIDNoMod.Digest().String(),
-		mod.Source.Self().Digest,
+		mod.Source.Value.Self().Digest,
 		mod.NameField, // the module source content digest only includes the original name
 	)
 
@@ -596,7 +604,7 @@ func (mod *Module) namespaceSourceMap(modPath string, sourceMap *SourceMap) *Sou
 		return nil
 	}
 
-	if mod.Source.Self().Kind != ModuleSourceKindLocal {
+	if mod.Source.Value.Self().Kind != ModuleSourceKindLocal {
 		// TODO: handle remote git files
 		return nil
 	}
@@ -609,7 +617,7 @@ func (mod *Module) namespaceSourceMap(modPath string, sourceMap *SourceMap) *Sou
 // modulePath gets the prefix for the file sourcemaps, so that the sourcemap is
 // relative to the context directory
 func (mod *Module) modulePath() string {
-	return mod.Source.Self().SourceSubpath
+	return mod.Source.Value.Self().SourceSubpath
 }
 
 // Patch is called after all types have been loaded - here we can update any
@@ -706,22 +714,22 @@ var _ HasPBDefinitions = (*Module)(nil)
 
 func (mod *Module) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	var defs []*pb.Definition
-	if mod.Source.Self() != nil {
-		dirDefs, err := mod.Source.Self().PBDefinitions(ctx)
+	if mod.Source.Valid && mod.Source.Value.Self() != nil {
+		dirDefs, err := mod.Source.Value.Self().PBDefinitions(ctx)
 		if err != nil {
 			return nil, err
 		}
 		defs = append(defs, dirDefs...)
 	}
-	if mod.ContextSource.Self() != nil {
-		dirDefs, err := mod.ContextSource.Self().PBDefinitions(ctx)
+	if mod.ContextSource.Valid && mod.ContextSource.Value.Self() != nil {
+		dirDefs, err := mod.ContextSource.Value.Self().PBDefinitions(ctx)
 		if err != nil {
 			return nil, err
 		}
 		defs = append(defs, dirDefs...)
 	}
-	if mod.Runtime.Self() != nil {
-		dirDefs, err := mod.Runtime.Self().PBDefinitions(ctx)
+	if mod.Runtime.Valid && mod.Runtime.Value.Self() != nil {
+		dirDefs, err := mod.Runtime.Value.Self().PBDefinitions(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/core/object.go
+++ b/core/object.go
@@ -210,7 +210,7 @@ func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callab
 			ctx,
 			mod,
 			t.typeDef,
-			mod.Runtime,
+			mod.Runtime.Value,
 			fun,
 		)
 	}
@@ -365,7 +365,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 		return fmt.Errorf("constructor function for object %s must return that object", objDef.OriginalName)
 	}
 
-	fn, err := NewModFunction(ctx, mod, objDef, mod.Runtime, fnTypeDef)
+	fn, err := NewModFunction(ctx, mod, objDef, mod.Runtime.Value, fnTypeDef)
 	if err != nil {
 		return fmt.Errorf("failed to create function: %w", err)
 	}
@@ -465,7 +465,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 		ctx,
 		mod,
 		objDef,
-		mod.Runtime,
+		mod.Runtime.Value,
 		fun,
 	)
 	if err != nil {

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -93,16 +93,17 @@ func namespaceFromModule(m *core.Module) string {
 		return "mainClient"
 	}
 
-	name := m.Source.Self().ModuleOriginalName
+	src := m.Source.Value
+	name := src.Self().ModuleOriginalName
 
 	var symbolic string
-	switch m.Source.Self().Kind {
+	switch src.Self().Kind {
 	case core.ModuleSourceKindLocal:
-		symbolic = m.Source.Self().SourceRootSubpath
+		symbolic = src.Self().SourceRootSubpath
 	case core.ModuleSourceKindGit:
-		symbolic = m.Source.Self().Git.Symbolic
+		symbolic = src.Self().Git.Symbolic
 	case core.ModuleSourceKindDir:
-		symbolic = m.Source.ID().Digest().String()
+		symbolic = m.Source.Value.ID().Digest().String()
 	}
 
 	return "mod(" + name + symbolic + ")"

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -603,7 +603,7 @@ func (s *moduleSchema) moduleGeneratedContextDirectory(
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
 
-	err = dag.Select(ctx, mod.Self().Source, &inst,
+	err = dag.Select(ctx, mod.Self().Source.Value, &inst,
 		dagql.Selector{
 			Field: "generatedContextDirectory",
 		},
@@ -700,7 +700,7 @@ func (s *moduleSchema) currentModuleSource(
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
 
-	curSrc := curMod.Self().Module.Source
+	curSrc := curMod.Self().Module.Source.Value
 	if curSrc.Self() == nil {
 		return inst, errors.New("invalid unset current module source")
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2975,7 +2975,7 @@ type Module {
   """
   The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
   """
-  runtime: Container!
+  runtime: Container
 
   """The SDK config used by this module."""
   sdk: SDKConfig
@@ -2992,7 +2992,7 @@ type Module {
   ): Void
 
   """The source for the module."""
-  source: ModuleSource!
+  source: ModuleSource
 
   """
   Forces evaluation of the module, including any loading into the engine and associated validation.

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -9738,7 +9738,7 @@
                         <td> Objects served by this module. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="Module-runtime" href="#Module-runtime"><code>runtime</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="Module-runtime" href="#Module-runtime"><code>runtime</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container</code></a></span> </td>
                         <td> The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile. </td>
                       </tr>
                       <tr>
@@ -9766,7 +9766,7 @@
                         </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="Module-source" href="#Module-source"><code>source</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="Module-source" href="#Module-source"><code>source</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource</code></a></span> </td>
                         <td> The source for the module. </td>
                       </tr>
                       <tr>

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -601,7 +601,7 @@ func (srv *Server) initializeDaggerClient(
 
 		// this is needed to set the view of the core api as compatible
 		// with the module we're currently calling from
-		engineVersion := client.mod.Source.Self().EngineVersion
+		engineVersion := client.mod.Source.Value.Self().EngineVersion
 		coreMod.Dag.View = dagql.View(engine.BaseVersion(engine.NormalizeVersion(engineVersion)))
 
 		// NOTE: *technically* we should reload the module here, so that we can

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -153,7 +153,7 @@ defmodule Dagger.Module do
   @doc """
   The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
   """
-  @spec runtime(t()) :: Dagger.Container.t()
+  @spec runtime(t()) :: Dagger.Container.t() | nil
   def runtime(%__MODULE__{} = module) do
     query_builder =
       module.query_builder |> QB.select("runtime")
@@ -199,7 +199,7 @@ defmodule Dagger.Module do
   @doc """
   The source for the module.
   """
-  @spec source(t()) :: Dagger.ModuleSource.t()
+  @spec source(t()) :: Dagger.ModuleSource.t() | nil
   def source(%__MODULE__{} = module) do
     query_builder =
       module.query_builder |> QB.select("source")


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10434. These fields can easily be constructed and be nullable.

Before:

```
❯ echo "{module{name,runtime,source}}" | dagger query
▶ connect 0.2s

● moduleSource(refString: ".", allowNotExists: true): ModuleSource! 0.0s
▶ .configExists: Boolean! 0.0s

● module: Module! 0.0s
● .name: String! 0.0s

● Module.runtime: Container! 0.0s

● Module.source: ModuleSource! 0.0s

Full trace at https://dagger.cloud/jedevc/traces/cbb397e127bbea9e419db824de5fb8d9
Error: make request: input: module.runtime panic while resolving Module.runtime: runtime error: invalid memory address or nil pointer dereference

goroutine 51275962 [running]:
runtime/debug.Stack()
	/usr/lib/go/src/runtime/debug/stack.go:26 +0x5e
github.com/dagger/dagger/dagql.(*Server).resolvePath.func1()
	/app/dagql/server.go:896 +0x77
panic({0x2c7ca60?, 0x5d0ea10?})
	/usr/lib/go/src/runtime/panic.go:792 +0x132
github.com/dagger/dagger/core.(*Container).PBDefinitions(0x0, {0x3a13b38, 0xc035a9a630})
	/app/core/container.go:126 +0x35
github.com/dagger/dagger/core.collectDefs({0x3a13b38, 0xc035a9a630}, {0x39e4ca0?, 0x0?})
	/app/core/telemetry.go:28 +0x62
github.com/dagger/dagger/core.collectEffects({0x3a13b38, 0xc035a9a630}, {0x39e4ca0, 0x0}, {0x3a3e5c0, 0xc003b77c20}, {0x3a2efd0, 0xc02a85a550})
	/app/core/telemetry.go:168 +0x165
github.com/dagger/dagger/core.AroundFunc.func1({0x39e4ca0, 0x0}, 0x90?, {0x0?, 0x0?})
	/app/core/telemetry.go:92 +0x17c
github.com/dagger/dagger/dagql.(*SessionCache).GetOrInitializeWithCallbacks.func1()
	/app/dagql/session_cache.go:139 +0x8c
github.com/dagger/dagger/dagql.(*SessionCache).GetOrInitializeWithCallbacks(0xc028706480, {0x3a13b38, 0xc035a9a540}, {0xc026b35488, 0x15}, 0x1, 0xc00d9a77a0, {0xc03b0e4150, 0x1, 0x1})
	/app/dagql/session_cache.go:154 +0x448
github.com/dagger/dagger/dagql.Instance[...].call(0x3a61cc0, {0x3a13b38, 0xc01e9cc690}, 0xc0119c37a0, 0xc02cf2a080, 0xc035a9a480, 0x0)
	/app/dagql/objects.go:598 +0x458
github.com/dagger/dagger/dagql.Instance[...].Select(0x3a61cc0, {0x3a13b38, 0xc01e9cc690}, 0xc0119c37a0, {{0xc015c4d9ad, 0x7}, {0x5dd5800, 0x0, 0x0}, 0x0, ...})
	/app/dagql/objects.go:384 +0x1b4
github.com/dagger/dagger/dagql.(*Server).resolvePath(0xc0119c37a0, {0x3a13b38, 0xc01e9cc690}, {0x3a2efd0?, 0xc02e3977c0?}, {{0xc015c4d9ad, 0x7}, {{0xc015c4d9ad, 0x7}, {0x5dd5800, ...}, ...}, ...})
	/app/dagql/server.go:912 +0x173
github.com/dagger/dagger/dagql.(*Server).Resolve.func1()
	/app/dagql/server.go:542 +0x7f
github.com/dagger/dagger/dagql.(*Server).Resolve.(*ErrorPool).Go.func3()
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/error_pool.go:30 +0x23
github.com/sourcegraph/conc/pool.(*Pool).worker(0x0?)
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/pool.go:154 +0x69
github.com/sourcegraph/conc/panics.(*Catcher).Try(0x3a13b38?, 0xc01dd5afd0?)
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/panics/panics.go:23 +0x42
github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:32 +0x4d
created by github.com/sourcegraph/conc.(*WaitGroup).Go in goroutine 51275990
	/go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:30 +0x73
```

After:

```
❯ echo "{module{name,runtime,source}}" | dagger-dev query
▶ connect 0.2s

● moduleSource(refString: ".", allowNotExists: true): ModuleSource! 0.0s
▶ .configExists: Boolean! 0.0s

● module: Module! 0.0s
● .name: String! 0.0s

● Module.runtime: Container 0.0s

● Module.source: ModuleSource 0.0s

{
    "module": {
        "name": "",
        "runtime": null,
        "source": null
    }
}
```

