### PR TITLE
fix: cleaning up --generator flag from dagger client install cmd

### DIFF
--- a/cmd/dagger/client.go
+++ b/cmd/dagger/client.go
@@ -20,8 +20,6 @@ var (
 )
 
 func init() {
-	clientInstallCmd.Flags().StringVar(&generator, "generator", "", "Generator to use to generate the client")
-
 	clientListCmd.Flags().BoolVar(&listJSONOutput, "json", false, "Output the list of available clients in JSON format")
 
 	clientCmd.AddCommand(clientInstallCmd)


### PR DESCRIPTION
When running the ```dagger client install --help``` command the output suggests there is a --generator option whose functionality was removed in PR https://github.com/dagger/dagger/pull/10454.

This PR assumes the intention was to remove that flag and cleans up the code that causes it to still show up in the commands help output.

[Corresponding issue](https://github.com/dagger/dagger/issues/10829)
