### PR TITLE
feat: add ability to combine outputs in WithExec

### DIFF
--- a/.changes/unreleased/Added-20250822-112220.yaml
+++ b/.changes/unreleased/Added-20250822-112220.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Allow to get a combined output of both standard output and standard error after a withExec on a container
+time: 2025-08-22T11:22:20.827952+02:00
+custom:
+    Author: eunomie
+    PR: "10924"

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -450,6 +450,10 @@ func (container *Container) Stderr(ctx context.Context) (string, error) {
 	return container.metaFileContents(ctx, buildkit.MetaMountStderrPath)
 }
 
+func (container *Container) CombinedOutput(ctx context.Context) (string, error) {
+	return container.metaFileContents(ctx, buildkit.MetaMountCombinedOutputPath)
+}
+
 func (container *Container) ExitCode(ctx context.Context) (int, error) {
 	contents, err := container.metaFileContents(ctx, buildkit.MetaMountExitCodePath)
 	if err != nil {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -494,6 +494,10 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			View(BeforeVersion("v0.12.0")).
 			Extend(),
 
+		dagql.Func("combinedOutput", s.combinedOutput).
+			Doc(`The combined buffered standard output and standard error stream of the last executed command`,
+				`Returns an error if no command was executed`),
+
 		dagql.Func("exitCode", s.exitCode).
 			Doc(`The exit code of the last executed command`,
 				`Returns an error if no command was executed`),
@@ -1085,6 +1089,10 @@ func (s *containerSchema) stderrLegacy(ctx context.Context, parent dagql.ObjectR
 		return ctr.Self().Stderr(ctx)
 	}
 	return out, err
+}
+
+func (s *containerSchema) combinedOutput(ctx context.Context, parent *core.Container, _ struct{}) (string, error) {
+	return parent.CombinedOutput(ctx)
 }
 
 func (s *containerSchema) exitCode(ctx context.Context, parent *core.Container, _ struct{}) (int, error) {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -247,6 +247,13 @@ type Container {
     noInit: Boolean = false
   ): Container! @deprecated(reason: "Use `Directory.build` instead")
 
+  """
+  The combined buffered standard output and standard error stream of the last executed command
+
+  Returns an error if no command was executed
+  """
+  combinedOutput: String!
+
   """Return the container's default arguments."""
   defaultArgs: [String!]!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4502,6 +4502,13 @@
                         </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="Container-combinedOutput" href="#Container-combinedOutput"><code>combinedOutput</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td>
+                          <p>The combined buffered standard output and standard error stream of the last executed command</p>
+                          <p>Returns an error if no command was executed</p>
+                        </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="Container-defaultArgs" href="#Container-defaultArgs"><code>defaultArgs</code></a> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span> </td>
                         <td> Return the container's default arguments. </td>
                       </tr>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -173,6 +173,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_combinedOutput">combinedOutput</a>()
+        
+                                            <p><p>The combined buffered standard output and standard error stream of the last executed command</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     array
                 </div>
                 <div class="col-md-8">
@@ -1153,8 +1163,40 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_combinedOutput">
+        <div class="location">at line 108</div>
+        <code>                    string
+    <strong>combinedOutput</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The combined buffered standard output and standard error stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_defaultArgs">
-        <div class="location">at line 106</div>
+        <div class="location">at line 117</div>
         <code>                    array
     <strong>defaultArgs</strong>()
         </code>
@@ -1186,7 +1228,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 117</div>
+        <div class="location">at line 128</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -1233,7 +1275,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_entrypoint">
-        <div class="location">at line 130</div>
+        <div class="location">at line 141</div>
         <code>                    array
     <strong>entrypoint</strong>()
         </code>
@@ -1265,7 +1307,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariable">
-        <div class="location">at line 139</div>
+        <div class="location">at line 150</div>
         <code>                    string
     <strong>envVariable</strong>(string $name)
         </code>
@@ -1307,7 +1349,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariables">
-        <div class="location">at line 149</div>
+        <div class="location">at line 160</div>
         <code>                    array
     <strong>envVariables</strong>()
         </code>
@@ -1339,7 +1381,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exists">
-        <div class="location">at line 158</div>
+        <div class="location">at line 169</div>
         <code>                    bool
     <strong>exists</strong>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -1391,7 +1433,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exitCode">
-        <div class="location">at line 176</div>
+        <div class="location">at line 187</div>
         <code>                    int
     <strong>exitCode</strong>()
         </code>
@@ -1423,7 +1465,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithAllGPUs">
-        <div class="location">at line 189</div>
+        <div class="location">at line 200</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithAllGPUs</strong>()
         </code>
@@ -1456,7 +1498,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithGPU">
-        <div class="location">at line 202</div>
+        <div class="location">at line 213</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithGPU</strong>(array $devices)
         </code>
@@ -1499,7 +1541,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_export">
-        <div class="location">at line 214</div>
+        <div class="location">at line 225</div>
         <code>                    string
     <strong>export</strong>(string $path, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, bool|null $expand = false)
         </code>
@@ -1561,7 +1603,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exportImage">
-        <div class="location">at line 241</div>
+        <div class="location">at line 252</div>
         <code>                    void
     <strong>exportImage</strong>(string $name, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -1618,7 +1660,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exposedPorts">
-        <div class="location">at line 266</div>
+        <div class="location">at line 277</div>
         <code>                    array
     <strong>exposedPorts</strong>()
         </code>
@@ -1650,7 +1692,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 277</div>
+        <div class="location">at line 288</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path, bool|null $expand = false)
         </code>
@@ -1697,7 +1739,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_from">
-        <div class="location">at line 290</div>
+        <div class="location">at line 301</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>from</strong>(string $address)
         </code>
@@ -1739,7 +1781,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 300</div>
+        <div class="location">at line 311</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1771,7 +1813,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_imageRef">
-        <div class="location">at line 309</div>
+        <div class="location">at line 320</div>
         <code>                    string
     <strong>imageRef</strong>()
         </code>
@@ -1803,7 +1845,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_import">
-        <div class="location">at line 318</div>
+        <div class="location">at line 329</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>import</strong>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $tag = &#039;&#039;)
         </code>
@@ -1850,7 +1892,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_label">
-        <div class="location">at line 331</div>
+        <div class="location">at line 342</div>
         <code>                    string
     <strong>label</strong>(string $name)
         </code>
@@ -1892,7 +1934,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_labels">
-        <div class="location">at line 341</div>
+        <div class="location">at line 352</div>
         <code>                    array
     <strong>labels</strong>()
         </code>
@@ -1924,7 +1966,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_mounts">
-        <div class="location">at line 350</div>
+        <div class="location">at line 361</div>
         <code>                    array
     <strong>mounts</strong>()
         </code>
@@ -1956,7 +1998,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_platform">
-        <div class="location">at line 359</div>
+        <div class="location">at line 370</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>platform</strong>()
         </code>
@@ -1988,7 +2030,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_publish">
-        <div class="location">at line 370</div>
+        <div class="location">at line 381</div>
         <code>                    string
     <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2045,7 +2087,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_rootfs">
-        <div class="location">at line 393</div>
+        <div class="location">at line 404</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>rootfs</strong>()
         </code>
@@ -2077,7 +2119,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stderr">
-        <div class="location">at line 404</div>
+        <div class="location">at line 415</div>
         <code>                    string
     <strong>stderr</strong>()
         </code>
@@ -2109,7 +2151,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stdout">
-        <div class="location">at line 415</div>
+        <div class="location">at line 426</div>
         <code>                    string
     <strong>stdout</strong>()
         </code>
@@ -2141,7 +2183,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 426</div>
+        <div class="location">at line 437</div>
         <code>                    <a href="../Dagger/ContainerId.html"><abbr title="Dagger\ContainerId">ContainerId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -2173,7 +2215,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 435</div>
+        <div class="location">at line 446</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>terminal</strong>(array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2225,7 +2267,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_up">
-        <div class="location">at line 458</div>
+        <div class="location">at line 469</div>
         <code>                    void
     <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = null, bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2302,7 +2344,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_user">
-        <div class="location">at line 499</div>
+        <div class="location">at line 510</div>
         <code>                    string
     <strong>user</strong>()
         </code>
@@ -2334,7 +2376,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAnnotation">
-        <div class="location">at line 508</div>
+        <div class="location">at line 519</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
@@ -2381,7 +2423,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultArgs">
-        <div class="location">at line 519</div>
+        <div class="location">at line 530</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultArgs</strong>(array $args)
         </code>
@@ -2423,7 +2465,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultTerminalCmd">
-        <div class="location">at line 529</div>
+        <div class="location">at line 540</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2475,7 +2517,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 548</div>
+        <div class="location">at line 559</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -2542,7 +2584,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 577</div>
+        <div class="location">at line 588</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2589,7 +2631,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 590</div>
+        <div class="location">at line 601</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -2641,7 +2683,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 604</div>
+        <div class="location">at line 615</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2733,7 +2775,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 661</div>
+        <div class="location">at line 672</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -2798,7 +2840,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 684</div>
+        <div class="location">at line 695</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -2860,7 +2902,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 709</div>
+        <div class="location">at line 720</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -2922,7 +2964,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 734</div>
+        <div class="location">at line 745</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -2969,7 +3011,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 745</div>
+        <div class="location">at line 756</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $cache, <abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3036,7 +3078,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 774</div>
+        <div class="location">at line 785</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3093,7 +3135,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 795</div>
+        <div class="location">at line 806</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3150,7 +3192,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 816</div>
+        <div class="location">at line 827</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $source, string|null $owner = &#039;&#039;, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3212,7 +3254,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 841</div>
+        <div class="location">at line 852</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3264,7 +3306,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 857</div>
+        <div class="location">at line 868</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3326,7 +3368,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 882</div>
+        <div class="location">at line 893</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
@@ -3378,7 +3420,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 894</div>
+        <div class="location">at line 905</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory)
         </code>
@@ -3420,7 +3462,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 904</div>
+        <div class="location">at line 915</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
@@ -3467,7 +3509,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 921</div>
+        <div class="location">at line 932</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service)
         </code>
@@ -3516,7 +3558,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 932</div>
+        <div class="location">at line 943</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -3568,7 +3610,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 946</div>
+        <div class="location">at line 957</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3625,7 +3667,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 967</div>
+        <div class="location">at line 978</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -3667,7 +3709,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 977</div>
+        <div class="location">at line 988</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -3714,7 +3756,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 990</div>
+        <div class="location">at line 1001</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -3756,7 +3798,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1000</div>
+        <div class="location">at line 1011</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -3788,7 +3830,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1009</div>
+        <div class="location">at line 1020</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -3835,7 +3877,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1022</div>
+        <div class="location">at line 1033</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -3877,7 +3919,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1034</div>
+        <div class="location">at line 1045</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -3919,7 +3961,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1044</div>
+        <div class="location">at line 1055</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -3966,7 +4008,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1057</div>
+        <div class="location">at line 1068</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4013,7 +4055,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1070</div>
+        <div class="location">at line 1081</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4060,7 +4102,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1083</div>
+        <div class="location">at line 1094</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4102,7 +4144,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1093</div>
+        <div class="location">at line 1104</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4149,7 +4191,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1106</div>
+        <div class="location">at line 1117</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4191,7 +4233,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1116</div>
+        <div class="location">at line 1127</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4233,7 +4275,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1126</div>
+        <div class="location">at line 1137</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4280,7 +4322,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1141</div>
+        <div class="location">at line 1152</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4312,7 +4354,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1152</div>
+        <div class="location">at line 1163</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -4344,7 +4386,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1161</div>
+        <div class="location">at line 1172</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -231,7 +231,9 @@
                     <dd></dd><dt><a href="Dagger/Connection.html#method_close">
 <abbr title="Dagger\Connection">Connection</abbr>::close</a>() &mdash; <em>Method in class <a href="Dagger/Connection.html"><abbr title="Dagger\Connection">Connection</abbr></a></em></dt>
                     <dd></dd><dt><a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
-                    <dd><p>An OCI-compatible container, also known as a Docker container.</p></dd><dt><a href="Dagger/ContainerId.html"><abbr title="Dagger\ContainerId">ContainerId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
+                    <dd><p>An OCI-compatible container, also known as a Docker container.</p></dd><dt><a href="Dagger/Container.html#method_combinedOutput">
+<abbr title="Dagger\Container">Container</abbr>::combinedOutput</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
+                    <dd><p>The combined buffered standard output and standard error stream of the last executed command</p></dd><dt><a href="Dagger/ContainerId.html"><abbr title="Dagger\ContainerId">ContainerId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>ContainerID</code> scalar type represents an identifier for an object of type Container.</p></dd><dt><a href="Dagger/CurrentModule.html"><abbr title="Dagger\CurrentModule">CurrentModule</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>Reflective module API provided to functions at runtime.</p></dd><dt><a href="Dagger/CurrentModuleId.html"><abbr title="Dagger\CurrentModuleId">CurrentModuleId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>CurrentModuleID</code> scalar type represents an identifier for an object of type CurrentModule.</p></dd><dt><a href="Dagger/Dagger.html#method_connect">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1923,6 +1923,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Container::combinedOutput",
+			"p": "Dagger/Container.html#method_combinedOutput",
+			"d": "<p>The combined buffered standard output and standard error stream of the last executed command</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Container::defaultArgs",
 			"p": "Dagger/Container.html#method_defaultArgs",
 			"d": "<p>Return the container's default arguments.</p>"

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -559,6 +559,13 @@ func (w *Worker) setupStdio(_ context.Context, state *execState) error {
 		return nil
 	}
 
+	combinedOutputPath := filepath.Join(state.metaMount.Source, MetaMountCombinedOutputPath)
+	combinedOutputFile, err := os.OpenFile(combinedOutputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open combined output file: %w", err)
+	}
+	state.cleanups.Add("close container combined output file", combinedOutputFile.Close)
+
 	var stdoutWriters []io.Writer
 	if state.procInfo.Stdout != nil {
 		stdoutWriters = append(stdoutWriters, state.procInfo.Stdout)
@@ -570,6 +577,7 @@ func (w *Worker) setupStdio(_ context.Context, state *execState) error {
 	}
 	state.cleanups.Add("close container stdout file", stdoutFile.Close)
 	stdoutWriters = append(stdoutWriters, stdoutFile)
+	stdoutWriters = append(stdoutWriters, combinedOutputFile)
 
 	var stderrWriters []io.Writer
 	if state.procInfo.Stderr != nil {
@@ -582,6 +590,7 @@ func (w *Worker) setupStdio(_ context.Context, state *execState) error {
 	}
 	state.cleanups.Add("close container stderr file", stderrFile.Close)
 	stderrWriters = append(stderrWriters, stderrFile)
+	stderrWriters = append(stderrWriters, combinedOutputFile)
 
 	if w.execMD != nil && (w.execMD.RedirectStdinPath != "" || w.execMD.RedirectStdoutPath != "" || w.execMD.RedirectStderrPath != "") {
 		ctrFS, err := containerfs.NewContainerFS(state.spec, nil)

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -47,11 +47,12 @@ const (
 	MaxFileContentsSize = 128 << 20
 
 	// MetaMountDestPath is the special path that the shim writes metadata to.
-	MetaMountDestPath     = "/.dagger_meta_mount"
-	MetaMountExitCodePath = "exitCode"
-	MetaMountStdoutPath   = "stdout"
-	MetaMountStderrPath   = "stderr"
-	MetaMountClientIDPath = "clientID"
+	MetaMountDestPath           = "/.dagger_meta_mount"
+	MetaMountExitCodePath       = "exitCode"
+	MetaMountStdoutPath         = "stdout"
+	MetaMountStderrPath         = "stderr"
+	MetaMountCombinedOutputPath = "combinedOutput"
+	MetaMountClientIDPath       = "clientID"
 )
 
 type Result = solverresult.Result[*ref]

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -113,6 +113,19 @@ defmodule Dagger.Container do
   end
 
   @doc """
+  The combined buffered standard output and standard error stream of the last executed command
+
+  Returns an error if no command was executed
+  """
+  @spec combined_output(t()) :: {:ok, String.t()} | {:error, term()}
+  def combined_output(%__MODULE__{} = container) do
+    query_builder =
+      container.query_builder |> QB.select("combinedOutput")
+
+    Client.execute(container.client, query_builder)
+  end
+
+  @doc """
   Return the container's default arguments.
   """
   @spec default_args(t()) :: {:ok, [String.t()]} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -699,22 +699,23 @@ func (r *Cloud) TraceURL(ctx context.Context) (string, error) {
 type Container struct {
 	query *querybuilder.Selection
 
-	envVariable *string
-	exists      *bool
-	exitCode    *int
-	export      *string
-	exportImage *Void
-	id          *ContainerID
-	imageRef    *string
-	label       *string
-	platform    *Platform
-	publish     *string
-	stderr      *string
-	stdout      *string
-	sync        *ContainerID
-	up          *Void
-	user        *string
-	workdir     *string
+	combinedOutput *string
+	envVariable    *string
+	exists         *bool
+	exitCode       *int
+	export         *string
+	exportImage    *Void
+	id             *ContainerID
+	imageRef       *string
+	label          *string
+	platform       *Platform
+	publish        *string
+	stderr         *string
+	stdout         *string
+	sync           *ContainerID
+	up             *Void
+	user           *string
+	workdir        *string
 }
 type WithContainerFunc func(r *Container) *Container
 
@@ -884,6 +885,21 @@ func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Conta
 	return &Container{
 		query: q,
 	}
+}
+
+// The combined buffered standard output and standard error stream of the last executed command
+//
+// Returns an error if no command was executed
+func (r *Container) CombinedOutput(ctx context.Context) (string, error) {
+	if r.combinedOutput != nil {
+		return *r.combinedOutput, nil
+	}
+	q := r.query.Select("combinedOutput")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // Return the container's default arguments.

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -101,6 +101,17 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The combined buffered standard output and standard error stream of the last executed command
+     *
+     * Returns an error if no command was executed
+     */
+    public function combinedOutput(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('combinedOutput');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'combinedOutput');
+    }
+
+    /**
      * Return the container's default arguments.
      */
     public function defaultArgs(): array

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -930,6 +930,30 @@ class Container(Type):
         _ctx = self._select("build", _args)
         return Container(_ctx)
 
+    async def combined_output(self) -> str:
+        """The combined buffered standard output and standard error stream of the
+        last executed command
+
+        Returns an error if no command was executed
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("combinedOutput", _args)
+        return await _ctx.execute(str)
+
     async def default_args(self) -> list[str]:
         """Return the container's default arguments.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2447,6 +2447,12 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// The combined buffered standard output and standard error stream of the last executed command
+    /// Returns an error if no command was executed
+    pub async fn combined_output(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("combinedOutput");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Return the container's default arguments.
     pub async fn default_args(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("defaultArgs");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2362,6 +2362,7 @@ export class Cloud extends BaseClient {
  */
 export class Container extends BaseClient {
   private readonly _id?: ContainerID = undefined
+  private readonly _combinedOutput?: string = undefined
   private readonly _envVariable?: string = undefined
   private readonly _exists?: boolean = undefined
   private readonly _exitCode?: number = undefined
@@ -2384,6 +2385,7 @@ export class Container extends BaseClient {
   constructor(
     ctx?: Context,
     _id?: ContainerID,
+    _combinedOutput?: string,
     _envVariable?: string,
     _exists?: boolean,
     _exitCode?: number,
@@ -2403,6 +2405,7 @@ export class Container extends BaseClient {
     super(ctx)
 
     this._id = _id
+    this._combinedOutput = _combinedOutput
     this._envVariable = _envVariable
     this._exists = _exists
     this._exitCode = _exitCode
@@ -2499,6 +2502,23 @@ export class Container extends BaseClient {
   build = (context: Directory, opts?: ContainerBuildOpts): Container => {
     const ctx = this._ctx.select("build", { context, ...opts })
     return new Container(ctx)
+  }
+
+  /**
+   * The combined buffered standard output and standard error stream of the last executed command
+   *
+   * Returns an error if no command was executed
+   */
+  combinedOutput = async (): Promise<string> => {
+    if (this._combinedOutput) {
+      return this._combinedOutput
+    }
+
+    const ctx = this._ctx.select("combinedOutput")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
   }
 
   /**


### PR DESCRIPTION
Allow to get a combined output of both standard output and standard error at once.

A new function `combinedOutput` is available, in addition to `stdout` and `stderr`. It means you can pick the one you want depending on the context. For instance to pick the combined output if the command failed.

```console
$ dagger -q <<EOF
container | from alpine |
with-new-file /test.sh "echo out; echo err >&2" |
with-exec -- sh /test.sh |
combined-output
EOF

out
err
```

> [!WARNING]
> As always while working with streams, order in the output is not guaranteed.

fixes #3496
