### PR TITLE
fix: bump alpine base to 3.22.1 + manually install `openssl`

### DIFF
--- a/cmd/engine/.dagger/build/sdk.go
+++ b/cmd/engine/.dagger/build/sdk.go
@@ -211,7 +211,7 @@ func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
 	sdkCtrTarball := dag.Container(dagger.ContainerOpts{Platform: build.platform}).
 		From(consts.GolangImage).
 		With(build.goPlatformEnv).
-		WithExec([]string{"apk", "add", "git", "openssh"}).
+		WithExec([]string{"apk", "add", "git", "openssh", "openssl"}).
 		WithEnvVariable("GOTOOLCHAIN", "auto").
 		WithFile("/usr/local/bin/codegen", build.CodegenBinary()).
 		// these cache directories should match the cache volume locations in the engine's goSDK.base

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -405,7 +405,7 @@ func (GitSuite) TestSSHAuthSock(ctx context.Context, t *testctx.T) {
 
 	gitSSH := c.Container().
 		From(alpineImage).
-		WithExec([]string{"apk", "add", "git", "openssh"})
+		WithExec([]string{"apk", "add", "git", "openssh", "openssl"})
 
 	hostKeyGen := gitSSH.
 		WithExec([]string{

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6102,7 +6102,7 @@ func (m *Foo) HowCoolIsDagger() string {
 		// 3. a dagger module that requires a dependency (NOT a dagger dependency) from a remote private repo.
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-			WithExec([]string{"apk", "add", "git", "openssh"}).
+			WithExec([]string{"apk", "add", "git", "openssh", "openssl"}).
 			WithUnixSocket("/sock/unix-socket", socket).
 			WithEnvVariable("SSH_AUTH_SOCK", "/sock/unix-socket").
 			WithWorkdir("/work").

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -24,7 +24,7 @@ const (
 )
 
 const (
-	AlpineVersion = "3.22.0"
+	AlpineVersion = "3.22.1"
 	AlpineImage   = "alpine:" + AlpineVersion
 
 	GolangVersion = "1.25.1"


### PR DESCRIPTION
Fixes CI

`TestPrivateDeps/golang` started failing in CI due to Alpine's recent security update in 3.22.1, addressing [CVE-2025-4575](https://security.alpinelinux.org/vuln/CVE-2025-4575) (details here: https://alpinelinux.org/posts/Alpine-3.19.8-3.20.7-3.21.4-3.22.1-released.html).

###### EDIT
Erik below realized that the real fix is to manually install the `openssl` lib conjointly with the `openssh` one