### PR TITLE
fix: set --no-tags for fetch

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -134,10 +134,7 @@ func doGitCheckout(
 
 	tmpref := "refs/dagger.tmp/" + identity.NewID()
 
-	// TODO: maybe this should use --no-tags by default, but that's a breaking change :(
-	// also, we currently don't do any special work to ensure that the fetched
-	// tags are consistent with the GitRepository.Remote (oops)
-	args := []string{"fetch", "-u"}
+	args := []string{"fetch", "-u", "--no-tags"}
 	if depth > 0 {
 		args = append(args, fmt.Sprintf("--depth=%d", depth))
 	}

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -240,8 +240,6 @@ func (repo *RemoteGitRepository) mount(ctx context.Context, depth int, refs []Gi
 				}
 			}
 
-			// TODO: should set doFetch if a tag in ls-remote has been updated?
-
 			if doFetch {
 				fetchRefs = append(fetchRefs, ref)
 			}


### PR DESCRIPTION
Following up from https://github.com/dagger/dagger/pull/11073.

It seems like this is universally the wrong behavior to me.

1. Cache performance is just weird. The cache key of a git checkout will have to mutate to account for *any* tag change in the repo, regardless of whether it's used.
2. The logic is hugely complex, and was badly handled. It was possible that the checked out repo tags didn't match the result of `.Tags`

:warning: This is a breaking change, but it seems unlikely anyone is relying on this.