### PR TITLE
feat: add Module.call

### DIFF
--- a/core/module.go
+++ b/core/module.go
@@ -334,7 +334,7 @@ func (mod *Module) ModTypeFor(ctx context.Context, typeDef *TypeDef, checkDirect
 		}
 		modType, ok = mod.modTypeForEnum(typeDef)
 	default:
-		return nil, false, fmt.Errorf("unexpected type def kind %s", typeDef.Kind)
+		return nil, false, fmt.Errorf("unexpected type def kind %q", typeDef.Kind)
 	}
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get mod type: %w", err)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2453,7 +2453,8 @@ func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInst
 			if err != nil {
 				return fmt.Errorf("failed to create module definition function for module %q: %w", modName, err)
 			}
-			result, err := getModDefFn.Call(ctx, &core.CallOpts{
+			_, result, err := getModDefFn.Call(ctx, &core.CallOpts{
+				CallID:         dagql.CurrentID(ctx),
 				SkipSelfSchema: true,
 				Server:         dag,
 				// Don't use the digest for the current call (which is a bunch of module source stuff, including

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -71,6 +71,11 @@ func AroundFunc(
 		attribute.String(telemetry.DagCallAttr, callAttr),
 	}
 
+	// HACK: probably some more elegant way to do make Module.call passthrough
+	// if base == "Module" && id.Field() == "call" {
+	// 	attrs = append(attrs, attribute.Bool(telemetry.UIPassthroughAttr, true))
+	// }
+
 	// if inside a module call, add call trace metadata. this is useful
 	// since within a single span, we can correlate the caller's and callee's
 	// module and functions calls

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -391,6 +391,11 @@ func (r Result[T]) WithSafeToPersistCache(safe bool) AnyResult {
 	return r
 }
 
+func (r Result[T]) ResultWithSafeToPersistCache(safe bool) Result[T] {
+	r.safeToPersistCache = safe
+	return r
+}
+
 func (r Result[T]) IsSafeToPersistCache() bool {
 	return r.safeToPersistCache
 }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3586,6 +3586,25 @@ scalar ListTypeDefID
 
 """A Dagger module."""
 type Module {
+  """
+  Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+  """
+  call(
+    """The name of the object the function is defined on."""
+    object: String!
+
+    """The name of the function to call, or empty for the object constructor."""
+    function: String!
+
+    """A JSON-encoded representation of the parent's state."""
+    parent: JSON!
+
+    """
+    A map of argument names to JSON-encoded representations of their values.
+    """
+    inputs: JSON!
+  ): JSON!
+
   """The dependencies of the module."""
   dependencies: [Module!]!
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -11539,6 +11539,35 @@
                       </tr>
                     </thead>
                     <tbody>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Module-call" href="#Module-call"><code>call</code></a> - <span class="property-type"><a href="#definition-JSON"><code>JSON!</code></a></span> </td>
+                        <td> Call a function defined in this module, returning a JSON-encoded representation of the resulting state. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>object</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the object the function is defined on.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>function</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the function to call, or empty for the object constructor.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>parent</code></span> - <span class="property-type"><a href="#definition-JSON"><code>JSON!</code></a></span></h6>
+                                <p>A JSON-encoded representation of the parent&#39;s state.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>inputs</code></span> - <span class="property-type"><a href="#definition-JSON"><code>JSON!</code></a></span></h6>
+                                <p>A map of argument names to JSON-encoded representations of their values.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Module-dependencies" href="#Module-dependencies"><code>dependencies</code></a> - <span class="property-type"><a href="#definition-Module"><code>[Module!]!</code></a></span> </td>
                         <td> The dependencies of the module. </td>

--- a/docs/static/reference/php/Dagger/Module.html
+++ b/docs/static/reference/php/Dagger/Module.html
@@ -143,6 +143,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_call">call</a>(string $object, string $function, <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $parent, <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $inputs)
+        
+                                            <p><p>Call a function defined in this module, returning a JSON-encoded representation of the resulting state.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     array
                 </div>
                 <div class="col-md-8">
@@ -427,8 +437,65 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_dependencies">
+                    <h3 id="method_call">
         <div class="location">at line 19</div>
+        <code>                    <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a>
+    <strong>call</strong>(string $object, string $function, <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $parent, <a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $inputs)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Call a function defined in this module, returning a JSON-encoded representation of the resulting state.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$object</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string</td>
+                <td>$function</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a></td>
+                <td>$parent</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a></td>
+                <td>$inputs</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_dependencies">
+        <div class="location">at line 32</div>
         <code>                    array
     <strong>dependencies</strong>()
         </code>
@@ -460,7 +527,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_description">
-        <div class="location">at line 28</div>
+        <div class="location">at line 41</div>
         <code>                    string
     <strong>description</strong>()
         </code>
@@ -492,7 +559,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_enums">
-        <div class="location">at line 37</div>
+        <div class="location">at line 50</div>
         <code>                    array
     <strong>enums</strong>()
         </code>
@@ -524,7 +591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedContextDirectory">
-        <div class="location">at line 46</div>
+        <div class="location">at line 59</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>generatedContextDirectory</strong>()
         </code>
@@ -556,7 +623,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 55</div>
+        <div class="location">at line 68</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -588,7 +655,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_interfaces">
-        <div class="location">at line 64</div>
+        <div class="location">at line 77</div>
         <code>                    array
     <strong>interfaces</strong>()
         </code>
@@ -620,7 +687,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_introspectionSchemaJSON">
-        <div class="location">at line 77</div>
+        <div class="location">at line 90</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>introspectionSchemaJSON</strong>()
         </code>
@@ -653,7 +720,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 86</div>
+        <div class="location">at line 99</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -685,7 +752,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_objects">
-        <div class="location">at line 95</div>
+        <div class="location">at line 108</div>
         <code>                    array
     <strong>objects</strong>()
         </code>
@@ -717,7 +784,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_runtime">
-        <div class="location">at line 104</div>
+        <div class="location">at line 117</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>runtime</strong>()
         </code>
@@ -749,7 +816,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 113</div>
+        <div class="location">at line 126</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>sdk</strong>()
         </code>
@@ -781,7 +848,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_serve">
-        <div class="location">at line 124</div>
+        <div class="location">at line 137</div>
         <code>                    void
     <strong>serve</strong>(bool|null $includeDependencies = null)
         </code>
@@ -823,7 +890,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_source">
-        <div class="location">at line 136</div>
+        <div class="location">at line 149</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>source</strong>()
         </code>
@@ -855,7 +922,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 145</div>
+        <div class="location">at line 158</div>
         <code>                    <a href="../Dagger/ModuleId.html"><abbr title="Dagger\ModuleId">ModuleId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -887,7 +954,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 154</div>
+        <div class="location">at line 167</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -919,7 +986,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDescription">
-        <div class="location">at line 163</div>
+        <div class="location">at line 176</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withDescription</strong>(string $description)
         </code>
@@ -961,7 +1028,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnum">
-        <div class="location">at line 173</div>
+        <div class="location">at line 186</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withEnum</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $enum)
         </code>
@@ -1003,7 +1070,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInterface">
-        <div class="location">at line 183</div>
+        <div class="location">at line 196</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withInterface</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $iface)
         </code>
@@ -1045,7 +1112,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withObject">
-        <div class="location">at line 193</div>
+        <div class="location">at line 206</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withObject</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $object)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -293,7 +293,9 @@
 <abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr>::cachedTokenReads</a>() &mdash; <em>Method in class <a href="Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a></em></dt>
                     <dd></dd><dt><a href="Dagger/LLMTokenUsage.html#method_cachedTokenWrites">
 <abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr>::cachedTokenWrites</a>() &mdash; <em>Method in class <a href="Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a></em></dt>
-                    <dd></dd><dt><a href="Dagger/ModuleSource.html#method_cloneRef">
+                    <dd></dd><dt><a href="Dagger/Module.html#method_call">
+<abbr title="Dagger\Module">Module</abbr>::call</a>() &mdash; <em>Method in class <a href="Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a></em></dt>
+                    <dd><p>Call a function defined in this module, returning a JSON-encoded representation of the resulting state.</p></dd><dt><a href="Dagger/ModuleSource.html#method_cloneRef">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::cloneRef</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
                     <dd><p>The ref to clone the root of the git repo from. Only valid for git sources.</p></dd><dt><a href="Dagger/ModuleSource.html#method_commit">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::commit</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -4287,6 +4287,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Module::call",
+			"p": "Dagger/Module.html#method_call",
+			"d": "<p>Call a function defined in this module, returning a JSON-encoded representation of the resulting state.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Module::dependencies",
 			"p": "Dagger/Module.html#method_dependencies",
 			"d": "<p>The dependencies of the module.</p>"

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -16,6 +16,23 @@ defmodule Dagger.Module do
   @type t() :: %__MODULE__{}
 
   @doc """
+  Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+  """
+  @spec call(t(), String.t(), String.t(), Dagger.JSON.t(), Dagger.JSON.t()) ::
+          {:ok, Dagger.JSON.t()} | {:error, term()}
+  def call(%__MODULE__{} = module, object, function, parent, inputs) do
+    query_builder =
+      module.query_builder
+      |> QB.select("call")
+      |> QB.put_arg("object", object)
+      |> QB.put_arg("function", function)
+      |> QB.put_arg("parent", parent)
+      |> QB.put_arg("inputs", inputs)
+
+    Client.execute(module.client, query_builder)
+  end
+
+  @doc """
   The dependencies of the module.
   """
   @spec dependencies(t()) :: {:ok, [Dagger.Module.t()]} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8533,6 +8533,7 @@ func (r *ListTypeDef) MarshalJSON() ([]byte, error) {
 type Module struct {
 	query *querybuilder.Selection
 
+	call        *JSON
 	description *string
 	id          *ModuleID
 	name        *string
@@ -8552,6 +8553,23 @@ func (r *Module) WithGraphQLQuery(q *querybuilder.Selection) *Module {
 	return &Module{
 		query: q,
 	}
+}
+
+// Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+func (r *Module) Call(ctx context.Context, object string, function string, parent JSON, inputs JSON) (JSON, error) {
+	if r.call != nil {
+		return *r.call, nil
+	}
+	q := r.query.Select("call")
+	q = q.Arg("object", object)
+	q = q.Arg("function", function)
+	q = q.Arg("parent", parent)
+	q = q.Arg("inputs", inputs)
+
+	var response JSON
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The dependencies of the module.

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -14,6 +14,19 @@ namespace Dagger;
 class Module extends Client\AbstractObject implements Client\IdAble
 {
     /**
+     * Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+     */
+    public function call(string $object, string $function, Json $parent, Json $inputs): Json
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('call');
+        $leafQueryBuilder->setArgument('object', $object);
+        $leafQueryBuilder->setArgument('function', $function);
+        $leafQueryBuilder->setArgument('parent', $parent);
+        $leafQueryBuilder->setArgument('inputs', $inputs);
+        return new \Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'call'));
+    }
+
+    /**
      * The dependencies of the module.
      */
     public function dependencies(): array

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -8774,6 +8774,50 @@ class ListTypeDef(Type):
 class Module(Type):
     """A Dagger module."""
 
+    async def call(
+        self,
+        object: str,
+        function: str,
+        parent: JSON,
+        inputs: JSON,
+    ) -> JSON:
+        """Call a function defined in this module, returning a JSON-encoded
+        representation of the resulting state.
+
+        Parameters
+        ----------
+        object:
+            The name of the object the function is defined on.
+        function:
+            The name of the function to call, or empty for the object
+            constructor.
+        parent:
+            A JSON-encoded representation of the parent's state.
+        inputs:
+            A map of argument names to JSON-encoded representations of their
+            values.
+
+        Returns
+        -------
+        JSON
+            An arbitrary JSON-encoded value.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("object", object),
+            Arg("function", function),
+            Arg("parent", parent),
+            Arg("inputs", inputs),
+        ]
+        _ctx = self._select("call", _args)
+        return await _ctx.execute(JSON)
+
     async def dependencies(self) -> list["Module"]:
         """The dependencies of the module."""
         _args: list[Arg] = []

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -9516,6 +9516,28 @@ pub struct ModuleServeOpts {
     pub include_dependencies: Option<bool>,
 }
 impl Module {
+    /// Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+    ///
+    /// # Arguments
+    ///
+    /// * `object` - The name of the object the function is defined on.
+    /// * `function` - The name of the function to call, or empty for the object constructor.
+    /// * `parent` - A JSON-encoded representation of the parent's state.
+    /// * `inputs` - A map of argument names to JSON-encoded representations of their values.
+    pub async fn call(
+        &self,
+        object: impl Into<String>,
+        function: impl Into<String>,
+        parent: Json,
+        inputs: Json,
+    ) -> Result<Json, DaggerError> {
+        let mut query = self.selection.select("call");
+        query = query.arg("object", object.into());
+        query = query.arg("function", function.into());
+        query = query.arg("parent", parent);
+        query = query.arg("inputs", inputs);
+        query.execute(self.graphql_client.clone()).await
+    }
     /// The dependencies of the module.
     pub fn dependencies(&self) -> Vec<Module> {
         let query = self.selection.select("dependencies");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -8675,6 +8675,7 @@ export class ListTypeDef extends BaseClient {
  */
 export class Module_ extends BaseClient {
   private readonly _id?: ModuleID = undefined
+  private readonly _call?: JSON = undefined
   private readonly _description?: string = undefined
   private readonly _name?: string = undefined
   private readonly _serve?: Void = undefined
@@ -8686,6 +8687,7 @@ export class Module_ extends BaseClient {
   constructor(
     ctx?: Context,
     _id?: ModuleID,
+    _call?: JSON,
     _description?: string,
     _name?: string,
     _serve?: Void,
@@ -8694,6 +8696,7 @@ export class Module_ extends BaseClient {
     super(ctx)
 
     this._id = _id
+    this._call = _call
     this._description = _description
     this._name = _name
     this._serve = _serve
@@ -8711,6 +8714,35 @@ export class Module_ extends BaseClient {
     const ctx = this._ctx.select("id")
 
     const response: Awaited<ModuleID> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * Call a function defined in this module, returning a JSON-encoded representation of the resulting state.
+   * @param object The name of the object the function is defined on.
+   * @param function The name of the function to call, or empty for the object constructor.
+   * @param parent A JSON-encoded representation of the parent's state.
+   * @param inputs A map of argument names to JSON-encoded representations of their values.
+   */
+  call = async (
+    object: string,
+    function_: string,
+    parent: JSON,
+    inputs: JSON,
+  ): Promise<JSON> => {
+    if (this._call) {
+      return this._call
+    }
+
+    const ctx = this._ctx.select("call", {
+      object,
+      function: function_,
+      parent,
+      inputs,
+    })
+
+    const response: Awaited<JSON> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
This PR adds a new `Module.call` API, which allows invoking a function call in a module, *without* going through the GraphQL API.

For example, take the following module:

```go
package main

type Test struct {
	X int
}

func (m *Test) Run(Y int) int {
	return m.X + Y
}
```

The following query is now possible:

```graphql
query {
  moduleSource(refString: ".") {
    asModule {
      call(
        object: "Test"
        function: "run"
        parent: "{\"X\": 101}"
        inputs: "{\"Y\": 202}"
      )
    }
  }
}
```
```json
{
    "moduleSource": {
        "asModule": {
            "call": "303"
        }
    }
}
```

This is intended for use in our scale-out functionality - an engine can remotely call another engine using this.