### PR TITLE
chore: update go to latest 1.25.0

### DIFF
--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.24.4-alpine").
+		From("golang:1.25.0-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/core/integration/testdata/sdks/only-runtime/main.go
+++ b/core/integration/testdata/sdks/only-runtime/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"dagger/only-runtime/internal/dagger"
+
+	"dagger.io/dagger/dag"
 )
 
 type OnlyRuntime struct {
@@ -24,7 +26,7 @@ func (m *OnlyRuntime) ModuleRuntime(
 	introspectionJSON *dagger.File,
 ) (*dagger.Container, error) {
 	return dag.Container().
-		From("golang:1.24.3-alpine").
+		From("golang:1.25.0-alpine").
 		WithDirectory("/src", m.Src).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "/bin/sdk", "."}).

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -27,7 +27,7 @@ const (
 	AlpineVersion = "3.22.0"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.24.6"
+	GolangVersion = "1.25.0"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 
 	BusyboxVersion = "1.37.0"

--- a/modules/go/main.go
+++ b/modules/go/main.go
@@ -23,7 +23,7 @@ func New(
 	source *dagger.Directory,
 	// Go version
 	// +optional
-	// +default="1.24.6"
+	// +default="1.25.0"
 	version string,
 	// Use a custom module cache
 	// +optional


### PR DESCRIPTION
go 1.25 release notes: https://go.dev/doc/go1.25