### PR TITLE
feat: capture contextual information for provisioning PARC engines

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -56,7 +56,7 @@ available functions.
 	),
 	GroupID: moduleGroup.ID,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) (rerr error) {
+		return withEngine(cmd.Context(), initModuleParams(args), func(ctx context.Context, engineClient *client.Client) (rerr error) {
 			mod, err := initializeDefaultModule(ctx, engineClient.Dagger())
 			if err != nil {
 				return err

--- a/cmd/dagger/function_name.go
+++ b/cmd/dagger/function_name.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/dagger/dagger/engine/client"
+)
+
+func initModuleParams(a []string) client.Params {
+	params := client.Params{
+		ExecCmd:  a,
+		Function: functionName(a),
+	}
+
+	if !moduleNoURL {
+		modRef, _ := getExplicitModuleSourceRef()
+		if modRef != "" {
+			params.Module = modRef
+		}
+	}
+	return params
+}
+
+func functionName(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") {
+				// this flag is not self-contained so we can't be sure what the
+				// top level function is
+				return ""
+			}
+			// it is a self contained flag os we are fine to continue scanning
+			continue
+		}
+
+		// we have the first non-flag argument which should be the top level function
+		// name so we return it
+		return arg
+	}
+
+	// weird case that would happen when users make a dagger call with no functions
+	// an edge-case but we cover it anyway
+	return ""
+}

--- a/cmd/dagger/function_name_test.go
+++ b/cmd/dagger/function_name_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionName(t *testing.T) {
+	type example struct {
+		name string
+		args []string
+		want string
+	}
+	for _, test := range []example{
+		{
+			name: "invalid flag without equals",
+			args: []string{"--cloud", "test", "specific"},
+			want: "",
+		},
+		{
+			name: "valid flag with equals before function",
+			args: []string{"--cloud=true", "test", "specific"},
+			want: "test",
+		},
+		{
+			name: "no flags before function",
+			args: []string{"test", "--race", "specific"},
+			want: "test",
+		},
+		{
+			name: "multiple valid flags before function",
+			args: []string{"--cloud=true", "--value=test", "test", "--race=true", "specific"},
+			want: "test",
+		},
+		{
+			name: "invalid second flag without equals",
+			args: []string{"--cloud=true", "--race", "test", "specific"},
+			want: "",
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: "",
+		},
+		{
+			name: "only valid flags no function",
+			args: []string{"--cloud=true", "--race=true"},
+			want: "",
+		},
+		{
+			name: "single dash flags before function",
+			args: []string{"-m", "dev", "test", "specific"},
+			want: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, functionName(test.args))
+		})
+	}
+}

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -172,7 +172,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 					c.SetContext(idtui.WithPrintTraceLink(c.Context(), true))
 				}
 
-				return withEngine(c.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) (rerr error) {
+				return withEngine(c.Context(), initModuleParams(a), func(ctx context.Context, engineClient *client.Client) (rerr error) {
 					fc.c = engineClient
 					fc.q = querybuilder.Query().Client(engineClient.Dagger().GraphQLClient())
 

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -46,7 +46,7 @@ var shellCmd = &cobra.Command{
 	Short: "Run an interactive dagger shell",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SetContext(idtui.WithPrintTraceLink(cmd.Context(), true))
-		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
+		return withEngine(cmd.Context(), initModuleParams(args), func(ctx context.Context, engineClient *client.Client) error {
 			dag := engineClient.Dagger()
 			handler := &shellCallHandler{
 				dag:      dag,

--- a/engine/client/drivers/cloud.go
+++ b/engine/client/drivers/cloud.go
@@ -81,20 +81,27 @@ func (d *daggerCloudDriver) Provision(ctx context.Context, _ *url.URL, opts *Dri
 		return nil, errors.New("please run `dagger login <org>` first or configure a DAGGER_CLOUD_TOKEN")
 	}
 
-	return d.create(ctx, client)
-}
+	var (
+		module, function string
+		execCmd          []string
+	)
+	if opts != nil {
+		module = opts.Module
+		function = opts.Function
+		execCmd = opts.ExecCmd
+	}
 
-func (d *daggerCloudDriver) ImageLoader(ctx context.Context) imageload.Backend {
-	return nil
-}
-
-func (d *daggerCloudDriver) create(ctx context.Context, client *cloud.Client) (*daggerCloudConnector, error) {
-	engineSpec, err := client.Engine(ctx)
+	engineSpec, err := client.Engine(ctx, cloud.EngineRequest{Module: module, Function: function, ExecCmd: execCmd})
 	if err != nil {
 		if errors.Is(err, cloud.ErrNoOrg) {
 			return nil, errors.New("please associate this Engine with an org by running `dagger login <org>")
 		}
 		return nil, err
 	}
+
 	return &daggerCloudConnector{EngineSpec: *engineSpec}, nil
+}
+
+func (d *daggerCloudDriver) ImageLoader(ctx context.Context) imageload.Backend {
+	return nil
 }

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -34,6 +34,9 @@ type Connector interface {
 type DriverOpts struct {
 	DaggerCloudToken string
 	GPUSupport       string
+	Module           string
+	Function         string
+	ExecCmd          []string
 }
 
 const (

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -98,6 +98,12 @@ type SerializableCertificate struct {
 	SCTs             [][]byte `json:"scts,omitempty"`
 }
 
+type EngineRequest struct {
+	Module   string   `json:"module,omitempty"`
+	Function string   ` json:"function,omitempty"`
+	ExecCmd  []string `json:"exec_cmd,omitempty"`
+}
+
 type EngineSpec struct {
 	Architecture   string                   `json:"architecture,omitempty"`
 	CacheSizeGb    int                      `json:"cache_size_gb,omitempty"`
@@ -111,6 +117,9 @@ type EngineSpec struct {
 	TTLDuration    time.Duration            `json:"ttl_duration,omitempty"`
 	URL            string                   `json:"url,omitempty"`
 	CertSerialized *SerializableCertificate `json:"cert,omitempty"`
+	Module         string                   `json:"module,omitempty"`
+	Function       string                   `json:"function,omitempty"`
+	ExecCmd        []string                 `json:"exec_cmd,omitempty"`
 }
 
 func (es *EngineSpec) TLSCertificate() (*tls.Certificate, error) {
@@ -149,7 +158,7 @@ type ErrResponse struct {
 	Message string `json:"message"`
 }
 
-func (c *Client) Engine(ctx context.Context) (*EngineSpec, error) {
+func (c *Client) Engine(ctx context.Context, req EngineRequest) (*EngineSpec, error) {
 	// Remote Engine version defaults to the CLI version - this guarantees the best compatibility
 	tag := engine.Tag
 	// Default to `main` when the CLI is a development version
@@ -160,7 +169,10 @@ func (c *Client) Engine(ctx context.Context) (*EngineSpec, error) {
 	// The only property that we can set is the Image tag.
 	// The rest will be handled by engine configs (follow-up).
 	engineSpec := &EngineSpec{
-		Image: "registry.dagger.io/engine:" + tag,
+		Image:    "registry.dagger.io/engine:" + tag,
+		Module:   req.Module,
+		Function: req.Function,
+		ExecCmd:  req.ExecCmd,
 	}
 	b, err := json.Marshal(engineSpec)
 	if err != nil {


### PR DESCRIPTION
We send the module, function name and command being executed to the API and let it make the decision for how to provision an engine. The function name parsing function added only supports commands when flags are set using the `--cloud=true` format. If flags do not use `=` to set values we do not set the function name. This was discussed on Monday's meeting and agreed as a good enough stop gap given current constraints. See the `spanName` function for a deeper explanation on why this is a stop gap.