### PR TITLE
add  CHANGIE_MAINTAINERS to fix release notes.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -160,6 +160,7 @@ to dagger.
 - [ ] Generate release notes `.changes/**/v0.12.4.md` for all releases:
 
   ```console
+  export CHANGIE_MAINTAINERS=$(dagger call -m releaser get-maintainers --github-org-name dagger --github-token="cmd://gh auth token" --json)
   find . sdk/go sdk/python sdk/typescript sdk/elixir sdk/php sdk/rust helm/dagger -maxdepth 1 -name .changie.yaml -execdir changie batch $ENGINE_VERSION \;
   ```
 


### PR DESCRIPTION
we accidentally removed it in a previous release.

fixes #11367

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
