### PR TITLE
bump midterm for panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
-	github.com/vito/midterm v0.2.2
+	github.com/vito/midterm v0.2.3
 	github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d
 	github.com/zeebo/xxh3 v1.0.2
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,8 @@ github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+G
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=
 github.com/vito/go-sse v1.1.3/go.mod h1:kMjgO+XCwBS0se2X/aS5T4aLBvHWAKOUqZOqXKdyrAg=
-github.com/vito/midterm v0.2.2 h1:Uo+nk1n/GYbh29Ha0y+NdIfMuzcUyTvRreurs4YQLYM=
-github.com/vito/midterm v0.2.2/go.mod h1:WkbqZBIhH4jfxXkE2bjhosM1BdF/dCp7sR4x9wQB6fA=
+github.com/vito/midterm v0.2.3 h1:UgukMrLJP/ALIcXxf7dm4YvRriZKil3mFCGVoX5gPJM=
+github.com/vito/midterm v0.2.3/go.mod h1:WkbqZBIhH4jfxXkE2bjhosM1BdF/dCp7sR4x9wQB6fA=
 github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d h1:xQcF7b7cZLWZG/+7A4G7un1qmEDYHIvId9qxRS1mZMs=
 github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d/go.mod h1:BzSc3WEF8R+lCaP5iGFRxd5kIXy4JKOZAwNe1w0cdc0=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=


### PR DESCRIPTION
fixes #11157

repro:

```sh
dagger-dev -M -c 'container | from alpine | with-exec vi /foo'
```

This doesn't actually _work_ since it just runs `vi` which realizes it has no stdin and exits. But it doesn't panic anymore.