### PR TITLE
fix(typescript-sdk): use `npm install` instead of `npm ci`

### DIFF
--- a/sdk/typescript/runtime/module.go
+++ b/sdk/typescript/runtime/module.go
@@ -231,17 +231,17 @@ func (m *moduleRuntimeContainer) withInstalledDependencies() *moduleRuntimeConta
 	case Yarn:
 		if semver.Compare(fmt.Sprintf("v%s", m.cfg.packageManagerVersion), "v3.0.0") <= 0 {
 			m.ctr = m.ctr.
-				WithExec([]string{"yarn", "install", "--frozen-lockfile", "--prod"})
+				WithExec([]string{"yarn", "install", "--prod"})
 			break
 		}
 
-		m.ctr = m.ctr.WithExec([]string{"yarn", "install", "--immutable"})
+		m.ctr = m.ctr.WithExec([]string{"yarn", "install"})
 	case Pnpm:
 		m.ctr = m.ctr.
-			WithExec([]string{"pnpm", "install", "--frozen-lockfile", "--shamefully-hoist=true", "--prod"})
+			WithExec([]string{"pnpm", "install", "--shamefully-hoist=true", "--prod"})
 	case Npm:
 		m.ctr = m.ctr.
-			WithExec([]string{"npm", "ci", "--omit=dev"})
+			WithExec([]string{"npm", "install", "--omit=dev"})
 	case BunManager:
 		m.ctr = m.ctr.
 			WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--omit=dev", "--omit=peer", "--omit=optional"})


### PR DESCRIPTION
Fixes an issue raised by @tiborvass  about module execution. `npm ci` would lead to a failure if the package.lock is out of date. That can happen for old modules that haven't been updated.

This can also happen for other package managers so we also disable it.

Benchmark shows a performance drawback of 3% with that changes. It's acceptable

<details>
<summary>Benchmarks</summary>


**Yarn**

```
                                        │ .ts-missmatch-main/node-yarn.txt │   .ts-missmatch-dev/node-yarn.txt   │
                                        │               s/op               │    s/op      vs base                │
NodeYarn/develop/develop                                       7.500 ± 25%   8.000 ± 21%       ~ (p=0.556 n=8)
NodeYarn/develop/cmdDuration                                   9.650 ± 60%   9.150 ± 72%       ~ (p=0.742 n=8)
NodeYarn/functions/cmdDuration                                 10.55 ± 60%   13.60 ± 39%       ~ (p=0.666 n=8)
NodeYarn/call/loadModule                                      12.000 ± 35%   9.150 ± 92%       ~ (p=0.858 n=8)
NodeYarn/call/containerEcho                                    2.700 ± 19%   2.600 ±  8%       ~ (p=0.759 n=7+8)
NodeYarn/call/cmdDuration                                      15.25 ± 32%   12.05 ± 68%       ~ (p=0.936 n=8)
NodeYarn/init/generatedContextDirectory                        7.550 ± 18%   8.100 ± 12%       ~ (p=0.291 n=8)
NodeYarn/init/cmdDuration                                      11.90 ± 45%   15.65 ± 48%       ~ (p=0.442 n=8)
NodeYarn/functions/loadModule                                  10.45 ± 61%   13.50 ± 39%       ~ (p=0.721 n=8)
geomean                                                        8.911         9.235        +3.63%

```

**Npm**

```
                                       │              s/op               │    s/op      vs base                │
NodeNpm/call/containerEcho                                   2.650 ± 17%   2.600 ± 12%       ~ (p=0.347 n=8+7)
NodeNpm/call/loadModule                                     12.100 ± 36%   9.200 ± 92%       ~ (p=1.000 n=8)
NodeNpm/call/cmdDuration                                     15.45 ± 33%   12.05 ± 68%       ~ (p=0.936 n=8)
NodeNpm/init/cmdDuration                                     11.95 ± 43%   15.55 ± 46%       ~ (p=0.382 n=8)
NodeNpm/develop/develop                                      7.600 ± 22%   8.050 ± 23%       ~ (p=0.667 n=8)
NodeNpm/init/generatedContextDirectory                       7.600 ± 18%   8.300 ± 12%       ~ (p=0.267 n=8)
NodeNpm/develop/cmdDuration                                  9.750 ± 59%   9.150 ± 74%       ~ (p=0.740 n=8)
NodeNpm/functions/loadModule                                 10.45 ± 59%   13.50 ± 39%       ~ (p=0.521 n=8)
NodeNpm/functions/cmdDuration                                10.50 ± 58%   13.60 ± 39%       ~ (p=0.505 n=8)
geomean                                                      8.943         9.265        +3.60%
```


**Pnpm**

```
                                        │ .ts-missmatch-main/node-pnpm.txt │   .ts-missmatch-dev/node-pnpm.txt   │
                                        │               s/op               │    s/op      vs base                │
NodePnpm/init/generatedContextDirectory                        7.550 ± 18%   8.350 ± 11%       ~ (p=0.224 n=8)
NodePnpm/init/cmdDuration                                      11.90 ± 45%   15.60 ± 46%       ~ (p=0.368 n=8)
NodePnpm/functions/loadModule                                  10.30 ± 60%   13.60 ± 39%       ~ (p=0.665 n=8)
NodePnpm/call/containerEcho                                    2.600 ± 27%   2.500 ±  8%       ~ (p=0.462 n=7+8)
NodePnpm/develop/develop                                       7.600 ± 20%   8.000 ± 22%       ~ (p=0.458 n=8)
NodePnpm/develop/cmdDuration                                   9.700 ± 59%   9.050 ± 75%       ~ (p=0.721 n=8)
NodePnpm/functions/cmdDuration                                 10.40 ± 60%   13.65 ± 38%       ~ (p=0.593 n=8)
NodePnpm/call/loadModule                                      12.100 ± 36%   9.150 ± 93%       ~ (p=0.959 n=8)
NodePnpm/call/cmdDuration                                      15.45 ± 34%   12.05 ± 68%       ~ (p=0.938 n=8)
geomean                                                        8.884         9.222        +3.80%
```

**Deno**

```
                                    │ .ts-missmatch-main/deno.txt │    .ts-missmatch-dev/deno.txt     │
                                    │            s/op             │    s/op      vs base              │
Deno/init/generatedContextDirectory                   2.850 ± 26%   2.850 ± 16%       ~ (p=0.857 n=8)
Deno/init/cmdDuration                                 3.050 ± 28%   3.000 ± 13%       ~ (p=0.878 n=8)
Deno/develop/develop                                  2.750 ± 20%   2.550 ± 18%       ~ (p=0.737 n=8)
Deno/call/containerEcho                               1.950 ± 13%   1.800 ±  6%       ~ (p=0.109 n=8)
Deno/call/cmdDuration                                 8.550 ±  8%   7.950 ±  6%       ~ (p=0.110 n=8)
Deno/develop/cmdDuration                              2.850 ± 19%   2.650 ± 17%       ~ (p=0.646 n=8)
Deno/functions/loadModule                             6.450 ± 19%   6.500 ± 12%       ~ (p=0.701 n=8)
Deno/functions/cmdDuration                            6.500 ± 20%   6.600 ± 12%       ~ (p=0.661 n=8)
Deno/call/loadModule                                  6.450 ± 12%   6.100 ±  7%       ~ (p=0.334 n=8)
geomean                                               4.071         3.916        -3.82%
```

**Bun**

```
                                   │ .ts-missmatch-main/bun.txt │     .ts-missmatch-dev/bun.txt     │
                                   │            s/op            │    s/op      vs base              │
Bun/develop/cmdDuration                             3.950 ± 14%   3.800 ± 11%       ~ (p=0.938 n=8)
Bun/call/containerEcho                              1.900 ±  5%   1.900 ± 11%       ~ (p=0.676 n=8)
Bun/init/generatedContextDirectory                  4.250 ± 32%   4.350 ± 22%       ~ (p=0.893 n=8)
Bun/init/cmdDuration                                4.450 ± 66%   5.000 ± 44%       ~ (p=0.776 n=8)
Bun/functions/loadModule                            6.400 ± 28%   6.000 ± 17%       ~ (p=0.979 n=8)
Bun/functions/cmdDuration                           6.450 ± 27%   6.050 ± 16%       ~ (p=0.939 n=8)
Bun/call/loadModule                                 5.600 ± 16%   5.350 ± 42%       ~ (p=0.894 n=8)
Bun/call/cmdDuration                                7.600 ± 13%   7.400 ± 27%       ~ (p=0.900 n=8)
Bun/develop/develop                                 3.850 ± 14%   3.700 ±  8%       ~ (p=0.857 n=8)
geomean                                             4.621         4.550        -1.54%
```

</details>

