### PR TITLE
test: use unique cache volume per sdk test

### DIFF
--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -119,7 +119,7 @@ defmodule Dagger.ClientTest do
   end
 
   test "container with mounted cache", %{dag: dag} do
-    cache_key = "example-cache"
+    cache_key = "example-cache-" <> Integer.to_string(Enum.random(1..1_000_000_000))
     filename = DateTime.utc_now() |> Calendar.strftime("%Y-%m-%d-%H-%M-%S")
 
     container =

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -2,6 +2,7 @@ package dagger_test
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"strconv"
 	"strings"
@@ -155,7 +156,7 @@ func ExampleContainer_WithMountedCache() {
 	}
 	defer client.Close()
 
-	cacheKey := "example-cache"
+	cacheKey := "example-cache-" + rand.Text()
 
 	cache := client.CacheVolume(cacheKey)
 

--- a/sdk/python/tests/client/test_integration.py
+++ b/sdk/python/tests/client/test_integration.py
@@ -1,4 +1,6 @@
 import pathlib
+import random
+import string
 from datetime import datetime
 from textwrap import dedent
 
@@ -105,7 +107,7 @@ async def test_container_with_mounted_directory(alpine_image: str):
 
 
 async def test_container_with_mounted_cache(alpine_image: str):
-    cache_key = "example-cache"
+    cache_key = "example-cache-" + "".join(random.choices(string.hexdigits, k=16))
     filename = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
     container = (


### PR DESCRIPTION
Otherwise, they run all over each other and create weird flakes.