### PR TITLE
fix: git ignore backward compatibility

### DIFF
--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -1322,3 +1322,43 @@ export class Test {
 		})
 	}
 }
+
+// Verify that we do not apply .gitignore rules automatically for defaultPath
+// if engine is older than v0.18.17
+func (LegacySuite) TestLegacyNoGitAutoIgnore(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	sourceCode := `package main
+
+import (
+  "dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+func (m *Test) Repo(
+  //+defaultPath="/"
+  dir *dagger.Directory,
+) *dagger.Directory {
+  return dir
+}`
+
+	modGen := daggerCliBase(t, c).
+		With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+		WithWorkdir("/work").
+		WithNewFile("dagger.json", `{"name": "test", "sdk": "go", "source": ".", "engineVersion": "v0.18.16"}`).
+		WithNewFile("main.go", sourceCode).
+		WithNewFile(".gitignore", `/dagger.gen.go
+/internal/dagger
+/internal/querybuilder
+/internal/telemetry
+/.env
+LICENSE
+*.json
+internal/
+.gitattributes`)
+
+	out, err := modGen.With(daggerCall("repo", "entries")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ".gitattributes\n.gitignore\nLICENSE\ndagger.gen.go\ndagger.json\ngo.mod\ngo.sum\ninternal/\nmain.go\n", out)
+}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -353,10 +353,7 @@ func (src *ModuleSource) LoadContextDir(
 		}
 
 		// Ensure backward compatibility by not applying .gitignore rules if the engine version is less than v0.17.17
-		noGitIgnore := false
-		if semver.Compare(src.EngineVersion, "v0.18.17") < 0 {
-			noGitIgnore = true
-		}
+		noGitIgnore := src.compareEngineVersion("v0.18.17") < 0
 
 		err = dag.Select(localSourceCtx, dag.Root(), &inst,
 			dagql.Selector{
@@ -517,6 +514,10 @@ func (src *ModuleSource) LoadContextGit(
 	}
 
 	return inst, nil
+}
+
+func (src *ModuleSource) compareEngineVersion(version string) int {
+	return semver.Compare(src.EngineVersion, version)
 }
 
 type LocalModuleSource struct {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	fsutiltypes "github.com/tonistiigi/fsutil/types"
 	"github.com/vektah/gqlparser/v2/ast"
+	"golang.org/x/mod/semver"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -351,6 +352,12 @@ func (src *ModuleSource) LoadContextDir(
 			return inst, fmt.Errorf("path %q is outside of context directory %q, path should be relative to the context directory", path, ctxPath)
 		}
 
+		// Ensure backward compatibility by not applying .gitignore rules if the engine version is less than v0.17.17
+		noGitIgnore := false
+		if semver.Compare(src.EngineVersion, "v0.18.17") < 0 {
+			noGitIgnore = true
+		}
+
 		err = dag.Select(localSourceCtx, dag.Root(), &inst,
 			dagql.Selector{
 				Field: "host",
@@ -360,6 +367,7 @@ func (src *ModuleSource) LoadContextDir(
 				Args: append([]dagql.NamedInput{
 					{Name: "path", Value: dagql.String(path)},
 					{Name: "noCache", Value: dagql.Boolean(true)},
+					{Name: "noGitAutoIgnore", Value: dagql.Boolean(noGitIgnore)},
 					{Name: "gitIgnoreRoot", Value: dagql.String(ctxPath)},
 				}, filterInputs...),
 			},

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -308,7 +308,7 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 		}
 	}
 
-	fmt.Println("loading host directory", "hostPath", hostPath, "relPath", relPath)
+	fmt.Println("loading host directory", "hostPath", hostPath, "relPath", relPath, "noGitAutoIgnore", args.NoGitAutoIgnore)
 
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/path-args
@@ -19,7 +19,7 @@ Expected stderr:
   ┆ file: Host.file(path: "/app/dagql/idtui/golden_test.go"): File!
   ┆ dir: Host.directory(path: "/app/dagql/idtui"): Directory!
   ┆ contextFile: Directory.file(path: "main.go"): File!
-  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", noCache: true, gitIgnoreRoot: "/app/dagql/idtui"): Directory!
+  ┆ contextDir: Host.directory(path: "/app/dagql/idtui/viztest", noCache: true, noGitAutoIgnore: true, gitIgnoreRoot: "/app/dagql/idtui"): Directory!
   ): Void X.Xs
 
 Setup tracing at https://dagger.cloud/traces/setup. To hide set DAGGER_NO_NAG=1


### PR DESCRIPTION
As discussed with @jedevc, this PR ensure that module with version < `v0.18.18` are not automatically loading .gitignore
so that we don't break compatibility.

I'm waiting for a clear response on https://discord.com/channels/707636530424053791/1413511775546118215/1414520241912021062 before applying any fixes on disabling gitignore for specific arguments