### PR TITLE
fix(python_sdk): register all enum members and add introspection test

### DIFF
--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -221,7 +221,7 @@ class Module:
                     value=str(member.value),
                     description=description,
                 )
-            mod = mod.with_enum(enum_def)
+        mod = mod.with_enum(enum_def)
 
         return await mod.id()
 


### PR DESCRIPTION
Fix `Module._register` so we add the enum once after building all members. Before this, only the first value (GO) ever showed up. Dropped in a Python integration test that introspects the module and expects all Language members, so we’ll catch it next time.