### PR TITLE
Update default Python version in docs

### DIFF
--- a/docs/current_docs/api/ide-integration.mdx
+++ b/docs/current_docs/api/ide-integration.mdx
@@ -103,10 +103,10 @@ uv pip install -r requirements.lock -e ./sdk -e .
 ```
 
 :::note
-By default, `uv venv` will create an environment with Python 3.12. To pin Python 3.11 both locally and in Dagger, run this first:
+By default, `uv venv` will create an environment with Python 3.13. To pin Python 3.12 both locally and in Dagger, run this first:
 
 ```shell
-echo 3.11 > .python-version
+echo 3.12 > .python-version
 ```
 
 :::
@@ -114,7 +114,7 @@ echo 3.11 > .python-version
 </TabItem>
 <TabItem value="pip">
 
-Make sure you have the same Python version that Dagger uses first. By default it's Python 3.12, unless it's overridden in `pyproject.toml` or in `.python-version`.
+Make sure you have the same Python version that Dagger uses first. By default it's Python 3.13, unless it's overridden in `pyproject.toml` or in `.python-version`.
 
 ```shell
 python -m venv .venv

--- a/docs/current_docs/api/module-structure.mdx
+++ b/docs/current_docs/api/module-structure.mdx
@@ -375,13 +375,13 @@ The runtime container is currently hardcoded to run in Go 1.21  (although this m
 </TabItem>
 <TabItem value="python" label="Python">
 
-The runtime container is based on the [python:3.12-slim](https://hub.docker.com/_/python/tags?name=3.12-slim) base image by default, but it can be overridden by setting [`requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires), or pinned with a `.python-version` file next to your `pyproject.toml`:
+The runtime container is based on the [python:3.13-slim](https://hub.docker.com/_/python/tags?name=3.13-slim) base image by default, but it can be overridden by setting [`requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires), or pinned with a `.python-version` file next to your `pyproject.toml`:
 
 ```shell
-echo "3.11" > .python-version
+echo "3.12" > .python-version
 ```
 
-This will instruct Dagger to use the `python:3.11-slim` base image instead.
+This will instruct Dagger to use the `python:3.12-slim` base image instead.
 
 Pinning the interpreter version can be useful to prevent an automatic upgrade from a future version of Dagger, or to select a newer version.
 
@@ -391,7 +391,7 @@ For more advanced needs, a different base image can be used by adding the follow
 
 ```toml
 [tool.dagger]
-base-image = "acme/python:3.11"
+base-image = "acme/python:3.12"
 ```
 
 This can be useful to add a few requirements to the module's execution environment such as system packages like `git`, or to add necessary environment variables, for example. However, don't deviate from the default base image too much or it may break in a future version of Dagger.


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/10825

Pushed as a separate PR (and in draft) so this is only published after releasing that change.