### PR TITLE
fix(sdk/rust): fix incorrect float type

### DIFF
--- a/sdk/rust/crates/dagger-codegen/src/rust/format.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/format.rs
@@ -27,7 +27,7 @@ impl FormatTypeFuncs for FormatTypeFunc {
 
     fn format_kind_scalar_float(&self, representation: &str) -> String {
         let mut rep = representation.to_string();
-        rep.push_str("float");
+        rep.push_str("f64");
         rep
     }
 


### PR DESCRIPTION
Fix translate GraphQL Float type from `float` (which's incorrect) into `f64`.