### PR TITLE
feat: allow contextual git to access uncommited changes

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -940,7 +940,7 @@ func (src *ModuleSource) LoadContextGit(
 
 	// bit harder, this is actually a local directory
 	dir, err := src.LoadContextDir(ctx, dag, "/", CopyFilter{
-		Include: []string{".git"},
+		Gitignore: true,
 	})
 	if err != nil {
 		return inst, fmt.Errorf("failed to load contextual git: %w", err)


### PR DESCRIPTION
Previously, a contextual git directory was loading a *bare* repository (essentially only including the `.git` path). However, we now want access to `GitRepository.uncommitted`, so that we can get the changes that haven't yet been committed to the repo.

To do this, *technically* all we need to do is remove the `Include` filter. However, the performance of this essentially means we'd upload everything, which is hugely expensive. Anything in the gitignore isn't actually going to be part of the changeset, so we can skip uploading it.