### PR TITLE
bump old dagger versions in ci

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.19.6"
+    default: "v0.19.7"
     required: false
 
   dev-engine:

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -15,7 +15,7 @@ on:
       dagger:
         description: "Dagger version"
         type: string
-        default: "0.19.6"
+        default: "0.19.7"
         required: false
       ubuntu:
         description: "Ubuntu version"


### PR DESCRIPTION
Seems like a couple version bumps got missed during last release, which is causing publish workflow to fail.