### PR TITLE
ci: migrate php docs gen to sdk

### DIFF
--- a/.dagger/util.go
+++ b/.dagger/util.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/dagger/dagger/.dagger/internal/dagger"
+)
+
+func formatJSONFile(ctx context.Context, f *dagger.File) (*dagger.File, error) {
+	name, err := f.Name(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	contents, err := f.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out bytes.Buffer
+	err = json.Indent(&out, []byte(contents), "", "\t")
+	if err != nil {
+		return nil, err
+	}
+
+	return dag.File(name, out.String()), nil
+}


### PR DESCRIPTION
This moves php docs generation out of the docs generator and into the sdk generation. It could kind of have gone both places - but there's a significant advantage to having it in the SDK.

We need to use the generated php code as the input to the doctum generation step - if we don't, we actually don't end up updating the docs in one pass, it requires *two* generation passes, which is super annoying (and means you end up running `generate` steps twice).

This fixes that issue!