### PR TITLE
infra: fix action.yml version formatting

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0\.18\.19"
+    default: "v0.18.19"
     required: false
 
   dev-engine:


### PR DESCRIPTION
This was causing dependent pipelines, like publish, to fail with:
> Error: /home/runner/_work/dagger/dagger/./.github/actions/call/action.yml: (Line: 16, Col: 14, Idx: 290) - (Line: 16, Col: 17, Idx: 293): While parsing a quoted scalar, find unknown escape character.