### PR TITLE
fix: directory.Exists did not follow abs symlink

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -1400,14 +1400,21 @@ func (dir *Directory) Exists(ctx context.Context, srv *dagql.Server, targetPath 
 	}
 
 	osStatFunc := os.Stat
+	rootPathFunc := containerdfs.RootPath
 	if targetType == ExistsTypeSymlink || doNotFollowSymlinks {
 		// symlink testing requires the Lstat call, which does NOT follow symlinks
 		osStatFunc = os.Lstat
+		// similarly, containerdfs.RootPath can't be used, since it follows symlinks
+		rootPathFunc = RootPathWithoutFinalSymlink
 	}
 
 	var fileInfo os.FileInfo
 	err = MountRef(ctx, immutableRef, nil, func(root string) error {
-		fileInfo, err = osStatFunc(path.Join(root, dir.Dir, targetPath))
+		resolvedPath, err := rootPathFunc(root, path.Join(dir.Dir, targetPath))
+		if err != nil {
+			return err
+		}
+		fileInfo, err = osStatFunc(resolvedPath)
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -2561,6 +2561,18 @@ func (DirectorySuite) TestExists(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (DirectorySuite) TestExistsUsingAbsoluteSymlink(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ok, err := c.Directory().
+		WithNewFile("/some-file", "some-content").
+		WithSymlink("/some-file", "/symlink-to-some-file").
+		Exists(ctx, "symlink-to-some-file", dagger.DirectoryExistsOpts{
+			ExpectedType: dagger.ExistsTypeRegularType,
+		})
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
 func (DirectorySuite) TestDirCaching(ctx context.Context, t *testctx.T) {
 	// NOTE: This test requires that WithNewFile sets the creation date to the current time,
 	// if this side-effect were to ever change (i.e. adopting SOURCE_DATE_EPOCH functionality),


### PR DESCRIPTION
This fixes a bug where directory.Exist failed to resolve an absolute symlink relative to the mounted filesystem, but instead escaped the mounted filesystem and incorrectly referenced / on the host's filesystem.