### PR TITLE
allow setting additional container ports to the Dagger Engine container

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -95,14 +95,25 @@ spec:
                 name: {{ include "dagger.fullname" . }}-magicache-token
                 {{- end }}
           {{- end }}
-          {{- if .Values.engine.port }}
+          {{- if or .Values.engine.containerPorts .Values.engine.port }}
           ports:
+            {{- if .Values.engine.containerPorts }}
+            {{- range .Values.engine.containerPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol | default "TCP" }}
+              {{- if .hostPort }}
+              hostPort: {{ .hostPort }}
+              {{- end }}
+            {{- end }}
+            {{- else if .Values.engine.port }}
             - name: dagger
               containerPort: {{ .Values.engine.port }}
               protocol: TCP
               {{- if .Values.engine.hostPort }}
               hostPort: {{ .Values.engine.hostPort }}
               {{- end }}
+            {{- end }}
           {{- end }}
           securityContext:
             privileged: true

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -99,14 +99,25 @@ spec:
               name: {{ include "dagger.fullname" . }}-magicache-token
               {{- end }}
           {{- end }}
-          {{- if .Values.engine.port }}
+          {{- if or .Values.engine.containerPorts .Values.engine.port }}
           ports:
+            {{- if .Values.engine.containerPorts }}
+            {{- range .Values.engine.containerPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol | default "TCP" }}
+              {{- if .hostPort }}
+              hostPort: {{ .hostPort }}
+              {{- end }}
+            {{- end }}
+            {{- else if .Values.engine.port }}
             - name: dagger
               containerPort: {{ .Values.engine.port }}
               protocol: TCP
               {{- if .Values.engine.hostPort }}
               hostPort: {{ .Values.engine.hostPort }}
               {{- end }}
+            {{- end }}
           {{- end }}
           securityContext:
             privileged: true

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -65,7 +65,18 @@ engine:
   ### Configure the port settings for the Dagger Engine
   #
   # port: 1234 # The container port that the Dagger Engine will listen on.
-  # hostPort: 1234    # Optional: Expose the engine port directly on the host node
+
+  ### Configure multiple ports for the Dagger Engine
+  # This allows defining all ports in a structured way
+  # Example configuration:
+  # containerPorts:
+  #   - name: dagger
+  #     containerPort: 1234 # Needs to be the same as engine.port if both are set
+  #     protocol: TCP
+  #     hostPort: 1234  # Optional: Expose the engine port directly on the host node
+  #   - name: metrics
+  #     containerPort: 8080
+  #     protocol: TCP
 
   ### Customize Dagger Engine start args
   args: []


### PR DESCRIPTION
this enables users that need to access the metrics server for example to
be able to expose ports to scrape them

coming from: https://discord.com/channels/707636530424053791/708371226174685314/1415154356332007474

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
