### PR TITLE
allows to override the trace name via env variable

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -24,6 +24,7 @@ const (
 	GPUSupportEnv        = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
 	RunnerHostEnv        = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
 	RunnerImageLoaderEnv = "_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE"
+	TraceNameEnv         = "DAGGER_TRACE_NAME"
 )
 
 var (
@@ -160,7 +161,11 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 	// If you pass credentials in plaintext, yes, they will be leaked; don't do
 	// that, since they will also be leaked in various other places (like the
 	// process tree). Use Secret arguments instead.
-	ctx, span := Tracer().Start(ctx, spanName(os.Args))
+	name := spanName(os.Args)
+	if os.Getenv(TraceNameEnv) != "" {
+		name = os.Getenv(TraceNameEnv)
+	}
+	ctx, span := Tracer().Start(ctx, name)
 
 	// Set up global slog to log to the primary span output.
 	slog.SetDefault(slog.SpanLogger(ctx, InstrumentationLibrary))


### PR DESCRIPTION
this is useful particularly in the cases where the trace is started from
the SDK which currently results in a generic span name like "dagger
session...."

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
