### PR TITLE
util/parallel: allow customizing tracer provider, to be usable both client-side and engine-side

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -741,7 +741,7 @@ func (s *moduleSourceSchema) loadBlueprintModule(
 		return fmt.Errorf("failed to get dag server: %w", err)
 	}
 
-	jobs := parallel.New().WithReveal(false)
+	jobs := parallel.New().WithContextualTracer(true).WithReveal(false)
 	// Load blueprint
 	if src.ConfigBlueprint != nil {
 		jobs = jobs.WithJob("load blueprint: "+src.ConfigBlueprint.Source, func(ctx context.Context) error {
@@ -758,7 +758,7 @@ func (s *moduleSourceSchema) loadBlueprintModule(
 	if len(src.ConfigToolchains) > 0 {
 		jobs = jobs.WithJob("load toolchains", func(ctx context.Context) error {
 			src.Toolchains = make([]dagql.ObjectResult[*core.ModuleSource], len(src.ConfigToolchains))
-			toolchainJobs := parallel.New().WithReveal(false)
+			toolchainJobs := parallel.New().WithReveal(false).WithContextualTracer(true)
 			for i, pcfg := range src.ConfigToolchains {
 				toolchainJobs = toolchainJobs.WithJob(pcfg.Name, func(ctx context.Context) error {
 					toolchain, err := core.ResolveDepToSource(ctx, bk, dag, src, pcfg.Source, pcfg.Pin, pcfg.Name)

--- a/go.mod
+++ b/go.mod
@@ -159,6 +159,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.57.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
@@ -344,7 +345,6 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	google.golang.org/api v0.239.0 // indirect


### PR DESCRIPTION
This fixes a regression in `util/parallel`, which causes it to work when called from the engine, but *not* from a client.

With this fix, the same calls will work by default client-side, and can be configured to work from the engine with a single chained call to `WithContextualTracer(true)`.