### PR TITLE
fix: add --first-parent for counting rev-list

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -540,7 +540,9 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 				if depth <= 0 {
 					doFetch = true
 				} else {
-					res, err := git.New().Run(ctx, "rev-list", "--count", ref.Commit)
+					// HACK: this is a pretty terrible way to guess the depth,
+					// since it only traces *one* path.
+					res, err := git.New().Run(ctx, "rev-list", "--first-parent", "--count", ref.Commit)
 					if err != nil {
 						return fmt.Errorf("failed to rev-list: %w", err)
 					}


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/10722

We always should have been using `--first-parent` here, without that, we always get *all* the parents, which counts all parents of a merge commit, which isn't really useful for estimating the depth.

This is also really just a guess - it's possible that different parents can end up with different depths. This means it's *theoretically* possible to get the wrong results here.