### PR TITLE
docs: mention GOPROXY configuration

### DIFF
--- a/docs/current_docs/reference/configuration/proxy.mdx
+++ b/docs/current_docs/reference/configuration/proxy.mdx
@@ -17,6 +17,9 @@ The engine supports the following standard environment variables:
 - `ALL_PROXY`
 - `FTP_PROXY`
 
+As well as the custom environment variables:
+- `_DAGGER_ENGINE_SYSTEMENV_GOPROXY` (only propagated to `GOPROXY` for go modules)
+
 Configuring Dagger with these settings currently requires [provisioning a custom engine](./custom-runner.mdx).
 
 To be applied, one or more of the environment variables listed above just need
@@ -25,7 +28,7 @@ to be set on the custom Dagger container.
 :::warning Applies to all containers
 As mentioned above, these proxy environment variables set on Dagger will also
 be automatically set on all containers created by userspace Dagger Functions
-(i.e. containers created via a `withExec` API call).
+(i.e. containers created via a `withExec` API call) unless otherwise specified.
 
 This is useful so that Dagger code you are not in direct control of (e.g. an
 external module dependency) does not need to be forked and updated to use your


### PR DESCRIPTION
See https://github.com/dagger/dagger/issues/9362.

We've supported this functionality since #7255, but we never added it in our docs (see #7814). I think it's worth including, otherwise there's really no way to know it exists.

It's hacky, but worth including :tada: We can easily our docs once we have a better method.