### PR TITLE
feat: add contextual git

### DIFF
--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -318,10 +318,6 @@ func (ps *parseState) parseParamSpecVar(field *types.Var, astField *ast.Field, d
 		if !ok {
 			return paramSpec{}, fmt.Errorf("defaultPath pragma %q, must be a valid string", v)
 		}
-		if strings.HasPrefix(defaultPath, `"`) && strings.HasSuffix(defaultPath, `"`) {
-			defaultPath = defaultPath[1 : len(defaultPath)-1]
-		}
-
 		optional = true // If defaultPath is set, the argument becomes optional
 	}
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -2386,14 +2386,16 @@ git config --global user.name "Test User"
 mkdir srv
 
 cd repo
-	git init
-	git branch -m %s
-	git add * || true
-	git commit -m "init"
+	if [ ! -d .git ]; then
+		git init
+		git branch -m %s
+		git add * || true
+		git commit -m "init"
+	fi
 cd ..
 
 cd srv
-	git clone --bare ../repo repo.git
+	git clone --no-local --bare ../repo repo.git
 	cd repo.git
 		git update-server-info
 	cd ..

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -244,7 +244,7 @@ func (src *ModuleSource) Pin() string {
 	case ModuleSourceKindLocal:
 		return ""
 	case ModuleSourceKindGit:
-		return src.Git.Pin
+		return src.Git.Commit
 	default:
 		return ""
 	}
@@ -497,7 +497,8 @@ type GitModuleSource struct {
 
 	// The resolved commit hash of the source
 	Commit string
-	Pin    string
+	// The fully resolved git ref string of the source
+	Ref string
 
 	// The full git repo for the module source without any include filtering
 	UnfilteredContextDir dagql.ObjectResult[*Directory]

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/sdk"
@@ -490,20 +491,40 @@ func (s *moduleSchema) functionWithArg(ctx context.Context, fn *core.Function, a
 	}
 
 	// Check if both values are used, return an error if so.
-	if args.DefaultValue != nil && args.DefaultPath != "" {
-		return nil, fmt.Errorf("cannot set both default value and default path from context")
+	defaultSet := []bool{
+		args.DefaultValue != nil,
+		args.DefaultPath != "",
+	}
+	defaultCount := 0
+	for _, v := range defaultSet {
+		if v {
+			defaultCount++
+		}
+	}
+	if defaultCount > 1 {
+		return nil, fmt.Errorf("cannot set more than one default value")
 	}
 
-	// Check if default path from context is set for non-directory or non-file type
-	if argType.Self().Kind == core.TypeDefKindObject && args.DefaultPath != "" &&
-		(argType.Self().AsObject.Value.Name != "Directory" && argType.Self().AsObject.Value.Name != "File") {
-		return nil, fmt.Errorf("can only set default path for Directory or File type, not %s", argType.Self().AsObject.Value.Name)
+	// Check if default path from context is set for supported type
+	if args.DefaultPath != "" {
+		if argType.Self().Kind != core.TypeDefKindObject {
+			return nil, fmt.Errorf("can only set default path for Object, not %s", argType.Self().Kind)
+		}
+		name := argType.Self().AsObject.Value.Name
+		if !slices.Contains([]string{"Directory", "File", "GitRepository", "GitRef"}, name) {
+			return nil, fmt.Errorf("cannot set default path for %s", name)
+		}
 	}
 
 	// Check if ignore is set for non-directory type
-	if argType.Self().Kind == core.TypeDefKindObject &&
-		len(args.Ignore) > 0 && argType.Self().AsObject.Value.Name != "Directory" {
-		return nil, fmt.Errorf("can only set ignore for Directory type, not %s", argType.Self().AsObject.Value.Name)
+	if len(args.Ignore) > 0 {
+		if argType.Self().Kind != core.TypeDefKindObject {
+			return nil, fmt.Errorf("can only set ignore for Object type, not %s", argType.Self().Kind)
+		}
+		name := argType.Self().AsObject.Value.Name
+		if name != "Directory" {
+			return nil, fmt.Errorf("can only set ignore for Directory type, not %s", name)
+		}
 	}
 
 	// When using a default path SDKs can't set a default value and the argument

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -254,6 +254,10 @@ func (*FunctionArg) TypeDescription() string {
 		an argument passed at function call time.`)
 }
 
+func (arg *FunctionArg) isContextual() bool {
+	return arg.DefaultPath != ""
+}
+
 type DynamicID struct {
 	typeName string
 	id       *call.ID

--- a/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
+++ b/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
@@ -296,12 +296,16 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
               var hasDefaultPathAnnotation = defaultPathAnnotation != null;
 
               if (hasDefaultPathAnnotation
-                  && !tm.toString().equals("io.dagger.client.Directory")
-                  && !tm.toString().equals("io.dagger.client.File")) {
+                  && !Set.of(
+                          "io.dagger.client.Directory",
+                          "io.dagger.client.File",
+                          "io.dagger.client.GitRepository",
+                          "io.dagger.client.GitRef")
+                      .contains(tm.toString())) {
                 throw new IllegalArgumentException(
                     "Parameter "
                         + param.getSimpleName()
-                        + " cannot have @DefaultPath annotation if it is not a Directory or File type");
+                        + " cannot have @DefaultPath annotation if it is not a Directory/File or GitRepository/GitRef type");
               }
 
               if (hasDefaultAnnotation && hasDefaultPathAnnotation) {

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -33,8 +33,10 @@ class Name:
 class DefaultPath:
     """If the argument is omitted, load it from the given path in the context directory.
 
-    Only applies to arguments of type :py:class:`dagger.Directory` or
-    :py:class:`dagger.File`.
+    Only applies to arguments of type
+    :py:class:`dagger.Directory`/:py:class:`dagger.File`
+    or :py:class:`dagger.GitRepository`/:py:class:`dagger.GitRef`.
+
 
     Mutually exclusive with setting a default value for the parameter. When
     used within Python, the parameter should be required.
@@ -43,6 +45,10 @@ class DefaultPath:
 
         @function
         def build(self, src: Annotated[dagger.Directory, DefaultPath("..")]): ...
+
+
+        @function
+        def build(self, src: Annotated[dagger.GitRef, DefaultPath("./.git")]): ...
     """
 
     from_context: ContextPath
@@ -122,7 +128,13 @@ class Parameter:
 
     @property
     def is_optional(self) -> bool:
-        return self.has_default or self.default_path is not None or self.is_nullable
+        return any(
+            [
+                self.has_default,
+                self.default_path is not None,
+                self.is_nullable,
+            ]
+        )
 
     def _validate(self):
         extra = {"parameter": self.signature}

--- a/sdk/typescript/dev/node/src/commands.ts
+++ b/sdk/typescript/dev/node/src/commands.ts
@@ -20,6 +20,11 @@ export class Commands {
   }
 
   @func()
+  format(): Container {
+    return this.run(["fmt"])
+  }
+
+  @func()
   test(): Container {
     return this.run(["test"])
   }

--- a/sdk/typescript/dev/src/index.ts
+++ b/sdk/typescript/dev/src/index.ts
@@ -1,4 +1,4 @@
-import { dag, Container, object, func, Directory } from "@dagger.io/dagger"
+import { argument, dag, Container, object, func, Directory } from "@dagger.io/dagger"
 
 @object()
 export class TypescriptSdkDev {
@@ -10,7 +10,9 @@ export class TypescriptSdkDev {
   @func()
   project: Container
 
-  constructor(source: Directory) {
+  constructor(
+    @argument({ defaultPath: "/sdk/typescript" }) source: Directory,
+  ) {
     // Extract package.json and yarn.lock to a temporary directory
     const dependencyFiles = dag
       .directory()
@@ -67,6 +69,14 @@ export class TypescriptSdkDev {
   @func()
   lint(): Container {
     return dag.node({ ctr: this.project }).commands().lint()
+  }
+
+  /**
+   * Format the TypeScript SDK.
+   */
+  @func()
+  format(): Directory {
+    return dag.node({ ctr: this.project }).commands().format().directory(".")
   }
 
   /**

--- a/sdk/typescript/src/module/entrypoint/register.ts
+++ b/sdk/typescript/src/module/entrypoint/register.ts
@@ -146,10 +146,8 @@ export class Register {
         }
 
         // Check if both values are used, return an error if so.
-        if (arg.defaultValue && arg.defaultPath) {
-          throw new Error(
-            "cannot set both default value and default path from context",
-          )
+        if ([arg.defaultValue, arg.defaultPath].filter((v) => v).length > 1) {
+          throw new Error("cannot set multiple defaults")
         }
 
         // We do not set the default value if it's not a primitive type, we let TypeScript

--- a/sdk/typescript/src/module/registry.ts
+++ b/sdk/typescript/src/module/registry.ts
@@ -24,9 +24,9 @@ export type ArgumentOptions = {
   /**
    * The contextual value to use for the argument.
    *
-   * This should only be used for Directory or File types.
+   * This should only be used for Directory/File or GitRepository/GitRef types.
    *
-   * An abslute path would be related to the context source directory (the git repo root or the module source root).
+   * An absolute path would be related to the context source directory (the git repo root or the module source root).
    * A relative path would be relative to the module source root.
    */
   defaultPath?: string


### PR DESCRIPTION
Fixes #8520. Follow-up to https://github.com/dagger/dagger/pull/10195.

This allows a module to get git information about itself - it can do this through the core `Git` type.

The `defaultPath` annotation is extended to allow setting a default value for a `GitRepository`/`GitRef` parameter. If the caller does not provide a value, the method uses the specified default - either a local path (e.g., `"./.git"`) or a remote repository URL (e.g., `"https://github.com/dagger/dagger.git"`).