### PR TITLE
cli: add TUI indicator when using cloud engines

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -443,6 +443,7 @@ func main() {
 	opts.DotOutputFilePath = dotOutputFilePath
 	opts.DotFocusField = dotFocusField
 	opts.DotShowInternal = dotShowInternal
+	opts.CloudEngine = useCloudEngine || strings.HasPrefix(RunnerHost, "dagger-cloud://")
 	if progress == "auto" {
 		if env := os.Getenv("DAGGER_PROGRESS"); env != "" {
 			progress = env

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -58,6 +58,9 @@ type FrontendOpts struct {
 
 	// TelemetryError indicates if an error has occurred while sending telemetry
 	TelemetryError error
+
+	// CloudEngine indicates whether the connected engine is a Cloud Engine
+	CloudEngine bool
 }
 
 const (

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -714,6 +714,12 @@ func (fe *frontendPretty) Render(out TermOutput) error {
 func (fe *frontendPretty) keymapView() string {
 	outBuf := new(strings.Builder)
 	out := NewOutput(outBuf, termenv.WithProfile(fe.profile))
+	if fe.CloudEngine {
+		fmt.Fprint(out, lipgloss.NewStyle().
+			Foreground(lipgloss.ANSIColor(termenv.ANSIBrightMagenta)).
+			Render("⬢ cloud"))
+		fmt.Fprint(out, KeymapStyle.Render(" "))
+	}
 	fmt.Fprint(out, KeymapStyle.Render(strings.Repeat(HorizBar, 1)))
 	fmt.Fprint(out, KeymapStyle.Render(" "))
 	fe.renderKeymap(out, KeymapStyle)


### PR DESCRIPTION
Adds a subtle indicator in the keymap section of the TUI for when a cloud engine is being used. For the other progress methods we will have a new span that will say "connecting to remote engine" and is a part of #10790 since an indicator that sticks doesn't really make sense in that context. Here is what it looks like:
 
<img width="1362" height="305" alt="2025-09-09-172329_hyprshot" src="https://github.com/user-attachments/assets/ef586621-e8cb-42fb-8fd6-926c34f90749" />
