### PR TITLE
fix: update Go version to match Alpine 3.22 package

### DIFF
--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -27,7 +27,7 @@ const (
 	AlpineVersion = "3.22.0"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.24.4"
+	GolangVersion = "1.24.6"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.24.4"
+	// +default="1.24.6"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
Alpine Linux 3.22 updated their Go package from 1.24.4 to 1.24.6-r0 on 2025-08-08. This change updates the Go version constant to match the available package, fixing the build error when building the dev version of the engine:

```shell
  go-1.24.6-r0.apk disqualified because "1.24.6-r0" does not
  satisfy "go~1.24.4"
```

The constraint "go~1.24.4" specifically requires version 1.24.4.x, but Alpine no longer provides this version: https://pkgs.alpinelinux.org/package/v3.22/community/x86_64/go