### PR TITLE
PHP SDK: Provide clear error message when not specifying array subtypes

### DIFF
--- a/sdk/php/src/Exception/MissingAttribute.php
+++ b/sdk/php/src/Exception/MissingAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Exception;
+
+final class MissingAttribute extends \RuntimeException
+{
+    public static function returnsListOfType(
+        string $methodName,
+    ): self {
+        $missingAttribute = \Dagger\Attribute\ReturnsListOfType::class;
+
+        return new self(
+            "DaggerFunction '$methodName' requires $missingAttribute"
+            . ', this is because it has an array return type',
+        );
+    }
+}

--- a/sdk/php/src/ValueObject/DaggerFunction.php
+++ b/sdk/php/src/ValueObject/DaggerFunction.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Dagger\ValueObject;
 
 use Dagger\Attribute;
+use Dagger\Exception\MissingAttribute;
+use Dagger\Exception\UnsupportedType;
 use ReflectionMethod;
+use ReflectionNamedType;
 use RuntimeException;
 
 /** @internal Value Object used for methods to expose to Dagger. */
@@ -36,7 +39,12 @@ final readonly class DaggerFunction
         $daggerFunction = (current($method
             ->getAttributes(Attribute\DaggerFunction::class)) ?: null)
             ?->newInstance()
-            ?? throw new RuntimeException('method is not a DaggerFunction');
+        ?? throw new RuntimeException(sprintf(
+            'Method "%s" is not considered a dagger function without the %s attribute',
+            $method->getName(),
+            Attribute\DaggerFunction::class
+        ));
+
 
         $description = (current($method
             ->getAttributes(Attribute\Doc::class)) ?: null)
@@ -47,7 +55,6 @@ final readonly class DaggerFunction
             fn($p) => Argument::fromReflection($p),
             $method->getParameters(),
         );
-
 
         return $method->isConstructor() ?
             new self(
@@ -72,12 +79,21 @@ final readonly class DaggerFunction
             $method->name,
         ));
 
-        $attribute = (current($method
-            ->getAttributes(Attribute\ReturnsListOfType::class)) ?: null)
-            ?->newInstance();
+        if (!($type instanceof ReflectionNamedType)) {
+            throw new UnsupportedType(
+                'The PHP SDK only supports named types and nullable named types',
+            );
+        }
 
-        return isset($attribute) ?
-            ListOfType::fromReflection($type, $attribute) :
-            Type::fromReflection($type);
+        if ($type->getName() === 'array') {
+            $attribute = (current($method
+                ->getAttributes(Attribute\ReturnsListOfType::class)) ?: null)
+                ?->newInstance()
+            ?? throw MissingAttribute::returnsListOfType($method->getName());
+
+            return ListOfType::fromReflection($type, $attribute);
+        }
+
+        return Type::fromReflection($type);
     }
 }

--- a/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
+++ b/sdk/php/tests/Unit/ValueObject/DaggerFunctionTest.php
@@ -6,6 +6,7 @@ namespace Dagger\Tests\Unit\ValueObject;
 
 use Dagger\Attribute\DaggerObject;
 use Dagger\Container;
+use Dagger\Exception\MissingAttribute;
 use Dagger\File;
 use Dagger\Json;
 use Dagger\Tests\Unit\Fixture\DaggerObjectWithDaggerFunctions;
@@ -27,34 +28,14 @@ use RuntimeException;
 class DaggerFunctionTest extends TestCase
 {
     #[Test]
-    public function itThrowsIfBuiltFromNonDaggerFunctions(): void
-    {
-        $reflection = new ReflectionMethod(
-            DaggerObjectWithDaggerFunctions::class,
-            'notADaggerFunction',
-        );
+    #[DataProvider('provideInvalidDaggerFunctions')]
+    public function itCannotTakeInvalidDaggerFunctions(
+	ReflectionMethod $reflection,
+	\RuntimeException $expected,
+    ): void {
+	self::expectExceptionObject($expected);
 
-        self::expectException(RuntimeException::class);
-
-        DaggerFunction::fromReflection($reflection);
-    }
-
-    #[Test]
-    public function ItRequiresReturnType(): void
-    {
-        $reflection = (new ReflectionClass(new #[DaggerObject] class () {
-                #[\Dagger\Attribute\DaggerFunction]
-                public function noReturnType()
-                {
-                    return 'hello world';
-                }
-            }))->getMethod('noReturnType');
-
-        self::expectExceptionMessage(
-            'DaggerFunction "noReturnType" cannot be supported without a return type',
-        );
-
-        DaggerFunction::fromReflection($reflection);
+	DaggerFunction::fromReflection($reflection);
     }
 
     #[Test]
@@ -76,6 +57,38 @@ class DaggerFunctionTest extends TestCase
         $actual = DaggerFunction::fromReflection($reflectionMethod);
 
         self::assertEquals($expected, $actual);
+    }
+
+    /** @return Generator<array{0: ReflectionMethod, 1: RuntimeException}> */
+    public static function provideInvalidDaggerFunctions(): Generator
+    {
+        yield 'DaggerFunction attribute missing' => [
+            (new ReflectionClass(new #[DaggerObject] class () {
+                public function noAttribute(): string {return 'hello world';}
+            }))->getMethod('noAttribute'),
+            new RuntimeException(sprintf(
+                'Method "noAttribute" is not considered a dagger function without the %s attribute',
+                \Dagger\Attribute\DaggerFunction::class,
+            )),
+        ];
+
+        yield 'return typehint missing' => [
+            (new ReflectionClass(new #[DaggerObject] class () {
+                #[\Dagger\Attribute\DaggerFunction]
+                public function noReturnType() {return 'hello world';}
+            }))->getMethod('noReturnType'),
+            new RuntimeException(
+                'DaggerFunction "noReturnType" cannot be supported without a return type'
+            ),
+        ];
+
+        yield 'missing attribute for returning arrays' => [
+            (new ReflectionClass(new #[DaggerObject] class () {
+                #[\Dagger\Attribute\DaggerFunction]
+                public function returnsArrayWithoutAttribute(): array {return ['hello', 'world'];}
+            }))->getMethod('returnsArrayWithoutAttribute'),
+            MissingAttribute::returnsListOfType('returnsArrayWithoutAttribute'),
+        ];
     }
 
     /** @return Generator<array{ 0: bool, 1:string }> */


### PR DESCRIPTION
Closes #10835

Users were faced with a misleading error message when returning an array from their function, but forgetting to specify its subtype.

This provides a clear message with the solution.