### PR TITLE
ci: update all github runners to 0.19.0

### DIFF
--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -15,7 +15,7 @@ on:
       dagger:
         description: "Dagger version"
         type: string
-        default: "0.18.11"
+        default: "0.19.0"
         required: false
       ubuntu:
         description: "Ubuntu version"

--- a/.github/workflows/benchmark-engine.yml
+++ b/.github/workflows/benchmark-engine.yml
@@ -23,7 +23,7 @@ jobs:
   benchdev:
     if: ${{ github.repository == 'dagger/dagger' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')) }}
     runs-on:
-        - 'dagger-g3-v0-18-19-16c-st-benchmark'
+        - 'dagger-g3-v0-19-0-16c-st-benchmark'
     timeout-minutes: 10
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g3-v0-18-19-16c-st
+    runs-on: dagger-g3-v0-19-0-16c-st
     steps:
       - uses: actions/checkout@v4
       - name: "Publish"
@@ -89,7 +89,7 @@ jobs:
   dagger-io-bump-dagger:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g3-v0-18-19-4c
+    runs-on: dagger-g3-v0-19-0-4c
     steps:
       # Configure credentials to clone dagger modules
       - uses: de-vri-es/setup-git-credentials@v2


### PR DESCRIPTION
Looks like this was missed during https://github.com/dagger/dagger/pull/11150.

There are still a few versions that need manually bumping and aren't automated.

This was causing publish to fail on main.