### PR TITLE
feat: add `git.commonAncestor`

### DIFF
--- a/.changes/unreleased/Added-20250811-130142.yaml
+++ b/.changes/unreleased/Added-20250811-130142.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added new `gitRef.commonAncestor` API to find the common ancestor between two references
+time: 2025-08-11T13:01:42.27738222+01:00
+custom:
+    Author: jedevc
+    PR: "10849"

--- a/core/git.go
+++ b/core/git.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/sys/mount"
 	"github.com/vektah/gqlparser/v2/ast"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 
 	"github.com/dagger/dagger/dagql"
@@ -50,6 +52,10 @@ type GitRepositoryBackend interface {
 	Ref(ctx context.Context, ref string) (GitRefBackend, error)
 	Tags(ctx context.Context, patterns []string, sort string) (tags []string, err error)
 	Branches(ctx context.Context, patterns []string, sort string) (branches []string, err error)
+
+	mount(ctx context.Context, depth int, refs []GitRefBackend, fn func(*gitutil.GitCLI) error) error
+
+	equivalent(GitRepositoryBackend) bool
 }
 
 func (*GitRepository) Type() *ast.Type {
@@ -91,8 +97,12 @@ type GitRef struct {
 type GitRefBackend interface {
 	HasPBDefinitions
 
+	Repo() GitRepositoryBackend
+
 	Resolve(ctx context.Context) (commit string, ref string, err error)
 	Tree(ctx context.Context, srv *dagql.Server, discard bool, depth int) (checkout *Directory, err error)
+
+	mount(ctx context.Context, depth int, fn func(*gitutil.GitCLI) error) error
 }
 
 func (*GitRef) Type() *ast.Type {
@@ -140,7 +150,7 @@ func (repo *RemoteGitRepository) PBDefinitions(ctx context.Context) ([]*pb.Defin
 
 func (repo *RemoteGitRepository) Ref(ctx context.Context, refstr string) (GitRefBackend, error) {
 	ref := &RemoteGitRef{
-		Repo: repo,
+		repo: repo,
 	}
 
 	// force resolution now, since the remote might change, and we don't want inconsistencies
@@ -197,6 +207,17 @@ func (repo *RemoteGitRepository) lsRemote(ctx context.Context, args []string, pa
 	defer cleanup()
 
 	return runLsRemote(ctx, git, repo.URL.Remote(), args, patterns, sort)
+}
+
+func (repo *RemoteGitRepository) equivalent(other GitRepositoryBackend) bool {
+	remoteRepo, ok := other.(*RemoteGitRepository)
+	if !ok {
+		return false
+	}
+	if repo.URL.Remote() != remoteRepo.URL.Remote() {
+		return false
+	}
+	return true
 }
 
 func (repo *RemoteGitRepository) setup(ctx context.Context) (_ *gitutil.GitCLI, _ func() error, rerr error) {
@@ -377,7 +398,137 @@ func mergeResolv(dst *os.File, src io.Reader, dns *oci.DNSConfig) error {
 	return nil
 }
 
-func (repo *RemoteGitRepository) mountRemote(ctx context.Context, g bksession.Group, fn func(string) error) (retErr error) {
+func (repo *RemoteGitRepository) mount(ctx context.Context, depth int, refs []GitRefBackend, fn func(*gitutil.GitCLI) error) (retErr error) {
+	g, _ := buildkit.CurrentBuildkitSessionGroup(ctx)
+	return repo.initRemote(ctx, g, func(remote string) error {
+		git, cleanup, err := repo.setup(ctx)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		git = git.New(gitutil.WithGitDir(remote))
+		gitDir, err := git.GitDir(ctx)
+		if err != nil {
+			return fmt.Errorf("could not find git dir: %w", err)
+		}
+
+		var fetchRefs []*RemoteGitRef
+		for _, ref := range refs {
+			ref := ref.(*RemoteGitRef)
+
+			// skip fetch if commit already exists
+			doFetch := true
+			if res, err := git.New(gitutil.WithIgnoreError()).Run(ctx, "rev-parse", "--verify", ref.FullRef+"^{commit}"); err != nil {
+				return fmt.Errorf("failed to rev-parse: %w", err)
+			} else if strings.TrimSpace(string(res)) == ref.Commit {
+				doFetch = false
+
+				if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
+					// if shallow, check we have enough depth
+					if depth <= 0 {
+						doFetch = true
+					} else {
+						// HACK: this is a pretty terrible way to guess the depth,
+						// since it only traces *one* path.
+						res, err := git.New().Run(ctx, "rev-list", "--first-parent", "--count", ref.Commit)
+						if err != nil {
+							return fmt.Errorf("failed to rev-list: %w", err)
+						}
+						res = bytes.TrimSpace(res)
+						count, err := strconv.Atoi(string(res))
+						if err != nil {
+							return fmt.Errorf("failed to parse rev-list output: %w", err)
+						}
+						if count < depth {
+							doFetch = true
+						}
+					}
+				}
+			}
+
+			if doFetch {
+				fetchRefs = append(fetchRefs, ref)
+			}
+		}
+
+		err = repo.fetch(ctx, git, depth, fetchRefs)
+		if err != nil {
+			return err
+		}
+		_, err = git.Run(ctx, "reflog", "expire", "--all", "--expire=now")
+		if err != nil {
+			return fmt.Errorf("failed to expire reflog for remote %s: %w", repo.URL.Remote(), err)
+		}
+
+		return fn(git)
+	})
+}
+
+func (repo *RemoteGitRepository) fetch(ctx context.Context, git *gitutil.GitCLI, depth int, refs []*RemoteGitRef) error {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+
+	gitDir, err := git.GitDir(ctx)
+	if err != nil {
+		return err
+	}
+
+	var refSpecs []string
+	for _, ref := range refs {
+		if gitutil.IsCommitSHA(ref.FullRef) {
+			// TODO: may need fallback if git remote doesn't support fetching by commit
+			refSpecs = append(refSpecs, ref.FullRef)
+		} else {
+			refSpecs = append(refSpecs, ref.FullRef+":"+ref.FullRef)
+		}
+	}
+
+	args := []string{
+		"fetch",
+		"--tags",
+		"--update-head-ok",
+		"--force",
+	}
+	if depth <= 0 {
+		if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
+			args = append(args, "--unshallow")
+		}
+	} else {
+		args = append(args, "--depth="+fmt.Sprint(depth))
+	}
+	args = append(args, "origin")
+	args = append(args, refSpecs...)
+
+	svcs, err := query.Services(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get services: %w", err)
+	}
+	detach, _, err := svcs.StartBindings(ctx, repo.Services)
+	if err != nil {
+		return err
+	}
+	defer detach()
+
+	if _, err := git.Run(ctx, args...); err != nil {
+		if strings.Contains(err.Error(), "does not support shallow") {
+			// fallback to full fetch
+			args = slices.DeleteFunc(args, func(s string) bool {
+				return strings.HasPrefix(s, "--depth")
+			})
+			_, err = git.Run(ctx, args...)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to fetch remote %s: %w", repo.URL.Remote(), err)
+		}
+	}
+
+	return nil
+}
+
+func (repo *RemoteGitRepository) initRemote(ctx context.Context, g bksession.Group, fn func(string) error) (retErr error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return err
@@ -467,7 +618,7 @@ func (repo *RemoteGitRepository) mountRemote(ctx context.Context, g bksession.Gr
 }
 
 type RemoteGitRef struct {
-	Repo *RemoteGitRepository
+	repo *RemoteGitRepository
 
 	FullRef string
 	Commit  string
@@ -477,6 +628,10 @@ var _ GitRefBackend = (*RemoteGitRef)(nil)
 
 func (ref *RemoteGitRef) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	return nil, nil
+}
+
+func (ref *RemoteGitRef) Repo() GitRepositoryBackend {
+	return ref.repo
 }
 
 func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGitDir bool, depth int) (_ *Directory, rerr error) {
@@ -516,63 +671,16 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 	if !ok {
 		return nil, fmt.Errorf("no buildkit session group in context")
 	}
-	err = ref.Repo.mountRemote(ctx, bkSessionGroup, func(remote string) error {
-		git, cleanup, err := ref.Repo.setup(ctx)
-		if err != nil {
-			return err
-		}
-		defer cleanup()
-		git = git.New(gitutil.WithGitDir(remote))
-		gitDir, err := git.GitDir(ctx)
+	err = ref.mount(ctx, depth, func(git *gitutil.GitCLI) error {
+		gitURL, err := git.URL(ctx)
 		if err != nil {
 			return fmt.Errorf("could not find git dir: %w", err)
-		}
-
-		// skip fetch if commit already exists
-		doFetch := true
-		if res, err := git.New(gitutil.WithIgnoreError()).Run(ctx, "rev-parse", "--verify", ref.FullRef+"^{commit}"); err != nil {
-			return fmt.Errorf("failed to rev-parse: %w", err)
-		} else if strings.TrimSpace(string(res)) == ref.Commit {
-			doFetch = false
-
-			if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
-				// if shallow, check we have enough depth
-				if depth <= 0 {
-					doFetch = true
-				} else {
-					// HACK: this is a pretty terrible way to guess the depth,
-					// since it only traces *one* path.
-					res, err := git.New().Run(ctx, "rev-list", "--first-parent", "--count", ref.Commit)
-					if err != nil {
-						return fmt.Errorf("failed to rev-list: %w", err)
-					}
-					res = bytes.TrimSpace(res)
-					count, err := strconv.Atoi(string(res))
-					if err != nil {
-						return fmt.Errorf("failed to parse rev-list output: %w", err)
-					}
-					if count < depth {
-						doFetch = true
-					}
-				}
-			}
-		}
-
-		if doFetch {
-			err := ref.fetchRemote(ctx, git, depth)
-			if err != nil {
-				return err
-			}
-			_, err = git.Run(ctx, "reflog", "expire", "--all", "--expire=now")
-			if err != nil {
-				return fmt.Errorf("failed to expire reflog for remote %s: %w", ref.Repo.URL.Remote(), err)
-			}
 		}
 
 		checkoutRef, err = cache.New(ctx, nil, bkSessionGroup,
 			bkcache.CachePolicyRetain,
 			bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
-			bkcache.WithDescription(fmt.Sprintf("git checkout for %s (%s %s)", ref.Repo.URL.Remote(), ref.FullRef, ref.Commit)))
+			bkcache.WithDescription(fmt.Sprintf("git checkout for %s (%s %s)", ref.repo.URL.Remote(), ref.FullRef, ref.Commit)))
 		if err != nil {
 			return err
 		}
@@ -588,15 +696,15 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 			if err != nil {
 				return err
 			}
-			_, err = checkoutGit.Run(ctx, "remote", "add", "origin", "file://"+gitDir)
+			_, err = checkoutGit.Run(ctx, "remote", "add", "origin", gitURL)
 			if err != nil {
 				return err
 			}
 
-			return doGitCheckout(ctx, checkoutGit, ref.Repo.URL.Remote(), ref.FullRef, ref.Commit, depth, discardGitDir)
+			return doGitCheckout(ctx, checkoutGit, ref.repo.URL.Remote(), ref.FullRef, ref.Commit, depth, discardGitDir)
 		})
 		if err != nil {
-			return fmt.Errorf("failed to checkout %s in %s: %w", ref.FullRef, ref.Repo.URL.Remote(), err)
+			return fmt.Errorf("failed to checkout %s in %s: %w", ref.FullRef, ref.repo.URL.Remote(), err)
 		}
 
 		return nil
@@ -626,65 +734,8 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 	return checkout, nil
 }
 
-func (ref *RemoteGitRef) fetchRemote(ctx context.Context, git *gitutil.GitCLI, depth int) error {
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return err
-	}
-
-	gitDir, err := git.GitDir(ctx)
-	if err != nil {
-		return err
-	}
-
-	var refSpec string
-	if gitutil.IsCommitSHA(ref.FullRef) {
-		// TODO: may need fallback if git remote doesn't support fetching by commit
-		refSpec = ref.FullRef
-	} else {
-		refSpec = ref.FullRef + ":" + ref.FullRef
-	}
-
-	args := []string{
-		"fetch",
-		"--tags",
-		"--update-head-ok",
-		"--force",
-	}
-	if depth <= 0 {
-		if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
-			args = append(args, "--unshallow")
-		}
-	} else {
-		args = append(args, "--depth="+fmt.Sprint(depth))
-	}
-	args = append(args, "origin", refSpec)
-
-	svcs, err := query.Services(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get services: %w", err)
-	}
-	detach, _, err := svcs.StartBindings(ctx, ref.Repo.Services)
-	if err != nil {
-		return err
-	}
-	defer detach()
-
-	if _, err := git.Run(ctx, args...); err != nil {
-		if strings.Contains(err.Error(), "does not support shallow") {
-			// fallback to full fetch
-			args = slices.DeleteFunc(args, func(s string) bool {
-				return strings.HasPrefix(s, "--depth")
-			})
-			_, err = git.Run(ctx, args...)
-		}
-
-		if err != nil {
-			return fmt.Errorf("failed to fetch remote %s: %w", ref.Repo.URL.Remote(), err)
-		}
-	}
-
-	return nil
+func (ref *RemoteGitRef) mount(ctx context.Context, depth int, fn func(*gitutil.GitCLI) error) error {
+	return ref.repo.mount(ctx, depth, []GitRefBackend{ref}, fn)
 }
 
 func doGitCheckout(
@@ -760,13 +811,13 @@ func (ref *RemoteGitRef) resolve(ctx context.Context, refstr string) (commit str
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get services: %w", err)
 	}
-	detach, _, err := svcs.StartBindings(ctx, ref.Repo.Services)
+	detach, _, err := svcs.StartBindings(ctx, ref.repo.Services)
 	if err != nil {
 		return "", "", err
 	}
 	defer detach()
 
-	git, cleanup, err := ref.Repo.setup(ctx)
+	git, cleanup, err := ref.repo.setup(ctx)
 	if err != nil {
 		return "", "", err
 	}
@@ -782,19 +833,19 @@ func (ref *RemoteGitRef) resolve(ctx context.Context, refstr string) (commit str
 	out, err := git.Run(ctx,
 		"ls-remote",
 		"--symref",
-		ref.Repo.URL.Remote(),
+		ref.repo.URL.Remote(),
 		target,
 		target+"^{}",
 	)
 	if err != nil {
-		return "", "", fmt.Errorf("cannot resolve %q: %w", ref.Repo.URL.Remote(), err)
+		return "", "", fmt.Errorf("cannot resolve %q: %w", ref.repo.URL.Remote(), err)
 	}
 
 	if gitutil.IsCommitSHA(refstr) {
 		return refstr, refstr, nil
 	}
 
-	return parseGitRefOutput(refstr, string(out), "\t")
+	return parseLsRemote(refstr, string(out))
 }
 
 func (ref *RemoteGitRef) Resolve(ctx context.Context) (commit string, fullref string, _ error) {
@@ -802,18 +853,18 @@ func (ref *RemoteGitRef) Resolve(ctx context.Context) (commit string, fullref st
 }
 
 type LocalGitRepository struct {
-	Directory *Directory
+	Directory dagql.ObjectResult[*Directory]
 }
 
 var _ GitRepositoryBackend = (*LocalGitRepository)(nil)
 
 func (repo *LocalGitRepository) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
-	return repo.Directory.PBDefinitions(ctx)
+	return repo.Directory.Self().PBDefinitions(ctx)
 }
 
 func (repo *LocalGitRepository) Ref(ctx context.Context, ref string) (GitRefBackend, error) {
 	return &LocalGitRef{
-		Repo: repo,
+		repo: repo,
 		Ref:  ref,
 	}, nil
 }
@@ -840,11 +891,25 @@ func (repo *LocalGitRepository) Branches(ctx context.Context, patterns []string,
 	return branches, nil
 }
 
+func (repo *LocalGitRepository) equivalent(other GitRepositoryBackend) bool {
+	localRepo, ok := other.(*LocalGitRepository)
+	if !ok {
+		return false
+	}
+	if repo.Directory.ID() != localRepo.Directory.ID() {
+		return false
+	}
+	return true
+}
+
 func (repo *LocalGitRepository) lsRemote(ctx context.Context, args []string, patterns []string, sort string) ([]string, error) {
 	results := []string{}
-	err := repo.mount(ctx, func(src string) error {
-		var err error
-		results, err = runLsRemote(ctx, gitutil.NewGitCLI(), "file://"+src, args, patterns, sort)
+	err := repo.mount(ctx, 0, nil, func(git *gitutil.GitCLI) error {
+		gitURL, err := git.URL(ctx)
+		if err != nil {
+			return err
+		}
+		results, err = runLsRemote(ctx, gitutil.NewGitCLI(), gitURL, args, patterns, sort)
 		return err
 	})
 	if err != nil {
@@ -853,7 +918,7 @@ func (repo *LocalGitRepository) lsRemote(ctx context.Context, args []string, pat
 	return results, nil
 }
 
-func (repo *LocalGitRepository) mount(ctx context.Context, f func(string) error) error {
+func (repo *LocalGitRepository) mount(ctx context.Context, depth int, refs []GitRefBackend, fn func(*gitutil.GitCLI) error) error {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return err
@@ -862,30 +927,41 @@ func (repo *LocalGitRepository) mount(ctx context.Context, f func(string) error)
 	if err != nil {
 		return fmt.Errorf("failed to get services: %w", err)
 	}
-	detach, _, err := svcs.StartBindings(ctx, repo.Directory.Services)
+	detach, _, err := svcs.StartBindings(ctx, repo.Directory.Self().Services)
 	if err != nil {
 		return err
 	}
 	defer detach()
 
-	return mountLLB(ctx, repo.Directory.LLB, func(root string) error {
-		src, err := fs.RootPath(root, repo.Directory.Dir)
+	return mountLLB(ctx, repo.Directory.Self().LLB, func(root string) error {
+		src, err := fs.RootPath(root, repo.Directory.Self().Dir)
 		if err != nil {
 			return err
 		}
-		return f(src)
+
+		git := gitutil.NewGitCLI(gitutil.WithDir(src))
+		return fn(git)
 	})
 }
 
+func (ref *LocalGitRef) mount(ctx context.Context, depth int, fn func(*gitutil.GitCLI) error) error {
+	return ref.repo.mount(ctx, depth, []GitRefBackend{ref}, fn)
+}
+
 type LocalGitRef struct {
-	Repo *LocalGitRepository
-	Ref  string
+	repo *LocalGitRepository
+
+	Ref string
 }
 
 var _ GitRefBackend = (*LocalGitRef)(nil)
 
 func (ref *LocalGitRef) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
-	return ref.Repo.PBDefinitions(ctx)
+	return ref.repo.PBDefinitions(ctx)
+}
+
+func (ref *LocalGitRef) Repo() GitRepositoryBackend {
+	return ref.repo
 }
 
 func (ref *LocalGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGitDir bool, depth int) (_ *Directory, rerr error) {
@@ -917,11 +993,10 @@ func (ref *LocalGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGitD
 		}
 	}()
 
-	err = ref.Repo.mount(ctx, func(src string) error {
-		git := gitutil.NewGitCLI(gitutil.WithDir(src))
-		gitDir, err := git.GitDir(ctx)
+	err = ref.mount(ctx, depth, func(git *gitutil.GitCLI) error {
+		gitURL, err := git.URL(ctx)
 		if err != nil {
-			return fmt.Errorf("could not find git dir: %w", err)
+			return fmt.Errorf("could not find git url: %w", err)
 		}
 
 		return MountRef(ctx, bkref, bkSessionGroup, func(checkoutDir string) error {
@@ -939,12 +1014,12 @@ func (ref *LocalGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGitD
 			if err != nil {
 				return err
 			}
-			_, err = checkoutGit.Run(ctx, "remote", "add", "origin", "file://"+gitDir)
+			_, err = checkoutGit.Run(ctx, "remote", "add", "origin", gitURL)
 			if err != nil {
 				return err
 			}
 
-			return doGitCheckout(ctx, checkoutGit, "file://"+gitDir, fullref, commit, depth, discardGitDir)
+			return doGitCheckout(ctx, checkoutGit, gitURL, fullref, commit, depth, discardGitDir)
 		})
 	})
 	if err != nil {
@@ -967,27 +1042,139 @@ func (ref *LocalGitRef) Resolve(ctx context.Context) (string, string, error) {
 	}
 
 	var commit, fullref string
-	err := ref.Repo.mount(ctx, func(src string) error {
-		git := gitutil.NewGitCLI(gitutil.WithDir(src))
-
-		targetref := ref.Ref
-		out, err := git.Run(ctx, "symbolic-ref", targetref)
-		if err == nil {
-			targetref = strings.TrimSpace(string(out))
-		} else if !strings.Contains(err.Error(), "is not a symbolic ref") {
-			return err
+	err := ref.mount(ctx, 0, func(git *gitutil.GitCLI) error {
+		target := ref.Ref
+		if gitutil.IsCommitSHA(ref.Ref) {
+			target = "HEAD"
 		}
-		out, err = git.Run(ctx, "show-ref", "--deref", "--head", targetref, targetref+"^{}")
+
+		gitURL, err := git.URL(ctx)
 		if err != nil {
 			return err
 		}
-		commit, fullref, err = parseGitRefOutput(targetref, string(out), " ")
+
+		out, err := git.Run(ctx,
+			"ls-remote",
+			"--symref",
+			gitURL,
+			target,
+			target+"^{}",
+		)
+		if err != nil {
+			return err
+		}
+
+		if gitutil.IsCommitSHA(ref.Ref) {
+			commit, fullref = ref.Ref, ref.Ref
+			return nil
+		}
+		commit, fullref, err = parseLsRemote(ref.Ref, string(out))
 		return err
 	})
 	if err != nil {
 		return "", "", err
 	}
 	return commit, fullref, nil
+}
+
+func MergeBase(ctx context.Context, ref1 GitRefBackend, ref2 GitRefBackend) (GitRefBackend, error) {
+	if ref1.Repo().equivalent(ref2.Repo()) { // fast-path, just grab both refs from the same repo
+		repo := ref1.Repo()
+		commit1, _, err := ref1.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		commit2, _, err := ref2.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var mergeBase string
+		err = repo.mount(ctx, 0, []GitRefBackend{ref1, ref2}, func(git *gitutil.GitCLI) error {
+			out, err := git.Run(ctx, "merge-base", commit1, commit2)
+			if err != nil {
+				return fmt.Errorf("git merge-base failed: %w", err)
+			}
+			mergeBase = strings.TrimSpace(string(out))
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return repo.Ref(ctx, mergeBase)
+	}
+
+	git, commits, cleanup, err := refJoin(ctx, []GitRefBackend{ref1, ref2})
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	out, err := git.Run(ctx, append([]string{"merge-base"}, commits...)...)
+	if err != nil {
+		return nil, fmt.Errorf("git merge-base failed: %w", err)
+	}
+	mergeBase := strings.TrimSpace(string(out))
+	return ref1.Repo().Ref(ctx, mergeBase)
+}
+
+// refJoin creates a temporary git repository, adds the given refs as remotes,
+// fetches them, and returns a GitCLI instance.
+func refJoin(ctx context.Context, refs []GitRefBackend) (_ *gitutil.GitCLI, _ []string, _ func() error, rerr error) {
+	tmpDir, err := os.MkdirTemp("", "dagger-mergebase")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	cleanup := func() error {
+		return os.RemoveAll(tmpDir)
+	}
+	defer func() {
+		if rerr != nil {
+			cleanup()
+		}
+	}()
+	git := gitutil.NewGitCLI(
+		gitutil.WithDir(tmpDir),
+		gitutil.WithGitDir(filepath.Join(tmpDir, ".git")),
+	)
+	if _, err := git.Run(ctx, "-c", "init.defaultBranch=main", "init"); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to init temp repo: %w", err)
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	mu := sync.Mutex{} // cannot simultaneously add+fetch remotes
+	commits := make([]string, len(refs))
+
+	for i, ref := range refs {
+		eg.Go(func() error {
+			commit, _, err := ref.Resolve(egCtx)
+			if err != nil {
+				return err
+			}
+			commits[i] = commit
+			return ref.mount(egCtx, 0, func(gitN *gitutil.GitCLI) error {
+				remoteURL, err := gitN.URL(egCtx)
+				if err != nil {
+					return err
+				}
+				remoteName := fmt.Sprintf("origin%d", i+1)
+				mu.Lock()
+				defer mu.Unlock()
+				if _, err := git.Run(egCtx, "remote", "add", remoteName, remoteURL); err != nil {
+					return fmt.Errorf("failed to add remote %s: %w", remoteName, err)
+				}
+				if _, err := git.Run(egCtx, "fetch", "--no-tags", remoteName, commit); err != nil {
+					return fmt.Errorf("failed to fetch ref %d: %w", i+1, err)
+				}
+				return nil
+			})
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, nil, nil, err
+	}
+	return git, commits, cleanup, nil
 }
 
 func mountKnownHosts(knownHosts string) (string, error) {
@@ -1151,9 +1338,9 @@ func runLsRemote(ctx context.Context, git *gitutil.GitCLI, remote string, args [
 	return results, nil
 }
 
-// parses output from git-show-ref and git-ls-remote to find the correctly
+// parseLsRemote parses output from git-ls-remote to find the correctly
 // matching ref and commit for a target
-func parseGitRefOutput(target string, out string, separator string) (commit string, ref string, err error) {
+func parseLsRemote(target string, out string) (commit string, ref string, err error) {
 	lines := strings.Split(out, "\n")
 
 	symrefs := make(map[string]string)
@@ -1172,7 +1359,7 @@ func parseGitRefOutput(target string, out string, separator string) (commit stri
 	var match, headMatch, tagMatch *reference
 
 	for _, line := range lines {
-		fields := strings.Split(line, separator)
+		fields := strings.Split(line, "\t")
 		if len(fields) < 2 {
 			continue
 		}

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -227,7 +227,7 @@ func (GitSuite) TestGit(ctx context.Context, t *testctx.T) {
 		_, err := git.Head().Commit(ctx)
 		require.ErrorContains(t, err, "not a git repository")
 		_, err = git.Tags(ctx)
-		require.ErrorContains(t, err, "does not appear to be a git repository")
+		require.ErrorContains(t, err, "not a git repository")
 	})
 }
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -178,7 +178,7 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("patch").Doc(`Patch to apply (e.g., "diff --git a/file.txt b/file.txt\nindex 1234567..abcdef8 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-Hello\n+World\n").`),
 			),
-		dagql.Func("asGit", s.asGit).
+		dagql.NodeFunc("asGit", s.asGit).
 			Doc(`Converts this directory to a local git repository`),
 		dagql.NodeFunc("terminal", s.terminal).
 			View(AfterVersion("v0.12.0")).
@@ -743,7 +743,7 @@ func (s *directorySchema) terminal(
 
 func (s *directorySchema) asGit(
 	ctx context.Context,
-	dir *core.Directory,
+	dir dagql.ObjectResult[*core.Directory],
 	_ struct{},
 ) (*core.GitRepository, error) {
 	return &core.GitRepository{

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2560,6 +2560,12 @@ type GitRef {
   """The resolved commit id at this ref."""
   commit: String!
 
+  """Find the best common ancestor between this ref and another ref."""
+  commonAncestor(
+    """The other ref to compare against."""
+    other: GitRefID!
+  ): GitRef!
+
   """A unique identifier for this GitRef."""
   id: GitRefID!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8592,6 +8592,23 @@
                         <td data-property-name=""><a class="property-name" id="GitRef-commit" href="#GitRef-commit"><code>commit</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The resolved commit id at this ref. </td>
                       </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="GitRef-commonAncestor" href="#GitRef-commonAncestor"><code>commonAncestor</code></a> - <span class="property-type"><a href="#definition-GitRef"><code>GitRef!</code></a></span> </td>
+                        <td> Find the best common ancestor between this ref and another ref. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>other</code></span> - <span class="property-type"><a href="#definition-GitRefID"><code>GitRefID!</code></a></span></h6>
+                                <p>The other ref to compare against.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="GitRef-id" href="#GitRef-id"><code>id</code></a> - <span class="property-type"><a href="#definition-GitRefID"><code>GitRefID!</code></a></span> </td>
                         <td> A unique identifier for this GitRef. </td>

--- a/docs/static/reference/php/Dagger/GitRef.html
+++ b/docs/static/reference/php/Dagger/GitRef.html
@@ -153,6 +153,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_commonAncestor">commonAncestor</a>(<abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $other)
+        
+                                            <p><p>Find the best common ancestor between this ref and another ref.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -309,8 +319,50 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_id">
+                    <h3 id="method_commonAncestor">
         <div class="location">at line 28</div>
+        <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+    <strong>commonAncestor</strong>(<abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $other)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Find the best common ancestor between this ref and another ref.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td><abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr></td>
+                <td>$other</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_id">
+        <div class="location">at line 38</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -342,7 +394,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_ref">
-        <div class="location">at line 37</div>
+        <div class="location">at line 47</div>
         <code>                    string
     <strong>ref</strong>()
         </code>
@@ -374,7 +426,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tree">
-        <div class="location">at line 46</div>
+        <div class="location">at line 56</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>tree</strong>(bool|null $discardGitDir = false, int|null $depth = 1)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -234,7 +234,9 @@
 <abbr title="Dagger\GeneratedCode">GeneratedCode</abbr>::code</a>() &mdash; <em>Method in class <a href="Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a></em></dt>
                     <dd><p>The directory containing the generated code.</p></dd><dt><a href="Dagger/GitRef.html#method_commit">
 <abbr title="Dagger\GitRef">GitRef</abbr>::commit</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
-                    <dd><p>The resolved commit id at this ref.</p></dd><dt><a href="Dagger/GitRepository.html#method_commit">
+                    <dd><p>The resolved commit id at this ref.</p></dd><dt><a href="Dagger/GitRef.html#method_commonAncestor">
+<abbr title="Dagger\GitRef">GitRef</abbr>::commonAncestor</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
+                    <dd><p>Find the best common ancestor between this ref and another ref.</p></dd><dt><a href="Dagger/GitRepository.html#method_commit">
 <abbr title="Dagger\GitRepository">GitRepository</abbr>::commit</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>
                     <dd><p>Returns details of a commit.</p></dd><dt><a href="Dagger/LLMTokenUsage.html#method_cachedTokenReads">
 <abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr>::cachedTokenReads</a>() &mdash; <em>Method in class <a href="Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -3277,6 +3277,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\GitRef::commonAncestor",
+			"p": "Dagger/GitRef.html#method_commonAncestor",
+			"d": "<p>Find the best common ancestor between this ref and another ref.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\GitRef::id",
 			"p": "Dagger/GitRef.html#method_id",
 			"d": "<p>A unique identifier for this GitRef.</p>"

--- a/sdk/elixir/lib/dagger/gen/git_ref.ex
+++ b/sdk/elixir/lib/dagger/gen/git_ref.ex
@@ -27,6 +27,22 @@ defmodule Dagger.GitRef do
   end
 
   @doc """
+  Find the best common ancestor between this ref and another ref.
+  """
+  @spec common_ancestor(t(), Dagger.GitRef.t()) :: Dagger.GitRef.t()
+  def common_ancestor(%__MODULE__{} = git_ref, other) do
+    query_builder =
+      git_ref.query_builder
+      |> QB.select("commonAncestor")
+      |> QB.put_arg("other", Dagger.ID.id!(other))
+
+    %Dagger.GitRef{
+      query_builder: query_builder,
+      client: git_ref.client
+    }
+  end
+
+  @doc """
   A unique identifier for this GitRef.
   """
   @spec id(t()) :: {:ok, Dagger.GitRefID.t()} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5802,6 +5802,14 @@ type GitRef struct {
 	id     *GitRefID
 	ref    *string
 }
+type WithGitRefFunc func(r *GitRef) *GitRef
+
+// With calls the provided function with current GitRef.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *GitRef) With(f WithGitRefFunc) *GitRef {
+	return f(r)
+}
 
 func (r *GitRef) WithGraphQLQuery(q *querybuilder.Selection) *GitRef {
 	return &GitRef{
@@ -5820,6 +5828,17 @@ func (r *GitRef) Commit(ctx context.Context) (string, error) {
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
+}
+
+// Find the best common ancestor between this ref and another ref.
+func (r *GitRef) CommonAncestor(other *GitRef) *GitRef {
+	assertNotNil("other", other)
+	q := r.query.Select("commonAncestor")
+	q = q.Arg("other", other)
+
+	return &GitRef{
+		query: q,
+	}
 }
 
 // A unique identifier for this GitRef.

--- a/sdk/php/generated/GitRef.php
+++ b/sdk/php/generated/GitRef.php
@@ -23,6 +23,16 @@ class GitRef extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Find the best common ancestor between this ref and another ref.
+     */
+    public function commonAncestor(GitRefId|GitRef $other): GitRef
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('commonAncestor');
+        $innerQueryBuilder->setArgument('other', $other);
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * A unique identifier for this GitRef.
      */
     public function id(): GitRefId

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6136,6 +6136,20 @@ class GitRef(Type):
         _ctx = self._select("commit", _args)
         return await _ctx.execute(str)
 
+    def common_ancestor(self, other: Self) -> Self:
+        """Find the best common ancestor between this ref and another ref.
+
+        Parameters
+        ----------
+        other:
+            The other ref to compare against.
+        """
+        _args = [
+            Arg("other", other),
+        ]
+        _ctx = self._select("commonAncestor", _args)
+        return GitRef(_ctx)
+
     async def id(self) -> GitRefID:
         """A unique identifier for this GitRef.
 
@@ -6202,6 +6216,13 @@ class GitRef(Type):
         ]
         _ctx = self._select("tree", _args)
         return Directory(_ctx)
+
+    def with_(self, cb: Callable[["GitRef"], "GitRef"]) -> "GitRef":
+        """Call the provided callable with current GitRef.
+
+        This is useful for reusability and readability by not breaking the calling chain.
+        """
+        return cb(self)
 
 
 @typecheck

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7019,6 +7019,26 @@ impl GitRef {
         let query = self.selection.select("commit");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Find the best common ancestor between this ref and another ref.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The other ref to compare against.
+    pub fn common_ancestor(&self, other: impl IntoID<GitRefId>) -> GitRef {
+        let mut query = self.selection.select("commonAncestor");
+        query = query.arg_lazy(
+            "other",
+            Box::new(move || {
+                let other = other.clone();
+                Box::pin(async move { other.into_id().await.unwrap().quote() })
+            }),
+        );
+        GitRef {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// A unique identifier for this GitRef.
     pub async fn id(&self) -> Result<GitRefId, DaggerError> {
         let query = self.selection.select("id");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6316,6 +6316,15 @@ export class GitRef extends BaseClient {
   }
 
   /**
+   * Find the best common ancestor between this ref and another ref.
+   * @param other The other ref to compare against.
+   */
+  commonAncestor = (other: GitRef): GitRef => {
+    const ctx = this._ctx.select("commonAncestor", { other })
+    return new GitRef(ctx)
+  }
+
+  /**
    * The resolved ref name at this ref.
    */
   ref = async (): Promise<string> => {
@@ -6338,6 +6347,15 @@ export class GitRef extends BaseClient {
   tree = (opts?: GitRefTreeOpts): Directory => {
     const ctx = this._ctx.select("tree", { ...opts })
     return new Directory(ctx)
+  }
+
+  /**
+   * Call the provided function with current GitRef.
+   *
+   * This is useful for reusability and readability by not breaking the calling chain.
+   */
+  with = (arg: (param: GitRef) => GitRef) => {
+    return arg(this)
   }
 }
 

--- a/util/gitutil/cli_helpers.go
+++ b/util/gitutil/cli_helpers.go
@@ -28,6 +28,14 @@ func (cli *GitCLI) GitDir(ctx context.Context) (string, error) {
 	return cli.clean(cli.Run(ctx, "rev-parse", "--absolute-git-dir"))
 }
 
+func (cli *GitCLI) URL(ctx context.Context) (string, error) {
+	gitDir, err := cli.GitDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	return "file://" + gitDir, nil
+}
+
 func (cli *GitCLI) clean(dt []byte, err error) (string, error) {
 	out := string(dt)
 	out = strings.ReplaceAll(strings.Split(out, "\n")[0], "'", "")


### PR DESCRIPTION
This is pretty much the main reason we need our own `Git` implementation in `version/git.go` (which is slow).

See https://github.com/dagger/dagger/pull/10801 for more context.

We can implement this ourselves (with a reasonable amount of reshuffling and refactoring).