### PR TITLE
docs: move kubernetes and openshift to deployment url

### DIFF
--- a/docs/current_docs/reference/deployment/kubernetes.mdx
+++ b/docs/current_docs/reference/deployment/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Learn how to deploy Dagger on a Kubernetes cluster."
-slug: /reference/container-runtimes/kubernetes
+slug: /reference/deployment/kubernetes
 ---
 
 # Kubernetes

--- a/docs/current_docs/reference/deployment/openshift.mdx
+++ b/docs/current_docs/reference/deployment/openshift.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenShift
 sidebar_label: OpenShift
-slug: /reference/container-runtimes/openshift
+slug: /reference/deployment/openshift
 description: "Learn how to run Dagger Engine on OpenShift."
 ---
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1325,6 +1325,16 @@
 
 ## end: wildcard redirects ##
 
+[[redirects]]
+  from = "/reference/container-runtimes/kubernetes"
+  to = "/reference/deployment/kubernetes"
+  status = 301
+
+[[redirects]]
+  from = "/reference/container-runtimes/openshift"
+  to = "/reference/deployment/openshift"
+  status = 301
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
During https://github.com/dagger/dagger/pull/11128, we moved the Kubernetes and OpenShift pages to a new Deployment section, which fits them better. See the justification here: https://github.com/dagger/dagger/pull/11128#discussion_r2379448890.

However, I didn't update the slugs, so the pages were still at the same place.

This patch moves them to the new locations, and updates the redirects.