### PR TITLE
ci: avoid throwing an absolutely massive error

### DIFF
--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -190,7 +190,7 @@ func gitPublish(ctx context.Context, git *dagger.VersionGit, opts gitPublishOpts
 		destCommit = strings.TrimSpace(destCommit)
 
 		if !strings.Contains(history, destCommit) {
-			return fmt.Errorf("publish would rewrite history - %s not found\n%s", destCommit, history)
+			return fmt.Errorf("publish would rewrite history - %s not found", destCommit)
 		}
 		return nil
 	}


### PR DESCRIPTION
Like in https://dagger.cloud/dagger/traces/3d6e590c8188182a11f03e03e1007809.