### PR TITLE
remove cancellation from context when stopping a service

### DIFF
--- a/core/services.go
+++ b/core/services.go
@@ -346,7 +346,7 @@ func (ss *Services) Detach(ctx context.Context, svc *RunningService) {
 	slog.Trace("detach: stopping")
 
 	// we should avoid blocking, and return immediately
-	go ss.stopGraceful(ctx, running, TerminateGracePeriod)
+	go ss.stopGraceful(context.WithoutCancel(ctx), running, TerminateGracePeriod)
 }
 
 func (ss *Services) stop(ctx context.Context, running *RunningService, force bool) error {


### PR DESCRIPTION
this was causing an issue while trying to stop services here https://github.com/dagger/dagger/blob/e669c2a22a319691f82ae2cfbe4d9925ef26e0c0/core/services.go?plain=1#L373-L380 since the parent context was being cancelled which caused services to never be removed
from the running service list. Since we are stopping the service in a
separate goroutine, we don't need to propagate the cancellation.


note: it's hard to add tests for this since the detach and graceful termination values can't be tuned and the test suite to validate this will be considerably long.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
