### PR TITLE
infra: setup alternative workflows to test cloud engines

### DIFF
--- a/.github/workflows/alternative-ci-engines-1.yml
+++ b/.github/workflows/alternative-ci-engines-1.yml
@@ -1,0 +1,128 @@
+# NOTE: this is a temporary workflow created to test side-by-side the performance
+# of running our CI using our cloud engines. This is not a production workflow.
+# It will not be run on PRs and won't block releases in any way.
+# There's a few steps being done here that will not be taken over to the main CI
+# when/if we migrate to cloud engines.
+name: Alternative CI Engines 1
+
+on:
+  # Run the workflow every day TWICE:
+  # 1. 9:06AM UTC (low activity)
+  # 2. 9:26AM UTC (cache test - high chance of no code changes)
+  schedule:
+    - cron: "6,26 9 * * *"
+  # Enable manual trigger for on-demand runs - helps when debugging
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-devcli:
+    runs-on:
+      - 'nscloud-ubuntu-24.04-amd64-16x32'
+    steps:
+      - name: Install dagger
+        shell: bash
+        run: |
+          echo "::group::Installing dagger"
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin/ sudo -E sh
+          echo "::endgroup::"
+
+      - name: exec
+        id: exec
+        run: |
+          dagger call cli dev-binaries --platform=current export --path ./bin
+        env:
+          DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
+      - name: Upload dagger binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: dagger-${{ github.sha }}
+          path: ./bin/dagger
+
+  test-everything-else:
+    needs: build-devcli
+    runs-on:
+      - 'ubuntu-24.04'
+    steps:
+      - uses: actions/download-artifact@v5
+        id: download-dagger
+        with:
+          name: dagger-${{ github.sha }}
+          path: /usr/local/bin/
+      - name: exec
+        id: exec
+        run: |
+          chmod +x /usr/local/bin/dagger
+
+          dagger call --cloud \
+            test specific \
+            --race=true \
+            --parallel=16 \
+            --skip='TestProvision|TestTelemetry|TestModule|TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava|TestContainer|TestDockerfile|TestLLM|TestCLI|TestEngine|TestClientGenerator|TestInterface|TestCall|TestShell|TestDaggerCMD'
+        env:
+          DAGGER_CLOUD_TOKEN: oidc
+          DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
+          NO_OUTPUT: "true"
+
+  test-module-runtimes:
+    needs: build-devcli
+    runs-on:
+      - 'ubuntu-24.04'
+    steps:
+      - uses: actions/download-artifact@v5
+        id: download-dagger
+        with:
+          name: dagger-${{ github.sha }}
+          path: /usr/local/bin/
+      - name: exec
+        id: exec
+        run: |
+          chmod +x /usr/local/bin/dagger
+          dagger call --cloud test specific --race=true --parallel=16 --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava'
+        env:
+          DAGGER_CLOUD_TOKEN: oidc
+          DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
+          NO_OUTPUT: "true"
+
+  go:
+    needs: build-devcli
+    runs-on:
+      - 'ubuntu-24.04'
+    steps:
+      - uses: actions/download-artifact@v5
+        id: download-dagger
+        with:
+          name: dagger-${{ github.sha }}
+          path: /usr/local/bin/
+      - name: exec
+        id: exec
+        run: |
+          chmod +x /usr/local/bin/dagger
+          dagger call --cloud --docker-cfg=file:$HOME/.docker/config.json check --targets=sdk/go
+        env:
+          DAGGER_CLOUD_TOKEN: oidc
+          DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
+          NO_OUTPUT: "true"
+
+  php:
+    needs: build-devcli
+    runs-on:
+      - 'ubuntu-24.04'
+    steps:
+      - uses: actions/download-artifact@v5
+        id: download-dagger
+        with:
+          name: dagger-${{ github.sha }}
+          path: /usr/local/bin/
+      - name: exec
+        id: exec
+        run: |
+          chmod +x /usr/local/bin/dagger
+          dagger call --cloud --docker-cfg=file:$HOME/.docker/config.json check --targets=sdk/php
+        env:
+          DAGGER_CLOUD_TOKEN: oidc
+          DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
+          NO_OUTPUT: "true"


### PR DESCRIPTION
We want to test the performance and reliability of the new cloud engines. In the past we've always introduced changes to our CI using "alternative-*" workflows. This is so that we can easily compare the performance of the new CI changes against our current baseline. We are initially using 4 jobs: `testdev-everything-else`, `testdev-module-runtimes`, `go` and `php`. This were picked because, in the case of Engine & CLI, they are the slowest and least reliable jobs as can be seen [here](https://ui.honeycomb.io/dagger/environments/experimental/board/tXGtVxx7uVP/Is-Dagger-Dagger-production-ready):

<img width="3309" height="925" alt="image" src="https://github.com/user-attachments/assets/1535eb6e-6e64-4d83-9a69-be11fa059f83" />

We don't expect any performance improvements on the individual jobs themselves since its the same underlying infrastructure. The only difference is caching, we did not have any before and we do now. However, these jobs are not particularly good at caching so its hard to tell whether we will see any performance improvements.

For now we will keep these jobs running twice per day as we monitor and move forward on other relevant changes to our CI.

This PR needs a [dagger.io](https://github.com/dagger/dagger.io/pull/4603) change to go out before a workflow can run.