### PR TITLE
feat: support OIDC auth with the Dagger Cloud API

### DIFF
--- a/core/integration/cloud_test.go
+++ b/core/integration/cloud_test.go
@@ -19,15 +19,15 @@ func (CloudSuite) TestTraceURL(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	// depends on where the test runs - in an already nested test, we're *not* logged in
-	org, _ := auth.CurrentOrg()
+	org, _ := auth.CurrentOrgName()
 
 	url, err := c.Cloud().TraceURL(ctx)
-	if org == nil {
+	if org == "" {
 		requireErrOut(t, err, "no cloud organization configured")
 	} else {
 		require.NoError(t, err)
 		require.Contains(t, url, "https://dagger.cloud/")
-		require.Contains(t, url, org.Name)
+		require.Contains(t, url, org)
 	}
 }
 
@@ -35,7 +35,7 @@ func (CloudSuite) TestTraceURLNested(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	// depends on where the test runs - in an already nested test, we're *not* logged in
-	org, _ := auth.CurrentOrg()
+	org, _ := auth.CurrentOrgName()
 
 	src := `package main
 
@@ -51,11 +51,11 @@ func (m *Test) TraceURL(ctx context.Context) (string, error) {
 `
 	modGen := modInit(t, c, "go", src)
 	out, err := modGen.With(daggerCall("trace-url")).Stdout(ctx)
-	if org == nil {
+	if org == "" {
 		requireErrOut(t, err, "no cloud organization configured")
 	} else {
 		require.NoError(t, err)
 		require.Contains(t, out, "https://dagger.cloud/")
-		require.Contains(t, out, org.Name)
+		require.Contains(t, out, org)
 	}
 }

--- a/engine/cache/cachemanager/manager.go
+++ b/engine/cache/cachemanager/manager.go
@@ -3,7 +3,6 @@ package cachemanager
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/moby/buildkit/solver"
@@ -16,15 +15,11 @@ type ManagerConfig struct {
 	ResultStore  solver.CacheResultStorage
 	Worker       worker.Worker
 	MountManager *mounts.MountManager
-	ServiceURL   string
-	Token        string
 	EngineID     string
 }
 
 const (
-	LocalCacheID            = "local"
-	startupImportTimeout    = 1 * time.Minute
-	backgroundImportTimeout = 10 * time.Minute
+	LocalCacheID = "local"
 )
 
 var contentStoreLayers = map[string]struct{}{}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1165,8 +1165,8 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 	}
 
 	var cloudOrg string
-	if o, _ := auth.CurrentOrg(); o != nil {
-		cloudOrg = o.Name
+	if o, _ := auth.CurrentOrgName(); o != "" {
+		cloudOrg = o
 	}
 
 	return engine.ClientMetadata{

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -489,24 +489,11 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		return nil, err
 	}
 
-	cacheServiceURL := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_URL")
-	cacheServiceToken := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN")
-	// add DAGGER_CLOUD_TOKEN in a backwards compat way.
-	// TODO: deprecate in a future release
-	if v, ok := os.LookupEnv("DAGGER_CLOUD_TOKEN"); ok {
-		cacheServiceToken = v
-	}
-
-	if cacheServiceURL == "" {
-		cacheServiceURL = daggerCacheServiceURL
-	}
 	srv.SolverCache, err = daggercache.NewManager(ctx, daggercache.ManagerConfig{
 		KeyStore:     srv.solverCacheDB,
 		ResultStore:  bkworker.NewCacheResultStorage(baseWorkerController),
 		Worker:       srv.baseWorker,
 		MountManager: mounts.NewMountManager("dagger-cache", srv.workerCache, srv.bkSessionManager),
-		ServiceURL:   cacheServiceURL,
-		Token:        cacheServiceToken,
 		EngineID:     opts.Name,
 	})
 	if err != nil {

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -82,10 +82,6 @@ import (
 	"github.com/dagger/dagger/engine/sources/local"
 )
 
-const (
-	daggerCacheServiceURL = "https://api.dagger.cloud/magicache"
-)
-
 type Server struct {
 	controlapi.UnimplementedControlServer
 	engineName string

--- a/engine/telemetry/cloud.go
+++ b/engine/telemetry/cloud.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"maps"
 	"net/url"
@@ -35,11 +34,16 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 			authHeader string
 			token      *oauth2.Token
 			org        *auth.Org
+			err        error
 		)
 
 		// Try token auth first
 		if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
-			authHeader = "Basic " + base64.StdEncoding.EncodeToString([]byte(cloudToken+":"))
+			authHeader, err = auth.GetDaggerCloudAuth(ctx, cloudToken)
+			if err != nil {
+				slog.Warn("failed to parse DAGGER_CLOUD_TOKEN", "error", err)
+				return
+			}
 		}
 
 		// Try OAuth next

--- a/engine/telemetry/url.go
+++ b/engine/telemetry/url.go
@@ -3,8 +3,6 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/dagger/dagger/internal/cloud/auth"
 	"go.opentelemetry.io/otel/trace"
@@ -15,28 +13,9 @@ func URLForTrace(ctx context.Context) (url string, msg string, ok bool) {
 		return "", "", false
 	}
 
-	var orgName string
-	if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
-		// Try token auth first
-		token, ok := ParseDaggerToken(cloudToken)
-		if ok {
-			orgName = token.orgName
-		} else {
-			// DAGGER_CLOUD_TOKEN might be OIDC so try fetching
-			// the org from the state
-			org, err := auth.CurrentOrg()
-			if err != nil {
-				return "", "", false
-			}
-			orgName = org.Name
-		}
-	} else {
-		// Try OAuth next
-		org, err := auth.CurrentOrg()
-		if err != nil {
-			return "", "", false
-		}
-		orgName = org.Name
+	orgName, err := auth.CurrentOrgName()
+	if err != nil {
+		return "", "", false
 	}
 
 	if orgName == "" {
@@ -49,26 +28,4 @@ func URLForTrace(ctx context.Context) (url string, msg string, ok bool) {
 		trace.SpanContextFromContext(ctx).TraceID().String(),
 	)
 	return url, "", true
-}
-
-type daggerToken struct {
-	orgName string
-	token   string
-}
-
-func ParseDaggerToken(s string) (daggerToken, bool) {
-	s, ok := strings.CutPrefix(s, "dag_")
-	if !ok {
-		return daggerToken{}, false
-	}
-
-	orgName, token, ok := strings.Cut(s, "_")
-	if !ok {
-		return daggerToken{}, false
-	}
-
-	return daggerToken{
-		orgName: orgName,
-		token:   token,
-	}, true
 }

--- a/engine/telemetry/url.go
+++ b/engine/telemetry/url.go
@@ -21,6 +21,14 @@ func URLForTrace(ctx context.Context) (url string, msg string, ok bool) {
 		token, ok := ParseDaggerToken(cloudToken)
 		if ok {
 			orgName = token.orgName
+		} else {
+			// DAGGER_CLOUD_TOKEN might be OIDC so try fetching
+			// the org from the state
+			org, err := auth.CurrentOrg()
+			if err != nil {
+				return "", "", false
+			}
+			orgName = org.Name
 		}
 	} else {
 		// Try OAuth next

--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -2,12 +2,15 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -25,7 +28,15 @@ var (
 	configRoot      = filepath.Join(xdg.ConfigHome, "dagger")
 	credentialsFile = filepath.Join(configRoot, "credentials.json")
 	orgFile         = filepath.Join(configRoot, "org")
+
+	apiURL = "https://api.dagger.cloud"
 )
+
+func init() {
+	if u := os.Getenv("DAGGER_CLOUD_URL"); u != "" {
+		apiURL = u
+	}
+}
 
 var authConfig = &oauth2.Config{
 	// https://manage.auth0.com/dashboard/us/dagger-io/applications/brEY7u4SEoFypOgYBdYMs32b4ShRVIEv/settings
@@ -175,4 +186,115 @@ func SetCurrentOrg(org *Org) error {
 	}
 
 	return writeFile(orgFile, data, 0o600)
+}
+
+var (
+	once      sync.Once
+	oidcLogin *oidcTokenResponse
+	oidcErr   error
+)
+
+func fetchOIDCAuth(ctx context.Context) (string, error) {
+	// getOIDCToken calls both GitHub OIDC as well as Dagger Cloud's own OIDC endpoint
+	// It's not a big deal if we call it more than once per session but
+	// it makes sense to avoid it were possible.
+	once.Do(func() {
+		oidcLogin, oidcErr = getOIDCToken(ctx)
+	})
+	if oidcErr != nil {
+		return "", fmt.Errorf("failed to get OIDC token: %w", oidcErr)
+	}
+
+	if err := SetCurrentOrg(&Org{ID: oidcLogin.OrgID, Name: oidcLogin.OrgName}); err != nil {
+		return "", fmt.Errorf("failed to set current org from OIDC token: %w", err)
+	}
+
+	return oidcLogin.Token, nil
+}
+
+func GetDaggerCloudAuth(ctx context.Context, token string) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("DAGGER_CLOUD_TOKEN environment variable is not set")
+	}
+	if token == "oidc" {
+		oidc, err := fetchOIDCAuth(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch OIDC auth: %w", err)
+		}
+		return "Bearer " + oidc, nil
+	}
+
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(token+":")), nil
+}
+
+func DaggerCloudTransport(ctx context.Context, token string) (http.RoundTripper, error) {
+	header, err := GetDaggerCloudAuth(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &authTransport{header: header}, nil
+}
+
+type oidcTokenResponse struct {
+	Token   string `json:"token"`
+	OrgID   string `json:"org_id"`
+	OrgName string `json:"org_name"`
+}
+
+func getOIDCToken(ctx context.Context) (*oidcTokenResponse, error) {
+	// support for GitHub's OIDC environment variables
+	ghToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	ghURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	if ghToken != "" && ghURL != "" {
+		r, err := http.NewRequestWithContext(ctx, http.MethodGet, ghURL+"&audience=dagger.cloud", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GitHub's OIDC request: %w", err)
+		}
+		r.Header.Set("Authorization", "Bearer "+ghToken)
+
+		res, err := http.DefaultClient.Do(r)
+		if err != nil {
+			return nil, fmt.Errorf("failed to request GitHub's OIDC token: %w", err)
+		}
+		defer res.Body.Close()
+
+		response := map[string]string{}
+		if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+			return nil, fmt.Errorf("failed to decode GitHub's OIDC token response: %w", err)
+		}
+
+		providerToken := response["value"]
+
+		r, err = http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/v1/oidc?provider=github", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request for fetching OIDC token: %w", err)
+		}
+		r.Header.Set("Authorization", "Bearer "+providerToken)
+
+		loginRes, err := http.DefaultClient.Do(r)
+		if err != nil {
+			return nil, fmt.Errorf("failed to request OIDC token: %w", err)
+		}
+		defer loginRes.Body.Close()
+
+		tokenResponse := &oidcTokenResponse{}
+		if err := json.NewDecoder(loginRes.Body).Decode(&tokenResponse); err != nil {
+			return nil, fmt.Errorf("failed to decode OIDC token response: %w", err)
+		}
+		return tokenResponse, nil
+	}
+
+	return nil, fmt.Errorf("OIDC authentication is not supported in this context, please use a DAGGER_CLOUD_TOKEN or 'dagger login'")
+}
+
+type authTransport struct {
+	header string
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r2 := req.Clone(req.Context())
+	r2.Header.Set("Authorization", t.header)
+
+	return http.DefaultTransport.RoundTrip(r2)
 }

--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -189,7 +189,7 @@ func SetCurrentOrg(org *Org) error {
 }
 
 var (
-	once      sync.Once
+	oidcOnce      sync.Once
 	oidcLogin *oidcTokenResponse
 	oidcErr   error
 )

--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -176,21 +176,19 @@ func CurrentOrg() (*Org, error) {
 }
 
 func CurrentOrgName() (string, error) {
-	var orgName string
 	if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
 		token, ok := ParseDaggerToken(cloudToken)
 		if ok {
-			orgName = token.orgName
-		} else {
-			org, err := CurrentOrg()
-			if err != nil {
-				return "", err
-			}
-			orgName = org.Name
+			return token.orgName, nil
 		}
-	} else {
 	}
-	return orgName, nil
+	// if the token is not valid or not present we fall back to reading from
+	// disk
+	org, err := CurrentOrg()
+	if err != nil {
+		return "", err
+	}
+	return org.Name, nil
 }
 
 func SetCurrentOrg(org *Org) error {

--- a/internal/cloud/auth/auth_test.go
+++ b/internal/cloud/auth/auth_test.go
@@ -1,4 +1,4 @@
-package telemetry
+package auth
 
 import (
 	"testing"

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -49,12 +49,17 @@ func NewClient(ctx context.Context) (*Client, error) {
 	if err != nil {
 		if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
 			httpClient.Transport, err = auth.DaggerCloudTransport(ctx, cloudToken)
+			if err != nil {
+				return nil, err
+			}
+
 			return &Client{
 				u:           u,
 				h:           httpClient,
 				engineToken: cloudToken,
 			}, nil
 		}
+
 		return nil, err
 	}
 	httpClient = oauth2.NewClient(ctx, tokenSource)

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -30,17 +30,6 @@ type Client struct {
 	engineToken string
 }
 
-type basicAuthTransport struct {
-	token string
-}
-
-func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	r2 := req.Clone(req.Context())
-	r2.SetBasicAuth(t.token, "")
-
-	return http.DefaultTransport.RoundTrip(r2)
-}
-
 func NewClient(ctx context.Context) (*Client, error) {
 	api := "https://api.dagger.cloud"
 	if cloudURL := os.Getenv("DAGGER_CLOUD_URL"); cloudURL != "" {
@@ -53,12 +42,13 @@ func NewClient(ctx context.Context) (*Client, error) {
 	}
 
 	httpClient := &http.Client{}
+
 	// Always prefer oauth if available. If not and a DAGGER_CLOUD_TOKEN
 	// is set then use Basic auth
 	tokenSource, err := auth.TokenSource(ctx)
 	if err != nil {
 		if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
-			httpClient.Transport = &basicAuthTransport{token: cloudToken}
+			httpClient.Transport, err = auth.DaggerCloudTransport(ctx, cloudToken)
 			return &Client{
 				u:           u,
 				h:           httpClient,


### PR DESCRIPTION
The problem: public repositories must expose their credentials if they wish to send telemetry Dagger Cloud. We expose our DAGGER_CLOUD_TOKEN in this repository. Since its only telemetry we don't worry much. But as we introduce compute-related features its critical that we have a secure mechanism to authenticate against api.dagger.cloud without exposing sensitive credentials.

To fix this issue we implement an OIDC authentication flow against our cloud API. To use this mechanism users need to specify `DAGGER_CLOUD_TOKEN=oidc` and be in a context where environment variables are correctly set for the supported providers. At the moment we only support GitHub as a provider. On top of specifying `DAGGER_CLOUD_TOKEN=oidc` users need to add the `id-token: write` permission to their workflow so that the dagger CLI can request an OIDC token from GitHub. 

Overall, the authentication flow is as follows:

<img width="1061" height="600" alt="image" src="https://github.com/user-attachments/assets/68024849-8d22-4125-bbfa-f31ba7ef39fb" />

- User sets `DAGGER_CLOUD_TOKEN="oidc"`
- Dagger CLI looks for environment variables of an OIDC provider. Right now only GitHub is supported through `id-token: write` workflow permissions and the `ACTIONS_ID_TOKEN_REQUEST_URL` env variable
- It queries the OIDC provider to get an OIDC JWT
- It sends that JWT to `api.dagger.cloud/v1/oidc`
- The API checks the token claims and looks for the `repository_owner` claim. It uses it to find an organization that has a source mapped to the `repository_owner`
- It creates a new JWT that can be used for all subsequent API calls
- It responds with the token plus the organization information so that the caller can know who is logged in.

In https://github.com/dagger/dagger.io/pull/4573 you'll find detailed information on the implementation as well as a demo showing how all works together in the context of a GitHub workflow.