### PR TITLE
go: allow vendor/* files through

### DIFF
--- a/cmd/dagger/.dagger/main.go
+++ b/cmd/dagger/.dagger/main.go
@@ -14,7 +14,7 @@ func New(
 
 	// +optional
 	// +defaultPath="/"
-	// +ignore=["*", ".*", "!cmd/dagger/*", "!**/go.sum", "!**/go.mod", "!**/*.go", "!**.graphql", "!.goreleaser*.yml", "!.changes", "!LICENSE", "!install.sh", "!install.ps1"]
+	// +ignore=["*", ".*", "!cmd/dagger/*", "!**/go.sum", "!**/go.mod", "!**/*.go", "!vendor/**/*", "!**.graphql", "!.goreleaser*.yml", "!.changes", "!LICENSE", "!install.sh", "!install.ps1"]
 	source *dagger.Directory,
 	// Base image for go build environment
 	// +optional


### PR DESCRIPTION
This allows to build Go apps that use vendoring, using Dagger's Go module. Useful when making local modifications to vendored libraries.