### PR TITLE
feat: allow gitignore filtering in more places

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -813,6 +813,9 @@ func (container *Container) WithDirectory(
 	if len(filter.Include) > 0 {
 		args = append(args, dagql.NamedInput{Name: "include", Value: asArrayInput(filter.Include, dagql.NewString)})
 	}
+	if filter.Gitignore {
+		args = append(args, dagql.NamedInput{Name: "gitignore", Value: dagql.Boolean(true)})
+	}
 	if owner != "" {
 		// directories only handle int uid/gid, so make sure we resolve names if needed
 		ownership, err := container.ownership(ctx, owner)

--- a/core/directory.go
+++ b/core/directory.go
@@ -696,15 +696,16 @@ func (e notAFileError) Unwrap() error {
 }
 
 type CopyFilter struct {
-	Exclude []string `default:"[]"`
-	Include []string `default:"[]"`
+	Exclude   []string `default:"[]"`
+	Include   []string `default:"[]"`
+	Gitignore bool     `default:"false"`
 }
 
 func (cf *CopyFilter) IsEmpty() bool {
 	if cf == nil {
 		return true
 	}
-	return len(cf.Exclude) == 0 && len(cf.Include) == 0
+	return len(cf.Exclude) == 0 && len(cf.Include) == 0 && !cf.Gitignore
 }
 
 //nolint:gocyclo
@@ -813,6 +814,9 @@ func (dir *Directory) WithDirectory(
 			for _, pattern := range filter.Exclude {
 				opts = append(opts, fscopy.WithExcludePattern(pattern))
 			}
+			if filter.Gitignore {
+				opts = append(opts, fscopy.WithGitignore())
+			}
 			if owner != "" {
 				ownership, err := parseDirectoryOwner(owner)
 				if err != nil {
@@ -863,6 +867,7 @@ func (dir *Directory) WithDirectory(
 				{Name: "source", Value: dagql.NewID[*Directory](srcID)},
 				{Name: "exclude", Value: asArrayInput(filter.Exclude, dagql.NewString)},
 				{Name: "include", Value: asArrayInput(filter.Include, dagql.NewString)},
+				{Name: "gitignore", Value: dagql.Boolean(filter.Gitignore)},
 				{Name: "owner", Value: dagql.String(owner)},
 			}},
 		)

--- a/core/host.go
+++ b/core/host.go
@@ -109,7 +109,7 @@ func (Host) FindUpAll(
 	return found, nil
 }
 
-func (*Host) Directory(ctx context.Context, rootPath string, filter CopyFilter, gitIgnore bool, noCache bool, relPath string) (*Directory, error) {
+func (*Host) Directory(ctx context.Context, rootPath string, filter CopyFilter, noCache bool, relPath string) (*Directory, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current query: %w", err)
@@ -123,7 +123,7 @@ func (*Host) Directory(ctx context.Context, rootPath string, filter CopyFilter, 
 	snapshotOpts := filesync.SnapshotOpts{
 		IncludePatterns: filter.Include,
 		ExcludePatterns: filter.Exclude,
-		GitIgnore:       gitIgnore,
+		GitIgnore:       filter.Gitignore,
 		RelativePath:    relPath,
 	}
 

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -389,6 +389,15 @@ func (DirectorySuite) TestDirectoryFilterIncludeExclude(ctx context.Context, t *
 		require.NoError(t, err)
 		require.Equal(t, []string{"d.txt", "e.txt"}, entries)
 	})
+
+	t.Run("gitignore works", func(ctx context.Context, t *testctx.T) {
+		dir := dir.WithNewFile(".gitignore", "b.txt\nsubdir/\n")
+		entries, err := dir.Filter(dagger.DirectoryFilterOpts{
+			Gitignore: true,
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{".gitignore", "a.txt", "c.txt.rar"}, entries)
+	})
 }
 
 func (DirectorySuite) TestWithDirectoryIncludeExclude(ctx context.Context, t *testctx.T) {
@@ -452,6 +461,15 @@ func (DirectorySuite) TestWithDirectoryIncludeExclude(ctx context.Context, t *te
 		}).Entries(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"d.txt", "e.txt"}, entries)
+	})
+
+	t.Run("gitignore works", func(ctx context.Context, t *testctx.T) {
+		dir := dir.WithNewFile(".gitignore", "b.txt\nsubdir/\n")
+		entries, err := dir.Filter(dagger.DirectoryFilterOpts{
+			Gitignore: true,
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{".gitignore", "a.txt", "c.txt.rar"}, entries)
 	})
 }
 

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -990,7 +990,9 @@ func (fn *ModuleFunction) loadContextualArg(
 
 	switch arg.TypeDef.AsObject.Value.Name {
 	case "Directory":
-		dir, err := fn.mod.ContextSource.Value.Self().LoadContextDir(ctx, dag, arg.DefaultPath, nil, arg.Ignore)
+		dir, err := fn.mod.ContextSource.Value.Self().LoadContextDir(ctx, dag, arg.DefaultPath, CopyFilter{
+			Exclude: arg.Ignore,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("load contextual directory %q: %w", arg.DefaultPath, err)
 		}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -416,6 +416,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("source").Doc(`Identifier of the directory to write`).View(AfterVersion("v0.19.0")),
 				dagql.Arg("exclude").Doc(`Patterns to exclude in the written directory (e.g. ["node_modules/**", ".gitignore", ".git/"]).`),
 				dagql.Arg("include").Doc(`Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).`),
+				dagql.Arg("gitignore").Doc(`Apply .gitignore rules when writing the directory.`),
 				dagql.Arg("owner").Doc(`A user:group to set for the directory and its contents.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -140,6 +140,7 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 				dagql.Arg("source").Doc(`Identifier of the directory to copy.`).View(AfterVersion("v0.19.0")),
 				dagql.Arg("exclude").Doc(`Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`),
 				dagql.Arg("include").Doc(`Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
+				dagql.Arg("gitignore").Doc(`Apply .gitignore filter rules inside the directory`),
 				dagql.Arg("owner").Doc(`A user:group to set for the copied directory and its contents.`,
 					`The user and group must be an ID (1000:1000), not a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
@@ -149,6 +150,7 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("exclude").Doc(`If set, paths matching one of these glob patterns is excluded from the new snapshot. Example: ["node_modules/", ".git*", ".env"]`),
 				dagql.Arg("include").Doc(`If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., ["app/", "package.*"]).`),
+				dagql.Arg("gitignore").Doc(`If set, apply .gitignore rules when filtering the directory.`),
 			),
 		dagql.NodeFunc("withNewDirectory", DagOpDirectoryWrapper(srv, s.withNewDirectory, WithPathFn(keepParentDir[withNewDirectoryArgs]))).
 			Doc(`Retrieves this directory plus a new directory created at the given path.`).

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -320,9 +320,10 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 	}
 
 	dir, err := host.Self().Directory(ctx, absRootCopyPath, core.CopyFilter{
-		Include: includePatterns,
-		Exclude: excludePatterns,
-	}, args.Gitignore, args.NoCache, relPathFromRoot)
+		Include:   includePatterns,
+		Exclude:   excludePatterns,
+		Gitignore: args.Gitignore,
+	}, args.NoCache, relPathFromRoot)
 
 	if err != nil {
 		return inst, fmt.Errorf("failed to get directory: %w", err)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -127,6 +127,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 				dagql.Arg("path").Doc(`Location of the directory to access (e.g., ".").`),
 				dagql.Arg("exclude").Doc(`Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`),
 				dagql.Arg("include").Doc(`Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
+				dagql.Arg("gitignore").Doc(`Apply .gitignore filter rules inside the directory`),
 			),
 
 		dagql.NodeFuncWithCacheKey("workdirFile", s.currentModuleWorkdirFile, dagql.CachePerClient).
@@ -873,6 +874,7 @@ func (s *moduleSchema) currentModuleWorkdir(
 				{Name: "path", Value: dagql.String(args.Path)},
 				{Name: "exclude", Value: asArrayInput(args.Exclude, dagql.NewString)},
 				{Name: "include", Value: asArrayInput(args.Include, dagql.NewString)},
+				{Name: "gitignore", Value: dagql.Boolean(args.Gitignore)},
 			},
 		},
 	)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -28,10 +28,10 @@ type Address {
   container: Container!
 
   """Load a directory from the address."""
-  directory(exclude: [String!] = [], include: [String!] = [], noCache: Boolean = false): Directory!
+  directory(exclude: [String!] = [], include: [String!] = [], gitignore: Boolean = false, noCache: Boolean = false): Directory!
 
   """Load a file from the address."""
-  file(exclude: [String!] = [], include: [String!] = [], noCache: Boolean = false): File!
+  file(exclude: [String!] = [], include: [String!] = [], gitignore: Boolean = false, noCache: Boolean = false): File!
 
   """Load a git ref (branch, tag or commit) from the address."""
   gitRef: GitRef!
@@ -751,6 +751,9 @@ type Container {
     """
     include: [String!] = []
 
+    """Apply .gitignore rules when writing the directory."""
+    gitignore: Boolean = false
+
     """
     A user:group to set for the directory and its contents.
 
@@ -1430,6 +1433,9 @@ type CurrentModule {
     Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
     """
     include: [String!] = []
+
+    """Apply .gitignore filter rules inside the directory"""
+    gitignore: Boolean = false
   ): Directory!
 
   """
@@ -1613,6 +1619,9 @@ type Directory {
     new snapshot. Example: (e.g., ["app/", "package.*"]).
     """
     include: [String!] = []
+
+    """If set, apply .gitignore rules when filtering the directory."""
+    gitignore: Boolean = false
   ): Directory!
 
   """
@@ -1731,6 +1740,9 @@ type Directory {
     Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
     """
     include: [String!] = []
+
+    """Apply .gitignore filter rules inside the directory"""
+    gitignore: Boolean = false
 
     """
     A user:group to set for the copied directory and its contents.

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -4501,6 +4501,9 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>noCache</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                               </div>
                             </div>
@@ -4521,6 +4524,9 @@
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>noCache</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -5645,6 +5651,10 @@
                                 <p>Patterns to include in the written directory (e.g. [&quot;*.go&quot;, &quot;go.mod&quot;, &quot;go.sum&quot;]).</p>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Apply .gitignore rules when writing the directory.</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A user:group to set for the directory and its contents.</p>
                                 <p>The user and group can either be an ID (1000:1000) or a name (foo:bar).</p>
@@ -6619,6 +6629,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Include only artifacts that match the given pattern (e.g., [&quot;app/&quot;, &quot;package.*&quot;]).</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Apply .gitignore filter rules inside the directory</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -6938,6 +6952,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., [&quot;app/&quot;, &quot;package.*&quot;]).</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>If set, apply .gitignore rules when filtering the directory.</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -7122,6 +7140,10 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Include only artifacts that match the given pattern (e.g., [&quot;app/&quot;, &quot;package.*&quot;]).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Apply .gitignore filter rules inside the directory</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>owner</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>

--- a/docs/static/reference/php/Dagger/Address.html
+++ b/docs/static/reference/php/Dagger/Address.html
@@ -156,7 +156,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_directory">directory</a>(array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+                    <a href="#method_directory">directory</a>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, bool|null $noCache = false)
         
                                             <p><p>Load a directory from the address.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -166,7 +166,7 @@
                     <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_file">file</a>(array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+                    <a href="#method_file">file</a>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, bool|null $noCache = false)
         
                                             <p><p>Load a file from the address.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -372,7 +372,7 @@
                     <h3 id="method_directory">
         <div class="location">at line 28</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>directory</strong>(array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+    <strong>directory</strong>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, bool|null $noCache = false)
         </code>
     </h3>
     <div class="details">    
@@ -394,6 +394,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
                 <td></td>
             </tr>
                     <tr>
@@ -422,9 +427,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 46</div>
+        <div class="location">at line 53</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
-    <strong>file</strong>(array|null $exclude = null, array|null $include = null, bool|null $noCache = false)
+    <strong>file</strong>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, bool|null $noCache = false)
         </code>
     </h3>
     <div class="details">    
@@ -446,6 +451,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
                 <td></td>
             </tr>
                     <tr>
@@ -474,7 +484,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_gitRef">
-        <div class="location">at line 64</div>
+        <div class="location">at line 78</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
     <strong>gitRef</strong>()
         </code>
@@ -506,7 +516,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_gitRepository">
-        <div class="location">at line 73</div>
+        <div class="location">at line 87</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>gitRepository</strong>()
         </code>
@@ -538,7 +548,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 82</div>
+        <div class="location">at line 96</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -570,7 +580,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 91</div>
+        <div class="location">at line 105</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>()
         </code>
@@ -602,7 +612,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_service">
-        <div class="location">at line 100</div>
+        <div class="location">at line 114</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>service</strong>()
         </code>
@@ -634,7 +644,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_socket">
-        <div class="location">at line 109</div>
+        <div class="location">at line 123</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>socket</strong>()
         </code>
@@ -666,7 +676,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_value">
-        <div class="location">at line 118</div>
+        <div class="location">at line 132</div>
         <code>                    string
     <strong>value</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -496,7 +496,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withDirectory">withDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
+                    <a href="#method_withDirectory">withDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $expand = false)
         
                                             <p><p>Return a new container snapshot, with a directory added to its filesystem</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -2452,7 +2452,7 @@
                     <h3 id="method_withDirectory">
         <div class="location">at line 528</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
+    <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
     <div class="details">    
@@ -2487,6 +2487,11 @@
                 <td></td>
             </tr>
                     <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td>string|null</td>
                 <td>$owner</td>
                 <td></td>
@@ -2517,7 +2522,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 557</div>
+        <div class="location">at line 561</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2564,7 +2569,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 570</div>
+        <div class="location">at line 574</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -2616,7 +2621,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 584</div>
+        <div class="location">at line 588</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -2658,7 +2663,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 594</div>
+        <div class="location">at line 598</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2750,7 +2755,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 651</div>
+        <div class="location">at line 655</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -2815,7 +2820,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 674</div>
+        <div class="location">at line 678</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -2877,7 +2882,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 699</div>
+        <div class="location">at line 703</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -2939,7 +2944,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 724</div>
+        <div class="location">at line 728</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -2986,7 +2991,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 735</div>
+        <div class="location">at line 739</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $cache, <abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3053,7 +3058,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 764</div>
+        <div class="location">at line 768</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3110,7 +3115,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 785</div>
+        <div class="location">at line 789</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3167,7 +3172,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 806</div>
+        <div class="location">at line 810</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $source, string|null $owner = &#039;&#039;, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3229,7 +3234,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 831</div>
+        <div class="location">at line 835</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3281,7 +3286,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 847</div>
+        <div class="location">at line 851</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3343,7 +3348,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 872</div>
+        <div class="location">at line 876</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
@@ -3395,7 +3400,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 884</div>
+        <div class="location">at line 888</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory)
         </code>
@@ -3437,7 +3442,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 894</div>
+        <div class="location">at line 898</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
@@ -3484,7 +3489,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 911</div>
+        <div class="location">at line 915</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service)
         </code>
@@ -3533,7 +3538,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 922</div>
+        <div class="location">at line 926</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -3585,7 +3590,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 936</div>
+        <div class="location">at line 940</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3642,7 +3647,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 957</div>
+        <div class="location">at line 961</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -3684,7 +3689,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 967</div>
+        <div class="location">at line 971</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -3731,7 +3736,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 980</div>
+        <div class="location">at line 984</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -3773,7 +3778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 990</div>
+        <div class="location">at line 994</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -3805,7 +3810,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 999</div>
+        <div class="location">at line 1003</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -3852,7 +3857,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1012</div>
+        <div class="location">at line 1016</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -3894,7 +3899,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1024</div>
+        <div class="location">at line 1028</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -3936,7 +3941,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1034</div>
+        <div class="location">at line 1038</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -3983,7 +3988,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1047</div>
+        <div class="location">at line 1051</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4030,7 +4035,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1060</div>
+        <div class="location">at line 1064</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4077,7 +4082,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1073</div>
+        <div class="location">at line 1077</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4119,7 +4124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1083</div>
+        <div class="location">at line 1087</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4166,7 +4171,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1096</div>
+        <div class="location">at line 1100</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4208,7 +4213,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1106</div>
+        <div class="location">at line 1110</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4250,7 +4255,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1116</div>
+        <div class="location">at line 1120</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4297,7 +4302,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1131</div>
+        <div class="location">at line 1135</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4329,7 +4334,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1142</div>
+        <div class="location">at line 1146</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -4361,7 +4366,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1151</div>
+        <div class="location">at line 1155</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/CurrentModule.html
+++ b/docs/static/reference/php/Dagger/CurrentModule.html
@@ -176,7 +176,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_workdir">workdir</a>(string $path, array|null $exclude = null, array|null $include = null)
+                    <a href="#method_workdir">workdir</a>(string $path, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         
                                             <p><p>Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -386,7 +386,7 @@
                     <h3 id="method_workdir">
         <div class="location">at line 46</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>workdir</strong>(string $path, array|null $exclude = null, array|null $include = null)
+    <strong>workdir</strong>(string $path, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         </code>
     </h3>
     <div class="details">    
@@ -415,6 +415,11 @@
                 <td>$include</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -436,7 +441,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdirFile">
-        <div class="location">at line 62</div>
+        <div class="location">at line 69</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>workdirFile</strong>(string $path)
         </code>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -276,7 +276,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_filter">filter</a>(array|null $exclude = null, array|null $include = null)
+                    <a href="#method_filter">filter</a>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         
                                             <p><p>Return a snapshot with some paths included or excluded</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -366,7 +366,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withDirectory">withDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;)
+                    <a href="#method_withDirectory">withDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;)
         
                                             <p><p>Return a snapshot with a directory added</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1161,7 +1161,7 @@
                     <h3 id="method_filter">
         <div class="location">at line 188</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>filter</strong>(array|null $exclude = null, array|null $include = null)
+    <strong>filter</strong>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         </code>
     </h3>
     <div class="details">    
@@ -1185,6 +1185,11 @@
                 <td>$include</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1206,7 +1211,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 203</div>
+        <div class="location">at line 206</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string $start)
         </code>
@@ -1253,7 +1258,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_glob">
-        <div class="location">at line 214</div>
+        <div class="location">at line 217</div>
         <code>                    array
     <strong>glob</strong>(string $pattern)
         </code>
@@ -1295,7 +1300,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 224</div>
+        <div class="location">at line 227</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1327,7 +1332,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 233</div>
+        <div class="location">at line 236</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -1359,7 +1364,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 244</div>
+        <div class="location">at line 247</div>
         <code>                    array
     <strong>search</strong>(string $pattern, array|null $paths = null, array|null $globs = null, bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1451,7 +1456,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 295</div>
+        <div class="location">at line 298</div>
         <code>                    <a href="../Dagger/DirectoryId.html"><abbr title="Dagger\DirectoryId">DirectoryId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1483,7 +1488,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 304</div>
+        <div class="location">at line 307</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>terminal</strong>(<abbr title="Dagger\Dagger\ContainerId|Dagger\Container|null">Container|null</abbr> $container = null, array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -1540,7 +1545,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 329</div>
+        <div class="location">at line 332</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withChanges</strong>(<abbr title="Dagger\ChangesetId|Dagger\Changeset">Changeset</abbr> $changes)
         </code>
@@ -1582,9 +1587,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 339</div>
+        <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, string|null $owner = &#039;&#039;)
+    <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;)
         </code>
     </h3>
     <div class="details">    
@@ -1619,6 +1624,11 @@
                 <td></td>
             </tr>
                     <tr>
+                <td>bool|null</td>
+                <td>$gitignore</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td>string|null</td>
                 <td>$owner</td>
                 <td></td>
@@ -1644,7 +1654,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 364</div>
+        <div class="location">at line 371</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -1686,7 +1696,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 374</div>
+        <div class="location">at line 381</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1743,7 +1753,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 395</div>
+        <div class="location">at line 402</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null)
         </code>
@@ -1795,7 +1805,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 409</div>
+        <div class="location">at line 416</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewDirectory</strong>(string $path, int|null $permissions = 420)
         </code>
@@ -1842,7 +1852,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 422</div>
+        <div class="location">at line 429</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -1894,7 +1904,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatch">
-        <div class="location">at line 436</div>
+        <div class="location">at line 443</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatch</strong>(string $patch)
         </code>
@@ -1936,7 +1946,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatchFile">
-        <div class="location">at line 446</div>
+        <div class="location">at line 453</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatchFile</strong>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $patch)
         </code>
@@ -1978,7 +1988,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 456</div>
+        <div class="location">at line 463</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -2025,7 +2035,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 467</div>
+        <div class="location">at line 474</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -2067,7 +2077,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 477</div>
+        <div class="location">at line 484</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2109,7 +2119,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 487</div>
+        <div class="location">at line 494</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2151,7 +2161,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 497</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/engine/filesync/copy/copy.go
+++ b/engine/filesync/copy/copy.go
@@ -236,6 +236,12 @@ func WithExcludePattern(excludePattern string) Opt {
 	}
 }
 
+func WithGitignore() Opt {
+	return func(ci *CopyInfo) {
+		ci.UseGitignore = true
+	}
+}
+
 func WithChangeNotifier(fn fsutil.ChangeFunc) Opt {
 	return func(ci *CopyInfo) {
 		ci.ChangeFunc = fn

--- a/sdk/elixir/lib/dagger/gen/address.ex
+++ b/sdk/elixir/lib/dagger/gen/address.ex
@@ -35,6 +35,7 @@ defmodule Dagger.Address do
   @spec directory(t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
+          {:gitignore, boolean() | nil},
           {:no_cache, boolean() | nil}
         ]) :: Dagger.Directory.t()
   def directory(%__MODULE__{} = address, optional_args \\ []) do
@@ -43,6 +44,7 @@ defmodule Dagger.Address do
       |> QB.select("directory")
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
       |> QB.maybe_put_arg("noCache", optional_args[:no_cache])
 
     %Dagger.Directory{
@@ -57,6 +59,7 @@ defmodule Dagger.Address do
   @spec file(t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
+          {:gitignore, boolean() | nil},
           {:no_cache, boolean() | nil}
         ]) :: Dagger.File.t()
   def file(%__MODULE__{} = address, optional_args \\ []) do
@@ -65,6 +68,7 @@ defmodule Dagger.Address do
       |> QB.select("file")
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
       |> QB.maybe_put_arg("noCache", optional_args[:no_cache])
 
     %Dagger.File{

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -666,6 +666,7 @@ defmodule Dagger.Container do
   @spec with_directory(t(), String.t(), Dagger.Directory.t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
+          {:gitignore, boolean() | nil},
           {:owner, String.t() | nil},
           {:expand, boolean() | nil}
         ]) :: Dagger.Container.t()
@@ -677,6 +678,7 @@ defmodule Dagger.Container do
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
 

--- a/sdk/elixir/lib/dagger/gen/current_module.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module.ex
@@ -54,8 +54,11 @@ defmodule Dagger.CurrentModule do
   @doc """
   Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
   """
-  @spec workdir(t(), String.t(), [{:exclude, [String.t()]}, {:include, [String.t()]}]) ::
-          Dagger.Directory.t()
+  @spec workdir(t(), String.t(), [
+          {:exclude, [String.t()]},
+          {:include, [String.t()]},
+          {:gitignore, boolean() | nil}
+        ]) :: Dagger.Directory.t()
   def workdir(%__MODULE__{} = current_module, path, optional_args \\ []) do
     query_builder =
       current_module.query_builder
@@ -63,6 +66,7 @@ defmodule Dagger.CurrentModule do
       |> QB.put_arg("path", path)
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
 
     %Dagger.Directory{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -230,13 +230,18 @@ defmodule Dagger.Directory do
   @doc """
   Return a snapshot with some paths included or excluded
   """
-  @spec filter(t(), [{:exclude, [String.t()]}, {:include, [String.t()]}]) :: Dagger.Directory.t()
+  @spec filter(t(), [
+          {:exclude, [String.t()]},
+          {:include, [String.t()]},
+          {:gitignore, boolean() | nil}
+        ]) :: Dagger.Directory.t()
   def filter(%__MODULE__{} = directory, optional_args \\ []) do
     query_builder =
       directory.query_builder
       |> QB.select("filter")
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
 
     %Dagger.Directory{
       query_builder: query_builder,
@@ -408,6 +413,7 @@ defmodule Dagger.Directory do
   @spec with_directory(t(), String.t(), Dagger.Directory.t(), [
           {:exclude, [String.t()]},
           {:include, [String.t()]},
+          {:gitignore, boolean() | nil},
           {:owner, String.t() | nil}
         ]) :: Dagger.Directory.t()
   def with_directory(%__MODULE__{} = directory, path, source, optional_args \\ []) do
@@ -418,6 +424,7 @@ defmodule Dagger.Directory do
       |> QB.put_arg("source", Dagger.ID.id!(source))
       |> QB.maybe_put_arg("exclude", optional_args[:exclude])
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("gitignore", optional_args[:gitignore])
       |> QB.maybe_put_arg("owner", optional_args[:owner])
 
     %Dagger.Directory{

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -353,6 +353,8 @@ type AddressDirectoryOpts struct {
 
 	Include []string
 
+	Gitignore bool
+
 	NoCache bool
 }
 
@@ -367,6 +369,10 @@ func (r *Address) Directory(opts ...AddressDirectoryOpts) *Directory {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 		// `noCache` optional argument
 		if !querybuilder.IsZeroValue(opts[i].NoCache) {
@@ -385,6 +391,8 @@ type AddressFileOpts struct {
 
 	Include []string
 
+	Gitignore bool
+
 	NoCache bool
 }
 
@@ -399,6 +407,10 @@ func (r *Address) File(opts ...AddressFileOpts) *File {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 		// `noCache` optional argument
 		if !querybuilder.IsZeroValue(opts[i].NoCache) {
@@ -1995,6 +2007,8 @@ type ContainerWithDirectoryOpts struct {
 	Exclude []string
 	// Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
 	Include []string
+	// Apply .gitignore rules when writing the directory.
+	Gitignore bool
 	// A user:group to set for the directory and its contents.
 	//
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -2017,6 +2031,10 @@ func (r *Container) WithDirectory(path string, source *Directory, opts ...Contai
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
@@ -3009,6 +3027,8 @@ type CurrentModuleWorkdirOpts struct {
 	Exclude []string
 	// Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
 	Include []string
+	// Apply .gitignore filter rules inside the directory
+	Gitignore bool
 }
 
 // Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
@@ -3022,6 +3042,10 @@ func (r *CurrentModule) Workdir(path string, opts ...CurrentModuleWorkdirOpts) *
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 	}
 	q = q.Arg("path", path)
@@ -3338,6 +3362,8 @@ type DirectoryFilterOpts struct {
 	Exclude []string
 	// If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., ["app/", "package.*"]).
 	Include []string
+	// If set, apply .gitignore rules when filtering the directory.
+	Gitignore bool
 }
 
 // Return a snapshot with some paths included or excluded
@@ -3351,6 +3377,10 @@ func (r *Directory) Filter(opts ...DirectoryFilterOpts) *Directory {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 	}
 
@@ -3609,6 +3639,8 @@ type DirectoryWithDirectoryOpts struct {
 	Exclude []string
 	// Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
 	Include []string
+	// Apply .gitignore filter rules inside the directory
+	Gitignore bool
 	// A user:group to set for the copied directory and its contents.
 	//
 	// The user and group must be an ID (1000:1000), not a name (foo:bar).
@@ -3629,6 +3661,10 @@ func (r *Directory) WithDirectory(path string, source *Directory, opts ...Direct
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
 		}
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {

--- a/sdk/php/generated/Address.php
+++ b/sdk/php/generated/Address.php
@@ -25,14 +25,21 @@ class Address extends Client\AbstractObject implements Client\IdAble
     /**
      * Load a directory from the address.
      */
-    public function directory(?array $exclude = null, ?array $include = null, ?bool $noCache = false): Directory
-    {
+    public function directory(
+        ?array $exclude = null,
+        ?array $include = null,
+        ?bool $gitignore = false,
+        ?bool $noCache = false,
+    ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         if (null !== $exclude) {
         $innerQueryBuilder->setArgument('exclude', $exclude);
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         if (null !== $noCache) {
         $innerQueryBuilder->setArgument('noCache', $noCache);
@@ -43,14 +50,21 @@ class Address extends Client\AbstractObject implements Client\IdAble
     /**
      * Load a file from the address.
      */
-    public function file(?array $exclude = null, ?array $include = null, ?bool $noCache = false): File
-    {
+    public function file(
+        ?array $exclude = null,
+        ?array $include = null,
+        ?bool $gitignore = false,
+        ?bool $noCache = false,
+    ): File {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         if (null !== $exclude) {
         $innerQueryBuilder->setArgument('exclude', $exclude);
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         if (null !== $noCache) {
         $innerQueryBuilder->setArgument('noCache', $noCache);

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -530,6 +530,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         DirectoryId|Directory $source,
         ?array $exclude = null,
         ?array $include = null,
+        ?bool $gitignore = false,
         ?string $owner = '',
         ?bool $expand = false,
     ): Container {
@@ -541,6 +542,9 @@ class Container extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);

--- a/sdk/php/generated/CurrentModule.php
+++ b/sdk/php/generated/CurrentModule.php
@@ -43,8 +43,12 @@ class CurrentModule extends Client\AbstractObject implements Client\IdAble
     /**
      * Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
      */
-    public function workdir(string $path, ?array $exclude = null, ?array $include = null): Directory
-    {
+    public function workdir(
+        string $path,
+        ?array $exclude = null,
+        ?array $include = null,
+        ?bool $gitignore = false,
+    ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('workdir');
         $innerQueryBuilder->setArgument('path', $path);
         if (null !== $exclude) {
@@ -52,6 +56,9 @@ class CurrentModule extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -185,7 +185,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     /**
      * Return a snapshot with some paths included or excluded
      */
-    public function filter(?array $exclude = null, ?array $include = null): Directory
+    public function filter(?array $exclude = null, ?array $include = null, ?bool $gitignore = false): Directory
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('filter');
         if (null !== $exclude) {
@@ -193,6 +193,9 @@ class Directory extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -341,6 +344,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble
         DirectoryId|Directory $source,
         ?array $exclude = null,
         ?array $include = null,
+        ?bool $gitignore = false,
         ?string $owner = '',
     ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDirectory');
@@ -351,6 +355,9 @@ class Directory extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $gitignore) {
+        $innerQueryBuilder->setArgument('gitignore', $gitignore);
         }
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -529,12 +529,14 @@ class Address(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
         no_cache: bool | None = False,
     ) -> "Directory":
         """Load a directory from the address."""
         _args = [
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
             Arg("noCache", no_cache, False),
         ]
         _ctx = self._select("directory", _args)
@@ -545,12 +547,14 @@ class Address(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
         no_cache: bool | None = False,
     ) -> "File":
         """Load a file from the address."""
         _args = [
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
             Arg("noCache", no_cache, False),
         ]
         _ctx = self._select("file", _args)
@@ -2125,6 +2129,7 @@ class Container(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
         owner: str | None = "",
         expand: bool | None = False,
     ) -> Self:
@@ -2143,6 +2148,8 @@ class Container(Type):
         include:
             Patterns to include in the written directory (e.g. ["*.go",
             "go.mod", "go.sum"]).
+        gitignore:
+            Apply .gitignore rules when writing the directory.
         owner:
             A user:group to set for the directory and its contents.
             The user and group can either be an ID (1000:1000) or a name
@@ -2158,6 +2165,7 @@ class Container(Type):
             Arg("source", source),
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
             Arg("owner", owner, ""),
             Arg("expand", expand, False),
         ]
@@ -3220,6 +3228,7 @@ class CurrentModule(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
     ) -> "Directory":
         """Load a directory from the module's scratch working directory,
         including any changes that may have been made to it during module
@@ -3235,11 +3244,14 @@ class CurrentModule(Type):
         include:
             Include only artifacts that match the given pattern (e.g.,
             ["app/", "package.*"]).
+        gitignore:
+            Apply .gitignore filter rules inside the directory
         """
         _args = [
             Arg("path", path),
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
         ]
         _ctx = self._select("workdir", _args)
         return Directory(_ctx)
@@ -3579,6 +3591,7 @@ class Directory(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
     ) -> Self:
         """Return a snapshot with some paths included or excluded
 
@@ -3590,10 +3603,13 @@ class Directory(Type):
         include:
             If set, only paths matching one of these glob patterns is included
             in the new snapshot. Example: (e.g., ["app/", "package.*"]).
+        gitignore:
+            If set, apply .gitignore rules when filtering the directory.
         """
         _args = [
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
         ]
         _ctx = self._select("filter", _args)
         return Directory(_ctx)
@@ -3841,6 +3857,7 @@ class Directory(Type):
         *,
         exclude: list[str] | None = None,
         include: list[str] | None = None,
+        gitignore: bool | None = False,
         owner: str | None = "",
     ) -> Self:
         """Return a snapshot with a directory added
@@ -3857,6 +3874,8 @@ class Directory(Type):
         include:
             Include only artifacts that match the given pattern (e.g.,
             ["app/", "package.*"]).
+        gitignore:
+            Apply .gitignore filter rules inside the directory
         owner:
             A user:group to set for the copied directory and its contents.
             The user and group must be an ID (1000:1000), not a name
@@ -3868,6 +3887,7 @@ class Directory(Type):
             Arg("source", source),
             Arg("exclude", [] if exclude is None else exclude, []),
             Arg("include", [] if include is None else include, []),
+            Arg("gitignore", gitignore, False),
             Arg("owner", owner, ""),
         ]
         _ctx = self._select("withDirectory", _args)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1832,6 +1832,8 @@ pub struct AddressDirectoryOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
     #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
+    #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
     #[builder(setter(into, strip_option), default)]
     pub no_cache: Option<bool>,
@@ -1840,6 +1842,8 @@ pub struct AddressDirectoryOpts<'a> {
 pub struct AddressFileOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
+    #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
     #[builder(setter(into, strip_option), default)]
@@ -1881,6 +1885,9 @@ impl Address {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
+        }
         if let Some(no_cache) = opts.no_cache {
             query = query.arg("noCache", no_cache);
         }
@@ -1915,6 +1922,9 @@ impl Address {
         }
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
         }
         if let Some(no_cache) = opts.no_cache {
             query = query.arg("noCache", no_cache);
@@ -2492,6 +2502,9 @@ pub struct ContainerWithDirectoryOpts<'a> {
     /// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
+    /// Apply .gitignore rules when writing the directory.
+    #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
     /// Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
@@ -3481,6 +3494,9 @@ impl Container {
         }
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
         }
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
@@ -4829,6 +4845,9 @@ pub struct CurrentModuleWorkdirOpts<'a> {
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
+    /// Apply .gitignore filter rules inside the directory
+    #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
     /// Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
@@ -4886,6 +4905,9 @@ impl CurrentModule {
         }
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
         }
         Directory {
             proc: self.proc.clone(),
@@ -4977,6 +4999,9 @@ pub struct DirectoryFilterOpts<'a> {
     /// If set, paths matching one of these glob patterns is excluded from the new snapshot. Example: ["node_modules/", ".git*", ".env"]
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
+    /// If set, apply .gitignore rules when filtering the directory.
+    #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
     /// If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., ["app/", "package.*"]).
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
@@ -5034,6 +5059,9 @@ pub struct DirectoryWithDirectoryOpts<'a> {
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
+    /// Apply .gitignore filter rules inside the directory
+    #[builder(setter(into, strip_option), default)]
+    pub gitignore: Option<bool>,
     /// Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
@@ -5389,6 +5417,9 @@ impl Directory {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
+        }
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5617,6 +5648,9 @@ impl Directory {
         }
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(gitignore) = opts.gitignore {
+            query = query.arg("gitignore", gitignore);
         }
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -20,12 +20,14 @@ class BaseClient {
 export type AddressDirectoryOpts = {
   exclude?: string[]
   include?: string[]
+  gitignore?: boolean
   noCache?: boolean
 }
 
 export type AddressFileOpts = {
   exclude?: string[]
   include?: string[]
+  gitignore?: boolean
   noCache?: boolean
 }
 
@@ -372,6 +374,11 @@ export type ContainerWithDirectoryOpts = {
    * Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
    */
   include?: string[]
+
+  /**
+   * Apply .gitignore rules when writing the directory.
+   */
+  gitignore?: boolean
 
   /**
    * A user:group to set for the directory and its contents.
@@ -727,6 +734,11 @@ export type CurrentModuleWorkdirOpts = {
    * Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
    */
   include?: string[]
+
+  /**
+   * Apply .gitignore filter rules inside the directory
+   */
+  gitignore?: boolean
 }
 
 /**
@@ -824,6 +836,11 @@ export type DirectoryFilterOpts = {
    * If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., ["app/", "package.*"]).
    */
   include?: string[]
+
+  /**
+   * If set, apply .gitignore rules when filtering the directory.
+   */
+  gitignore?: boolean
 }
 
 export type DirectorySearchOpts = {
@@ -915,6 +932,11 @@ export type DirectoryWithDirectoryOpts = {
    * Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
    */
   include?: string[]
+
+  /**
+   * Apply .gitignore filter rules inside the directory
+   */
+  gitignore?: boolean
 
   /**
    * A user:group to set for the copied directory and its contents.
@@ -3604,6 +3626,7 @@ export class Container extends BaseClient {
    * @param source Identifier of the directory to write
    * @param opts.exclude Patterns to exclude in the written directory (e.g. ["node_modules/**", ".gitignore", ".git/"]).
    * @param opts.include Patterns to include in the written directory (e.g. ["*.go", "go.mod", "go.sum"]).
+   * @param opts.gitignore Apply .gitignore rules when writing the directory.
    * @param opts.owner A user:group to set for the directory and its contents.
    *
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -4268,6 +4291,7 @@ export class CurrentModule extends BaseClient {
    * @param path Location of the directory to access (e.g., ".").
    * @param opts.exclude Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
    * @param opts.include Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
+   * @param opts.gitignore Apply .gitignore filter rules inside the directory
    */
   workdir = (path: string, opts?: CurrentModuleWorkdirOpts): Directory => {
     const ctx = this._ctx.select("workdir", { path, ...opts })
@@ -4515,6 +4539,7 @@ export class Directory extends BaseClient {
    * Return a snapshot with some paths included or excluded
    * @param opts.exclude If set, paths matching one of these glob patterns is excluded from the new snapshot. Example: ["node_modules/", ".git*", ".env"]
    * @param opts.include If set, only paths matching one of these glob patterns is included in the new snapshot. Example: (e.g., ["app/", "package.*"]).
+   * @param opts.gitignore If set, apply .gitignore rules when filtering the directory.
    */
   filter = (opts?: DirectoryFilterOpts): Directory => {
     const ctx = this._ctx.select("filter", { ...opts })
@@ -4633,6 +4658,7 @@ export class Directory extends BaseClient {
    * @param source Identifier of the directory to copy.
    * @param opts.exclude Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
    * @param opts.include Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
+   * @param opts.gitignore Apply .gitignore filter rules inside the directory
    * @param opts.owner A user:group to set for the copied directory and its contents.
    *
    * The user and group must be an ID (1000:1000), not a name (foo:bar).


### PR DESCRIPTION
We can just add this to `CopyFilter` and allow it everywhere we allow that.

I hit this because I needed it for https://github.com/dagger/dagger/pull/11326, so that I could load the entire target directory that backs contextual git so that we can access `uncommitted` details.