### PR TITLE
EnvFile: better dotenv compatibility, more tests

### DIFF
--- a/core/dotenv/dotenv.go
+++ b/core/dotenv/dotenv.go
@@ -1,0 +1,201 @@
+package dotenv
+
+import (
+	"fmt"
+	"strings"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Evaluate an array of key=value strings in the dotenv syntax,
+// and return a map of evaluated variables
+func All(environ []string) (map[string]string, error) {
+	vars := make(map[string]string, len(environ))
+	for _, line := range environ {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue // skip empty lines
+		}
+		name, value, err := parseEnvLine(line, vars)
+		if err != nil {
+			return vars, err
+		}
+		if name != "" {
+			vars[name] = value
+		}
+	}
+	return vars, nil
+}
+
+// Evaluate an array of key=value strings in the dotenv syntax,
+// in raw mode: values are left unprocessed.
+func AllRaw(environ []string) map[string]string {
+	vars := make(map[string]string, len(environ))
+	for _, kv := range environ {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue // skip empty lines
+		}
+		name, value, _ := strings.Cut(kv, "=")
+		vars[name] = value
+	}
+	return vars
+}
+
+// Evaluate an array of key=value strings in the dotenv syntax,
+// and return the value of the specified variable
+func Lookup(environ []string, name string) (string, bool, error) {
+	vars, err := All(environ)
+	if err != nil {
+		return "", false, err
+	}
+	value, ok := vars[name]
+	return value, ok, nil
+}
+
+// Evaluate an array of key=value strings in the dotenv syntax,
+// and return the value of the specified variable in raw mode
+func LookupRaw(environ []string, name string) (string, bool) {
+	vars := AllRaw(environ)
+	value, ok := vars[name]
+	return value, ok
+}
+
+func Exists(environ []string, name string) bool {
+	for _, kv := range environ {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue // skip empty lines
+		}
+		k, _, _ := strings.Cut(kv, "=")
+		if k == name {
+			return true
+		}
+	}
+	return false
+}
+
+// parseEnvLine parses one line of a dotenv file into (key, value).
+func parseEnvLine(line string, lookup map[string]string) (string, string, error) {
+	// For simple KEY=VALUE assignments without quotes or $ expansion,
+	// handle them directly to avoid shell parser issues with special chars like ()
+	if idx := strings.Index(line, "="); idx != -1 {
+		key := line[:idx]
+		value := line[idx+1:]
+
+		// Check if this is a simple assignment without shell features
+		if isSimpleKey(key) && !containsShellFeatures(value) {
+			return key, value, nil
+		}
+	}
+
+	parser := syntax.NewParser()
+	file, err := parser.Parse(strings.NewReader(line), "")
+	if err != nil {
+		return "", "", fmt.Errorf("parse error: %q: %w", line, err)
+	}
+	if len(file.Stmts) == 0 {
+		return "", "", nil // blank line
+	}
+	stmt := file.Stmts[0]
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) == 0 {
+		return "", "", fmt.Errorf("parse error: %q: not a bare assignment", line)
+	}
+	assigns := call.Assigns
+	if len(assigns) != 1 {
+		return "", "", fmt.Errorf("can't assign multiple variables: %q", line)
+	}
+	assign := assigns[0]
+	if assign.Name == nil {
+		return "", "", fmt.Errorf("missing name in variable assignment: %q", line)
+	}
+	key := assign.Name.Value
+
+	// dotenv twist: handle 'foo=a b c'
+	if assign.Value == nil && len(call.Args) == 0 {
+		return key, "", nil // empty assignment
+	}
+	var words []string
+	// Catch the 'foo=a' part of 'foo=a b c'
+	if assign.Value != nil {
+		assignExpanded, err := expandShellWord(assign.Value, lookup)
+		if err != nil {
+			return key, "", fmt.Errorf("%s: shell parse error: %w", key, err)
+		}
+		words = append(words, assignExpanded)
+	}
+	// Catch the 'b c' part of 'foo=a b c'
+	// The shell parser sees those as command arguments
+	for _, arg := range call.Args {
+		argExpanded, err := expandShellWord(arg, lookup)
+		if err != nil {
+			return key, "", err
+		}
+		words = append(words, argExpanded)
+	}
+	return key, strings.Join(words, " "), nil
+}
+
+// isSimpleKey checks if a key is a valid environment variable name
+func isSimpleKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, ch := range key {
+		if !((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '_' || (i > 0 && ch >= '0' && ch <= '9')) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsShellFeatures checks if a value contains shell features that require parsing
+func containsShellFeatures(value string) bool {
+	for i, ch := range value {
+		switch ch {
+		// Quotes require shell parser
+		case '`', '"', '\'':
+			return true
+		// Escaping requires shell parser
+		case '\\':
+			return true
+		// Variable expansion requires shell parser
+		case '$':
+			if i+1 < len(value) {
+				next := value[i+1]
+				// Check for ${VAR}, $VAR, or $(command)
+				if (next >= 'A' && next <= 'Z') ||
+					(next >= 'a' && next <= 'z') ||
+					next == '_' || next == '{' || next == '(' {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// expandWord flattens a *syntax.Word into a string.
+func expandShellWord(w *syntax.Word, lookup map[string]string) (string, error) {
+	cfg := &expand.Config{
+		Env: expand.FuncEnviron(func(name string) string {
+			value, ok := lookup[name]
+			if !ok {
+				return ""
+			}
+			return value
+		}),
+		NoUnset: true,
+	}
+	// Perform shell-like expansion: escapes, quotes, parameters
+	fields, err := expand.Fields(cfg, w)
+	if err != nil {
+		return "", err
+	}
+	if len(fields) == 0 {
+		return "", fmt.Errorf("empty expansion")
+	}
+	return strings.Join(fields, " "), nil
+}

--- a/core/dotenv/dotenv_test.go
+++ b/core/dotenv/dotenv_test.go
@@ -1,0 +1,264 @@
+package dotenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllRaw(t *testing.T) {
+	input := []string{
+		"FOO=bar",
+		"EMPTY=",
+	}
+	want := map[string]string{
+		"FOO":   "bar",
+		"EMPTY": "",
+	}
+	got := AllRaw(input)
+	require.Equal(t, want, got)
+}
+
+func TestAllExpansion(t *testing.T) {
+	tests := []struct {
+		name      string
+		environ   []string
+		want      map[string]string
+		wantError bool
+	}{
+		{
+			name: "basic assignment",
+			environ: []string{
+				"FOO=bar",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name: "quoted string",
+			environ: []string{
+				`FOO="a b c"`,
+			},
+			want: map[string]string{
+				"FOO": "a b c",
+			},
+		},
+		{
+			name: "unquoted multiple words collapse to one",
+			environ: []string{
+				"FOO=a b c",
+			},
+			want: map[string]string{
+				"FOO": "a b c", // dotenv semantics
+			},
+		},
+		{
+			name: "unquoted multiple words, multiple spacs",
+			environ: []string{
+				"FOO=a   b c",
+			},
+			want: map[string]string{
+				"FOO": "a   b c",
+			},
+		},
+		{
+			name: "variable expansion",
+			environ: []string{
+				"FOO=bar",
+				"BAZ=$FOO-baz",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "bar-baz",
+			},
+		},
+		{
+			name: "error on missing variable",
+			environ: []string{
+				"QUX=$MISSING",
+			},
+			wantError: true,
+		},
+		{
+			name: "order matters",
+			environ: []string{
+				"BAZ=$FOO-baz",
+				"FOO=bar",
+			},
+			wantError: true,
+		},
+		{
+			name: "expansion with default value",
+			environ: []string{
+				"FOO=bar",
+				"BAZ=${MISSING:-default}",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "default",
+			},
+		},
+		{
+			name: "expansion with default value when variable exists",
+			environ: []string{
+				"FOO=bar",
+				"EXISTING=value",
+				"BAZ=${EXISTING:-default}",
+			},
+			want: map[string]string{
+				"FOO":      "bar",
+				"EXISTING": "value",
+				"BAZ":      "value",
+			},
+		},
+		{
+			name: "quoted string with expansion",
+			environ: []string{
+				`FOO=bar`,
+				`BAZ="prefix $FOO suffix"`,
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "prefix bar suffix",
+			},
+		},
+		{
+			name: "quoted string with 2 levels of expansion",
+			environ: []string{
+				`animal="dog"`,
+				`message="hello, nice ${animal}"`,
+				`story="once upon a time, there was a man who said $message"`,
+			},
+			want: map[string]string{
+				"animal":  "dog",
+				"message": "hello, nice dog",
+				"story":   "once upon a time, there was a man who said hello, nice dog",
+			},
+		},
+		{
+			name: "single quoted assignment (no expansion)",
+			environ: []string{
+				`animal=dog`,
+				`single_quoted_var='hello, nice $animal'`,
+			},
+			want: map[string]string{
+				"animal":            "dog",
+				"single_quoted_var": "hello, nice $animal", // single quotes prevent expansion
+			},
+		},
+		{
+			name: "single quoted variable (no expansion)",
+			environ: []string{
+				`animal=dog`,
+				`single_quoted_var=hello, nice '$animal'`,
+			},
+			want: map[string]string{
+				"animal":            "dog",
+				"single_quoted_var": "hello, nice $animal", // single quotes prevent expansion
+			},
+		},
+		{
+			name: "escaped spaces",
+			environ: []string{
+				`FOO=a\ b\ c`,
+			},
+			want: map[string]string{
+				"FOO": "a b c",
+			},
+		},
+		{
+			name: "empty line",
+			environ: []string{
+				"",
+				"FOO=bar",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name: "whitespace only line",
+			environ: []string{
+				"   ",
+				"FOO=bar",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name: "empty assignment",
+			environ: []string{
+				"EMPTY=",
+			},
+			want: map[string]string{
+				"EMPTY": "",
+			},
+		},
+		{
+			name: "self reference",
+			environ: []string{
+				"FOO=bar",
+				"FOO=$FOO-suffix",
+			},
+			want: map[string]string{
+				"FOO": "bar-suffix",
+			},
+		},
+		{
+			name: "braced variable expansion",
+			environ: []string{
+				"FOO=bar",
+				"BAZ=${FOO}baz",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "barbaz",
+			},
+		},
+		{
+			name: "mixed quotes and expansion",
+			environ: []string{
+				"FOO=bar",
+				`BAZ='$FOO'`,
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "$FOO", // single quotes prevent expansion
+			},
+		},
+		{
+			name: "special characters in value",
+			environ: []string{
+				"SPECIAL=!@#$%^&*()",
+			},
+			want: map[string]string{
+				"SPECIAL": "!@#$%^&*()",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := All(tt.environ)
+			if tt.wantError {
+				require.Error(t, err, tt.name)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got, tt.name)
+			}
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	environ := []string{
+		"FOO=bar",
+		"BAZ=$FOO-baz",
+	}
+	val, ok, err := Lookup(environ, "BAZ")
+	require.NoError(t, err)
+	require.True(t, ok, "Lookup should find BAZ")
+	require.Equal(t, "bar-baz", val)
+}

--- a/core/integration/envfile_test.go
+++ b/core/integration/envfile_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/dotenv"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -15,163 +16,163 @@ func TestEnvFile(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(EnvFileSuite{})
 }
 
-// Test converting a file to an environment file and reading its variables
-func (EnvFileSuite) TestAsEnvFile(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
+// Test that the Dagger type matches the behavior of the underlying dotenv library,
+// when evaluating values.
+// This covers variable expansion, quotes and escape handling, etc.
+//
+// Since the underlying library is well-tested, this avoids duplicating those tests here.
+// Instead we can focus on tests specific to this layer.
+func (EnvFileSuite) TestEvalMatch(ctx context.Context, t *testctx.T) {
+	tests := []struct {
+		name string
+		vars map[string]string
+	}{
+		{
+			name: "simple",
+			vars: map[string]string{
+				"FOO":     "bar",
+				"hello":   "world",
+				"StoRy":   "once upon a time...",
+				"various": "lots of (weird) characters &^",
+			},
+		},
+		{
+			name: "expansion",
+			vars: map[string]string{
+				"animal":    "dog",
+				"superhero": "${animal}man",
+				"message":   "hello, nice $animal !",
+				"message2":  "hello, nice ${animal}",
+				"message3":  "hello, nice '${animal}'",
+			},
+		},
+		{
+			name: "quoted_values",
+			vars: map[string]string{
+				"animal":            `"dog"`,
+				"message":           `"hello, nice ${animal}"`,
+				"message2":          `"hello, nice $animal"`,
+				"story":             `"once upon a time, there was a man who said $message"`,
+				"QUOTES":            `"this sentence is double-quoted (with \"), 'and this is single-quoted'"`,
+				"single_quoted_var": `"hello, nice '$animal'"`,
+			},
+		},
+		{
+			name: "raw",
+			vars: map[string]string{
+				"simple":        "hello world",
+				"quotes":        `"hello world"`,
+				"single_quotes": `'hello world'`,
+				"dollar_sign":   "$FOO",
+				"expansion":     "${FOO}",
+				"command_sub":   "$(echo hello)",
+				"backticks":     "`echo hello`",
+				"backslash":     `hello\nworld`,
+				"mixed":         `"$FOO ${BAR} $(cmd)" and 'more'`,
+				"special_chars": "()&^%$#@!",
+			},
+		},
+		{
+			name: "remove_referenced_variable",
+			vars: map[string]string{
+				"GREETING": "bonjour",
+				"NAME":     "monde",
+				"message":  "$GREETING, $NAME!",
+			},
+		},
+		{
+			name: "get_unset",
+			vars: map[string]string{
+				"FOO":   "bar",
+				"HELLO": "world",
+				"DOG":   "${FOO}-${HELLO}",
+			},
+		},
+		{
+			name: "override",
+			vars: map[string]string{
+				"FOO": "newbar",
+			},
+		},
+		{
+			name: "file",
+			vars: map[string]string{
+				"animal":            "dog",
+				"message":           "hello, nice ${animal}",
+				"message2":          `"hello, nice $animal"`,
+				"story":             "once upon a time, there was a man who said $message",
+				"QUOTED":            `"this sentence is double-quoted (with \"), 'and this is single-quoted'"`,
+				"single_quoted_var": `"hello, nice '$animal'"`,
+			},
+		},
+	}
 
-	requireEnvFileEqual(ctx, t,
-		c.File(".env",
-			`FOO=bar
-HELLO=world
-DOG=${FOO}-${HELLO}
-`).AsEnvFile(),
-		map[string]string{
-			"FOO":   "bar",
-			"HELLO": "world",
-			"DOG":   "${FOO}-${HELLO}", // expansion disabled
+	for _, tt := range tests {
+		t.Run(tt.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+			env := c.EnvFile()
+			var environ []string
+			for name, inputValue := range tt.vars {
+				environ = append(environ, name+"="+inputValue)
+				env = env.WithVariable(name, inputValue)
+			}
+
+			for name := range tt.vars {
+				expectedValue, expectedFound, expectedErr := dotenv.Lookup(environ, name)
+				if !expectedFound {
+					expectedValue = ""
+				}
+				actualValue, actualErr := env.Get(ctx, name)
+				if expectedErr != nil {
+					require.Error(t, actualErr, tt.name)
+				} else {
+					require.NoError(t, actualErr, tt.name)
+				}
+				if expectedErr == nil {
+					require.Equal(t, expectedValue, actualValue, tt.name)
+				}
+			}
 		})
+	}
 }
 
-// Test environment variable expansion when enabled from a file
-func (EnvFileSuite) TestFileExpand(ctx context.Context, t *testctx.T) {
+func (EnvFileSuite) TestFile(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
-
-	env := c.File(".env", `toosoon=hello $animal
-animal=dog
+	inputFile := c.File(".env", `animal=dog
 message=hello, nice ${animal}
+message2="hello, nice $animal"
 story=once upon a time, there was a man who said $message
-`).AsEnvFile(dagger.FileAsEnvFileOpts{
-		Expand: true,
-	})
-	expected := map[string]string{
-		"toosoon": "hello ",
-		"animal":  "dog",
-		"message": "hello, nice dog",
-		"story":   "once upon a time, there was a man who said hello, nice dog",
-	}
-	requireEnvFileEqual(ctx, t, env, expected)
-}
-
-func (EnvFileSuite) TestQuotes(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	expected := map[string]string{
-		"partial":  `The hero said: "beware of dragons!"`,
-		"complete": `"This sentence is entirely quotes"`,
-	}
-	t.Run("created inline, expanded", func(ctx context.Context, t *testctx.T) {
-		env := c.
-			EnvFile(dagger.EnvFileOpts{Expand: true}).
-			WithVariable("partial", `The hero said: "beware of dragons!"`).
-			WithVariable("complete", `"This sentence is entirely quotes"`)
-		requireEnvFileEqual(ctx, t, env, expected)
-	})
-	t.Run("created inline, not expanded", func(ctx context.Context, t *testctx.T) {
-		env := c.
-			EnvFile(dagger.EnvFileOpts{Expand: false}).
-			WithVariable("partial", `The hero said: "beware of dragons!"`).
-			WithVariable("complete", `"This sentence is entirely quotes"`)
-		requireEnvFileEqual(ctx, t, env, expected)
-	})
-	t.Run("created from file, expanded", func(ctx context.Context, t *testctx.T) {
-		env := c.
-			File(
-				".env",
-				`partial=The hero said: "beware of dragons!"
-complete="This sentence is entirely quotes"`).
-			AsEnvFile(dagger.FileAsEnvFileOpts{Expand: true})
-		requireEnvFileEqual(ctx, t, env, expected)
-	})
-	t.Run("created from file, not expanded", func(ctx context.Context, t *testctx.T) {
-		env := c.
-			File(
-				".env",
-				`partial=The hero said: "beware of dragons!"
-complete="This sentence is entirely quotes"`).
-			AsEnvFile(dagger.FileAsEnvFileOpts{Expand: false})
-		requireEnvFileEqual(ctx, t, env, expected)
-	})
-}
-
-// Test environment variable expansion when enabled
-func (EnvFileSuite) TestExpand(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-
-	env := c.
-		EnvFile(dagger.EnvFileOpts{
-			Expand: true,
-		}).
-		WithVariable("toosoon", "hello $animal").
-		WithVariable("animal", "dog").
-		WithVariable("message", "hello, nice ${animal}").
-		WithVariable("story", "once upon a time, there was a man who said $message")
-	expected := map[string]string{
-		"toosoon": "hello ",
-		"animal":  "dog",
-		"message": "hello, nice dog",
-		"story":   "once upon a time, there was a man who said hello, nice dog",
-	}
-	requireEnvFileEqual(ctx, t, env, expected)
-}
-
-// Test environment variable expansion when disabled
-func (EnvFileSuite) TestNoExpand(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	env := c.
-		EnvFile(dagger.EnvFileOpts{
-			Expand: false,
-		}).
-		WithVariable("toosoon", "hello $animal").
-		WithVariable("animal", "dog").
-		WithVariable("message", "hello, nice ${animal}").
-		WithVariable("story", `"once upon a time, there was a man who said $message"`).
-		WithVariable("meta", `'this file sets $toosoon, ${animal}, $message and $story'`)
-	expected := map[string]string{
-		"toosoon": "hello $animal",
-		"animal":  "dog",
-		"message": "hello, nice ${animal}",
-		"story":   `"once upon a time, there was a man who said $message"`,
-		"meta":    `'this file sets $toosoon, ${animal}, $message and $story'`,
-	}
-	requireEnvFileEqual(ctx, t, env, expected)
-}
-
-// Test adding variables to an environment file
-func (EnvFileSuite) TestWithVariable(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	env := c.EnvFile().
-		WithVariable("FOO", "bar").
-		WithVariable("HELLO", "world").
-		WithVariable("DOG", "${FOO}-${HELLO}")
-	expected := map[string]string{
-		"FOO":   "bar",
-		"HELLO": "world",
-		"DOG":   "${FOO}-${HELLO}", // expand is disabled
-	}
-	requireEnvFileEqual(ctx, t, env, expected)
-}
-
-// Test removing variables from an environment file
-func (EnvFileSuite) TestWithoutVariable(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	env := c.EnvFile().
-		WithVariable("FOO", "bar").
-		WithVariable("HELLO", "world").
-		WithoutVariable("FOO")
-	expected := map[string]string{
-		"HELLO": "world",
-	}
-	requireEnvFileEqual(ctx, t, env, expected)
-}
-
-func (EnvFileSuite) TestUnknown(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-	env := c.EnvFile().
-		WithVariable("FOO", "bar").
-		WithVariable("HELLO", "world").
-		WithVariable("DOG", "${FOO}-${HELLO}")
-	variable, err := env.Get(ctx, "UNKNOWN")
+QUOTED="this sentence is double-quoted (with \"), 'and this is single-quoted'"
+single_quoted_var="hello, nice '$animal'"
+`)
+	env := inputFile.AsEnvFile()
+	outputFile := env.AsFile()
+	inputContents, err := inputFile.Contents(ctx)
 	require.NoError(t, err)
-	require.Empty(t, variable)
+	outputContents, err := outputFile.Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, inputContents, outputContents)
+}
+
+func (EnvFileSuite) TestRemoveReferencedVariable(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	env := c.EnvFile().
+		WithVariable("GREETING", "bonjour").
+		WithVariable("NAME", "monde").
+		WithVariable("message", `$GREETING, $NAME!`)
+
+	before, err := env.Get(ctx, "message")
+	require.NoError(t, err)
+	require.Equal(t, `bonjour, monde!`, before)
+
+	env = env.WithoutVariable("NAME")
+
+	_, err = env.Get(ctx, "message")
+	require.Error(t, err)
+
+	afterRaw, err := env.Get(ctx, "message", dagger.EnvFileGetOpts{Raw: true})
+	require.NoError(t, err)
+	require.Equal(t, `$GREETING, $NAME!`, afterRaw)
 }
 
 // Test overriding an existing variable with a new value
@@ -185,62 +186,4 @@ func (EnvFileSuite) TestOverride(ctx context.Context, t *testctx.T) {
 	variable, err := envFile.Get(ctx, "FOO")
 	require.NoError(t, err)
 	require.Equal(t, "newbar", variable)
-}
-
-// Test converting an environment file back to a regular file
-func (EnvFileSuite) TestEnvToFile(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-
-	envFile := c.EnvFile().
-		WithVariable("FOO", "bar").
-		WithVariable("HELLO", "world")
-
-	contents, err := envFile.AsFile().Contents(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "FOO=bar\nHELLO=world\n", contents)
-}
-
-func requireEnvFileEqual(ctx context.Context, t *testctx.T, ef *dagger.EnvFile, expectedVars map[string]string) {
-	var expectedNames []string
-	for name, expectedValue := range expectedVars {
-		expectedNames = append(expectedNames, name)
-		requireEnvFileVariableEqual(ctx, t, ef, name, expectedValue)
-	}
-	requireEnvFileKeysEqual(ctx, t, ef, expectedNames...)
-	vars, err := ef.Variables(ctx)
-	require.NoError(t, err)
-	for _, envVar := range vars {
-		name, err := envVar.Name(ctx)
-		require.NoError(t, err)
-		value, err := envVar.Value(ctx)
-		require.NoError(t, err)
-		_, expected := expectedVars[name]
-		require.True(t, expected)
-		require.Equal(t, expectedVars[name], value)
-	}
-}
-
-func requireEnvFileKeysEqual(ctx context.Context, t *testctx.T, ef *dagger.EnvFile, expectedKeys ...string) {
-	keys := map[string]bool{}
-	for _, key := range expectedKeys {
-		keys[key] = false
-	}
-	vars, err := ef.Variables(ctx)
-	require.NoError(t, err)
-	for _, v := range vars {
-		name, err := v.Name(ctx)
-		require.NoError(t, err)
-		_, expected := keys[name]
-		require.True(t, expected, "envfile contains unexpected key: %q", name)
-		keys[name] = true
-	}
-	for key, found := range keys {
-		require.True(t, found, "envfile is missing expected key: %q", key)
-	}
-}
-
-func requireEnvFileVariableEqual(ctx context.Context, t *testctx.T, ef *dagger.EnvFile, name, expectedValue string) {
-	value, err := ef.Get(ctx, name)
-	require.NoError(t, err)
-	require.Equal(t, expectedValue, value)
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -64,6 +64,7 @@ func BenchMiddleware() []testctx.Middleware[*testing.B] {
 
 func connect(ctx context.Context, t testing.TB, opts ...dagger.ClientOpt) *dagger.Client {
 	opts = append([]dagger.ClientOpt{
+		// FIXME: test spans are easier to read in the TUI when this is silenced
 		dagger.WithLogOutput(testutil.NewTWriter(t)),
 	}, opts...)
 	client, err := dagger.Connect(ctx, opts...)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2567,13 +2567,23 @@ type EnvFile {
   get(
     """Variable name"""
     name: String!
+
+    """
+    Return the value exactly as written to the file. No quote removal or variable expansion
+    """
+    raw: Boolean
   ): String!
 
   """A unique identifier for this EnvFile."""
   id: EnvFileID!
 
   """Return all variables"""
-  variables: [EnvVariable!]!
+  variables(
+    """
+    Return values exactly as written to the file. No quote removal or variable expansion
+    """
+    raw: Boolean
+  ): [EnvVariable!]!
 
   """Add a variable"""
   withVariable(

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8939,6 +8939,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Variable name</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>raw</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Return the value exactly as written to the file. No quote removal or variable expansion</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -8947,9 +8951,22 @@
                         <td data-property-name=""><a class="property-name" id="EnvFile-id" href="#EnvFile-id"><code>id</code></a> - <span class="property-type"><a href="#definition-EnvFileID"><code>EnvFileID!</code></a></span> </td>
                         <td> A unique identifier for this EnvFile. </td>
                       </tr>
-                      <tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="EnvFile-variables" href="#EnvFile-variables"><code>variables</code></a> - <span class="property-type"><a href="#definition-EnvVariable"><code>[EnvVariable!]!</code></a></span> </td>
                         <td> Return all variables </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>raw</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Return values exactly as written to the file. No quote removal or variable expansion</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="EnvFile-withVariable" href="#EnvFile-withVariable"><code>withVariable</code></a> - <span class="property-type"><a href="#definition-EnvFile"><code>EnvFile!</code></a></span> </td>

--- a/docs/static/reference/php/Dagger/EnvFile.html
+++ b/docs/static/reference/php/Dagger/EnvFile.html
@@ -166,7 +166,7 @@
                     string
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_get">get</a>(string $name)
+                    <a href="#method_get">get</a>(string $name, bool|null $raw = null)
         
                                             <p><p>Lookup a variable (last occurrence wins) and return its value, or an empty string</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -186,7 +186,7 @@
                     array
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_variables">variables</a>()
+                    <a href="#method_variables">variables</a>(bool|null $raw = null)
         
                                             <p><p>Return all variables</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -384,7 +384,7 @@
                     <h3 id="method_get">
         <div class="location">at line 38</div>
         <code>                    string
-    <strong>get</strong>(string $name)
+    <strong>get</strong>(string $name, bool|null $raw = null)
         </code>
     </h3>
     <div class="details">    
@@ -401,6 +401,11 @@
                     <tr>
                 <td>string</td>
                 <td>$name</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$raw</td>
                 <td></td>
             </tr>
             </table>
@@ -424,7 +429,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 48</div>
+        <div class="location">at line 51</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -456,9 +461,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_variables">
-        <div class="location">at line 57</div>
+        <div class="location">at line 60</div>
         <code>                    array
-    <strong>variables</strong>()
+    <strong>variables</strong>(bool|null $raw = null)
         </code>
     </h3>
     <div class="details">    
@@ -469,6 +474,16 @@
                             <p><p>Return all variables</p></p>                        
         </div>
         <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>bool|null</td>
+                <td>$raw</td>
+                <td></td>
+            </tr>
+            </table>
+
             
                             <h4>Return Value</h4>
 
@@ -488,7 +503,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withVariable">
-        <div class="location">at line 66</div>
+        <div class="location">at line 72</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>withVariable</strong>(string $name, string $value)
         </code>
@@ -535,7 +550,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutVariable">
-        <div class="location">at line 77</div>
+        <div class="location">at line 83</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>withoutVariable</strong>(string $name)
         </code>

--- a/sdk/elixir/lib/dagger/gen/env_file.ex
+++ b/sdk/elixir/lib/dagger/gen/env_file.ex
@@ -43,10 +43,13 @@ defmodule Dagger.EnvFile do
   @doc """
   Lookup a variable (last occurrence wins) and return its value, or an empty string
   """
-  @spec get(t(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  def get(%__MODULE__{} = env_file, name) do
+  @spec get(t(), String.t(), [{:raw, boolean() | nil}]) :: {:ok, String.t()} | {:error, term()}
+  def get(%__MODULE__{} = env_file, name, optional_args \\ []) do
     query_builder =
-      env_file.query_builder |> QB.select("get") |> QB.put_arg("name", name)
+      env_file.query_builder
+      |> QB.select("get")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("raw", optional_args[:raw])
 
     Client.execute(env_file.client, query_builder)
   end
@@ -65,10 +68,14 @@ defmodule Dagger.EnvFile do
   @doc """
   Return all variables
   """
-  @spec variables(t()) :: {:ok, [Dagger.EnvVariable.t()]} | {:error, term()}
-  def variables(%__MODULE__{} = env_file) do
+  @spec variables(t(), [{:raw, boolean() | nil}]) ::
+          {:ok, [Dagger.EnvVariable.t()]} | {:error, term()}
+  def variables(%__MODULE__{} = env_file, optional_args \\ []) do
     query_builder =
-      env_file.query_builder |> QB.select("variables") |> QB.select("id")
+      env_file.query_builder
+      |> QB.select("variables")
+      |> QB.maybe_put_arg("raw", optional_args[:raw])
+      |> QB.select("id")
 
     with {:ok, items} <- Client.execute(env_file.client, query_builder) do
       {:ok,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5346,12 +5346,24 @@ func (r *EnvFile) Exists(ctx context.Context, name string) (bool, error) {
 	return response, q.Execute(ctx)
 }
 
+// EnvFileGetOpts contains options for EnvFile.Get
+type EnvFileGetOpts struct {
+	// Return the value exactly as written to the file. No quote removal or variable expansion
+	Raw bool
+}
+
 // Lookup a variable (last occurrence wins) and return its value, or an empty string
-func (r *EnvFile) Get(ctx context.Context, name string) (string, error) {
+func (r *EnvFile) Get(ctx context.Context, name string, opts ...EnvFileGetOpts) (string, error) {
 	if r.get != nil {
 		return *r.get, nil
 	}
 	q := r.query.Select("get")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `raw` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Raw) {
+			q = q.Arg("raw", opts[i].Raw)
+		}
+	}
 	q = q.Arg("name", name)
 
 	var response string
@@ -5400,9 +5412,21 @@ func (r *EnvFile) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
+// EnvFileVariablesOpts contains options for EnvFile.Variables
+type EnvFileVariablesOpts struct {
+	// Return values exactly as written to the file. No quote removal or variable expansion
+	Raw bool
+}
+
 // Return all variables
-func (r *EnvFile) Variables(ctx context.Context) ([]EnvVariable, error) {
+func (r *EnvFile) Variables(ctx context.Context, opts ...EnvFileVariablesOpts) ([]EnvVariable, error) {
 	q := r.query.Select("variables")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `raw` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Raw) {
+			q = q.Arg("raw", opts[i].Raw)
+		}
+	}
 
 	q = q.Select("id")
 

--- a/sdk/php/generated/EnvFile.php
+++ b/sdk/php/generated/EnvFile.php
@@ -35,10 +35,13 @@ class EnvFile extends Client\AbstractObject implements Client\IdAble
     /**
      * Lookup a variable (last occurrence wins) and return its value, or an empty string
      */
-    public function get(string $name): string
+    public function get(string $name, ?bool $raw = null): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('get');
         $leafQueryBuilder->setArgument('name', $name);
+        if (null !== $raw) {
+        $leafQueryBuilder->setArgument('raw', $raw);
+        }
         return (string)$this->queryLeaf($leafQueryBuilder, 'get');
     }
 
@@ -54,9 +57,12 @@ class EnvFile extends Client\AbstractObject implements Client\IdAble
     /**
      * Return all variables
      */
-    public function variables(): array
+    public function variables(?bool $raw = null): array
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('variables');
+        if (null !== $raw) {
+        $leafQueryBuilder->setArgument('raw', $raw);
+        }
         return (array)$this->queryLeaf($leafQueryBuilder, 'variables');
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5792,7 +5792,12 @@ class EnvFile(Type):
         _ctx = self._select("exists", _args)
         return await _ctx.execute(bool)
 
-    async def get(self, name: str) -> str:
+    async def get(
+        self,
+        name: str,
+        *,
+        raw: bool | None = None,
+    ) -> str:
         """Lookup a variable (last occurrence wins) and return its value, or an
         empty string
 
@@ -5800,6 +5805,9 @@ class EnvFile(Type):
         ----------
         name:
             Variable name
+        raw:
+            Return the value exactly as written to the file. No quote removal
+            or variable expansion
 
         Returns
         -------
@@ -5817,6 +5825,7 @@ class EnvFile(Type):
         """
         _args = [
             Arg("name", name),
+            Arg("raw", raw, None),
         ]
         _ctx = self._select("get", _args)
         return await _ctx.execute(str)
@@ -5845,9 +5854,18 @@ class EnvFile(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(EnvFileID)
 
-    async def variables(self) -> list["EnvVariable"]:
-        """Return all variables"""
-        _args: list[Arg] = []
+    async def variables(self, *, raw: bool | None = None) -> list["EnvVariable"]:
+        """Return all variables
+
+        Parameters
+        ----------
+        raw:
+            Return values exactly as written to the file. No quote removal or
+            variable expansion
+        """
+        _args = [
+            Arg("raw", raw, None),
+        ]
         _ctx = self._select("variables", _args)
         return await _ctx.execute_object_list(EnvVariable)
 

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1042,6 +1042,20 @@ export type EnumTypeDefID = string & { __EnumTypeDefID: never }
  */
 export type EnumValueTypeDefID = string & { __EnumValueTypeDefID: never }
 
+export type EnvFileGetOpts = {
+  /**
+   * Return the value exactly as written to the file. No quote removal or variable expansion
+   */
+  raw?: boolean
+}
+
+export type EnvFileVariablesOpts = {
+  /**
+   * Return values exactly as written to the file. No quote removal or variable expansion
+   */
+  raw?: boolean
+}
+
 /**
  * The `EnvFileID` scalar type represents an identifier for an object of type EnvFile.
  */
@@ -6116,13 +6130,14 @@ export class EnvFile extends BaseClient {
   /**
    * Lookup a variable (last occurrence wins) and return its value, or an empty string
    * @param name Variable name
+   * @param opts.raw Return the value exactly as written to the file. No quote removal or variable expansion
    */
-  get = async (name: string): Promise<string> => {
+  get = async (name: string, opts?: EnvFileGetOpts): Promise<string> => {
     if (this._get) {
       return this._get
     }
 
-    const ctx = this._ctx.select("get", { name })
+    const ctx = this._ctx.select("get", { name, ...opts })
 
     const response: Awaited<string> = await ctx.execute()
 
@@ -6131,13 +6146,14 @@ export class EnvFile extends BaseClient {
 
   /**
    * Return all variables
+   * @param opts.raw Return values exactly as written to the file. No quote removal or variable expansion
    */
-  variables = async (): Promise<EnvVariable[]> => {
+  variables = async (opts?: EnvFileVariablesOpts): Promise<EnvVariable[]> => {
     type variables = {
       id: EnvVariableID
     }
 
-    const ctx = this._ctx.select("variables").select("id")
+    const ctx = this._ctx.select("variables", { ...opts }).select("id")
 
     const response: Awaited<variables[]> = await ctx.execute()
 


### PR DESCRIPTION
- Evaluate quotes by default: `foo="a b c"`
- Support default values in variables: `foo=${bar:-baz}`
- Cleaner implementation, with a low-level go package
- Lots of tests
- Optional "raw" mode
