### PR TITLE
ci: directly call with module in more cases

### DIFF
--- a/.github/workflows/_dagger_on_depot_local_engine.yml
+++ b/.github/workflows/_dagger_on_depot_local_engine.yml
@@ -39,10 +39,12 @@ jobs:
       - name: ${{ inputs.function }}
         uses: ./.github/actions/call-ci-alt-runner
         with:
+          module: github.com/${{ github.repository }}@${{ github.sha }}
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
         uses: ./.github/actions/call-ci-alt-runner
         with:
+          module: github.com/${{ github.repository }}@${{ github.sha }}
           function: ${{ inputs.function }}
           dev-engine: ${{ inputs.dev }}

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -36,12 +36,14 @@ jobs:
       - name: ${{ inputs.function }}
         uses: ./.github/actions/call-ci-alt-runner
         with:
+          module: github.com/${{ github.repository }}@${{ github.sha }}
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}
           dev-engine: ${{ inputs.dev }}
       - name: ${{ inputs.function }} (CACHE TEST)
         uses: ./.github/actions/call-ci-alt-runner
         with:
+          module: github.com/${{ github.repository }}@${{ github.sha }}
           function: ${{ inputs.function }}
           version: v${{ inputs.dagger }}
           dev-engine: ${{ inputs.dev }}

--- a/.github/workflows/benchmark-engine.yml
+++ b/.github/workflows/benchmark-engine.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         with:
+          module: github.com/${{ github.repository }}@${{ github.sha }}
           function: bench all --prewarm ${{ github.event_name != 'pull_request' && '--discord-webhook="op://releng/Discord Webhook - Engine Benchmarks/credential"' || '' }}
           dev-engine: false
           upload-logs: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Publish"
         uses: ./.github/actions/call
         with:
-          module: ./releaser
+          module: github.com/${{ github.repository }}/releaser@${{ github.sha }}
           function: |-
             publish \
             --tag="${{ github.ref_name }}" --commit="${{ github.sha }}" \


### PR DESCRIPTION
Follow-up to #10852.

We still need the checkout step (annoyingly), but we should be directly invoking the dagger module, for the reasons explained there.