### PR TITLE
fix(ci): fix go sdk `dry-run`

### DIFF
--- a/.dagger/sdk_go.go
+++ b/.dagger/sdk_go.go
@@ -103,7 +103,7 @@ func (t GoSDK) Publish(
 		sdk:          "go",
 		sourceTag:    tag,
 		sourcePath:   "sdk/go/",
-		sourceFilter: "if [ -f go.mod ]; then go mod edit -dropreplace github.com/dagger/dagger; fi",
+		sourceFilter: "if [ -d sdk/go ]; then rm -rf .changes; fi; if [ -f go.mod ]; then go mod edit -dropreplace github.com/dagger/dagger; fi",
 		sourceEnv:    t.BaseContainer(), // Just need git and go installed
 		dest:         gitRepo,
 		destTag:      version,


### PR DESCRIPTION
Since #11161 the worktree now includes `.changes/` (as it has been added as a dependency inside the top-level dagger.json), which impacts the _go sdk_ git rewrite.

The way the _publish_ job rewrites history is:

```shell
git filter-branch -f --prune-empty \
  --subdirectory-filter sdk/go/ \
  --tree-filter 'if [ -f go.mod ]; then go mod edit -dropreplace github.com/dagger/dagger; fi' -- HEAD
```
and now fails with `error: Entry '.changes/v0.10.0.md' not uptodate. Cannot merge.` (https://dagger.cloud/dagger/traces/1f9ef08806c6bf1bbfc0b298eb19a586)

To manually reproduce on a clean checkout (or test variations):

```shell
git clone https://github.com/dagger/dagger.git repro
cd repro
FILTER_BRANCH_SQUELCH_WARNING=1 GOTOOLCHAIN=local \
  git filter-branch -f --prune-empty --subdirectory-filter sdk/go/ \
    --tree-filter 'if [ -f go.mod ]; then go mod edit -dropreplace github.com/dagger/dagger; fi' -- HEAD
```

The conflict is just the leftover `.changes/v0.10.0.md` sitting in the worktree between the merge parents.

The fix is to just drop the top-level `.changes/` before `--subdirectory-filter` runs. It's _hacky_ but safe, as once the repo is trimmed down to `sdk/go`, it would have been discarded anyway.
