### PR TITLE
feat: Add pie and docker-php-ext-install config hooks on dagger.json for PHP sdk

### DIFF
--- a/sdk/php/runtime/scripts/init-template.sh
+++ b/sdk/php/runtime/scripts/init-template.sh
@@ -9,7 +9,20 @@ if ! [ -f composer.json ]; then
     sed -i "s/Example/$CLASS/g" ./src/Example.php
     mv ./src/Example.php ./src/$CLASS.php
 
+    PHP_VERSION=${PHP_VERSION:?}
     PACKAGE_NAME=$(echo $1 | tr '[:upper:]' '[:lower:]' | tr -s '[:blank:]' '\-')
 
-    sed -i "s/daggermodule\/example/daggermodule\/$PACKAGE_NAME/g" ./composer.json
+    PHP_MAJOR_MINOR=$(printf '%s\n' "$PHP_VERSION" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1.\2/');
+    PHP_CONSTRAINT="^${PHP_MAJOR_MINOR}";
+
+    tmpfile=$(mktemp);
+    jq \
+      --arg pkg "daggermodule/${PACKAGE_NAME}" \
+      --arg phpversion "${PHP_VERSION}" \
+      --arg phpconstraint "${PHP_CONSTRAINT}" \
+      '.name = $pkg
+       | .config.platform.php = $phpversion
+       | .require.php = $phpconstraint' ./composer.json \
+    > "${tmpfile}" \
+    && mv "${tmpfile}" ./composer.json;
 fi

--- a/sdk/php/src/Connection/CliDownloader.php
+++ b/sdk/php/src/Connection/CliDownloader.php
@@ -28,7 +28,7 @@ class CliDownloader implements LoggerAwareInterface
         $this->logger = $logger;
     }
 
-    public function download(string $version = null): string
+    public function download(string|null $version = null): string
     {
         if (null === $version) {
             $version = Provisioning::getCliVersion();


### PR DESCRIPTION
Hi.

In this PR I add :
* `sdk.config.phpExtInstall` to install additional extension for the module (such as pcntl for example)
* `sdk.config.usePie` to enable or not `php/pie`
* `sdk.config.phpVersion` to use a different php version per module
* Use the official composer image (official not in the docker registry meaning) which is smaller and built for COPYing the binary.
* fixed an issue with `func(string $var = null)` where nullability of `$var` was implicit and this is deprecated (was causing issues when trying with php 8.5)
* update php template to update php versions in composer.json

I have a few TODOs left because I need your help on some subjects.

I know this may be a too much for a single PR so let me know if and how we can split things up but it seemed easier to put it all in for discussion.