### PR TITLE
tui: limit change summary width

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -733,7 +733,7 @@ func handleChangesetResponse(ctx context.Context, dag *dagger.Client, response a
 			return nil
 		}
 
-		return idtui.SummarizePatch(idtui.NewOutput(&summary), patch, -1)
+		return idtui.SummarizePatch(idtui.NewOutput(&summary), patch, 50)
 	})(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Helps avoid this scenario:

<img width="2445" height="1216" alt="image" src="https://github.com/user-attachments/assets/ef0b916b-2c3d-4466-bcde-7d9b2338ca61" />
