### PR TITLE
findup API: find a file or directory by walking up the directory tree

### DIFF
--- a/.changes/unreleased/Added-20250915-142940.yaml
+++ b/.changes/unreleased/Added-20250915-142940.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |-
+    Add API for "find-up search": search up the directory tree for a file or directory, and return its path
+
+    - Directory.findUp(): perform a find-up search in a directory snapshot
+    - Host.findUp(): perform a find-up search in the host filesystem
+time: 2025-09-15T14:29:40.960133-07:00
+custom:
+    Author: shykes
+    PR: "10956"

--- a/core/host.go
+++ b/core/host.go
@@ -1,6 +1,12 @@
 package core
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -16,4 +22,61 @@ func (*Host) Type() *ast.Type {
 
 func (*Host) TypeDescription() string {
 	return "Information about the host environment."
+}
+
+// find-up a given soughtName in curDirPath and its parent directories, return the dir
+// it was found in, if any
+func (Host) FindUp(
+	ctx context.Context,
+	statFS StatFS,
+	curDirPath string,
+	soughtName string,
+) (string, bool, error) {
+	found, err := Host{}.FindUpAll(ctx, statFS, curDirPath, map[string]struct{}{soughtName: {}})
+	if err != nil {
+		return "", false, err
+	}
+	p, ok := found[soughtName]
+	return p, ok, nil
+}
+
+// find-up a set of soughtNames in curDirPath and its parent directories return what
+// was found (name -> absolute path of dir containing it)
+func (Host) FindUpAll(
+	ctx context.Context,
+	statFS StatFS,
+	curDirPath string,
+	soughtNames map[string]struct{},
+) (map[string]string, error) {
+	found := make(map[string]string, len(soughtNames))
+	for {
+		for soughtName := range soughtNames {
+			stat, err := statFS.Stat(ctx, filepath.Join(curDirPath, soughtName))
+			if err == nil {
+				delete(soughtNames, soughtName)
+				// NOTE: important that we use stat.Path here rather than curDirPath since the stat also
+				// does some normalization of paths when the client is using case-insensitive filesystems
+				// and we are stat'ing caller host filesystems
+				found[soughtName] = filepath.Dir(stat.Path)
+				continue
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("failed to lstat %s: %w", soughtName, err)
+			}
+		}
+
+		if len(soughtNames) == 0 {
+			// found everything
+			break
+		}
+
+		nextDirPath := filepath.Dir(curDirPath)
+		if curDirPath == nextDirPath {
+			// hit root, nowhere else to look
+			break
+		}
+		curDirPath = nextDirPath
+	}
+
+	return found, nil
 }

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -40,6 +40,63 @@ func (DirectorySuite) TestEmpty(ctx context.Context, t *testctx.T) {
 	require.Empty(t, res.Directory.Entries)
 }
 
+func (DirectorySuite) TestFindUp(ctx context.Context, t *testctx.T) {
+	// Reuse the same utility used to test Host.findUp()
+	// It creates a directory on the host, but we just load it as a Directory
+	dirPath := findupTestDir(t)
+	c := connect(ctx, t)
+	dir := c.Host().Directory(dirPath)
+	start := "a/b"
+
+	t.Run("find file in current directory", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "other.txt", start)
+		require.NoError(t, err)
+		require.Equal(t, "a/b/other.txt", found)
+		content, err := dir.File(found).Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "this is a/b/other.txt", content)
+	})
+
+	t.Run("find file in parent directory", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "target.txt", start)
+		require.NoError(t, err)
+		require.Equal(t, "a/target.txt", found)
+		content, err := dir.File(found).Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "this is a/target.txt", content)
+	})
+
+	t.Run("find file in root", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "root.txt", start)
+		require.NoError(t, err)
+		require.Equal(t, "root.txt", found)
+		content, err := dir.File(found).Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "this is root.txt", content)
+	})
+
+	t.Run("find directory in parent directory", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "somedir", start)
+		require.NoError(t, err)
+		require.Equal(t, "a/somedir", found)
+		entries, err := dir.Directory(found).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"hi.txt"}, entries)
+	})
+
+	t.Run("DO NOT find file in child directory", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "leaf.txt", start)
+		require.NoError(t, err)
+		require.Equal(t, "", found)
+	})
+
+	t.Run("DO NOT find non-existent file", func(ctx context.Context, t *testctx.T) {
+		found, err := dir.FindUp(ctx, "nonexistent.txt", start)
+		require.NoError(t, err)
+		require.Equal(t, "", found)
+	})
+}
+
 func (DirectorySuite) TestScratch(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1534,6 +1534,17 @@ type Directory {
     include: [String!] = []
   ): Directory!
 
+  """
+  Search up the directory tree for a file or directory, and return its path. If no match, return null
+  """
+  findUp(
+    """The name of the file or directory to search for"""
+    name: String!
+
+    """The path to start the search from"""
+    start: String!
+  ): String
+
   """Returns a list of files and directories that matche the given pattern."""
   glob(
     """Pattern to match (e.g., "*.md")."""
@@ -3014,6 +3025,17 @@ type Host {
     """If true, the file will always be reloaded from the host."""
     noCache: Boolean = false
   ): File!
+
+  """
+  Search for a file or directory by walking up the tree from system workdir.
+  Return its relative path. If no match, return null
+  """
+  findUp(
+    """name of the file or directory to search for"""
+    name: String!
+
+    noCache: Boolean = false
+  ): String
 
   """A unique identifier for this Host."""
   id: HostID!

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6524,6 +6524,27 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Directory-findUp" href="#Directory-findUp"><code>findUp</code></a> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span> </td>
+                        <td> Search up the directory tree for a file or directory, and return its path. If no match, return null </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the file or directory to search for</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>start</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The path to start the search from</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Directory-glob" href="#Directory-glob"><code>glob</code></a> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span> </td>
                         <td> Returns a list of files and directories that matche the given pattern. </td>
                       </tr>
@@ -9824,6 +9845,26 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>noCache</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>If true, the file will always be reloaded from the host.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Host-findUp" href="#Host-findUp"><code>findUp</code></a> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span> </td>
+                        <td> Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>name of the file or directory to search for</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noCache</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                               </div>
                             </div>
                           </div>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -273,6 +273,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_findUp">findUp</a>(string $name, string $start)
+        
+                                            <p><p>Search up the directory tree for a file or directory, and return its path. If no match, return null</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     array
                 </div>
                 <div class="col-md-8">
@@ -1113,8 +1123,55 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_glob">
+                    <h3 id="method_findUp">
         <div class="location">at line 191</div>
+        <code>                    string
+    <strong>findUp</strong>(string $name, string $start)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Search up the directory tree for a file or directory, and return its path. If no match, return null</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string</td>
+                <td>$start</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_glob">
+        <div class="location">at line 202</div>
         <code>                    array
     <strong>glob</strong>(string $pattern)
         </code>
@@ -1156,7 +1213,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 201</div>
+        <div class="location">at line 212</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1188,7 +1245,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 210</div>
+        <div class="location">at line 221</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -1220,7 +1277,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 221</div>
+        <div class="location">at line 232</div>
         <code>                    array
     <strong>search</strong>(array|null $paths = null, array|null $globs = null, string $pattern, bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1312,7 +1369,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 272</div>
+        <div class="location">at line 283</div>
         <code>                    <a href="../Dagger/DirectoryId.html"><abbr title="Dagger\DirectoryId">DirectoryId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1344,7 +1401,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 281</div>
+        <div class="location">at line 292</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>terminal</strong>(<abbr title="Dagger\Dagger\ContainerId|Dagger\Container|null">Container|null</abbr> $container = null, array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -1401,7 +1458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 306</div>
+        <div class="location">at line 317</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1463,7 +1520,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 331</div>
+        <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1520,7 +1577,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 352</div>
+        <div class="location">at line 363</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null)
         </code>
@@ -1572,7 +1629,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 366</div>
+        <div class="location">at line 377</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewDirectory</strong>(string $path, int|null $permissions = 420)
         </code>
@@ -1619,7 +1676,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 379</div>
+        <div class="location">at line 390</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -1671,7 +1728,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatch">
-        <div class="location">at line 393</div>
+        <div class="location">at line 404</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatch</strong>(string $patch)
         </code>
@@ -1713,7 +1770,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 403</div>
+        <div class="location">at line 414</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -1760,7 +1817,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 414</div>
+        <div class="location">at line 425</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -1802,7 +1859,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 424</div>
+        <div class="location">at line 435</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -1844,7 +1901,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 434</div>
+        <div class="location">at line 445</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -1886,7 +1943,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 444</div>
+        <div class="location">at line 455</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/docs/static/reference/php/Dagger/Host.html
+++ b/docs/static/reference/php/Dagger/Host.html
@@ -173,6 +173,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_findUp">findUp</a>(string $name, bool|null $noCache = false)
+        
+                                            <p><p>Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -468,8 +478,55 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_id">
+                    <h3 id="method_findUp">
         <div class="location">at line 69</div>
+        <code>                    string
+    <strong>findUp</strong>(string $name, bool|null $noCache = false)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noCache</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_id">
+        <div class="location">at line 82</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -501,7 +558,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_service">
-        <div class="location">at line 78</div>
+        <div class="location">at line 91</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>service</strong>(array $ports, string|null $host = &#039;localhost&#039;)
         </code>
@@ -548,7 +605,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecretFile">
-        <div class="location">at line 93</div>
+        <div class="location">at line 106</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecretFile</strong>(string $name, string $path)
         </code>
@@ -595,7 +652,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tunnel">
-        <div class="location">at line 104</div>
+        <div class="location">at line 117</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>tunnel</strong>(<abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service, bool|null $native = false, array|null $ports = null)
         </code>
@@ -647,7 +704,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_unixSocket">
-        <div class="location">at line 120</div>
+        <div class="location">at line 133</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>unixSocket</strong>(string $path)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -454,7 +454,9 @@
 <abbr title="Dagger\Directory">Directory</abbr>::file</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
                     <dd><p>Retrieve a file at the given path.</p></dd><dt><a href="Dagger/Directory.html#method_filter">
 <abbr title="Dagger\Directory">Directory</abbr>::filter</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
-                    <dd><p>Return a snapshot with some paths included or excluded</p></dd><dt><a href="Dagger/FieldTypeDef.html"><abbr title="Dagger\FieldTypeDef">FieldTypeDef</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
+                    <dd><p>Return a snapshot with some paths included or excluded</p></dd><dt><a href="Dagger/Directory.html#method_findUp">
+<abbr title="Dagger\Directory">Directory</abbr>::findUp</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
+                    <dd><p>Search up the directory tree for a file or directory, and return its path. If no match, return null</p></dd><dt><a href="Dagger/FieldTypeDef.html"><abbr title="Dagger\FieldTypeDef">FieldTypeDef</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>A definition of a field on a custom object defined in a Module.</p></dd><dt><a href="Dagger/FieldTypeDefId.html"><abbr title="Dagger\FieldTypeDefId">FieldTypeDefId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>FieldTypeDefID</code> scalar type represents an identifier for an object of type FieldTypeDef.</p></dd><dt><a href="Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>A file.</p></dd><dt><a href="Dagger/FileId.html"><abbr title="Dagger\FileId">FileId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
@@ -468,7 +470,9 @@
                     <dd><p>The <code>FunctionID</code> scalar type represents an identifier for an object of type Function.</p></dd><dt><a href="Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>Function represents a resolver provided by a Module.</p></dd><dt><a href="Dagger/Host.html#method_file">
 <abbr title="Dagger\Host">Host</abbr>::file</a>() &mdash; <em>Method in class <a href="Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a></em></dt>
-                    <dd><p>Accesses a file on the host.</p></dd><dt><a href="Dagger/InputTypeDef.html#method_fields">
+                    <dd><p>Accesses a file on the host.</p></dd><dt><a href="Dagger/Host.html#method_findUp">
+<abbr title="Dagger\Host">Host</abbr>::findUp</a>() &mdash; <em>Method in class <a href="Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a></em></dt>
+                    <dd><p>Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null</p></dd><dt><a href="Dagger/InputTypeDef.html#method_fields">
 <abbr title="Dagger\InputTypeDef">InputTypeDef</abbr>::fields</a>() &mdash; <em>Method in class <a href="Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a></em></dt>
                     <dd><p>Static fields defined on this input object, if any.</p></dd><dt><a href="Dagger/InterfaceTypeDef.html#method_functions">
 <abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr>::functions</a>() &mdash; <em>Method in class <a href="Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2571,6 +2571,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Directory::findUp",
+			"p": "Dagger/Directory.html#method_findUp",
+			"d": "<p>Search up the directory tree for a file or directory, and return its path. If no match, return null</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Directory::glob",
 			"p": "Dagger/Directory.html#method_glob",
 			"d": "<p>Returns a list of files and directories that matche the given pattern.</p>"
@@ -3660,6 +3666,12 @@
 			"n": "Dagger\\Host::file",
 			"p": "Dagger/Host.html#method_file",
 			"d": "<p>Accesses a file on the host.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Host::findUp",
+			"p": "Dagger/Host.html#method_findUp",
+			"d": "<p>Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -229,6 +229,20 @@ defmodule Dagger.Directory do
   end
 
   @doc """
+  Search up the directory tree for a file or directory, and return its path. If no match, return null
+  """
+  @spec find_up(t(), String.t(), String.t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def find_up(%__MODULE__{} = directory, name, start) do
+    query_builder =
+      directory.query_builder
+      |> QB.select("findUp")
+      |> QB.put_arg("name", name)
+      |> QB.put_arg("start", start)
+
+    Client.execute(directory.client, query_builder)
+  end
+
+  @doc """
   Returns a list of files and directories that matche the given pattern.
   """
   @spec glob(t(), String.t()) :: {:ok, [String.t()]} | {:error, term()}

--- a/sdk/elixir/lib/dagger/gen/host.ex
+++ b/sdk/elixir/lib/dagger/gen/host.ex
@@ -72,6 +72,21 @@ defmodule Dagger.Host do
   end
 
   @doc """
+  Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null
+  """
+  @spec find_up(t(), String.t(), [{:no_cache, boolean() | nil}]) ::
+          {:ok, String.t() | nil} | {:error, term()}
+  def find_up(%__MODULE__{} = host, name, optional_args \\ []) do
+    query_builder =
+      host.query_builder
+      |> QB.select("findUp")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("noCache", optional_args[:no_cache])
+
+    Client.execute(host.client, query_builder)
+  end
+
+  @doc """
   A unique identifier for this Host.
   """
   @spec id(t()) :: {:ok, Dagger.HostID.t()} | {:error, term()}

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -186,6 +186,17 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Search up the directory tree for a file or directory, and return its path. If no match, return null
+     */
+    public function findUp(string $name, string $start): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('findUp');
+        $leafQueryBuilder->setArgument('name', $name);
+        $leafQueryBuilder->setArgument('start', $start);
+        return (string)$this->queryLeaf($leafQueryBuilder, 'findUp');
+    }
+
+    /**
      * Returns a list of files and directories that matche the given pattern.
      */
     public function glob(string $pattern): array

--- a/sdk/php/generated/Host.php
+++ b/sdk/php/generated/Host.php
@@ -64,6 +64,19 @@ class Host extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null
+     */
+    public function findUp(string $name, ?bool $noCache = false): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('findUp');
+        $leafQueryBuilder->setArgument('name', $name);
+        if (null !== $noCache) {
+        $leafQueryBuilder->setArgument('noCache', $noCache);
+        }
+        return (string)$this->queryLeaf($leafQueryBuilder, 'findUp');
+    }
+
+    /**
      * A unique identifier for this Host.
      */
     public function id(): HostId

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3287,6 +3287,38 @@ class Directory(Type):
         _ctx = self._select("filter", _args)
         return Directory(_ctx)
 
+    async def find_up(self, name: str, start: str) -> str | None:
+        """Search up the directory tree for a file or directory, and return its
+        path. If no match, return null
+
+        Parameters
+        ----------
+        name:
+            The name of the file or directory to search for
+        start:
+            The path to start the search from
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("name", name),
+            Arg("start", start),
+        ]
+        _ctx = self._select("findUp", _args)
+        return await _ctx.execute(str | None)
+
     async def glob(self, pattern: str) -> list[str]:
         """Returns a list of files and directories that matche the given pattern.
 
@@ -7154,6 +7186,42 @@ class Host(Type):
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
+
+    async def find_up(
+        self,
+        name: str,
+        *,
+        no_cache: bool | None = False,
+    ) -> str | None:
+        """Search for a file or directory by walking up the tree from system
+        workdir. Return its relative path. If no match, return null
+
+        Parameters
+        ----------
+        name:
+            name of the file or directory to search for
+        no_cache:
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("name", name),
+            Arg("noCache", no_cache, False),
+        ]
+        _ctx = self._select("findUp", _args)
+        return await _ctx.execute(str | None)
 
     async def id(self) -> HostID:
         """A unique identifier for this Host.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1316,6 +1316,10 @@ export type HostFileOpts = {
   noCache?: boolean
 }
 
+export type HostFindUpOpts = {
+  noCache?: boolean
+}
+
 export type HostServiceOpts = {
   /**
    * Upstream host to forward traffic to.
@@ -3939,6 +3943,7 @@ export class Directory extends BaseClient {
   private readonly _digest?: string = undefined
   private readonly _exists?: boolean = undefined
   private readonly _export?: string = undefined
+  private readonly _findUp?: string = undefined
   private readonly _name?: string = undefined
   private readonly _sync?: DirectoryID = undefined
 
@@ -3951,6 +3956,7 @@ export class Directory extends BaseClient {
     _digest?: string,
     _exists?: boolean,
     _export?: string,
+    _findUp?: string,
     _name?: string,
     _sync?: DirectoryID,
   ) {
@@ -3960,6 +3966,7 @@ export class Directory extends BaseClient {
     this._digest = _digest
     this._exists = _exists
     this._export = _export
+    this._findUp = _findUp
     this._name = _name
     this._sync = _sync
   }
@@ -4152,6 +4159,23 @@ export class Directory extends BaseClient {
   filter = (opts?: DirectoryFilterOpts): Directory => {
     const ctx = this._ctx.select("filter", { ...opts })
     return new Directory(ctx)
+  }
+
+  /**
+   * Search up the directory tree for a file or directory, and return its path. If no match, return null
+   * @param name The name of the file or directory to search for
+   * @param start The path to start the search from
+   */
+  findUp = async (name: string, start: string): Promise<string> => {
+    if (this._findUp) {
+      return this._findUp
+    }
+
+    const ctx = this._ctx.select("findUp", { name, start })
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
   }
 
   /**
@@ -7158,14 +7182,16 @@ export class GitRepository extends BaseClient {
  */
 export class Host extends BaseClient {
   private readonly _id?: HostID = undefined
+  private readonly _findUp?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
    */
-  constructor(ctx?: Context, _id?: HostID) {
+  constructor(ctx?: Context, _id?: HostID, _findUp?: string) {
     super(ctx)
 
     this._id = _id
+    this._findUp = _findUp
   }
 
   /**
@@ -7213,6 +7239,22 @@ export class Host extends BaseClient {
   file = (path: string, opts?: HostFileOpts): File => {
     const ctx = this._ctx.select("file", { path, ...opts })
     return new File(ctx)
+  }
+
+  /**
+   * Search for a file or directory by walking up the tree from system workdir. Return its relative path. If no match, return null
+   * @param name name of the file or directory to search for
+   */
+  findUp = async (name: string, opts?: HostFindUpOpts): Promise<string> => {
+    if (this._findUp) {
+      return this._findUp
+    }
+
+    const ctx = this._ctx.select("findUp", { name, ...opts })
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
   }
 
   /**


### PR DESCRIPTION
[Schema diff](https://github.com/dagger/dagger/pull/10956/files#diff-6d45938d3a99ad730e8d639cd2218f57c90828f1deeaad17c073cad22bfd0b50)

This adds support for executing a "findup" search, like for example looking for the nearest `.git`, `dagger.json` etc.

It is available in `Directory` and `Host`