### PR TITLE
cloud: send trace ID when requesting a new engine

### DIFF
--- a/engine/client/drivers/cloud.go
+++ b/engine/client/drivers/cloud.go
@@ -91,7 +91,12 @@ func (d *daggerCloudDriver) Provision(ctx context.Context, _ *url.URL, opts *Dri
 		execCmd = opts.ExecCmd
 	}
 
-	engineSpec, err := client.Engine(ctx, cloud.EngineRequest{Module: module, Function: function, ExecCmd: execCmd, ClientID: opts.ClientID})
+	engineSpec, err := client.Engine(ctx, cloud.EngineRequest{
+		Module:   module,
+		Function: function,
+		ExecCmd:  execCmd,
+		ClientID: opts.ClientID,
+	})
 	if err != nil {
 		if errors.Is(err, cloud.ErrNoOrg) {
 			return nil, errors.New("please associate this Engine with an org by running `dagger login <org>")

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/shurcooL/graphql"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 
 	"github.com/dagger/dagger/engine"
@@ -103,6 +104,7 @@ type EngineRequest struct {
 	ExecCmd              []string `json:"exec_cmd,omitempty"`
 	ClientID             string   `json:"client_id,omitempty"`
 	MinimumEngineVersion string   `json:"minimum_engine_version,omitempty"`
+	TraceID              string   `json:"trace_id,omitempty"`
 }
 
 type EngineSpec struct {
@@ -165,6 +167,7 @@ func (c *Client) Engine(ctx context.Context, req EngineRequest) (*EngineSpec, er
 	}
 
 	req.MinimumEngineVersion = engine.MinimumEngineVersion
+	req.TraceID = trace.SpanContextFromContext(ctx).TraceID().String()
 	engineSpec := &EngineSpec{
 		Image:         "registry.dagger.io/engine:" + tag,
 		EngineRequest: req,


### PR DESCRIPTION
When we provision an engine the trace has already been created. For cloud to have full traceability of which trace requested which engine we send the trace ID associated with the call making the request.