### PR TITLE
feat: add native gitignore in fsutil

### DIFF
--- a/.changes/unreleased/Added-20250723-184041.yaml
+++ b/.changes/unreleased/Added-20250723-184041.yaml
@@ -1,0 +1,13 @@
+kind: Breaking
+body: |-
+  Automatically apply .gitignore patterns on directory loading for module call.
+  
+  - Apply .gitignore patterns when loading contextual directory argument.
+  - Apply .gitignore pattenrs when a directory is sent as an argument to a module function.
+  - Apply .gitignore patterns when a local module is loaded.
+
+  Add `NoGitAutoIgnore` argument to `Host.Directory` to disable this behavior.
+time: 2025-07-23T18:40:41.664219+02:00
+custom:
+  Author: TomChv,jedevc
+  PR: "10883"

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -989,11 +989,11 @@ func (m *Test) Mod(ctx context.Context, module *dagger.Module) *dagger.Module {
 
 		out, err := modGen.With(daggerCall("mod-src", "--mod-src", ".", "context-directory", "entries")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, ".git/\n.gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+		require.Equal(t, ".git/\n.gitattributes\n.gitignore\nLICENSE\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 
 		out, err = modGen.With(daggerCall("mod", "--module", ".", "source", "context-directory", "entries")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, ".git/\n.gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+		require.Equal(t, ".git/\n.gitattributes\n.gitignore\nLICENSE\ndagger.json\nfoo.txt\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 	})
 
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {

--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -1446,6 +1446,7 @@ func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
+			WithoutFile("/work/.gitignore"). // Remove .gitignore so we can override files inside internal/dagger without ignoring them.
 			WithNewFile("/work/internal/dagger/more.go", moreContents).
 			With(daggerQuery(`{container{from(address:"` + alpineImage + `"){echo(msg:"echo!"){stdout}}}}`)).
 			Sync(ctx)
@@ -1462,6 +1463,7 @@ func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(daggerExec("init", "--source=.", "--name=container", "--sdk=go")).
+			WithoutFile("/work/.gitignore"). // Remove .gitignore so we can override files inside internal/dagger without ignoring them.
 			WithNewFile("/work/internal/dagger/more.go", moreContents).
 			With(daggerQuery(`{container{from(address:"` + alpineImage + `"){echo(msg:"echo!"){stdout}}}}`)).
 			Sync(ctx)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5029,12 +5029,16 @@ func (t *Test) IgnoreEveryGoFileExceptMainGo(
 }
 
 func (t *Test) IgnoreDirButKeepFileInSubdir(
-  // +ignore=["internal/telemetry", "!internal/telemetry/proxy.go"]
+  // +ignore=["internal/foo", "!internal/foo/bar.go"]
   // +defaultPath="./dagger"
   dir *dagger.Directory,
 ) *dagger.Directory {
   return dir
 }`)).
+		WithDirectory("./internal/foo", c.Directory().
+			WithNewFile("bar.go", "package foo").
+			WithNewFile("baz.go", "package foo"),
+		).
 		WithWorkdir("/work")
 
 	t.Run("ignore with context directory", func(ctx context.Context, t *testctx.T) {
@@ -5047,25 +5051,25 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 		t.Run("ignore all then reverse ignore all", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-reverse-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore all then reverse ignore then exclude files", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-reverse-ignore-then-exclude-git-files", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "dagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+			require.Equal(t, "go.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore all then exclude files then reverse ignore", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-then-exclude-files-then-reverse-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore dir", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("ignore-dir", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\nmain.go\n", out)
 		})
 
 		t.Run("ignore everything but main.go", func(ctx context.Context, t *testctx.T) {
@@ -5077,7 +5081,7 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 		t.Run("no ignore", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("no-ignore", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, ".gitattributes\n.gitignore\ndagger.gen.go\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 		})
 
 		t.Run("ignore every go files except main.go", func(ctx context.Context, t *testctx.T) {
@@ -5085,20 +5089,16 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 			require.NoError(t, err)
 			require.Equal(t, ".gitattributes\n.gitignore\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
 
-			// Verify the directories exist but files are correctlyignored
+			// Verify the directories exist but files are correctly ignored (including the .gitiginore exclusion)
 			out, err = modGen.With(daggerCall("ignore-every-go-file-except-main-go", "directory", "--path", "internal", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "dagger/\nquerybuilder/\ntelemetry/\n", out)
-
-			out, err = modGen.With(daggerCall("ignore-every-go-file-except-main-go", "directory", "--path", "internal/telemetry", "entries")).Stdout(ctx)
-			require.NoError(t, err)
-			require.Equal(t, "", out)
+			require.Equal(t, "foo/\n", out)
 		})
 
 		t.Run("ignore dir but keep file in subdir", func(ctx context.Context, t *testctx.T) {
-			out, err := modGen.With(daggerCall("ignore-dir-but-keep-file-in-subdir", "directory", "--path", "internal/telemetry", "entries")).Stdout(ctx)
+			out, err := modGen.With(daggerCall("ignore-dir-but-keep-file-in-subdir", "directory", "--path", "internal/foo", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "proxy.go\n", out)
+			require.Equal(t, "bar.go\n", out)
 		})
 	})
 
@@ -5116,6 +5116,234 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 			require.NoError(t, err)
 			require.Equal(t, ".git/\nLICENSE\nbackend/\ndagger/\ndagger.json\nfrontend/\n", out)
 		})
+	})
+}
+
+func (ModuleSuite) TestDefaultGitIgnore(ctx context.Context, t *testctx.T) {
+	type gitIgnoreFile struct {
+		path    string
+		content string
+	}
+
+	type expectedDir struct {
+		path string
+		want string
+	}
+
+	t.Run("correctly use .gitignore files", func(ctx context.Context, t *testctx.T) {
+		sourceFile := `
+package main
+
+import (
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Repo      *dagger.Directory
+	ModuleDir *dagger.Directory
+}
+
+func New(
+	//+defaultPath="/"
+	repo *dagger.Directory,
+
+	//+defaultPath="."
+	moduleDir *dagger.Directory,
+) *Test {
+	return &Test{
+		Repo:      repo,
+		ModuleDir: moduleDir,
+	}
+}`
+
+		gitIgnore := []gitIgnoreFile{
+			{
+				path: "/work",
+				content: `**.txt
+bar/*.go
+!c.txt
+*.py
+/.git
+**.gitignore
+**.gitattributes
+`,
+			},
+			{
+				path:    "/work/yamlFiles",
+				content: `foo.yaml`,
+			},
+			{
+				path: "/work/mod",
+				content: `/internal
+/dagger.gen.go
+/dagger.json
+/go.mod
+/go.sum
+**.go
+!main.go
+`,
+			},
+		}
+
+		expected := []expectedDir{
+			{
+				path: ".",
+				want: "a.json\nbar/\nc.txt\nfoo.xml\nmod/\nyamlFiles/\n",
+			},
+			{
+				path: "bar",
+				want: "",
+			},
+			{
+				path: "yamlFiles",
+				want: "a.md\nbar.yaml\n",
+			},
+		}
+
+		expectedModuleDir := "LICENSE\nmain.go\n"
+		c := connect(ctx, t)
+
+		repo := c.Directory().
+			WithNewFile("a.json", "{}").
+			WithNewFile("b.txt", "b").
+			WithNewFile("c.txt", "c").
+			WithNewFile("foo.xml", "<>").
+			WithNewFile("script.py", "print('hello')").
+			WithDirectory("bar", c.Directory().WithNewFile("baz.txt", "baz").WithNewFile("d.go", "package main").WithNewFile("sub.py", "")).
+			WithDirectory("yamlFiles", c.Directory().WithNewFile("foo.yaml", "foo").WithNewFile("bar.yaml", "bar").WithNewFile("a.md", "a"))
+
+		modGen := c.Container().From(golangImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory("/work", repo).
+			WithWorkdir("/work").
+			// Setup context directory
+			WithExec([]string{"git", "init"}).
+			WithWorkdir("/work/mod").
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
+			WithNewFile("main.go", sourceFile)
+
+		for _, ignore := range gitIgnore {
+			modGen = modGen.WithNewFile(filepath.Join(ignore.path, ".gitignore"), ignore.content)
+		}
+
+		for _, expected := range expected {
+			expectedResult := expected.want
+
+			dir, err := modGen.With(daggerCall("repo", "directory", "--path", expected.path, "entries")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, expectedResult, dir)
+		}
+
+		moduleDir, err := modGen.With(daggerCall("module-dir", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedModuleDir, moduleDir)
+	})
+
+	t.Run("correctly rebase path based on defaultPath", func(ctx context.Context, t *testctx.T) {
+		sourceFile := `
+package main
+
+import (
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Repo      *dagger.Directory
+	ModuleDir *dagger.Directory
+}
+
+func New(
+	//+defaultPath="/bar"
+	repo *dagger.Directory,
+
+	//+defaultPath="./dagger"
+	moduleDir *dagger.Directory,
+) *Test {
+	return &Test{
+		Repo:      repo,
+		ModuleDir: moduleDir,
+	}
+}`
+
+		gitIgnore := []gitIgnoreFile{
+			{
+				path: "/work",
+				content: `**.txt
+bar/*.go
+!c.txt
+*.py
+/.git
+**.gitignore
+**.gitattributes
+`,
+			},
+			{
+				path:    "/work/bar",
+				content: `yamlFiles/foo.yaml`,
+			},
+			{
+				path: "/work/mod",
+				content: `/dagger/internal
+dagger.gen.go
+dagger.json
+/go.mod
+/go.sum
+**.go
+!main.go
+`,
+			},
+		}
+
+		expected := []expectedDir{
+			{
+				path: ".",
+				want: "yamlFiles/\n",
+			},
+			{
+				path: "yamlFiles",
+				want: "bar.yaml\n",
+			},
+		}
+
+		expectedModuleDir := "go.mod\ngo.sum\nmain.go\n"
+		c := connect(ctx, t)
+
+		repo := c.Directory().
+			WithNewFile("a.json", "{}").
+			WithNewFile("b.txt", "b").
+			WithNewFile("c.txt", "c").
+			WithNewFile("foo.xml", "<>").
+			WithNewFile("script.py", "print('hello')").
+			WithDirectory("bar", c.Directory().WithNewFile("baz.txt", "baz").WithNewFile("d.go", "package main").WithNewFile("sub.py", "").
+				WithDirectory("yamlFiles", c.Directory().WithNewFile("foo.yaml", "foo").WithNewFile("bar.yaml", "bar")))
+
+		modGen := c.Container().From(golangImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory("/work", repo).
+			WithWorkdir("/work").
+			// Setup context directory
+			WithExec([]string{"git", "init"}).
+			WithWorkdir("/work/mod").
+			With(daggerExec("init", "--source=dagger", "--name=test", "--sdk=go")).
+			WithNewFile("dagger/main.go", sourceFile)
+
+		for _, ignore := range gitIgnore {
+			modGen = modGen.WithNewFile(filepath.Join(ignore.path, ".gitignore"), ignore.content)
+		}
+
+		for _, expected := range expected {
+			expectedResult := expected.want
+
+			dir, err := modGen.With(daggerCall("repo", "directory", "--path", expected.path, "entries")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, expectedResult, dir)
+		}
+
+		moduleDir, err := modGen.With(daggerCall("module-dir", "entries")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedModuleDir, moduleDir)
 	})
 }
 
@@ -6130,7 +6358,7 @@ func currentSchema(ctx context.Context, t *testctx.T, ctr *dagger.Container) *in
 }
 
 var moduleIntrospection = daggerQuery(`
-query { host { directory(path: ".") { asModule {
+query { host { directory(path: ".", noGitAutoIgnore: true) { asModule {
     description
     objects {
         asObject {

--- a/core/integration/testdata/modules/python/extended/dagger.json
+++ b/core/integration/testdata/modules/python/extended/dagger.json
@@ -4,10 +4,6 @@
   "sdk": {
     "source": "python"
   },
-  "include": [
-    "!.venv",
-    "!sdk"
-  ],
   "dependencies": [
     {
       "name": "python-sdk",

--- a/core/integration/testdata/modules/python/extended/src/main/__init__.py
+++ b/core/integration/testdata/modules/python/extended/src/main/__init__.py
@@ -15,8 +15,8 @@ class ExtPythonSdk:
         gitattrs = await dag.current_module().source().file(".gitattributes").contents()
         return (
             dag.generated_code(sdk.container().directory(await sdk.context_dir_path()))
-            .with_vcs_generated_paths("\n".split(gitattrs))
-            .with_vcs_ignored_paths("\n".split(gitignore))
+            .with_vcs_generated_paths(gitattrs.split("\n"))
+            .with_vcs_ignored_paths(gitignore.split("\n"))
         )
 
     @dagger.function

--- a/core/integration/testdata/modules/python/git-dep/dagger.json
+++ b/core/integration/testdata/modules/python/git-dep/dagger.json
@@ -1,11 +1,6 @@
 {
   "name": "git-dep",
-  "engineVersion": "v0.18.14",
-  "sdk": {
-    "source": "../extended"
-  },
-  "include": [
-    "!.venv",
-    "!sdk"
-  ]
+  "sdk": "../extended",
+  "source": ".",
+  "engineVersion": "v0.13.6"
 }

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -360,6 +360,7 @@ func (src *ModuleSource) LoadContext(
 				Args: append([]dagql.NamedInput{
 					{Name: "path", Value: dagql.String(path)},
 					{Name: "noCache", Value: dagql.Boolean(true)},
+					{Name: "gitIgnoreRoot", Value: dagql.String(ctxPath)},
 				}, filterInputs...),
 			},
 		)

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
@@ -19,7 +19,7 @@ Expected stderr:
   ┆ file: Host.file(path: "/app/dagql/idtui/golden_test.go"): File!
   ┆ dir: Host.directory(path: "/app/dagql/idtui"): Directory!
   ┆ contextFile: Directory.file(path: "main.go"): File!
-  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", noCache: true): Directory!
+  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", noCache: true, gitIgnoreRoot: "/app/dagql/idtui"): Directory!
   ): Void X.Xs
 
 Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2880,6 +2880,9 @@ type Host {
 
     """If true, the directory will always be reloaded from the host."""
     noCache: Boolean = false
+
+    """Don't apply .gitignore filter rules inside the directory"""
+    noGitAutoIgnore: Boolean = false
   ): Directory!
 
   """Accesses a file on the host."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -9445,6 +9445,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>noCache</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>If true, the directory will always be reloaded from the host.</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noGitAutoIgnore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Don&#39;t apply .gitignore filter rules inside the directory</p>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/docs/static/reference/php/Dagger/Host.html
+++ b/docs/static/reference/php/Dagger/Host.html
@@ -156,7 +156,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_directory">directory</a>(string $path, array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+                    <a href="#method_directory">directory</a>(string $path, array|null $exclude = null, array|null $include = null, bool|null $noCache = false, bool|null $noGitAutoIgnore = false)
         
                                             <p><p>Accesses a directory on the host.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -362,7 +362,7 @@
                     <h3 id="method_directory">
         <div class="location">at line 29</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>directory</strong>(string $path, array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+    <strong>directory</strong>(string $path, array|null $exclude = null, array|null $include = null, bool|null $noCache = false, bool|null $noGitAutoIgnore = false)
         </code>
     </h3>
     <div class="details">    
@@ -396,6 +396,11 @@
                 <td>$noCache</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGitAutoIgnore</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -417,7 +422,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 52</div>
+        <div class="location">at line 56</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path, bool|null $noCache = false)
         </code>
@@ -464,7 +469,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 65</div>
+        <div class="location">at line 69</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -496,7 +501,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_service">
-        <div class="location">at line 74</div>
+        <div class="location">at line 78</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>service</strong>(array $ports, string|null $host = &#039;localhost&#039;)
         </code>
@@ -543,7 +548,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecretFile">
-        <div class="location">at line 89</div>
+        <div class="location">at line 93</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecretFile</strong>(string $name, string $path)
         </code>
@@ -590,7 +595,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tunnel">
-        <div class="location">at line 100</div>
+        <div class="location">at line 104</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>tunnel</strong>(<abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service, bool|null $native = false, array|null $ports = null)
         </code>
@@ -642,7 +647,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_unixSocket">
-        <div class="location">at line 116</div>
+        <div class="location">at line 120</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>unixSocket</strong>(string $path)
         </code>

--- a/engine/client/filesync.go
+++ b/engine/client/filesync.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client/pathutil"
+	"github.com/dagger/dagger/util/fsxutil"
 )
 
 type Filesyncer struct {
@@ -103,6 +104,12 @@ func (s FilesyncSource) DiffCopy(stream filesync.FileSync_DiffCopyServer) error 
 		fs, err := fsutil.NewFS(absPath)
 		if err != nil {
 			return err
+		}
+		if opts.UseGitIgnore {
+			fs, err = fsxutil.NewGitIgnoreFS(fs)
+			if err != nil {
+				return err
+			}
 		}
 		fs, err = fsutil.NewFilterFS(fs, &fsutil.FilterOpt{
 			IncludePatterns: opts.IncludePatterns,

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -29,6 +29,8 @@ const (
 	localDirImportExcludePatternsMetaKey = "exclude-patterns"
 	localDirImportFollowPathsMetaKey     = "followpaths"
 
+	localDirImportGitIgnoreMetaKey = "dagger.gitignore"
+
 	// socket session attachable keys
 	SocketURLEncodedKey = "X-Dagger-Socket-URLEncoded"
 )
@@ -135,6 +137,7 @@ func (m ClientMetadata) AppendToHTTPHeaders(h http.Header) http.Header {
 
 type LocalImportOpts struct {
 	Path               string   `json:"path"`
+	UseGitIgnore       bool     `json:"use_gitignore"`
 	IncludePatterns    []string `json:"include_patterns"`
 	ExcludePatterns    []string `json:"exclude_patterns"`
 	FollowPaths        []string `json:"follow_paths"`
@@ -150,6 +153,7 @@ func (o LocalImportOpts) ToGRPCMD() metadata.MD {
 	o.Path = filepath.ToSlash(o.Path)
 	md := encodeMeta(localImportOptsMetaKey, o)
 	md[localDirImportDirNameMetaKey] = []string{o.Path}
+	md[localDirImportGitIgnoreMetaKey] = []string{strconv.FormatBool(o.UseGitIgnore)}
 	md[localDirImportIncludePatternsMetaKey] = o.IncludePatterns
 	md[localDirImportExcludePatternsMetaKey] = o.ExcludePatterns
 	md[localDirImportFollowPathsMetaKey] = o.FollowPaths
@@ -172,6 +176,9 @@ func (o *LocalImportOpts) FromGRPCMD(md metadata.MD) error {
 		o.IncludePatterns = md[localDirImportIncludePatternsMetaKey]
 		o.ExcludePatterns = md[localDirImportExcludePatternsMetaKey]
 		o.FollowPaths = md[localDirImportFollowPathsMetaKey]
+		if v, ok := md[localDirImportGitIgnoreMetaKey]; ok && len(v) > 0 {
+			o.UseGitIgnore, _ = strconv.ParseBool(v[0])
+		}
 	}
 	o.Path = filepath.FromSlash(o.Path)
 	return nil

--- a/engine/sources/local/copy/copy.go
+++ b/engine/sources/local/copy/copy.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/util/fsxutil"
 	"github.com/moby/patternmatcher"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
@@ -88,7 +89,7 @@ func Copy(ctx context.Context, srcRoot, src, dstRoot, dst string, opts ...Opt) e
 		return err
 	}
 
-	c, err := newCopier(dstRoot, ci.Chown, ci.Utime, ci.Mode, ci.XAttrErrorHandler, ci.IncludePatterns, ci.ExcludePatterns, ci.AlwaysReplaceExistingDestPaths, ci.ChangeFunc)
+	c, err := newCopier(dstRoot, ci.Chown, ci.Utime, ci.Mode, ci.XAttrErrorHandler, ci.IncludePatterns, ci.ExcludePatterns, ci.UseGitignore, ci.AlwaysReplaceExistingDestPaths, ci.ChangeFunc)
 	if err != nil {
 		return err
 	}
@@ -172,6 +173,8 @@ type CopyInfo struct {
 	IncludePatterns []string
 	// Exclude files/dir matching any of these patterns (even if they match an include pattern)
 	ExcludePatterns []string
+	// UseGitignore indicates that .gitignore files should be respected
+	UseGitignore bool
 	// If true, any source path that overwrite existing destination paths will always replace
 	// the existing destination path, even if they are of different types (e.g. a directory will
 	// replace any existing symlink or file)
@@ -238,9 +241,10 @@ type copier struct {
 	xattrErrorHandler              XAttrErrorHandler
 	includePatternMatcher          *patternmatcher.PatternMatcher
 	excludePatternMatcher          *patternmatcher.PatternMatcher
+	gitignoreMatcher               *fsxutil.GitignoreMatcher
 	parentDirs                     []parentDir
 	changefn                       fsutil.ChangeFunc
-	root                           string
+	destRoot                       string
 	alwaysReplaceExistingDestPaths bool
 }
 
@@ -250,7 +254,7 @@ type parentDir struct {
 	copied  bool
 }
 
-func newCopier(root string, chown Chowner, tm *time.Time, mode *int, xeh XAttrErrorHandler, includePatterns, excludePatterns []string, alwaysReplaceExistingDestPaths bool, changeFunc fsutil.ChangeFunc) (*copier, error) {
+func newCopier(destRoot string, chown Chowner, tm *time.Time, mode *int, xeh XAttrErrorHandler, includePatterns, excludePatterns []string, useGitignore bool, alwaysReplaceExistingDestPaths bool, changeFunc fsutil.ChangeFunc) (*copier, error) {
 	if xeh == nil {
 		xeh = func(dst, src, key string, err error) error {
 			return err
@@ -275,8 +279,17 @@ func newCopier(root string, chown Chowner, tm *time.Time, mode *int, xeh XAttrEr
 		}
 	}
 
+	var gitignoreMatcher *fsxutil.GitignoreMatcher
+	if useGitignore {
+		fs, err := fsutil.NewFS("/")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create fs for gitignore matcher")
+		}
+		gitignoreMatcher = fsxutil.NewGitIgnoreMatcher(fs)
+	}
+
 	return &copier{
-		root:                           root,
+		destRoot:                       destRoot,
 		inodes:                         map[uint64]string{},
 		chown:                          chown,
 		utime:                          tm,
@@ -284,6 +297,7 @@ func newCopier(root string, chown Chowner, tm *time.Time, mode *int, xeh XAttrEr
 		mode:                           mode,
 		includePatternMatcher:          includePatternMatcher,
 		excludePatternMatcher:          excludePatternMatcher,
+		gitignoreMatcher:               gitignoreMatcher,
 		changefn:                       changeFunc,
 		alwaysReplaceExistingDestPaths: alwaysReplaceExistingDestPaths,
 	}, nil
@@ -297,6 +311,14 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
+	}
+
+	fi, statErr := os.Lstat(src)
+	if statErr != nil {
+		if !os.IsNotExist(statErr) {
+			return errors.Wrapf(statErr, "failed to stat source path %s", src)
+		}
+		fi = nil
 	}
 
 	include := true
@@ -321,23 +343,32 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 		if matchesExcludePattern {
 			include = false
 		}
+
+		if c.gitignoreMatcher != nil {
+			isDir := fi == nil || fi.IsDir()
+			matchesGitignore, err := c.gitignoreMatcher.Matches(src, isDir)
+			if err != nil {
+				return err
+			}
+			if matchesGitignore {
+				include = false
+			}
+		}
 	}
 
-	fi, err := os.Lstat(src)
-	switch {
-	case err == nil:
-	case os.IsNotExist(err) && !include:
-		// If the source does not exist and we are not including it, then nothing to do here.
-		//
-		// Tricky case: if this is a directory which isn't included but there are sub files/dirs
-		// that do end up being included, it will be skipped here. We rely on the caller performing
-		// synchronization to ensure that directories which will end up being included are not
-		// modified during this call.
-		// Handling this case only saves the caller from trying to lock modifications to *files* that
-		// are not included in the copy, which they shouldn't be responsible for anyways.
-		return nil
-	default:
-		return errors.Wrapf(err, "failed to stat source path %s", src)
+	if fi == nil {
+		if !include {
+			// If the source does not exist and we are not including it, then nothing to do here.
+			//
+			// Tricky case: if this is a directory which isn't included but there are sub files/dirs
+			// that do end up being included, it will be skipped here. We rely on the caller performing
+			// synchronization to ensure that directories which will end up being included are not
+			// modified during this call.
+			// Handling this case only saves the caller from trying to lock modifications to *files* that
+			// are not included in the copy, which they shouldn't be responsible for anyways.
+			return nil
+		}
+		return errors.Wrapf(statErr, "failed to stat source path %s", src)
 	}
 
 	targetFi, err := os.Lstat(target)
@@ -432,7 +463,7 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 
 func (c *copier) notifyChange(target string, fi os.FileInfo) error {
 	if c.changefn != nil {
-		if err := c.changefn(fsutil.ChangeKindAdd, path.Clean(strings.TrimPrefix(target, c.root)), fi, nil); err != nil {
+		if err := c.changefn(fsutil.ChangeKindAdd, path.Clean(strings.TrimPrefix(target, c.destRoot)), fi, nil); err != nil {
 			return errors.Wrap(err, "failed to notify file change")
 		}
 	}

--- a/engine/sources/local/remotefs.go
+++ b/engine/sources/local/remotefs.go
@@ -17,10 +17,11 @@ import (
 )
 
 type remoteFS struct {
-	caller     session.Caller
-	clientPath string
-	includes   []string
-	excludes   []string
+	caller       session.Caller
+	clientPath   string
+	includes     []string
+	excludes     []string
+	useGitIgnore bool
 
 	startOnce   sync.Once
 	client      filesync.FileSync_DiffCopyClient
@@ -33,12 +34,14 @@ func newRemoteFS(
 	caller session.Caller,
 	clientPath string,
 	includes, excludes []string,
+	useGitIgnore bool,
 ) *remoteFS {
 	return &remoteFS{
-		caller:     caller,
-		clientPath: clientPath,
-		includes:   includes,
-		excludes:   excludes,
+		caller:       caller,
+		clientPath:   clientPath,
+		useGitIgnore: useGitIgnore,
+		includes:     includes,
+		excludes:     excludes,
 	}
 }
 
@@ -62,6 +65,7 @@ func (fs *remoteFS) Walk(ctx context.Context, path string, walkFn fs.WalkDirFunc
 	var err error
 	fs.client, err = filesync.NewFileSyncClient(fs.caller.Conn()).DiffCopy(engine.LocalImportOpts{
 		Path:            fs.clientPath,
+		UseGitIgnore:    fs.useGitIgnore,
 		IncludePatterns: fs.includes,
 		ExcludePatterns: fs.excludes,
 	}.AppendToOutgoingContext(ctx))

--- a/engine/sources/local/source.go
+++ b/engine/sources/local/source.go
@@ -110,9 +110,27 @@ func (ls *localSource) Resolve(ctx context.Context, id source.Identifier, sm *se
 	if !ok {
 		return nil, fmt.Errorf("invalid local identifier %v", id)
 	}
+	clone := *localIdentifier
+	localIdentifier = &clone
 
+	gitIgnore := false
+	cachebuster := ""
+
+	excludes := make([]string, 0, len(localIdentifier.ExcludePatterns))
+	for _, pattern := range localIdentifier.ExcludePatterns {
+		if pattern == "[dagger.gitignore]" {
+			gitIgnore = true
+		} else if strings.HasPrefix(pattern, "[dagger.cachebuster=") && strings.HasSuffix(pattern, "]") {
+			cachebuster = strings.TrimSuffix(strings.TrimPrefix(pattern, "[dagger.cachebuster="), "]")
+		} else {
+			excludes = append(excludes, pattern)
+		}
+	}
+	localIdentifier.ExcludePatterns = excludes
 	return &localSourceHandler{
 		src:         *localIdentifier,
+		gitIgnore:   gitIgnore,
+		cachebuster: cachebuster,
 		sm:          sm,
 		localSource: ls,
 	}, nil
@@ -122,6 +140,8 @@ type localSourceHandler struct {
 	src upstreamlocal.LocalIdentifier
 	sm  *session.Manager
 	*localSource
+	gitIgnore   bool
+	cachebuster string
 }
 
 func (ls *localSourceHandler) CacheKey(ctx context.Context, g session.Group, index int) (string, string, solver.CacheOpts, bool, error) {
@@ -138,12 +158,16 @@ func (ls *localSourceHandler) CacheKey(ctx context.Context, g session.Group, ind
 		SessionID       string
 		IncludePatterns []string
 		ExcludePatterns []string
+		Gitignore       bool
 		FollowPaths     []string
+		Cachebuster     string
 	}{
 		SessionID:       sessionID,
 		IncludePatterns: ls.src.IncludePatterns,
 		ExcludePatterns: ls.src.ExcludePatterns,
+		Gitignore:       ls.gitIgnore,
 		FollowPaths:     ls.src.FollowPaths,
+		Cachebuster:     ls.cachebuster,
 	})
 	if err != nil {
 		return "", "", nil, false, err
@@ -265,8 +289,8 @@ func (ls *localSourceHandler) sync(
 	}()
 
 	// now sync in the clientPath dir
-	remote := newRemoteFS(caller, drive+clientPath, ls.src.IncludePatterns, ls.src.ExcludePatterns)
-	local, err := newLocalFS(ref.sharedState, clientPath, ls.src.IncludePatterns, ls.src.ExcludePatterns)
+	remote := newRemoteFS(caller, drive+clientPath, ls.src.IncludePatterns, ls.src.ExcludePatterns, ls.gitIgnore)
+	local, err := newLocalFS(ref.sharedState, clientPath, ls.src.IncludePatterns, ls.src.ExcludePatterns, ls.gitIgnore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local fs: %w", err)
 	}
@@ -301,9 +325,9 @@ func (ls *localSourceHandler) syncParentDirs(
 	if drive != "" {
 		root = drive + "/"
 	}
-	remote := newRemoteFS(caller, root, includes, excludes)
+	remote := newRemoteFS(caller, root, includes, excludes, false)
 
-	local, err := newLocalFS(ref.sharedState, "/", includes, excludes)
+	local, err := newLocalFS(ref.sharedState, "/", includes, excludes, false)
 	if err != nil {
 		return fmt.Errorf("failed to create local fs: %w", err)
 	}

--- a/sdk/elixir/lib/dagger/gen/host.ex
+++ b/sdk/elixir/lib/dagger/gen/host.ex
@@ -35,7 +35,8 @@ defmodule Dagger.Host do
   @spec directory(t(), String.t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
-          {:no_cache, boolean() | nil}
+          {:no_cache, boolean() | nil},
+          {:no_git_auto_ignore, boolean() | nil}
         ]) :: Dagger.Directory.t()
   def directory(%__MODULE__{} = host, path, optional_args \\ []) do
     query_builder =
@@ -45,6 +46,7 @@ defmodule Dagger.Host do
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
       |> QB.maybe_put_arg("noCache", optional_args[:no_cache])
+      |> QB.maybe_put_arg("noGitAutoIgnore", optional_args[:no_git_auto_ignore])
 
     %Dagger.Directory{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6540,6 +6540,8 @@ type HostDirectoryOpts struct {
 	Include []string
 	// If true, the directory will always be reloaded from the host.
 	NoCache bool
+	// Don't apply .gitignore filter rules inside the directory
+	NoGitAutoIgnore bool
 }
 
 // Accesses a directory on the host.
@@ -6557,6 +6559,10 @@ func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
 		// `noCache` optional argument
 		if !querybuilder.IsZeroValue(opts[i].NoCache) {
 			q = q.Arg("noCache", opts[i].NoCache)
+		}
+		// `noGitAutoIgnore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGitAutoIgnore) {
+			q = q.Arg("noGitAutoIgnore", opts[i].NoGitAutoIgnore)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/php/generated/Host.php
+++ b/sdk/php/generated/Host.php
@@ -31,6 +31,7 @@ class Host extends Client\AbstractObject implements Client\IdAble
         ?array $exclude = null,
         ?array $include = null,
         ?bool $noCache = false,
+        ?bool $noGitAutoIgnore = false,
     ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         $innerQueryBuilder->setArgument('path', $path);
@@ -42,6 +43,9 @@ class Host extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $noCache) {
         $innerQueryBuilder->setArgument('noCache', $noCache);
+        }
+        if (null !== $noGitAutoIgnore) {
+        $innerQueryBuilder->setArgument('noGitAutoIgnore', $noGitAutoIgnore);
         }
         return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6852,6 +6852,7 @@ class Host(Type):
         exclude: list[str] | None = None,
         include: list[str] | None = None,
         no_cache: bool | None = False,
+        no_git_auto_ignore: bool | None = False,
     ) -> Directory:
         """Accesses a directory on the host.
 
@@ -6867,12 +6868,15 @@ class Host(Type):
             ["app/", "package.*"]).
         no_cache:
             If true, the directory will always be reloaded from the host.
+        no_git_auto_ignore:
+            Don't apply .gitignore filter rules inside the directory
         """
         _args = [
             Arg("path", path),
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
             Arg("noCache", no_cache, False),
+            Arg("noGitAutoIgnore", no_git_auto_ignore, False),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)

--- a/sdk/rust/crates/dagger-sdk/examples/build-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/build-the-application/main.rs
@@ -9,6 +9,7 @@ async fn main() -> eyre::Result<()> {
                 exclude: Some(vec!["node_modules", "ci/"]),
                 include: None,
                 no_cache: None,
+                no_git_auto_ignore: None,
             },
         );
 

--- a/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
@@ -22,6 +22,7 @@ async fn main() -> eyre::Result<()> {
                     exclude: Some(vec!["node_modules", "ci/"]),
                     include: None,
                     no_cache: None,
+                    no_git_auto_ignore: None,
                 },
             );
 

--- a/sdk/rust/crates/dagger-sdk/examples/multi-stage-build/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/multi-stage-build/main.rs
@@ -10,6 +10,7 @@ async fn main() -> eyre::Result<()> {
                 exclude: Some(vec!["node_modules", "ci/"]),
                 include: None,
                 no_cache: None,
+                no_git_auto_ignore: None,
             },
         );
 

--- a/sdk/rust/crates/dagger-sdk/examples/publish-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/publish-the-application/main.rs
@@ -12,6 +12,7 @@ async fn main() -> eyre::Result<()> {
                 exclude: Some(vec!["node_modules", "ci/"]),
                 include: None,
                 no_cache: None,
+                no_git_auto_ignore: None,
             },
         );
 

--- a/sdk/rust/crates/dagger-sdk/examples/test-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/test-the-application/main.rs
@@ -9,6 +9,7 @@ async fn main() -> eyre::Result<()> {
                 exclude: Some(vec!["node_modules", "ci/"]),
                 include: None,
                 no_cache: None,
+                no_git_auto_ignore: None,
             },
         );
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7862,6 +7862,9 @@ pub struct HostDirectoryOpts<'a> {
     /// If true, the directory will always be reloaded from the host.
     #[builder(setter(into, strip_option), default)]
     pub no_cache: Option<bool>,
+    /// Don't apply .gitignore filter rules inside the directory
+    #[builder(setter(into, strip_option), default)]
+    pub no_git_auto_ignore: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostFileOpts {
@@ -7939,6 +7942,9 @@ impl Host {
         }
         if let Some(no_cache) = opts.no_cache {
             query = query.arg("noCache", no_cache);
+        }
+        if let Some(no_git_auto_ignore) = opts.no_git_auto_ignore {
+            query = query.arg("noGitAutoIgnore", no_git_auto_ignore);
         }
         Directory {
             proc: self.proc.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1272,6 +1272,11 @@ export type HostDirectoryOpts = {
    * If true, the directory will always be reloaded from the host.
    */
   noCache?: boolean
+
+  /**
+   * Don't apply .gitignore filter rules inside the directory
+   */
+  noGitAutoIgnore?: boolean
 }
 
 export type HostFileOpts = {
@@ -6948,6 +6953,7 @@ export class Host extends BaseClient {
    * @param opts.exclude Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
    * @param opts.include Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
    * @param opts.noCache If true, the directory will always be reloaded from the host.
+   * @param opts.noGitAutoIgnore Don't apply .gitignore filter rules inside the directory
    */
   directory = (path: string, opts?: HostDirectoryOpts): Directory => {
     const ctx = this._ctx.select("directory", { path, ...opts })

--- a/util/fsxutil/gitignore_fs.go
+++ b/util/fsxutil/gitignore_fs.go
@@ -1,0 +1,95 @@
+package fsxutil
+
+import (
+	"context"
+	"io"
+	gofs "io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+)
+
+// gitignoreFS wraps an FS and filters files based on .gitignore rules
+type gitignoreFS struct {
+	fs      fsutil.FS
+	matcher *GitignoreMatcher
+}
+
+// NewGitIgnoreFS creates a new FS that filters the given FS using gitignore rules
+func NewGitIgnoreFS(fs fsutil.FS) (fsutil.FS, error) {
+	gfs := &gitignoreFS{
+		fs:      fs,
+		matcher: NewGitIgnoreMatcher(fs),
+	}
+	return gfs, nil
+}
+
+// Open implements fsutil.FS
+func (gfs *gitignoreFS) Open(path string) (io.ReadCloser, error) {
+	ignored, err := gfs.matcher.Matches(path, false)
+	if err != nil {
+		return nil, err
+	}
+	if ignored {
+		return nil, errors.Wrapf(os.ErrNotExist, "open %s", path)
+	}
+	return gfs.fs.Open(path)
+}
+
+// Walk implements fsutil.FS
+func (gfs *gitignoreFS) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
+	type visitedDir struct {
+		entry       gofs.DirEntry
+		pathWithSep string
+	}
+	var parentDirs []visitedDir
+
+	return gfs.fs.Walk(ctx, target, func(path string, dirEntry gofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		for len(parentDirs) != 0 {
+			lastParentDir := parentDirs[len(parentDirs)-1].pathWithSep
+			if strings.HasPrefix(path, lastParentDir) {
+				break
+			}
+			parentDirs = parentDirs[:len(parentDirs)-1]
+		}
+
+		isDir := dirEntry != nil && dirEntry.IsDir()
+
+		// Check if this path should be ignored
+		ignored, err := gfs.matcher.Matches(path, isDir)
+		if err != nil {
+			return err
+		}
+
+		if ignored {
+			if isDir {
+				dir := visitedDir{
+					entry:       dirEntry,
+					pathWithSep: path + string(filepath.Separator),
+				}
+				parentDirs = append(parentDirs, dir)
+
+				// Skip the entire directory
+				// return filepath.SkipDir
+				return nil
+			}
+			// Skip this file
+			return nil
+		}
+
+		for _, dir := range slices.Backward(parentDirs) {
+			if err := fn(strings.TrimSuffix(dir.pathWithSep, string(filepath.Separator)), dir.entry, nil); err != nil {
+				return err
+			}
+		}
+		return fn(path, dirEntry, nil)
+	})
+}

--- a/util/fsxutil/gitignore_fs_test.go
+++ b/util/fsxutil/gitignore_fs_test.go
@@ -1,0 +1,415 @@
+package fsxutil
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+func TestGitIgnoreBasic(t *testing.T) {
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "*.log\ntemp/"`,
+		`ADD foo.txt file`,
+		`ADD bar.log file`,
+		`ADD temp dir`,
+		`ADD temp/nested.txt file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// Should include .gitignore, foo.txt but exclude bar.log and temp/
+	assert.Equal(t, `file .gitignore
+file foo.txt
+`, b.String())
+}
+
+func TestGitIgnoreNestedGitIgnore(t *testing.T) {
+	// Test that nested .gitignore files properly override parent rules
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "*.log"`,
+		`ADD subdir dir`,
+		`ADD subdir/.gitignore file "!important.log"`,
+		`ADD subdir/test.log file`,
+		`ADD subdir/important.log file`,
+		`ADD root.log file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// Root .log files should be ignored, but subdir/important.log should be included due to negation
+	expected := `file .gitignore
+dir subdir
+file subdir/.gitignore
+file subdir/important.log
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreDirectoryOnly(t *testing.T) {
+	// Test directory-only patterns (trailing slash)
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "build/\n*.tmp"`,
+		`ADD build dir`,
+		`ADD build/output.txt file`,
+		`ADD build.tmp file`, // This file should be ignored by *.tmp
+		`ADD buildfile file`, // This file should NOT be ignored (no trailing slash)
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// build/ directory ignored, build.tmp ignored by *.tmp, but buildfile included
+	expected := `file .gitignore
+file buildfile
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreNegationPrecedence(t *testing.T) {
+	// Test complex negation patterns where later rules override earlier ones
+	// Expected behavior: gitignore processes patterns in order, so later patterns
+	// take precedence. A negation pattern (!) can un-ignore files that were
+	// previously ignored.
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "*.log\n!important.log\ntemp/\n!temp/keep.txt"`,
+		`ADD regular.log file`,
+		`ADD important.log file`,
+		`ADD temp dir`,
+		`ADD temp/delete.txt file`,
+		`ADD temp/keep.txt file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// *.log ignores all .log files, but !important.log brings it back
+	// temp/ ignores the directory, but !temp/keep.txt should bring back that specific file
+	expected := `file .gitignore
+file important.log
+dir temp
+file temp/keep.txt
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreDoublestar(t *testing.T) {
+	// Test ** patterns that match any number of directories
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "**/node_modules/\n**/*.pyc"`,
+		`ADD node_modules dir`,
+		`ADD node_modules/react file`,
+		`ADD project dir`,
+		`ADD project/node_modules dir`,
+		`ADD project/node_modules/vue file`,
+		`ADD script.py file`,
+		`ADD script.pyc file`,
+		`ADD deep dir`,
+		`ADD deep/nested dir`,
+		`ADD deep/nested/file.pyc file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// All node_modules directories and .pyc files should be ignored
+	expected := `file .gitignore
+dir deep
+dir deep/nested
+dir project
+file script.py
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreRelativePatterns(t *testing.T) {
+	// Test patterns that are relative to the gitignore file location
+	// Expected behavior: patterns without leading slash are relative to the
+	// gitignore file's directory, patterns with leading slash are relative
+	// to the repository root.
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "/root-only.txt"`,
+		`ADD absolute.txt file`,
+		`ADD root-only.txt file`,
+		`ADD build file`,
+		`ADD subdir dir`,
+		`ADD subdir/.gitignore file "build\n/absolute.txt"`,
+		`ADD subdir/build file`,
+		`ADD subdir/other file`,
+		`ADD subdir/absolute.txt file`,
+		`ADD subdir/subdir2 dir`,
+		`ADD subdir/subdir2/absolute.txt file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// /root-only.txt ignored by root .gitignore
+	// build ignored by root .gitignore
+	// subdir/build ignored by subdir/.gitignore
+	// subdir/other/build NOT ignored (subdir/.gitignore only applies to its level)
+	// absolute.txt NOT ignored (/ pattern in subdir doesn't affect root)
+	expected := `file .gitignore
+file absolute.txt
+file build
+dir subdir
+file subdir/.gitignore
+file subdir/other
+dir subdir/subdir2
+file subdir/subdir2/absolute.txt
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreTrailingSlash(t *testing.T) {
+	// Test that trailing slashes in patterns are handled correctly
+	// Expected behavior: Patterns with trailing slashes should only match directories.
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "build*/"`,
+		`ADD build-foo dir`,
+		`ADD build-foo/file.txt file`,
+		`ADD build-bar file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	expected := `file .gitignore
+file build-bar
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreEmptyAndComments(t *testing.T) {
+	// Test that empty lines and comments are properly ignored
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "# This is a comment\n\n*.log\n# Another comment\n\ntemp.txt\n\n"`,
+		`ADD test.log file`,
+		`ADD temp.txt file`,
+		`ADD keep.txt file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	expected := `file .gitignore
+file keep.txt
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreNoGitIgnoreFile(t *testing.T) {
+	// Test behavior when no .gitignore file exists
+	d, err := tmpDir(changeStream([]string{
+		`ADD foo.txt file`,
+		`ADD bar.log file`,
+		`ADD subdir dir`,
+		`ADD subdir/nested.txt file`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// Without .gitignore, all files should be included
+	expected := `file bar.log
+file foo.txt
+dir subdir
+file subdir/nested.txt
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreOpen(t *testing.T) {
+	// Test that Open() respects gitignore rules
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "*.log"`,
+		`ADD allowed.txt file "content"`,
+		`ADD blocked.log file "content"`,
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	// Should be able to open allowed file
+	r, err := gfs.Open("allowed.txt")
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	// Should NOT be able to open blocked file
+	_, err = gfs.Open("blocked.log")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestGitIgnoreComplexHierarchy(t *testing.T) {
+	// Test complex directory hierarchy with multiple .gitignore files
+	// Expected behavior: Each .gitignore file adds its patterns to the
+	// accumulated set from parent directories. Child patterns can override
+	// parent patterns using negation.
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "*.tmp\nignore/"`,
+		`ADD level1 dir`,
+		`ADD level1/.gitignore file "*.log\n!important.log"`,
+		`ADD level1/level2 dir`,
+		`ADD level1/level2/.gitignore file "*.txt\n!keep.txt"`,
+		`ADD test.tmp file`,                // ignored by root
+		`ADD level1/test.log file`,         // ignored by level1
+		`ADD level1/important.log file`,    // NOT ignored (negated by level1)
+		`ADD level1/level2/file.txt file`,  // ignored by level2
+		`ADD level1/level2/keep.txt file`,  // NOT ignored (negated by level2)
+		`ADD level1/level2/test.tmp file`,  // ignored by root (inherited)
+		`ADD level1/level2/other.log file`, // ignored by level1 (inherited)
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// Complex inheritance and negation should work correctly
+	expected := `file .gitignore
+dir level1
+file level1/.gitignore
+file level1/important.log
+dir level1/level2
+file level1/level2/.gitignore
+file level1/level2/keep.txt
+`
+	assert.Equal(t, expected, b.String())
+}
+
+func TestGitIgnoreEdgeCasePatterns(t *testing.T) {
+	// Test edge case patterns that might cause issues
+	// Expected behavior: Various special characters and patterns should
+	// work correctly, including escaping and bracket expressions.
+	d, err := tmpDir(changeStream([]string{
+		`ADD .gitignore file "file[123].txt\n*.log\nspecial\\*file.txt\ndir with spaces/"`,
+		`ADD file1.txt file`,        // ignored by bracket pattern
+		`ADD file2.txt file`,        // ignored by bracket pattern
+		`ADD file4.txt file`,        // NOT ignored (not in bracket range)
+		`ADD test.log file`,         // ignored by *.log
+		`ADD special*file.txt file`, // ignored by escaped pattern
+		`ADD "dir with spaces" dir`, // ignored by dir pattern
+		`ADD "dir with spaces/content.txt" file`,
+		`ADD normal.txt file`, // NOT ignored
+	}))
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	fs, err := fsutil.NewFS(d)
+	require.NoError(t, err)
+
+	gfs, err := NewGitIgnoreFS(fs)
+	require.NoError(t, err)
+
+	b := &bytes.Buffer{}
+	err = gfs.Walk(context.Background(), "", bufWalkDir(b))
+	require.NoError(t, err)
+
+	// Only file4.txt and normal.txt should remain
+	expected := `file .gitignore
+file file4.txt
+file normal.txt
+`
+	assert.Equal(t, expected, b.String())
+}

--- a/util/fsxutil/gitignore_matcher.go
+++ b/util/fsxutil/gitignore_matcher.go
@@ -1,0 +1,174 @@
+package fsxutil
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+)
+
+type GitignoreMatcher struct {
+	fs fsutil.FS
+
+	// Cache for parsed gitignore files to avoid re-reading
+	gitignoreCache         map[string]gitignore.Matcher
+	gitignoreCachePatterns map[string][]gitignore.Pattern
+	gitignoreCacheMu       sync.RWMutex
+}
+
+// NewGitignoreMatcher creates a new GitignoreMatcher for the given FS
+func NewGitIgnoreMatcher(fs fsutil.FS) *GitignoreMatcher {
+	gfs := &GitignoreMatcher{
+		fs:                     fs,
+		gitignoreCache:         make(map[string]gitignore.Matcher),
+		gitignoreCachePatterns: make(map[string][]gitignore.Pattern),
+	}
+	return gfs
+}
+
+// Matches checks if a path should be ignored based on gitignore rules
+func (gfs *GitignoreMatcher) Matches(path string, isDir bool) (out bool, _ error) {
+	// Clean the path and ensure it's relative
+	path = filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		path = strings.TrimPrefix(path, "/")
+	}
+
+	// Get the directory containing this path
+	var dirPath string
+	if isDir {
+		dirPath = path
+	} else {
+		dirPath = filepath.Dir(path)
+		if dirPath == "." && path != "." {
+			dirPath = ""
+		}
+	}
+
+	// Get all accumulated patterns for this directory
+	matcher, err := gfs.getGitIgnoreMatcher(dirPath)
+	if err != nil {
+		return false, err
+	}
+	if matcher == nil {
+		// No patterns found, nothing to ignore
+		return false, nil
+	}
+
+	pathComponents := strings.Split(path, string(filepath.Separator))
+	return matcher.Match(pathComponents, isDir), nil
+}
+
+func (gfs *GitignoreMatcher) getGitIgnoreMatcher(dirPath string) (matcher gitignore.Matcher, rerr error) {
+	if dirPath == "" {
+		dirPath = "."
+	}
+
+	gfs.gitignoreCacheMu.RLock()
+	if matcher, exists := gfs.gitignoreCache[dirPath]; exists {
+		gfs.gitignoreCacheMu.RUnlock()
+		return matcher, nil
+	}
+	gfs.gitignoreCacheMu.RUnlock()
+
+	defer func() {
+		if rerr == nil {
+			gfs.gitignoreCacheMu.Lock()
+			gfs.gitignoreCache[dirPath] = matcher
+			gfs.gitignoreCacheMu.Unlock()
+		}
+	}()
+
+	patterns, err := gfs.getGitIgnorePatterns(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(patterns) > 0 {
+		matcher = gitignore.NewMatcher(patterns)
+	}
+	return matcher, nil
+}
+
+func (gfs *GitignoreMatcher) getGitIgnorePatterns(dirPath string) (patterns []gitignore.Pattern, rerr error) {
+	if dirPath == "" {
+		dirPath = "."
+	}
+
+	gfs.gitignoreCacheMu.RLock()
+	if patterns, exists := gfs.gitignoreCachePatterns[dirPath]; exists {
+		gfs.gitignoreCacheMu.RUnlock()
+		return patterns, nil
+	}
+	gfs.gitignoreCacheMu.RUnlock()
+
+	defer func() {
+		if rerr == nil {
+			gfs.gitignoreCacheMu.Lock()
+			gfs.gitignoreCachePatterns[dirPath] = patterns
+			gfs.gitignoreCacheMu.Unlock()
+		}
+	}()
+
+	if dirPath != "." {
+		parentDir := filepath.Dir(dirPath)
+		var err error
+		patterns, err = gfs.getGitIgnorePatterns(parentDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	gitignorePath := filepath.Join(dirPath, ".gitignore")
+	reader, err := gfs.fs.Open(gitignorePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return patterns, nil
+		}
+		return nil, err
+	}
+	defer reader.Close()
+
+	// Parse the .gitignore file
+	domain := strings.Split(dirPath, string(filepath.Separator))
+	if dirPath == "." {
+		domain = nil
+	}
+
+	// Read patterns from the .gitignore filepath
+	newPatterns, err := parseGitIgnoreFile(reader, domain)
+	if err != nil {
+		return nil, err
+	}
+	patterns = slices.Clone(patterns)
+	patterns = append(patterns, newPatterns...)
+
+	return patterns, nil
+}
+
+// parseGitIgnoreFile parses a gitignore file and returns patterns
+func parseGitIgnoreFile(reader io.Reader, domain []string) ([]gitignore.Pattern, error) {
+	var patterns []gitignore.Pattern
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			// skip empty lines and comments
+			continue
+		}
+		pattern := gitignore.ParsePattern(line, domain)
+		patterns = append(patterns, pattern)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return patterns, nil
+}

--- a/util/fsxutil/helpers_test.go
+++ b/util/fsxutil/helpers_test.go
@@ -1,0 +1,198 @@
+package fsxutil
+
+import (
+	"bytes"
+	"fmt"
+	gofs "io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+// bufWalkDir is a helper function that matches the style in filter_test.go
+func bufWalkDir(buf *bytes.Buffer) gofs.WalkDirFunc {
+	return func(path string, entry gofs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fi, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		t := "file"
+		if fi.IsDir() {
+			t = "dir"
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t = "symlink"
+		}
+		fmt.Fprintf(buf, "%s %s\n", t, path)
+		return nil
+	}
+}
+
+func tmpDir(inp []*change) (dir string, retErr error) {
+	tmpdir, err := os.MkdirTemp("", "diff")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if retErr != nil {
+			os.RemoveAll(tmpdir)
+		}
+	}()
+	for _, c := range inp {
+		if c.kind == fsutil.ChangeKindAdd {
+			p := filepath.Join(tmpdir, c.path)
+			stat, ok := c.fi.Sys().(*types.Stat)
+			if !ok {
+				return "", errors.Errorf("invalid symlink change %s", p)
+			}
+			if c.fi.IsDir() {
+				if err := os.Mkdir(p, 0700); err != nil {
+					return "", err
+				}
+			} else if c.fi.Mode()&os.ModeSymlink != 0 {
+				if err := os.Symlink(stat.Linkname, p); err != nil {
+					return "", err
+				}
+			} else if len(stat.Linkname) > 0 {
+				if err := os.Link(filepath.Join(tmpdir, stat.Linkname), p); err != nil {
+					return "", err
+				}
+			} else if c.fi.Mode()&os.ModeSocket != 0 {
+				// not closing listener because it would remove the socket file
+				if _, err := net.Listen("unix", p); err != nil {
+					return "", err
+				}
+			} else {
+				f, err := os.Create(p)
+				if err != nil {
+					return "", err
+				}
+
+				// Make sure all files start with the same default permissions,
+				// regardless of OS settings.
+				err = os.Chmod(p, 0644)
+				if err != nil {
+					return "", err
+				}
+
+				if len(c.data) > 0 {
+					if _, err := f.Write([]byte(c.data)); err != nil {
+						return "", err
+					}
+				}
+				f.Close()
+			}
+		}
+	}
+	return tmpdir, nil
+}
+
+type change struct {
+	kind fsutil.ChangeKind
+	path string
+	fi   os.FileInfo
+	data string
+}
+
+func changeStream(dt []string) (changes []*change) {
+	for _, s := range dt {
+		changes = append(changes, parseChange(s))
+	}
+	return
+}
+
+func parseChange(str string) *change {
+	errStr := fmt.Sprintf("invalid change %q", str)
+
+	f := splitFields(str)
+	if len(f) < 3 {
+		panic(errStr)
+	}
+
+	c := &change{}
+	switch f[0] {
+	case "ADD":
+		c.kind = fsutil.ChangeKindAdd
+	case "CHG":
+		c.kind = fsutil.ChangeKindModify
+	case "DEL":
+		c.kind = fsutil.ChangeKindDelete
+	default:
+		panic(errStr)
+	}
+	c.path = filepath.FromSlash(f[1])
+	st := &types.Stat{}
+	switch f[2] {
+	case "file":
+		if len(f) > 3 {
+			if f[3][0] == '>' {
+				st.Linkname = f[3][1:]
+			} else {
+				c.data = f[3]
+			}
+		}
+	case "dir":
+		st.Mode |= uint32(os.ModeDir)
+	case "socket":
+		st.Mode |= uint32(os.ModeSocket)
+	case "symlink":
+		if len(f) < 4 {
+			panic(errStr)
+		}
+		st.Mode |= uint32(os.ModeSymlink)
+		st.Linkname = f[3]
+	}
+	c.fi = &fsutil.StatInfo{Stat: st}
+	return c
+}
+
+func splitFields(s string) []string {
+	// Split the string by spaces, but handle quoted strings correctly
+	var fields []string
+	var current strings.Builder
+	inQuotes := false
+	escapeNext := false
+
+	for _, r := range s {
+		if escapeNext {
+			switch r {
+			case 'n':
+				current.WriteRune('\n')
+			case 't':
+				current.WriteRune('\t')
+			default:
+				current.WriteRune(r)
+			}
+			escapeNext = false
+			continue
+		}
+		if r == '"' {
+			inQuotes = !inQuotes
+			continue
+		}
+		if r == '\\' {
+			escapeNext = true
+			continue
+		}
+		if r == ' ' && !inQuotes {
+			fields = append(fields, current.String())
+			current.Reset()
+		} else {
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		fields = append(fields, current.String())
+	}
+
+	return fields
+}


### PR DESCRIPTION
Implements my suggestion in https://github.com/dagger/dagger/issues/10868#issuecomment-3183991570.

We remove the original approach from https://github.com/dagger/dagger/pull/10736, which attempts to convert `gitignore`-style patterns into `dockerignore`-style patterns (supported by buildkit, which uses mobypatternmatcher). Instead, we add a `gitignoreFS`, which creates a filtered FS in the style of `filterFS`, but that automatically extracts gitignore filters from `.gitignore` files in the tree, and applies them using go-git.

This has a couple of advantages:
- Instead of converting, we directly process gitignore patterns. No weird issues like https://github.com/dagger/dagger/pull/10870 can ever occur again. Using a mature implementation like `go-git` ensures we're as close to `git` as possible.
- Fewer file transfers to-and-from the host filesystem - we don't need to load gitignores to process patterns, the file-transfer protocol simply understands them natively.
- Simpler implementation - all the gitignore code is completely isolated to *one* component in the file transfer stack, instead of being spread out through gitignores and the like.