### PR TITLE
feat: add eager-mod-loading flag

### DIFF
--- a/cmd/dagger/function_name.go
+++ b/cmd/dagger/function_name.go
@@ -8,9 +8,9 @@ import (
 
 func initModuleParams(a []string) client.Params {
 	params := client.Params{
-		ExecCmd:            a,
-		Function:           functionName(a),
-		EagerModuleLoading: eagerModuleLoading,
+		ExecCmd:      a,
+		Function:     functionName(a),
+		EagerRuntime: eagerRuntime,
 	}
 
 	if !moduleNoURL {

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -58,8 +58,8 @@ var (
 
 	force bool
 
-	autoApply          bool
-	eagerModuleLoading bool
+	autoApply    bool
+	eagerRuntime bool
 )
 
 const (
@@ -120,7 +120,7 @@ func moduleAddFlags(cmd *cobra.Command, flags *pflag.FlagSet, optional bool) {
 	flags.StringSliceVar(&allowedLLMModules, "allow-llm", defaultAllowLLM, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
 
 	// Add the eager module loading flag to disable lazy load on runtime.
-	flags.BoolVar(&eagerModuleLoading, "eager-mod-loading", false, "load module runtime eagerly")
+	flags.BoolVar(&eagerRuntime, "eager-runtime", false, "load module runtime eagerly")
 }
 
 func init() {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2837,7 +2837,7 @@ func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInst
 		return nil, fmt.Errorf("failed to get client metadata: %w", err)
 	}
 
-	if clientMetadata.EagerModuleLoading && !mod.Runtime.Valid {
+	if clientMetadata.EagerRuntime && !mod.Runtime.Valid {
 		runtime, err := runtimeImpl.Runtime(ctx, mod.Deps, srcInstContentHashed)
 		if err != nil {
 			return nil, err

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -19,7 +19,7 @@ dagger [options] [subcommand | file...]
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -c, --command string               Execute a dagger shell command
   -d, --debug                        Show debug logs and full verbosity
-      --eager-mod-loading            load module runtime eagerly
+      --eager-runtime                load module runtime eagerly
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
   -m, --mod string                   Module reference to load, either a local path or a remote git repo (defaults to current directory)
@@ -63,7 +63,7 @@ dagger call [options]
 
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -j, --json                Present result as JSON
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
@@ -112,7 +112,7 @@ dagger config -m github.com/dagger/hello-dagger
 
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
       --json                output in JSON format
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
@@ -203,7 +203,7 @@ dagger develop [options]
 ```
       --allow-llm strings        List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string[="skip"]   Engine API version to target (default "latest")
-      --eager-mod-loading        load module runtime eagerly
+      --eager-runtime            load module runtime eagerly
       --license string           License identifier to generate. See https://spdx.org/licenses/ (default "Apache-2.0")
   -m, --mod string               Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -r, --recursive                Develop recursively into local dependencies
@@ -252,7 +252,7 @@ dagger functions [options] [function]...
 
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 
@@ -362,7 +362,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -n, --name string         Name to use for the dependency in the module. Defaults to the name of the module being installed.
 ```
@@ -480,7 +480,7 @@ EOF
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --doc string          Read query from file (defaults to reading from stdin)
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
       --var strings         List of query variables, in key=value format
@@ -616,7 +616,7 @@ dagger toolchain install github.com/dagger/dagger/toolchains/go
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
   -n, --name string         Name to use for the toolchain in the module. Defaults to the name of the toolchain being installed.
 ```
@@ -662,7 +662,7 @@ dagger toolchain list
 
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 
@@ -708,7 +708,7 @@ dagger toolchain uninstall mytoolchain
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 
@@ -754,7 +754,7 @@ dagger toolchain update
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 
@@ -800,7 +800,7 @@ dagger uninstall hello
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 
@@ -851,7 +851,7 @@ dagger update [options] [<DEPENDENCY>...]
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --compat string       Engine API version to target (default "latest")
-      --eager-mod-loading   load module runtime eagerly
+      --eager-runtime       load module runtime eagerly
   -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
 ```
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -108,7 +108,7 @@ type Params struct {
 	Function string
 	ExecCmd  []string
 
-	EagerModuleLoading bool
+	EagerRuntime bool
 }
 
 type Client struct {
@@ -1194,7 +1194,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		InteractiveCommand:        c.InteractiveCommand,
 		SSHAuthSocketPath:         sshAuthSock,
 		AllowedLLMModules:         c.AllowedLLMModules,
-		EagerModuleLoading:        c.EagerModuleLoading,
+		EagerRuntime:              c.EagerRuntime,
 	}
 }
 

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -89,7 +89,7 @@ type ClientMetadata struct {
 	AllowedLLMModules []string `json:"allowed_llm_modules"`
 
 	// Disable lazy loading on module runtime.
-	EagerModuleLoading bool `json:"eager_module_loading"`
+	EagerRuntime bool `json:"eager_runtime"`
 }
 
 type clientMetadataCtxKey struct{}


### PR DESCRIPTION
As discussed with @shykes, with the lazy runtime loading addition, it became hard  to verify that your module and its dependencies compiles just by running dagger functions.

This PR adds the flag `eager-runtime` to all modules commands so it disables lazy loading on module runtime. That way, running `dagger functions --eager-runtime` also let you verify that your module compiles properly.

Add `EagerModuleLoading` in engine client metadata.

**Difference between [`dagger functions --eager-runtime`](https://dagger.cloud/Quartz/traces/d9456aa3b8559a4163258804a454f079?listen=01a416d941de42de&listen=95d02eab609ac765&listen=a762178577185ff8) & [`dagger functions`](https://dagger.cloud/Quartz/traces/7e831d54c9f9aa3b8dcc4ac0f0cdd39c?listen=ac3ac0ec32ba7b05&listen=73b735068de22090&listen=e06cf8adf8612a21&listen=987a1df74aafef41)**

<img width="1600" height="383" alt="Screenshot 2025-11-14 at 15 28 43" src="https://github.com/user-attachments/assets/a400ed74-9045-4287-8cf4-256c54c7e9a9" />
