### PR TITLE
docs: remove php-sdk-dev module and refs

### DIFF
--- a/docs/.dagger/main.go
+++ b/docs/.dagger/main.go
@@ -20,20 +20,16 @@ func New(
 	source *dagger.Directory,
 	// +defaultPath="nginx.conf"
 	nginxConfig *dagger.File,
-	// +defaultPath="doctum-config.php"
-	doctumConfig *dagger.File,
 ) Docs {
 	return Docs{
-		Source:       source,
-		NginxConfig:  nginxConfig,
-		DoctumConfig: doctumConfig,
+		Source:      source,
+		NginxConfig: nginxConfig,
 	}
 }
 
 type Docs struct {
-	Source       *dagger.Directory
-	NginxConfig  *dagger.File // +private
-	DoctumConfig *dagger.File // +private
+	Source      *dagger.Directory
+	NginxConfig *dagger.File // +private
 }
 
 const (

--- a/docs/dagger.json
+++ b/docs/dagger.json
@@ -23,10 +23,6 @@
       "source": "../modules/go"
     },
     {
-      "name": "php-sdk-dev",
-      "source": "../sdk/php/dev"
-    },
-    {
       "name": "version",
       "source": "../version"
     }


### PR DESCRIPTION
Removes a module dep and constructor args no longer needed. 

Follow up to #10916.