### PR TITLE
optimize out complex introspection queries

### DIFF
--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	dagqlintrospection "github.com/dagger/dagger/dagql/introspection"
 	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/opencontainers/go-digest"
@@ -195,15 +195,17 @@ func (m *CoreMod) typedefs(ctx context.Context) ([]*core.TypeDef, error) {
 func (m *CoreMod) TypeDefs(ctx context.Context, dag *dagql.Server) ([]*core.TypeDef, error) {
 	initialSchema := m.Dag.Schema()
 
-	introspectionJSON, err := SchemaIntrospectionJSON(ctx, dag)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get schema introspection JSON for core: %w", err)
+	dagqlSchema := dagqlintrospection.WrapSchema(dag.Schema())
+	schema := &introspection.Schema{}
+	if queryName := dagqlSchema.QueryType().Name(); queryName != nil {
+		schema.QueryType.Name = *queryName
 	}
-	var schemaResp introspection.Response
-	if err := json.Unmarshal([]byte(introspectionJSON), &schemaResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal introspection JSON: %w", err)
+	for _, dagqlType := range dagqlSchema.Types() {
+		schema.Types = append(schema.Types, dagqlToCodegenType(dagqlType))
 	}
-	schema := schemaResp.Schema
+	for _, dagqlDirective := range dagqlSchema.Directives() {
+		schema.Directives = append(schema.Directives, dagqlToCodegenDirectiveDef(dagqlDirective))
+	}
 
 	typeDefs := make([]*core.TypeDef, 0, len(schema.Types))
 	for _, introspectionType := range schema.Types {


### PR DESCRIPTION
Introspection queries go through dagql and trigger a pretty insane
amount of calls to dagql.Server.Resolve each time a client connects
or a new server is made.

This isn't a currently bottleneck on machines with enough CPU, but it
makes pprof traces almost unusable at times due to the sheer number of
goroutines. I would not be shocked if there are scenarios where it is a
genuine bottleneck too (especially in cases of lots of concurrent
clients).

This change updates some of our internal calls to introspection queries
to be implemented directly rather than as an actual dagql query. It also
tweaks dagql.Server.Resolve a bit to only use separate goroutines when
there are multiple selections, otherwise just calling directly.

To test the difference, the number of times Resolve gets called when
running `dagger -m ./modules/alpine call --help`:
* Before: 23712
* After: 3548

There are also pprof traces that previously were not even loadable in my
browser that I can now open successfully.

This isn't a complete fix; the CLI typedef queries appear to be another
significant source that could be optimized out. And like I said there
isn't a immediately obvious bottleneck getting cleared here. But still
seems worth it overall.