### PR TITLE
ci: switch to runners without cache

### DIFF
--- a/.github/main.go
+++ b/.github/main.go
@@ -32,6 +32,7 @@ type CI struct {
 	Workflows *dagger.Gha
 
 	AltRunner          *dagger.Gha // +private
+	AltSilverRunner    *dagger.Gha // +private
 	AltRunnerWithCache *dagger.Gha // +private
 }
 
@@ -57,6 +58,13 @@ func New() *CI {
 		AltRunner: dag.Gha(dagger.GhaOpts{
 			JobDefaults: dag.Gha().Job("", "", dagger.GhaJobOpts{
 				Runner:         AltGoldRunner(),
+				TimeoutMinutes: timeoutMinutes,
+			}),
+			WorkflowDefaults: workflow,
+		}),
+		AltSilverRunner: dag.Gha(dagger.GhaOpts{
+			JobDefaults: dag.Gha().Job("", "", dagger.GhaJobOpts{
+				Runner:         AltSilverRunner(),
 				TimeoutMinutes: timeoutMinutes,
 			}),
 			WorkflowDefaults: workflow,
@@ -99,7 +107,7 @@ func (ci *CI) Generate(
 
 // Add a simple workflow that runs 'dagger call' in a standard template
 func (ci *CI) withSimpleDaggerCheck(command, name string) *CI {
-	template := ci.AltRunnerWithCache
+	template := ci.AltSilverRunner
 	ci.Workflows = ci.Workflows.WithWorkflow(
 		template.
 			Workflow(name).
@@ -338,6 +346,11 @@ func AltBronzeRunnerWithCache() []string {
 // Alternative Silver runner with caching: Single-tenant, 8 cpu
 func AltSilverRunnerWithCache() []string {
 	return Alt2Runner(8, true)
+}
+
+// Alternative Silver runner without caching: Single-tenant, 8 cpu
+func AltSilverRunner() []string {
+	return Alt2Runner(8, false)
 }
 
 // Alternative Gold runner: Single-tenant with Docker, 16 cpu

--- a/.github/workflows/check-generated-files.gen.yml
+++ b/.github/workflows/check-generated-files.gen.yml
@@ -21,7 +21,6 @@ jobs:
     check-generated-files:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Check generated files
         steps:
             - name: Checkout

--- a/.github/workflows/check-go-tidy.gen.yml
+++ b/.github/workflows/check-go-tidy.gen.yml
@@ -21,7 +21,6 @@ jobs:
     check-go-tidy:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Check go tidy
         steps:
             - name: Checkout

--- a/.github/workflows/ci-in-ci.gen.yml
+++ b/.github/workflows/ci-in-ci.gen.yml
@@ -21,7 +21,6 @@ jobs:
     ci-in-ci:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: CI in CI
         steps:
             - name: Checkout

--- a/.github/workflows/lint-docs-helm-chart-and-install-scripts.gen.yml
+++ b/.github/workflows/lint-docs-helm-chart-and-install-scripts.gen.yml
@@ -21,7 +21,6 @@ jobs:
     lint-docs-helm-chart-and-install-scripts:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Lint docs, helm chart and install scripts
         steps:
             - name: Checkout

--- a/.github/workflows/release-dry-run.gen.yml
+++ b/.github/workflows/release-dry-run.gen.yml
@@ -21,7 +21,6 @@ jobs:
     release-dry-run:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Release dry run
         steps:
             - name: Checkout

--- a/.github/workflows/run-all-sdk-linters.gen.yml
+++ b/.github/workflows/run-all-sdk-linters.gen.yml
@@ -21,7 +21,6 @@ jobs:
     run-all-sdk-linters:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Run all SDK linters
         steps:
             - name: Checkout

--- a/.github/workflows/run-go-linter.gen.yml
+++ b/.github/workflows/run-go-linter.gen.yml
@@ -21,7 +21,6 @@ jobs:
     run-go-linter:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Run Go Linter
         steps:
             - name: Checkout

--- a/.github/workflows/security-scan.gen.yml
+++ b/.github/workflows/security-scan.gen.yml
@@ -21,7 +21,6 @@ jobs:
     security-scan:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Security scan
         steps:
             - name: Checkout

--- a/.github/workflows/test-helm-chart.gen.yml
+++ b/.github/workflows/test-helm-chart.gen.yml
@@ -21,7 +21,6 @@ jobs:
     test-helm-chart:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Test Helm chart
         steps:
             - name: Checkout

--- a/.github/workflows/test-install-scripts.gen.yml
+++ b/.github/workflows/test-install-scripts.gen.yml
@@ -21,7 +21,6 @@ jobs:
     test-install-scripts:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Test install scripts
         steps:
             - name: Checkout

--- a/.github/workflows/test-sdks.gen.yml
+++ b/.github/workflows/test-sdks.gen.yml
@@ -21,7 +21,6 @@ jobs:
     test-sdks:
         runs-on:
             - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-8x16' || 'ubuntu-24.04' }}
-            - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.6' || 'ubuntu-24.04' }}
         name: Test SDKs
         steps:
             - name: Checkout


### PR DESCRIPTION
We've seeing a few issues on our CI that are related to the state of the underlying engine provisioned and managed by namespace. A few examples here:
- https://dagger.cloud/dagger/traces/7148ab0874f4f47c06458481f8b2c949
- https://dagger.cloud/dagger/traces/425ccc4b797aec8a6f42cd2b9a996cac

This PR moves away of the namespace managed dagger engine to an engine that is started on demand within the runner instance.