### PR TITLE
chore(sdk/python): do not return runtime files

### DIFF
--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -162,7 +162,10 @@ func (m *PythonSdk) Codegen(
 		genPaths = []string{m.VendorPath + "/**"}
 	}
 
-	return dag.GeneratedCode(m.Container.Directory(m.ContextDirPath)).
+	return dag.
+		GeneratedCode(
+			m.Container.Directory(m.ContextDirPath).
+				WithoutDirectory("sdk/runtime")).
 		WithVCSGeneratedPaths(genPaths).
 		WithVCSIgnoredPaths(ignorePaths), nil
 }


### PR DESCRIPTION
After a `dagger init --sdk=python` or a `dagger develop` on a python module, do not return the `sdk/python/runtime` files as part of the generated code.
Those files are not necessary for the python module itself, they are only necessary to build the python SDK on the engine side.

This helps to keep the user module code cleaner and more understandable.

Before:

```
$ tree
.
├── dagger.json
├── LICENSE
├── pyproject.toml
├── sdk
│   ├── codegen
│   │   ├── pyproject.toml
│   │   └── src
│   │       └── codegen
│   │           ├── __init__.py
│   │           ├── __main__.py
│   │           ├── ast.py
│   │           ├── cli.py
│   │           └── generator.py
│   ├── LICENSE
│   ├── pyproject.toml
│   ├── README.md
│   ├── runtime
│   │   ├── dagger.json
│   │   ├── discovery.go
│   │   ├── Dockerfile
│   │   ├── extension.go
│   │   ├── go.mod
│   │   ├── go.sum
│   │   ├── image.go
│   │   ├── main.go
│   │   ├── python.go
│   │   └── template
│   │       ├── __init__.py
│   │       ├── main.py
│   │       ├── pyproject.toml
│   │       └── runtime.py
│   ├── src
│   │   └── dagger
│   │       ├── __init__.py
│   │       ├── _exceptions.py
│   │       ├── _managers.py
│   │       ├── client
│   │       │   ├── __init__.py
│   │       │   ├── _config.py
│   │       │   ├── _connection.py
│   │       │   ├── _core.py
│   │       │   ├── _guards.py
│   │       │   ├── _session.py
│   │       │   ├── base.py
│   │       │   └── gen.py
│   │       ├── log.py
│   │       ├── mod
│   │       │   ├── __init__.py
│   │       │   ├── _arguments.py
│   │       │   ├── _converter.py
│   │       │   ├── _exceptions.py
│   │       │   ├── _module.py
│   │       │   ├── _resolver.py
│   │       │   ├── _types.py
│   │       │   ├── _utils.py
│   │       │   └── cli.py
│   │       ├── py.typed
│   │       └── telemetry.py
│   └── uv.lock
├── src
│   └── check_generated
│       ├── __init__.py
│       └── main.py
└── uv.lock

13 directories, 52 files
```

After:

```
$ tree
.
├── dagger.json
├── LICENSE
├── pyproject.toml
├── sdk
│   ├── codegen
│   │   ├── pyproject.toml
│   │   └── src
│   │       └── codegen
│   │           ├── __init__.py
│   │           ├── __main__.py
│   │           ├── ast.py
│   │           ├── cli.py
│   │           └── generator.py
│   ├── LICENSE
│   ├── pyproject.toml
│   ├── README.md
│   ├── src
│   │   └── dagger
│   │       ├── __init__.py
│   │       ├── _exceptions.py
│   │       ├── _managers.py
│   │       ├── client
│   │       │   ├── __init__.py
│   │       │   ├── _config.py
│   │       │   ├── _connection.py
│   │       │   ├── _core.py
│   │       │   ├── _guards.py
│   │       │   ├── _session.py
│   │       │   ├── base.py
│   │       │   └── gen.py
│   │       ├── log.py
│   │       ├── mod
│   │       │   ├── __init__.py
│   │       │   ├── _arguments.py
│   │       │   ├── _converter.py
│   │       │   ├── _exceptions.py
│   │       │   ├── _module.py
│   │       │   ├── _resolver.py
│   │       │   ├── _types.py
│   │       │   ├── _utils.py
│   │       │   └── cli.py
│   │       ├── py.typed
│   │       └── telemetry.py
│   └── uv.lock
├── src
│   └── check_generated
│       ├── __init__.py
│       └── main.py
└── uv.lock

11 directories, 39 files
```