### PR TITLE
fix(sdk/elixir): fix default argument doesn't set to Elixir

### DIFF
--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -126,6 +126,17 @@ func (ElixirSuite) TestOptionalValue(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "bar", out)
 	})
+
+	t.Run("default value in Elixir should be set", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "defaults").
+			With(daggerCall("call-echo-value")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "foo", out)
+	})
 }
 
 func (ElixirSuite) TestDefaultPath(ctx context.Context, t *testctx.T) {

--- a/core/integration/testdata/modules/elixir/defaults/lib/defaults.ex
+++ b/core/integration/testdata/modules/elixir/defaults/lib/defaults.ex
@@ -11,6 +11,10 @@ defmodule Defaults do
     value
   end
 
+  defn call_echo_value() :: String.t() do
+    echo_value()
+  end
+
   defn file_name(file: {Dagger.File.t(), default_path: "dagger.json"}) :: String.t() do
     Dagger.File.name(file)
   end

--- a/sdk/elixir/.changes/unreleased/Fixed-20250729-002032.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20250729-002032.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix default value doesn't set to Elixir default value properly.
+time: 2025-07-29T00:20:32.056859132+07:00
+custom:
+    Author: wingyplus
+    PR: "10804"

--- a/sdk/elixir/lib/dagger/mod/object/defn.ex
+++ b/sdk/elixir/lib/dagger/mod/object/defn.ex
@@ -15,10 +15,10 @@ defmodule Dagger.Mod.Object.Defn do
     args =
       case args do
         {self, args} ->
-          [var(self) | Enum.map(args, &var_or_default/1)]
+          [var(self) | Enum.map(args, &var/1)]
 
         args ->
-          Enum.map(args, &var_or_default/1)
+          Enum.map(args, &var/1)
       end
 
     quote do
@@ -29,12 +29,13 @@ defmodule Dagger.Mod.Object.Defn do
     end
   end
 
-  defp var_or_default({name, {_, [default_value: def_val]}}) do
-    {:\\, [], [Macro.var(name, nil), def_val]}
-  end
-
-  defp var_or_default(arg) do
-    var(arg)
+  # {var, {type, opts}}
+  defp var({name, {_, opts}}) do
+    if Keyword.has_key?(opts, :default) do
+      {:\\, [], [Macro.var(name, nil), opts[:default]]}
+    else
+      Macro.var(name, nil)
+    end
   end
 
   # {var, type}


### PR DESCRIPTION
This changeset fix default value in Elixir doesn't set properly when default value declared via `:default` option.

Now if user declare a signature like:

```elixir
defn sample(hello: {String.t(), default: "world"}) :: String.t() do
  hello
end
```

The `defn` will transform into:

```elixir
def sample(hello \\ "world") do
  hello
end
```

Closes #9744 