### PR TITLE
fix: rotate gitlab readonly token

### DIFF
--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -744,7 +744,7 @@ func (GitSuite) TestAuthProviders(ctx context.Context, t *testctx.T) {
 
 	t.Run("GitLab auth", func(ctx context.Context, t *testctx.T) {
 		// Base64-encoded read-only PAT for test repo
-		pat := "Z2xwYXQtQXlHQU4zR0xOeEhfM3VSckNzck0K"
+		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -111,7 +111,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 	t.Run("gitlab private module", func(ctx context.Context, t *testctx.T) {
 		workDir := t.TempDir()
 
-		pat := "Z2xwYXQtQXlHQU4zR0xOeEhfM3VSckNzck0K"
+		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1273,7 +1273,7 @@ var vcsTestCases = []vcsTestCase{
 		expectedURLPathComponent: "tree",
 		expectedPathPrefix:       "",
 		isPrivateRepo:            true,
-		encodedToken:             "Z2xwYXQtQXlHQU4zR0xOeEhfM3VSckNzck0K",
+		encodedToken:             "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
 	},
 	// BitBucket private repository using SCP-like SSH reference format
 	{


### PR DESCRIPTION
On the gitlab free tier, they only last 1 year. As before, it's a read-only. CI started breaking starting today