### PR TITLE
fix handling of private images in terminal

### DIFF
--- a/.changes/unreleased/Fixed-20251007-171917.yaml
+++ b/.changes/unreleased/Fixed-20251007-171917.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fixed engine crash when container sourced from private image was used with terminal
+  or as a service (and was not already cached in the engine).
+time: 2025-10-07T17:19:17.840364128-07:00
+custom:
+  Author: sipsma
+  PR: "11198"

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -2287,7 +2287,7 @@ func (ServiceSuite) TestServiceFromUncachedPrivateImage(ctx context.Context, t *
 			"engine", "local-cache", "prune",
 		)).
 		With(daggerNonNestedExec("-c",
-			"container | from "+alpineImage+" | with-service-binding idc $(container | from "+privateImageRef+" | as-service) | with-exec apk add curl | with-exec curl http://idc | stdout",
+			"container | from "+alpineImage+" | with-service-binding idc $(container | from "+privateImageRef+" | with-exposed-port 80 | as-service) | with-exec apk add curl | with-exec curl http://idc | stdout",
 		))
 
 	out, err := ctr.Stdout(ctx)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -30,7 +30,9 @@ import (
 	"text/template"
 	"time"
 
+	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/dagger/dagger/internal/buildkit/identity"
+	resolverconfig "github.com/dagger/dagger/internal/buildkit/util/resolver/config"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -2229,6 +2231,68 @@ func (ServiceSuite) TestSearchDomainAlwaysSet(ctx context.Context, t *testctx.T)
 		}
 	}
 	require.True(t, found)
+}
+
+func (ServiceSuite) TestServiceFromUncachedPrivateImage(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const htpasswd = "john:$2y$05$/iP8ud0Fs8o3NLlElyfVVOp6LesJl3oRLYoc3neArZKWX10OhynSC"
+	privateRegistrySvc := c.Container().
+		From("registry:2").
+		WithNewFile("/auth/htpasswd", htpasswd).
+		WithEnvVariable("REGISTRY_AUTH", "htpasswd").
+		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_REALM", "Registry Realm").
+		WithEnvVariable("REGISTRY_AUTH_HTPASSWD_PATH", "/auth/htpasswd").
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
+
+	engineSvc := devEngineContainerAsService(devEngineContainer(c,
+		func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithServiceBinding("registry", privateRegistrySvc)
+		},
+		engineWithBkConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg bkconfig.Config) bkconfig.Config {
+			cfg.Registries = map[string]resolverconfig.RegistryConfig{
+				"registry:5000": {
+					PlainHTTP: ptr(true),
+				},
+			}
+			return cfg
+		}),
+	))
+
+	const authFile = `{
+        "auths": {
+                "registry:5000": {
+                        "auth": "am9objp4RmxlamFQZGpydDI1RHZy"
+                }
+        }
+}`
+
+	privateImageRef := "registry:5000/test:latest"
+	ctr := engineClientContainer(ctx, t, c, engineSvc).
+		WithNewFile("/docker/config.json", authFile).
+		WithEnvVariable("DOCKER_CONFIG", "/docker").
+		With(daggerNonNestedExec("core",
+			"container",
+			"from", "--address", busyboxImage,
+			"with-workdir", "--path", "/srv",
+			"with-new-file", "--path", "index.html", "--contents", "yoyoyo",
+			"with-default-args", "--args", "httpd,-v,-f",
+			"with-exposed-port", "--port", "80",
+			"publish", "--address", privateImageRef,
+		)).
+		// prune the engine to ensure it's not cached no mo
+		With(daggerNonNestedExec("core",
+			"engine", "local-cache", "prune",
+		)).
+		With(daggerNonNestedExec("-c",
+			"container | from "+alpineImage+" | with-service-binding idc $(container | from "+privateImageRef+" | as-service) | with-exec apk add curl | with-exec curl http://idc | stdout",
+		))
+
+	out, err := ctr.Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "yoyoyo", strings.TrimSpace(out))
 }
 
 func httpService(ctx context.Context, t testing.TB, c *dagger.Client, content string) (*dagger.Service, string) {


### PR DESCRIPTION
Fixes #11195 

The terminal implementation was not providing a session group when creating new mounts. This meant that if an input mount was derived from a still-lazy private image, no auth was available and pulling the image would fail.

This was exacerbated by a missing check for `err != nil`, which meant we went ahead and tried to start the container even though all the mounts were nil, which crashed the engine.

---

Added integ test coverage now too