### PR TITLE
exp: allow to run dagger 'tasks' from a dagger.yaml file

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -151,6 +151,7 @@ func init() {
 		shellCmd,
 		clientCmd,
 		mcpCmd,
+		taskCmd,
 	)
 
 	rootCmd.AddGroup(moduleGroup)

--- a/cmd/dagger/task.go
+++ b/cmd/dagger/task.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DaggerFileName = "dagger.yaml"
+)
+
+var taskCmd = &cobra.Command{
+	Use:   "task [TASK]",
+	Short: "Run a task defined in a dagger.yaml",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTask(cmd.Context(), args)
+	},
+	Annotations: map[string]string{
+		"experimental": "true",
+	},
+}
+
+func runTask(ctx context.Context, args []string) error {
+	daggerfile, err := readDaggerFile()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		fmt.Println("Available tasks:")
+		for taskName := range daggerfile.Tasks {
+			fmt.Println("- ", taskName)
+		}
+		return nil
+	}
+
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	taskName := args[0]
+
+	taskDef, err := daggerfile.FullDefinition(taskName)
+	if err != nil {
+		return err
+	}
+
+	binary, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(binary, []string{binary, "-c", taskDef}, os.Environ())
+}
+
+type DaggerFile struct {
+	Vars  map[string]string `yaml:"vars"`
+	Tasks map[string]string `yaml:"tasks"`
+}
+
+func readDaggerFile() (*DaggerFile, error) {
+	data, err := os.ReadFile(DaggerFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	var daggerfile DaggerFile
+	if err := yaml.Unmarshal(data, &daggerfile); err != nil {
+		return nil, err
+	}
+
+	return &daggerfile, nil
+}
+
+func (d *DaggerFile) FullDefinition(task string) (string, error) {
+	taskDef, ok := d.Tasks[task]
+	if !ok {
+		return "", fmt.Errorf("task %q not found", task)
+	}
+
+	var vars []string
+	for k, v := range d.Vars {
+		vars = append(vars, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	fullDef := strings.Join(vars, "\n") + "\n" + taskDef
+	return fullDef, nil
+}


### PR DESCRIPTION
This is experimental, just to see if that could be a good idea or not.

All start with a `dagger.yaml` file you can put in your project. The `dagger.yaml` file is composed of two sections: `vars` and `tasks`.

`vars` allow to define some variable (could be basic variable like strings, or more complex using any dagger primitives).

For instance this is declaring a Go version and defining a `ctr` variable representing a basic container to work on a go project:

```yaml
vars:
  go_version: 1.24.4
  ctr: >-
    $(container |
    from golang:$go_version-alpine |
    with-exec go install golang.org/x/tools/cmd/goimports@latest |
    with-exec go install mvdan.cc/gofumpt@latest |
    with-workdir /go/src |
    with-mounted-file /go/src/go.mod go.mod |
    with-mounted-file /go/src/go.sum go.sum |
    with-mounted-cache /root/.cache $(cache-volume go-cache) |
    with-mounted-cache /go/pkg/mod $(cache-volume go-pkg-mod) |
    with-exec go mod download |
    with-mounted-directory /go/src .)
```

Those variables will be translated as dagger shell variables, so available as `$go_version` and `$ctr`.

`tasks` allow to define some tasks to run. They have a name and a body that is a dagger shell command. This command can use previously defined variables.

For instance:

```yaml
tasks:
  terminal: >
    $ctr | terminal

  go:test: >
    $ctr |
    with-exec -- go test -coverpkg=./... -coverprofile=.coverage -shuffle=on ./... |
    stdout
```

This will define two tasks, one `terminal` that will open a terminal on the dev environment defined by `$ctr` and the second will run tests inside this container.

Usage:

- dagger task: list all available tasks
- dagger task TASK: will run the corresponding task by concatenating all the vars and the task body and run it as a dagger shell command

To test it, you can use `daggerfile` branch of `eunomie/docker-runx` project that contains a quick example: https://github.com/eunomie/docker-runx/tree/daggerfile

Clone the project, switch to daggerfile branch and run `dagger task` then `dagger task go:test`