### PR TITLE
fix: go client generator now works on empty dir

### DIFF
--- a/cmd/codegen/generator/config.go
+++ b/cmd/codegen/generator/config.go
@@ -67,8 +67,14 @@ type ModuleSourceDependency struct {
 
 // Specific configuration for client generation.
 type ClientGeneratorConfig struct {
+	// The name of the module to generate for.
+	ModuleName string
+
 	// The list of all dependencies used by the module.
 	// This is used by the client generator to automatically serves the
 	// dependencies when connecting to the client.
 	ModuleDependencies []ModuleSourceDependency
+
+	// The directory where the client will be generated.
+	ClientDir string
 }

--- a/cmd/codegen/generator/go/generate_client.go
+++ b/cmd/codegen/generator/go/generate_client.go
@@ -18,8 +18,6 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
-const defaultGoModClientLib string = "dagger/client"
-
 func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.Schema, schemaVersion string) (*generator.GeneratedState, error) {
 	generator.SetSchema(schema)
 
@@ -43,7 +41,7 @@ func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.
 			return nil, fmt.Errorf("failed to format go.mod: %w", err)
 		}
 
-		if err := mfs.WriteFile("go.mod", []byte(modBody), 0600); err != nil {
+		if err := mfs.WriteFile("go.mod", modBody, 0600); err != nil {
 			return nil, fmt.Errorf("failed to write go.mod: %w", err)
 		}
 

--- a/cmd/codegen/generator/go/generate_client.go
+++ b/cmd/codegen/generator/go/generate_client.go
@@ -2,6 +2,7 @@ package gogenerator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -17,15 +18,42 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+const defaultGoModClientLib string = "dagger/client"
+
 func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.Schema, schemaVersion string) (*generator.GeneratedState, error) {
 	generator.SetSchema(schema)
 
-	outDir := "."
 	mfs := memfs.New()
 
 	layers := []fs.FS{mfs}
 
-	replacedPath, replaced, err := g.daggerPackageReplacement()
+	goModFile, exist, err := g.readGoMod()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read go.mod: %w", err)
+	}
+
+	if !exist {
+		// If no go.mod is found, we will generate a go.mod
+		goMod := new(modfile.File)
+		goMod.AddModuleStmt(strings.ToLower(g.Config.ClientConfig.ModuleName))
+		goMod.AddGoStmt(goVersion)
+
+		modBody, err := goMod.Format()
+		if err != nil {
+			return nil, fmt.Errorf("failed to format go.mod: %w", err)
+		}
+
+		if err := mfs.WriteFile("go.mod", []byte(modBody), 0600); err != nil {
+			return nil, fmt.Errorf("failed to write go.mod: %w", err)
+		}
+
+		return &generator.GeneratedState{
+			Overlay:        layerfs.New(mfs),
+			NeedRegenerate: true,
+		}, nil
+	}
+
+	replacedPath, replaced, err := g.daggerPackageReplacement(goModFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if dagger.io/dagger package is replaced: %w", err)
 	}
@@ -40,13 +68,21 @@ func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.
 
 	// Get the go package from the module
 	// We assume that we'll be located at the root source directory
-	pkg, _, err := loadPackage(ctx, ".")
+	// If no main package is found, we will generat the client as a sub module library.
+	pkg, _, err := loadPackage(ctx, g.Config.OutputDir, true)
 	if err != nil {
-		return nil, fmt.Errorf("load package %q: %w", outDir, err)
+		return nil, fmt.Errorf("load package %q: %w", g.Config.OutputDir, err)
 	}
 
-	// respect existing package import path
-	packageImport := filepath.Join(pkg.Module.Path, g.Config.OutputDir)
+	packageImport := filepath.Join(
+		strings.ToLower(g.Config.ClientConfig.ModuleName),
+		g.Config.ClientConfig.ClientDir,
+	)
+
+	// respect existing package import path if a package is set
+	if goModFile.Module != nil {
+		packageImport = filepath.Join(goModFile.Module.Mod.Path, g.Config.ClientConfig.ClientDir)
+	}
 
 	genSt := &generator.GeneratedState{
 		Overlay: layerfs.New(layers...),
@@ -56,7 +92,7 @@ func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.
 	}
 
 	packageName := "dagger"
-	if g.Config.OutputDir == "." {
+	if pkg.Module != nil && pkg.Module.Main && g.Config.ClientConfig.ClientDir == "." {
 		packageName = "main"
 	}
 
@@ -71,17 +107,7 @@ func (g *GoGenerator) GenerateClient(ctx context.Context, schema *introspection.
 	return genSt, nil
 }
 
-func (g *GoGenerator) daggerPackageReplacement() (string, bool, error) {
-	goModFile, err := os.ReadFile("go.mod")
-	if err != nil {
-		return "", false, fmt.Errorf("failed to read go.mod: %w", err)
-	}
-
-	goMod, err := modfile.Parse("go.mod", goModFile, nil)
-	if err != nil {
-		return "", false, fmt.Errorf("failed to parse go.mod: %w", err)
-	}
-
+func (g *GoGenerator) daggerPackageReplacement(goMod *modfile.File) (string, bool, error) {
 	for _, replace := range goMod.Replace {
 		if replace.Old.Path == "dagger.io/dagger" {
 			// We need to exclude the first parent directory of the replaced path since it's the
@@ -111,4 +137,22 @@ func (g *GoGenerator) daggerPackageReplacement() (string, bool, error) {
 	}
 
 	return "", false, nil
+}
+
+func (g *GoGenerator) readGoMod() (*modfile.File, bool, error) {
+	goModFile, err := os.ReadFile(filepath.Join(g.Config.OutputDir, "go.mod"))
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read go.mod: %w", err)
+	}
+
+	goMod, err := modfile.Parse("go.mod", goModFile, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse go.mod: %w", err)
+	}
+
+	return goMod, true, nil
 }

--- a/cmd/codegen/generator/go/generate_library.go
+++ b/cmd/codegen/generator/go/generate_library.go
@@ -21,7 +21,7 @@ func (g *GoGenerator) GenerateLibrary(ctx context.Context, schema *introspection
 		Overlay: overlay,
 	}
 
-	pkg, fset, err := loadPackage(ctx, filepath.Join(g.Config.OutputDir, outDir))
+	pkg, fset, err := loadPackage(ctx, filepath.Join(g.Config.OutputDir, outDir), false)
 	if err != nil {
 		return nil, fmt.Errorf("load package %q: %w", outDir, err)
 	}

--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -97,7 +97,7 @@ func (g *GoGenerator) GenerateModule(ctx context.Context, schema *introspection.
 		return genSt, nil
 	}
 
-	pkg, fset, err := loadPackage(ctx, filepath.Join(g.Config.OutputDir, outDir))
+	pkg, fset, err := loadPackage(ctx, filepath.Join(g.Config.OutputDir, outDir), false)
 	if err != nil {
 		return nil, fmt.Errorf("load package %q: %w", outDir, err)
 	}

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -58,6 +58,19 @@ func generateCode(
 			// no contents, skip
 			continue
 		}
+
+		// Special case for client generation, we want to write the file in the specified client directory.
+		if cfg.ClientConfig != nil && cfg.ClientConfig.ClientDir != "" {
+			if err := mfs.MkdirAll(filepath.Join(cfg.ClientConfig.ClientDir, filepath.Dir(k)), 0o755); err != nil {
+				return err
+			}
+			if err := mfs.WriteFile(filepath.Join(cfg.ClientConfig.ClientDir, k), dt, 0600); err != nil {
+				return err
+			}
+
+			continue
+		}
+
 		if err := mfs.MkdirAll(filepath.Dir(k), 0o755); err != nil {
 			return err
 		}

--- a/cmd/codegen/generator/go/loader.go
+++ b/cmd/codegen/generator/go/loader.go
@@ -17,7 +17,7 @@ type PackageInfo struct {
 	PackageImport string // import path of package in which this file appears
 }
 
-func loadPackage(ctx context.Context, dir string) (_ *packages.Package, _ *token.FileSet, rerr error) {
+func loadPackage(ctx context.Context, dir string, allowEmpty bool) (_ *packages.Package, _ *token.FileSet, rerr error) {
 	ctx, span := trace.Tracer().Start(ctx, "loadPackage")
 	defer telemetry.End(span, func() error { return rerr })
 
@@ -56,7 +56,7 @@ func loadPackage(ctx context.Context, dir string) (_ *packages.Package, _ *token
 	case 0:
 		return nil, nil, fmt.Errorf("no packages found in %s", dir)
 	case 1:
-		if pkgs[0].Name == "" {
+		if pkgs[0].Name == "" && !allowEmpty {
 			// this can happen when:
 			// - loading an empty dir within an existing Go module
 			// - loading a dir that is not included in a parent go.work

--- a/cmd/codegen/modsourcedeps.graphql
+++ b/cmd/codegen/modsourcedeps.graphql
@@ -1,5 +1,6 @@
 query ModuleSourceDependencies($source: ModuleSourceID!) {
   source: loadModuleSourceFromID(id: $source) {
+    moduleOriginalName
     dependencies {
       kind
       moduleOriginalName

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1473,7 +1473,7 @@ func main() {
 
 	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
 	if err != nil {
-    panic(err)
+		panic(err)
 	}
 
 	fmt.Println("result:", res)
@@ -1514,7 +1514,7 @@ func main() {
 
 	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
 	if err != nil {
-    panic(err)
+		panic(err)
 	}
 
 	fmt.Println("result:", res)
@@ -1550,7 +1550,7 @@ func main() {
 
 	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
 	if err != nil {
-    panic(err)
+		panic(err)
 	}
 
 	fmt.Println("result:", res)

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1440,6 +1440,129 @@ func (ClientGeneratorTest) TestMissmatchDependencyVersion(ctx context.Context, t
 	require.Contains(t, out, "error serving dependency hello: module hello")
 }
 
+func (ClientGeneratorTest) TestNoGoProjectSetup(ctx context.Context, t *testctx.T) {
+	t.Run("add main after generating the client on an empty directory", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modCtr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+			With(nonNestedDevEngine(c)).
+			With(daggerNonNestedExec("init", "--name=test")).
+			With(daggerClientInstall("go"))
+
+		// Verify that we generated the go.mod and the library in the default location
+		generatedFiles, err := modCtr.Directory(".").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, generatedFiles, "dagger.json")
+		require.Contains(t, generatedFiles, "go.mod")
+		require.Contains(t, generatedFiles, "dagger/")
+
+		// Add a main.go file to use the generated client.
+		modCtr = modCtr.WithNewFile("main.go", `package main
+import (
+	"context"
+	"fmt"
+
+	"test/dagger/dag"
+)
+
+func main() {
+	ctx := context.Background()
+
+	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
+	if err != nil {
+    panic(err)
+	}
+
+	fmt.Println("result:", res)
+}
+`)
+
+		out, err := modCtr.With(daggerNonNestedRun("go", "run", "main.go")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "result: hello\n")
+	})
+
+	t.Run("generate client as a sub module of an existing go project", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modCtr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+			With(nonNestedDevEngine(c)).
+			WithWorkdir("/work").
+			WithExec([]string{"go", "mod", "init", "test"}).
+			WithWorkdir("/work/lib").
+			With(daggerNonNestedExec("init", "--name=testlib")).
+			With(daggerClientInstall("go")).
+			WithWorkdir("/work").
+			// Add the generated client to the parent go.mod
+			WithExec([]string{"go", "mod", "edit", "-require", "testlib@v0.0.0"}).
+			WithExec([]string{"go", "mod", "edit", "-replace", "testlib=./lib"}).
+			WithNewFile("main.go", `package main
+import (
+	"context"
+	"fmt"
+
+	"testlib/dagger/dag"
+)
+
+func main() {
+	ctx := context.Background()
+
+	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
+	if err != nil {
+    panic(err)
+	}
+
+	fmt.Println("result:", res)
+}`).
+			WithExec([]string{"go", "mod", "tidy"})
+
+		out, err := modCtr.With(daggerNonNestedRun("go", "run", "main.go")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "result: hello\n")
+	})
+
+	t.Run("generate a client on a go project with only a go.mod file", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modCtr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+			With(nonNestedDevEngine(c)).
+			WithExec([]string{"go", "mod", "init", "test.com/test"}).
+			With(daggerNonNestedExec("init", "--name=test")).
+			With(daggerClientInstall("go")).
+			WithNewFile("main.go", `package main
+import (
+	"context"
+	"fmt"
+
+	"test.com/test/dagger/dag"
+)
+
+func main() {
+	ctx := context.Background()
+
+	res, err := dag.Container().From("alpine:3.20.2").WithExec([]string{"echo", "hello"}).Stdout(ctx)
+	if err != nil {
+    panic(err)
+	}
+
+	fmt.Println("result:", res)
+}
+`)
+
+		out, err := modCtr.With(daggerNonNestedRun("go", "run", "main.go")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "result: hello\n")
+	})
+}
+
 func withGoSetup(content string, outputDir string) func(*dagger.Container) *dagger.Container {
 	return func(ctr *dagger.Container) *dagger.Container {
 		return ctr.

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -87,9 +87,10 @@ func (sdk *goSDK) GenerateClient(
 
 	codegenArgs := dagql.ArrayInput[dagql.String]{
 		"generate-client",
-		"--output", dagql.String(outputDir),
+		"--output", dagql.String(filepath.Join(goSDKUserModContextDirPath, rootSourcePath)),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
 		dagql.String(fmt.Sprintf("--module-source-id=%s", modSourceID)),
+		dagql.String(fmt.Sprintf("--client-dir=%s", outputDir)),
 	}
 
 	err = dag.Select(ctx, ctr, &ctr,


### PR DESCRIPTION
Previously, the following operations were failing:

```
mkdir test && cd test
dagger init
dagger client install go
```

Because the go client generator assumed that the module was aside a go module, same as module generation before we generate a default go.mod.

This PR fixes that issue by: generating a default go.mod based on the module name if no go.mod exist in the current directory. This allows an user to create a submodule in a go project and import the client from there.

Also fixes an issue where the client installation failed if no go file were found in the module directory.

Add integration tests to verify the new behaviour.