### PR TITLE
llm: bump Sonnet to 4.5, grab bag of fixes + eval improvements

### DIFF
--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -38,7 +38,7 @@ var (
 
 func shellAddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a dagger shell command")
-	cmd.Flags().StringVar(&llmModel, "model", "", "LLM model to use (e.g., 'claude-sonnet-4-0', 'gpt-4.1')")
+	cmd.Flags().StringVar(&llmModel, "model", "", "LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')")
 }
 
 var shellCmd = &cobra.Command{

--- a/core/integration/llmtest/allow-llm.golden
+++ b/core/integration/llmtest/allow-llm.golden
@@ -5,13 +5,13 @@
   },
   {
     "role": "assistant",
-    "content": "Hello! How can I assist you today?",
+    "content": "Hello! 👋 How can I assist you today?",
     "token_usage": {
-      "input_tokens": 337,
-      "output_tokens": 10,
+      "input_tokens": 310,
+      "output_tokens": 12,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 347
+      "total_tokens": 322
     }
   }
 ]

--- a/core/integration/llmtest/api-limit.golden
+++ b/core/integration/llmtest/api-limit.golden
@@ -8,14 +8,13 @@
     "content": "",
     "tool_calls": [
       {
-        "id": "call_Eey2LsfcdFnfUeD4bCHPXyA6",
+        "id": "call_EWSB10di7AfVusXRvKR3A8xy",
         "function": {
           "name": "Container_withExec",
           "arguments": {
             "args": [
-              "sh",
-              "-c",
-              "echo $PATH"
+              "printenv",
+              "PATH"
             ],
             "self": "Container#1"
           }
@@ -24,27 +23,27 @@
       }
     ],
     "token_usage": {
-      "input_tokens": 5510,
-      "output_tokens": 29,
+      "input_tokens": 5483,
+      "output_tokens": 25,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5539
+      "total_tokens": 5508
     }
   },
   {
     "role": "user",
     "content": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n\n{\n  \"result\": \"Container#2\"\n}",
-    "tool_call_id": "call_Eey2LsfcdFnfUeD4bCHPXyA6"
+    "tool_call_id": "call_EWSB10di7AfVusXRvKR3A8xy"
   },
   {
     "role": "assistant",
     "content": "The value of PATH in the Alpine Linux container is:\n/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "token_usage": {
-      "input_tokens": 5601,
+      "input_tokens": 5570,
       "output_tokens": 32,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5633
+      "total_tokens": 5602
     }
   },
   {
@@ -56,14 +55,13 @@
     "content": "",
     "tool_calls": [
       {
-        "id": "call_vMP4nSYdIL3kbEg9tbCj91Tc",
+        "id": "call_cnUG7qUmBc1fEaVprLFh77xp",
         "function": {
           "name": "Container_withExec",
           "arguments": {
             "args": [
-              "sh",
-              "-c",
-              "echo $TERM"
+              "printenv",
+              "TERM"
             ],
             "self": "Container#2"
           }
@@ -72,55 +70,28 @@
       }
     ],
     "token_usage": {
-      "input_tokens": 5647,
-      "output_tokens": 29,
+      "input_tokens": 5616,
+      "output_tokens": 25,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5676
+      "total_tokens": 5641
     }
   },
   {
     "role": "user",
-    "content": "{\n  \"result\": \"Container#3\"\n}",
-    "tool_call_id": "call_vMP4nSYdIL3kbEg9tbCj91Tc"
+    "content": "select: process \"printenv TERM\" did not complete successfully: exit code: 1\n\n\u003c_type\u003e\nEXEC_ERROR\n\u003c/_type\u003e\n\n\u003ccmd\u003e\n[\"printenv\",\"TERM\"]\n\u003c/cmd\u003e\n\n\u003cexitCode\u003e\n1\n\u003c/exitCode\u003e\n\n\u003cstderr\u003e\n\n\u003c/stderr\u003e\n\n\u003cstdout\u003e\n\n\u003c/stdout\u003e",
+    "tool_call_id": "call_cnUG7qUmBc1fEaVprLFh77xp",
+    "tool_errored": true
   },
   {
     "role": "assistant",
-    "content": "",
-    "tool_calls": [
-      {
-        "id": "call_EYxBlsxhafynqzTtjma5rYgh",
-        "function": {
-          "name": "Container_stdout",
-          "arguments": {
-            "self": "Container#3"
-          }
-        },
-        "type": "function"
-      }
-    ],
+    "content": "The TERM environment variable is not set in this Alpine Linux container. That is why there was no output when trying to print its value.",
     "token_usage": {
-      "input_tokens": 5696,
-      "output_tokens": 16,
+      "input_tokens": 5715,
+      "output_tokens": 28,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5712
-    }
-  },
-  {
-    "role": "user",
-    "content": "\n",
-    "tool_call_id": "call_EYxBlsxhafynqzTtjma5rYgh"
-  },
-  {
-    "role": "assistant",
-    "content": "The TERM environment variable is not set in this Alpine Linux container (its value is empty).",
-    "token_usage": {
-      "input_tokens": 5721,
-      "output_tokens": 19,
-      "cached_token_reads": 0,
-      "cached_token_writes": 0,
-      "total_tokens": 5740
+      "total_tokens": 5743
     }
   }
 ]

--- a/core/integration/llmtest/hello-world.golden
+++ b/core/integration/llmtest/hello-world.golden
@@ -5,14 +5,14 @@
   },
   {
     "role": "assistant",
-    "content": "I will start by creating a new Go source file in the workspace and writing a simple \"Hello, World!\" program to it. Then I'll attempt to build the code to ensure it compiles.",
+    "content": "",
     "tool_calls": [
       {
-        "id": "call_QpBs8W6YCvSl9rMoMKE6hxHf",
+        "id": "call_jaKcJ6QhPkHpIBgkxk2GQSXw",
         "function": {
           "name": "ToyWorkspace_write",
           "arguments": {
-            "content": "package main\n\nimport \"fmt\"\n\nfunc main() {\n    fmt.Println(\"Hello, World!\")\n}\n",
+            "content": "package main\n\nimport \"fmt\"\n\nfunc main() {\n    fmt.Println(\"Hello, world!\")\n}\n",
             "self": "ToyWorkspace#1"
           }
         },
@@ -20,24 +20,24 @@
       }
     ],
     "token_usage": {
-      "input_tokens": 680,
-      "output_tokens": 90,
+      "input_tokens": 646,
+      "output_tokens": 50,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 770
+      "total_tokens": 696
     }
   },
   {
     "role": "user",
     "content": "{\n  \"data\": {\n    \"container\": \"Container#1\"\n  },\n  \"result\": \"ToyWorkspace#2\"\n}\n",
-    "tool_call_id": "call_QpBs8W6YCvSl9rMoMKE6hxHf"
+    "tool_call_id": "call_jaKcJ6QhPkHpIBgkxk2GQSXw"
   },
   {
     "role": "assistant",
     "content": "",
     "tool_calls": [
       {
-        "id": "call_prTmO8niHbea3qlKCnz1m7fv",
+        "id": "call_RPkayJjUmHAqsvOStgXq77dA",
         "function": {
           "name": "ToyWorkspace_build",
           "arguments": {
@@ -48,44 +48,45 @@
       }
     ],
     "token_usage": {
-      "input_tokens": 5933,
+      "input_tokens": 5856,
       "output_tokens": 19,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5952
+      "total_tokens": 5875
     }
   },
   {
     "role": "user",
     "content": "",
-    "tool_call_id": "call_prTmO8niHbea3qlKCnz1m7fv"
+    "tool_call_id": "call_RPkayJjUmHAqsvOStgXq77dA"
   },
   {
     "role": "assistant",
     "content": "",
     "tool_calls": [
       {
-        "id": "call_L3DKQCF0kz87EQ7PY97ttmmO",
+        "id": "call_LXzUnFd9WdRdIxhfyM6IHZpl",
         "function": {
           "name": "Save",
           "arguments": {
-            "result": "ToyWorkspace#2"
+            "name": "result",
+            "value": "ToyWorkspace#2"
           }
         },
         "type": "function"
       }
     ],
     "token_usage": {
-      "input_tokens": 5961,
-      "output_tokens": 16,
+      "input_tokens": 5884,
+      "output_tokens": 20,
       "cached_token_reads": 0,
       "cached_token_writes": 0,
-      "total_tokens": 5977
+      "total_tokens": 5904
     }
   },
   {
     "role": "user",
-    "content": "ok",
-    "tool_call_id": "call_L3DKQCF0kz87EQ7PY97ttmmO"
+    "content": "- [x] result (ToyWorkspace): The workspace after running the assignment",
+    "tool_call_id": "call_LXzUnFd9WdRdIxhfyM6IHZpl"
   }
 ]

--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -53,6 +53,7 @@ var anthropicRetryable = []string{
 	// there's gotta be a better way to do this...
 	string(constant.RateLimitError("").Default()),
 	string(constant.OverloadedError("").Default()),
+	"Internal server error",
 }
 
 func (c *AnthropicClient) IsRetryable(err error) bool {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -277,10 +277,7 @@ func (m *MCP) Tools(ctx context.Context) ([]LLMTool, error) {
 			allTools.Add(t)
 		}
 	}
-	if err := m.loadBuiltins(srv, allTools, objectMethods); err != nil {
-		return nil, err
-	}
-
+	m.loadBuiltins(srv, allTools, objectMethods)
 	return allTools.Order, nil
 }
 
@@ -1470,7 +1467,7 @@ func (m *MCP) saveTool(srv *dagql.Server) LLMTool {
 	}
 }
 
-func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, objectMethods *LLMToolSet) error {
+func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, objectMethods *LLMToolSet) {
 	schema := srv.Schema()
 
 	if m.env.Self().writable {
@@ -1650,8 +1647,6 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, objectMethods *LLMToolSe
 			},
 		})
 	}
-
-	return nil
 }
 
 func (m *MCP) readLogsTool(srv *dagql.Server) LLMToolFunc {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -369,6 +369,7 @@ func (m *MCP) updateEnvWorkspace(ctx context.Context, workspace dagql.ObjectResu
 
 	var newEnv dagql.ObjectResult[*Env]
 	if err := srv.Select(ctx, m.env, &newEnv, dagql.Selector{
+		View:  srv.View,
 		Field: "withWorkspace",
 		Args: []dagql.NamedInput{
 			{
@@ -678,6 +679,7 @@ func (m *MCP) call(ctx context.Context,
 	if changes, ok := dagql.UnwrapAs[dagql.ObjectResult[*Changeset]](val); ok {
 		var newWS dagql.ObjectResult[*Directory]
 		if err := srv.Select(ctx, m.env.Self().Workspace, &newWS, dagql.Selector{
+			View:  srv.View,
 			Field: "withChanges",
 			Args: []dagql.NamedInput{
 				{
@@ -840,6 +842,7 @@ func (m *MCP) toolCallToSelections(
 	}
 
 	sel := dagql.Selector{
+		View:  srv.View,
 		Field: fieldDef.Name,
 	}
 	field, ok := targetObjType.FieldSpec(fieldDef.Name, call.View(engine.Version))
@@ -912,6 +915,7 @@ func (m *MCP) toolCallToSelections(
 			// If the Object supports "sync", auto-select it.
 			//
 			syncSel := dagql.Selector{
+				View:  srv.View,
 				Field: sync.Name,
 			}
 			sels = append(sels, syncSel)
@@ -954,6 +958,7 @@ func (m *MCP) maybeLoadContextualArg(ctx context.Context, srv *dagql.Server, env
 			dirArg = workspace
 		default:
 			if err := srv.Select(ctx, workspace, &dirArg, dagql.Selector{
+				View:  srv.View,
 				Field: "directory",
 				Args: []dagql.NamedInput{
 					{
@@ -973,6 +978,7 @@ func (m *MCP) maybeLoadContextualArg(ctx context.Context, srv *dagql.Server, env
 	case "FileID":
 		var fileArg dagql.ObjectResult[*File]
 		if err := srv.Select(ctx, workspace, &fileArg, dagql.Selector{
+			View:  srv.View,
 			Field: "file",
 			Args: []dagql.NamedInput{
 				{
@@ -1558,6 +1564,7 @@ func (m *MCP) Builtins(srv *dagql.Server, allMethods map[string]LLMTool) ([]LLMT
 			}) (any, error) {
 				var dest dagql.ObjectResult[*Env]
 				err := srv.Select(ctx, m.env, &dest, dagql.Selector{
+					View:  srv.View,
 					Field: "with" + args.Type + "Output",
 					Args: []dagql.NamedInput{
 						{
@@ -2261,6 +2268,7 @@ func (m *MCP) toolObjectResponse(ctx context.Context, srv *dagql.Server, target 
 			continue
 		}
 		val, err := target.Select(ctx, srv, dagql.Selector{
+			View:  srv.View,
 			Field: field.Name,
 		})
 		if err != nil {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -156,6 +156,9 @@ func (m *MCP) DefaultSystemPrompt() string {
 	if len(env.outputsByName) > 0 {
 		promptFiles = append(promptFiles, "outputs.md")
 	}
+	if env.writable {
+		promptFiles = append(promptFiles, "writable.md")
+	}
 	var prompt string
 	for _, file := range promptFiles {
 		content, err := prompts.FS.ReadFile(file)
@@ -173,7 +176,9 @@ func (m *MCP) DefaultSystemPrompt() string {
 			if prompt != "" {
 				prompt += "\n\n"
 			}
-			prompt += fmt.Sprintf("The following values have been provided:\n\n```\n%s\n```", values)
+			prompt += "## User-provided values\n\n"
+			prompt += "The following values have been provided:\n\n"
+			prompt += fmt.Sprintf("```\n%s\n```", values)
 		}
 	}
 	return prompt

--- a/core/openrouter/openrouter.go
+++ b/core/openrouter/openrouter.go
@@ -55,6 +55,7 @@ type Model struct {
 }
 
 var daggerToOpenRouter = map[string]string{
+	"claude-sonnet-4-5": "anthropic/claude-sonnet-4.5",
 	"claude-sonnet-4-0": "anthropic/claude-sonnet-4",
 }
 

--- a/core/prompts/basics.md
+++ b/core/prompts/basics.md
@@ -5,5 +5,3 @@ You operate a tool system that interacts with immutable objects, following these
 3. Objects returned by tool calls are available for subsequent operations
 
 For example, a tool call might transform Container#1 into Container#2, which you would then use for the next operation.
-
-As you use tools, briefly describe what you are doing and why. If you can't come up with a good reason, or you detect that you're looping, halt.

--- a/core/prompts/outputs.md
+++ b/core/prompts/outputs.md
@@ -1,5 +1,3 @@
 ## Completing your task
 
-You are an agent - please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when all desired outputs are saved.
-
-You MUST call the Save tool when your task is complete, with all requested values.
+The Save tool doubles as a checklist. Keep going until all requested outputs have been saved. New outputs may be declared and added to the checklist at any time.

--- a/core/prompts/outputs.md
+++ b/core/prompts/outputs.md
@@ -1,3 +1,3 @@
 ## Completing your task
 
-The Save tool doubles as a checklist. Keep going until all requested outputs have been saved. New outputs may be declared and added to the checklist at any time.
+The Save tool doubles as a checklist. Keep going until all requested outputs have been saved.

--- a/core/prompts/writable.md
+++ b/core/prompts/writable.md
@@ -1,0 +1,3 @@
+## Declaring new outputs
+
+New outputs may be declared and added to the Save tool's checklist at any time using the DeclareOutput tool.

--- a/dagql/dagui/ordered_set.go
+++ b/dagql/dagui/ordered_set.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 )
 
-type OrderedSet[K, V comparable] struct {
+type OrderedSet[K comparable, V any] struct {
 	Order    []V
 	KeyFunc  func(V) K
 	LessFunc func(V, V) bool
@@ -21,7 +21,7 @@ func NewSet[T comparable]() *OrderedSet[T, T] {
 	}
 }
 
-func NewOrderedSet[K comparable, V comparable](keyFunc func(V) K, vs ...V) *OrderedSet[K, V] {
+func NewOrderedSet[K comparable, V any](keyFunc func(V) K, vs ...V) *OrderedSet[K, V] {
 	set := &OrderedSet[K, V]{
 		KeyFunc: keyFunc,
 	}
@@ -85,7 +85,7 @@ func (set *OrderedSet[K, V]) Remove(value V) bool {
 	delete(set.Map, key)
 	var removeIdx int
 	for i, v := range set.Order {
-		if v == value {
+		if set.KeyFunc(v) == key {
 			removeIdx = i
 			break
 		}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -21,7 +21,7 @@ dagger [options] [subcommand | file...]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
   -m, --mod string                   Module reference to load, either a local path or a remote git repo (defaults to current directory)
-      --model string                 LLM model to use (e.g., 'claude-sonnet-4-0', 'gpt-4.1')
+      --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
   -E, --no-exit                      Leave the TUI running after completion
   -M, --no-mod                       Don't automatically load a module (mutually exclusive with --mod)
       --progress string              Progress output format (auto, plain, tty, dots) (default "auto")

--- a/docs/current_docs/reference/configuration/llm.mdx
+++ b/docs/current_docs/reference/configuration/llm.mdx
@@ -24,7 +24,7 @@ OPENAI_API_KEY="op://Private/OpenAI API Key/password"
 ## Anthropic
 
 - `ANTHROPIC_API_KEY`: required
-- `ANTHROPIC_MODEL`: optional, defaults to `"claude-sonnet-4-0"`. See other [model name strings](https://docs.anthropic.com/en/docs/about-claude/models/all-models)
+- `ANTHROPIC_MODEL`: optional, defaults to `"claude-sonnet-4-5"`. See other [model name strings](https://docs.anthropic.com/en/docs/about-claude/models/all-models)
 
 ## OpenAI
 

--- a/modules/evals/main.go
+++ b/modules/evals/main.go
@@ -13,7 +13,7 @@ var SmartModels = []string{
 	"gemini-2.0-flash",
 	"claude-3-5-sonnet-latest",
 	"claude-3-7-sonnet-latest",
-	"claude-sonnet-4-0",
+	"claude-sonnet-4-5",
 }
 
 // Dagger's eval suite.

--- a/modules/evals/mcp_server.go
+++ b/modules/evals/mcp_server.go
@@ -39,7 +39,7 @@ func (e *ModelContextProtocol) Prompt(base *dagger.LLM) *dagger.LLM {
 		WithPrompt(`Please make the following changes to the workspace:
 
 1. Update the README.md file to add a "Getting Started" section with installation instructions
-2. Remove main.go - we don't need it anymore.
+2. Use Bash to rm main.go - we don't need it anymore.
 3. Create a new file called "config.json" with some basic configuration settings
 
 Make sure to use the file editing tools available through the MCP server to make these changes.`)

--- a/modules/evals/responses.go
+++ b/modules/evals/responses.go
@@ -27,7 +27,7 @@ func (e *Responses) Prompt(base *dagger.LLM) *dagger.LLM {
 			WithFileInput("hello_file",
 				dag.File("foo.txt", "Hello, world!"),
 				"The file to inspect.").
-			WithModuleSourceInput("module",
+			WithModuleSourceInput("my_module",
 				dag.ModuleSource("github.com/dagger/dagger-test-modules/llm-dir-module-depender"),
 				"The module source to inspect.").
 			WithDirectoryInput("some_dir",
@@ -36,7 +36,7 @@ func (e *Responses) Prompt(base *dagger.LLM) *dagger.LLM {
 					WithNewFile("file-2", ""),
 				"The directory to inspect.").
 			WithStringOutput("module_config_exists",
-				"Whether the module config exists (true/false).").
+				"Whether the module config exists for the my_module input (true/false).").
 			WithStringOutput("file_contents",
 				"The contents of the file.").
 			WithStringOutput("file_size",

--- a/modules/evals/writable.go
+++ b/modules/evals/writable.go
@@ -28,7 +28,9 @@ func (e *Writable) Prompt(base *dagger.LLM) *dagger.LLM {
 		})).
 		WithPrompt("Declare a new File output, `helloFile`, and save a new File to it with the contents 'Hello, world!'").
 		Loop().
-		WithPrompt("Declare a String output, `food`, and save the value 'potato'.")
+		WithPrompt("Declare a String output, `food`.").
+		Loop().
+		WithPrompt("Save the value 'potato' as `food`.")
 }
 
 func (e *Writable) Check(ctx context.Context, prompt *dagger.LLM) error {

--- a/modules/evals/writable.go
+++ b/modules/evals/writable.go
@@ -26,11 +26,11 @@ func (e *Writable) Prompt(base *dagger.LLM) *dagger.LLM {
 			Writable:   true,
 			Privileged: true,
 		})).
-		WithPrompt("Declare a new File output, `helloFile`, and save a new File to it with the contents 'Hello, world!'").
+		WithPrompt(`Create a new file, hello.txt, with the contents "Hello, world!".`).
 		Loop().
-		WithPrompt("Declare a String output, `food`.").
+		WithPrompt(`Save the File as a new output, "helloFile".`).
 		Loop().
-		WithPrompt("Save the value 'potato' as `food`.")
+		WithPrompt(`Now declare another output "food" of type String, and save it as "potato".`)
 }
 
 func (e *Writable) Check(ctx context.Context, prompt *dagger.LLM) error {

--- a/modules/evaluator/main.go
+++ b/modules/evaluator/main.go
@@ -49,7 +49,7 @@ type Evaluator struct {
 const MinSuccessRate = 0.8
 
 func New(
-	// The AI model name to use for the evaluator agent (e.g., "gpt-4o", "claude-sonnet-4-0").
+	// The AI model name to use for the evaluator agent (e.g., "gpt-4o", "claude-sonnet-4-5").
 	// If not specified, uses the default model configured in the environment.
 	// +optional
 	model string,

--- a/modules/evaluator/workspace/main.go
+++ b/modules/evaluator/workspace/main.go
@@ -54,7 +54,7 @@ var testedModels = []string{
 	"gpt-4.1",
 	// "qwen2.5-coder:14b",
 	"gemini-2.0-flash",
-	"claude-sonnet-4-0",
+	"claude-sonnet-4-5",
 }
 
 // Set the system prompt for future evaluations.


### PR DESCRIPTION
This started off as a simple bump to Claude Sonnet 4.5, which was released today: https://www.anthropic.com/news/claude-sonnet-4-5

But in doing so I wanted to make sure the evals were solid, which led to fixing a bunch of things, mostly driven by Gemini's limitations. I tried bumping Gemini to 2.5 Flash instead of 2.0 Flash, but it consistently hits `MALFORMED_FUNCTION_CALL` specifically for the MCP server case. That led me to un-namespacing the tool names, as one way that can happen is Gemini calling an unknown tool. That fixed things for 2.0 Flash, but 2.5 Flash continues to return the same error, with absolutely no indication as to why, even after inspecting the tool schemas. Incredibly frustrating.

Along the way it became clear that the recently added `Writable` eval was very turbulent on Gemini, owing to some nuance in how `Save` works, so I've essentially redesigned it, and now it's more solid.