### PR TITLE
ci: avoid use of custom VersionGit type

### DIFF
--- a/.dagger/bench.go
+++ b/.dagger/bench.go
@@ -265,7 +265,7 @@ func (b *Bench) notifyOnFailure(ctx context.Context, err error, discordWebhook *
 		return err
 	}
 
-	commit, err := b.Test.Dagger.Git.Head().Commit(ctx)
+	commit, err := b.Test.Dagger.Git.Commit(ctx)
 	if err != nil {
 		commit = "failed to find commit SHA"
 	}

--- a/.dagger/checks.go
+++ b/.dagger/checks.go
@@ -72,20 +72,9 @@ func (dev *DaggerDev) checksForSDK(name string, sdk sdkBase) []Check {
 		{
 			Name: name + "/test-publish",
 			Check: func(ctx context.Context) error {
-				branches, err := dev.Git.Branches(ctx, dagger.VersionGitBranchesOpts{
-					Commit: "HEAD",
-				})
+				name, err := dev.Git.Ref(ctx)
 				if err != nil {
 					return err
-				}
-				var name string
-				if len(branches) == 0 {
-					name = "HEAD"
-				} else {
-					name, err = branches[0].Branch(ctx)
-					if err != nil {
-						return err
-					}
 				}
 				return sdk.TestPublish(ctx, name)
 			},

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -17,7 +17,7 @@ type DaggerDev struct {
 
 	Version string
 	Tag     string
-	Git     *dagger.VersionGit // +private
+	Git     *dagger.GitRef
 
 	// When set, module codegen is automatically applied when retrieving the Dagger source code
 	ModCodegenTargets []string
@@ -62,7 +62,7 @@ func New(
 	dev := &DaggerDev{
 		Source:    source,
 		Tag:       tag,
-		Git:       v.Git(),
+		Git:       v.Git().Head(),
 		Version:   version,
 		DockerCfg: dockerCfg,
 	}

--- a/.dagger/sdk.go
+++ b/.dagger/sdk.go
@@ -112,7 +112,7 @@ type gitPublishOpts struct {
 	dryRun bool
 }
 
-func gitPublish(ctx context.Context, git *dagger.VersionGit, opts gitPublishOpts) error {
+func gitPublish(ctx context.Context, git *dagger.GitRef, opts gitPublishOpts) error {
 	base := opts.sourceEnv
 	if base == nil {
 		base = dag.
@@ -141,7 +141,7 @@ func gitPublish(ctx context.Context, git *dagger.VersionGit, opts gitPublishOpts
 	result := base.
 		WithEnvVariable("CACHEBUSTER", rand.Text()).
 		WithWorkdir("/src/dagger").
-		WithDirectory(".", git.Directory()).
+		WithDirectory(".", git.Tree(dagger.GitRefTreeOpts{Depth: -1})).
 		WithExec([]string{"git", "restore", "."}). // clean up the dirty state
 		WithEnvVariable("FILTER_BRANCH_SQUELCH_WARNING", "1").
 		WithExec([]string{

--- a/cmd/dagger/.dagger/main.go
+++ b/cmd/dagger/.dagger/main.go
@@ -54,7 +54,7 @@ func New(
 type DaggerCli struct {
 	Version string
 	Tag     string
-	Git     *dagger.VersionGit // +private
+	Git     *dagger.GitRepository // +private
 
 	Go *dagger.Go // +private
 }

--- a/cmd/dagger/.dagger/publish.go
+++ b/cmd/dagger/.dagger/publish.go
@@ -44,7 +44,7 @@ func (cli *DaggerCli) Publish(
 	ctr = ctr.
 		WithWorkdir("/app").
 		WithDirectory(".", cli.Go.Source()).
-		WithDirectory(".", cli.Git.Directory()).
+		WithDirectory(".", cli.Git.Tag(tag).Tree()).
 		WithDirectory("build", cli.goreleaserBinaries())
 
 	if !semver.IsValid(tag) {

--- a/docs/.dagger/main.go
+++ b/docs/.dagger/main.go
@@ -289,7 +289,7 @@ func (d Docs) Deploy(
 	if err != nil {
 		return "", err
 	}
-	dirty, err := dag.Version().Git().Dirty(ctx)
+	dirty, err := dag.Version().Dirty(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/releaser/util.go
+++ b/releaser/util.go
@@ -49,7 +49,7 @@ func (r Releaser) githubRelease(
 		return err
 	}
 
-	commit, err := dag.Version().Git().Commit(src).Commit(ctx)
+	commit, err := dag.Version().Git().Ref(src).Commit(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This type was built while the core git type was kinda bad - but it's significantly better now, so we should be using that instead.

The *eventual* aim is to remove this custom type entirely, this is a step towards that.