### PR TITLE
chore: deprecate Container.build

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -73,8 +73,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"`,
 				),
 			),
-		// FIXME: deprecate
 		dagql.Func("build", s.build).
+			Deprecated("Use `Directory.build` instead").
 			Doc(`Initializes this container from a Dockerfile build.`).
 			Args(
 				dagql.Arg("context").Doc("Directory context used by the Dockerfile."),

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -242,7 +242,7 @@ type Container {
     behavior.
     """
     noInit: Boolean = false
-  ): Container!
+  ): Container! @deprecated(reason: "Use `Directory.build` instead")
 
   """Return the container's default arguments."""
   defaultArgs: [String!]!

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4367,8 +4367,9 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="Container-build" href="#Container-build"><code>build</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td> Initializes this container from a Dockerfile build. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="Container-build" href="#Container-build"><code>build</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td> Initializes this container from a Dockerfile build. <span class="deprecation-reason">Use <code>Directory.build</code> instead</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -76,6 +76,9 @@ defmodule Dagger.Container do
     }
   end
 
+  @deprecated """
+  Use `Directory.build` instead
+  """
   @doc """
   Initializes this container from a Dockerfile build.
   """

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -840,6 +840,8 @@ type ContainerBuildOpts struct {
 }
 
 // Initializes this container from a Dockerfile build.
+//
+// Deprecated: Use `Directory.build` instead
 func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Container {
 	assertNotNil("context", context)
 	q := r.query.Select("build")

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -874,6 +874,9 @@ class Container(Type):
     ) -> Self:
         """Initializes this container from a Dockerfile build.
 
+        .. deprecated::
+            Use `Directory.build` instead
+
         Parameters
         ----------
         context:
@@ -900,6 +903,11 @@ class Container(Type):
             processes be the pid 1 process in the container. Otherwise it may
             result in unexpected behavior.
         """
+        warnings.warn(
+            'Method "build" is deprecated: Use `Directory.build` instead',
+            DeprecationWarning,
+            stacklevel=4,
+        )
         _args = [
             Arg("context", context),
             Arg("dockerfile", dockerfile, "Dockerfile"),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2452,6 +2452,7 @@ export class Container extends BaseClient {
    * @param opts.noInit If set, skip the automatic init process injected into containers created by RUN statements.
    *
    * This should only be used if the user requires that their exec processes be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   * @deprecated Use `Directory.build` instead
    */
   build = (context: Directory, opts?: ContainerBuildOpts): Container => {
     const ctx = this._ctx.select("build", { context, ...opts })


### PR DESCRIPTION
[This had a `FIXME`](https://github.com/dagger/dagger/pull/10106#discussion_r2035061974), we've wanted to do this for a while.

We can deprecate functions whenever we like, depending on time-frame we could remove this in the next minor release.