### PR TITLE
Source map improvements

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -52,6 +52,10 @@ func (funcs goTemplateFuncs) HasLocalDependencies() bool {
 }
 
 func (funcs goTemplateFuncs) moduleRelPath(path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+
 	moduleParentPath := ""
 	if funcs.cfg.ModuleConfig != nil {
 		moduleParentPath = funcs.cfg.ModuleConfig.ModuleParentPath

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -370,6 +370,10 @@ func (funcs typescriptTemplateFuncs) toSingleType(value string) string {
 }
 
 func (funcs typescriptTemplateFuncs) moduleRelPath(path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+
 	moduleParentPath := ""
 	if funcs.cfg.ModuleConfig != nil {
 		moduleParentPath = funcs.cfg.ModuleConfig.ModuleParentPath

--- a/core/enum.go
+++ b/core/enum.go
@@ -150,8 +150,8 @@ func (e *ModuleEnum) TypeDefinition(view dagql.View) *ast.Definition {
 		EnumValues:  e.PossibleValues(),
 		Description: e.TypeDescription(),
 	}
-	if e.TypeDef.SourceMap != nil {
-		def.Directives = append(def.Directives, e.TypeDef.SourceMap.TypeDirective())
+	if e.TypeDef.SourceMap.Valid {
+		def.Directives = append(def.Directives, e.TypeDef.SourceMap.Value.TypeDirective())
 	}
 	return def
 }
@@ -168,8 +168,8 @@ func (e *ModuleEnum) PossibleValues() ast.EnumValueList {
 			Description: val.Description,
 			Directives:  val.EnumValueDirectives(),
 		}
-		if val.SourceMap != nil {
-			def.Directives = append(def.Directives, val.SourceMap.TypeDirective())
+		if val.SourceMap.Valid {
+			def.Directives = append(def.Directives, val.SourceMap.Value.TypeDirective())
 		}
 		values = append(values, def)
 	}

--- a/core/interface.go
+++ b/core/interface.go
@@ -233,8 +233,8 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 			Type:        fnTypeDef.ReturnType.ToTyped(),
 			Module:      iface.mod.IDModule(),
 		}
-		if fnTypeDef.SourceMap != nil {
-			fieldDef.Directives = append(fieldDef.Directives, fnTypeDef.SourceMap.TypeDirective())
+		if fnTypeDef.SourceMap.Valid {
+			fieldDef.Directives = append(fieldDef.Directives, fnTypeDef.SourceMap.Value.TypeDirective())
 		}
 
 		for _, argMetadata := range fnTypeDef.Args {
@@ -264,8 +264,8 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 				Description: formatGqlDescription(argMetadata.Description),
 				Type:        argMetadata.TypeDef.ToInput(),
 			}
-			if argMetadata.SourceMap != nil {
-				inputSpec.Directives = append(inputSpec.Directives, argMetadata.SourceMap.TypeDirective())
+			if argMetadata.SourceMap.Valid {
+				inputSpec.Directives = append(inputSpec.Directives, argMetadata.SourceMap.Value.TypeDirective())
 			}
 			fieldDef.Args.Add(inputSpec)
 		}
@@ -491,8 +491,8 @@ func (iface *InterfaceAnnotatedValue) TypeDefinition(view dagql.View) *ast.Defin
 		Kind: ast.Object,
 		Name: iface.Type().Name(),
 	}
-	if iface.TypeDef.SourceMap != nil {
-		def.Directives = append(def.Directives, iface.TypeDef.SourceMap.TypeDirective())
+	if iface.TypeDef.SourceMap.Valid {
+		def.Directives = append(def.Directives, iface.TypeDef.SourceMap.Value.TypeDirective())
 	}
 	return def
 }

--- a/core/module.go
+++ b/core/module.go
@@ -599,9 +599,9 @@ func (mod *Module) namespaceTypeDef(ctx context.Context, modPath string, typeDef
 	return nil
 }
 
-func (mod *Module) namespaceSourceMap(modPath string, sourceMap *SourceMap) *SourceMap {
-	if sourceMap == nil {
-		return nil
+func (mod *Module) namespaceSourceMap(modPath string, sourceMap dagql.Nullable[*SourceMap]) dagql.Nullable[*SourceMap] {
+	if !sourceMap.Valid {
+		return sourceMap
 	}
 
 	if mod.Source.Value.Self().Kind != ModuleSourceKindLocal {
@@ -609,8 +609,8 @@ func (mod *Module) namespaceSourceMap(modPath string, sourceMap *SourceMap) *Sou
 		return nil
 	}
 
-	sourceMap.Module = mod.Name()
-	sourceMap.Filename = filepath.Join(modPath, sourceMap.Filename)
+	sourceMap.Value.Module = mod.Name()
+	sourceMap.Value.Filename = filepath.Join(modPath, sourceMap.Value.Filename)
 	return sourceMap
 }
 

--- a/core/module.go
+++ b/core/module.go
@@ -604,13 +604,17 @@ func (mod *Module) namespaceSourceMap(modPath string, sourceMap dagql.Nullable[*
 		return sourceMap
 	}
 
-	if mod.Source.Value.Self().Kind != ModuleSourceKindLocal {
-		// TODO: handle remote git files
-		return nil
-	}
-
 	sourceMap.Value.Module = mod.Name()
 	sourceMap.Value.Filename = filepath.Join(modPath, sourceMap.Value.Filename)
+
+	if mod.Source.Value.Self().Kind == ModuleSourceKindGit {
+		link, err := mod.Source.Value.Self().Git.Link(sourceMap.Value.Filename, sourceMap.Value.Line, sourceMap.Value.Column)
+		if err != nil {
+			return dagql.Null[*SourceMap]()
+		}
+		sourceMap.Value.URL = link
+	}
+
 	return sourceMap
 }
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -487,6 +489,30 @@ type GitModuleSource struct {
 
 	// The full git repo for the module source without any include filtering
 	UnfilteredContextDir dagql.ObjectResult[*Directory]
+}
+
+func (src GitModuleSource) Link(filepath string, line int, column int) (string, error) {
+	parsedURL, err := url.Parse(src.HTMLRepoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse git repo URL %q: %w", src.HTMLRepoURL, err)
+	}
+
+	switch parsedURL.Host {
+	case "github.com", "gitlab.com":
+		result := src.HTMLRepoURL + path.Join("/tree", src.Commit, filepath)
+		if line > 0 {
+			result += fmt.Sprintf("#L%d", line)
+		}
+		return result, nil
+	case "dev.azure.com":
+		result := src.HTMLRepoURL + path.Join("/commit", src.Commit)
+		if filepath != "." {
+			result += "?path=/" + filepath
+		}
+		return result, nil
+	default:
+		return src.HTMLRepoURL + path.Join("/src", src.Commit, filepath), nil
+	}
 }
 
 func (src GitModuleSource) Clone() *GitModuleSource {

--- a/core/object.go
+++ b/core/object.go
@@ -288,8 +288,8 @@ func (obj *ModuleObject) TypeDefinition(view dagql.View) *ast.Definition {
 		Kind: ast.Object,
 		Name: obj.Type().Name(),
 	}
-	if obj.TypeDef.SourceMap != nil {
-		def.Directives = append(def.Directives, obj.TypeDef.SourceMap.TypeDirective())
+	if obj.TypeDef.SourceMap.Valid {
+		def.Directives = append(def.Directives, obj.TypeDef.SourceMap.Value.TypeDirective())
 	}
 	return def
 }
@@ -336,8 +336,8 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 			Module: obj.Module.IDModule(),
 		}
 
-		if objDef.SourceMap != nil {
-			spec.Directives = append(spec.Directives, objDef.SourceMap.TypeDirective())
+		if objDef.SourceMap.Valid {
+			spec.Directives = append(spec.Directives, objDef.SourceMap.Value.TypeDirective())
 		}
 
 		dag.Root().ObjectType().Extend(
@@ -432,8 +432,8 @@ func objField(mod *Module, field *FieldTypeDef) dagql.Field[*ModuleObject] {
 	spec.Directives = append(spec.Directives, &ast.Directive{
 		Name: trivialFieldDirectiveName,
 	})
-	if field.SourceMap != nil {
-		spec.Directives = append(spec.Directives, field.SourceMap.TypeDirective())
+	if field.SourceMap.Valid {
+		spec.Directives = append(spec.Directives, field.SourceMap.Value.TypeDirective())
 	}
 	return dagql.Field[*ModuleObject]{
 		Spec: spec,

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -593,22 +591,9 @@ func (s *moduleSourceSchema) gitModuleSource(
 		gitSrc.Git.Symbolic += "/" + gitSrc.SourceRootSubpath
 	}
 
-	parsedURL, err := url.Parse(gitSrc.Git.HTMLRepoURL)
+	gitSrc.Git.HTMLURL, err = gitSrc.Git.Link(gitSrc.SourceRootSubpath, -1, -1)
 	if err != nil {
-		gitSrc.Git.HTMLURL = gitSrc.Git.HTMLRepoURL + path.Join("/src", gitSrc.Git.Commit, gitSrc.SourceRootSubpath)
-	} else {
-		switch parsedURL.Host {
-		case "github.com", "gitlab.com":
-			gitSrc.Git.HTMLURL = gitSrc.Git.HTMLRepoURL + path.Join("/tree", gitSrc.Git.Commit, gitSrc.SourceRootSubpath)
-		case "dev.azure.com":
-			if gitSrc.SourceRootSubpath != "." {
-				gitSrc.Git.HTMLURL = fmt.Sprintf("%s/commit/%s?path=/%s", gitSrc.Git.HTMLRepoURL, gitSrc.Git.Commit, gitSrc.SourceRootSubpath)
-			} else {
-				gitSrc.Git.HTMLURL = gitSrc.Git.HTMLRepoURL + path.Join("/commit", gitSrc.Git.Commit)
-			}
-		default:
-			gitSrc.Git.HTMLURL = gitSrc.Git.HTMLRepoURL + path.Join("/src", gitSrc.Git.Commit, gitSrc.SourceRootSubpath)
-		}
+		return inst, fmt.Errorf("failed to get git module source HTML URL: %w", err)
 	}
 
 	var configContents string

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -24,7 +24,7 @@ type Function struct {
 	Args        []*FunctionArg `field:"true" doc:"Arguments accepted by the function, if any."`
 	ReturnType  *TypeDef       `field:"true" doc:"The type returned by the function."`
 
-	SourceMap *SourceMap `field:"true" doc:"The location of this function declaration."`
+	SourceMap dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this function declaration."`
 
 	// Below are not in public API
 
@@ -67,8 +67,8 @@ func (fn Function) Clone() *Function {
 	if fn.ReturnType != nil {
 		cp.ReturnType = fn.ReturnType.Clone()
 	}
-	if fn.SourceMap != nil {
-		cp.SourceMap = fn.SourceMap.Clone()
+	if fn.SourceMap.Valid {
+		cp.SourceMap.Value = fn.SourceMap.Value.Clone()
 	}
 	return &cp
 }
@@ -79,8 +79,8 @@ func (fn *Function) FieldSpec(ctx context.Context, mod *Module) (dagql.FieldSpec
 		Description: formatGqlDescription(fn.Description),
 		Type:        fn.ReturnType.ToTyped(),
 	}
-	if fn.SourceMap != nil {
-		spec.Directives = append(spec.Directives, fn.SourceMap.TypeDirective())
+	if fn.SourceMap.Valid {
+		spec.Directives = append(spec.Directives, fn.SourceMap.Value.TypeDirective())
 	}
 	for _, arg := range fn.Args {
 		modType, ok, err := mod.ModTypeFor(ctx, arg.TypeDef, true)
@@ -114,8 +114,8 @@ func (fn *Function) FieldSpec(ctx context.Context, mod *Module) (dagql.FieldSpec
 			Type:        input,
 			Default:     defaultVal,
 		}
-		if arg.SourceMap != nil {
-			argSpec.Directives = append(argSpec.Directives, arg.SourceMap.TypeDirective())
+		if arg.SourceMap.Valid {
+			argSpec.Directives = append(argSpec.Directives, arg.SourceMap.Value.TypeDirective())
 		}
 
 		spec.Args.Add(argSpec)
@@ -131,22 +131,28 @@ func (fn *Function) WithDescription(desc string) *Function {
 
 func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, ignore []string, sourceMap *SourceMap) *Function {
 	fn = fn.Clone()
-	fn.Args = append(fn.Args, &FunctionArg{
+	arg := &FunctionArg{
 		Name:         strcase.ToLowerCamel(name),
 		Description:  desc,
-		SourceMap:    sourceMap,
 		TypeDef:      typeDef,
 		DefaultValue: defaultValue,
 		OriginalName: name,
 		DefaultPath:  defaultPath,
 		Ignore:       ignore,
-	})
+	}
+	if sourceMap != nil {
+		arg.SourceMap = dagql.NonNull(sourceMap)
+	}
+	fn.Args = append(fn.Args, arg)
 	return fn
 }
 
 func (fn *Function) WithSourceMap(sourceMap *SourceMap) *Function {
+	if sourceMap == nil {
+		return fn
+	}
 	fn = fn.Clone()
-	fn.SourceMap = sourceMap
+	fn.SourceMap = dagql.NonNull(sourceMap)
 	return fn
 }
 
@@ -205,13 +211,13 @@ func (fn *Function) LookupArg(name string) (*FunctionArg, bool) {
 
 type FunctionArg struct {
 	// Name is the standardized name of the argument (lowerCamelCase), as used for the resolver in the graphql schema
-	Name         string     `field:"true" doc:"The name of the argument in lowerCamelCase format."`
-	Description  string     `field:"true" doc:"A doc string for the argument, if any."`
-	SourceMap    *SourceMap `field:"true" doc:"The location of this arg declaration."`
-	TypeDef      *TypeDef   `field:"true" doc:"The type of the argument."`
-	DefaultValue JSON       `field:"true" doc:"A default value to use for this argument when not explicitly set by the caller, if any."`
-	DefaultPath  string     `field:"true" doc:"Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"`
-	Ignore       []string   `field:"true" doc:"Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."`
+	Name         string                     `field:"true" doc:"The name of the argument in lowerCamelCase format."`
+	Description  string                     `field:"true" doc:"A doc string for the argument, if any."`
+	SourceMap    dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this arg declaration."`
+	TypeDef      *TypeDef                   `field:"true" doc:"The type of the argument."`
+	DefaultValue JSON                       `field:"true" doc:"A default value to use for this argument when not explicitly set by the caller, if any."`
+	DefaultPath  string                     `field:"true" doc:"Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"`
+	Ignore       []string                   `field:"true" doc:"Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."`
 
 	// Below are not in public API
 
@@ -224,8 +230,8 @@ func (arg FunctionArg) Clone() *FunctionArg {
 	if arg.TypeDef != nil {
 		cp.TypeDef = arg.TypeDef.Clone()
 	}
-	if arg.SourceMap != nil {
-		cp.SourceMap = arg.SourceMap.Clone()
+	if arg.SourceMap.Valid {
+		cp.SourceMap.Value = arg.SourceMap.Value.Clone()
 	}
 	// NB(vito): don't bother copying DefaultValue, it's already 'any' so it's
 	// hard to imagine anything actually mutating it at runtime vs. replacing it
@@ -481,13 +487,17 @@ func (typeDef *TypeDef) WithObjectField(name string, fieldType *TypeDef, desc st
 		return nil, fmt.Errorf("cannot add function to non-object type: %s", typeDef.Kind)
 	}
 	typeDef = typeDef.Clone()
-	typeDef.AsObject.Value.Fields = append(typeDef.AsObject.Value.Fields, &FieldTypeDef{
+
+	field := &FieldTypeDef{
 		Name:         strcase.ToLowerCamel(name),
 		OriginalName: name,
 		Description:  desc,
-		SourceMap:    sourceMap,
 		TypeDef:      fieldType,
-	})
+	}
+	if sourceMap != nil {
+		field.SourceMap = dagql.NonNull(sourceMap)
+	}
+	typeDef.AsObject.Value.Fields = append(typeDef.AsObject.Value.Fields, field)
 	return typeDef, nil
 }
 
@@ -624,12 +634,12 @@ func (typeDef *TypeDef) IsSubtypeOf(otherDef *TypeDef) bool {
 
 type ObjectTypeDef struct {
 	// Name is the standardized name of the object (CamelCase), as used for the object in the graphql schema
-	Name        string                    `field:"true" doc:"The name of the object."`
-	Description string                    `field:"true" doc:"The doc string for the object, if any."`
-	SourceMap   *SourceMap                `field:"true" doc:"The location of this object declaration."`
-	Fields      []*FieldTypeDef           `field:"true" doc:"Static fields defined on this object, if any."`
-	Functions   []*Function               `field:"true" doc:"Functions defined on this object, if any."`
-	Constructor dagql.Nullable[*Function] `field:"true" doc:"The function used to construct new instances of this object, if any"`
+	Name        string                     `field:"true" doc:"The name of the object."`
+	Description string                     `field:"true" doc:"The doc string for the object, if any."`
+	SourceMap   dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this object declaration."`
+	Fields      []*FieldTypeDef            `field:"true" doc:"Static fields defined on this object, if any."`
+	Functions   []*Function                `field:"true" doc:"Functions defined on this object, if any."`
+	Constructor dagql.Nullable[*Function]  `field:"true" doc:"The function used to construct new instances of this object, if any"`
 
 	// SourceModuleName is currently only set when returning the TypeDef from the Objects field on Module
 	SourceModuleName string `field:"true" doc:"If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise."`
@@ -692,16 +702,19 @@ func (obj ObjectTypeDef) Clone() *ObjectTypeDef {
 		cp.Constructor.Value = obj.Constructor.Value.Clone()
 	}
 
-	if cp.SourceMap != nil {
-		cp.SourceMap = cp.SourceMap.Clone()
+	if cp.SourceMap.Valid {
+		cp.SourceMap.Value = cp.SourceMap.Value.Clone()
 	}
 
 	return &cp
 }
 
 func (obj *ObjectTypeDef) WithSourceMap(sourceMap *SourceMap) *ObjectTypeDef {
+	if sourceMap == nil {
+		return obj
+	}
 	obj = obj.Clone()
-	obj.SourceMap = sourceMap
+	obj.SourceMap = dagql.NonNull(sourceMap)
 	return obj
 }
 
@@ -773,7 +786,7 @@ type FieldTypeDef struct {
 	Description string   `field:"true" doc:"A doc string for the field, if any."`
 	TypeDef     *TypeDef `field:"true" doc:"The type of the field."`
 
-	SourceMap *SourceMap `field:"true" doc:"The location of this field declaration."`
+	SourceMap dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this field declaration."`
 
 	// Below are not in public API
 
@@ -802,18 +815,18 @@ func (typeDef FieldTypeDef) Clone() *FieldTypeDef {
 	if typeDef.TypeDef != nil {
 		cp.TypeDef = typeDef.TypeDef.Clone()
 	}
-	if typeDef.SourceMap != nil {
-		cp.SourceMap = typeDef.SourceMap.Clone()
+	if typeDef.SourceMap.Valid {
+		cp.SourceMap.Value = typeDef.SourceMap.Value.Clone()
 	}
 	return &cp
 }
 
 type InterfaceTypeDef struct {
 	// Name is the standardized name of the interface (CamelCase), as used for the interface in the graphql schema
-	Name        string      `field:"true" doc:"The name of the interface."`
-	Description string      `field:"true" doc:"The doc string for the interface, if any."`
-	SourceMap   *SourceMap  `field:"true" doc:"The location of this interface declaration."`
-	Functions   []*Function `field:"true" doc:"Functions defined on this interface, if any."`
+	Name        string                     `field:"true" doc:"The name of the interface."`
+	Description string                     `field:"true" doc:"The doc string for the interface, if any."`
+	SourceMap   dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this interface declaration."`
+	Functions   []*Function                `field:"true" doc:"Functions defined on this interface, if any."`
 	// SourceModuleName is currently only set when returning the TypeDef from the Objects field on Module
 	SourceModuleName string `field:"true" doc:"If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise."`
 
@@ -850,16 +863,19 @@ func (iface InterfaceTypeDef) Clone() *InterfaceTypeDef {
 	for i, fn := range iface.Functions {
 		cp.Functions[i] = fn.Clone()
 	}
-	if cp.SourceMap != nil {
-		cp.SourceMap = cp.SourceMap.Clone()
+	if cp.SourceMap.Valid {
+		cp.SourceMap.Value = cp.SourceMap.Value.Clone()
 	}
 
 	return &cp
 }
 
 func (iface *InterfaceTypeDef) WithSourceMap(sourceMap *SourceMap) *InterfaceTypeDef {
+	if sourceMap == nil {
+		return iface
+	}
 	iface = iface.Clone()
-	iface.SourceMap = sourceMap
+	iface.SourceMap = dagql.NonNull(sourceMap)
 	return iface
 }
 
@@ -989,10 +1005,10 @@ func (typeDef *InputTypeDef) ToInputObjectSpec() dagql.InputObjectSpec {
 
 type EnumTypeDef struct {
 	// Name is the standardized name of the enum (CamelCase), as used for the enum in the graphql schema
-	Name        string               `field:"true" doc:"The name of the enum."`
-	Description string               `field:"true" doc:"A doc string for the enum, if any."`
-	Members     []*EnumMemberTypeDef `field:"true" doc:"The members of the enum."`
-	SourceMap   *SourceMap           `field:"true" doc:"The location of this enum declaration."`
+	Name        string                     `field:"true" doc:"The name of the enum."`
+	Description string                     `field:"true" doc:"A doc string for the enum, if any."`
+	Members     []*EnumMemberTypeDef       `field:"true" doc:"The members of the enum."`
+	SourceMap   dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this enum declaration."`
 
 	// SourceModuleName is currently only set when returning the TypeDef from the Enum field on Module
 	SourceModuleName string `field:"true" doc:"If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise."`
@@ -1016,12 +1032,15 @@ func (*EnumTypeDef) TypeDescription() string {
 }
 
 func NewEnumTypeDef(name, description string, sourceMap *SourceMap) *EnumTypeDef {
-	return &EnumTypeDef{
+	typedef := &EnumTypeDef{
 		Name:         strcase.ToCamel(name),
 		OriginalName: name,
 		Description:  description,
-		SourceMap:    sourceMap,
 	}
+	if sourceMap != nil {
+		typedef.SourceMap = dagql.NonNull(sourceMap)
+	}
+	return typedef
 }
 
 func (enum EnumTypeDef) Clone() *EnumTypeDef {
@@ -1031,18 +1050,18 @@ func (enum EnumTypeDef) Clone() *EnumTypeDef {
 	for i, value := range enum.Members {
 		cp.Members[i] = value.Clone()
 	}
-	if enum.SourceMap != nil {
-		cp.SourceMap = enum.SourceMap.Clone()
+	if enum.SourceMap.Valid {
+		cp.SourceMap.Value = enum.SourceMap.Value.Clone()
 	}
 
 	return &cp
 }
 
 type EnumMemberTypeDef struct {
-	Name        string     `field:"true" doc:"The name of the enum member."`
-	Value       string     `field:"true" doc:"The value of the enum member"`
-	Description string     `field:"true" doc:"A doc string for the enum member, if any."`
-	SourceMap   *SourceMap `field:"true" doc:"The location of this enum member declaration."`
+	Name        string                     `field:"true" doc:"The name of the enum member."`
+	Value       string                     `field:"true" doc:"The value of the enum member"`
+	Description string                     `field:"true" doc:"A doc string for the enum member, if any."`
+	SourceMap   dagql.Nullable[*SourceMap] `field:"true" doc:"The location of this enum member declaration."`
 
 	OriginalName string
 }
@@ -1061,30 +1080,36 @@ func (*EnumMemberTypeDef) TypeDescription() string {
 }
 
 func NewEnumMemberTypeDef(name, value, description string, sourceMap *SourceMap) *EnumMemberTypeDef {
-	return &EnumMemberTypeDef{
+	typedef := &EnumMemberTypeDef{
 		OriginalName: name,
 		Name:         strcase.ToScreamingSnake(name),
 		Value:        value,
 		Description:  description,
-		SourceMap:    sourceMap,
 	}
+	if sourceMap != nil {
+		typedef.SourceMap = dagql.NonNull(sourceMap)
+	}
+	return typedef
 }
 
 func NewEnumValueTypeDef(name, value, description string, sourceMap *SourceMap) *EnumMemberTypeDef {
-	return &EnumMemberTypeDef{
+	typedef := &EnumMemberTypeDef{
 		OriginalName: name,
 		Name:         value,
 		Value:        value,
 		Description:  description,
-		SourceMap:    sourceMap,
 	}
+	if sourceMap != nil {
+		typedef.SourceMap = dagql.NonNull(sourceMap)
+	}
+	return typedef
 }
 
 func (enumValue EnumMemberTypeDef) Clone() *EnumMemberTypeDef {
 	cp := enumValue
 
-	if enumValue.SourceMap != nil {
-		cp.SourceMap = enumValue.SourceMap.Clone()
+	if enumValue.SourceMap.Valid {
+		cp.SourceMap.Value = enumValue.SourceMap.Value.Clone()
 	}
 
 	return &cp

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -1298,6 +1298,7 @@ type SourceMap struct {
 	Filename string `field:"true" doc:"The filename from the module source."`
 	Line     int    `field:"true" doc:"The line number within the filename."`
 	Column   int    `field:"true" doc:"The column number within the line."`
+	URL      string `field:"true" doc:"The URL to the file, if any. This can be used to link to the source map in the browser."`
 }
 
 func (*SourceMap) Type() *ast.Type {
@@ -1317,37 +1318,58 @@ func (sourceMap SourceMap) Clone() *SourceMap {
 }
 
 func (sourceMap *SourceMap) TypeDirective() *ast.Directive {
-	return &ast.Directive{
-		Name: "sourceMap",
-		Arguments: ast.ArgumentList{
-			{
-				Name: "module",
-				Value: &ast.Value{
-					Kind: ast.StringValue,
-					Raw:  sourceMap.Module,
-				},
-			},
-			{
-				Name: "filename",
-				Value: &ast.Value{
-					Kind: ast.StringValue,
-					Raw:  sourceMap.Filename,
-				},
-			},
-			{
-				Name: "line",
-				Value: &ast.Value{
-					Kind: ast.IntValue,
-					Raw:  fmt.Sprint(sourceMap.Line),
-				},
-			},
-			{
-				Name: "column",
-				Value: &ast.Value{
-					Kind: ast.IntValue,
-					Raw:  fmt.Sprint(sourceMap.Column),
-				},
-			},
-		},
+	if sourceMap == nil {
+		return nil
 	}
+
+	directive := &ast.Directive{
+		Name:      "sourceMap",
+		Arguments: ast.ArgumentList{},
+	}
+	if sourceMap.Module != "" {
+		directive.Arguments = append(directive.Arguments, &ast.Argument{
+			Name: "module",
+			Value: &ast.Value{
+				Kind: ast.StringValue,
+				Raw:  sourceMap.Module,
+			},
+		})
+	}
+	if sourceMap.Filename != "" {
+		directive.Arguments = append(directive.Arguments, &ast.Argument{
+			Name: "filename",
+			Value: &ast.Value{
+				Kind: ast.StringValue,
+				Raw:  sourceMap.Filename,
+			},
+		})
+	}
+	if sourceMap.Line != 0 {
+		directive.Arguments = append(directive.Arguments, &ast.Argument{
+			Name: "line",
+			Value: &ast.Value{
+				Kind: ast.IntValue,
+				Raw:  fmt.Sprint(sourceMap.Line),
+			},
+		})
+	}
+	if sourceMap.Column != 0 {
+		directive.Arguments = append(directive.Arguments, &ast.Argument{
+			Name: "column",
+			Value: &ast.Value{
+				Kind: ast.IntValue,
+				Raw:  fmt.Sprint(sourceMap.Column),
+			},
+		})
+	}
+	if sourceMap.URL != "" {
+		directive.Arguments = append(directive.Arguments, &ast.Argument{
+			Name: "url",
+			Value: &ast.Value{
+				Kind: ast.StringValue,
+				Raw:  sourceMap.URL,
+			},
+		})
+	}
+	return directive
 }

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -239,6 +239,10 @@ var coreDirectives = []DirectiveSpec{
 				Name: "column",
 				Type: Int(0),
 			},
+			InputSpec{
+				Name: "url",
+				Type: String(""),
+			},
 		),
 		Locations: []DirectiveLocation{
 			DirectiveLocationScalar,

--- a/dagql/testdata/introspection.json
+++ b/dagql/testdata/introspection.json
@@ -1950,6 +1950,23 @@
                 "ofType": null
               }
             }
+          },
+          {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "description": "",
+            "directives": [],
+            "isDeprecated": false,
+            "name": "url",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
           }
         ],
         "description": "Indicates the source information for where a given field is defined.",

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1789,7 +1789,7 @@ type EnumTypeDef {
   name: String!
 
   """The location of this enum declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """
   If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -1816,7 +1816,7 @@ type EnumValueTypeDef {
   name: String!
 
   """The location of this enum member declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """The value of the enum member"""
   value: String!
@@ -2280,7 +2280,7 @@ type FieldTypeDef {
   name: String!
 
   """The location of this field declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """The type of the field."""
   typeDef: TypeDef!
@@ -2376,7 +2376,7 @@ type Function {
   returnType: TypeDef!
 
   """The location of this function declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """Returns the function with the provided argument"""
   withArg(
@@ -2453,7 +2453,7 @@ type FunctionArg {
   name: String!
 
   """The location of this arg declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """The type of the argument."""
   typeDef: TypeDef!
@@ -2817,7 +2817,7 @@ type InterfaceTypeDef {
   name: String!
 
   """The location of this interface declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """
   If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -3305,7 +3305,7 @@ type ObjectTypeDef {
   name: String!
 
   """The location of this object declaration."""
-  sourceMap: SourceMap!
+  sourceMap: SourceMap
 
   """
   If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -10,7 +10,7 @@ directive @experimental(
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
 """Indicates the source information for where a given field is defined."""
-directive @sourceMap(module: String!, filename: String!, line: Int!, column: Int!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT
+directive @sourceMap(module: String!, filename: String!, line: Int!, column: Int!, url: String!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT
 
 type Binding {
   """Retrieve the binding value, as type CacheVolume"""
@@ -3917,6 +3917,11 @@ type SourceMap {
 
   """The module dependency this was declared in."""
   module: String!
+
+  """
+  The URL to the file, if any. This can be used to link to the source map in the browser.
+  """
+  url: String!
 }
 
 """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -11117,6 +11117,10 @@
                         <td data-property-name=""><a class="property-name" id="SourceMap-module" href="#SourceMap-module"><code>module</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The module dependency this was declared in. </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="SourceMap-url" href="#SourceMap-url"><code>url</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The URL to the file, if any. This can be used to link to the source map in the browser. </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6784,7 +6784,7 @@
                         <td> The name of the enum. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumTypeDef-sourceMap" href="#EnumTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="EnumTypeDef-sourceMap" href="#EnumTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this enum declaration. </td>
                       </tr>
                       <tr>
@@ -6851,7 +6851,7 @@
                         <td> The name of the enum member. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-sourceMap" href="#EnumValueTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="EnumValueTypeDef-sourceMap" href="#EnumValueTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this enum member declaration. </td>
                       </tr>
                       <tr>
@@ -7954,7 +7954,7 @@
                         <td> The name of the field in lowerCamelCase format. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="FieldTypeDef-sourceMap" href="#FieldTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="FieldTypeDef-sourceMap" href="#FieldTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this field declaration. </td>
                       </tr>
                       <tr>
@@ -8158,7 +8158,7 @@
                         <td> The type returned by the function. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="Function-sourceMap" href="#Function-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="Function-sourceMap" href="#Function-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this function declaration. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
@@ -8289,7 +8289,7 @@
                         <td> The name of the argument in lowerCamelCase format. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="FunctionArg-sourceMap" href="#FunctionArg-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="FunctionArg-sourceMap" href="#FunctionArg-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this arg declaration. </td>
                       </tr>
                       <tr>
@@ -9299,7 +9299,7 @@
                         <td> The name of the interface. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="InterfaceTypeDef-sourceMap" href="#InterfaceTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="InterfaceTypeDef-sourceMap" href="#InterfaceTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this interface declaration. </td>
                       </tr>
                       <tr>
@@ -10471,7 +10471,7 @@
                         <td> The name of the object. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="ObjectTypeDef-sourceMap" href="#ObjectTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap!</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="ObjectTypeDef-sourceMap" href="#ObjectTypeDef-sourceMap"><code>sourceMap</code></a> - <span class="property-type"><a href="#definition-SourceMap"><code>SourceMap</code></a></span> </td>
                         <td> The location of this object declaration. </td>
                       </tr>
                       <tr>

--- a/docs/static/reference/php/Dagger/SourceMap.html
+++ b/docs/static/reference/php/Dagger/SourceMap.html
@@ -191,6 +191,16 @@
                                             <p><p>The module dependency this was declared in.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_url">url</a>()
+        
+                                            <p><p>The URL to the file, if any. This can be used to link to the source map in the browser.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -427,6 +437,38 @@
 
         <div class="method-description">
                             <p><p>The module dependency this was declared in.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_url">
+        <div class="location">at line 64</div>
+        <code>                    string
+    <strong>url</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The URL to the file, if any. This can be used to link to the source map in the browser.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1012,7 +1012,9 @@
 <abbr title="Dagger\Secret">Secret</abbr>::uri</a>() &mdash; <em>Method in class <a href="Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a></em></dt>
                     <dd><p>The URI of this secret.</p></dd><dt><a href="Dagger/Service.html#method_up">
 <abbr title="Dagger\Service">Service</abbr>::up</a>() &mdash; <em>Method in class <a href="Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a></em></dt>
-                    <dd><p>Creates a tunnel that forwards traffic from the caller's network to this service.</p></dd>        </dl><h2 id="letterV">V</h2>
+                    <dd><p>Creates a tunnel that forwards traffic from the caller's network to this service.</p></dd><dt><a href="Dagger/SourceMap.html#method_url">
+<abbr title="Dagger\SourceMap">SourceMap</abbr>::url</a>() &mdash; <em>Method in class <a href="Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></em></dt>
+                    <dd><p>The URL to the file, if any. This can be used to link to the source map in the browser.</p></dd>        </dl><h2 id="letterV">V</h2>
         <dl id="indexV"><dt><a href="Dagger/Client.html#method_version">
 <abbr title="Dagger\Client">Client</abbr>::version</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Get the current Dagger Engine version.</p></dd><dt><a href="Dagger/EnumTypeDef.html#method_values">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -4243,6 +4243,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\SourceMap::url",
+			"p": "Dagger/SourceMap.html#method_url",
+			"d": "<p>The URL to the file, if any. This can be used to link to the source map in the browser.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Terminal::id",
 			"p": "Dagger/Terminal.html#method_id",
 			"d": "<p>A unique identifier for this Terminal.</p>"

--- a/sdk/elixir/lib/dagger/gen/enum_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_type_def.ex
@@ -73,7 +73,7 @@ defmodule Dagger.EnumTypeDef do
   @doc """
   The location of this enum declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = enum_type_def) do
     query_builder =
       enum_type_def.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
@@ -51,7 +51,7 @@ defmodule Dagger.EnumValueTypeDef do
   @doc """
   The location of this enum member declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = enum_value_type_def) do
     query_builder =
       enum_value_type_def.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/field_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/field_type_def.ex
@@ -53,7 +53,7 @@ defmodule Dagger.FieldTypeDef do
   @doc """
   The location of this field declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = field_type_def) do
     query_builder =
       field_type_def.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -89,7 +89,7 @@ defmodule Dagger.Function do
   @doc """
   The location of this function declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = function) do
     query_builder =
       function.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -86,7 +86,7 @@ defmodule Dagger.FunctionArg do
   @doc """
   The location of this arg declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = function_arg) do
     query_builder =
       function_arg.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/interface_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/interface_type_def.ex
@@ -73,7 +73,7 @@ defmodule Dagger.InterfaceTypeDef do
   @doc """
   The location of this interface declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = interface_type_def) do
     query_builder =
       interface_type_def.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/object_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/object_type_def.ex
@@ -109,7 +109,7 @@ defmodule Dagger.ObjectTypeDef do
   @doc """
   The location of this object declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t()
+  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
   def source_map(%__MODULE__{} = object_type_def) do
     query_builder =
       object_type_def.query_builder |> QB.select("sourceMap")

--- a/sdk/elixir/lib/dagger/gen/source_map.ex
+++ b/sdk/elixir/lib/dagger/gen/source_map.ex
@@ -69,6 +69,17 @@ defmodule Dagger.SourceMap do
 
     Client.execute(source_map.client, query_builder)
   end
+
+  @doc """
+  The URL to the file, if any. This can be used to link to the source map in the browser.
+  """
+  @spec url(t()) :: {:ok, String.t()} | {:error, term()}
+  def url(%__MODULE__{} = source_map) do
+    query_builder =
+      source_map.query_builder |> QB.select("url")
+
+    Client.execute(source_map.client, query_builder)
+  end
 end
 
 defimpl Jason.Encoder, for: Dagger.SourceMap do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -9831,6 +9831,7 @@ type SourceMap struct {
 	id       *SourceMapID
 	line     *int
 	module   *string
+	url      *string
 }
 
 func (r *SourceMap) WithGraphQLQuery(q *querybuilder.Selection) *SourceMap {
@@ -9924,6 +9925,19 @@ func (r *SourceMap) Module(ctx context.Context) (string, error) {
 		return *r.module, nil
 	}
 	q := r.query.Select("module")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The URL to the file, if any. This can be used to link to the source map in the browser.
+func (r *SourceMap) URL(ctx context.Context) (string, error) {
+	if r.url != nil {
+		return *r.url, nil
+	}
+	q := r.query.Select("url")
 
 	var response string
 

--- a/sdk/php/generated/SourceMap.php
+++ b/sdk/php/generated/SourceMap.php
@@ -57,4 +57,13 @@ class SourceMap extends Client\AbstractObject implements Client\IdAble
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('module');
         return (string)$this->queryLeaf($leafQueryBuilder, 'module');
     }
+
+    /**
+     * The URL to the file, if any. This can be used to link to the source map in the browser.
+     */
+    public function url(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('url');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'url');
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -9903,6 +9903,28 @@ class SourceMap(Type):
         _ctx = self._select("module", _args)
         return await _ctx.execute(str)
 
+    async def url(self) -> str:
+        """The URL to the file, if any. This can be used to link to the source
+        map in the browser.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("url", _args)
+        return await _ctx.execute(str)
+
 
 @typecheck
 class Terminal(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -10171,6 +10171,11 @@ impl SourceMap {
         let query = self.selection.select("module");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The URL to the file, if any. This can be used to link to the source map in the browser.
+    pub async fn url(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("url");
+        query.execute(self.graphql_client.clone()).await
+    }
 }
 #[derive(Clone)]
 pub struct Terminal {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -9463,6 +9463,7 @@ export class SourceMap extends BaseClient {
   private readonly _filename?: string = undefined
   private readonly _line?: number = undefined
   private readonly _module?: string = undefined
+  private readonly _url?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
@@ -9474,6 +9475,7 @@ export class SourceMap extends BaseClient {
     _filename?: string,
     _line?: number,
     _module?: string,
+    _url?: string,
   ) {
     super(ctx)
 
@@ -9482,6 +9484,7 @@ export class SourceMap extends BaseClient {
     this._filename = _filename
     this._line = _line
     this._module = _module
+    this._url = _url
   }
 
   /**
@@ -9553,6 +9556,21 @@ export class SourceMap extends BaseClient {
     }
 
     const ctx = this._ctx.select("module")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The URL to the file, if any. This can be used to link to the source map in the browser.
+   */
+  url = async (): Promise<string> => {
+    if (this._url) {
+      return this._url
+    }
+
+    const ctx = this._ctx.select("url")
 
     const response: Awaited<string> = await ctx.execute()
 


### PR DESCRIPTION
Sparked by a bug reported by @jasonmccallister.

1. Essentially, not every SDK supports generating/displaying sourcemaps, so these fields must be nullable.
2. We weren't displaying sourcemaps for modules loaded from directories / git (we were only doing local).
	- We can very reasonably display for these cases.
	- We just need to construct an HTML URL!