### PR TITLE
feat: auto apply changeset with -y

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -332,6 +332,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")
 	flags.BoolVarP(&noExit, "no-exit", "E", false, "Leave the TUI running after completion")
+	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
 
 	flags.StringVar(&dotOutputFilePath, "dot-output", "", "If set, write the calls made during execution to a dot file at the given path before exiting")
 	flags.StringVar(&dotFocusField, "dot-focus-field", "", "In dot output, filter out vertices that aren't this field or descendents of this field")

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -55,6 +55,8 @@ var (
 	noSelfCalls bool
 
 	force bool
+
+	autoApply bool
 )
 
 const (

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -16,6 +16,7 @@ dagger [options] [subcommand | file...]
 
 ```
       --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -c, --command string               Execute a dagger shell command
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -69,6 +70,7 @@ dagger call [options]
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -114,6 +116,7 @@ dagger config -m github.com/dagger/hello-dagger
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -147,6 +150,7 @@ dagger core [options]
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -207,6 +211,7 @@ dagger develop [options]
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -248,6 +253,7 @@ dagger functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -311,6 +317,7 @@ dagger init --sdk=go
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -356,6 +363,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -382,6 +390,7 @@ dagger login [options] [org]
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -408,6 +417,7 @@ dagger logout
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -472,6 +482,7 @@ EOF
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -531,6 +542,7 @@ dagger run python main.py
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -575,6 +587,7 @@ dagger uninstall hello
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -624,6 +637,7 @@ dagger update [options] [<DEPENDENCY>...]
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -656,6 +670,7 @@ dagger version
 ### Options inherited from parent commands
 
 ```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")


### PR DESCRIPTION
On dagger call, with `-y` or `--auto-apply`, returned `changeset` will be automatically applied without to ask the user.

For instance

    dagger -y call build