### PR TITLE
reduce mutex contention during disk usage calculation 

### DIFF
--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -35,10 +35,16 @@ func setupDebugHandlers(addr string) error {
 	m.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	m.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	m.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	m.Handle("/debug/pprof/block", pprof.Handler("block"))
 	m.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
 	m.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
 	m.Handle("/debug/events", http.HandlerFunc(trace.Events))
 	// m.Handle("/debug/fgtrace", fgtrace.Config{})
+
+	// uncomment these to get data from /mutex and /block
+	// runtime.SetMutexProfileFraction(1)
+	// runtime.SetBlockProfileRate(1)
 
 	m.Handle("/debug/gc", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		runtime.GC()


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/11336 reduced mutex contention quite a bit around various boltdb operations, but after that the next biggest source of contention as seen in pprof profiles is around locks used to acquire refs during disk pruning.

This change results in reusing already known cache records rather than trying to reacquire them, saving us from a lot of extra locks/unlocks. This matters during disk pruning since there can be an enormous number of refs to work through.