### PR TITLE
fix: speed up loading contextual files

### DIFF
--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -635,7 +635,7 @@ func (fn *ModuleFunction) loadContextualArg(
 	case "Directory":
 		slog.Debug("moduleFunction.loadContextualArg: loading contextual directory", "fn", arg.Name, "dir", arg.DefaultPath)
 
-		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, arg.DefaultPath, arg.Ignore)
+		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, arg.DefaultPath, nil, arg.Ignore)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load contextual directory %q: %w", arg.DefaultPath, err)
 		}
@@ -649,7 +649,7 @@ func (fn *ModuleFunction) loadContextualArg(
 		filePath := filepath.Base(arg.DefaultPath)
 
 		// Load the directory containing the file.
-		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, dirPath, nil)
+		dir, err := fn.mod.ContextSource.Value.Self().LoadContext(ctx, dag, dirPath, []string{filePath}, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load contextual directory %q: %w", dirPath, err)
 		}

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
@@ -19,7 +19,7 @@ Expected stderr:
   ┆ file: Host.file(path: "/app/dagql/idtui/golden_test.go"): File!
   ┆ dir: Host.directory(path: "/app/dagql/idtui"): Directory!
   ┆ contextFile: Directory.file(path: "main.go"): File!
-  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", exclude: [], noCache: true): Directory!
+  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", noCache: true): Directory!
   ): Void X.Xs
 
 Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/10913

Ideally, we'd just call `host.file` here, but then we'd have to reproduce all of the other logic in `LoadContext`, which doesn't sound incredibly fun.

So this is a quick fix!