### PR TITLE
feat: stabilize `DAGGER_HOST` env var

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -20,8 +20,11 @@ import (
 )
 
 const (
-	GPUSupportEnv        = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
-	RunnerHostEnv        = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
+	GPUSupportEnv = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+
+	RunnerHostEnv       = "DAGGER_HOST"
+	RunnerHostEnvLegacy = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
+
 	RunnerImageLoaderEnv = "_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE"
 )
 
@@ -37,6 +40,8 @@ var (
 
 func init() {
 	if v, ok := os.LookupEnv(RunnerHostEnv); ok {
+		RunnerHost = v
+	} else if v, ok := os.LookupEnv(RunnerHostEnvLegacy); ok {
 		RunnerHost = v
 	}
 	if RunnerHost == "" {


### PR DESCRIPTION
This environment variable is used by *many* users - changing it's format would be a major breaking change, that we'd need to release note anyways.

I think we should bite the bullet, and consider it stable. Especially with the changes around #10714, it would be useful to have a "proper" way to do this.