### PR TITLE
fix long-standing panic in disk usage

### DIFF
--- a/.changes/unreleased/Fixed-20251119-193114.yaml
+++ b/.changes/unreleased/Fixed-20251119-193114.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed rare panic during disk usage calculation.
+time: 2025-11-19T19:31:14.797050656-08:00
+custom:
+  Author: sipsma
+  PR: "11450"

--- a/internal/buildkit/cache/manager.go
+++ b/internal/buildkit/cache/manager.go
@@ -1435,11 +1435,13 @@ func (cm *cacheManager) DiskUsage(ctx context.Context, opt client.DiskUsageInfo)
 			v := m[id]
 			if v.refs == 0 {
 				for _, p := range v.parents {
-					m[p].refs--
-					if v.doubleRef {
-						m[p].refs--
+					if pInfo, ok := m[p]; ok && pInfo != nil {
+						pInfo.refs--
+						if v.doubleRef {
+							pInfo.refs--
+						}
+						rescan[p] = struct{}{}
 					}
-					rescan[p] = struct{}{}
 				}
 			}
 			delete(rescan, id)


### PR DESCRIPTION
User reported a v0.19.3 engine crashing with this stack:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xecd5f6]

goroutine 521 [running]:
github.com/dagger/dagger/internal/buildkit/cache.(*cacheManager).DiskUsage(0xc000390370, {0x3efeef0, 0xc0005ae280}, {{0x0?, 0xffffffffffffffff?, 0xc008bb8b50?}})
	/app/internal/buildkit/cache/manager.go:1434 +0x1116
github.com/dagger/dagger/internal/buildkit/worker/base.(*Worker).DiskUsage(...)
	/app/internal/buildkit/worker/base/worker.go:436
github.com/dagger/dagger/engine/server.(*Server).EngineLocalCacheEntries(0xc008bb8a80?, {0x3efeef0?, 0xc0005ae280?})
	/app/engine/server/gc.go:25 +0x4c
main.setupMetricsServer.func1.1()
	/app/cmd/engine/metrics.go:59 +0x25
main.setupMetricsServer.func1()
	/app/cmd/engine/metrics.go:78 +0x82
created by main.setupMetricsServer in goroutine 1
	/app/cmd/engine/metrics.go:57 +0x225
```

As far as I can tell this has existed since the beginning of time? So must be rare but possible. Simple update to handle.