### PR TITLE
feat: add stripped variants for some secret providers

### DIFF
--- a/.changes/unreleased/Added-20250804-141150.yaml
+++ b/.changes/unreleased/Added-20250804-141150.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |-
+    New `file+strip`, `env+strip` and `cmd+strip` secret providers
+
+    These new secret providers are like the base providers, but additionally strip
+    any whitespace from the output.
+time: 2025-08-04T14:11:50.660055633+01:00
+custom:
+    Author: jedevc
+    PR: "10836"

--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -61,6 +61,16 @@ func (SecretProvider) TestEnv(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
 
+	secretValue = "secret" + identity.NewID()
+	out, err = fetchSecret(
+		ctx,
+		ctr.WithEnvVariable("TOPSECRET", secretValue+"  \n   \t   "),
+		"env+strip://TOPSECRET",
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	)
+	require.NoError(t, err)
+	require.Equal(t, secretValue, out)
+
 	_, err = fetchSecret(
 		ctx,
 		ctr,
@@ -81,6 +91,16 @@ func (SecretProvider) TestFile(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr.WithNewFile("/tmp/topsecret", secretValue),
 		"file:///tmp/topsecret",
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	)
+	require.NoError(t, err)
+	require.Equal(t, secretValue, out)
+
+	secretValue = "secret" + identity.NewID()
+	out, err = fetchSecret(
+		ctx,
+		ctr.WithNewFile("/tmp/topsecret", secretValue+"  \n   \t   "),
+		"file+strip:///tmp/topsecret",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
@@ -107,6 +127,17 @@ func (SecretProvider) TestCmd(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		`cmd://echo `+secretValueEncoded+` | base64 -d`,
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	)
+	require.NoError(t, err)
+	require.Equal(t, secretValue, out)
+
+	secretValue = "secret" + identity.NewID()
+	secretValueEncoded = base64.StdEncoding.EncodeToString([]byte(secretValue + "  \n   \t   "))
+	out, err = fetchSecret(
+		ctx,
+		ctr,
+		`cmd+strip://echo `+secretValueEncoded+` | base64 -d`,
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8034.

Hit this, decided to do `cmd+strip`, which is a fairly standard way of doing "protocol variations".

In the future, we could switch the default, but decided to pass on that change for now.