### PR TITLE
docs: fix link to the engine schema

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -165,7 +165,7 @@ module.exports = {
         {
           type: "link",
           label: "Engine Configuration Schema",
-          href: "https://docs.dagger.io/engine.schema.json",
+          href: "https://docs.dagger.io/reference/engine.schema.json",
         },
       ],
     },


### PR DESCRIPTION
Fixes the link for the `engine.schema.json` under reference.