### PR TITLE
chore: remove terminal restriction with --output flag

### DIFF
--- a/cmd/dagger/terminal.go
+++ b/cmd/dagger/terminal.go
@@ -18,9 +18,6 @@ func withTerminal(fn func(stdin io.Reader, stdout, stderr io.Writer) error) erro
 	if silent || !(progress == "auto" && hasTTY || progress == "tty") {
 		return fmt.Errorf("running shell without the TUI is not supported")
 	}
-	if outputPath != "" {
-		return fmt.Errorf("running shell with --output is not supported")
-	}
 
 	return Frontend.Background(&terminalSession{
 		fn: fn,


### PR DESCRIPTION
This restriction seems to have been introduced way back in #6482. Regardless, it does just work, and it's *very* annoying to hit an error condition and then have to remove the `--output` flag to just get it working.