### PR TITLE
chore: fix incorrect function name in comment

### DIFF
--- a/internal/buildkit/cache/blobs_linux.go
+++ b/internal/buildkit/cache/blobs_linux.go
@@ -22,7 +22,7 @@ import (
 
 var emptyDesc = ocispecs.Descriptor{}
 
-// computeOverlayBlob provides overlayfs-specialized method to compute
+// tryComputeOverlayBlob provides overlayfs-specialized method to compute
 // diff between lower and upper snapshot. If the passed mounts cannot
 // be computed (e.g. because the mounts aren't overlayfs), it returns
 // an error.

--- a/internal/buildkit/cache/refs.go
+++ b/internal/buildkit/cache/refs.go
@@ -686,7 +686,7 @@ func (sr *immutableRef) Clone() ImmutableRef {
 	return sr.clone()
 }
 
-// layertoDistributable changes the passed in media type to the "distributable" version of the media type.
+// layerToDistributable changes the passed in media type to the "distributable" version of the media type.
 func layerToDistributable(mt string) string {
 	if !images.IsNonDistributable(mt) {
 		// Layer is already a distributable media type (or this is not even a layer).

--- a/util/fsxutil/gitignore_matcher.go
+++ b/util/fsxutil/gitignore_matcher.go
@@ -23,7 +23,7 @@ type GitignoreMatcher struct {
 	gitignoreCacheMu       sync.RWMutex
 }
 
-// NewGitignoreMatcher creates a new GitignoreMatcher for the given FS
+// NewGitIgnoreMatcher creates a new GitignoreMatcher for the given FS
 func NewGitIgnoreMatcher(fs fsutil.FS) *GitignoreMatcher {
 	gfs := &GitignoreMatcher{
 		fs:                     fs,


### PR DESCRIPTION
fix incorrect function name in comment