### PR TITLE
`CLAUDECODE=1` sets `--progress=report`

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -436,6 +436,8 @@ func main() {
 	if progress == "auto" {
 		if env := os.Getenv("DAGGER_PROGRESS"); env != "" {
 			progress = env
+		} else if os.Getenv("CLAUDECODE") == "1" {
+			progress = "report"
 		} else if hasTTY {
 			progress = "tty"
 		} else {


### PR DESCRIPTION
A teeny tiny QoL improvement for when you run Dagger from Claude Code. Right now it uses the plain format which is too overwhelming. It seems to handle `--progress=report` really well.