### PR TITLE
Improved TUI debugging

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -132,6 +132,8 @@ func withEngine(
 		}
 		cleanup.Add("close dagger session", sess.Close)
 
+		Frontend.SetClient(sess.Dagger())
+
 		return cleanup.Run, fn(ctx, sess)
 	})
 }

--- a/core/services.go
+++ b/core/services.go
@@ -63,8 +63,12 @@ type RunningService struct {
 	// have detached, but may also be called manually by the user.
 	Stop func(ctx context.Context, force bool) error
 
-	// Block until the service has exited or the provided context is canceled.
+	// Wait blocks until the service has exited or the provided context is canceled.
 	Wait func(ctx context.Context) error
+
+	// Exec runs a command in the service. It is only supported for services
+	// with a backing container.
+	Exec func(ctx context.Context, cmd []string, env []string, io *ServiceIO) error
 }
 
 // ServiceKey is a unique identifier for a service.
@@ -126,7 +130,6 @@ type Startable interface {
 	Start(
 		ctx context.Context,
 		id *call.ID,
-		interactive bool,
 		io *ServiceIO,
 	) (*RunningService, error)
 }
@@ -178,7 +181,7 @@ dance:
 
 	svcCtx, stop := context.WithCancelCause(context.WithoutCancel(ctx))
 
-	running, err := svc.Start(svcCtx, id, false, nil)
+	running, err := svc.Start(svcCtx, id, nil)
 	if err != nil {
 		stop(err)
 		ss.l.Lock()

--- a/core/services_test.go
+++ b/core/services_test.go
@@ -303,7 +303,7 @@ func (f *fakeStartable) ID() *call.ID {
 	return id
 }
 
-func (f *fakeStartable) Start(context.Context, *call.ID, bool, *core.ServiceIO) (*core.RunningService, error) {
+func (f *fakeStartable) Start(context.Context, *call.ID, *core.ServiceIO) (*core.RunningService, error) {
 	atomic.AddInt32(&f.starts, 1)
 	res := <-f.startResults
 	return res.Started, res.Failed

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -20,8 +20,12 @@ const (
 	defaultTerminalImage = distconsts.AlpineImage
 )
 
-type TerminalArgs struct {
+type ExecTerminalArgs struct {
 	Cmd []string `default:"[]"`
+}
+
+type TerminalArgs struct {
+	ExecTerminalArgs
 
 	// Provide dagger access to the executed command
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
@@ -61,51 +65,12 @@ func (container *Container) terminal(
 		return fmt.Errorf("failed to evaluate container: %w", err)
 	}
 
-	query, err := CurrentQuery(ctx)
+	term, output, err := prepTerminal(ctx, svcID, richErr)
 	if err != nil {
-		return fmt.Errorf("failed to get current query: %w", err)
+		return err
 	}
-	bk, err := query.Buildkit(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get buildkit client: %w", err)
-	}
-
-	term, err := bk.OpenTerminal(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to open terminal: %w", err)
-	}
-	// always close term; it's wrapped in a once so it won't be called multiple times
-	defer term.Close(bkgwpb.UnknownExitStatus)
-
-	output := idtui.NewOutput(term.Stderr)
-	if richErr == nil {
-		fmt.Fprint(
-			term.Stderr,
-			output.String(idtui.DotFilled).Foreground(termenv.ANSIYellow).String()+" Attaching terminal: ",
-		)
-	} else {
-		fmt.Fprint(
-			term.Stderr,
-			output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal: ",
-		)
-	}
-	dump := idtui.Dump{Newline: "\r\n", Prefix: "    "}
-	fmt.Fprint(term.Stderr, dump.Newline)
-	if err := dump.DumpID(output, svcID); err != nil {
-		return fmt.Errorf("failed to serialize service ID: %w", err)
-	}
-	fmt.Fprint(term.Stderr, dump.Newline)
-	if richErr != nil {
-		fmt.Fprintf(term.Stderr,
-			output.String("! %s").Foreground(termenv.ANSIYellow).String(), richErr.Error())
-		fmt.Fprint(term.Stderr, dump.Newline)
-	}
-
-	// Inject a custom shell prompt `dagger:<cwd>$`
-	container.Config.Env = append(container.Config.Env, fmt.Sprintf("PS1=%s %s $ ",
-		output.String("dagger").Foreground(termenv.ANSIYellow).String(),
-		output.String(`$(pwd | sed "s|^$HOME|~|")`).Faint().String(),
-	))
+	defer term.Close(bkgwpb.UnknownExitStatus) // always close term; it's wrapped in a once so it won't be called multiple times
+	container.Config.Env = prepTerminalEnv(output, container.Config.Env)
 
 	var svc *Service
 	if richErr == nil {
@@ -125,12 +90,12 @@ func (container *Container) terminal(
 	runningSvc, err := svc.Start(
 		ctx,
 		svcID,
-		true,
 		&ServiceIO{
-			Stdin:    term.Stdin,
-			Stdout:   term.Stdout,
-			Stderr:   term.Stderr,
-			ResizeCh: term.ResizeCh,
+			Stdin:       term.Stdin,
+			Stdout:      term.Stdout,
+			Stderr:      term.Stderr,
+			ResizeCh:    term.ResizeCh,
+			Interactive: true,
 		},
 	)
 	if err != nil {
@@ -193,4 +158,95 @@ func (dir *Directory) Terminal(
 		return fmt.Errorf("failed to create terminal container: %w", err)
 	}
 	return ctr.Terminal(ctx, svcID, args)
+}
+
+func (*Service) Terminal(
+	ctx context.Context,
+	svc dagql.ObjectResult[*Service],
+	args *ExecTerminalArgs,
+) error {
+	term, output, err := prepTerminal(ctx, svc.ID(), nil)
+	if err != nil {
+		return err
+	}
+	defer term.Close(bkgwpb.UnknownExitStatus) // always close term; it's wrapped in a once so it won't be called multiple times
+
+	env := prepTerminalEnv(output, nil)
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	svcs, err := query.Services(ctx)
+	if err != nil {
+		return err
+	}
+	detach, runnings, err := svcs.StartBindings(ctx, ServiceBindings{{Service: svc}})
+	if err != nil {
+		return err
+	}
+	defer detach()
+
+	running := runnings[0]
+	if running.Exec == nil {
+		return fmt.Errorf("service %s does not support terminal", svc.ID().Digest())
+	}
+	return running.Exec(ctx, args.Cmd, env, &ServiceIO{
+		Stdin:       term.Stdin,
+		Stdout:      term.Stdout,
+		Stderr:      term.Stderr,
+		ResizeCh:    term.ResizeCh,
+		Interactive: true,
+	})
+}
+
+func prepTerminal(ctx context.Context, svcID *call.ID, richErr *buildkit.RichError) (*buildkit.TerminalClient, *termenv.Output, error) {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get current query: %w", err)
+	}
+	bk, err := query.Buildkit(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+
+	term, err := bk.OpenTerminal(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open terminal: %w", err)
+	}
+
+	output := idtui.NewOutput(term.Stderr)
+	if richErr == nil {
+		fmt.Fprint(
+			term.Stderr,
+			output.String(idtui.DotFilled).Foreground(termenv.ANSIYellow).String()+" Attaching terminal: ",
+		)
+	} else {
+		fmt.Fprint(
+			term.Stderr,
+			output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal: ",
+		)
+	}
+	dump := idtui.Dump{Newline: "\r\n", Prefix: "    "}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	if err := dump.DumpID(output, svcID); err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize service ID: %w", err)
+	}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	if richErr != nil {
+		fmt.Fprintf(term.Stderr,
+			output.String("! %s").Foreground(termenv.ANSIYellow).String(), richErr.Error())
+		fmt.Fprint(term.Stderr, dump.Newline)
+	}
+
+	return term, output, nil
+}
+
+// prepTerminalEnv creates a custom shell prompt `dagger:<cwd>$`
+func prepTerminalEnv(output *termenv.Output, env []string) []string {
+	env = append(env, fmt.Sprintf("PS1=%s %s $ ",
+		output.String("dagger").Foreground(termenv.ANSIYellow).String(),
+		output.String(`$(pwd | sed "s|^$HOME|~|")`).Faint().String(),
+	))
+	return env
 }

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -372,6 +372,16 @@ func (id *ID) ToProto() (*callpbv1.DAG, error) {
 	return dagPB, nil
 }
 
+func (id *ID) FromProto(dagPB *callpbv1.DAG) error {
+	if id == nil {
+		return fmt.Errorf("cannot decode into nil ID")
+	}
+	if err := id.decode(dagPB.RootDigest, dagPB.CallsByDigest, map[string]*ID{}); err != nil {
+		return fmt.Errorf("failed to decode DAG: %w", err)
+	}
+	return nil
+}
+
 func (id *ID) gatherCalls(callsByDigest map[string]*callpbv1.Call) {
 	if id == nil {
 		return

--- a/dagql/dagui/extract.go
+++ b/dagql/dagui/extract.go
@@ -1,0 +1,54 @@
+package dagui
+
+import "github.com/dagger/dagger/dagql/call/callpbv1"
+
+// extractIntoDAG recursively populates dag.CallsByDigest from the call and its dependencies.
+func extractIntoDAG(dag *callpbv1.DAG, db *DB, call *callpbv1.Call) {
+	if _, exists := dag.CallsByDigest[call.Digest]; exists {
+		return
+	}
+	dag.CallsByDigest[call.Digest] = call
+	if call.ReceiverDigest != "" {
+		if recv := db.Call(call.ReceiverDigest); recv != nil {
+			extractIntoDAG(dag, db, recv)
+		}
+	}
+	for _, arg := range call.Args {
+		if arg.Value != nil {
+			extractLitIntoDAG(dag, db, arg.Value)
+		}
+	}
+	if call.Module != nil && call.Module.CallDigest != "" {
+		if mod := db.Call(call.Module.CallDigest); mod != nil {
+			extractIntoDAG(dag, db, mod)
+		}
+	}
+}
+
+// extractLitIntoDAG recursively extracts calls from literals.
+func extractLitIntoDAG(dag *callpbv1.DAG, db *DB, lit *callpbv1.Literal) {
+	switch v := lit.Value.(type) {
+	case *callpbv1.Literal_CallDigest:
+		if v.CallDigest != "" {
+			if call := db.Call(v.CallDigest); call != nil {
+				extractIntoDAG(dag, db, call)
+			}
+		}
+	case *callpbv1.Literal_List:
+		if v.List != nil {
+			for _, val := range v.List.Values {
+				extractLitIntoDAG(dag, db, val)
+			}
+		}
+	case *callpbv1.Literal_Object:
+		if v.Object != nil {
+			for _, val := range v.Object.Values {
+				if val.Value != nil {
+					extractLitIntoDAG(dag, db, val.Value)
+				}
+			}
+		}
+	default:
+		// Other literal types do not reference calls, so ignore.
+	}
+}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -22,6 +22,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/term"
 
+	"dagger.io/dagger"
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
@@ -86,6 +87,10 @@ type Frontend interface {
 
 	// SetCloudURL is called after the CLI checks auth and sets the cloud URL.
 	SetCloudURL(ctx context.Context, url string, msg string, logged bool)
+
+	// SetClient is called to notify the frontend of a created dagger client.
+	// This can be used to make requests to the engine for more information.
+	SetClient(*dagger.Client)
 
 	// Shell is called when the CLI enters interactive mode.
 	Shell(ctx context.Context, handler ShellHandler)

--- a/dagql/idtui/frontend_dots.go
+++ b/dagql/idtui/frontend_dots.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"dagger.io/dagger"
 	"dagger.io/dagger/telemetry"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dagger/dagger/dagql/dagui"
@@ -68,6 +69,9 @@ func NewDots(output io.Writer) Frontend {
 		prefixW:     multiprefixw.New(out),
 		pendingLogs: make(map[dagui.SpanID][]sdklog.Record),
 	}
+}
+
+func (fe *frontendDots) SetClient(client *dagger.Client) {
 }
 
 func (fe *frontendDots) Run(ctx context.Context, opts dagui.FrontendOpts, f func(context.Context) (cleanups.CleanupF, error)) error {

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"dagger.io/dagger"
 	"dagger.io/dagger/telemetry"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
@@ -145,6 +146,9 @@ func (fe *frontendPlain) SetCloudURL(ctx context.Context, url string, msg string
 			fe.msgPreFinalRender.WriteString(fmt.Sprintf(loggedOutTraceMsg, url))
 		}
 	}
+}
+
+func (fe *frontendPlain) SetClient(client *dagger.Client) {
 }
 
 // addVirtualLog attaches a fake log row to a given span

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3968,6 +3968,11 @@ type Service {
     kill: Boolean = false
   ): ServiceID!
 
+  """Forces evaluation of the pipeline in the engine."""
+  sync: ServiceID!
+
+  terminal(cmd: [String!] = []): Service!
+
   """
   Creates a tunnel that forwards traffic from the caller's network to this service.
   """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -11303,6 +11303,27 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Service-sync" href="#Service-sync"><code>sync</code></a> - <span class="property-type"><a href="#definition-ServiceID"><code>ServiceID!</code></a></span> </td>
+                        <td> Forces evaluation of the pipeline in the engine. </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Service-terminal" href="#Service-terminal"><code>terminal</code></a> - <span class="property-type"><a href="#definition-Service"><code>Service!</code></a></span> </td>
+                        <td>
+                        </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>cmd</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Service-up" href="#Service-up"><code>up</code></a> - <span class="property-type"><a href="#definition-Void"><code>Void</code></a></span> </td>
                         <td> Creates a tunnel that forwards traffic from the caller's network to this service. </td>

--- a/docs/static/reference/php/Dagger/Service.html
+++ b/docs/static/reference/php/Dagger/Service.html
@@ -203,6 +203,27 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_sync">sync</a>()
+        
+                                            <p><p>Forces evaluation of the pipeline in the engine.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_terminal">terminal</a>(array|null $cmd = null)
+        
+                                            <p class="no-description">No description</p>
+                                    </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     void
                 </div>
                 <div class="col-md-8">
@@ -535,8 +556,83 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_up">
+                    <h3 id="method_sync">
         <div class="location">at line 88</div>
+        <code>                    <a href="../Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a>
+    <strong>sync</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Forces evaluation of the pipeline in the engine.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_terminal">
+        <div class="location">at line 94</div>
+        <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
+    <strong>terminal</strong>(array|null $cmd = null)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p class="no-description">No description</p>
+                    
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>array|null</td>
+                <td>$cmd</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_up">
+        <div class="location">at line 106</div>
         <code>                    void
     <strong>up</strong>(array|null $ports = null, bool|null $random = false)
         </code>
@@ -583,7 +679,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withHostname">
-        <div class="location">at line 103</div>
+        <div class="location">at line 121</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>withHostname</strong>(string $hostname)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -991,7 +991,9 @@
 <abbr title="Dagger\Service">Service</abbr>::start</a>() &mdash; <em>Method in class <a href="Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></em></dt>
                     <dd><p>Start the service and wait for its health checks to succeed.</p></dd><dt><a href="Dagger/Service.html#method_stop">
 <abbr title="Dagger\Service">Service</abbr>::stop</a>() &mdash; <em>Method in class <a href="Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></em></dt>
-                    <dd><p>Stop the service.</p></dd><dt><a href="Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
+                    <dd><p>Stop the service.</p></dd><dt><a href="Dagger/Service.html#method_sync">
+<abbr title="Dagger\Service">Service</abbr>::sync</a>() &mdash; <em>Method in class <a href="Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></em></dt>
+                    <dd><p>Forces evaluation of the pipeline in the engine.</p></dd><dt><a href="Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>ServiceID</code> scalar type represents an identifier for an object of type Service.</p></dd><dt><a href="Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>A Unix or TCP/IP socket that can be mounted into a container.</p></dd><dt><a href="Dagger/SocketId.html"><abbr title="Dagger\SocketId">SocketId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>SocketID</code> scalar type represents an identifier for an object of type Socket.</p></dd><dt><a href="Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
@@ -1029,6 +1031,8 @@
 <abbr title="Dagger\LLM">LLM</abbr>::tools</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
                     <dd><p>print documentation for available tools</p></dd><dt><a href="Dagger/LLMTokenUsage.html#method_totalTokens">
 <abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr>::totalTokens</a>() &mdash; <em>Method in class <a href="Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a></em></dt>
+                    <dd></dd><dt><a href="Dagger/Service.html#method_terminal">
+<abbr title="Dagger\Service">Service</abbr>::terminal</a>() &mdash; <em>Method in class <a href="Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></em></dt>
                     <dd></dd><dt><a href="Dagger/Terminal.html"><abbr title="Dagger\Terminal">Terminal</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>An interactive terminal that clients can connect to.</p></dd><dt><a href="Dagger/TerminalId.html"><abbr title="Dagger\TerminalId">TerminalId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>TerminalID</code> scalar type represents an identifier for an object of type Terminal.</p></dd><dt><a href="Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -4329,6 +4329,18 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Service::sync",
+			"p": "Dagger/Service.html#method_sync",
+			"d": "<p>Forces evaluation of the pipeline in the engine.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Service::terminal",
+			"p": "Dagger/Service.html#method_terminal",
+			"d": null
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Service::up",
 			"p": "Dagger/Service.html#method_up",
 			"d": "<p>Creates a tunnel that forwards traffic from the caller's network to this service.</p>"

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -9857,6 +9857,7 @@ type Service struct {
 	id       *ServiceID
 	start    *ServiceID
 	stop     *ServiceID
+	sync     *ServiceID
 	up       *Void
 }
 type WithServiceFunc func(r *Service) *Service
@@ -10033,6 +10034,38 @@ func (r *Service) Stop(ctx context.Context, opts ...ServiceStopOpts) (*Service, 
 	return &Service{
 		query: q.Root().Select("loadServiceFromID").Arg("id", id),
 	}, nil
+}
+
+// Forces evaluation of the pipeline in the engine.
+func (r *Service) Sync(ctx context.Context) (*Service, error) {
+	q := r.query.Select("sync")
+
+	var id ServiceID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Service{
+		query: q.Root().Select("loadServiceFromID").Arg("id", id),
+	}, nil
+}
+
+// ServiceTerminalOpts contains options for Service.Terminal
+type ServiceTerminalOpts struct {
+	Cmd []string
+}
+
+func (r *Service) Terminal(opts ...ServiceTerminalOpts) *Service {
+	q := r.query.Select("terminal")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `cmd` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Cmd) {
+			q = q.Arg("cmd", opts[i].Cmd)
+		}
+	}
+
+	return &Service{
+		query: q,
+	}
 }
 
 // ServiceUpOpts contains options for Service.Up

--- a/sdk/php/generated/Service.php
+++ b/sdk/php/generated/Service.php
@@ -83,6 +83,24 @@ class Service extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Forces evaluation of the pipeline in the engine.
+     */
+    public function sync(): ServiceId
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
+        return new \Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+    }
+
+    public function terminal(?array $cmd = null): Service
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
+        if (null !== $cmd) {
+        $innerQueryBuilder->setArgument('cmd', $cmd);
+        }
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Creates a tunnel that forwards traffic from the caller's network to this service.
      */
     public function up(?array $ports = null, ?bool $random = false): void

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -10031,6 +10031,29 @@ class Service(Type):
         ]
         return await self._ctx.execute_sync(self, "stop", _args)
 
+    async def sync(self) -> Self:
+        """Forces evaluation of the pipeline in the engine.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        return await self._ctx.execute_sync(self, "sync", _args)
+
+    def __await__(self):
+        return self.sync().__await__()
+
+    def terminal(self, *, cmd: list[str] | None = None) -> Self:
+        _args = [
+            Arg("cmd", [] if cmd is None else cmd, []),
+        ]
+        _ctx = self._select("terminal", _args)
+        return Service(_ctx)
+
     async def up(
         self,
         *,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -10298,6 +10298,11 @@ pub struct ServiceStopOpts {
     pub kill: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ServiceTerminalOpts<'a> {
+    #[builder(setter(into, strip_option), default)]
+    pub cmd: Option<Vec<&'a str>>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ServiceUpOpts {
     /// List of frontend/backend port mappings to forward.
     /// Frontend is the port accepting traffic on the host, backend is the service port.
@@ -10384,6 +10389,38 @@ impl Service {
             query = query.arg("kill", kill);
         }
         query.execute(self.graphql_client.clone()).await
+    }
+    /// Forces evaluation of the pipeline in the engine.
+    pub async fn sync(&self) -> Result<ServiceId, DaggerError> {
+        let query = self.selection.select("sync");
+        query.execute(self.graphql_client.clone()).await
+    }
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn terminal(&self) -> Service {
+        let query = self.selection.select("terminal");
+        Service {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn terminal_opts<'a>(&self, opts: ServiceTerminalOpts<'a>) -> Service {
+        let mut query = self.selection.select("terminal");
+        if let Some(cmd) = opts.cmd {
+            query = query.arg("cmd", cmd);
+        }
+        Service {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
     }
     /// Creates a tunnel that forwards traffic from the caller's network to this service.
     ///

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1696,6 +1696,10 @@ export type ServiceStopOpts = {
   kill?: boolean
 }
 
+export type ServiceTerminalOpts = {
+  cmd?: string[]
+}
+
 export type ServiceUpOpts = {
   /**
    * List of frontend/backend port mappings to forward.
@@ -9563,6 +9567,7 @@ export class Service extends BaseClient {
   private readonly _hostname?: string = undefined
   private readonly _start?: ServiceID = undefined
   private readonly _stop?: ServiceID = undefined
+  private readonly _sync?: ServiceID = undefined
   private readonly _up?: Void = undefined
 
   /**
@@ -9575,6 +9580,7 @@ export class Service extends BaseClient {
     _hostname?: string,
     _start?: ServiceID,
     _stop?: ServiceID,
+    _sync?: ServiceID,
     _up?: Void,
   ) {
     super(ctx)
@@ -9584,6 +9590,7 @@ export class Service extends BaseClient {
     this._hostname = _hostname
     this._start = _start
     this._stop = _stop
+    this._sync = _sync
     this._up = _up
   }
 
@@ -9676,6 +9683,21 @@ export class Service extends BaseClient {
     const response: Awaited<ServiceID> = await ctx.execute()
 
     return new Client(ctx.copy()).loadServiceFromID(response)
+  }
+
+  /**
+   * Forces evaluation of the pipeline in the engine.
+   */
+  sync = async (): Promise<Service> => {
+    const ctx = this._ctx.select("sync")
+
+    const response: Awaited<ServiceID> = await ctx.execute()
+
+    return new Client(ctx.copy()).loadServiceFromID(response)
+  }
+  terminal = (opts?: ServiceTerminalOpts): Service => {
+    const ctx = this._ctx.select("terminal", { ...opts })
+    return new Service(ctx)
   }
 
   /**


### PR DESCRIPTION
This PR adds improved TUI debugging, by allowing a new `T` hotkey to open a terminal on a span.

[![asciicast](https://asciinema.org/a/jhVkugQYzGpLM6rzjmoMvPLTM.svg)](https://asciinema.org/a/jhVkugQYzGpLM6rzjmoMvPLTM)

This is supported for existing terminal functions on `Container` and `Directory`, as well as on `Service`, where `Service.terminal` has now been added as well!

Related:
- https://github.com/dagger/dagger/issues/10923