### PR TITLE
feat: add changeset native export

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -1244,7 +1244,7 @@ func (dir *Directory) Export(ctx context.Context, destPath string, merge bool) (
 	ctx, span := Tracer(ctx).Start(ctx, fmt.Sprintf("export directory %s to host %s", dir.Dir, destPath))
 	defer telemetry.End(span, func() error { return rerr })
 
-	return bk.LocalDirExport(ctx, defPB, destPath, merge)
+	return bk.LocalDirExport(ctx, defPB, destPath, merge, nil)
 }
 
 // Root removes any relative path from the directory.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -192,6 +192,12 @@ type Changeset {
   """The older/lower snapshot to compare against."""
   before: Directory!
 
+  """Applies the diff represented by this changeset to a path on the host."""
+  export(
+    """Location of the copied directory (e.g., "logs/")."""
+    path: String!
+  ): String!
+
   """A unique identifier for this Changeset."""
   id: ChangesetID!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4881,6 +4881,23 @@
                         <td data-property-name=""><a class="property-name" id="Changeset-before" href="#Changeset-before"><code>before</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td> The older/lower snapshot to compare against. </td>
                       </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Changeset-export" href="#Changeset-export"><code>export</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Applies the diff represented by this changeset to a path on the host. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Location of the copied directory (e.g., &quot;logs/&quot;).</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Changeset-id" href="#Changeset-id"><code>id</code></a> - <span class="property-type"><a href="#definition-ChangesetID"><code>ChangesetID!</code></a></span> </td>
                         <td> A unique identifier for this Changeset. </td>

--- a/docs/static/reference/php/Dagger/Changeset.html
+++ b/docs/static/reference/php/Dagger/Changeset.html
@@ -183,6 +183,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_export">export</a>(string $path)
+        
+                                            <p><p>Applies the diff represented by this changeset to a path on the host.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -455,8 +465,50 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_id">
+                    <h3 id="method_export">
         <div class="location">at line 55</div>
+        <code>                    string
+    <strong>export</strong>(string $path)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Applies the diff represented by this changeset to a path on the host.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_id">
+        <div class="location">at line 65</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -488,7 +540,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_layer">
-        <div class="location">at line 64</div>
+        <div class="location">at line 74</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>layer</strong>()
         </code>
@@ -520,7 +572,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_modifiedPaths">
-        <div class="location">at line 73</div>
+        <div class="location">at line 83</div>
         <code>                    array
     <strong>modifiedPaths</strong>()
         </code>
@@ -552,7 +604,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_removedPaths">
-        <div class="location">at line 82</div>
+        <div class="location">at line 92</div>
         <code>                    array
     <strong>removedPaths</strong>()
         </code>
@@ -584,7 +636,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 91</div>
+        <div class="location">at line 101</div>
         <code>                    <a href="../Dagger/ChangesetId.html"><abbr title="Dagger\ChangesetId">ChangesetId</abbr></a>
     <strong>sync</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -383,7 +383,9 @@
                     <dd><p>The port description.</p></dd><dt><a href="Dagger/ScalarTypeDef.html#method_description">
 <abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr>::description</a>() &mdash; <em>Method in class <a href="Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a></em></dt>
                     <dd><p>A doc string for the scalar, if any.</p></dd>        </dl><h2 id="letterE">E</h2>
-        <dl id="indexE"><dt><a href="Dagger/Client.html#method_engine">
+        <dl id="indexE"><dt><a href="Dagger/Changeset.html#method_export">
+<abbr title="Dagger\Changeset">Changeset</abbr>::export</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
+                    <dd><p>Applies the diff represented by this changeset to a path on the host.</p></dd><dt><a href="Dagger/Client.html#method_engine">
 <abbr title="Dagger\Client">Client</abbr>::engine</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>The Dagger engine container configuration and state</p></dd><dt><a href="Dagger/Client.html#method_env">
 <abbr title="Dagger\Client">Client</abbr>::env</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1567,6 +1567,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Changeset::export",
+			"p": "Dagger/Changeset.html#method_export",
+			"d": "<p>Applies the diff represented by this changeset to a path on the host.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Changeset::id",
 			"p": "Dagger/Changeset.html#method_id",
 			"d": "<p>A unique identifier for this Changeset.</p>"

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -92,6 +92,7 @@ func (c *Client) LocalDirExport(
 	def *bksolverpb.Definition,
 	destPath string,
 	merge bool,
+	removePaths []string,
 ) (rerr error) {
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("export_path", destPath))
 	bklog.G(ctx).Debug("exporting local dir")
@@ -137,8 +138,9 @@ func (c *Client) LocalDirExport(
 	}
 
 	ctx = engine.LocalExportOpts{
-		Path:  destPath,
-		Merge: merge,
+		Path:        destPath,
+		Merge:       merge,
+		RemovePaths: removePaths,
 	}.AppendToOutgoingContext(ctx)
 
 	_, descRef, err := expResult.Export(ctx, cacheRes, nil, clientMetadata.ClientID)

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -219,7 +219,8 @@ type LocalExportOpts struct {
 	// whether to just merge in contents of a directory to the target on the host
 	// or to replace the target entirely such that it matches the source directory,
 	// which includes deleting any files that are not in the source directory
-	Merge bool
+	Merge       bool
+	RemovePaths []string `json:"remove_paths"`
 }
 
 func (o LocalExportOpts) ToGRPCMD() metadata.MD {

--- a/sdk/elixir/lib/dagger/gen/changeset.ex
+++ b/sdk/elixir/lib/dagger/gen/changeset.ex
@@ -69,6 +69,17 @@ defmodule Dagger.Changeset do
   end
 
   @doc """
+  Applies the diff represented by this changeset to a path on the host.
+  """
+  @spec export(t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def export(%__MODULE__{} = changeset, path) do
+    query_builder =
+      changeset.query_builder |> QB.select("export") |> QB.put_arg("path", path)
+
+    Client.execute(changeset.client, query_builder)
+  end
+
+  @doc """
   A unique identifier for this Changeset.
   """
   @spec id(t()) :: {:ok, Dagger.ChangesetID.t()} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -877,8 +877,9 @@ func (r *CacheVolume) MarshalJSON() ([]byte, error) {
 type Changeset struct {
 	query *querybuilder.Selection
 
-	id   *ChangesetID
-	sync *ChangesetID
+	export *string
+	id     *ChangesetID
+	sync   *ChangesetID
 }
 
 func (r *Changeset) WithGraphQLQuery(q *querybuilder.Selection) *Changeset {
@@ -922,6 +923,20 @@ func (r *Changeset) Before() *Directory {
 	return &Directory{
 		query: q,
 	}
+}
+
+// Applies the diff represented by this changeset to a path on the host.
+func (r *Changeset) Export(ctx context.Context, path string) (string, error) {
+	if r.export != nil {
+		return *r.export, nil
+	}
+	q := r.query.Select("export")
+	q = q.Arg("path", path)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this Changeset.

--- a/sdk/php/generated/Changeset.php
+++ b/sdk/php/generated/Changeset.php
@@ -50,6 +50,16 @@ class Changeset extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Applies the diff represented by this changeset to a path on the host.
+     */
+    public function export(string $path): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
+        $leafQueryBuilder->setArgument('path', $path);
+        return (string)$this->queryLeaf($leafQueryBuilder, 'export');
+    }
+
+    /**
      * A unique identifier for this Changeset.
      */
     public function id(): ChangesetId

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -944,6 +944,34 @@ class Changeset(Type):
         _ctx = self._select("before", _args)
         return Directory(_ctx)
 
+    async def export(self, path: str) -> str:
+        """Applies the diff represented by this changeset to a path on the host.
+
+        Parameters
+        ----------
+        path:
+            Location of the copied directory (e.g., "logs/").
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("export", _args)
+        return await _ctx.execute(str)
+
     async def id(self) -> ChangesetID:
         """A unique identifier for this Changeset.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2260,6 +2260,16 @@ impl Changeset {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Applies the diff represented by this changeset to a path on the host.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied directory (e.g., "logs/").
+    pub async fn export(&self, path: impl Into<String>) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("export");
+        query = query.arg("path", path.into());
+        query.execute(self.graphql_client.clone()).await
+    }
     /// A unique identifier for this Changeset.
     pub async fn id(&self) -> Result<ChangesetId, DaggerError> {
         let query = self.selection.select("id");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2673,15 +2673,22 @@ export class CacheVolume extends BaseClient {
  */
 export class Changeset extends BaseClient {
   private readonly _id?: ChangesetID = undefined
+  private readonly _export?: string = undefined
   private readonly _sync?: ChangesetID = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
    */
-  constructor(ctx?: Context, _id?: ChangesetID, _sync?: ChangesetID) {
+  constructor(
+    ctx?: Context,
+    _id?: ChangesetID,
+    _export?: string,
+    _sync?: ChangesetID,
+  ) {
     super(ctx)
 
     this._id = _id
+    this._export = _export
     this._sync = _sync
   }
 
@@ -2733,6 +2740,22 @@ export class Changeset extends BaseClient {
   before = (): Directory => {
     const ctx = this._ctx.select("before")
     return new Directory(ctx)
+  }
+
+  /**
+   * Applies the diff represented by this changeset to a path on the host.
+   * @param path Location of the copied directory (e.g., "logs/").
+   */
+  export = async (path: string): Promise<string> => {
+    if (this._export) {
+      return this._export
+    }
+
+    const ctx = this._ctx.select("export", { path })
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
   }
 
   /**


### PR DESCRIPTION
Follow up to @vito's #10946.

This adds a new `Changeset.export` field that exports, handling the deleted files - this removes the need for the specialized client handling.