### PR TITLE
PHP: Store test results in .cache directory

### DIFF
--- a/sdk/php/.gitignore
+++ b/sdk/php/.gitignore
@@ -1,9 +1,8 @@
-/vendor/
+.cache/
+vendor/
 
-/.php-cs-fixer.php
-/.php-cs-fixer.cache
+.php-cs-fixer.php
+.php-cs-fixer.cache
+phpunit.xml
 
-.phpunit.result.cache
-/phpunit.xml
-
-/docker-compose.override.yml
+docker-compose.override.yml

--- a/sdk/php/dagger.json
+++ b/sdk/php/dagger.json
@@ -5,7 +5,8 @@
     "source": "go"
   },
   "include": [
-    "!vendor/"
+    "!vendor/",
+    "!.cache/"
   ],
   "source": "runtime"
 }

--- a/sdk/php/phpunit.xml.dist
+++ b/sdk/php/phpunit.xml.dist
@@ -1,20 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" failOnRisky="true" failOnWarning="true">
-  <php>
-    <ini name="error_reporting" value="-1"/>
-  </php>
-  <testsuites>
-    <testsuite name="dagger-php-sdk">
-      <directory>./tests/</directory>
-    </testsuite>
-  </testsuites>
-  <groups>
-    <exclude>
-      <group>functional</group>
-    </exclude>
-  </groups>
-  <coverage/>
-  <source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".cache/phpunit"
+         colors="true"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+  <source ignoreIndirectDeprecations="true"
+          restrictNotices="true"
+          restrictWarnings="true">
     <include>
       <directory>./src</directory>
       <directory>./generated</directory>


### PR DESCRIPTION
Tweaks PHPUnit config to use a .cache/ directory

The idea is to transition each CI tool's cache to this directory, minimizing boilerplate ignores and excludes elsewhere (i.e. dagger.jsons, Ignore decorators, .gitignores)



