### PR TITLE
DAGGER_HOST, DAGGER_IMAGE

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
@@ -67,7 +68,9 @@ var (
 	interactiveCommandParsed []string
 	web                      bool
 	noExit                   bool
-	_, useCloudEngine        = os.LookupEnv("DAGGER_CLOUD_ENGINE")
+	engineConfig             = client.DefaultParams()
+
+	imageLoader = os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE")
 
 	dotOutputFilePath string
 	dotFocusField     string
@@ -174,7 +177,7 @@ func init() {
 
 	// this flag changes the behaviour of a few commands, e.g. call, functions, core, shell, etc.
 	// all those functions will run in a remote cloud engine which gets created at execution time
-	rootCmd.PersistentFlags().BoolVar(&useCloudEngine, "cloud", useCloudEngine, "Run in a Dagger Cloud Engine")
+	rootCmd.PersistentFlags().BoolVar(&engineConfig.CloudEngine, "cloud", engineConfig.CloudEngine, "Run in a Dagger Cloud Engine")
 	rootCmd.PersistentFlags().Lookup("cloud").Hidden = true
 
 	disableFlagsInUseLine(rootCmd)

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -57,9 +57,9 @@ func versionCmd() *cobra.Command {
 }
 
 func version() string {
-	return fmt.Sprintf("dagger %s (%s) %s",
+	// FIXME: replace deprecated 'runnerHost' for display
+	return fmt.Sprintf("dagger %s %s",
 		engine.Version,
-		RunnerHost,
 		platforms.DefaultString(),
 	)
 }

--- a/engine/client/buildkit.go
+++ b/engine/client/buildkit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"time"
 
 	bkclient "github.com/moby/buildkit/client"
@@ -21,7 +20,7 @@ const (
 	envDaggerCloudCachetoken = "_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN"
 )
 
-func newBuildkitClient(ctx context.Context, remote *url.URL, connector drivers.Connector) (_ *bkclient.Client, _ *bkclient.Info, rerr error) {
+func newBuildkitClient(ctx context.Context, connector drivers.Connector) (_ *bkclient.Client, _ *bkclient.Info, rerr error) {
 	backoffConfig := backoff.DefaultConfig
 	backoffConfig.MaxDelay = 30 * time.Second
 	opts := []bkclient.ClientOpt{
@@ -35,7 +34,8 @@ func newBuildkitClient(ctx context.Context, remote *url.URL, connector drivers.C
 		})),
 	}
 
-	c, err := bkclient.New(ctx, remote.String(), opts...)
+	// We don't need to specify a buildkit address, since we take over the dialer anyway
+	c, err := bkclient.New(ctx, "", opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("buildkit client: %w", err)
 	}

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -33,12 +33,26 @@ type Connector interface {
 
 type DriverOpts struct {
 	DaggerCloudToken string
-	GPUSupport       string
+	// Options specific to the "image driver" (DAGGER_IMAGE)
+	// FIXME: move this to specialized opts. We don't need the abstraction.
+	// Run engine image with custom container name
+	ContainerName string
+	// Run engine image with custom volume name
+	VolumeName string
+	// Force cleanup of old engine containers
+	Cleanup bool
+	// Run engine image with custom port
+	Port int
+	// Run engine image with custom number of CPUs
+	CPUs string
+	// Run engine image with custom memory
+	Memory     string
+	GPUSupport bool
 }
 
+// FIXME: move definition with other env variables
 const (
 	EnvDaggerCloudToken = "DAGGER_CLOUD_TOKEN"
-	EnvGPUSupport       = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
 )
 
 var drivers = map[string][]Driver{}


### PR DESCRIPTION
## Overview

Stable configuration for provisioning and connecting to the dagger engine from the dagger CLI.

| Variable  | Description |
| -- |  -- |
| `DAGGER_CLOUD_ENGINE` | Connect to Dagger Cloud experimental engine |
| `DAGGER_HOST` | Connect directly to a Dagger Engine. Supports `tcp://`, `ssh://`, `unix://`, `container://`, `kube-pod://`. You are responsible for engine provisioning, and version management. Warranty is void. |
| `DAGGER_IMAGE` | Provision a Dagger Engine from the given container image. Tag is optional: if omitted, the current CLI version is used |
| `DAGGER_IMAGE_VERSION` | Provision a Dagger Engine of the given version. Can be used in combination with `DAGGER_IMAGE`, or standalone. |
| `DAGGER_IMAGE_RUNNER` | Provision a Dagger Engine with the given container runner. If omitted, a runner is auto-discovered. Supports `docker`, `podman`, `containerd`, `apple` |
| `DAGGER_IMAGE_MEMORY` | Provision a Dagger Engine with custom memory configuration |
| `DAGGER_IMAGE_CPUS` | Provision a Dagger Engine with custom CPU allocation |
| `DAGGER_IMAGE_PORT` | Provision a Dagger Engine with a custom port number |
| `DAGGER_IMAGE_CONTAINER_NAME` | Provision a Dagger Engine with a custom container name |
| `DAGGER_IMAGE_VOLUME_NAME` | Provision a Dagger Engine with a custom volume name |
| `DAGGER_IMAGE_VOLUME_NAME` | Provision a Dagger Engine with a custom volume name |

## Compatibility

`_EXPERIMENTAL_DAGGER_RUNNER_HOST` is deprecated, but we maintain backwards compatibility, with a warning.

## Hooks

~~An experimental hook is included, to override how to provision and connect to the engine: `.config/dagger/hooks/engine-run`.~~

I removed the hook implementation, for simplicity. We may not need it after all?

## Implementation

This is built on top of #10714 by @jedevc . It acts as a facade to the driver system. Drivers are still used, but they are no longer presented directly to the user via a URL scheme system. This implies a follow-up, which can collapse much of the driver system to simplify the code. For now, I am prioritizing continuity with Justin's work at the expense of overall simplicity, seems worth it!