### PR TITLE
feat(sdk/elixir): change the Elixir image

### DIFF
--- a/sdk/elixir/dev/lib/elixir_sdk_dev.ex
+++ b/sdk/elixir/dev/lib/elixir_sdk_dev.ex
@@ -5,7 +5,7 @@ defmodule ElixirSdkDev do
 
   use Dagger.Mod.Object, name: "ElixirSdkDev"
 
-  @base_image "hexpm/elixir:1.18.3-erlang-27.3.3-alpine-3.21.3@sha256:854a84827d9758fcc6a6d7b1b233974c052d767c9929af31ef4b089320caae92"
+  @base_image "elixir:1.18.4-otp-28-alpine@sha256:35777d29cf6c00c66b2c4ae135bf187dd9e3d5d4b75d0922b75e073732a1613a"
 
   object do
     field :source, Dagger.Directory.t()

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -18,7 +18,7 @@ const (
 	sdkSrc           = "/sdk"
 	genDir           = "dagger_sdk"
 	schemaPath       = "/schema.json"
-	elixirImage      = "hexpm/elixir:1.18.3-erlang-27.3.3-alpine-3.21.3@sha256:854a84827d9758fcc6a6d7b1b233974c052d767c9929af31ef4b089320caae92"
+	elixirImage      = "elixir:1.18.4-otp-28-alpine@sha256:35777d29cf6c00c66b2c4ae135bf187dd9e3d5d4b75d0922b75e073732a1613a"
 )
 
 //go:embed template/mix.exs


### PR DESCRIPTION
* Change the Elixir image from `hexpm/elixir` to `elixir` which's maintained by Erlang Ecosystem Foundation Team (https://github.com/erlef/docker-elixir).
* Bump the Erlang OTP to 28