### PR TITLE
refactor: break up ID.Append

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -2605,7 +2605,10 @@ func UpdatedRootFS(
 		return nil, fmt.Errorf("field spec for rootfs not found in object type Container")
 	}
 	astType := fieldSpec.Type.Type()
-	rootfsID := curID.Append(astType, "rootfs", view, fieldSpec.Module, 0, "")
+	rootfsID := curID.Append(
+		astType, "rootfs",
+		call.WithView(view),
+		call.WithModule(fieldSpec.Module))
 	updatedRootfs, err := dagql.NewObjectResultForID(dir, curSrv, rootfsID)
 	if err != nil {
 		return nil, err
@@ -2642,7 +2645,11 @@ func updatedDirMount(
 	}
 	astType := fieldSpec.Type.Type()
 	dirIDPathArg := call.NewArgument("path", call.NewLiteralString(mntTarget), false)
-	dirID := curID.Append(astType, "directory", view, fieldSpec.Module, 0, "", dirIDPathArg)
+	dirID := curID.Append(
+		astType, "directory",
+		call.WithView(view),
+		call.WithModule(fieldSpec.Module),
+		call.WithArgs(dirIDPathArg))
 	updatedDirMnt, err := dagql.NewObjectResultForID(dir, curSrv, dirID)
 	if err != nil {
 		return nil, err
@@ -2679,7 +2686,11 @@ func updatedFileMount(
 	}
 	astType := fieldSpec.Type.Type()
 	fileIDPathArg := call.NewArgument("path", call.NewLiteralString(mntTarget), false)
-	fileID := curID.Append(astType, "file", view, fieldSpec.Module, 0, "", fileIDPathArg)
+	fileID := curID.Append(
+		astType, "file",
+		call.WithView(view),
+		call.WithModule(fieldSpec.Module),
+		call.WithArgs(fileIDPathArg))
 	updatedFileMnt, err := dagql.NewObjectResultForID(file, curSrv, fileID)
 	if err != nil {
 		return nil, err

--- a/core/interface.go
+++ b/core/interface.go
@@ -522,10 +522,8 @@ func (iface *InterfaceAnnotatedValue) PBDefinitions(ctx context.Context) ([]*pb.
 		fieldID := curID.Append(
 			field.TypeDef.ToType(),
 			field.Name,
-			curID.View(),
-			curID.Module(),
-			0,
-			"",
+			call.WithView(curID.View()),
+			call.WithModule(curID.Module()),
 		)
 		ctx := dagql.ContextWithID(ctx, fieldID)
 

--- a/core/module.go
+++ b/core/module.go
@@ -280,21 +280,15 @@ func (mod *Module) CacheConfigForCall(
 	// the module ID digest (which has a per-client cache key in order to deal with
 	// local dir and git repo loading)
 	id := dagql.CurrentID(ctx)
-	curIDNoMod := id.Receiver().Append(
-		id.Type().ToAST(),
-		id.Field(),
-		id.View(),
-		nil,
-		int(id.Nth()),
-		"",
-		id.Args()...,
+	curIDNoMod := id.With(
+		call.WithModule(nil),
+		call.WithCustomDigest(""),
 	)
 	cacheCfg.Digest = dagql.HashFrom(
 		curIDNoMod.Digest().String(),
 		mod.Source.Value.Self().Digest,
 		mod.NameField, // the module source content digest only includes the original name
 	)
-
 	return &cacheCfg, nil
 }
 

--- a/core/object.go
+++ b/core/object.go
@@ -130,10 +130,8 @@ func (t *ModuleObjectType) CollectCoreIDs(ctx context.Context, value dagql.AnyRe
 		fieldID := curID.Append(
 			fieldTypeDef.TypeDef.ToType(),
 			fieldTypeDef.Name,
-			curID.View(),
-			curID.Module(),
-			0,
-			"",
+			call.WithView(curID.View()),
+			call.WithModule(curID.Module()),
 		)
 		ctx := dagql.ContextWithID(ctx, fieldID)
 
@@ -256,10 +254,8 @@ func (obj *ModuleObject) PBDefinitions(ctx context.Context) ([]*pb.Definition, e
 		fieldID := curID.Append(
 			field.TypeDef.ToType(),
 			field.Name,
-			curID.View(),
-			curID.Module(),
-			0,
-			"",
+			call.WithView(curID.View()),
+			call.WithModule(curID.Module()),
 		)
 		ctx := dagql.ContextWithID(ctx, fieldID)
 

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -166,18 +166,14 @@ func (s *secretSchema) setSecret(
 		accessor,
 	)
 
-	currentID := dagql.CurrentID(ctx)
-	callID := currentID.Receiver().Append(
-		currentID.Type().ToAST(),
-		currentID.Field(),
-		currentID.View(),
-		currentID.Module(),
-		0,
-		dgst,
-		call.NewArgument("name", call.NewLiteralString(args.Name), false),
-		// hide plaintext in the returned ID, we instead rely on the
-		// digest of the ID for uniqueness+identity
-		call.NewArgument("plaintext", call.NewLiteralString("***"), false),
+	callID := dagql.CurrentID(ctx).With(
+		call.WithArgs(
+			call.NewArgument("name", call.NewLiteralString(args.Name), false),
+			// hide plaintext in the returned ID, we instead rely on the
+			// digest of the ID for uniqueness+identity
+			call.NewArgument("plaintext", call.NewLiteralString("***"), false),
+		),
+		call.WithCustomDigest(dgst),
 	)
 
 	secretStore, err := parent.Self().Secrets(ctx)

--- a/core/services_test.go
+++ b/core/services_test.go
@@ -299,7 +299,7 @@ func (f *fakeStartable) ID() *call.ID {
 	id := call.New().Append(&ast.Type{
 		NamedType: "FakeService",
 		NonNull:   true,
-	}, f.name, "", nil, 0, "")
+	}, f.name)
 	return id
 }
 

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -111,7 +111,7 @@ func TestBasic(t *testing.T) {
 
 	pointT := (&points.Point{}).Type()
 	expectedID := call.New().
-		Append(pointT, "point", "", nil, 0, "",
+		Append(pointT, "point", call.WithArgs(
 			call.NewArgument(
 				"x",
 				call.NewLiteralInt(6),
@@ -122,8 +122,8 @@ func TestBasic(t *testing.T) {
 				call.NewLiteralInt(7),
 				false,
 			),
-		).
-		Append(pointT, "shiftLeft", "", nil, 0, "")
+		)).
+		Append(pointT, "shiftLeft")
 	expectedEnc, err := dagql.NewID[*points.Point](expectedID).Encode()
 	assert.NilError(t, err)
 	assert.Equal(t, 6, res.Point.X)
@@ -880,7 +880,7 @@ func TestIDsReflectQuery(t *testing.T) {
 
 	pointT := (&points.Point{}).Type()
 	expectedID := call.New().
-		Append(pointT, "point", "", nil, 0, "",
+		Append(pointT, "point", call.WithArgs(
 			call.NewArgument(
 				"x",
 				call.NewLiteralInt(6),
@@ -891,8 +891,8 @@ func TestIDsReflectQuery(t *testing.T) {
 				call.NewLiteralInt(7),
 				false,
 			),
-		).
-		Append(pointT, "shiftLeft", "", nil, 0, "")
+		)).
+		Append(pointT, "shiftLeft")
 	expectedEnc, err := dagql.NewID[*points.Point](expectedID).Encode()
 	assert.NilError(t, err)
 	eqIDs(t, res.Point.ShiftLeft.ID, expectedEnc)
@@ -982,7 +982,7 @@ func TestIDsDoNotContainSensitiveValues(t *testing.T) {
 
 	pointT := (&points.Point{}).Type()
 	expectedID := call.New().
-		Append(pointT, "point", "", nil, 0, "",
+		Append(pointT, "point", call.WithArgs(
 			call.NewArgument(
 				"x",
 				call.NewLiteralInt(6),
@@ -993,15 +993,15 @@ func TestIDsDoNotContainSensitiveValues(t *testing.T) {
 				call.NewLiteralInt(7),
 				false,
 			),
-		).
-		Append(pointT, "loginTag", "", nil, 0, "")
+		)).
+		Append(pointT, "loginTag")
 
 	expectedEnc, err := dagql.NewID[*points.Point](expectedID).Encode()
 	assert.NilError(t, err)
 	eqIDs(t, res.Point.LoginTag.ID, expectedEnc)
 
 	expectedID = call.New().
-		Append(pointT, "point", "", nil, 0, "",
+		Append(pointT, "point", call.WithArgs(
 			call.NewArgument(
 				"x",
 				call.NewLiteralInt(6),
@@ -1012,15 +1012,15 @@ func TestIDsDoNotContainSensitiveValues(t *testing.T) {
 				call.NewLiteralInt(7),
 				false,
 			),
-		).
-		Append(pointT, "loginChain", "", nil, 0, "")
+		)).
+		Append(pointT, "loginChain")
 
 	expectedEnc, err = dagql.NewID[*points.Point](expectedID).Encode()
 	assert.NilError(t, err)
 	eqIDs(t, res.Point.LoginChain.ID, expectedEnc)
 
 	expectedID = call.New().
-		Append(pointT, "point", "", nil, 0, "",
+		Append(pointT, "point", call.WithArgs(
 			call.NewArgument(
 				"x",
 				call.NewLiteralInt(6),
@@ -1031,14 +1031,14 @@ func TestIDsDoNotContainSensitiveValues(t *testing.T) {
 				call.NewLiteralInt(7),
 				false,
 			),
-		).
-		Append(pointT, "loginTagFalse", "", nil, 0, "",
+		)).
+		Append(pointT, "loginTagFalse", call.WithArgs(
 			call.NewArgument(
 				"password",
 				call.NewLiteralString("hunter2"),
 				false,
 			),
-		)
+		))
 	expectedEnc, err = dagql.NewID[*points.Point](expectedID).Encode()
 	assert.NilError(t, err)
 	eqIDs(t, res.Point.LoginTagFalse.ID, expectedEnc)
@@ -2517,9 +2517,8 @@ func TestServerSelect(t *testing.T) {
 
 	t.Run("basic selection", func(t *testing.T) {
 		// Create a test object and wrap it as a dagql.Object
-		testObj, err := dagql.NewResultForID(&TestObject{Value: 42, Text: "hello"}, call.New().Append(
-			(TestObject{}).Type(), "fake", "", nil, 0, "",
-		))
+		testObj, err := dagql.NewResultForID(&TestObject{Value: 42, Text: "hello"},
+			call.New().Append((TestObject{}).Type(), "fake"))
 		require.NoError(t, err)
 
 		// Get the installed class from the server
@@ -2549,7 +2548,7 @@ func TestServerSelect(t *testing.T) {
 		nestedObj, err := dagql.NewResultForID(&NestedObject{
 			Name:  "nested",
 			Inner: innerObj,
-		}, call.New().Append((TestObject{}).Type(), "fake", "", nil, 0, ""))
+		}, call.New().Append((TestObject{}).Type(), "fake"))
 		require.NoError(t, err)
 
 		// Get the installed class from the server
@@ -2572,7 +2571,7 @@ func TestServerSelect(t *testing.T) {
 	t.Run("null result", func(t *testing.T) {
 		// Create an object with a null field
 		testObj, err := dagql.NewResultForID(&TestObject{Value: 42, Text: "hello", NullableField: nil},
-			call.New().Append((TestObject{}).Type(), "fake", "", nil, 0, ""),
+			call.New().Append((TestObject{}).Type(), "fake"),
 		)
 		require.NoError(t, err)
 
@@ -2675,7 +2674,7 @@ func TestServerSelect(t *testing.T) {
 	t.Run("error cases", func(t *testing.T) {
 		// Create a test object
 		testObj, err := dagql.NewResultForID(&TestObject{Value: 42, Text: "hello"},
-			call.New().Append((TestObject{}).Type(), "fake", "", nil, 0, ""),
+			call.New().Append((TestObject{}).Type(), "fake"),
 		)
 		require.NoError(t, err)
 

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -530,11 +530,10 @@ func (r ObjectResult[T]) preselect(ctx context.Context, s *Server, sel Selector)
 	newID := r.constructor.Append(
 		astType,
 		sel.Field,
-		view,
-		field.Spec.Module,
-		sel.Nth,
-		"",
-		idArgs...,
+		call.WithView(view),
+		call.WithModule(field.Spec.Module),
+		call.WithNth(sel.Nth),
+		call.WithArgs(idArgs...),
 	)
 
 	doNotCache := field.CacheSpec.DoNotCache != ""
@@ -573,11 +572,10 @@ func (r ObjectResult[T]) preselect(ctx context.Context, s *Server, sel Selector)
 			newID = r.constructor.Append(
 				astType,
 				sel.Field,
-				view,
-				field.Spec.Module,
-				sel.Nth,
-				"",
-				idArgs...,
+				call.WithView(view),
+				call.WithModule(field.Spec.Module),
+				call.WithNth(sel.Nth),
+				call.WithArgs(idArgs...),
 			)
 		}
 


### PR DESCRIPTION
This was already getting a bit unwieldy as we've been gradually adding
bits and bobs to the protocol, and it was also used to represent all
forms of modification.

Refactored into an `IDOpts` pattern, and added `ID.With(...IDOpts)` for
applying selective modifications to an ID, rather than having to
re-`Append` from its receiver.

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>
