### PR TITLE
evals: slight tweaks

### DIFF
--- a/modules/evals/build_multi.go
+++ b/modules/evals/build_multi.go
@@ -57,7 +57,7 @@ func buildMultiAssert(ctx context.Context, t testing.TB, llm *dagger.LLM) {
 
 	history, err := llm.History(ctx)
 	require.NoError(t, err)
-	if !strings.Contains(strings.Join(history, "\n"), "Container.withEnvVariable") {
+	if !strings.Contains(strings.Join(history, "\n"), "withEnvVariable") {
 		t.Error("should have used Container.withEnvVariable - use the right tool for the job!")
 	}
 

--- a/modules/evals/responses.go
+++ b/modules/evals/responses.go
@@ -38,11 +38,11 @@ func (e *Responses) Prompt(base *dagger.LLM) *dagger.LLM {
 			WithStringOutput("module_config_exists",
 				"Whether the module config exists (true/false).").
 			WithStringOutput("file_contents",
-				"The contents of hello_file").
+				"The contents of the file.").
 			WithStringOutput("file_size",
-				"The size of hello_file.").
+				"The size of the file.").
 			WithStringOutput("dir_entries",
-				"Line-separated list of some_dir entries.")).
+				"Line-separated list of directory entries.")).
 		WithPrompt("Provide the requested values.")
 }
 

--- a/modules/evaluator/workspace/main.go
+++ b/modules/evaluator/workspace/main.go
@@ -122,7 +122,7 @@ func (*Workspace) defaultAttempts(provider string) int {
 	switch strings.ToLower(provider) {
 	case "google":
 		// Gemini has no token usage limit, just an API rate limit.
-		return 10
+		return 3
 	case "openai":
 		// OpenAI is more sensitive to token usage.
 		return 5


### PR DESCRIPTION
* avoid using names since names aren't actually exposed, LLM may confuse for filenames
* don't be over-precise for withEnvVariable tool naming convention
* bring Gemini down from 10 to 3 in parallel - we're hitting rate limits now, seems like they wisened up