### PR TITLE
alpine module: pin busybox too

### DIFF
--- a/modules/alpine/main.go
+++ b/modules/alpine/main.go
@@ -125,7 +125,7 @@ func (m *Alpine) Container(ctx context.Context) (*dagger.Container, error) {
 			// ld-linux, specifies a dependency on an exact version that is not present.
 			// This resolves itself usually within an hour, but to avoid fundamental breakage of
 			// builds we are currently pinning these packages for now.
-			"busybox",
+			"busybox=1.37.0-r49",
 			"glibc=2.42-r0",
 			"ld-linux=2.42-r0",
 			"libcrypt1=2.42-r0",


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/10951

Pinning busybox would have prevented the breakage fixed in that PR, so following up w/ that to lessen re-occurrences down the line