### PR TITLE
chore: remove explicit loop captures

### DIFF
--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -205,7 +205,6 @@ func TestParseGit(t *testing.T) {
 			wantRemote: "git@github.com:sipsma/daggerverse.git",
 		},
 	} {
-		tc := tc
 		t.Run(tc.urlStr, func(t *testing.T) {
 			t.Parallel()
 			parsedGit, err := gitutil.ParseURL(tc.urlStr)

--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -593,7 +593,6 @@ func customCACertTests(
 	require.NoError(t, err)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(ctx context.Context, t *testctx.T) {
 			test.run(ctx, t, c2, caCertsTestFixtures{
 				caCertContents: caCertContents,

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -92,8 +92,6 @@ main()`))
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -210,8 +208,6 @@ main()
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -337,8 +333,6 @@ main()
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -476,8 +470,6 @@ main()
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -584,8 +576,6 @@ main()
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -720,8 +710,6 @@ main()
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -854,8 +842,6 @@ main()`))
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s %q", tc.name, tc.outputDir), func(ctx context.Context, t *testctx.T) {
 			for _, ts := range []testSetup{
 				goTestSetup(tc.outputDir),
@@ -955,8 +941,6 @@ main()`))
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -1050,8 +1034,6 @@ main()`))
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -1143,8 +1125,6 @@ export class Generator {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.generatorSDK, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1365,8 +1345,6 @@ main()`))
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3717,7 +3717,6 @@ func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 			"application/vnd.oci.image.layer.v1.tar+gzip",
 		},
 	} {
-		tc := tc
 		t.Run(string(tc.compression), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -3789,7 +3788,6 @@ func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 			"application/vnd.docker.image.rootfs.diff.tar.gzip",
 		},
 	} {
-		tc := tc
 		t.Run(string(tc.mediaTypes), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -3817,7 +3815,6 @@ func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 			}
 
 			for _, useAsTarball := range []bool{true, false} {
-				useAsTarball := useAsTarball
 				t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(ctx context.Context, t *testctx.T) {
 					tarPath := filepath.Join(t.TempDir(), "export.tar")
 					if useAsTarball {
@@ -3904,9 +3901,7 @@ func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx
 	for _, dockerVersion := range []string{"20.10", "23.0", "24.0"} {
 		dockerc := dockerSetup(ctx, t, c, containerSetupOpts{name: t.Name(), version: dockerVersion})
 		for _, mediaType := range []dagger.ImageMediaTypes{dagger.ImageMediaTypesOcimediaTypes, dagger.ImageMediaTypesDockerMediaTypes} {
-			mediaType := mediaType
 			for _, compression := range []dagger.ImageLayerCompression{dagger.ImageLayerCompressionGzip, dagger.ImageLayerCompressionZstd, dagger.ImageLayerCompressionUncompressed} {
-				compression := compression
 				t.Run(fmt.Sprintf("%s-%s-%s-%s", t.Name(), dockerVersion, mediaType, compression), func(ctx context.Context, t *testctx.T) {
 					tmpdir := t.TempDir()
 					tmpfile := filepath.Join(tmpdir, fmt.Sprintf("test-%s-%s-%s.tar", dockerVersion, mediaType, compression))

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1057,8 +1057,6 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			t.Run("include only markdown", func(ctx context.Context, t *testctx.T) {
 				entries, err := tc.src.Glob(ctx, "*.md")

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -486,7 +486,6 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 
 	for _, tc := range tcs {
 		// get a cached engine if possible (saves spinning up more engines than we need to)
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			devEngineSvcKey := tc.engineVersion + " " + tc.clientMinVersion
 			enginesMu.Lock()
@@ -599,7 +598,6 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 
 	for _, tc := range tcs {
 		// get a cached engine if possible (saves spinning up more engines than we need to)
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			devEngineSvcKey := tc.engineVersion + " " + tc.moduleMinVersion
 			enginesMu.Lock()

--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -1304,8 +1304,6 @@ export class Test {
 		},
 	}
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 

--- a/core/integration/module_benchmark_test.go
+++ b/core/integration/module_benchmark_test.go
@@ -49,7 +49,6 @@ func (ModuleSuite) BenchmarkLotsOfFunctions(ctx context.Context, b *testctx.B) {
 
 			var eg errgroup.Group
 			for i := range funcCount {
-				i := i
 				// just verify a subset work
 				if i%10 != 0 {
 					continue
@@ -91,7 +90,6 @@ class PotatoSack:
 
 		var eg errgroup.Group
 		for i := range funcCount {
-			i := i
 			// just verify a subset work
 			if i%10 != 0 {
 				continue
@@ -137,7 +135,6 @@ export class PotatoSack {
 
 		var eg errgroup.Group
 		for i := range funcCount {
-			i := i
 			// just verify a subset work
 			if i%10 != 0 {
 				continue
@@ -322,7 +319,6 @@ func (m *Test) Fn(ctx context.Context) ([]string, error) {
 	var eg errgroup.Group
 	results := make([]string, 10)
 	for i := 0; i < 10; i++ {
-		i := i
 		eg.Go(func() error {
 			res, err := dag.Dep().DepFn(ctx, dag.SetSecret("foo", "bar"))
 			if err != nil {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -342,7 +342,6 @@ func (m *Test) Fn(
 					subpath: ".changes",
 				},
 			} {
-				tc := tc
 				t.Run(fmt.Sprintf("%s:%s", tc.baseURL, tc.subpath), func(ctx context.Context, t *testctx.T) {
 					url := tc.baseURL + "#v0.9.1"
 					if tc.subpath != "" {
@@ -2528,8 +2527,6 @@ func (m *Test) ToStatus(status string) Status {
 				enumValue: "foo bar",
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.enumValue, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -2680,8 +2677,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 			modGen := modInit(t, c, tc.sdk, tc.source)

--- a/core/integration/module_cli_test.go
+++ b/core/integration/module_cli_test.go
@@ -68,7 +68,6 @@ func (CLISuite) TestDaggerInit(ctx context.Context, t *testctx.T) {
 				sourceDirEnt: "src/",
 			},
 		} {
-			tc := tc
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				srcRootDir := ctr.
 					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk)).
@@ -332,7 +331,6 @@ func (CLISuite) TestDaggerInitGit(ctx context.Context, t *testctx.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("module %s git", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -418,7 +416,6 @@ func (CLISuite) TestDaggerDevelop(ctx context.Context, t *testctx.T) {
 
 		// test develop from source root and from subdir (in which case find-up should kick in)
 		for _, wd := range []string{"/work", "/work/from/some/otherdir"} {
-			wd := wd
 			t.Run(wd, func(ctx context.Context, t *testctx.T) {
 				sourceDir, err := filepath.Rel(wd, "/work/cool/subdir")
 				require.NoError(t, err)

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -511,7 +511,6 @@ func (ConfigSuite) TestDaggerConfig(ctx context.Context, t *testctx.T) {
 			modFlagVal: "..",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := ctr.
 				WithWorkdir(tc.workdir).
@@ -903,7 +902,6 @@ func (m *Coolsdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dag
 `,
 		},
 	} {
-		tc := tc
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1257,7 +1255,6 @@ var vcsTestCases = []vcsTestCase{
 
 func testOnMultipleVCS(t *testctx.T, testFunc func(ctx context.Context, t *testctx.T, tc vcsTestCase)) {
 	for _, tc := range vcsTestCases {
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			testFunc(ctx, t, tc)
 		})
@@ -1389,7 +1386,6 @@ func (ConfigSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 func (ConfigSuite) TestDaggerGitWithSources(ctx context.Context, t *testctx.T) {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		for _, modSubpath := range []string{"samedir", "subdir"} {
-			modSubpath := modSubpath
 			t.Run(modSubpath, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				privateSetup, cleanup := privateRepoSetup(c, t, tc)

--- a/core/integration/module_iface_test.go
+++ b/core/integration/module_iface_test.go
@@ -29,8 +29,6 @@ func (InterfaceSuite) TestIfaceBasic(ctx context.Context, t *testctx.T) {
 		{sdk: "typescript", path: "./testdata/modules/typescript/ifaces"},
 		{sdk: "python", path: "./testdata/modules/python/ifaces"},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -202,11 +200,7 @@ class Test:
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		for _, rtc := range tests {
-			rtc := rtc
-
 			// No need for every permutation, just within the same SDK and
 			// with Go as a reference implementation.
 			if tc.sdk != "go" && rtc.sdk != "go" && tc.sdk != rtc.sdk {

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -552,8 +552,6 @@ build-backend = "poetry.core.masonry.api"
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s/%s", tc.name, tc.path), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1153,7 +1151,6 @@ func (PythonSuite) TestSignatures(ctx context.Context, t *testctx.T) {
 			expected: `{"test":{"echoOpts":"hello!hello!hello!"}}`,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerQuery(tc.query)).Stdout(ctx)
 			require.NoError(t, err)
@@ -1214,7 +1211,6 @@ func (PythonSuite) TestSignaturesBuiltinTypes(ctx context.Context, t *testctx.T)
 			expected: `{"test":{"readOptional":""}}`,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerQuery(tc.query)).Stdout(ctx)
 			require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -262,8 +262,6 @@ export class Test {
 			},
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s with %d files (#%d)", tc.sdk, len(tc.sources), i+1), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -272,7 +270,6 @@ export class Test {
 				WithWorkdir("/work")
 
 			for _, src := range tc.sources {
-				src := src
 				modGen = modGen.WithNewFile(src.file, heredoc.Doc(src.contents))
 			}
 
@@ -369,8 +366,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 			modGen := modInit(t, c, tc.sdk, tc.source)
@@ -472,8 +467,6 @@ export class Test {
 			expected: "\"test\", , \"foo\", null, \"bar\"",
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -620,8 +613,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -689,8 +680,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -930,8 +919,6 @@ func (ModuleSuite) TestUseLocal(ctx context.Context, t *testctx.T) {
 			source: useTSOuter,
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s uses go", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -985,8 +972,6 @@ func (ModuleSuite) TestCodegenOnDepChange(ctx context.Context, t *testctx.T) {
 			changed:  strings.ReplaceAll(useTSOuter, `.hello()`, `.hellov2()`),
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s uses go", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1046,8 +1031,6 @@ func (ModuleSuite) TestSyncDeps(ctx context.Context, t *testctx.T) {
 			source: useTSOuter,
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s uses go", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1139,8 +1122,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("%s uses go", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1321,8 +1302,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				ctr := modInit(t, c, tc.sdk, tc.source)
@@ -1432,8 +1411,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -1498,8 +1475,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				var logs safeBuffer
 				c := connect(ctx, t, dagger.WithLogOutput(&logs))
@@ -1686,8 +1661,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -1798,8 +1771,6 @@ func (ModuleSuite) TestReservedWords(ctx context.Context, t *testctx.T) {
 					source: goodIDArgTSSrc,
 				},
 			} {
-				tc := tc
-
 				t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 					c := connect(ctx, t)
 
@@ -1823,8 +1794,6 @@ func (ModuleSuite) TestReservedWords(ctx context.Context, t *testctx.T) {
 					source: badIDFieldTSSrc,
 				},
 			} {
-				tc := tc
-
 				t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 					c := connect(ctx, t)
 
@@ -1856,8 +1825,6 @@ func (ModuleSuite) TestReservedWords(ctx context.Context, t *testctx.T) {
 					source: badIDFnTSSrc,
 				},
 			} {
-				tc := tc
-
 				t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 					c := connect(ctx, t)
 
@@ -3921,8 +3888,6 @@ class Test:
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -4229,8 +4194,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -4494,8 +4457,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -4664,8 +4625,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 
@@ -5620,8 +5579,6 @@ class Test:
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 

--- a/core/integration/module_type_test.go
+++ b/core/integration/module_type_test.go
@@ -106,8 +106,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(fmt.Sprintf("custom %s types", tc.sdk), func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -183,8 +181,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -278,8 +274,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -373,8 +367,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -479,8 +471,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -615,8 +605,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -698,8 +686,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -829,8 +815,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 
@@ -985,8 +969,6 @@ export class Test {
 `,
 		},
 	} {
-		tc := tc
-
 		t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 			c := connect(ctx, t)
 			modGen := modInit(t, c, tc.sdk, tc.source)
@@ -1103,8 +1085,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				modGen := modInit(t, c, tc.sdk, tc.source)
@@ -1190,8 +1170,6 @@ class Test:
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				modGen := modInit(t, c, tc.sdk, tc.source)
@@ -1371,8 +1349,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 				modGen := modInit(t, c, tc.sdk, tc.source)
@@ -1587,8 +1563,6 @@ export class Test {
 `,
 			},
 		} {
-			tc := tc
-
 			t.Run(tc.sdk, func(ctx context.Context, t *testctx.T) {
 				c := connect(ctx, t)
 

--- a/core/integration/ownership_test.go
+++ b/core/integration/ownership_test.go
@@ -55,7 +55,6 @@ func testOwnership(
 		//    the above, making it opt-in seems obvious.
 		{name: "no-inherit", owner: "", output: "root root"},
 	} {
-		example := example
 		t.Run(example.name, func(ctx context.Context, t *testctx.T) {
 			withOwner := addContent(ctr, example.name, example.owner)
 			output, err := withOwner.

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -82,7 +82,6 @@ func (PlatformSuite) TestCrossCompile(ctx context.Context, t *testctx.T) {
 	for platform := range platformToUname {
 		i++
 		i := i - 1
-		platform := platform
 		eg.Go(func() error {
 			ctr := c.Container().
 				From("crazymax/goxx:latest").

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -250,7 +250,6 @@ redirect ^(https?://)(.*).example(/.*)$		$1$2$3
 
 		require.NoError(t, err)
 		for _, test := range tests {
-			test := test
 			if test.proxyLogTest != nil {
 				t.Run(test.name+"-proxy-logs", func(ctx context.Context, t *testctx.T) {
 					test.proxyLogTest(t, c, func(ctx context.Context) (string, error) {
@@ -270,7 +269,6 @@ redirect ^(https?://)(.*).example(/.*)$		$1$2$3
 	// we're in the container depending on the custom engine, run the actual tests
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(ctx context.Context, t *testctx.T) {
 			test.run(t, c, proxyTestFixtures{
 				caCert: c.Host().File("/ca.pem"),

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	eg := new(errgroup.Group)
 	for _, u := range svcURLs {
-		u := u
 		eg.Go(func() error {
 			out, err := fetch(ctx, c, mode, u)
 			if err != nil {

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -122,7 +122,6 @@ func TestLlmConfigDisableStreaming(t *testing.T) {
 			false,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			q := LLMTestQuery{}
 

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -360,7 +360,6 @@ func TestParseRefString(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.urlStr, func(t *testing.T) {
 			t.Parallel()
 			parsed, err := ParseRefString(

--- a/core/typedef_test.go
+++ b/core/typedef_test.go
@@ -62,7 +62,6 @@ var Samples = map[TypeDefKind]*TypeDef{
 
 func TestTypeDefConversions(t *testing.T) {
 	for _, val := range TypeDefKinds.PossibleValues("") {
-		val := val
 		sample, ok := Samples[TypeDefKind(val.Name)]
 		if !ok {
 			if val.Name == TypeDefKindInput.String() {

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -446,7 +446,6 @@ func (activity *Activity) Intervals(now time.Time) iter.Seq[Interval] {
 	return func(yield func(Interval) bool) {
 		var lastIval *Interval
 		for _, ival := range activity.CompletedIntervals {
-			ival := ival
 			lastIval = &ival
 			if !activity.EarliestRunning.IsZero() &&
 				activity.EarliestRunning.Before(ival.Start) {

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -312,7 +312,6 @@ func (r *renderer) renderCall(
 				fmt.Fprint(out, out.String(" "))
 				if argDig := val.GetCallDigest(); argDig != "" {
 					forceSimplify := false
-					internal := internal
 					argSpan := r.db.MostInterestingSpan(argDig)
 					if argSpan != nil {
 						forceSimplify = argSpan.Internal && !internal // only for the first internal call (not it's children)

--- a/engine/buildkit/exporter/oci/export.go
+++ b/engine/buildkit/exporter/oci/export.go
@@ -245,7 +245,6 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	eg, egCtx := errgroup.WithContext(ctx)
 	mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
 	for _, ref := range refs {
-		ref := ref
 		eg.Go(func() error {
 			remotes, err := ref.GetRemotes(egCtx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
 			if err != nil {

--- a/engine/cache/cache_test.go
+++ b/engine/cache/cache_test.go
@@ -23,7 +23,6 @@ func TestCacheConcurrent(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	for i := range 100 {
-		i := i
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -86,7 +86,6 @@ func TestLoadGitLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			labels := telemetry.Labels{}.WithGitLabels(example.Repo)
 			require.Subset(t, labels, example.Labels)
@@ -136,7 +135,6 @@ func TestLoadGitRefEnvLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			for _, e := range example.Env {
 				k, v, _ := strings.Cut(e, "=")
@@ -230,7 +228,6 @@ func TestLoadGitHubLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			for _, e := range example.Env {
 				k, v, _ := strings.Cut(e, "=")
@@ -327,7 +324,6 @@ func TestLoadGitLabLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			// Set environment variables
 			for k, v := range example.Env {
@@ -381,7 +377,6 @@ func TestLoadCircleCILabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			// Set environment variables
 			for k, v := range example.Env {
@@ -423,7 +418,6 @@ func TestLoadJenkinsLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			// Set environment variables
 			for k, v := range example.Env {
@@ -465,7 +459,6 @@ func TestLoadHarnessLabels(t *testing.T) {
 			},
 		},
 	} {
-		example := example
 		t.Run(example.Name, func(t *testing.T) {
 			// Set environment variables
 			for k, v := range example.Env {

--- a/sdk/python/runtime/discovery.go
+++ b/sdk/python/runtime/discovery.go
@@ -303,7 +303,6 @@ func (d *Discovery) loadFiles(ctx context.Context, m *PythonSdk) error {
 
 	if d.EnableCustomConfig {
 		for _, name := range FileContents {
-			name := name
 			if d.HasFile(name) {
 				eg.Go(func() error {
 					contents, err := m.GetFile(name).Contents(gctx)


### PR DESCRIPTION
The need for this was removed by go 1.22: https://go.dev/doc/go1.22#language