### PR TITLE
add service

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -27,6 +27,9 @@ spec:
       {{- end }}
       labels:
         name: {{ include "dagger.fullname" . }}-engine
+        {{- if .Values.engine.service.enabled }}
+        app: {{ include "dagger.fullname" . }}-engine
+        {{- end }}
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
       {{- if .Values.engine.runtimeClassName }}
@@ -100,7 +103,7 @@ spec:
             - name: dagger
               containerPort: {{ .Values.engine.port }}
               protocol: TCP
-              {{- if .Values.engine.hostPort }}
+              {{- if and .Values.engine.hostPort (not .Values.engine.service.enabled) }}
               hostPort: {{ .Values.engine.hostPort }}
               {{- end }}
           {{- end }}

--- a/helm/dagger/templates/engine-service.yaml
+++ b/helm/dagger/templates/engine-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.engine.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dagger.fullname" . }}-engine-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dagger.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.engine.service.type }}
+  selector:
+    app: {{ include "dagger.fullname" . }}-engine
+  ports:
+    - protocol: TCP
+      port: {{ .Values.engine.port }}
+      targetPort: {{ .Values.engine.port }}
+      {{- if and (eq .Values.engine.service.type "NodePort") .Values.engine.service.nodePort }}
+      nodePort: {{ .Values.engine.service.nodePort }}
+      {{- end }}
+  {{- if .Values.engine.service.sessionAffinity.enabled }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.engine.service.sessionAffinity.sessionAffinitytimeoutSeconds }}
+  {{- end }}
+{{- end }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
       {{- end }}
       labels:
         name: {{ include "dagger.fullname" . }}-engine
+        {{- if .Values.engine.service.enabled }}
+        app: {{ include "dagger.fullname" . }}-engine
+        {{- end }}
         {{- include "dagger.labels" . | nindent 8 }}
     spec:
       {{- with .Values.engine.nodeSelector }}
@@ -104,7 +107,7 @@ spec:
             - name: dagger
               containerPort: {{ .Values.engine.port }}
               protocol: TCP
-              {{- if .Values.engine.hostPort }}
+              {{- if and .Values.engine.hostPort (not .Values.engine.service.enabled) }}
               hostPort: {{ .Values.engine.hostPort }}
               {{- end }}
           {{- end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -190,6 +190,36 @@ engine:
   #       - name: data
   #         mountPath: /data
 
+  service:
+    enabled: true
+
+    # Kubernetes service type: ClusterIP, NodePort, LoadBalancer, or ExternalName.
+    # Default is ClusterIP, which exposes the service internally within the cluster.
+    type: ClusterIP
+
+    # nodePort is only used when type is set to NodePort.
+    nodePort: null
+
+    # Session affinity ensures that client requests are consistently routed to the same pod.
+    # This is **critical** when Dagger is accessed via a Kubernetes Service,
+    # especially in CI/CD pipelines.
+    #
+    # Dagger does not share execution context across multiple pods.
+    # If requests from the same pipeline are routed to different pods,
+    # it can break the execution flow, as each pod will have an isolated context.
+    #
+    # Therefore, all requests for a given pipeline must be routed to the **same pod**
+    # to maintain context and ensure correct execution of Dagger commands.
+    sessionAffinity:
+      enabled: true
+
+      # sessionAffinitytimeoutSeconds defines how long (in seconds) the client IP
+      # will be consistently routed to the same pod.
+      #
+      # The default maximum allowed value is **10800 seconds** (3 hours),
+      # which is typically sufficient to run a full pipeline.
+      sessionAffinitytimeoutSeconds: 10800
+
 magicache:
   enabled: false
   url: https://api.dagger.cloud/magicache


### PR DESCRIPTION
# Add Kubernetes `Service` for Dagger Engine

## Context

We operate a large-scale software factory supporting key business units (DSM/DSI).  
To enhance our CI capabilities and accelerate delivery, we are deploying **Dagger** as our new CI solution.

Our setup:  
- Dagger runs as a **DaemonSet** in Kubernetes  
- Shared Dagger modules live in GitLab  
- Projects use these modules via GitLab CI pipelines

This aims to provide a scalable and reliable CI platform aligned with our business objectives.

## Current Limitation

The current Helm chart exposes Dagger **only via a NodePort configured directly on the pods** (`DaemonSet` or `StatefulSet`).  
As a result, each CI pipeline must explicitly target a specific node IP, for example:

```yaml
_EXPERIMENTAL_DAGGER_RUNNER_HOST: "tcp://<node_IP>:<dagger-port>"
```
This approach:
- Strongly couples the CI to the cluster's topology
- Prevents load distribution across nodes
- Reduces resilience, e.g., if the targeted node is restarted

## ✅ Solution

This PR introduces:
- A **Kubernetes Service** to expose the `dagger-engine` pod :
```yaml
_EXPERIMENTAL_DAGGER_RUNNER_HOST: "tcp://dagger-engine-service.dagger.svc.cluster.local:<dagger-port>"
```
- **Session affinity (`sessionAffinity: ClientIP`)** to ensure that all requests from a pipeline are routed to the **same pod**, maintaining execution consistency.

## Changes
- Added `engine.service.*` configuration in `values.yaml`
- Created new Helm template: `engine-service.yaml`
- Added `app:` label to pods so the Service selector can match them
- Modified pod templates to skip `hostPort` configuration if `service.enabled` is `true`

## Goal

This change enables a more scalable, resilient, and Kubernetes-native integration of Dagger, and removes the need to target specific nodes from the CI.

