### PR TITLE
bugfix: preserve git ref and subdirectory when updating blueprint

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1493,19 +1493,13 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateBlueprint(
 		return parentSrc.Result, nil
 	}
 
-	// Get the blueprint's symbolic ref without version
-	bpRef := bpSrc.Git.CloneRef
-	if bpSrc.SourceRootSubpath != "" {
-		bpRef += "/" + strings.TrimPrefix(bpSrc.SourceRootSubpath, "/")
-	}
-
 	// Update the blueprint by loading it fresh
 	var bpUpdated dagql.ObjectResult[*core.ModuleSource]
 	err = dag.Select(ctx, dag.Root(), &bpUpdated,
 		dagql.Selector{
 			Field: "moduleSource",
 			Args: []dagql.NamedInput{
-				{Name: "refString", Value: dagql.String(bpRef)},
+				{Name: "refString", Value: dagql.String(bpSrc.AsString())},
 			},
 		},
 	)


### PR DESCRIPTION
Fixes #10785 

Repro script for reference:

```
set -e

mkdir repro
cd repro

cat >dagger.json <<'.'
{
  "name": "test",
  "engineVersion": "v0.18.14",
  "blueprint": {
    "name": "not-main",
    "source": "github.com/shykes/x/not-main@test",
    "pin": "6b29f8aa297117bc06181050cab1b067c4927c6d"
  }
}
.
dagger call -q hello
dagger update
dagger call -q hello

cat dagger.json
```