### PR TITLE
telemetry: bump sqlite write timeout

### DIFF
--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -58,7 +58,7 @@ func (dbs *DBs) Open(clientID string) (*sql.DB, error) {
 				"foreign_keys=ON",    // we don't use em yet, but makes sense anyway
 				"journal_mode=WAL",   // readers don't block writers and vice versa
 				"synchronous=OFF",    // we don't care about durability and don't want to be surprised by syncs
-				"busy_timeout=10000", // wait up to 10s when there are concurrent writers
+				"busy_timeout=20000", // wait up to 20s when there are concurrent writers
 			},
 			"_txlock": []string{"immediate"}, // use BEGIN IMMEDIATE for transactions
 		}.Encode(),


### PR DESCRIPTION
We've seen in CI some SQLITE BUSY errors popping up again in the telemetry client dbs. It's *possible* (but far from confirmed) that other performance improvements may be resulting in us writing to those dbs faster and thus making it easier to hit that error.

Trying out a bump of the timeout to see if it helps in the short term.