### PR TITLE
ci: bring back checkout step

### DIFF
--- a/.github/workflows/daggerverse-preview.gen.yml
+++ b/.github/workflows/daggerverse-preview.gen.yml
@@ -64,6 +64,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/docs.gen.yml
+++ b/.github/workflows/docs.gen.yml
@@ -66,6 +66,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/engine-cli.gen.yml
+++ b/.github/workflows/engine-cli.gen.yml
@@ -66,6 +66,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -221,6 +223,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -376,6 +380,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -531,6 +537,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -686,6 +694,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -857,6 +867,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1047,6 +1059,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1237,6 +1251,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1427,6 +1443,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1617,6 +1635,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1807,6 +1827,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1997,6 +2019,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -2187,6 +2211,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -2377,6 +2403,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -2567,6 +2595,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/evals.gen.yml
+++ b/.github/workflows/evals.gen.yml
@@ -80,6 +80,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/github.gen.yml
+++ b/.github/workflows/github.gen.yml
@@ -66,6 +66,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/helm.gen.yml
+++ b/.github/workflows/helm.gen.yml
@@ -66,6 +66,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/.github/workflows/sdks.gen.yml
+++ b/.github/workflows/sdks.gen.yml
@@ -83,6 +83,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -255,6 +257,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -427,6 +431,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -599,6 +605,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -771,6 +779,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -943,6 +953,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1115,6 +1127,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |
@@ -1287,6 +1301,8 @@ jobs:
                 dagger version
                 dagger core version
               shell: bash
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: scripts/exec.sh
               id: exec
               run: |

--- a/modules/gha/job.go
+++ b/modules/gha/job.go
@@ -24,11 +24,6 @@ type Job struct {
 	TimeoutMinutes int
 	// Run the workflow in debug mode
 	Debug bool
-	// Use a sparse git checkout, only including the given paths
-	// Example: ["src", "tests", "Dockerfile"]
-	SparseCheckout []string
-	// Enable lfs on git checkout
-	LFS bool
 	// Github secrets to inject into the workflow environment.
 	// For each secret, an env variable with the same name is created.
 	// Example: ["PROD_DEPLOY_TOKEN", "PRIVATE_SSH_KEY"]
@@ -84,13 +79,6 @@ func (gha *Gha) Job(
 	// Run the workflow in debug mode
 	// +optional
 	debug bool,
-	// Use a sparse git checkout, only including the given paths
-	// Example: ["src", "tests", "Dockerfile"]
-	// +optional
-	sparseCheckout []string,
-	// Enable lfs on git checkout
-	// +optional
-	lfs bool,
 	// Github secrets to inject into the workflow environment.
 	// For each secret, an env variable with the same name is created.
 	// Example: ["PROD_DEPLOY_TOKEN", "PRIVATE_SSH_KEY"]
@@ -127,8 +115,6 @@ func (gha *Gha) Job(
 		TeardownCommands: teardownCommands,
 		TimeoutMinutes:   timeoutMinutes,
 		Debug:            debug,
-		SparseCheckout:   sparseCheckout,
-		LFS:              lfs,
 		Secrets:          secrets,
 		Env:              env,
 		Runner:           runner,

--- a/modules/gha/steps.go
+++ b/modules/gha/steps.go
@@ -12,6 +12,13 @@ func (j *Job) warmEngineStep() api.JobStep {
 	return j.bashStep("warm-engine", nil)
 }
 
+func (j *Job) checkoutStep() api.JobStep {
+	return api.JobStep{
+		Name: "Checkout",
+		Uses: "actions/checkout@v4",
+	}
+}
+
 func (j *Job) installDaggerSteps() []api.JobStep {
 	steps := []api.JobStep{
 		j.bashStep("install-dagger", map[string]string{"DAGGER_VERSION": j.DaggerVersion}),

--- a/modules/gha/workflow.go
+++ b/modules/gha/workflow.go
@@ -403,6 +403,10 @@ func (w *Workflow) asWorkflow() api.Workflow {
 				Run:   cmd,
 			})
 		}
+		// HACK: this *isn't* required! we load the module using DAGGER_MODULE
+		// directly from git, *but* this is currently required so that we can
+		// get the right labels :(
+		steps = append(steps, job.checkoutStep())
 		callStep := job.callDaggerStep()
 		steps = append(steps, callStep)
 		if job.UploadLogs {


### PR DESCRIPTION
Partial revert to #10852, but not fully.

We now *only* need the checkout step to do telemetry, nothing else. So we can put it more last minute, and don't need to revert any of the other refactorings.