### PR TITLE
docker: speed up local connect time by using version instead of info

### DIFF
--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -28,7 +28,7 @@ func (d docker) Available(ctx context.Context) (bool, error) {
 	}
 
 	// check daemon is running
-	cmd := exec.CommandContext(ctx, d.cmd, "info")
+	cmd := exec.CommandContext(ctx, d.cmd, "version")
 	if err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated()); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
My unscientific testing on my machine of `dagger core version` says that the connect time goes from about 1s-2s to 200-400ms.