### PR TITLE
llm: allow module constructors with defaults

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -411,7 +411,7 @@ func (m *MCP) loadModuleTools(srv *dagql.Server, allTools *LLMToolSet) error {
 			var hasRequiredArgs bool
 			if def.Constructor.Valid {
 				for _, arg := range def.Constructor.Value.Args {
-					if !arg.TypeDef.Optional && arg.DefaultPath == "" {
+					if !arg.TypeDef.Optional && arg.DefaultPath == "" && arg.DefaultValue == nil {
 						hasRequiredArgs = true
 						break
 					}


### PR DESCRIPTION
A little papercut I ran into; the intent is to only error on required args, and it handled `// +defaultPath` but not `// +default`.