### PR TITLE
cli: add support for a []BuildArg flag

### DIFF
--- a/.changes/unreleased/Added-20250722-180740.yaml
+++ b/.changes/unreleased/Added-20250722-180740.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'cli: add support for passing build arguments to a docker build'
+time: 2025-07-22T18:07:40.271813Z
+custom:
+    Author: helderco
+    PR: "10779"

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -58,6 +58,8 @@ func GetCustomFlagValue(name string) DaggerValue {
 		return &moduleValue{}
 	case Platform:
 		return &platformValue{}
+	case BuildArg:
+		return &buildArgValue{}
 	case Socket:
 		return &socketValue{}
 	case GitRepository:
@@ -101,6 +103,9 @@ func GetCustomFlagValueSlice(name string, defVal []string) (DaggerValue, error) 
 	case Platform:
 		v := &sliceValue[*platformValue]{}
 		return v.SetDefault(defVal)
+	case BuildArg:
+		v := &sliceValue[*buildArgValue]{}
+		return v.SetDefault(defVal)
 	case Socket:
 		v := &sliceValue[*socketValue]{}
 		return v.SetDefault(defVal)
@@ -132,7 +137,7 @@ func (v *sliceValue[T]) Type() string {
 	if v.Init != nil {
 		t = v.Init()
 	}
-	return t.Type()
+	return "[]" + t.Type()
 }
 
 func (v *sliceValue[T]) String() string {
@@ -739,6 +744,43 @@ func (v *platformValue) Get(ctx context.Context, dag *dagger.Client, _ *dagger.M
 		return nil, fmt.Errorf("platform cannot be empty")
 	}
 	return v.platform, nil
+}
+
+type buildArgValue struct {
+	name  string
+	value string
+}
+
+func (v *buildArgValue) Type() string {
+	return BuildArg
+}
+
+func (v *buildArgValue) Set(s string) error {
+	if !strings.Contains(s, "=") {
+		return fmt.Errorf("%s must be formatted as name=value", s)
+	}
+	pair := strings.Trim(s, `"`)
+	kv := strings.SplitN(pair, "=", 2)
+	if len(kv) != 2 {
+		return fmt.Errorf("%s must be formatted as name=value", pair)
+	}
+	if kv[0] == "" {
+		return fmt.Errorf("%s cannot have an empty name", pair)
+	}
+	v.name = kv[0]
+	v.value = kv[1]
+	return nil
+}
+
+func (v *buildArgValue) String() string {
+	return fmt.Sprintf("%s=%s", v.name, v.value)
+}
+
+func (v *buildArgValue) Get(ctx context.Context, dag *dagger.Client, _ *dagger.ModuleSource, _ *modFunctionArg) (any, error) {
+	if v.name == "" {
+		return nil, fmt.Errorf("build arg cannot be empty")
+	}
+	return dagger.BuildArg{Name: v.name, Value: v.value}, nil
 }
 
 type gitRepositoryValue struct {

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -760,15 +760,15 @@ func (v *buildArgValue) Set(s string) error {
 		return fmt.Errorf("%s must be formatted as name=value", s)
 	}
 	pair := strings.Trim(s, `"`)
-	kv := strings.SplitN(pair, "=", 2)
-	if len(kv) != 2 {
+	name, value, found := strings.Cut(pair, "=")
+	if !found {
 		return fmt.Errorf("%s must be formatted as name=value", pair)
 	}
-	if kv[0] == "" {
+	if name == "" {
 		return fmt.Errorf("%s cannot have an empty name", pair)
 	}
-	v.name = kv[0]
-	v.value = kv[1]
+	v.name = name
+	v.value = value
 	return nil
 }
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -46,6 +46,7 @@ const (
 	ModuleSource  string = "ModuleSource"
 	Module        string = "Module"
 	Platform      string = "Platform"
+	BuildArg      string = "BuildArg"
 	Socket        string = "Socket"
 	GitRepository string = "GitRepository"
 	GitRef        string = "GitRef"


### PR DESCRIPTION
This allows passing build args to a docker build via the CLI.

Example
```
host | directory . | docker-build --platform darwin/arm64 --build-args BIN_NAME=docker-run,NO_ARCHIVE=true --target export-bin | export .
```

\cc @eunomie