### PR TITLE
feat: add dagger client update command

### DIFF
--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1300,7 +1300,7 @@ func main() {
 
 func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
 	const (
-		// pins from github.com/TomChv/dagger-client-generator module
+		// pins from github.com/dagger/client-generator-test module
 		// to test the update command
 		latestPin = "d76af75d104a2777bcd7dc6d240966760801b81f"
 		v01Pin    = "446f2691deba58f99b55b86430fade1c773e486f"
@@ -1316,7 +1316,7 @@ func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
 	"name": "test",
 	"clients": [
 		{
-			"generator": "github.com/TomChv/dagger-client-generator@` + v01Pin + `",
+			"generator": "github.com/dagger/client-generator-test@` + v01Pin + `",
 			"directory": "dagger"
 		}
 	]
@@ -1326,7 +1326,7 @@ func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
 	"name": "test",
 	"clients": [
 		{
-			"generator": "github.com/TomChv/dagger-client-generator@main",
+			"generator": "github.com/dagger/client-generator-test@main",
 			"directory": "dagger"
 		}
 	]
@@ -1336,7 +1336,7 @@ func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
 	"name": "test",
 	"clients": [
 		{
-			"generator": "github.com/TomChv/dagger-client-generator",
+			"generator": "github.com/dagger/client-generator-test",
 			"directory": "dagger"
 		}
 	]
@@ -1355,81 +1355,81 @@ func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
 		{
 			name:        "existing client has version, update cmd has version",
 			daggerjson:  clientwithOldVersion,
-			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
-			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
-			notContains: []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", v01Pin)},
+			updateCmd:   []string{"client", "update", "github.com/dagger/client-generator-test@v0.0.2"},
+			contains:    []string{"github.com/dagger/client-generator-test@v0.0.2"},
+			notContains: []string{fmt.Sprintf("github.com/dagger/client-generator-test@%s", v01Pin)},
 		},
 		{
 			name:        "existing client has branch, update cmd has version",
 			daggerjson:  clientwithBranch,
-			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
-			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
-			notContains: []string{"github.com/TomChv/dagger-client-generator@main"},
+			updateCmd:   []string{"client", "update", "github.com/dagger/client-generator-test@v0.0.2"},
+			contains:    []string{"github.com/dagger/client-generator-test@v0.0.2"},
+			notContains: []string{"github.com/dagger/client-generator-test@main"},
 		},
 		{
 			name:        "existing client dont have version, update cmd has version",
 			daggerjson:  clientWithNoVersion,
-			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
-			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
-			notContains: []string{"github.com/TomChv/dagger-client-generator\""},
+			updateCmd:   []string{"client", "update", "github.com/dagger/client-generator-test@v0.0.2"},
+			contains:    []string{"github.com/dagger/client-generator-test@v0.0.2"},
+			notContains: []string{"github.com/dagger/client-generator-test\""},
 		},
 		{
 			name:       "existing client has version, update cmd has no version",
 			daggerjson: clientwithOldVersion,
-			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
-			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			updateCmd:  []string{"client", "update", "github.com/dagger/client-generator-test"},
+			contains:   []string{fmt.Sprintf("github.com/dagger/client-generator-test@%s", latestPin)},
 			notContains: []string{
-				"github.com/TomChv/dagger-client-generator@v0.0.2",
-				"github.com/TomChv/dagger-client-generator@main",
+				"github.com/dagger/client-generator-test@v0.0.2",
+				"github.com/dagger/client-generator-test@main",
 			},
 		},
 		{
 			name:       "existing client has no version, update cmd has no version",
 			daggerjson: clientWithNoVersion,
-			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
-			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			updateCmd:  []string{"client", "update", "github.com/dagger/client-generator-test"},
+			contains:   []string{fmt.Sprintf("github.com/dagger/client-generator-test@%s", latestPin)},
 			notContains: []string{
-				"github.com/TomChv/dagger-client-generator\"",
+				"github.com/dagger/client-generator-test\"",
 			},
 		},
 		{
 			name:       "existing client has branch, update cmd has no version",
 			daggerjson: clientwithBranch,
-			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
-			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			updateCmd:  []string{"client", "update", "github.com/dagger/client-generator-test"},
+			contains:   []string{fmt.Sprintf("github.com/dagger/client-generator-test@%s", latestPin)},
 			notContains: []string{
-				"github.com/TomChv/dagger-client-generator@main",
+				"github.com/dagger/client-generator-test@main",
 			},
 		},
 		{
 			name:       "existing client has version, update cmd has branch",
 			daggerjson: clientwithOldVersion,
-			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator@main"},
-			contains:   []string{"github.com/TomChv/dagger-client-generator@main"},
+			updateCmd:  []string{"client", "update", "github.com/dagger/client-generator-test@main"},
+			contains:   []string{"github.com/dagger/client-generator-test@main"},
 			notContains: []string{
-				fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", v01Pin),
+				fmt.Sprintf("github.com/dagger/client-generator-test@%s", v01Pin),
 			},
 		},
 		{
 			name:       "existing client has no version, update cmd has branch",
 			daggerjson: clientWithNoVersion,
-			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator@main"},
-			contains:   []string{"github.com/TomChv/dagger-client-generator@main"},
+			updateCmd:  []string{"client", "update", "github.com/dagger/client-generator-test@main"},
+			contains:   []string{"github.com/dagger/client-generator-test@main"},
 			notContains: []string{
-				"github.com/TomChv/dagger-client-generator\"",
+				"github.com/dagger/client-generator-test\"",
 			},
 		},
 		{
 			name:          "update a client not in the dagger.json",
 			daggerjson:    noClient,
-			updateCmd:     []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
-			expectedError: `client(s) "github.com/TomChv/dagger-client-generator" were requested to be updated, but were not found in the clients list`,
+			updateCmd:     []string{"client", "update", "github.com/dagger/client-generator-test@v0.0.2"},
+			expectedError: `client(s) "github.com/dagger/client-generator-test" were requested to be updated, but were not found in the clients list`,
 		},
 		{
 			name:       "can update all clients",
 			daggerjson: clientwithOldVersion,
 			updateCmd:  []string{"client", "update"},
-			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			contains:   []string{fmt.Sprintf("github.com/dagger/client-generator-test@%s", latestPin)},
 		},
 	}
 

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1284,18 +1284,187 @@ func main() {
 	})
 
 	t.Run("uninstall client", func(ctx context.Context, t *testctx.T) {
-		ctr := moduleSrc.WithExec([]string{"dagger", "client", "uninstall", "./dagger"})
+		ctr := moduleSrc.WithExec([]string{"dagger", "client", "uninstall", "dagger"})
 
 		out, err := ctr.Stdout(ctx)
 
 		require.NoError(t, err)
-		require.Contains(t, out, "Client at ./dagger removed from config.\n")
+		require.Contains(t, out, "Client at dagger removed from config.\n")
 
 		out, err = ctr.WithExec([]string{"dagger", "client", "list", "--json"}).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"Generator":"go","Directory":"./dagger2"}]`, out)
 	})
+}
+
+func (ClientGeneratorTest) TestClientUpdate(ctx context.Context, t *testctx.T) {
+	const (
+		// pins from github.com/TomChv/dagger-client-generator module
+		// to test the update command
+		latestPin = "d76af75d104a2777bcd7dc6d240966760801b81f"
+		v01Pin    = "446f2691deba58f99b55b86430fade1c773e486f"
+	)
+
+	// dagger.json files to use for initial setup
+	noClient := `{
+	"name": "test",
+	"clients": []
+}`
+
+	clientwithOldVersion := `{
+	"name": "test",
+	"clients": [
+		{
+			"generator": "github.com/TomChv/dagger-client-generator@` + v01Pin + `",
+			"directory": "dagger"
+		}
+	]
+}`
+
+	clientwithBranch := `{
+	"name": "test",
+	"clients": [
+		{
+			"generator": "github.com/TomChv/dagger-client-generator@main",
+			"directory": "dagger"
+		}
+	]
+}`
+
+	clientWithNoVersion := `{
+	"name": "test",
+	"clients": [
+		{
+			"generator": "github.com/TomChv/dagger-client-generator",
+			"directory": "dagger"
+		}
+	]
+}`
+
+	type testCase struct {
+		name          string
+		daggerjson    string
+		updateCmd     []string
+		contains      []string
+		notContains   []string
+		expectedError string
+	}
+
+	testCases := []testCase{
+		{
+			name:        "existing client has version, update cmd has version",
+			daggerjson:  clientwithOldVersion,
+			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
+			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
+			notContains: []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", v01Pin)},
+		},
+		{
+			name:        "existing client has branch, update cmd has version",
+			daggerjson:  clientwithBranch,
+			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
+			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
+			notContains: []string{"github.com/TomChv/dagger-client-generator@main"},
+		},
+		{
+			name:        "existing client dont have version, update cmd has version",
+			daggerjson:  clientWithNoVersion,
+			updateCmd:   []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
+			contains:    []string{"github.com/TomChv/dagger-client-generator@v0.0.2"},
+			notContains: []string{"github.com/TomChv/dagger-client-generator\""},
+		},
+		{
+			name:       "existing client has version, update cmd has no version",
+			daggerjson: clientwithOldVersion,
+			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
+			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			notContains: []string{
+				"github.com/TomChv/dagger-client-generator@v0.0.2",
+				"github.com/TomChv/dagger-client-generator@main",
+			},
+		},
+		{
+			name:       "existing client has no version, update cmd has no version",
+			daggerjson: clientWithNoVersion,
+			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
+			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			notContains: []string{
+				"github.com/TomChv/dagger-client-generator\"",
+			},
+		},
+		{
+			name:       "existing client has branch, update cmd has no version",
+			daggerjson: clientwithBranch,
+			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator"},
+			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+			notContains: []string{
+				"github.com/TomChv/dagger-client-generator@main",
+			},
+		},
+		{
+			name:       "existing client has version, update cmd has branch",
+			daggerjson: clientwithOldVersion,
+			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator@main"},
+			contains:   []string{"github.com/TomChv/dagger-client-generator@main"},
+			notContains: []string{
+				fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", v01Pin),
+			},
+		},
+		{
+			name:       "existing client has no version, update cmd has branch",
+			daggerjson: clientWithNoVersion,
+			updateCmd:  []string{"client", "update", "github.com/TomChv/dagger-client-generator@main"},
+			contains:   []string{"github.com/TomChv/dagger-client-generator@main"},
+			notContains: []string{
+				"github.com/TomChv/dagger-client-generator\"",
+			},
+		},
+		{
+			name:          "update a client not in the dagger.json",
+			daggerjson:    noClient,
+			updateCmd:     []string{"client", "update", "github.com/TomChv/dagger-client-generator@v0.0.2"},
+			expectedError: `client(s) "github.com/TomChv/dagger-client-generator" were requested to be updated, but were not found in the clients list`,
+		},
+		{
+			name:       "can update all clients",
+			daggerjson: clientwithOldVersion,
+			updateCmd:  []string{"client", "update"},
+			contains:   []string{fmt.Sprintf("github.com/TomChv/dagger-client-generator@%s", latestPin)},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+
+			modCtr := c.Container().From("alpine:3.20.2").
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				With(daggerExec("init")).
+				WithNewFile("/work/dagger.json", tc.daggerjson)
+
+			daggerjson, err := modCtr.
+				With(daggerExec(tc.updateCmd...)).
+				File("dagger.json").
+				Contents(ctx)
+
+			if tc.expectedError != "" {
+				requireErrOut(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+
+				for _, s := range tc.contains {
+					require.Contains(t, daggerjson, s)
+				}
+
+				for _, s := range tc.notContains {
+					require.NotContains(t, daggerjson, s)
+				}
+			}
+		})
+	}
 }
 
 func (ClientGeneratorTest) TestHostCall(ctx context.Context, t *testctx.T) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -2646,10 +2648,8 @@ func (s *moduleSourceSchema) moduleSourceWithUpdatedClients(
 	// Verify that all updateReq has been processed, otherwise there's a
 	// invalid update request.
 	if len(updateReqs) > 0 {
-		deps := make([]string, 0, len(updateReqs))
-		for updateReq := range updateReqs {
-			deps = append(deps, updateReq)
-		}
+		deps := slices.Collect(maps.Keys(updateReqs))
+
 		return nil, fmt.Errorf("client(s) %q were requested to be updated, but were not found in the clients list", strings.Join(deps, ","))
 	}
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2578,14 +2578,12 @@ func (s *moduleSourceSchema) moduleSourceWithUpdatedClients(
 		// If the client is a builtin SDK, the version is tied to the engine so we skip it.
 		if sdk.IsModuleSDKBuiltin(client.Generator) {
 			newClientConfig[i] = client.Clone()
-
 			continue
 		}
 
 		// If there is an update request but the client is not in the input list, skip it
 		if _, ok := updateReqs[clientGeneratorSource]; !ok && len(updateReqs) > 0 {
 			newClientConfig[i] = client.Clone()
-
 			continue
 		}
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -207,6 +207,12 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 				dagql.Arg("outputDir").Doc(`The output directory for the generated client.`),
 			),
 
+		dagql.Func("withUpdatedClients", s.moduleSourceWithUpdatedClients).
+			Doc(`Update one or more clients.`).
+			Args(
+				dagql.Arg("clients").Doc(`The clients to update`),
+			),
+
 		dagql.Func("withoutClient", s.moduleSourceWithoutClient).
 			Doc(`Remove a client from the module source.`).
 			Args(
@@ -2501,9 +2507,155 @@ func (s *moduleSourceSchema) moduleSourceWithClient(
 		}
 	}
 
+	// Verify that the generator can be loaded as a module and clean
+	// the generator path if it's a local path.
+	if !sdk.IsModuleSDKBuiltin(moduleConfigClient.Generator) {
+		dag, err := core.CurrentDagqlServer(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dag server: %w", err)
+		}
+
+		query, err := core.CurrentQuery(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current query: %w", err)
+		}
+
+		bk, err := query.Buildkit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+		}
+
+		clientModule, err := core.ResolveDepToSource(ctx, bk, dag, src, moduleConfigClient.Generator, "", "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve client module source: %w", err)
+		}
+
+		if clientModule.Self().Kind == core.ModuleSourceKindLocal {
+			moduleConfigClient.Generator = filepath.Clean(moduleConfigClient.Generator)
+		}
+	}
+
 	src.ConfigClients = append(src.ConfigClients, moduleConfigClient)
 
 	src.Digest = src.CalcDigest().String()
+
+	return src, nil
+}
+
+func (s *moduleSourceSchema) moduleSourceWithUpdatedClients(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		Clients []string
+	},
+) (*core.ModuleSource, error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current query: %w", err)
+	}
+
+	bk, err := query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+
+	updateReqs := make(map[string]string, len(args.Clients))
+	for _, updateArg := range args.Clients {
+		source, version, _ := strings.Cut(updateArg, "@")
+		updateReqs[source] = version
+	}
+
+	src = src.Clone()
+	newClientConfig := make([]*modules.ModuleConfigClient, len(src.ConfigClients))
+	for i, client := range src.ConfigClients {
+		clientGeneratorSource, _, _ := strings.Cut(client.Generator, "@")
+
+		// If the client is a builtin SDK, the version is tied to the engine so we skip it.
+		if sdk.IsModuleSDKBuiltin(client.Generator) {
+			newClientConfig[i] = client.Clone()
+
+			continue
+		}
+
+		// If there is an update request but the client is not in the input list, skip it
+		if _, ok := updateReqs[clientGeneratorSource]; !ok && len(updateReqs) > 0 {
+			newClientConfig[i] = client.Clone()
+
+			continue
+		}
+
+		// At that point, we know that the client must be updated either with a given version
+		// or for a global update.
+		var clientModule dagql.ObjectResult[*core.ModuleSource]
+		clientModule, err = core.ResolveDepToSource(ctx, bk, dag, src, client.Generator, "", "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve client module source: %w", err)
+		}
+
+		// Ignore local dependency except if it's in the list of update then we throw an error
+		if clientModule.Self().Kind == core.ModuleSourceKindLocal {
+			if _, ok := updateReqs[filepath.Clean(clientGeneratorSource)]; ok {
+				return nil, fmt.Errorf("cannot update local client %s", clientGeneratorSource)
+			}
+
+			newClientConfig[i] = client.Clone()
+
+			continue
+		}
+
+		// If the client generator is a git module, we fetch the latest commit and
+		// reconstruct the git ref with it or use the given version.
+		repo := clientModule.Self().Git.CloneRef
+		var updatedVersion string
+
+		if version, ok := updateReqs[clientGeneratorSource]; ok && version != "" {
+			updatedVersion = version
+		} else {
+			var latestCommit dagql.String
+			err = dag.Select(ctx, dag.Root(), &latestCommit,
+				dagql.Selector{
+					Field: "git",
+					Args: []dagql.NamedInput{
+						{Name: "url", Value: dagql.String(repo)},
+					},
+				},
+				dagql.Selector{
+					Field: "head",
+				},
+				dagql.Selector{
+					Field: "commit",
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get git module (%s) latest commit: %w", repo, err)
+			}
+
+			updatedVersion = latestCommit.String()
+		}
+
+		newClientConfig[i] = client.Clone()
+		newClientConfig[i].Generator = fmt.Sprintf("%s@%s", clientModule.Self().Git.Symbolic, updatedVersion)
+
+		// Remove the update request from the map
+		delete(updateReqs, clientGeneratorSource)
+	}
+
+	// Verify that all updateReq has been processed, otherwise there's a
+	// invalid update request.
+	if len(updateReqs) > 0 {
+		deps := make([]string, 0, len(updateReqs))
+		for updateReq := range updateReqs {
+			deps = append(deps, updateReq)
+		}
+		return nil, fmt.Errorf("client(s) %q were requested to be updated, but were not found in the clients list", strings.Join(deps, ","))
+	}
+
+	src.ConfigClients = newClientConfig
 
 	return src, nil
 }

--- a/core/sdk/utils.go
+++ b/core/sdk/utils.go
@@ -1,0 +1,8 @@
+package sdk
+
+import "slices"
+
+// Return true if the given module is a builtin SDK.
+func IsModuleSDKBuiltin(module string) bool {
+	return slices.Contains(validInbuiltSDKs, sdk(module))
+}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3520,6 +3520,12 @@ type ModuleSource {
     dependencies: [String!]!
   ): ModuleSource!
 
+  """Update one or more clients."""
+  withUpdatedClients(
+    """The clients to update"""
+    clients: [String!]!
+  ): ModuleSource!
+
   """Remove the current blueprint from the module source."""
   withoutBlueprint: ModuleSource!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -10977,6 +10977,23 @@
                           </div>
                         </td>
                       </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-withUpdatedClients" href="#ModuleSource-withUpdatedClients"><code>withUpdatedClients</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Update one or more clients. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>clients</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span></h6>
+                                <p>The clients to update</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-withoutBlueprint" href="#ModuleSource-withoutBlueprint"><code>withoutBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
                         <td> Remove the current blueprint from the module source. </td>

--- a/docs/static/reference/php/Dagger/ModuleSource.html
+++ b/docs/static/reference/php/Dagger/ModuleSource.html
@@ -526,6 +526,16 @@
                     <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withUpdatedClients">withUpdatedClients</a>(array $clients)
+        
+                                            <p><p>Update one or more clients.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withoutBlueprint">withoutBlueprint</a>()
         
                                             <p><p>Remove the current blueprint from the module source.</p></p>                </div>
@@ -1968,8 +1978,50 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withoutBlueprint">
+                    <h3 id="method_withUpdatedClients">
         <div class="location">at line 372</div>
+        <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+    <strong>withUpdatedClients</strong>(array $clients)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Update one or more clients.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>array</td>
+                <td>$clients</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withoutBlueprint">
+        <div class="location">at line 382</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutBlueprint</strong>()
         </code>
@@ -2001,7 +2053,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutClient">
-        <div class="location">at line 381</div>
+        <div class="location">at line 391</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutClient</strong>(string $path)
         </code>
@@ -2043,7 +2095,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDependencies">
-        <div class="location">at line 391</div>
+        <div class="location">at line 401</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutDependencies</strong>(array $dependencies)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1364,7 +1364,9 @@
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::withUpdateBlueprint</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
                     <dd><p>Update the blueprint module to the latest version.</p></dd><dt><a href="Dagger/ModuleSource.html#method_withUpdateDependencies">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::withUpdateDependencies</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
-                    <dd><p>Update one or more module dependencies.</p></dd><dt><a href="Dagger/ModuleSource.html#method_withoutBlueprint">
+                    <dd><p>Update one or more module dependencies.</p></dd><dt><a href="Dagger/ModuleSource.html#method_withUpdatedClients">
+<abbr title="Dagger\ModuleSource">ModuleSource</abbr>::withUpdatedClients</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
+                    <dd><p>Update one or more clients.</p></dd><dt><a href="Dagger/ModuleSource.html#method_withoutBlueprint">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::withoutBlueprint</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
                     <dd><p>Remove the current blueprint from the module source.</p></dd><dt><a href="Dagger/ModuleSource.html#method_withoutClient">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::withoutClient</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -4243,6 +4243,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\ModuleSource::withUpdatedClients",
+			"p": "Dagger/ModuleSource.html#method_withUpdatedClients",
+			"d": "<p>Update one or more clients.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\ModuleSource::withoutBlueprint",
 			"p": "Dagger/ModuleSource.html#method_withoutBlueprint",
 			"d": "<p>Remove the current blueprint from the module source.</p>"

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -527,6 +527,22 @@ defmodule Dagger.ModuleSource do
   end
 
   @doc """
+  Update one or more clients.
+  """
+  @spec with_updated_clients(t(), [String.t()]) :: Dagger.ModuleSource.t()
+  def with_updated_clients(%__MODULE__{} = module_source, clients) do
+    query_builder =
+      module_source.query_builder
+      |> QB.select("withUpdatedClients")
+      |> QB.put_arg("clients", clients)
+
+    %Dagger.ModuleSource{
+      query_builder: query_builder,
+      client: module_source.client
+    }
+  end
+
+  @doc """
   Remove the current blueprint from the module source.
   """
   @spec without_blueprint(t()) :: Dagger.ModuleSource.t()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8686,6 +8686,16 @@ func (r *ModuleSource) WithUpdateDependencies(dependencies []string) *ModuleSour
 	}
 }
 
+// Update one or more clients.
+func (r *ModuleSource) WithUpdatedClients(clients []string) *ModuleSource {
+	q := r.query.Select("withUpdatedClients")
+	q = q.Arg("clients", clients)
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
 // Remove the current blueprint from the module source.
 func (r *ModuleSource) WithoutBlueprint() *ModuleSource {
 	q := r.query.Select("withoutBlueprint")

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -367,6 +367,16 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Update one or more clients.
+     */
+    public function withUpdatedClients(array $clients): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withUpdatedClients');
+        $innerQueryBuilder->setArgument('clients', $clients);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Remove the current blueprint from the module source.
      */
     public function withoutBlueprint(): ModuleSource

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -8866,6 +8866,20 @@ class ModuleSource(Type):
         _ctx = self._select("withUpdateDependencies", _args)
         return ModuleSource(_ctx)
 
+    def with_updated_clients(self, clients: list[str]) -> Self:
+        """Update one or more clients.
+
+        Parameters
+        ----------
+        clients:
+            The clients to update
+        """
+        _args = [
+            Arg("clients", clients),
+        ]
+        _ctx = self._select("withUpdatedClients", _args)
+        return ModuleSource(_ctx)
+
     def without_blueprint(self) -> Self:
         """Remove the current blueprint from the module source."""
         _args: list[Arg] = []

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -9175,6 +9175,26 @@ impl ModuleSource {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Update one or more clients.
+    ///
+    /// # Arguments
+    ///
+    /// * `clients` - The clients to update
+    pub fn with_updated_clients(&self, clients: Vec<impl Into<String>>) -> ModuleSource {
+        let mut query = self.selection.select("withUpdatedClients");
+        query = query.arg(
+            "clients",
+            clients
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
+        ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Remove the current blueprint from the module source.
     pub fn without_blueprint(&self) -> ModuleSource {
         let query = self.selection.select("withoutBlueprint");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -8702,6 +8702,15 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
+   * Update one or more clients.
+   * @param clients The clients to update
+   */
+  withUpdatedClients = (clients: string[]): ModuleSource => {
+    const ctx = this._ctx.select("withUpdatedClients", { clients })
+    return new ModuleSource(ctx)
+  }
+
+  /**
    * Remove the current blueprint from the module source.
    */
   withoutBlueprint = (): ModuleSource => {


### PR DESCRIPTION
Add `dagger client update` command so you can update external client generator.



Add `WithUpdatedClients` to `ModuleSource` to update one or more clients.
Add integration tests.

Additional changes:
- Small fix on client install to clean the path in the generator is a local module