### PR TITLE
hack/build: always start with debug

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -28,7 +28,7 @@ engine_pid=$!
         ${_EXPERIMENTAL_DAGGER_GPU_SUPPORT:+--gpu-support} |\
     start \
         --name=$CONTAINER \
-        ${DEBUG:+--debug} \
+        --debug \
         ${DAGGER_EXTRA_HOSTS:+--extra-hosts=${DAGGER_EXTRA_HOSTS-}} \
         ${DAGGER_CLOUD_TOKEN:+--cloud-token=env://DAGGER_CLOUD_TOKEN} \
         ${DAGGER_CLOUD_URL:+--cloud-url=${DAGGER_CLOUD_URL-}} &


### PR DESCRIPTION
Don't think there's any reason NOT to do this, helps to have the debug listeners set up before you know you need'em (e.g. a deadlock).
