### PR TITLE
chore: allow spaces in azdevops vcs regex

### DIFF
--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -666,7 +666,7 @@ var vcsPaths = []*vcsPath{
 	// HTTPS ref
 	{
 		prefix: "dev.azure.com/",
-		re:     `^(?P<root>dev\.azure\.com/(?P<account>[A-Za-z0-9_.%\-]+)(/(?P<project>[A-Za-z0-9_.%\-]+))?/_git/(?P<repo>[A-Za-z0-9_.%\-]+)(\.git)?)(/[\p{L}0-9_.\-]+)*(/.*)?$`,
+		re:     `^(?P<root>dev\.azure\.com/(?P<account>[A-Za-z0-9_.% \-]+)(/(?P<project>[A-Za-z0-9_.% \-]+))?/_git/(?P<repo>[A-Za-z0-9_.% \-]+)(\.git)?)(/[\p{L}0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 		check: func(match map[string]string) error {
@@ -677,7 +677,7 @@ var vcsPaths = []*vcsPath{
 	// SSH ref
 	{
 		prefix: "ssh.dev.azure.com/",
-		re:     `^(?P<root>ssh\.dev\.azure\.com/v\d+/(?P<account>[A-Za-z0-9_.%\-]+)/(?P<project>[A-Za-z0-9_.%\-]+)/(?P<repo>[A-Za-z0-9_.%\-]+))(/[\p{L}0-9_.\-]+)*(/.*)?$`,
+		re:     `^(?P<root>ssh\.dev\.azure\.com/v\d+/(?P<account>[A-Za-z0-9_.% \-]+)/(?P<project>[A-Za-z0-9_.% \-]+)/(?P<repo>[A-Za-z0-9_.% \-]+))(/[\p{L}0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://dev.azure.com/{account}/{project}/_git/{repo}",
 		check: func(match map[string]string) error {

--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -283,6 +283,14 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Root: "dev.azure.com/dagger%20e2e/public/_git/dagger%20test%20modules.git",
 			},
 		},
+		{
+			"dev.azure.com/dagger e2e/public/_git/dagger test modules.git/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/dagger e2e/public/_git/dagger test modules",
+				Root: "dev.azure.com/dagger e2e/public/_git/dagger test modules.git",
+			},
+		},
 
 		// SSH ref - new ref style
 		// https://learn.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops
@@ -308,6 +316,14 @@ func TestRepoRootForImportPath(t *testing.T) {
 				VCS:  vcsGit,
 				Repo: "https://dev.azure.com/dagger%20e2e/private/_git/dagger%20test%20modules",
 				Root: "ssh.dev.azure.com/v3/dagger%20e2e/private/dagger%20test%20modules.git",
+			},
+		},
+		{
+			"ssh.dev.azure.com/v3/dagger e2e/private/dagger test modules.git/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/dagger e2e/private/_git/dagger test modules",
+				Root: "ssh.dev.azure.com/v3/dagger e2e/private/dagger test modules.git",
 			},
 		},
 		{


### PR DESCRIPTION
reference: 
https://github.com/dagger/dagger/pull/11026

Should've also included allowing spaces directly, as it seems part of parsing url-decodes `%20` to ` ` when the regex is being used