### PR TITLE
telemetry: don't print IDs

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -271,6 +271,8 @@ func logResult(ctx context.Context, res dagql.AnyResult, self dagql.AnyObjectRes
 	}
 	if str, ok := dagql.UnwrapAs[dagql.String](res); ok {
 		fmt.Fprint(stdio.Stdout, str)
+	} else if _, ok := dagql.UnwrapAs[dagql.IDType](res); ok {
+		// Don't print IDs; they can get quite large
 	} else if lit, ok := dagql.UnwrapAs[call.Literate](res); ok {
 		fmt.Fprint(stdio.Stdout, lit.ToLiteral().Display())
 	}


### PR DESCRIPTION
Tiny tweak to avoid this behavior: https://dagger.cloud/vito/traces/1dcacb86a7f118f881acdeab4af72d38?span=63724b6fc580ade5

<img width="2345" height="600" alt="image" src="https://github.com/user-attachments/assets/d08f51d0-6826-4306-b01f-1ebe283d360b" />

Post-fix: https://dagger.cloud/vito/traces/1489bd1c14f3efb73b4af764d9b6bf11?span=8ec435fcdc2ee4b3

<img width="1536" height="124" alt="image" src="https://github.com/user-attachments/assets/cd5734b4-8f49-4422-a7a8-dde3e53fbaae" />
