### PR TITLE
feat: add GitRepository.url api

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -40,6 +40,7 @@ import (
 )
 
 type GitRepository struct {
+	URL     dagql.Nullable[dagql.String] `field:"true" doc:"The URL of the git repository."`
 	Backend GitRepositoryBackend
 
 	DiscardGitDir bool

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -231,6 +231,25 @@ func (GitSuite) TestGit(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (GitSuite) TestGitURL(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	input := "https://github.com/dagger/dagger.git"
+	url, err := c.Git(input).URL(ctx)
+	require.NoError(t, err)
+	require.Equal(t, input, url)
+
+	input = "github.com/dagger/dagger.git"
+	url, err = c.Git(input).URL(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "https://"+input, url)
+
+	input = "https://github.com/dagger/dagger.git"
+	url, err = c.Git(input).Head().Tree().AsGit().URL(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", url)
+}
+
 func (GitSuite) TestDiscardGitDir(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -406,6 +406,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 	}
 
 	inst, err = dagql.NewResultForCurrentID(ctx, &core.GitRepository{
+		URL: dagql.NonNull(dagql.NewString(remote.String())),
 		Backend: &core.RemoteGitRepository{
 			URL:           remote,
 			SSHKnownHosts: args.SSHKnownHosts,

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2669,6 +2669,9 @@ type GitRepository {
     patterns: [String!]
   ): [String!]!
 
+  """The URL of the git repository."""
+  url: String
+
   """Header to authenticate the remote with."""
   withAuthHeader(
     """Secret used to populate the Authorization HTTP header"""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8940,6 +8940,10 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="GitRepository-url" href="#GitRepository-url"><code>url</code></a> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span> </td>
+                        <td> The URL of the git repository. </td>
+                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name="" class="definition-deprecated"><a class="property-name" id="GitRepository-withAuthHeader" href="#GitRepository-withAuthHeader"><code>withAuthHeader</code></a> - <span class="property-type"><a href="#definition-GitRepository"><code>GitRepository!</code></a></span> </td>
                         <td> Header to authenticate the remote with. <span class="deprecation-reason">Use "httpAuthHeader" in the constructor instead.</span>

--- a/docs/static/reference/php/Dagger/GitRepository.html
+++ b/docs/static/reference/php/Dagger/GitRepository.html
@@ -233,6 +233,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_url">url</a>()
+        
+                                            <p><p>The URL of the git repository.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -695,8 +705,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withAuthHeader">
+                    <h3 id="method_url">
         <div class="location">at line 110</div>
+        <code>                    string
+    <strong>url</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The URL of the git repository.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withAuthHeader">
+        <div class="location">at line 119</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>withAuthHeader</strong>(<abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $header)
         </code>
@@ -738,7 +780,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAuthToken">
-        <div class="location">at line 120</div>
+        <div class="location">at line 129</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>withAuthToken</strong>(<abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $token)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1040,7 +1040,9 @@
 <abbr title="Dagger\Container">Container</abbr>::up</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></dd><dt><a href="Dagger/Container.html#method_user">
 <abbr title="Dagger\Container">Container</abbr>::user</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves the user to be set for all commands.</p></dd><dt><a href="Dagger/Host.html#method_unixSocket">
+                    <dd><p>Retrieves the user to be set for all commands.</p></dd><dt><a href="Dagger/GitRepository.html#method_url">
+<abbr title="Dagger\GitRepository">GitRepository</abbr>::url</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>
+                    <dd><p>The URL of the git repository.</p></dd><dt><a href="Dagger/Host.html#method_unixSocket">
 <abbr title="Dagger\Host">Host</abbr>::unixSocket</a>() &mdash; <em>Method in class <a href="Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a></em></dt>
                     <dd><p>Accesses a Unix socket on the host.</p></dd><dt><a href="Dagger/Secret.html#method_uri">
 <abbr title="Dagger\Secret">Secret</abbr>::uri</a>() &mdash; <em>Method in class <a href="Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -3411,6 +3411,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\GitRepository::url",
+			"p": "Dagger/GitRepository.html#method_url",
+			"d": "<p>The URL of the git repository.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\GitRepository::withAuthHeader",
 			"p": "Dagger/GitRepository.html#method_withAuthHeader",
 			"d": "<p>Header to authenticate the remote with.</p>"

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -136,6 +136,17 @@ defmodule Dagger.GitRepository do
     Client.execute(git_repository.client, query_builder)
   end
 
+  @doc """
+  The URL of the git repository.
+  """
+  @spec url(t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def url(%__MODULE__{} = git_repository) do
+    query_builder =
+      git_repository.query_builder |> QB.select("url")
+
+    Client.execute(git_repository.client, query_builder)
+  end
+
   @deprecated """
   Use \\"httpAuthHeader\\" in the constructor instead.
   """

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5979,7 +5979,8 @@ func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
 type GitRepository struct {
 	query *querybuilder.Selection
 
-	id *GitRepositoryID
+	id  *GitRepositoryID
+	url *string
 }
 type WithGitRepositoryFunc func(r *GitRepository) *GitRepository
 
@@ -6133,6 +6134,19 @@ func (r *GitRepository) Tags(ctx context.Context, opts ...GitRepositoryTagsOpts)
 	}
 
 	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The URL of the git repository.
+func (r *GitRepository) URL(ctx context.Context) (string, error) {
+	if r.url != nil {
+		return *r.url, nil
+	}
+	q := r.query.Select("url")
+
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -105,6 +105,15 @@ class GitRepository extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The URL of the git repository.
+     */
+    public function url(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('url');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'url');
+    }
+
+    /**
      * Header to authenticate the remote with.
      */
     public function withAuthHeader(SecretId|Secret $header): GitRepository

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6464,6 +6464,27 @@ class GitRepository(Type):
         _ctx = self._select("tags", _args)
         return await _ctx.execute(list[str])
 
+    async def url(self) -> str | None:
+        """The URL of the git repository.
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("url", _args)
+        return await _ctx.execute(str | None)
+
     def with_auth_header(self, header: "Secret") -> Self:
         """Header to authenticate the remote with.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7327,6 +7327,11 @@ impl GitRepository {
         }
         query.execute(self.graphql_client.clone()).await
     }
+    /// The URL of the git repository.
+    pub async fn url(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("url");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Header to authenticate the remote with.
     ///
     /// # Arguments

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6445,14 +6445,16 @@ export class GitRef extends BaseClient {
  */
 export class GitRepository extends BaseClient {
   private readonly _id?: GitRepositoryID = undefined
+  private readonly _url?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
    */
-  constructor(ctx?: Context, _id?: GitRepositoryID) {
+  constructor(ctx?: Context, _id?: GitRepositoryID, _url?: string) {
     super(ctx)
 
     this._id = _id
+    this._url = _url
   }
 
   /**
@@ -6542,6 +6544,21 @@ export class GitRepository extends BaseClient {
     const ctx = this._ctx.select("tags", { ...opts })
 
     const response: Awaited<string[]> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The URL of the git repository.
+   */
+  url = async (): Promise<string> => {
+    if (this._url) {
+      return this._url
+    }
+
+    const ctx = this._ctx.select("url")
+
+    const response: Awaited<string> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
There's currently no easy way to get this without checking out the whole repo using `tree`.

A few use cases: 
- Determining the fully-resolved ref (if an implied URL is provided, like `github.com/dagger/dagger`, without the leading `https://`, see #10960 for where this now becomes ambiguous)
- Getting the URL of a remote, as in the case of #10200

Note, this can *only* be implemented for remote repos, local repos have no externally accessible url, so we should return an error.