### PR TITLE
Lazy Runtime loading

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -189,6 +189,7 @@ type Callable interface {
 
 func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callable, error) {
 	mod := t.mod
+
 	if field, ok := t.typeDef.FieldByName(name); ok {
 		fieldType, ok, err := mod.ModTypeFor(ctx, field.TypeDef, true)
 		if err != nil {
@@ -203,12 +204,12 @@ func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callab
 			Return: fieldType,
 		}, nil
 	}
+
 	if fun, ok := t.typeDef.FunctionByName(name); ok {
 		return NewModFunction(
 			ctx,
 			mod,
 			t.typeDef,
-			mod.Runtime.Value,
 			fun,
 		)
 	}
@@ -358,7 +359,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 		return fmt.Errorf("constructor function for object %s must return that object", objDef.OriginalName)
 	}
 
-	fn, err := NewModFunction(ctx, mod, objDef, mod.Runtime.Value, fnTypeDef)
+	fn, err := NewModFunction(ctx, mod, objDef, fnTypeDef)
 	if err != nil {
 		return fmt.Errorf("failed to create function: %w", err)
 	}
@@ -470,7 +471,6 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 		ctx,
 		mod,
 		objDef,
-		mod.Runtime.Value,
 		fun,
 	)
 	if err != nil {

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -385,6 +385,9 @@ func (sdk *goSDK) Runtime(
 	deps *core.ModDeps,
 	source dagql.ObjectResult[*core.ModuleSource],
 ) (inst dagql.ObjectResult[*core.Container], rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "go SDK: load runtime")
+	defer telemetry.End(span, func() error { return rerr })
+
 	dag, err := sdk.root.Server.Server(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag for go module sdk runtime: %w", err)

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken-dep/use-broken
@@ -6,7 +6,16 @@ Expected stderr:
 │ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰╴✔ starting session X.Xs
  
-▼ load module: ./viztest/broken-dep X.Xs ERROR
+▼ load module: ./viztest/broken-dep X.Xs
+├╴✔ finding module configuration X.Xs
+├╴✔ initializing module X.Xs
+├╴✔ inspecting module metadata X.Xs
+╰╴✔ loading type definitions X.Xs
+ 
+✔ parsing command line arguments X.Xs
+
+✔ brokenDep: BrokenDep! X.Xs
+▼ .useBroken: Void X.Xs ERROR
   ▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
   ┃ # dagger/broken
   ┃ ./main.go:6:6: undefined: ctx

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/broken/broken
@@ -6,7 +6,16 @@ Expected stderr:
 │ ┃ XX:XX:XX INF connected name=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local client-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx server-version=vX.X.X-xxxxxxxxxxxx-xxxxxxxxxxxx
 ╰╴✔ starting session X.Xs
  
-▼ load module: ./viztest/broken-dep/broken X.Xs ERROR
+▼ load module: ./viztest/broken-dep/broken X.Xs
+├╴✔ finding module configuration X.Xs
+├╴✔ initializing module X.Xs
+├╴✔ inspecting module metadata X.Xs
+╰╴✔ loading type definitions X.Xs
+ 
+✔ parsing command line arguments X.Xs
+
+✔ broken: Broken! X.Xs
+▼ .broken: Void X.Xs ERROR
   ▼ Container.withExec(args: ["go", "build", "-ldflags", "-s -w", "-o", "/runtime", "."]): Container! X.Xs ERROR
   ┃ # dagger/broken
   ┃ ./main.go:6:6: undefined: ctx

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -25,7 +25,7 @@ Expected stderr:
 ├╴✔ .withExec(args: ["sleep", "1"]): Container! X.Xs
 ├╴▼ .withExec(args: ["echo", "im busted by that buster"]): Container! X.Xs
 │ ┃ im busted by that buster
-├╴✔ .withNewFile(path: "/srv/index.html", contents: "<h1>hello, world!</h1>"): Container! X.Xs
+├╴$ .withNewFile(path: "/srv/index.html", contents: "<h1>hello, world!</h1>"): Container! X.Xs CACHED
 ├╴✔ .withExposedPort(port: 80): Container! X.Xs
 ├╴▼ .asService(args: ["httpd", "-v", "-h", "/srv", "-f"]): Service! X.Xs ✔ 1
 │ ┃ [::ffff:10.XX.XX.XX]:XXXXX: response:200

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3625,7 +3625,7 @@ type Module {
   """
   The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
   """
-  runtime: Container
+  runtime: Container!
 
   """The SDK config used by this module."""
   sdk: SDKConfig

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -11580,7 +11580,7 @@
                         <td> Objects served by this module. </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="Module-runtime" href="#Module-runtime"><code>runtime</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container</code></a></span> </td>
+                        <td data-property-name=""><a class="property-name" id="Module-runtime" href="#Module-runtime"><code>runtime</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
                         <td> The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile. </td>
                       </tr>
                       <tr>

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -171,7 +171,7 @@ defmodule Dagger.Module do
   @doc """
   The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
   """
-  @spec runtime(t()) :: Dagger.Container.t() | nil
+  @spec runtime(t()) :: Dagger.Container.t()
   def runtime(%__MODULE__{} = module) do
     query_builder =
       module.query_builder |> QB.select("runtime")


### PR DESCRIPTION
**Summary**

Update moduleSource loading to no longer force load the runtime container if it's not required.
Instead, we load the module runtime just before actually calling it so it's much more efficient.

:warning: **ONLY sdks that implements`ModuleTypes` interface from #10584 benefits from this optimization**

Effects:
- If a module A with a dependency on B & C only use the module B in a function, we will load the module B runtime just in time when the query calls B.
- We no longer load the runtime when executing `dagger functions` or `--help`
- The `moduleRuntime` traces are no longer part of `initializing module`, they are now wrap inside the function call (this can be improve later).


**Trace for dagger functions (using the typescript SDK)**
<img width="1263" height="180" alt="Screenshot 2025-10-23 at 15 30 10" src="https://github.com/user-attachments/assets/bf3a03f1-b2f1-45eb-a326-470487449aa9" />

**Trace for `dagger call` (using the TypeScript SDK)**
<img width="1345" height="363" alt="Screenshot 2025-10-23 at 15 39 02" src="https://github.com/user-attachments/assets/f8b0be7a-5908-42db-b9b5-dab9ebe7f207" />

**Benchmark**

**NOTE**: It's normal that `call/XXX` takes more times now since the module loading happens at this stage but it's expect, the important things to look at is the overall cmd duration.

For Typescript with default setup

<img width="1077" height="248" alt="Screenshot 2025-10-23 at 16 52 28" src="https://github.com/user-attachments/assets/4e6ede43-e3a3-4240-bdb1-90d48d094037" />

We can see a 50% improvement for functions which is what we expect since we no longer build the runtime when simply exploring functions.

For Golang with default setup

<img width="1077" height="241" alt="Screenshot 2025-10-23 at 16 59 04" src="https://github.com/user-attachments/assets/5afa9e68-a25d-4627-a19c-fcf53553f05f" />

We also see around 50% improvement for dagger functions.
