### PR TITLE
chore: bump java sdk dependencies

### DIFF
--- a/sdk/java/dagger-java-annotation-processor/pom.xml
+++ b/sdk/java/dagger-java-annotation-processor/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
-            <version>0.21.0</version>
+            <version>0.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,7 +73,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <argLine>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</argLine>
+                    <argLine>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -293,7 +293,7 @@
         <commons-lang.version>3.18.0</commons-lang.version>
         <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
         <fluent-process.version>1.0.1</fluent-process.version>
-        <fmt-maven-plugin.version>2.27</fmt-maven-plugin.version>
+        <fmt-maven-plugin.version>2.28</fmt-maven-plugin.version>
         <inject-maven-plugin.version>1.8</inject-maven-plugin.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
@@ -311,12 +311,12 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.19.0</versions-maven-plugin.version>
         <mockito-core.version>5.19.0</mockito-core.version>
         <slf4j-api.version>2.0.17</slf4j-api.version>
         <slf4j-simple.version>2.0.17</slf4j-simple.version>
-        <smallrye-graphql.version>2.14.0</smallrye-graphql.version>
-        <vertx-web-client.version>4.5.18</vertx-web-client.version>
+        <smallrye-graphql.version>2.14.1</smallrye-graphql.version>
+        <vertx-web-client.version>4.5.21</vertx-web-client.version>
         <system-stubs-jupiter.version>2.1.8</system-stubs-jupiter.version>
         <xdg-java.version>0.1.1</xdg-java.version>
         <yasson.version>3.0.4</yasson.version>


### PR DESCRIPTION
This replaces https://github.com/dagger/dagger/pull/11042 as bumping com.google.testing.compile:compile-testing requires more configuration in order to work correctly.