### PR TITLE
fix(core/git): ensure HTTP auth is propagated to submodules

### DIFF
--- a/.changes/unreleased/Fixed-20250819-081619.yaml
+++ b/.changes/unreleased/Fixed-20250819-081619.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: ensure HTTP auth is propagated to submodules
+time: 2025-08-19T08:16:19.523483245-07:00
+custom:
+    Author: grouville
+    PR: "10855"

--- a/core/git.go
+++ b/core/git.go
@@ -256,7 +256,7 @@ func (repo *RemoteGitRepository) setup(ctx context.Context) (_ *gitutil.GitCLI, 
 		if err != nil {
 			return nil, nil, err
 		}
-		authHeader = "basic " + base64.StdEncoding.EncodeToString(
+		authHeader = "Basic " + base64.StdEncoding.EncodeToString(
 			fmt.Appendf(nil, "%s:%s", username, password),
 		)
 	} else if repo.AuthHeader.Self() != nil {

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -773,7 +772,7 @@ func (GitSuite) TestSubmoduleAuth(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	t.Cleanup(func() { _ = c.Close() })
 
-	authToken := c.SetSecret("submodule-test-token", "test-token-"+uuid.NewString())
+	authToken := c.SetSecret("submodule-test-token", "test-token-"+identity.NewID())
 
 	submoduleContent := c.Directory().WithNewFile("submodule.txt", "This is the submodule content")
 	parentContent := c.Directory().WithNewFile("parent.txt", "This is the parent content")
@@ -842,6 +841,8 @@ git --git-dir=/srv/parent.git    update-server-info
 				ExperimentalServiceHost: gitSrv,
 			}).Branch("main").Tree().File("parent.txt").Contents(ctx)
 			require.Error(t, err)
+			requireErrOut(t, err, "git error")
+			requireErrOut(t, err, "Authentication failed")
 		})
 	})
 
@@ -869,6 +870,8 @@ git --git-dir=/srv/parent.git    update-server-info
 				ExperimentalServiceHost: httpSrv,
 			}).Branch("main").Tree().File("parent.txt").Contents(ctx)
 			require.Error(t, err)
+			requireErrOut(t, err, "git error")
+			requireErrOut(t, err, "Authentication failed")
 		})
 	})
 }

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -2264,85 +2264,75 @@ func gitSmartHTTPServiceDirAuth(ctx context.Context, t testing.TB, c *dagger.Cli
 		username = "x-access-token"
 	}
 
-	var tokenPlain string
+	var tokenPlaintext string
 	if token != nil {
 		var err error
-		tokenPlain, err = token.Plaintext(ctx)
+		tokenPlaintext, err = token.Plaintext(ctx)
 		require.NoError(t, err)
 	}
 
-	conf := `
-server.document-root = "/var/empty"
-server.port = 80
-server.modules = (
-  "mod_auth",
-  "mod_authn_file",
-  "mod_cgi",
-  "mod_setenv",
-  "mod_accesslog",
-  "mod_rewrite"
-)
+	tmpl, err := template.New("").Parse(`
+server {
+	listen       80;
+	server_name  localhost;
 
-accesslog.filename = "/dev/fd/1"
-server.errorlog    = "/dev/fd/2"
+	# Route everything to git-http-backend (smart-HTTP)
+	location ~ ^/(.*)$ {
+		{{ if .token }}
+		auth_basic            "Git";
+		auth_basic_user_file  /usr/share/nginx/htpasswd;
+		{{ end }}
 
-setenv.add-environment = (
-  "GIT_PROJECT_ROOT"    => "/var/www",
-  "GIT_HTTP_EXPORT_ALL" => ""
-)
-
-url.rewrite-if-not-file = ( "^/(.*)$" => "/git-http-backend.cgi/$1" )
-cgi.assign = ( ".cgi" => "" )
-`
-	if token != nil {
-		conf += `
-auth.backend = "plain"
-auth.backend.plain.userfile = "/etc/lighttpd/.htpasswd"
-auth.require = ( "/" => ( "method" => "basic", "realm" => "Git", "require" => "valid-user" ) )
-`
+		include               /etc/nginx/fastcgi_params;
+		fastcgi_param         GIT_HTTP_EXPORT_ALL "";
+		fastcgi_param         GIT_PROJECT_ROOT      /var/www;
+		fastcgi_param         PATH_INFO             /$1;
+		fastcgi_param         SCRIPT_FILENAME       /usr/lib/git-core/git-http-backend;
+		fastcgi_pass          unix:/var/run/fcgiwrap.socket;
 	}
+}
+`)
+	require.NoError(t, err)
+
+	var config bytes.Buffer
+	require.NoError(t, tmpl.Execute(&config, map[string]any{
+		"token": tokenPlaintext,
+	}))
 
 	ctr := c.Container().
-		From("debian:bookworm-slim").
-		WithExec([]string{"bash", "-lc", `
+		From("nginx").
+		WithExec([]string{"sh", "-lc", `
 set -eux
 apt-get update
-apt-get install -y --no-install-recommends git lighttpd ca-certificates
+apt-get install -y --no-install-recommends git fcgiwrap spawn-fcgi ca-certificates
 rm -rf /var/lib/apt/lists/*
 test -x /usr/lib/git-core/git-http-backend
 `}).
-		WithDirectory("/var/www", dir).
-		WithNewFile("/var/empty/git-http-backend.cgi", `#!/bin/sh
-set -eu
-exec /usr/lib/git-core/git-http-backend
-`).
-		WithExec([]string{"chmod", "+x", "/var/empty/git-http-backend.cgi"}).
-		WithNewFile("/etc/lighttpd/lighttpd.conf", conf).
-		WithExposedPort(80).
-		WithEnvVariable("CACHE_BUSTER", time.Now().Format(time.RFC3339Nano))
+		WithNewFile("/etc/nginx/conf.d/default.conf", config.String()).
+		WithMountedDirectory("/var/www", dir).
+		WithEnvVariable("CACHE_BUSTER", fmt.Sprintf("%s-%d", username, time.Now().UnixNano()))
 
 	if token != nil {
 		ctr = ctr.WithMountedSecret(
-			"/etc/lighttpd/.htpasswd",
-			c.SetSecret("htpasswd-"+identity.NewID(), username+":"+tokenPlain),
-			dagger.ContainerWithMountedSecretOpts{
-				Owner: "www-data",
-			},
+			"/usr/share/nginx/htpasswd",
+			c.SetSecret("htpasswd-"+identity.NewID(), username+":{PLAIN}"+tokenPlaintext),
+			dagger.ContainerWithMountedSecretOpts{Owner: "nginx"},
 		)
 	}
 
 	svc := ctr.
-		WithEntrypoint([]string{"lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"}).
+		WithExposedPort(80).
+		WithEntrypoint([]string{"sh", "-lc",
+			"spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap && exec nginx -g 'daemon off;'"}).
 		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 
-	if hostname != "" {
-		svc = svc.WithHostname(hostname)
-	} else {
+	if hostname == "" {
 		var err error
 		hostname, err = svc.Hostname(ctx)
 		require.NoError(t, err)
+	} else {
+		svc = svc.WithHostname(hostname)
 	}
-
 	return svc, "http://" + hostname
 }
 

--- a/util/gitutil/config_env.go
+++ b/util/gitutil/config_env.go
@@ -37,11 +37,13 @@ func MergeGitConfigEnv(env []string, entries map[string]string) []string {
 			continue
 		}
 		if s, ok := strings.CutPrefix(e, keyPrefix); ok {
-			if n, err := strconv.Atoi(strings.SplitN(s, "=", 2)[0]); err == nil && n > maxIdx {
+			head, _, _ := strings.Cut(s, "=")
+			if n, err := strconv.Atoi(head); err == nil && n > maxIdx {
 				maxIdx = n
 			}
 		} else if s, ok := strings.CutPrefix(e, valPrefix); ok {
-			if n, err := strconv.Atoi(strings.SplitN(s, "=", 2)[0]); err == nil && n > maxIdx {
+			head, _, _ := strings.Cut(s, "=")
+			if n, err := strconv.Atoi(head); err == nil && n > maxIdx {
 				maxIdx = n
 			}
 		}

--- a/util/gitutil/config_env.go
+++ b/util/gitutil/config_env.go
@@ -1,0 +1,68 @@
+package gitutil
+
+import (
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// MergeGitConfigEnv appends git config entries to the environment using
+// GIT_CONFIG_COUNT/KEY_i/VALUE_i. It preserves existing env vars (except it
+// drops any prior COUNT lines), appends new pairs in sorted key order for
+// determinism, and writes exactly one final COUNT.
+//
+// It defensively scans both the current COUNT and the highest existing KEY_/VALUE_
+// index, then appends after max(COUNT, maxIndex+1).
+func MergeGitConfigEnv(env []string, entries map[string]string) []string {
+	if len(entries) == 0 {
+		return env
+	}
+
+	const (
+		countPrefix = "GIT_CONFIG_COUNT="
+		keyPrefix   = "GIT_CONFIG_KEY_"
+		valPrefix   = "GIT_CONFIG_VALUE_"
+	)
+
+	maxCount := 0
+	maxIdx := -1
+	out := make([]string, 0, len(env)+len(entries)*2+1)
+
+	for _, e := range env {
+		if s, ok := strings.CutPrefix(e, countPrefix); ok {
+			if n, err := strconv.Atoi(s); err == nil && n > maxCount {
+				maxCount = n
+			}
+			continue
+		}
+		if s, ok := strings.CutPrefix(e, keyPrefix); ok {
+			if n, err := strconv.Atoi(strings.SplitN(s, "=", 2)[0]); err == nil && n > maxIdx {
+				maxIdx = n
+			}
+		} else if s, ok := strings.CutPrefix(e, valPrefix); ok {
+			if n, err := strconv.Atoi(strings.SplitN(s, "=", 2)[0]); err == nil && n > maxIdx {
+				maxIdx = n
+			}
+		}
+		out = append(out, e)
+	}
+
+	next := maxCount
+	if maxIdx+1 > next {
+		next = maxIdx + 1
+	}
+
+	keys := slices.Sorted(maps.Keys(entries))
+	for i, k := range keys {
+		v := entries[k]
+		idx := next + i
+		out = append(out,
+			"GIT_CONFIG_KEY_"+strconv.Itoa(idx)+"="+k,
+			"GIT_CONFIG_VALUE_"+strconv.Itoa(idx)+"="+v,
+		)
+	}
+
+	out = append(out, countPrefix+strconv.Itoa(next+len(keys)))
+	return out
+}

--- a/util/gitutil/config_env_test.go
+++ b/util/gitutil/config_env_test.go
@@ -1,0 +1,64 @@
+package gitutil
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeGitConfigEnv_AppendsAfterMaxIndexOrCount(t *testing.T) {
+	env := []string{
+		"FOO=bar",
+		"GIT_CONFIG_KEY_7=core.abbrev",
+		"GIT_CONFIG_VALUE_7=12",
+		"GIT_CONFIG_COUNT=5",
+		"OTHER=keepme",
+	}
+	add := map[string]string{
+		"http.https://host/.extraheader": "Authorization: basic abc",
+		"core.autocrlf":                  "false",
+	}
+	got := MergeGitConfigEnv(env, add)
+
+	idx := map[string]int{}
+	for _, e := range got {
+		if strings.HasPrefix(e, "GIT_CONFIG_KEY_") {
+			parts := strings.SplitN(e, "=", 2)
+			n, _ := strconv.Atoi(strings.TrimPrefix(parts[0], "GIT_CONFIG_KEY_"))
+			idx[parts[1]] = n
+		}
+	}
+
+	require.Contains(t, idx, "http.https://host/.extraheader")
+	require.Contains(t, idx, "core.autocrlf")
+
+	gotIdx := []int{idx["http.https://host/.extraheader"], idx["core.autocrlf"]}
+	sort.Ints(gotIdx)
+	require.Equal(t, []int{8, 9}, gotIdx)
+
+	require.Equal(t, "GIT_CONFIG_COUNT=10", got[len(got)-1])
+}
+
+func TestMergeGitConfigEnv_DeterministicOrder(t *testing.T) {
+	env := []string{}
+	add := map[string]string{
+		"b.key": "2",
+		"a.key": "1",
+	}
+	got := MergeGitConfigEnv(env, add)
+	idxA, idxB := -1, -1
+	for _, e := range got {
+		if strings.HasPrefix(e, "GIT_CONFIG_KEY_") && strings.HasSuffix(e, "=a.key") {
+			idxA, _ = strconv.Atoi(strings.TrimPrefix(strings.SplitN(e, "=", 2)[0], "GIT_CONFIG_KEY_"))
+		}
+		if strings.HasPrefix(e, "GIT_CONFIG_KEY_") && strings.HasSuffix(e, "=b.key") {
+			idxB, _ = strconv.Atoi(strings.TrimPrefix(strings.SplitN(e, "=", 2)[0], "GIT_CONFIG_KEY_"))
+		}
+	}
+	require.NotEqual(t, -1, idxA)
+	require.NotEqual(t, -1, idxB)
+	require.Less(t, idxA, idxB, "keys must be appended in sorted order (a before b)")
+}


### PR DESCRIPTION
Fixes https://discord.com/channels/707636530424053791/1397694731496067194/1397694731496067194

Previously, HTTP(S) authentication worked only for the parent repository clone. Submodule clones failed because the auth header (http.<scheme>://<host>/.extraheader) passed via CLI args (-c) wasn’t inherited by nested Git processes (git submodule update). By injecting the header through the GIT_CONFIG_* environment variables instead, the auth configuration propagates to submodules automatically, fixing the inheritance issue and ensuring consistent authentication.

### Update 2025-08-12

Since opening this PR, I’ve made a few adjustments:
- Implemented shallow fetch fallback:
> Now we always attempt git submodule update with --depth=1 first. If the server doesn’t support shallow clones (fatal: dumb http transport does not support shallow capabilities), we retry without the --depth argument. This preserves performance benefits where supported while ensuring compatibility.
- Added smart-HTTP test helper:
> Extracted the previously inline smart-HTTP setup into a reusable helper (gitSmartHTTPServiceDirAuth). This simplifies writing tests involving authenticated smart-HTTP git clones, which are necessary to properly support shallow fetches.
- Extended submodule auth tests:
> Expanded TestSubmoduleAuth to verify behavior for both smart and dumb HTTP protocols using the same repository setup. This clearly demonstrates the new fallback mechanism works correctly in both cases.
- Reduced PR scope:
> Removed unrelated refactors and kept the changes tightly focused on submodule auth and shallow-fetch behavior.