### PR TITLE
avoids starting service twice when used by different clients

### DIFF
--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -695,6 +695,8 @@ func (m *Caller) Run(ctx context.Context) (string, error) {
 		WithDefaultArgs([]string{"sh", "-c", "echo started >> /cache/svc.txt && while true; do wc -l /cache/svc.txt && sleep 5; done"}).
 		AsService()
 
+	// we're passing the service to a different module that calls "up" on it so it's a different client
+	// which is what triggers the behavior this test is testing.
 	dag.Starter().Start(ctx, svc)
 
 	dag.Container().From("alpine").WithServiceBinding("db", svc).

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -644,6 +644,76 @@ func (m *Caller) Run(ctx context.Context) error {
 	require.NoError(t, err)
 }
 
+func (ServiceSuite) TestServiceTunnelStartsOnceForDifferentClients(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	out, err := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work/starter").
+		With(daggerExec("init", "--source=.", "--name=starter", "--sdk=go")).
+		WithNewFile("main.go", `package main
+
+import (
+	_ "embed"
+	"context"
+
+	"dagger/starter/internal/dagger"
+)
+
+type Starter struct{}
+
+
+func (m *Starter) Start(ctx context.Context, s *dagger.Service) {
+	go func() {s.Up(ctx)}()
+}
+`,
+		).
+		WithWorkdir("/work/caller").
+		With(daggerExec("init", "--source=.", "--name=caller", "--sdk=go")).
+		With(daggerExec("install", "../starter")).
+		WithNewFile("main.go", `package main
+
+import (
+	"context"
+	"time"
+	"dagger/caller/internal/dagger"
+
+)
+
+type Caller struct{}
+
+func (m *Caller) Run(ctx context.Context) (string, error) {
+	svcCache := dag.CacheVolume("svc_cache")
+
+	dag.Container().From("alpine").WithMountedCache("/cache", svcCache).
+		WithEnvVariable("CACHE", time.Now().String()).
+		WithExec([]string{"truncate", "-s", "0", "/cache/svc.txt"}).Sync(ctx)
+
+	svc := dag.Container().From("alpine").
+		WithMountedCache("/cache", svcCache).
+		WithExposedPort(8080, dagger.ContainerWithExposedPortOpts{ExperimentalSkipHealthcheck: true}).
+		WithDefaultArgs([]string{"sh", "-c", "echo started >> /cache/svc.txt && while true; do wc -l /cache/svc.txt && sleep 5; done"}).
+		AsService()
+
+	dag.Starter().Start(ctx, svc)
+
+	dag.Container().From("alpine").WithServiceBinding("db", svc).
+		WithEnvVariable("CACHE", time.Now().String()).
+		WithExec([]string{"echo", "hello"}).
+		Sync(ctx)
+
+	return dag.Container().From("alpine").WithMountedCache("/cache", svcCache).
+		WithEnvVariable("CACHE", time.Now().String()).
+		WithExec([]string{"wc", "-l", "/cache/svc.txt"}).Stdout(ctx)
+}
+`,
+		).
+		With(daggerCall("run")).
+		Stdout(ctx)
+	require.Equal(t, "1 /cache/svc.txt", strings.TrimSpace(out))
+	require.NoError(t, err)
+}
+
 func (ServiceSuite) TestPorts(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/service.go
+++ b/core/service.go
@@ -777,7 +777,7 @@ func (svc *Service) startTunnel(ctx context.Context) (running *RunningService, r
 		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
 	}
 
-	upstream, err := svcs.Start(svcCtx, svc.TunnelUpstream.ID(), svc.TunnelUpstream.Self(), true)
+	upstream, err := svcs.Start(svcCtx, svc.TunnelUpstream.ID(), svc.TunnelUpstream.Self(), svc.TunnelUpstream.Self().TunnelUpstream.Self() != nil)
 	if err != nil {
 		return nil, fmt.Errorf("start upstream: %w", err)
 	}


### PR DESCRIPTION
this commit fixes the issue where running `dagger call svc up` only runs
the service once even if used by different clients.

Fixes #11014

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
