### PR TITLE
ts: skip extremely slow npm install step when possible

### DIFF
--- a/sdk/typescript/runtime/config.go
+++ b/sdk/typescript/runtime/config.go
@@ -32,7 +32,10 @@ const (
 const (
 	PnpmDefaultVersion = "8.15.4"
 	YarnDefaultVersion = "1.22.22"
-	NpmDefaultVersion  = "10.7.0"
+
+	// NOTE: when changing this version, check if the `DefaultNodeVersion` var in sdk/typescript/runtime/tsdistconsts/consts.go
+	// should be updated to an image that has the same version of npm pre-installed in the container
+	NpmDefaultVersion = "10.9.0"
 )
 
 type SDKLibOrigin string

--- a/sdk/typescript/runtime/module.go
+++ b/sdk/typescript/runtime/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"typescript-sdk/internal/dagger"
 	"typescript-sdk/tsdistconsts"
@@ -188,7 +189,7 @@ func (m *moduleRuntimeContainer) withSetupPackageManager() *moduleRuntimeContain
 		}
 	case Npm:
 		m.ctr = m.ctr.
-			WithExec([]string{"npm", "install", "-g", fmt.Sprintf("npm@%s", version)})
+			WithExec([]string{"sh", "-c", "npm -v | grep -qx " + strings.ReplaceAll(version, ".", `\.`) + " || npm install -g npm@" + version})
 	}
 
 	return m

--- a/sdk/typescript/runtime/tsdistconsts/consts.go
+++ b/sdk/typescript/runtime/tsdistconsts/consts.go
@@ -1,6 +1,8 @@
 package tsdistconsts
 
 const (
+	// NOTE: when changing this version, check if the `NpmDefaultVersion` var in sdk/typescript/runtime/config.go
+	// should be updated to match the version of npm pre-installed in this container
 	DefaultNodeVersion  = "22.11.0" // LTS version, JOD (https://nodejs.org/en/about/previous-releases)
 	nodeImageDigest     = "sha256:b64ced2e7cd0a4816699fe308ce6e8a08ccba463c757c00c14cd372e3d2c763e"
 	DefaultNodeImageRef = "node:" + DefaultNodeVersion + "-alpine@" + nodeImageDigest


### PR DESCRIPTION
Rather than re-using the `npm` already installed in the node base container, we were re-installing it every time, which took 40s. The cache is invalidated whenever anything in the module dependency/package manager config changes and also isn't shared across modules, so this made ts module init extremely slow.

Seems to make an absurd difference in init times, [before](https://dagger.cloud/dagger/traces/2370e52a7e688d2bfac3f01196011429) (1m50s) + [after](https://dagger.cloud/dagger/traces/f559d15bd7de6339672c379279e015e3) (56s)