### PR TITLE
Little view chores

### DIFF
--- a/cmd/introspect/introspect.go
+++ b/cmd/introspect/introspect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/schema"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/cache"
 	"github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func Introspect(cmd *cobra.Command, args []string) error {
 func getIntrospection(ctx context.Context) (*introspection.Response, error) {
 	root := &core.Query{}
 	dag := dagql.NewServer(root, dagql.NewSessionCache(cache.NewCache[digest.Digest, dagql.AnyResult]()))
-	dag.View = dagql.View(version)
+	dag.View = call.View(version)
 	coreMod := &schema.CoreMod{Dag: dag}
 	if err := coreMod.Install(ctx, dag); err != nil {
 		return nil, err

--- a/core/directory.go
+++ b/core/directory.go
@@ -240,11 +240,8 @@ func (dir *Directory) Stat(ctx context.Context, bk *buildkit.Client, src string)
 func (dir *Directory) Entries(ctx context.Context, src string) ([]string, error) {
 	src = path.Join(dir.Dir, src)
 	paths := []string{}
-	useSlash, err := SupportsDirSlash(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, err = execInMount(ctx, dir, func(root string) error {
+	useSlash := SupportsDirSlash(ctx)
+	_, err := execInMount(ctx, dir, func(root string) error {
 		resolvedDir, err := containerdfs.RootPath(root, src)
 		if err != nil {
 			return err
@@ -302,10 +299,7 @@ func (dir *Directory) Glob(ctx context.Context, pattern string) ([]string, error
 	}
 	onlyPrefixIncludes := !strings.ContainsAny(patternWithoutTrailingGlob(pat), patternChars)
 
-	useSlash, err := SupportsDirSlash(ctx)
-	if err != nil {
-		return nil, err
-	}
+	useSlash := SupportsDirSlash(ctx)
 	_, err = execInMount(ctx, dir, func(root string) error {
 		resolvedDir, err := containerdfs.RootPath(root, dir.Dir)
 		if err != nil {
@@ -1167,7 +1161,7 @@ func validateFileName(file string) error {
 	return nil
 }
 
-func SupportsDirSlash(ctx context.Context) (bool, error) {
+func SupportsDirSlash(ctx context.Context) bool {
 	return Supports(ctx, "v0.17.0")
 }
 

--- a/core/enum.go
+++ b/core/enum.go
@@ -143,7 +143,7 @@ func (e *ModuleEnum) TypeDescription() string {
 	return formatGqlDescription(e.TypeDef.Description)
 }
 
-func (e *ModuleEnum) TypeDefinition(view dagql.View) *ast.Definition {
+func (e *ModuleEnum) TypeDefinition(view call.View) *ast.Definition {
 	def := &ast.Definition{
 		Kind:        ast.Enum,
 		Name:        e.TypeName(),

--- a/core/interface.go
+++ b/core/interface.go
@@ -272,7 +272,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 
 		fields = append(fields, dagql.Field[*InterfaceAnnotatedValue]{
 			Spec: fieldDef,
-			Func: func(ctx context.Context, self dagql.ObjectResult[*InterfaceAnnotatedValue], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*InterfaceAnnotatedValue], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				runtimeVal := self.Self()
 
 				// TODO: support core types too
@@ -340,7 +340,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 					ctx context.Context,
 					parentObj dagql.AnyResult,
 					args map[string]dagql.Input,
-					view dagql.View,
+					view call.View,
 					cacheCfg dagql.CacheConfig,
 				) (*dagql.CacheConfig, error) {
 					parent, ok := parentObj.(dagql.ObjectResult[*InterfaceAnnotatedValue])
@@ -486,7 +486,7 @@ func (iface *InterfaceAnnotatedValue) TypeDescription() string {
 	return iface.TypeDef.Description
 }
 
-func (iface *InterfaceAnnotatedValue) TypeDefinition(view dagql.View) *ast.Definition {
+func (iface *InterfaceAnnotatedValue) TypeDefinition(view call.View) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Object,
 		Name: iface.Type().Name(),

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -535,7 +535,7 @@ func (m *MCP) toolCallToSelection(
 		Field: fieldDef.Name,
 	}
 	targetObjType := target.ObjectType()
-	field, ok := targetObjType.FieldSpec(fieldDef.Name, dagql.View(engine.Version))
+	field, ok := targetObjType.FieldSpec(fieldDef.Name, call.View(engine.Version))
 	if !ok {
 		return sel, fmt.Errorf("field %q not found in object type %q",
 			fieldDef.Name,

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/server/resource"
@@ -200,7 +201,7 @@ func (fn *ModuleFunction) CacheConfigForCall(
 	ctx context.Context,
 	parent dagql.AnyResult,
 	args map[string]dagql.Input,
-	view dagql.View,
+	view call.View,
 	inputCfg dagql.CacheConfig,
 ) (*dagql.CacheConfig, error) {
 	cacheCfg, err := fn.mod.CacheConfigForCall(ctx, parent, args, view, inputCfg)

--- a/core/module.go
+++ b/core/module.go
@@ -219,7 +219,7 @@ func (mod *Module) TypeDefs(ctx context.Context, dag *dagql.Server) ([]*TypeDef,
 	return typeDefs, nil
 }
 
-func (mod *Module) View() (dagql.View, bool) {
+func (mod *Module) View() (call.View, bool) {
 	return "", false
 }
 
@@ -227,7 +227,7 @@ func (mod *Module) CacheConfigForCall(
 	ctx context.Context,
 	_ dagql.AnyResult,
 	_ map[string]dagql.Input,
-	_ dagql.View,
+	_ call.View,
 	cacheCfg dagql.CacheConfig,
 ) (*dagql.CacheConfig, error) {
 	// Function calls on a module should be cached based on the module's content hash, not
@@ -692,7 +692,7 @@ type Mod interface {
 	Name() string
 
 	// View gets the name of the module's view of its underlying schema
-	View() (dagql.View, bool)
+	View() (call.View, bool)
 
 	// Install modifies the provided server to install the contents of the
 	// modules declared fields.

--- a/core/object.go
+++ b/core/object.go
@@ -186,7 +186,7 @@ type Callable interface {
 	Call(context.Context, *CallOpts) (dagql.AnyResult, error)
 	ReturnType() (ModType, error)
 	ArgType(argName string) (ModType, error)
-	CacheConfigForCall(context.Context, dagql.AnyResult, map[string]dagql.Input, dagql.View, dagql.CacheConfig) (*dagql.CacheConfig, error)
+	CacheConfigForCall(context.Context, dagql.AnyResult, map[string]dagql.Input, call.View, dagql.CacheConfig) (*dagql.CacheConfig, error)
 }
 
 func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callable, error) {
@@ -283,7 +283,7 @@ func (obj *ModuleObject) TypeDescription() string {
 	return formatGqlDescription(obj.TypeDef.Description)
 }
 
-func (obj *ModuleObject) TypeDefinition(view dagql.View) *ast.Definition {
+func (obj *ModuleObject) TypeDefinition(view call.View) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Object,
 		Name: obj.Type().Name(),
@@ -437,7 +437,7 @@ func objField(mod *Module, field *FieldTypeDef) dagql.Field[*ModuleObject] {
 	}
 	return dagql.Field[*ModuleObject]{
 		Spec: spec,
-		Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], _ map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+		Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], _ map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 			modType, ok, err := mod.ModTypeFor(ctx, field.TypeDef, true)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get mod type for field %q: %w", field.Name, err)
@@ -479,7 +479,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 
 	return dagql.Field[*ModuleObject]{
 		Spec: &spec,
-		Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+		Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 			opts := &CallOpts{
 				ParentTyped:  obj,
 				ParentFields: obj.Self().Fields,
@@ -540,7 +540,7 @@ func (f *CallableField) CacheConfigForCall(
 	ctx context.Context,
 	parent dagql.AnyResult,
 	args map[string]dagql.Input,
-	view dagql.View,
+	view call.View,
 	inputCfg dagql.CacheConfig,
 ) (*dagql.CacheConfig, error) {
 	return f.Module.CacheConfigForCall(ctx, parent, args, view, inputCfg)

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -37,7 +37,7 @@ func (m *CoreMod) GetSource() *core.ModuleSource {
 	return &core.ModuleSource{}
 }
 
-func (m *CoreMod) View() (dagql.View, bool) {
+func (m *CoreMod) View() (call.View, bool) {
 	return m.Dag.View, true
 }
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -323,11 +323,7 @@ func (s *directorySchema) withTimestamps(ctx context.Context, parent dagql.Objec
 
 func (s *directorySchema) name(ctx context.Context, parent *core.Directory, args struct{}) (dagql.String, error) {
 	name := path.Base(parent.Dir)
-	useSlash, err := core.SupportsDirSlash(ctx)
-	if err != nil {
-		return "", err
-	}
-	if useSlash {
+	if core.SupportsDirSlash(ctx) {
 		name = strings.TrimSuffix(name, "/") + "/"
 	}
 	return dagql.NewString(name), nil

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -306,7 +306,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			err = srv.Select(ctx, parent, &inst, dagql.Selector{
 				Field: "git",
 				Args:  selectArgs,
-				View:  dagql.View(dagql.CurrentID(ctx).View()),
+				View:  dagql.CurrentID(ctx).View(),
 			})
 			return inst, err
 		} else {
@@ -431,7 +431,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			err = srv.Select(ctx, parent, &inst, dagql.Selector{
 				Field: "git",
 				Args:  selectArgs,
-				View:  dagql.View(dagql.CurrentID(ctx).View()),
+				View:  dagql.CurrentID(ctx).View(),
 			})
 			return inst, err
 		}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -402,17 +402,13 @@ func (s *moduleSchema) typeDefWithEnumMember(ctx context.Context, def *core.Type
 		return nil, err
 	}
 
-	supports, err := supportEnumMembers(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if !supports {
+	if !supportEnumMembers(ctx) {
 		return def.WithEnumValue(args.Name, args.Value, args.Description, sourceMap)
 	}
 	return def.WithEnumMember(args.Name, args.Value, args.Description, sourceMap)
 }
 
-func supportEnumMembers(ctx context.Context) (bool, error) {
+func supportEnumMembers(ctx context.Context) bool {
 	return core.Supports(ctx, "v0.18.11")
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/sdk"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/client/pathutil"
@@ -2468,7 +2469,7 @@ func (s *moduleSourceSchema) loadDependencyModules(ctx context.Context, src *cor
 			// uses the correct schema version
 			dag := *coreMod.Dag
 
-			dag.View = dagql.View(engine.BaseVersion(engine.NormalizeVersion(src.EngineVersion)))
+			dag.View = call.View(engine.BaseVersion(engine.NormalizeVersion(src.EngineVersion)))
 			deps.Mods[i] = &CoreMod{Dag: &dag}
 		}
 	}

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -178,7 +178,7 @@ func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent dag
 	}
 
 	// extract the withExec args
-	withExecField, ok := ctr.ObjectType().FieldSpec(id.Field(), dagql.View(id.View()))
+	withExecField, ok := ctr.ObjectType().FieldSpec(id.Field(), id.View())
 	if !ok {
 		return inst, fmt.Errorf("could not find %s on %s", id.Field(), ctr.Type().NamedType)
 	}
@@ -187,7 +187,7 @@ func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent dag
 		return inst, err
 	}
 	var withExecArgs containerExecArgs
-	err = withExecField.Args.Decode(inputs, &withExecArgs, dagql.View(id.View()))
+	err = withExecField.Args.Decode(inputs, &withExecArgs, id.View())
 	if err != nil {
 		return inst, err
 	}
@@ -272,7 +272,7 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[
 	err = srv.Select(ctx, ctr, &svc,
 		dagql.Selector{
 			Field: "asService",
-			View:  dagql.View(dagql.CurrentID(ctx).View()),
+			View:  dagql.CurrentID(ctx).View(),
 			Args:  inputs,
 		},
 	)
@@ -293,7 +293,7 @@ func (s *serviceSchema) containerUpLegacy(ctx context.Context, ctr dagql.ObjectR
 	err = srv.Select(ctx, ctr, &svc,
 		dagql.Selector{
 			Field: "asService",
-			View:  dagql.View(dagql.CurrentID(ctx).View()),
+			View:  dagql.CurrentID(ctx).View(),
 		},
 	)
 	if err != nil {

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -261,7 +261,7 @@ func recordStatus(ctx context.Context, res dagql.AnyResult, span trace.Span, cac
 func logResult(ctx context.Context, res dagql.AnyResult, self dagql.AnyObjectResult, id *call.ID) {
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
 	defer stdio.Close()
-	fieldSpec, ok := self.ObjectType().FieldSpec(id.Field(), dagql.View(id.View()))
+	fieldSpec, ok := self.ObjectType().FieldSpec(id.Field(), id.View())
 	if !ok {
 		return
 	}

--- a/core/util.go
+++ b/core/util.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/dagger/dagger/core/reffs"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/slog"
 )
@@ -363,9 +362,10 @@ func mountLLB(ctx context.Context, llb *pb.Definition, f func(string) error) err
 	return ref.Mount(ctx, f)
 }
 
-func Supports(ctx context.Context, minVersion string) (bool, error) {
-	id := dagql.CurrentID(ctx)
-	return engine.CheckVersionCompatibility(id.View(), minVersion), nil
+func Supports(ctx context.Context, minVersion string) bool {
+	return AfterVersion(minVersion).Contains(
+		dagql.View(dagql.CurrentID(ctx).View()),
+	)
 }
 
 // AllVersion is a view that contains all versions.

--- a/core/util.go
+++ b/core/util.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dagger/dagger/core/reffs"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/slog"
 )
@@ -364,7 +365,7 @@ func mountLLB(ctx context.Context, llb *pb.Definition, f func(string) error) err
 
 func Supports(ctx context.Context, minVersion string) bool {
 	return AfterVersion(minVersion).Contains(
-		dagql.View(dagql.CurrentID(ctx).View()),
+		dagql.CurrentID(ctx).View(),
 	)
 }
 
@@ -377,7 +378,7 @@ type AfterVersion string
 
 var _ dagql.ViewFilter = AfterVersion("")
 
-func (minVersion AfterVersion) Contains(version dagql.View) bool {
+func (minVersion AfterVersion) Contains(version call.View) bool {
 	if version == "" {
 		return true
 	}
@@ -390,7 +391,7 @@ type BeforeVersion string
 
 var _ dagql.ViewFilter = BeforeVersion("")
 
-func (maxVersion BeforeVersion) Contains(version dagql.View) bool {
+func (maxVersion BeforeVersion) Contains(version call.View) bool {
 	if version == "" {
 		return false
 	}

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -54,6 +54,8 @@ type ID struct {
 	typ      *Type
 }
 
+type View string
+
 // The ID of the object that the field selection will be evaluated against.
 //
 // If nil, the root Query object is implied.
@@ -85,8 +87,8 @@ func (id *ID) Field() string {
 }
 
 // GraphQL view.
-func (id *ID) View() string {
-	return id.pb.View
+func (id *ID) View() View {
+	return View(id.pb.View)
 }
 
 // GraphQL field arguments, always in alphabetical order.
@@ -219,7 +221,7 @@ func (id *ID) SelectNth(nth int) *ID {
 	return id.Append(
 		id.pb.Type.Elem.ToAST(),
 		id.pb.Field,
-		id.pb.View,
+		View(id.pb.View),
 		id.module,
 		nth,
 		dgst,
@@ -229,7 +231,7 @@ func (id *ID) SelectNth(nth int) *ID {
 func (id *ID) Append(
 	ret *ast.Type,
 	field string,
-	view string,
+	view View,
 	mod *Module,
 	nth int,
 	customDigest digest.Digest,
@@ -239,7 +241,7 @@ func (id *ID) Append(
 		pb: &callpbv1.Call{
 			ReceiverDigest: string(id.Digest()),
 			Field:          field,
-			View:           view,
+			View:           string(view),
 			Args:           make([]*callpbv1.Argument, 0, len(args)),
 			Nth:            int64(nth),
 		},
@@ -284,7 +286,7 @@ func (id *ID) WithDigest(customDigest digest.Digest) *ID {
 	return id.receiver.Append(
 		id.pb.Type.ToAST(),
 		id.pb.Field,
-		id.pb.View,
+		View(id.pb.View),
 		id.module,
 		int(id.pb.Nth),
 		customDigest,
@@ -320,7 +322,7 @@ func (id *ID) WithArgument(arg *Argument) *ID {
 	return id.receiver.Append(
 		id.pb.Type.ToAST(),
 		id.pb.Field,
-		id.pb.View,
+		View(id.pb.View),
 		id.module,
 		int(id.pb.Nth),
 		"", // reset to default digest

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -2766,7 +2766,7 @@ func InstallTestTypes(srv *dagql.Server) {
 				Name: "value",
 				Type: dagql.Int(0),
 			},
-			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				return dagql.NewResultForCurrentID(ctx, dagql.Int(self.Self().Value))
 			},
 		},
@@ -2775,7 +2775,7 @@ func InstallTestTypes(srv *dagql.Server) {
 				Name: "text",
 				Type: dagql.String(""),
 			},
-			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				return dagql.NewResultForCurrentID(ctx, dagql.String(self.Self().Text))
 			},
 		},
@@ -2784,7 +2784,7 @@ func InstallTestTypes(srv *dagql.Server) {
 				Name: "nullableField",
 				Type: dagql.Null[dagql.String](),
 			},
-			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*TestObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				if self.Self().NullableField == nil {
 					return dagql.NewResultForCurrentID(ctx, dagql.Null[dagql.String]())
 				}
@@ -2805,7 +2805,7 @@ func InstallTestTypes(srv *dagql.Server) {
 				Name: "name",
 				Type: dagql.String(""),
 			},
-			Func: func(ctx context.Context, self dagql.ObjectResult[*NestedObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*NestedObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				return dagql.NewResultForCurrentID(ctx, dagql.String(self.Self().Name))
 			},
 		},
@@ -2814,7 +2814,7 @@ func InstallTestTypes(srv *dagql.Server) {
 				Name: "inner",
 				Type: &TestObject{},
 			},
-			Func: func(ctx context.Context, self dagql.ObjectResult[*NestedObject], args map[string]dagql.Input, view dagql.View) (dagql.AnyResult, error) {
+			Func: func(ctx context.Context, self dagql.ObjectResult[*NestedObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
 				return dagql.NewResultForCurrentID(ctx, self.Self().Inner)
 			},
 		},

--- a/dagql/directives.go
+++ b/dagql/directives.go
@@ -23,7 +23,7 @@ func (DirectiveLocation) Type() *ast.Type {
 	}
 }
 
-func (d DirectiveSpec) DirectiveDefinition(view View) *ast.DirectiveDefinition {
+func (d DirectiveSpec) DirectiveDefinition(view call.View) *ast.DirectiveDefinition {
 	def := &ast.DirectiveDefinition{
 		Name:         d.Name,
 		Description:  d.Description,

--- a/dagql/introspection/types.go
+++ b/dagql/introspection/types.go
@@ -20,7 +20,7 @@ func Install[T dagql.Typed](srv *dagql.Server) {
 
 		// custom dagger field
 		dagql.Func("__schemaVersion", func(ctx context.Context, self T, args struct{}) (string, error) {
-			return dagql.CurrentID(ctx).View(), nil
+			return string(dagql.CurrentID(ctx).View()), nil
 		}).View(dagql.AllView{}),
 
 		dagql.FuncWithCacheKey("__type", func(ctx context.Context, self T, args struct {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -50,9 +50,9 @@ type Server struct {
 	typeDefs   map[string]TypeDef
 	directives map[string]DirectiveSpec
 
-	schemas       map[View]*ast.Schema
-	schemaDigests map[View]digest.Digest
-	schemaOnces   map[View]*sync.Once
+	schemas       map[call.View]*ast.Schema
+	schemaDigests map[call.View]digest.Digest
+	schemaOnces   map[call.View]*sync.Once
 	schemaLock    *sync.Mutex
 
 	installLock  *sync.Mutex
@@ -62,7 +62,7 @@ type Server struct {
 	//
 	// WARNING: this is *not* the view of the current query (for that, inspect
 	// the current id)
-	View View
+	View call.View
 
 	// Cache is the inner cache used by the server. It can be replicated to
 	// another *Server to inherit and share caches.
@@ -81,7 +81,7 @@ func (s *ServerSchema) WithCache(c *SessionCache) *Server {
 	return &inner
 }
 
-func (s *ServerSchema) View() View {
+func (s *ServerSchema) View() call.View {
 	return s.inner.View
 }
 
@@ -126,9 +126,9 @@ func NewServer[T Typed](root T, c *SessionCache) *Server {
 		typeDefs:      map[string]TypeDef{},
 		directives:    map[string]DirectiveSpec{},
 		installLock:   &sync.Mutex{},
-		schemas:       make(map[View]*ast.Schema),
-		schemaDigests: make(map[View]digest.Digest),
-		schemaOnces:   make(map[View]*sync.Once),
+		schemas:       make(map[call.View]*ast.Schema),
+		schemaDigests: make(map[call.View]digest.Digest),
+		schemaOnces:   make(map[call.View]*sync.Once),
 		schemaLock:    &sync.Mutex{},
 	}
 	rootClass := NewClass(srv, ClassOpts[T]{
@@ -1094,7 +1094,7 @@ type Selector struct {
 	Field string
 	Args  []NamedInput
 	Nth   int
-	View  View
+	View  call.View
 }
 
 func (sel Selector) String() string {

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -44,7 +44,7 @@ type ObjectType interface {
 	New(val AnyResult) (AnyObjectResult, error)
 	// ParseField parses the given field and returns a Selector and an expected
 	// return type.
-	ParseField(ctx context.Context, view View, astField *ast.Field, vars map[string]any) (Selector, *ast.Type, error)
+	ParseField(ctx context.Context, view call.View, astField *ast.Field, vars map[string]any) (Selector, *ast.Type, error)
 	// Extend registers an additional field onto the type.
 	//
 	// Unlike natively added fields, the extended func is limited to the external
@@ -52,7 +52,7 @@ type ObjectType interface {
 	// cacheKeyFun is optional, if not set the default dagql ID cache key will be used.
 	Extend(spec FieldSpec, fun FieldFunc, cacheSpec CacheSpec)
 	// FieldSpec looks up a field spec by name.
-	FieldSpec(name string, view View) (FieldSpec, bool)
+	FieldSpec(name string, view call.View) (FieldSpec, bool)
 }
 
 type IDType interface {
@@ -205,7 +205,7 @@ func (Int) TypeName() string {
 	return "Int"
 }
 
-func (i Int) TypeDefinition(view View) *ast.Definition {
+func (i Int) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        i.TypeName(),
@@ -311,7 +311,7 @@ func (Float) TypeName() string {
 	return "Float"
 }
 
-func (f Float) TypeDefinition(view View) *ast.Definition {
+func (f Float) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        f.TypeName(),
@@ -412,7 +412,7 @@ func (Boolean) TypeName() string {
 	return "Boolean"
 }
 
-func (b Boolean) TypeDefinition(view View) *ast.Definition {
+func (b Boolean) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        b.TypeName(),
@@ -497,7 +497,7 @@ func (String) TypeName() string {
 	return "String"
 }
 
-func (s String) TypeDefinition(view View) *ast.Definition {
+func (s String) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Name:        s.TypeName(),
@@ -662,7 +662,7 @@ func (s Scalar[T]) TypeName() string {
 	return s.Name
 }
 
-func (s Scalar[T]) TypeDefinition(view View) *ast.Definition {
+func (s Scalar[T]) TypeDefinition(view call.View) *ast.Definition {
 	def := &ast.Definition{
 		Kind: ast.Scalar,
 		Name: s.TypeName(),
@@ -753,7 +753,7 @@ func (i ID[T]) ID() *call.ID {
 var _ ScalarType = ID[Typed]{}
 
 // TypeDefinition returns the GraphQL definition of the type.
-func (i ID[T]) TypeDefinition(view View) *ast.Definition {
+func (i ID[T]) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind: ast.Scalar,
 		Name: i.TypeName(),
@@ -1182,7 +1182,7 @@ func (e *EnumValues[T]) TypeName() string {
 	return e.Type().Name()
 }
 
-func (e *EnumValues[T]) TypeDefinition(view View) *ast.Definition {
+func (e *EnumValues[T]) TypeDefinition(view call.View) *ast.Definition {
 	def := &ast.Definition{
 		Kind:       ast.Enum,
 		Name:       e.TypeName(),
@@ -1207,7 +1207,7 @@ func (e *EnumValues[T]) DecodeInput(val any) (Input, error) {
 	return e.Lookup(v.(*EnumValueName).Name)
 }
 
-func (e *EnumValues[T]) PossibleValues(view View) ast.EnumValueList {
+func (e *EnumValues[T]) PossibleValues(view call.View) ast.EnumValueList {
 	var values ast.EnumValueList
 	for _, val := range *e {
 		if val.View != nil && !val.View.Contains(view) {
@@ -1320,7 +1320,7 @@ func (e *EnumValueName) Type() *ast.Type {
 	}
 }
 
-func (e *EnumValueName) TypeDefinition(view View) *ast.Definition {
+func (e *EnumValueName) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind: ast.Enum,
 		Name: e.TypeName(),
@@ -1390,7 +1390,7 @@ func (spec InputObjectSpec) TypeName() string {
 	return spec.Name
 }
 
-func (spec InputObjectSpec) TypeDefinition(view View) *ast.Definition {
+func (spec InputObjectSpec) TypeDefinition(view call.View) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.InputObject,
 		Name:        spec.Name,

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -584,7 +584,7 @@ func (srv *Server) initializeDaggerClient(
 	client.defaultDeps = core.NewModDeps(client.dagqlRoot, []core.Mod{coreMod})
 
 	client.deps = core.NewModDeps(client.dagqlRoot, []core.Mod{coreMod})
-	coreMod.Dag.View = dagql.View(engine.BaseVersion(engine.NormalizeVersion(client.clientVersion)))
+	coreMod.Dag.View = call.View(engine.BaseVersion(engine.NormalizeVersion(client.clientVersion)))
 
 	if opts.EncodedModuleID != "" {
 		modID := new(call.ID)
@@ -600,7 +600,7 @@ func (srv *Server) initializeDaggerClient(
 		// this is needed to set the view of the core api as compatible
 		// with the module we're currently calling from
 		engineVersion := client.mod.Source.Value.Self().EngineVersion
-		coreMod.Dag.View = dagql.View(engine.BaseVersion(engine.NormalizeVersion(engineVersion)))
+		coreMod.Dag.View = call.View(engine.BaseVersion(engine.NormalizeVersion(engineVersion)))
 
 		// NOTE: *technically* we should reload the module here, so that we can
 		// use the new typedefs api - but at this point we likely would


### PR DESCRIPTION
- Cherry-pick of [`06126db` (#10946)](https://github.com/dagger/dagger/pull/10946/commits/06126db402643e8a402b3e18657fce0e2e19707a)
- And also a change to move the `View` type into `dagql/call`, so `ID.View` can directly return a rich type, which avoids the need to convert it later, a fiddly and annoying thing.