### PR TITLE
core: fix exponential logs query

### DIFF
--- a/engine/clientdb/queries.sql
+++ b/engine/clientdb/queries.sql
@@ -133,7 +133,7 @@ WITH RECURSIVE descendant_spans AS (
   FROM spans s
   WHERE s.parent_span_id = @span_id
   UNION ALL
-  SELECT s.span_id
+  SELECT DISTINCT s.span_id
   FROM spans s
   INNER JOIN descendant_spans ds ON s.parent_span_id = ds.span_id
 )

--- a/engine/clientdb/queries.sql.go
+++ b/engine/clientdb/queries.sql.go
@@ -179,7 +179,7 @@ WITH RECURSIVE descendant_spans AS (
   FROM spans s
   WHERE s.parent_span_id = ?
   UNION ALL
-  SELECT s.span_id
+  SELECT DISTINCT s.span_id
   FROM spans s
   INNER JOIN descendant_spans ds ON s.parent_span_id = ds.span_id
 )


### PR DESCRIPTION
This query was causing a hang when calling a tool that had a somewhat significant amount of child spans. Adding a `DISTINCT` fixes the issue straight away.