### PR TITLE
Grab bag of engine optimizations

### DIFF
--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -3,7 +3,9 @@ package call
 import (
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 
@@ -19,6 +21,10 @@ import (
 var marshalBufPool = &sync.Pool{New: func() any {
 	b := make([]byte, 0, 1024)
 	return &b
+}}
+
+var hasherPool = &sync.Pool{New: func() any {
+	return xxh3.New()
 }}
 
 func New() *ID {
@@ -487,17 +493,172 @@ func (id *ID) calcDigest() (string, error) {
 		return "", fmt.Errorf("call digest already set")
 	}
 
-	buf := *(marshalBufPool.Get().(*[]byte))
+	var err error
+
+	// re-use buffers to save some allocations and work for the go GC
+	// don't do a defer Put to avoid the overhead of defers
+	bufPtr := marshalBufPool.Get().(*[]byte)
+	buf := *bufPtr
 	buf = buf[:0]
-	defer marshalBufPool.Put(&buf)
-	pbBytes, err := proto.MarshalOptions{Deterministic: true}.MarshalAppend(buf, id.pb)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal Call proto: %w", err)
+
+	// also re-use xxh3 hashers since the struct has some large arrays (not slices), which
+	// are expensive to allocate and (surprisingly) trigger a lot of cpu work expanding the
+	// stack when not stored in heap
+	h := hasherPool.Get().(*xxh3.Hasher)
+
+	// ReceiverDigest
+	buf = append(buf, []byte(id.pb.ReceiverDigest)...)
+	buf = append(buf, 0)
+
+	// Type
+	var curType *callpbv1.Type
+	for curType = id.pb.Type; curType != nil; curType = curType.Elem {
+		buf = append(buf, []byte(curType.NamedType)...)
+		buf = append(buf, 0)
+		if curType.NonNull {
+			buf = append(buf, 2, 0)
+		} else {
+			buf = append(buf, 1, 0)
+		}
 	}
-	h := xxh3.New()
-	if _, err := h.Write(pbBytes); err != nil {
-		return "", fmt.Errorf("failed to write Call proto to hash: %w", err)
+	buf = append(buf, 0)
+
+	// Field
+	buf = append(buf, []byte(id.pb.Field)...)
+	buf = append(buf, 0)
+
+	// Args
+	for _, arg := range id.pb.Args {
+		buf, err = appendArgumentBytes(arg, buf)
+		if err != nil {
+			marshalBufPool.Put(bufPtr)
+			h.Reset()
+			hasherPool.Put(h)
+			return "", err
+		}
+	}
+	buf = append(buf, 0)
+
+	// Nth
+	buf = binary.BigEndian.AppendUint64(buf, uint64(id.pb.Nth))
+	buf = append(buf, 0)
+
+	// Module
+	if id.pb.Module != nil {
+		buf = append(buf, []byte(id.pb.Module.CallDigest)...)
+		buf = append(buf, 0)
+		buf = append(buf, []byte(id.pb.Module.Name)...)
+		buf = append(buf, 0)
+		buf = append(buf, []byte(id.pb.Module.Ref)...)
+		buf = append(buf, 0)
+		buf = append(buf, []byte(id.pb.Module.Pin)...)
+		buf = append(buf, 0)
+	}
+	buf = append(buf, 0)
+
+	// View
+	buf = append(buf, []byte(id.pb.View)...)
+	buf = append(buf, 0)
+
+	_, _ = h.Write(buf) // docs say it never errors even though it returns one
+
+	// format as a hex string; do it the efficient way rather than fmt.Sprintf
+	hashBuf := make([]byte, 8)
+	binary.BigEndian.PutUint64(hashBuf, h.Sum64())
+	hexStr := make([]byte, 5+16) // 5 for "xxh3:" + 16 for the hex
+	hexStr[0], hexStr[1], hexStr[2], hexStr[3], hexStr[4] = 'x', 'x', 'h', '3', ':'
+	hex.Encode(hexStr[5:], hashBuf)
+
+	marshalBufPool.Put(bufPtr)
+	h.Reset()
+	hasherPool.Put(h)
+	return string(hexStr), nil
+}
+
+// appendArgumentBytes appends a binary representation of the given argument to the given byte slice.
+func appendArgumentBytes(arg *callpbv1.Argument, buf []byte) ([]byte, error) {
+	var err error
+
+	buf = append(buf, []byte(arg.Name)...)
+	buf = append(buf, 0)
+
+	buf, err = appendLiteralBytes(arg.Value, buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append argument %q: %w", arg.Name, err)
 	}
 
-	return fmt.Sprintf("xxh3:%x", h.Sum(nil)), nil
+	buf = append(buf, 0)
+	return buf, nil
+}
+
+// appendLiteralBytes appends a binary representation of the given literal to the given byte slice.
+func appendLiteralBytes(lit *callpbv1.Literal, buf []byte) ([]byte, error) {
+	var err error
+	// we use a unique prefix byte for each type to avoid collisions
+	switch v := lit.Value.(type) {
+	case *callpbv1.Literal_CallDigest:
+		const prefix = '0'
+		buf = append(buf, prefix)
+		buf = append(buf, []byte(v.CallDigest)...)
+		buf = append(buf, 0)
+	case *callpbv1.Literal_Null:
+		const prefix = '1'
+		buf = append(buf, prefix)
+		if v.Null {
+			buf = append(buf, prefix, 1, 0)
+		} else {
+			buf = append(buf, prefix, 2, 0)
+		}
+	case *callpbv1.Literal_Bool:
+		const prefix = '2'
+		buf = append(buf, prefix)
+		if v.Bool {
+			buf = append(buf, prefix, 1, 0)
+		} else {
+			buf = append(buf, prefix, 2, 0)
+		}
+	case *callpbv1.Literal_Enum:
+		const prefix = '3'
+		buf = append(buf, prefix)
+		buf = append(buf, []byte(v.Enum)...)
+		buf = append(buf, 0)
+	case *callpbv1.Literal_Int:
+		const prefix = '4'
+		buf = append(buf, prefix)
+		buf = binary.BigEndian.AppendUint64(buf, uint64(v.Int))
+		buf = append(buf, 0)
+	case *callpbv1.Literal_Float:
+		const prefix = '5'
+		buf = append(buf, prefix)
+		buf = binary.BigEndian.AppendUint64(buf, math.Float64bits(v.Float))
+		buf = append(buf, 0)
+	case *callpbv1.Literal_String_:
+		const prefix = '6'
+		buf = append(buf, prefix)
+		buf = append(buf, []byte(v.String_)...)
+		buf = append(buf, 0)
+	case *callpbv1.Literal_List:
+		const prefix = '7'
+		buf = append(buf, prefix)
+		for _, elem := range v.List.Values {
+			buf, err = appendLiteralBytes(elem, buf)
+			if err != nil {
+				return nil, err
+			}
+		}
+		buf = append(buf, 0)
+	case *callpbv1.Literal_Object:
+		const prefix = '8'
+		buf = append(buf, prefix)
+		for _, arg := range v.Object.Values {
+			buf, err = appendArgumentBytes(arg, buf)
+			if err != nil {
+				return nil, err
+			}
+		}
+		buf = append(buf, 0)
+	default:
+		return nil, fmt.Errorf("unknown literal type %T", v)
+	}
+	return buf, nil
 }

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -66,13 +66,19 @@ func TestTelemetry(t *testing.T) {
 
 func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 	// setup a git repo so function call tests can pick up the right metadata
+
+	// remove the repo if it exists now too, since the Cleanup doesn't always run, e.g. after a ctrl-C
+	exec.Command("rm", "-rf", ".git").Run()
+
 	cmd := exec.Command("sh", "-c", "git init && git remote add origin git@github.com:dagger/dagger")
 	if co, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to initialize viztest git repo: %v: (%s)", err, co)
 	}
+
 	t.Cleanup(func() {
 		exec.Command("rm", "-rf", ".git").Run()
 	})
+
 	for _, ex := range []Example{
 		// implementations of these functions can be found in viztest/main.go
 		{Function: "hello-world"},
@@ -324,6 +330,8 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 		ex.Env = append(ex.Env, "DAGGER_REVEAL=1")
 	}
 
+	realHome, _ := os.UserHomeDir()
+
 	// NOTE: we care about CACHED states for these tests, so we need some way for
 	// them to not be flaky (cache hit/miss), but still produce the same golden
 	// output every time. So, we run everything twice. The first run will cache
@@ -339,6 +347,12 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 		)
 		warmup.Env = append(warmup.Env, telemetry.PropagationEnv(ctx)...)
 		warmup.Env = append(warmup.Env, ex.Env...)
+
+		// still try use docker credentials even though we overrode HOME, lest we get rate limited
+		if realHome != "" {
+			warmup.Env = append(warmup.Env, fmt.Sprintf("DOCKER_CONFIG=%s/.docker", realHome))
+		}
+
 		warmupBuf := new(bytes.Buffer)
 		defer func() {
 			if t.Failed() {
@@ -366,6 +380,11 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 	)
 	cmd.Env = append(cmd.Env, telemetry.PropagationEnv(ctx)...)
 	cmd.Env = append(cmd.Env, ex.Env...)
+
+	// still try use docker credentials even though we overrode HOME, lest we get rate limited
+	if realHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_CONFIG=%s/.docker", realHome))
+	}
 
 	errBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)

--- a/engine/sources/local/hash.go
+++ b/engine/sources/local/hash.go
@@ -47,11 +47,11 @@ func (h *statHash) Reset() {
 	buf := *(statHashBufPool.Get().(*[]byte))
 	buf = buf[:0]
 
-	binary.LittleEndian.AppendUint32(buf, h.stat.Mode)
-	binary.LittleEndian.AppendUint32(buf, h.stat.Uid)
-	binary.LittleEndian.AppendUint32(buf, h.stat.Gid)
-	binary.LittleEndian.AppendUint64(buf, uint64(h.stat.Devmajor))
-	binary.LittleEndian.AppendUint64(buf, uint64(h.stat.Devminor))
+	buf = binary.LittleEndian.AppendUint32(buf, h.stat.Mode)
+	buf = binary.LittleEndian.AppendUint32(buf, h.stat.Uid)
+	buf = binary.LittleEndian.AppendUint32(buf, h.stat.Gid)
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(h.stat.Devmajor))
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(h.stat.Devminor))
 	buf = append(buf, []byte("\x00"+h.stat.Linkname+"\x00")...)
 
 	xattrs := make([]string, 0, len(h.stat.Xattrs))


### PR DESCRIPTION
Needed to debug some perf regressions in https://github.com/dagger/dagger/pull/10761; while doing so I found a lot of extremely low hanging fruit. Just gonna group them together rather than send out 5+ separate PRs.

Draft because I'm pushing more commits here still. Pushing them one-by-one so I can verify they independently fix individual bottlenecks (i.e. don't make each other redundant) and don't have any dependency on #10761 

---

[dagql: optimize InputSpecs.Inputs](https://github.com/dagger/dagger/pull/10965/commits/d68a30b39ac99a33890e0d87f12e65f400f25e13)

Before this, a pprof cpu profile of the engine while running TestTelemetry showed that 7-10% of our cpu time was spent in dagql.InputSpecs.Inputs. Most of this was due to the `seen` map creation and read/writes.

Given the small size of `n` for the function, using an O(n^2) scan of the slice to check for whether an arg was already seen is actually much more performant than the map.

After that fix, Inputs went down to only consuming 0.1% of the cpu time. It could probably be optimized further by e.g. caching results but given its no longer a bottleneck that extra complication doesn't seem worth it at the moment.

---

[optimize ID calcDigest](https://github.com/dagger/dagger/pull/10965/commits/1acfc183633f2ab35dcdfbe62e8f6712287334b6)

After the previous optimizations in this commit series, ID.calcDigest was using ~13% of cpu time during runs of TestTelemetry.

The biggest bottleneck in it was (surprisingly) that it grew the stack enough to trigger a resize, which the go runtime spent a lot of work doing. Since `calcDigest` is called *a lot*, that resizing added up quite a bit and was much more expensive than the actual marshaling and hashing.

To fix the usage of stack size:
1. The xxh3 hash object is stored in a sync.Pool. That hasher includes a >1kb array (not slice) and it appears the call to xxh3.New() was always being inlined, so it didn't end up in the heap. Using a sync.Pool ensures it is heap-stored while also saving work allocating/GC'ing the object.
2. After the above, the protobuf marshal code started being the one triggering stack size growth. To fix that, we now roll our own by just writing each relevant pb field to the hash. This requires some tedious manual effort + maintaince, but given the perf benefits seems worth it.

After all the above, `calcDigest` went from 13% of cpu usage down to 0.9%.

---

[fix local source stat hash byte append](https://github.com/dagger/dagger/pull/10965/commits/c89216e84cdd867ba74a240033adb4480e546105)

We were appending to a []byte but not using the newly updated slice, so the data written was just being overwritten each time. Surprisingly, this didn't *noticeably* break anything yet? I just noticed it while working on something else in the ID code that also used the same Append methods.

---

TODO:
- [ ] ~~Disable accidentally enabled content-hashing in dag-op for non-container ops, which results in 30GB+ of (very short lived) memory allocations over the course of just 1m of integ test execution~~
   * Nevermind, seems to be reliant on #10761, will include there instead
- [ ] ~~Reduce goroutine creation in various places; 200k+ are spawned in a single minute of integ test execution, which is possibly a genuine burden on the go runtime scheduler~~
   * Didn't seem to make much of a difference with the other stuff right now
- [x] optimize id `calcDigest` (avoid fmt.Sprintf, etc.)
- [ ] ~~avoid frequent running of extremely complicated queries for introspection+typeDefs; dagql is not optimized for it (it's better at things that are "core API"-shaped) and it results in massive amounts of work~~
   * This is VERY much worth doing (the amount of calls this triggers is mind boggling) but I'm running into weird issues with it right now where CI seems to sometimes be faster but then randomly take 20+ minutes? So I'll skip this for now
   * Spun out to a separate pr here https://github.com/dagger/dagger/pull/10967