### PR TITLE
feat: add `Changeset.isEmpty`

### DIFF
--- a/.changes/unreleased/Added-20251015-095633.yaml
+++ b/.changes/unreleased/Added-20251015-095633.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |
+    New `Changeset.isEmpty` API
+time: 2025-10-15T09:56:33.082981011-07:00
+custom:
+    Author: jedevc
+    PR: "11237"

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -961,3 +961,41 @@ func (ChangesetSuite) testChangeApplying(t *testctx.T, apply func(*dagger.Direct
 		require.Empty(t, exists2) // Should be empty
 	})
 }
+
+func (ChangesetSuite) TestEmpty(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseDir := c.Directory().
+		WithNewFile("file.txt", "content")
+
+	// empty
+	empty, err := baseDir.Changes(baseDir).IsEmpty(ctx)
+	require.NoError(t, err)
+	require.True(t, empty)
+
+	// empty - added + removed
+	addedAndRemovedDir := baseDir.
+		WithNewFile("newfile.txt", "new").
+		WithoutFile("newfile.txt")
+	empty, err = addedAndRemovedDir.Changes(baseDir).IsEmpty(ctx)
+	require.NoError(t, err)
+	require.True(t, empty)
+
+	// not empty - modified
+	modifiedDir := baseDir.WithNewFile("file.txt", "modified")
+	empty, err = modifiedDir.Changes(baseDir).IsEmpty(ctx)
+	require.NoError(t, err)
+	require.False(t, empty)
+
+	// not empty - added
+	addedDir := baseDir.WithNewFile("newfile.txt", "new")
+	empty, err = addedDir.Changes(baseDir).IsEmpty(ctx)
+	require.NoError(t, err)
+	require.False(t, empty)
+
+	// not empty - removed
+	removedDir := baseDir.WithoutFile("file.txt")
+	empty, err = removedDir.Changes(baseDir).IsEmpty(ctx)
+	require.NoError(t, err)
+	require.False(t, empty)
+}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -204,6 +204,9 @@ type Changeset {
   """A unique identifier for this Changeset."""
   id: ChangesetID!
 
+  """Returns true if the changeset is empty (i.e. there are no changes)."""
+  isEmpty: Boolean!
+
   """Return a snapshot containing only the created and modified files"""
   layer: Directory!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4936,6 +4936,10 @@
                         <td> A unique identifier for this Changeset. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="Changeset-isEmpty" href="#Changeset-isEmpty"><code>isEmpty</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
+                        <td> Returns true if the changeset is empty (i.e. there are no changes). </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="Changeset-layer" href="#Changeset-layer"><code>layer</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td> Return a snapshot containing only the created and modified files </td>
                       </tr>

--- a/docs/static/reference/php/Dagger/Changeset.html
+++ b/docs/static/reference/php/Dagger/Changeset.html
@@ -203,6 +203,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    bool
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_isEmpty">isEmpty</a>()
+        
+                                            <p><p>Returns true if the changeset is empty (i.e. there are no changes).</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -539,8 +549,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_layer">
+                    <h3 id="method_isEmpty">
         <div class="location">at line 74</div>
+        <code>                    bool
+    <strong>isEmpty</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Returns true if the changeset is empty (i.e. there are no changes).</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>bool</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_layer">
+        <div class="location">at line 83</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>layer</strong>()
         </code>
@@ -572,7 +614,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_modifiedPaths">
-        <div class="location">at line 83</div>
+        <div class="location">at line 92</div>
         <code>                    array
     <strong>modifiedPaths</strong>()
         </code>
@@ -604,7 +646,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_removedPaths">
-        <div class="location">at line 92</div>
+        <div class="location">at line 101</div>
         <code>                    array
     <strong>removedPaths</strong>()
         </code>
@@ -636,7 +678,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 101</div>
+        <div class="location">at line 110</div>
         <code>                    <a href="../Dagger/ChangesetId.html"><abbr title="Dagger\ChangesetId">ChangesetId</abbr></a>
     <strong>sync</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -581,7 +581,9 @@
 <abbr title="Dagger\CacheVolume">CacheVolume</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a></em></dt>
                     <dd><p>A unique identifier for this CacheVolume.</p></dd><dt><a href="Dagger/Changeset.html#method_id">
 <abbr title="Dagger\Changeset">Changeset</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
-                    <dd><p>A unique identifier for this Changeset.</p></dd><dt><a href="Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a> &mdash; <em>Class in namespace <a href="Dagger/Client.html">Dagger\Client</a></em></dt>
+                    <dd><p>A unique identifier for this Changeset.</p></dd><dt><a href="Dagger/Changeset.html#method_isEmpty">
+<abbr title="Dagger\Changeset">Changeset</abbr>::isEmpty</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
+                    <dd><p>Returns true if the changeset is empty (i.e. there are no changes).</p></dd><dt><a href="Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a> &mdash; <em>Class in namespace <a href="Dagger/Client.html">Dagger\Client</a></em></dt>
                     <dd></dd><dt><a href="Dagger/Client/IdAble.html#method_id">
 <abbr title="Dagger\Client\IdAble">IdAble</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a></em></dt>
                     <dd></dd><dt><a href="Dagger/Cloud.html#method_id">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1551,6 +1551,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Changeset::isEmpty",
+			"p": "Dagger/Changeset.html#method_isEmpty",
+			"d": "<p>Returns true if the changeset is empty (i.e. there are no changes).</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Changeset::layer",
 			"p": "Dagger/Changeset.html#method_layer",
 			"d": "<p>Return a snapshot containing only the created and modified files</p>"

--- a/sdk/elixir/lib/dagger/gen/changeset.ex
+++ b/sdk/elixir/lib/dagger/gen/changeset.ex
@@ -91,6 +91,17 @@ defmodule Dagger.Changeset do
   end
 
   @doc """
+  Returns true if the changeset is empty (i.e. there are no changes).
+  """
+  @spec empty?(t()) :: {:ok, boolean()} | {:error, term()}
+  def empty?(%__MODULE__{} = changeset) do
+    query_builder =
+      changeset.query_builder |> QB.select("isEmpty")
+
+    Client.execute(changeset.client, query_builder)
+  end
+
+  @doc """
   Return a snapshot containing only the created and modified files
   """
   @spec layer(t()) :: Dagger.Directory.t()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -868,9 +868,10 @@ func (r *CacheVolume) MarshalJSON() ([]byte, error) {
 type Changeset struct {
 	query *querybuilder.Selection
 
-	export *string
-	id     *ChangesetID
-	sync   *ChangesetID
+	export  *string
+	id      *ChangesetID
+	isEmpty *bool
+	sync    *ChangesetID
 }
 
 func (r *Changeset) WithGraphQLQuery(q *querybuilder.Selection) *Changeset {
@@ -968,6 +969,19 @@ func (r *Changeset) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// Returns true if the changeset is empty (i.e. there are no changes).
+func (r *Changeset) IsEmpty(ctx context.Context) (bool, error) {
+	if r.isEmpty != nil {
+		return *r.isEmpty, nil
+	}
+	q := r.query.Select("isEmpty")
+
+	var response bool
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // Return a snapshot containing only the created and modified files

--- a/sdk/php/generated/Changeset.php
+++ b/sdk/php/generated/Changeset.php
@@ -69,6 +69,15 @@ class Changeset extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Returns true if the changeset is empty (i.e. there are no changes).
+     */
+    public function isEmpty(): bool
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('isEmpty');
+        return (bool)$this->queryLeaf($leafQueryBuilder, 'isEmpty');
+    }
+
+    /**
      * Return a snapshot containing only the created and modified files
      */
     public function layer(): Directory

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -997,6 +997,25 @@ class Changeset(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(ChangesetID)
 
+    async def is_empty(self) -> bool:
+        """Returns true if the changeset is empty (i.e. there are no changes).
+
+        Returns
+        -------
+        bool
+            The `Boolean` scalar type represents `true` or `false`.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("isEmpty", _args)
+        return await _ctx.execute(bool)
+
     def layer(self) -> "Directory":
         """Return a snapshot containing only the created and modified files"""
         _args: list[Arg] = []

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2266,6 +2266,11 @@ impl Changeset {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Returns true if the changeset is empty (i.e. there are no changes).
+    pub async fn is_empty(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("isEmpty");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Return a snapshot containing only the created and modified files
     pub fn layer(&self) -> Directory {
         let query = self.selection.select("layer");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2686,6 +2686,7 @@ export class CacheVolume extends BaseClient {
 export class Changeset extends BaseClient {
   private readonly _id?: ChangesetID = undefined
   private readonly _export?: string = undefined
+  private readonly _isEmpty?: boolean = undefined
   private readonly _sync?: ChangesetID = undefined
 
   /**
@@ -2695,12 +2696,14 @@ export class Changeset extends BaseClient {
     ctx?: Context,
     _id?: ChangesetID,
     _export?: string,
+    _isEmpty?: boolean,
     _sync?: ChangesetID,
   ) {
     super(ctx)
 
     this._id = _id
     this._export = _export
+    this._isEmpty = _isEmpty
     this._sync = _sync
   }
 
@@ -2766,6 +2769,21 @@ export class Changeset extends BaseClient {
     const ctx = this._ctx.select("export", { path })
 
     const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * Returns true if the changeset is empty (i.e. there are no changes).
+   */
+  isEmpty = async (): Promise<boolean> => {
+    if (this._isEmpty) {
+      return this._isEmpty
+    }
+
+    const ctx = this._ctx.select("isEmpty")
+
+    const response: Awaited<boolean> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
Adds a shorthand `Changeset.empty` which can now be used to check if the Changeset has any patches to apply.

TODO:
- [x] Tests
- [x] Implementation should check the patch (the paths have false positives because of overlay semantics)