### PR TITLE
Improve docs on private dependencies

### DIFF
--- a/docs/current_docs/extending/modules/module-dependencies.mdx
+++ b/docs/current_docs/extending/modules/module-dependencies.mdx
@@ -5,6 +5,21 @@ description: "Learn how to manage module dependencies in Dagger"
 
 # Module Dependencies
 
+A module reference follows the format: `[proto://]host/repo[/subpath][@version]`, where:
+- `host` is the domain name of the Git hosting service, e.g. `github.com`.
+- `repo` is the repository path, typically in the format `owner/name`.
+- `proto://` is optional and can be either `ssh://` or `https://` if you want to be explicit about the protocol. If omitted, Dagger will automatically choose the protocol based on available authentication methods.
+- `/subpath` is optional and specifies a subdirectory within the repository, useful for monorepos.
+- `@version` can be a tag, branch, or commit. If omitted, the default branch is used.
+
+For example, in the reference `github.com/shykes/daggerverse/hello@v0.3.0`:
+- `github.com` is the host
+- `shykes/daggerverse` is the repository
+- `hello` is the subpath within the repository
+- `v0.3.0` is the version tag
+
+The `.git` extension for the repository is optional for HTTP refs or explicit SSH refs, except for [GitLab, when referencing modules stored on a private repo or private subgroup](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/gitlab/middleware/go.rb#L229-237).
+
 ## Installation
 
 You can call Dagger Functions from any other Dagger module in your own Dagger module simply by adding it as a module dependency with `dagger install`, as in the following example:
@@ -151,6 +166,18 @@ dagger install ./path/to/module
 :::note
 Installing a module using a local path (relative or absolute) is only possible if your module is within the repository root (for Git repositories) or the directory containing the `dagger.json` file (for all other cases).
 :::
+
+### Private modules
+
+You can also install private modules from remote repositories, as long as you have access to them. Dagger supports authentication via both HTTPS (using Git credential managers) and SSH (using `SSH_AUTH_SOCK`). For more information, see [Remote Repositories](/extending/remote-repositories).
+
+When installing a private module, you can use either the normal ref style (preferred if possible, since it allows any available auth method to be used) or be explicit, and specify the protocol. For example, the following commands install the same private module:
+
+```shell
+dagger install github.com/username/private-repo/module
+dagger install https://github.com/username/private-repo/module
+dagger install ssh://git@github.com/username/private-repo/module
+```
 
 ## Uninstallation
 

--- a/docs/current_docs/extending/modules/module-dependencies.mdx
+++ b/docs/current_docs/extending/modules/module-dependencies.mdx
@@ -169,9 +169,9 @@ Installing a module using a local path (relative or absolute) is only possible i
 
 ### Private modules
 
-You can also install private modules from remote repositories, as long as you have access to them. Dagger supports authentication via both HTTPS (using Git credential managers) and SSH (using `SSH_AUTH_SOCK`). For more information, see [Remote Repositories](/extending/remote-repositories).
+You can also install private modules from remote repositories, as long as you have access to them. Dagger supports authentication via both HTTPS (using Git credential managers) and SSH (using `SSH_AUTH_SOCK`). For more information, see the [documentation on remote repositories](../extending/modules/remote-repositories.mdx).
 
-When installing a private module, you can use either the normal ref style (preferred if possible, since it allows any available auth method to be used) or be explicit, and specify the protocol. For example, the following commands install the same private module:
+When installing a private module, you can use either the normal ref style (preferred if possible, since it allows any available authentication method to be used), or explicitly specify the protocol. For example, the following commands all install the same private module:
 
 ```shell
 dagger install github.com/username/private-repo/module

--- a/docs/current_docs/extending/modules/remote-repositories.mdx
+++ b/docs/current_docs/extending/modules/remote-repositories.mdx
@@ -8,8 +8,6 @@ description: Learn how to use remote repositories with Dagger, including authent
 
 Dagger supports the use of HTTP and SSH protocols for accessing directories, files, and Dagger modules in remote repositories. This feature is compatible with all major Git hosting platforms such as GitHub, GitLab, BitBucket, Azure DevOps, Codeberg, and Sourcehut. Dagger supports authentication via both HTTPS (using Git credential managers) and SSH (using a unified authentication approach).
 
-<Tabs>
-<TabItem value="Remote directories and files">
 Dagger supports the following reference schemes for directory and file arguments:
 
 | Protocol | Scheme     | Authentication | Example |
@@ -26,28 +24,6 @@ Dagger provides additional flexibility in referencing file and directory argumen
 
 - **Version specification**: Add `#version` to target a particular version of the repository. This can be a tag, branch name, or full commit hash. If omitted, the default branch is used.
 - **Monorepo support**: Append `:subpath` after the version specification to access a specific subdirectory within the repository. Note that specifying a version is mandatory when including a subpath.
-
-:::important
-When referencing a specific subdirectory (subpath) within a repository, you must always include a version specification. The format is always `#version:subpath`.
-:::
-</TabItem>
-<TabItem value="Remote modules">
-Dagger supports various reference schemes for Dagger modules, as below:
-
-| Protocol | Scheme            | Authentication | Example |
-|----------|-------------------|----------------|---------|
-| HTTP(S)  | Go-like ref style | Git credential manager | `github.com/username/repo[/subdir][@version]`  |
-| HTTP(S)  | Git HTTP style    | Git credential manager | `https://github.com/username/repo.git[/subdir][@version]` |
-| SSH      | SCP-like          | SSH keys | `git@github.com:username/repo.git[/subdir][@version]`     |
-| SSH      | Explicit SSH      | SSH keys | `ssh://git@github.com/username/repo.git[/subdir][@version]` |
-
-Dagger provides additional flexibility in referencing modules through the following options:
-
-- **Optional extension**: The `.git` extension is optional for HTTP refs or explicit SSH refs, except for [GitLab, when referencing modules stored on a private repo or private subgroup](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/gitlab/middleware/go.rb#L229-237).
-- **Monorepo support**: Append `/subpath` to access a specific subdirectory within the repository.
-- **Version specification**: Add `@version` to target a particular version of the module. This can be a tag, branch name, or full commit hash. If omitted, the default branch is used.
-</TabItem>
-</Tabs>
 
 ## Common SSH cloning patterns
 


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/10960 should vastly simplify installation of private dependencies.

It's now easier to just skip the explicit `https`/`ssh` proto, since it can be automagically determined in more cases. I've updated the docs to make this clearer.

I've also moved the info on private repos directly next to the info on installing other dependencies, instead of living in remote repositories, where I don't really expect it to be.