### PR TITLE
re-add --restart=always to docker run for engine

### DIFF
--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -62,7 +62,11 @@ func (d docker) ImageLoader(ctx context.Context) imageload.Backend {
 }
 
 func (d docker) ContainerRun(ctx context.Context, name string, opts runOpts) error {
-	args := []string{"run", "--name", name, "-d"}
+	args := []string{"run",
+		"--name", name,
+		"-d",
+		"--restart", "always", // load-bearing to prevent https://github.com/dagger/dagger/issues/7785 from being fatal
+	}
 	for _, volume := range opts.volumes {
 		args = append(args, "-v", volume)
 	}


### PR DESCRIPTION
This option got dropped during driver refactoring, which seems to have caused engine start in CI to fail >50% of the time due to `sed: write error` when the engine tries to setup cgroups during its entrypoint.
* https://github.com/dagger/dagger/issues/7785

Previously that would happen, the engine would restart and then succeed since the sed error is ephemeral. However, without the option the engine just never starts.

This change just re-adds that to the docker run command line.