### PR TITLE
prefer DAGGER_CLOUD_TOKEN over oauth for cloud engine provider

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -43,23 +43,21 @@ func NewClient(ctx context.Context) (*Client, error) {
 
 	httpClient := &http.Client{}
 
-	// Always prefer oauth if available. If not and a DAGGER_CLOUD_TOKEN
-	// is set then use Basic auth
-	tokenSource, err := auth.TokenSource(ctx)
-	if err != nil {
-		if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
-			httpClient.Transport, err = auth.DaggerCloudTransport(ctx, cloudToken)
-			if err != nil {
-				return nil, err
-			}
-
-			return &Client{
-				u:           u,
-				h:           httpClient,
-				engineToken: cloudToken,
-			}, nil
+	if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
+		httpClient.Transport, err = auth.DaggerCloudTransport(ctx, cloudToken)
+		if err != nil {
+			return nil, err
 		}
 
+		return &Client{
+			u:           u,
+			h:           httpClient,
+			engineToken: cloudToken,
+		}, nil
+	}
+
+	tokenSource, err := auth.TokenSource(ctx)
+	if err != nil {
 		return nil, err
 	}
 	httpClient = oauth2.NewClient(ctx, tokenSource)


### PR DESCRIPTION
this is in line with the way that the OTEL exporters also authenticate

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
