### PR TITLE
ci: use git-filter-repo for git publishing

### DIFF
--- a/.dagger/sdk_php.go
+++ b/.dagger/sdk_php.go
@@ -139,8 +139,6 @@ func (t PHPSDK) CheckReleaseDryRun(ctx context.Context) error {
 		"HEAD",
 		true,
 		"https://github.com/dagger/dagger-php-sdk.git",
-		"dagger-ci",
-		"hello@dagger.io",
 		nil,
 	)
 }
@@ -157,13 +155,6 @@ func (t PHPSDK) Publish(
 	// +default="https://github.com/dagger/dagger-php-sdk.git"
 	gitRepo string,
 	// +optional
-	// +default="dagger-ci"
-	gitUserName string,
-	// +optional
-	// +default="hello@dagger.io"
-	gitUserEmail string,
-
-	// +optional
 	githubToken *dagger.Secret,
 ) error {
 	version := strings.TrimPrefix(tag, "sdk/php/")
@@ -174,8 +165,6 @@ func (t PHPSDK) Publish(
 		sourceTag:   tag,
 		dest:        gitRepo,
 		destTag:     version,
-		username:    gitUserName,
-		email:       gitUserEmail,
 		githubToken: githubToken,
 		dryRun:      dryRun,
 	}); err != nil {


### PR DESCRIPTION
In our publishing flow we create `dagger-go-sdk` and `dagger-php-sdk` repos that include the contents of `sdk/go/` and `sdk/php/` respectively. To create these, we were using `git-filter-branch`.

According to the [git docs](https://git-scm.com/docs/git-filter-branch):

> git filter-branch has a plethora of pitfalls that can produce
> non-obvious manglings of the intended history rewrite (and can leave you
> with little time to investigate such problems since it has such abysmal
> performance). These safety and performance issues cannot be backward
> compatibly fixed and as such, its use is not recommended.

I suspect this was leading to weird flakes in git publishing, and because `git filter-branch` is just a shell script, it was kinda miserable to debug.

This patch switches to using `git filter-repo` - the official docs recommend migrating to this third-party tool. It's significantly easier to use, faster, and has better defaults out-of-the-box.

This allows us to simplify a lot of the code around our `gitPublish`ing functionality, and should *hopefully* be more performant and less buggy.