### PR TITLE
fully disable all buildkit edge merging

### DIFF
--- a/internal/buildkit/solver/debug.go
+++ b/internal/buildkit/solver/debug.go
@@ -63,50 +63,6 @@ func debugSchedulerCheckEdge(e *edge) bool {
 	return false
 }
 
-func debugSchedulerSkipMergeDueToDependency(e, origEdge *edge) {
-	bklog.G(context.TODO()).
-		WithField("edge_vertex_name", e.edge.Vertex.Name()).
-		WithField("edge_vertex_digest", e.edge.Vertex.Digest()).
-		WithField("edge_index", e.edge.Index).
-		WithField("origEdge_vertex_name", origEdge.edge.Vertex.Name()).
-		WithField("origEdge_vertex_digest", origEdge.edge.Vertex.Digest()).
-		WithField("origEdge_index", origEdge.edge.Index).
-		Debug("skip merge due to dependency")
-}
-
-func debugSchedulerSwapMergeDueToOwner(e, origEdge *edge) {
-	bklog.G(context.TODO()).
-		WithField("edge_vertex_name", e.edge.Vertex.Name()).
-		WithField("edge_vertex_digest", e.edge.Vertex.Digest()).
-		WithField("edge_index", e.edge.Index).
-		WithField("origEdge_vertex_name", origEdge.edge.Vertex.Name()).
-		WithField("origEdge_vertex_digest", origEdge.edge.Vertex.Digest()).
-		WithField("origEdge_index", origEdge.edge.Index).
-		Debug("swap merge due to owner")
-}
-
-func debugSchedulerMergingEdges(src, dest *edge) {
-	bklog.G(context.TODO()).
-		WithField("source_edge_vertex_name", src.edge.Vertex.Name()).
-		WithField("source_edge_vertex_digest", src.edge.Vertex.Digest()).
-		WithField("source_edge_index", src.edge.Index).
-		WithField("dest_vertex_name", dest.edge.Vertex.Name()).
-		WithField("dest_vertex_digest", dest.edge.Vertex.Digest()).
-		WithField("dest_index", dest.edge.Index).
-		Debug("merging edges")
-}
-
-func debugSchedulerMergingEdgesSkipped(src, dest *edge) {
-	bklog.G(context.TODO()).
-		WithField("source_edge_vertex_name", src.edge.Vertex.Name()).
-		WithField("source_edge_vertex_digest", src.edge.Vertex.Digest()).
-		WithField("source_edge_index", src.edge.Index).
-		WithField("dest_vertex_name", dest.edge.Vertex.Name()).
-		WithField("dest_vertex_digest", dest.edge.Vertex.Digest()).
-		WithField("dest_index", dest.edge.Index).
-		Debug("merging edges skipped")
-}
-
 func debugSchedulerPreUnpark(e *edge, inc []pipeSender, updates, allPipes []pipeReceiver) {
 	if e.debug {
 		debugSchedulerPreUnparkSlow(e, inc, updates, allPipes)

--- a/internal/buildkit/solver/edge.go
+++ b/internal/buildkit/solver/edge.go
@@ -957,22 +957,6 @@ func (e *edge) execOp(ctx context.Context) (interface{}, error) {
 	return NewCachedResult(res, ek), nil
 }
 
-func (e *edge) isDep(e2 *edge) bool {
-	return isDep(e.edge.Vertex, e2.edge.Vertex)
-}
-
-func isDep(vtx, vtx2 Vertex) bool {
-	if vtx.Digest() == vtx2.Digest() {
-		return true
-	}
-	for _, e := range vtx.Inputs() {
-		if isDep(e.Vertex, vtx2) {
-			return true
-		}
-	}
-	return false
-}
-
 func toResultSlice(cres []CachedResult) (out []Result) {
 	out = make([]Result, len(cres))
 	for i := range cres {


### PR DESCRIPTION
I saw in our engine logs that edge merging was still happening in a few places, due to the fact that we aren't providing the SkipEdgeMerge option everywhere.

Rather than whack-a-mole, this change just removes that code from the buildkit solver ([which is now in-tree).](https://github.com/dagger/dagger/pull/11075)