### PR TITLE
fix a couple of `TestTelemetry` flakes

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -59,6 +59,7 @@ var (
 	silent                   bool
 	verbose                  int
 	quiet, _                 = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
+	reveal                   = os.Getenv("DAGGER_REVEAL") != ""
 	debug                    bool
 	progress                 string
 	interactive              bool
@@ -436,6 +437,7 @@ func main() {
 	opts.Verbosity -= quiet                        // lower verbosity with -q
 	opts.Silent = silent                           // show no progress
 	opts.Debug = debug                             // show everything
+	opts.RevealNoisySpans = reveal                 // disable 'reveal: true' mechanic (for tests)
 	opts.OpenWeb = web
 	opts.NoExit = noExit
 	opts.DotOutputFilePath = dotOutputFilePath

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -649,6 +649,9 @@ func (db *DB) integrateSpan(span *Span) { //nolint: gocyclo
 			}
 			linked := db.initSpan(linkedCtx.SpanID)
 			span.ErrorOrigin = linked
+			if linked.HasParent(span) {
+				span.RevealedSpans.Add(linked)
+			}
 		}
 	}
 

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -15,6 +15,10 @@ type FrontendOpts struct {
 	// Verbosity is the level of detail to show in the TUI.
 	Verbosity int
 
+	// A distinct option from Verbosity just for disabling the 'reveal: true'
+	// mechanism - mostly for tests.
+	RevealNoisySpans bool
+
 	// Don't show things that completed beneath this duration. (default 100ms)
 	TooFastThreshold time.Duration
 

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -175,7 +175,7 @@ func (db *DB) WalkSpans(opts FrontendOpts, spans iter.Seq[*Span], f func(*TraceT
 			verbosity = v
 		}
 
-		if verbosity < ShowSpammyVerbosity {
+		if verbosity < ShowSpammyVerbosity && !opts.RevealNoisySpans {
 			// Process revealed spans before normal children
 			for _, revealed := range span.RevealedSpans.Order {
 				if revealed.Passthrough && !opts.Debug {

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -81,7 +81,7 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 		{Function: "fail-log-native", Fail: true},
 		{Function: "encapsulate"},
 		{Function: "fail-encapsulated", Fail: true},
-		{Function: "pending", Fail: true},
+		{Function: "pending", Fail: true, RevealNoisySpans: true},
 		{Function: "list", Args: []string{"--dir", "."}},
 		{Function: "object-lists"},
 		{Function: "nested-calls"},
@@ -159,11 +159,11 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 		{Function: "use-cached-exec-service", Flaky: "nested Dagger causes cache misses"},
 
 		// Python SDK tests
-		{Module: "./viztest/python", Function: "pending", Fail: true},
+		{Module: "./viztest/python", Function: "pending", Fail: true, RevealNoisySpans: true},
 		{Module: "./viztest/python", Function: "custom-span"},
 
 		// TypeScript SDK tests
-		{Module: "./viztest/typescript", Function: "pending", Fail: true},
+		{Module: "./viztest/typescript", Function: "pending", Fail: true, RevealNoisySpans: true},
 		{Module: "./viztest/typescript", Function: "custom-span"},
 		{Module: "./viztest/typescript", Function: "fail-log", Fail: true},
 		{Module: "./viztest/typescript", Function: "fail-effect", Fail: true},
@@ -290,6 +290,8 @@ type Example struct {
 	// verbosities 3 and higher do not work well with golden, they're not very deterministic atm
 	Verbosity int
 	Fail      bool
+	// used for tests that need to see through errors (e.g. 'pending')
+	RevealNoisySpans bool
 	// if a reason is given for Flaky, ignore failures, but log the failure and the provided explanation.
 	// ineffectual if FuzzyTest is in use.
 	Flaky  string
@@ -316,6 +318,10 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 
 	if ex.Verbosity > 0 {
 		daggerArgs = append(daggerArgs, "-"+strings.Repeat("v", ex.Verbosity))
+	}
+
+	if ex.RevealNoisySpans {
+		ex.Env = append(ex.Env, "DAGGER_REVEAL=1")
 	}
 
 	// NOTE: we care about CACHED states for these tests, so we need some way for

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -472,7 +472,7 @@ var scrubs = []scrubber{
 	},
 	// version=
 	{
-		regexp.MustCompile(`version=v[a-f0-9.-]+`),
+		regexp.MustCompile(`version=v[a-fv0-9.-]+`), // "v" is in "dev" :)
 		"version=v0.18.13-250710134709-7edd4496ecc1",
 		"version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx",
 	},

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
@@ -7,17 +7,10 @@ Expected stderr:
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/broken-dep X.Xs ERROR
-├─● finding module configuration X.Xs
-╰─▼ initializing module X.Xs ERROR
-  ╰─▼ ModuleSource.asModule: Module! X.Xs ERROR
-    ╰─▼ load dep modules X.Xs ERROR
-      ╰─▼ ModuleSource.asModule: Module! X.Xs ERROR
-        ├─▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
-        │ ┃ # dagger/broken
-        │ ┃ ./main.go:6:6: undefined: ctx
-        │ ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
-        │
-        ╰─✘ asModule getModDef X.Xs ERROR
+╰─▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
+  ┃ # dagger/broken
+  ┃ ./main.go:6:6: undefined: ctx
+  ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 
 Error logs:
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
@@ -7,15 +7,10 @@ Expected stderr:
 ╰─● starting session X.Xs
  
 ▼ load module: ./viztest/broken-dep/broken X.Xs ERROR
-├─● finding module configuration X.Xs
-╰─▼ initializing module X.Xs ERROR
-  ╰─▼ ModuleSource.asModule: Module! X.Xs ERROR
-    ├─▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
-    │ ┃ # dagger/broken
-    │ ┃ ./main.go:6:6: undefined: ctx
-    │ ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
-    │
-    ╰─✘ asModule getModDef X.Xs ERROR
+╰─▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
+  ┃ # dagger/broken
+  ┃ ./main.go:6:6: undefined: ctx
+  ! process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1
 
 Error logs:
 

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/call-bubbling-dep
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/call-bubbling-dep
@@ -16,10 +16,7 @@ Expected stderr:
 
 ● viztest: Viztest! X.Xs
 ▼ .callBubblingDep: Void X.Xs ERROR
-├─● dep: Dep! X.Xs
-╰─▼ .bubblingFunction: Void X.Xs ERROR
-  ├─● nestedDep: NestedDep! X.Xs
-  ╰─✘ .failingFunction: Void X.Xs ERROR
-    ! im a failing nested function
+╰─✘ NestedDep.failingFunction: Void X.Xs ERROR
+  ! im a failing nested function
 
 Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -16,17 +16,14 @@ Expected stderr:
 
 ● viztest: Viztest! X.Xs
 ▼ .failLog: Void X.Xs ERROR
-├─● container: Container! X.Xs
-├─$ .from(address: "alpine"): Container! X.Xs CACHED
-├─● .withEnvVariable(name: "NOW", value: "20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X"): Container! X.Xs
-╰─▼ .withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
+╰─▼ Container.withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
   ┃ im doing a lot of work
   ┃ and then failing
   ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
 
 Error logs:
 
-▼ .withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
+▼ Container.withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
 im doing a lot of work
 and then failing
 ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
@@ -16,16 +16,14 @@ Expected stderr:
 
 ● typescript: Typescript! X.Xs
 ▼ .failLog: Void X.Xs ERROR
-├─$ Container.from(address: "alpine"): Container! X.Xs CACHED
-├─● .withEnvVariable(name: "NOW", value: "XXXX-XX-XXTXX:XX:XX.XXXZ"): Container! X.Xs
-╰─▼ .withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
+╰─▼ Container.withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
   ┃ im doing a lot of work
   ┃ and then failing
   ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1
 
 Error logs:
 
-▼ .withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
+▼ Container.withExec(args: ["sh", "-c", "echo im doing a lot of work; echo and then failing; exit 1"]): Container! X.Xs ERROR
 im doing a lot of work
 and then failing
 ! process "sh -c echo im doing a lot of work; echo and then failing; exit 1" did not complete successfully: exit code: 1


### PR DESCRIPTION
* error origins could sometimes not be wired up depending on span receiving order
* engine version scrubber choked on the `v` in `-dev`