### PR TITLE
test: update benchmark test use of identity package

### DIFF
--- a/core/integration/module_benchmark_test.go
+++ b/core/integration/module_benchmark_test.go
@@ -294,14 +294,14 @@ func (ModuleSuite) BenchmarkCallSameModuleInParallel(ctx context.Context, b *tes
 			With(sdkSource("go", `package main
 
 import (
-	"github.com/dagger/dagger/internal/buildkit/identity"
 	"dagger/dep/internal/dagger"
+	"crypto/rand"
 )
 
 type Dep struct {}
 
 func (m *Dep) DepFn(s *dagger.Secret) string {
-	return identity.NewID()
+	return rand.Text()
 }
 `)).
 			WithWorkdir("/work").


### PR DESCRIPTION
This was [recently updated](https://github.com/dagger/dagger/pull/11075) to use an `internal` package. Which cannot be accessed externally. YAY `go`.

We can just use the shiny new `rand.Text` here, it's just for testing caching-y things.