### PR TITLE
dagui: use `json.RawMessage` for extra attrs

### DIFF
--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -1,6 +1,7 @@
 package dagui
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"time"
@@ -163,7 +164,7 @@ type SpanSnapshot struct {
 	ChildCount int  `json:",omitempty"`
 	HasLogs    bool `json:",omitempty"`
 
-	ExtraAttributes map[string]any `json:",omitempty"`
+	ExtraAttributes map[string]json.RawMessage `json:",omitempty"`
 }
 
 type SpanLink struct {
@@ -243,9 +244,14 @@ func (snapshot *SpanSnapshot) ProcessAttribute(name string, val any) {
 
 	default:
 		if snapshot.ExtraAttributes == nil {
-			snapshot.ExtraAttributes = make(map[string]any)
+			snapshot.ExtraAttributes = make(map[string]json.RawMessage)
 		}
-		snapshot.ExtraAttributes[name] = val
+		payload, err := json.Marshal(val)
+		if err != nil {
+			slog.Warn("failed to marshal attribute", "attribute", name, "val", val)
+			return
+		}
+		snapshot.ExtraAttributes[name] = json.RawMessage(payload)
 	}
 }
 

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -3,6 +3,7 @@ package idtui_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -175,16 +176,17 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 				var depCalled, rootCalled bool
 				for _, s := range db.Spans.Order {
 					if s.Name == "Dep.getFiles" {
-						require.Equal(t, "Viztest.TraceFunctionCalls", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(s.ExtraAttributes[telemetry.ModuleCallerRefAttr].(string), "@")[0])
-						require.Equal(t, "Dep.getFiles", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger/viztest/dep", strings.Split(s.ExtraAttributes[telemetry.ModuleRefAttr].(string), "@")[0])
+						require.Equal(t, "Viztest.TraceFunctionCalls", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(strAttr(t, s, telemetry.ModuleCallerRefAttr), "@")[0])
+						require.Equal(t, "Dep.getFiles", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger/viztest/dep", strings.Split(strAttr(t, s, telemetry.ModuleRefAttr), "@")[0])
 						depCalled = true
 					} else if s.Name == "Viztest.traceFunctionCalls" {
-						require.Equal(t, "", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, s.ExtraAttributes[telemetry.ModuleCallerRefAttr], "")
-						require.Equal(t, "Viztest.traceFunctionCalls", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(s.ExtraAttributes[telemetry.ModuleRefAttr].(string), "@")[0])
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerRefAttr))
+						require.Equal(t, "Viztest.traceFunctionCalls", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger/viztest",
+							strings.Split(strAttr(t, s, telemetry.ModuleRefAttr), "@")[0])
 						rootCalled = true
 					}
 				}
@@ -200,16 +202,16 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 				var depCalled, rootCalled bool
 				for _, s := range db.Spans.Order {
 					if s.Name == "Versioned.hello" {
-						require.Equal(t, "Viztest.TraceRemoteFunctionCalls", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(s.ExtraAttributes[telemetry.ModuleCallerRefAttr].(string), "@")[0])
-						require.Equal(t, "Versioned.hello", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger-test-modules/versioned@73670b0338c02cdd190f56b34c6e25066c7c8875", s.ExtraAttributes[telemetry.ModuleRefAttr].(string))
+						require.Equal(t, "Viztest.TraceRemoteFunctionCalls", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(strAttr(t, s, telemetry.ModuleCallerRefAttr), "@")[0])
+						require.Equal(t, "Versioned.hello", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger-test-modules/versioned@73670b0338c02cdd190f56b34c6e25066c7c8875", strAttr(t, s, telemetry.ModuleRefAttr))
 						depCalled = true
 					} else if s.Name == "Viztest.traceRemoteFunctionCalls" {
-						require.Equal(t, "", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, "", s.ExtraAttributes[telemetry.ModuleCallerRefAttr].(string))
-						require.Equal(t, "Viztest.traceRemoteFunctionCalls", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(s.ExtraAttributes[telemetry.ModuleRefAttr].(string), "@")[0])
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerRefAttr))
+						require.Equal(t, "Viztest.traceRemoteFunctionCalls", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger/viztest", strings.Split(strAttr(t, s, telemetry.ModuleRefAttr), "@")[0])
 						rootCalled = true
 					}
 				}
@@ -226,16 +228,16 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 				var depCalled, rootCalled bool
 				for _, s := range db.Spans.Order {
 					if s.Name == "DepAlias.fn" {
-						require.Equal(t, "RootMod.Fn", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875", s.ExtraAttributes[telemetry.ModuleCallerRefAttr].(string))
-						require.Equal(t, "DepAlias.fn", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger-test-modules/dep@73670b0338c02cdd190f56b34c6e25066c7c8875", s.ExtraAttributes[telemetry.ModuleRefAttr].(string))
+						require.Equal(t, "RootMod.Fn", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875", strAttr(t, s, telemetry.ModuleCallerRefAttr))
+						require.Equal(t, "DepAlias.fn", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger-test-modules/dep@73670b0338c02cdd190f56b34c6e25066c7c8875", strAttr(t, s, telemetry.ModuleRefAttr))
 						depCalled = true
 					} else if s.Name == "RootMod.fn" {
-						require.Equal(t, "", s.ExtraAttributes[telemetry.ModuleCallerFunctionCallNameAttr])
-						require.Equal(t, "", s.ExtraAttributes[telemetry.ModuleCallerRefAttr].(string))
-						require.Equal(t, "RootMod.fn", s.ExtraAttributes[telemetry.ModuleFunctionCallNameAttr])
-						require.Equal(t, "github.com/dagger/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875", s.ExtraAttributes[telemetry.ModuleRefAttr].(string))
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerFunctionCallNameAttr))
+						require.Equal(t, "", strAttr(t, s, telemetry.ModuleCallerRefAttr))
+						require.Equal(t, "RootMod.fn", strAttr(t, s, telemetry.ModuleFunctionCallNameAttr))
+						require.Equal(t, "github.com/dagger/dagger-test-modules@73670b0338c02cdd190f56b34c6e25066c7c8875", strAttr(t, s, telemetry.ModuleRefAttr))
 						rootCalled = true
 					}
 				}
@@ -267,6 +269,18 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 			}
 		})
 	}
+}
+
+func strAttr(t testing.TB, s *dagui.Span, name string) string {
+	return unmarshalAs[string](t, s.ExtraAttributes[name])
+}
+
+func unmarshalAs[T any](t testing.TB, data json.RawMessage) T {
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+	return result
 }
 
 type Example struct {


### PR DESCRIPTION
Noticed the v3 UI was choking on traces generated by dev engines, because `encoding/gob` can't handle `[]any`. `SpanSnapshot`s get sent over the wire with `encoding/gob` for performance reasons; it's generally safe because we control both sides (client + server), so we don't need to worry about schemas and compatibility drift, but it does restrict what types we can feed into it.