### PR TITLE
PHP: Upgrade image to php8.4

### DIFF
--- a/sdk/php/.changes/unreleased/Changed-20250923-090719.yaml
+++ b/sdk/php/.changes/unreleased/Changed-20250923-090719.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Update SDK runtime to PHP8.4
+time: 2025-09-23T09:07:19.491689045Z
+custom:
+    Author: charjr
+    PR: "11109"

--- a/sdk/php/runtime/main.go
+++ b/sdk/php/runtime/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	PhpImage      = "php:8.3-cli-alpine"
-	PhpDigest     = "sha256:e4ffe0a17a6814009b5f0713a5444634a9c5b688ee34b8399e7d4f2db312c3b4"
+	PhpImage = "php:8.4-cli-alpine" +
+		"@sha256:ef24d42ed7297dc8c9a6672988594c5f18702a434b3af48a3128fed8d2569746"
 	ComposerImage = "composer/composer:2.8-bin" +
 		"@sha256:c735b6a52ea118693178babc601984dbbbd07f1d31ec87eaa881173622b467ed"
 	ModSourcePath = "/src"
@@ -73,7 +73,7 @@ func (m *PhpSdk) CodegenBase(
 	}
 
 	base := dag.Container().
-		From(fmt.Sprintf("%s@%s", PhpImage, PhpDigest)).
+		From(PhpImage).
 		WithExec([]string{"apk", "add", "git", "openssh", "curl"}).
 		WithFile("/usr/bin/composer", dag.Container().From(ComposerImage).File("/composer")).
 		WithMountedCache("/root/.composer", dag.CacheVolume(fmt.Sprintf("composer-%s", PhpImage))).

--- a/sdk/php/src/Connection/CliDownloader.php
+++ b/sdk/php/src/Connection/CliDownloader.php
@@ -28,7 +28,7 @@ class CliDownloader implements LoggerAwareInterface
         $this->logger = $logger;
     }
 
-    public function download(string $version = null): string
+    public function download(?string $version = null): string
     {
         if (null === $version) {
             $version = Provisioning::getCliVersion();


### PR DESCRIPTION
Upgrading to PHP SDK runtime from 8.3 to 8.4

[No significant breaking changes](https://php.watch/versions/8.4#removed-functionality) unless someone out there is trying to use a PHP Dagger Module as a mail client.