### PR TITLE
fix race condition in cache when context canceled

### DIFF
--- a/engine/cache/cache.go
+++ b/engine/cache/cache.go
@@ -272,7 +272,7 @@ func (c *cache[K, V]) wait(ctx context.Context, key K, res *result[K, V]) (*perC
 		}, nil
 	}
 
-	if res.refCount == 0 {
+	if res.refCount == 0 && res.waiters == 0 {
 		// error happened and no refs left, delete it now
 		delete(c.ongoingCalls, key)
 		delete(c.completedCalls, key)


### PR DESCRIPTION
CI hit an error in the cache unit tests, locally I could repro it in ~2 runs when running w/ `-count=100000`, so unclear if it was really causing any genuine problems.

Was a legit problem though; with the right timing it was possible to remove a call from internal maps when there were waiters remaining, which would result in extra calls appearing.