### PR TITLE
core: enable nesting by default

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4284,9 +4284,7 @@ func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().From(alpineImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithNewFile("/query.graphql", `{ defaultPlatform }`). // arbitrary valid query
-			WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}).
 			Sync(ctx)
 		require.NoError(t, err)
 	})

--- a/core/integration/dind_test.go
+++ b/core/integration/dind_test.go
@@ -37,7 +37,7 @@ curl \
 -u $DAGGER_SESSION_TOKEN: \
 -H "content-type:application/json" \
 -d '{"query":"{host{directory(path:\"/root/dir\"){entries}}}"}' http://127.0.0.1:$DAGGER_SESSION_PORT/query
-        """], experimentalPrivilegedNesting: true) {
+        """]) {
           stdout
         }
         }

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -18,17 +18,13 @@ func TestShell(t *testing.T) {
 
 func daggerShell(script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec([]string{"dagger", "shell", "-c", script}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec([]string{"dagger", "shell", "-c", script})
 	}
 }
 
 func daggerShellNoLoad(script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec([]string{"dagger", "shell", "--no-load", "-c", script}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec([]string{"dagger", "shell", "--no-load", "-c", script})
 	}
 }
 
@@ -292,7 +288,7 @@ func New(foo string, bar string) *Test {
 }
 
 type Test struct{
-	Foo string 
+	Foo string
 	Bar string
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5380,9 +5380,7 @@ func (m *Dep) Collect(MyEnum, MyInterface) error {
 
 func daggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger"}, args...))
 	}
 }
 
@@ -5398,8 +5396,7 @@ func daggerQueryAt(modPath string, query string, args ...any) dagger.WithContain
 			execArgs = append(execArgs, "-m", modPath)
 		}
 		return c.WithExec(execArgs, dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: query,
 		})
 	}
 }
@@ -5415,8 +5412,7 @@ func daggerCallAt(modPath string, args ...string) dagger.WithContainerFunc {
 			execArgs = append(execArgs, "-m", modPath)
 		}
 		return c.WithExec(append(execArgs, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }
@@ -5440,9 +5436,7 @@ func mountedPrivateRepoSocket(c *dagger.Client, t *testctx.T) (dagger.WithContai
 
 func daggerFunctions(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "functions"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger", "functions"}, args...))
 	}
 }
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -226,7 +226,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
 		WithExposedPort(80).
 		AsService()
-	
+
 	hn, err := srv.Hostname(ctx)
 	if err != nil {
 		return err
@@ -401,7 +401,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup0")
-	
+
 	_, err := srv.Start(ctx)
 	if err != nil {
 		return err
@@ -462,7 +462,7 @@ func (m *Caller) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
-	
+
 	_, err = srv.Start(ctx)
 	if err != nil {
 		return err
@@ -505,7 +505,7 @@ func (m *Hoster) Run(ctx context.Context) error {
 		WithExposedPort(80).
 		AsService().
 		WithHostname("wwwhatsup1")
-	
+
 	_, err := srv.Start(ctx)
 	if err != nil {
 		return err
@@ -1125,8 +1125,6 @@ func (ContainerSuite) TestExecServicesNestedExec(ctx context.Context, t *testctx
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"exec", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -1160,8 +1158,6 @@ func (ContainerSuite) TestExecServicesNestedHTTP(ctx context.Context, t *testctx
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"http", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -1195,8 +1191,6 @@ func (ContainerSuite) TestExecServicesNestedGit(ctx context.Context, t *testctx.
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"git", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -95,9 +95,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 		WithEnvVariable("NOW", identity.NewID()).
 		WithExec([]string{"cat", "/etc/resolv.conf"}).
 		WithServiceBinding("mirror", mirrorSvc).
-		WithExec(args, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		}).
+		WithExec(args).
 		Stdout(ctx)
 	if err != nil {
 		fatal(err)

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -32,11 +32,7 @@ func (s *serviceSchema) Install() {
 				`If empty, the container's default command is used.`).
 			ArgDoc("useEntrypoint",
 				`If the container has an entrypoint, prepend it to the args.`).
-			ArgDoc("experimentalPrivilegedNesting",
-				`Provides Dagger access to the executed command.`,
-				`Do not use this option unless you trust the command being executed;
-				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
-				FILESYSTEM.`).
+			ArgDeprecated("experimentalPrivilegedNesting", "Nesting is now enabled by default").
 			ArgDoc("insecureRootCapabilities",
 				`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -104,6 +100,10 @@ func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent *co
 }
 
 func (s *serviceSchema) containerAsService(ctx context.Context, parent *core.Container, args core.ContainerAsServiceArgs) (*core.Service, error) {
+	if args.ExperimentalPrivilegedNesting {
+		slog.SpanLogger(ctx, InstrumentationLibrary).Warn("experimentalPrivilegedNesting is deprecated and ignored; nesting is now enabled by default")
+	}
+	args.ExperimentalPrivilegedNesting = true
 	expandedArgs := make([]string, len(args.Args))
 	for i, arg := range args.Args {
 		expandedArg, err := expandEnvVar(ctx, parent, arg, args.Expand)


### PR DESCRIPTION
Nesting is now considered stable and safe. Therefore we can enable it by default.

This allows any containerized tool or service executed by Dagger to open a client session to the same Dagger engine,
without accessing parent resources. This is similar to a unix process being able to make system calls, without
accessing the context of its parent process.

- Deprecate `experimentalPrivilegedNesting` argument. It can safely be omitted
- Keep the plumbing for simplicity. It's simply enabled at the schema level

