### PR TITLE
core: fix error from cache hit on same git repo with different auth

### DIFF
--- a/.changes/unreleased/Fixed-20251120-122452.yaml
+++ b/.changes/unreleased/Fixed-20251120-122452.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix "failed to add secret" errors when concurrently using a private git repo
+  from multiple clients that each have a different auth token value.
+time: 2025-11-20T12:24:52.320500703-08:00
+custom:
+  Author: sipsma
+  PR: "11456"

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1190,12 +1190,18 @@ type vcsTestCase struct {
 
 	// encodedToken is a based64 encoded read-only PAT
 	encodedToken string
+	// encodedToken2 is an optional second token to test cases of using different tokens for the same repo
+	encodedToken2 string
 	// sshKey determines whether to propagate the host's ssh-key
 	sshKey bool
 }
 
 func (tc vcsTestCase) token() string {
-	decodedToken, err := base64.StdEncoding.DecodeString(tc.encodedToken)
+	return decodedGitToken(tc.encodedToken)
+}
+
+func decodedGitToken(encodedToken string) string {
+	decodedToken, err := base64.StdEncoding.DecodeString(encodedToken)
 	if err != nil {
 		return ""
 	}
@@ -1273,7 +1279,10 @@ var vcsTestCases = []vcsTestCase{
 		expectedURLPathComponent: "tree",
 		expectedPathPrefix:       "",
 		isPrivateRepo:            true,
-		encodedToken:             "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
+		// NOTE: this is not a security vulnerability, these tokens are read-only and scoped to a test repository
+		// with no actual private code
+		encodedToken:  "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
+		encodedToken2: "Z2xwYXQtcFVIWDVmZmVCUmdjZ2FYTHdndjNPVzg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxa2oyMHJi",
 	},
 	// BitBucket private repository using SCP-like SSH reference format
 	{


### PR DESCRIPTION
See the added integ test for the case being fixed here.

In retrospect erroring out when transfering secrets/sockets from one client to another was unnecessarily zealous since in the worst case an attempt to use those by the client would just result in an error eventually.

In the current dagql caching system, it's possible for content-digested resources like git repo trees to end up in a client's call ID with auth sourced from an earlier client making the same call. In this case, even though the specific auth used to pull the git repo may differ between the two, it doesn't matter because both clients have already "proven" access to the repo by having constructed the tree already.

It's also not possible for the specific token value to leak between the two because the token's secret name is also content hashed, so to retrieve its plaintext you'd need to know its plaintext already.