### PR TITLE
fix: pin dang sdk in `cmd/codegen` to a pre-check commit.

### DIFF
--- a/cmd/codegen/dagger.json
+++ b/cmd/codegen/dagger.json
@@ -2,7 +2,7 @@
   "name": "codegen",
   "engineVersion": "v0.19.6",
   "sdk": {
-    "source": "github.com/vito/dang/dagger-sdk"
+    "source": "github.com/vito/dang/dagger-sdk@0fc10d961e421944c1f3dbff4961dd5b0a59998c"
   },
   "dependencies": [
     {


### PR DESCRIPTION
The dang sdk is breaking the engine dev build because it is using unreleased API, we pin the dang SDK to a commit that work to let the engine build

Full incident at: https://discord.com/channels/707636530424053791/1003718839739105300/1439929385103654965

/cc @eunomie 