### PR TITLE
fix: typescript codegen option argument format

### DIFF
--- a/cmd/codegen/generator/typescript/templates/src/method.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method.ts.gtpl
@@ -23,7 +23,7 @@
 	{{- if $optionals }}
 		{{- /* Insert a comma if there was previous required arguments. */ -}}
 		{{- if $required }}, {{ end }}
-		{{- "" }}opts?: {{ $parentName | PascalCase }}{{ .Name | PascalCase }}Opts {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) 
+		{{- "" }}opts?: {{ $parentName }}{{ .Name | PascalCase }}Opts {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) 
 		{{ "" }} 
 		{{- end }}
 	{{- end }}

--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -23,7 +23,7 @@
 	{{- if $optionals }}
 		{{- /* Insert a comma if there was previous required arguments. */ -}}
 		{{- if $required }}, {{ end }}
-    opts?: {{ $parentName | PascalCase }}{{ .Name | PascalCase }}Opts {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) 
+    opts?: {{ $parentName }}{{ .Name | PascalCase }}Opts {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) 
     {{ "" }} 
     {{- end }}
 	{{- end }}

--- a/cmd/codegen/generator/typescript/templates/src/object_test.go
+++ b/cmd/codegen/generator/typescript/templates/src/object_test.go
@@ -26,6 +26,20 @@ func TestObject(t *testing.T) {
 	require.Equal(t, want, b.String())
 }
 
+func TestObjectCasingConsistency(t *testing.T) {
+	tmpl := templateHelper(t)
+
+	object := objectInit(t, JSONValueJSON)
+
+	var b bytes.Buffer
+	err := tmpl.ExecuteTemplate(&b, "object", object)
+	require.NoError(t, err)
+
+	want := updateAndGetFixtures(t, "testdata/object_json_test_want.ts", b.String())
+
+	require.Equal(t, want, b.String())
+}
+
 func objectInit(t *testing.T, jsonString string) *introspection.Type {
 	t.Helper()
 	var object introspection.Type
@@ -55,6 +69,57 @@ func objectsInit(t *testing.T, jsonString string) introspection.Schema {
 	generator.SetSchemaParents(&schema)
 	return schema
 }
+
+var JSONValueJSON = `
+{
+  "kind": "OBJECT",
+  "name": "JSONValue",
+  "description": "",
+  "fields": [
+    {
+      "name": "bytes",
+      "description": "",
+      "args": [
+        {
+           "name": "pretty",
+           "description": "",
+           "type": {
+             "kind": "SCALAR",
+             "name": "Boolean",
+             "ofType": null
+           },
+           "defaultValue": null
+        },
+        {
+          "name": "indent",
+          "description": "",
+          "type": {
+            "kind": "SCALAR",
+            "name": "Int",
+            "ofType": null
+          },
+          "defaultValue": null
+        }
+      ],
+      "type": {
+        "kind": "NON_NULL",
+        "name": null,
+        "ofType": {
+          "kind": "SCALAR",
+          "name": "JSON",
+          "ofType": null
+        }
+      },
+      "isDeprecated": false,
+      "deprecationReason": null
+    }
+  ],
+  "inputFields": null,
+  "interfaces": [],
+  "enumValues": null,
+  "possibleTypes": null
+}
+`
 
 var containerExecArgsJSON = `
       {

--- a/cmd/codegen/generator/typescript/templates/src/testdata/object_json_test_want.ts
+++ b/cmd/codegen/generator/typescript/templates/src/testdata/object_json_test_want.ts
@@ -1,0 +1,32 @@
+
+export class JSONValue extends BaseClient {
+  private readonly _bytes?: JSON = undefined
+
+  /**
+   * Constructor is used for internal usage only, do not create object from it.
+   */
+   constructor(
+    ctx?: Context,
+     _bytes?: JSON,
+   ) {
+     super(ctx)
+
+     this._bytes = _bytes
+   }
+  bytes = async (
+    opts?: JSONValueBytesOpts): Promise<JSON> => {
+    if (this._bytes) {
+      return this._bytes
+    }
+
+    const ctx = this._ctx.select(
+      "bytes",
+      { ...opts},
+    )
+
+    const response: Awaited<JSON> = await ctx.execute()
+
+    
+    return response
+  }
+}


### PR DESCRIPTION
@shykes notices that JSONValue was badly formatted when defined as object (https://discord.com/channels/707636530424053791/1397223053452120144/1397553194699198578)

It's the first time we have this case, that's why we never saw it before.

This PR fixes that behaviour.