### PR TITLE
chore: defer session cleanups while in no-exit state

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
+	"github.com/dagger/dagger/util/cleanups"
 	"go.opentelemetry.io/otel"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -65,8 +66,10 @@ func withEngine(
 	ctx context.Context,
 	params client.Params,
 	fn runClientCallback,
-) error {
-	return Frontend.Run(ctx, opts, func(ctx context.Context) (rerr error) {
+) (rerr error) {
+	return Frontend.Run(ctx, opts, func(ctx context.Context) (_ cleanups.CleanupF, rerr error) {
+		var cleanup cleanups.Cleanups
+
 		// Init tracing as early as possible and shutdown after the command
 		// completes, ensuring progress is fully flushed to the frontend.
 		ctx, cleanupTelemetry := initEngineTelemetry(ctx)
@@ -77,8 +80,10 @@ func withEngine(
 			}
 			Frontend.Opts().TelemetryError = err
 		}))
-
-		defer func() { cleanupTelemetry(rerr) }()
+		cleanup.Add("close telemetry", func() error {
+			cleanupTelemetry(rerr)
+			return nil
+		})
 
 		if debug {
 			params.LogLevel = slog.LevelDebug
@@ -93,7 +98,7 @@ func withEngine(
 		if RunnerImageLoader != "" {
 			backend, err := imageload.GetBackend(RunnerImageLoader)
 			if err != nil {
-				return err
+				return cleanup.Run, err
 			}
 			params.ImageLoaderBackend = backend
 		}
@@ -123,11 +128,11 @@ func withEngine(
 		// Connect to and run with the engine
 		sess, ctx, err := client.Connect(ctx, params)
 		if err != nil {
-			return err
+			return cleanup.Run, err
 		}
-		defer sess.Close()
+		cleanup.Add("close dagger session", sess.Close)
 
-		return fn(ctx, sess)
+		return cleanup.Run, fn(ctx, sess)
 	})
 }
 

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/engine/session/prompt"
+	"github.com/dagger/dagger/util/cleanups"
 )
 
 type (
@@ -63,7 +64,7 @@ var loggedOutTraceMsg = fmt.Sprintf("Setup tracing at %%s. To hide set %s=1", Sk
 
 type Frontend interface {
 	// Run starts a frontend, and runs the target function.
-	Run(ctx context.Context, opts dagui.FrontendOpts, f func(context.Context) error) error
+	Run(ctx context.Context, opts dagui.FrontendOpts, f func(context.Context) (cleanups.CleanupF, error)) error
 
 	// Opts returns the opts of the currently running frontend.
 	Opts() *dagui.FrontendOpts

--- a/dagql/idtui/frontend_dots.go
+++ b/dagql/idtui/frontend_dots.go
@@ -15,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui/multiprefixw"
+	"github.com/dagger/dagger/util/cleanups"
 	"github.com/muesli/termenv"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/log"
@@ -69,13 +70,13 @@ func NewDots(output io.Writer) Frontend {
 	}
 }
 
-func (fe *frontendDots) Run(ctx context.Context, opts dagui.FrontendOpts, f func(context.Context) error) error {
+func (fe *frontendDots) Run(ctx context.Context, opts dagui.FrontendOpts, f func(context.Context) (cleanups.CleanupF, error)) error {
 	fe.opts = opts
-	return fe.reporter.Run(ctx, opts, func(ctx context.Context) error {
-		err := f(ctx)
+	return fe.reporter.Run(ctx, opts, func(ctx context.Context) (cleanups.CleanupF, error) {
+		cleanup, err := f(ctx)
 		fmt.Fprintln(fe.out)
 		fmt.Fprintln(fe.out)
-		return err
+		return cleanup, err
 	})
 }
 

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -2,6 +2,7 @@ package idtui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -14,6 +15,7 @@ import (
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/util/cleanups"
 	"github.com/muesli/termenv"
 	"github.com/pkg/browser"
 	"github.com/vito/go-interact/interact"
@@ -168,7 +170,7 @@ func (fe *frontendPlain) addVirtualLog(span trace.Span, name string, fields ...s
 	spanDt.logs = append(spanDt.logs, logLine{newCursorBuffer([]byte(line)), time.Now()})
 }
 
-func (fe *frontendPlain) Run(ctx context.Context, opts dagui.FrontendOpts, run func(context.Context) error) error {
+func (fe *frontendPlain) Run(ctx context.Context, opts dagui.FrontendOpts, run func(context.Context) (cleanups.CleanupF, error)) error {
 	if opts.TooFastThreshold == 0 {
 		opts.TooFastThreshold = 100 * time.Millisecond
 	}
@@ -192,7 +194,11 @@ func (fe *frontendPlain) Run(ctx context.Context, opts dagui.FrontendOpts, run f
 		}()
 	}
 
-	runErr := run(ctx)
+	cleanup, runErr := run(ctx)
+	if cleanup != nil {
+		runErr = errors.Join(runErr, cleanup())
+	}
+
 	fe.finalRender()
 
 	fe.db.WriteDot(opts.DotOutputFilePath, opts.DotFocusField, opts.DotShowInternal)


### PR DESCRIPTION
By using the `-E` flag, or the `E` hotkey, we can enter a special TUI no-exit state.
    
While in this state, even after the dagger operation is completed, we keep the TUI open and running. However, previously, we were completely shutting down the session and the telemetry.
    
For some interesting future operations (e.g. #10867), we want to defer these callbacks until we're quitting the TUI completely - we want to keep an active client as long as the TUI is running in some form :smile: 
