### PR TITLE
Fix Dagger build in corporate proxy environments

### DIFF
--- a/cmd/engine/.dagger/build/sdk.go
+++ b/cmd/engine/.dagger/build/sdk.go
@@ -76,6 +76,7 @@ func (build *Builder) pythonSDKContent(ctx context.Context) (*sdkContent, error)
 			WithWorkdir("/src").
 			WithDirectory("/usr/local/bin", rootfs.Directory("dist")).
 			WithMountedDirectory("", rootfs.Directory("codegen")).
+			WithEnvVariable("UV_NATIVE_TLS", "true").
 			WithExec([]string{
 				"uv", "export",
 				"--no-hashes",

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -75,6 +75,7 @@ func (m *ElixirSdk) ModuleRuntime(
 
 	return ctr.
 		WithEnvVariable("MIX_ENV", "prod").
+		WithEnvVariable("HEX_CACERTS_PATH", "/etc/ssl/certs/ca-certificates.crt").
 		WithExec([]string{"mix", "deps.get", "--only", "prod"}).
 		WithExec([]string{"mix", "deps.compile"}).
 		WithExec([]string{"mix", "compile"}).


### PR DESCRIPTION
Certain (mostly corporate) proxies intercept TLS and thus need to re-sign using their own certificate authority. Dagger already supports specifying custom CAs for regular usage. This patch fixes ./hack/build in environments where a custom CA is needed.