### PR TITLE
llm: fix static tool calling scheme, add eval

### DIFF
--- a/modules/evals/main.go
+++ b/modules/evals/main.go
@@ -45,6 +45,7 @@ func (es *Evals) Check(
 		"basic",
 		"buildMulti",
 		"buildMultiNoVar",
+		"buildMultiStatic",
 		"workspacePattern",
 		"readImplicitVars",
 		"undoChanges",

--- a/modules/evals/static.go
+++ b/modules/evals/static.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"dagger/evals/internal/dagger"
+)
+
+// Test that BuildMulti works when configured with a static tool calling scheme.
+func (m *Evals) BuildMultiStatic() *BuildMultiStatic {
+	return &BuildMultiStatic{
+		BuildMulti: m.BuildMulti(),
+	}
+}
+
+type BuildMultiStatic struct {
+	*BuildMulti
+}
+
+func (e *BuildMultiStatic) Name() string {
+	return "BuildMultiStatic"
+}
+
+func (e *BuildMultiStatic) Prompt(base *dagger.LLM) *dagger.LLM {
+	return e.BuildMulti.Prompt(base).WithStaticTools()
+}


### PR DESCRIPTION
* Fix static method calling tools being discarded
* Add eval coverage, by just re-using the BuildMulti eval + assertion by configuring it for static calling (this worked out nicely!)