### PR TITLE
fix: preserve call ids during id extraction

### DIFF
--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -79,7 +79,7 @@ func (span *Span) CallID() (*call.ID, error) {
 		RootDigest:    spanCall.Digest,
 		CallsByDigest: map[string]*callpbv1.Call{},
 	}
-	extractIntoDAG(dag, span.db, spanCall)
+	extractIntoDAG(dag, span.db, spanCall.Digest)
 
 	var id call.ID
 	err := id.FromProto(dag)

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1311,11 +1311,11 @@ func (fe *frontendPretty) terminalCallback(span *dagui.Span) func() error {
 			break
 		}
 		return func() error {
-			id := loadIDFromSpan(span)
-			if id == "" {
-				return nil
+			id, err := loadIDFromSpan(span)
+			if err != nil {
+				return err
 			}
-			_, err := fe.dag.LoadContainerFromID(dagger.ContainerID(id)).Terminal().Sync(fe.runCtx)
+			_, err = fe.dag.LoadContainerFromID(dagger.ContainerID(id)).Terminal().Sync(fe.runCtx)
 			return err
 		}
 	case "Directory":
@@ -1323,20 +1323,20 @@ func (fe *frontendPretty) terminalCallback(span *dagui.Span) func() error {
 			break
 		}
 		return func() error {
-			id := loadIDFromSpan(span)
-			if id == "" {
-				return nil
+			id, err := loadIDFromSpan(span)
+			if err != nil {
+				return err
 			}
-			_, err := fe.dag.LoadDirectoryFromID(dagger.DirectoryID(id)).Terminal().Sync(fe.runCtx)
+			_, err = fe.dag.LoadDirectoryFromID(dagger.DirectoryID(id)).Terminal().Sync(fe.runCtx)
 			return err
 		}
 	case "Service":
 		return func() error {
-			id := loadIDFromSpan(span)
-			if id == "" {
-				return nil
+			id, err := loadIDFromSpan(span)
+			if err != nil {
+				return err
 			}
-			_, err := fe.dag.LoadServiceFromID(dagger.ServiceID(id)).Terminal().Sync(fe.runCtx)
+			_, err = fe.dag.LoadServiceFromID(dagger.ServiceID(id)).Terminal().Sync(fe.runCtx)
 			return err
 		}
 	}
@@ -1344,16 +1344,16 @@ func (fe *frontendPretty) terminalCallback(span *dagui.Span) func() error {
 	return nil
 }
 
-func loadIDFromSpan(span *dagui.Span) string {
+func loadIDFromSpan(span *dagui.Span) (string, error) {
 	callID, err := span.CallID()
 	if err != nil {
-		return ""
+		return "", err
 	}
 	id, err := callID.Encode()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return id
+	return id, nil
 }
 
 func (fe *frontendPretty) handleEditlineKey(msg tea.KeyMsg) (cmd tea.Cmd) {


### PR DESCRIPTION
See the following command:

	$ dagger core -E container from --address=alpine with-mounted-directory --path=/src --source=. with-exec --args ls,-lh,src stdout

<img width="1586" height="310" alt="image" src="https://github.com/user-attachments/assets/3639092e-24b9-4848-ac94-edafe1251b63" />

(this is the issue I observed during a live demo last week lol)

We need to make sure to preserve the IDs that we actually observe!