### PR TITLE
core: handle nil returns in various places

### DIFF
--- a/core/dagop.go
+++ b/core/dagop.go
@@ -571,6 +571,12 @@ func (op ContainerDagOp) Exec(ctx context.Context, g bksession.Group, inputs []s
 	if err != nil {
 		return nil, err
 	}
+	if obj == nil {
+		return nil, fmt.Errorf("invalid unset container load: %s", op.ID.Display())
+	}
+	if obj.Unwrap() == nil {
+		return nil, fmt.Errorf("invalid unset wrapped container load: %s", op.ID.Display())
+	}
 
 	bk, err := query.Buildkit(ctx)
 	if err != nil {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -7264,16 +7264,39 @@ import (
 )
 
 type Test struct {
+	Dirs []*dagger.Directory
 }
 
 func (m *Test) Nothing() (*dagger.Directory, error) {
 	return nil, nil
 }
+
+func (m *Test) ListWithNothing() ([]*dagger.Directory, error) {
+	return []*dagger.Directory{nil}, nil
+}
+
+func (m *Test) ObjsWithNothing() ([]*Test, error) {
+	return []*Test{
+		nil,
+		{
+			Dirs: []*dagger.Directory{nil},
+		},
+	}, nil
+}
 `,
 		)
 
-	_, err := modGen.With(daggerQuery(`{test{nothing{id}}}`)).Stdout(ctx)
+	out, err := modGen.With(daggerQuery(`{test{nothing{entries}}}`)).Stdout(ctx)
 	require.NoError(t, err)
+	require.JSONEq(t, `{"test":{"nothing":null}}`, out)
+
+	out, err = modGen.With(daggerQuery(`{test{listWithNothing{entries}}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"test":{"listWithNothing":[null]}}`, out)
+
+	out, err = modGen.With(daggerQuery(`{test{objsWithNothing{dirs{entries}}}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"test":{"objsWithNothing":[null,{"dirs":[null]}]}}`, out)
 }
 
 func (ModuleSuite) TestFunctionCacheControl(ctx context.Context, t *testctx.T) {

--- a/core/modtypes.go
+++ b/core/modtypes.go
@@ -143,6 +143,9 @@ func (t *ListType) CollectCoreIDs(ctx context.Context, value dagql.AnyResult, id
 		if err != nil {
 			return err
 		}
+		if item == nil {
+			continue
+		}
 
 		ctx := dagql.ContextWithID(ctx, item.ID())
 

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -163,6 +163,9 @@ func (d DynamicResultArrayOutput) Nth(i int) (Typed, error) {
 	if err != nil {
 		return nil, err
 	}
+	if val == nil {
+		return nil, nil
+	}
 	return val.Unwrap(), nil
 }
 

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1013,8 +1013,12 @@ func (s *Server) resolvePath(ctx context.Context, self AnyObjectResult, sel Sele
 			if err != nil {
 				return nil, err
 			}
+			if val == nil {
+				results = append(results, nil)
+				continue
+			}
 			val, ok := val.DerefValue()
-			if !ok {
+			if !ok || val == nil {
 				results = append(results, nil)
 				continue
 			}


### PR DESCRIPTION
A user reported a panic from ContainerDagOp where it was hitting either a nil return from LoadType or a return that when unwrapped is nil.

I don't have a repro for that yet, so the code there is just an update to turn that into an error and include more debug information to help track it down if/when it happens again.

However while attempting repros of it I managed to hit independent panics involving modules returning various permutations of nil things in lists. Fixed those here and included integ test coverage.