### PR TITLE
fix podman docs modprobe command

### DIFF
--- a/docs/current_docs/troubleshooting.mdx
+++ b/docs/current_docs/troubleshooting.mdx
@@ -63,7 +63,7 @@ You can load this module by running `sudo modprobe iptable_nat`.
 To have this module loaded automatically on startup, add it to the `/etc/modules-load.d/modules` file with the following command:
 
 ```shell
-echo iptable_nat | sudo tee -a /etc/modules-load.d/modules
+echo iptable_nat | sudo tee -a /etc/modules-load.d/iptables_nat.conf
 ```
 
 ## Calling a Dagger Function fails with an error


### PR DESCRIPTION
in order for kernel modules to be automatically loaded on startup, the
file should be named with a `.conf` extension.

ref: https://man7.org/linux/man-pages/man5/modules-load.d.5.html

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
