### PR TITLE
chore: lift nil output detection to custom op

### DIFF
--- a/core/dagop.go
+++ b/core/dagop.go
@@ -869,15 +869,6 @@ func extractContainerBkOutputs(ctx context.Context, container *Container, bk *bu
 		}
 		outputs[mount.Output] = ref
 	}
-	for i, output := range outputs {
-		if output == nil {
-			// this *shouldn't* happen, and means we've got somehow got gaps in
-			// the output araray. the mounts are therefore badly constructed,
-			// so we should error out. otherwise we'll get weird panics deep in
-			// buildkit that are near impossible to debug.
-			return nil, fmt.Errorf("internal: output %d was empty", i)
-		}
-	}
 
 	return outputs, nil
 }

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -862,6 +862,8 @@ func extractContainerBkOutputs(ctx context.Context, container *Container, bk *bu
 				ref, err = getResult(mnt.DirectorySource.Self().LLB, mnt.DirectorySource.Self().Result)
 			case mnt.FileSource != nil:
 				ref, err = getResult(mnt.FileSource.Self().LLB, mnt.FileSource.Self().Result)
+			default:
+				err = fmt.Errorf("mount %d has no source", mountIdx)
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
cc @marcosnils 

Got this far investigating the weird `nil` issues.

I think this is due to something wrong in a dagop somewhere. I *suspect* `LLB` and `Result` on a single `Directory` are somehow ending up `nil`, but I can't *quite* work out what that is.

This should help debug the issue though:
- We'll get an error, which should propagate to a specific schema handler, so we're able to reproduce more easily.
- We'll get some more detailed logs.