### PR TITLE
fix another set of old 0.19.6 strings

### DIFF
--- a/.github/workflows/benchmark-engine.yml
+++ b/.github/workflows/benchmark-engine.yml
@@ -23,7 +23,7 @@ jobs:
   benchdev:
     if: ${{ github.repository == 'dagger/dagger' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')) }}
     runs-on:
-        - 'dagger-g3-v0-19-6-16c-st-benchmark'
+        - 'dagger-g3-v0-19-7-16c-st-benchmark'
     timeout-minutes: 10
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g3-v0-19-6-16c-st
+    runs-on: dagger-g3-v0-19-7-16c-st
     steps:
       - uses: actions/checkout@v4
       - name: "Publish"
@@ -89,7 +89,7 @@ jobs:
   dagger-io-bump-dagger:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g3-v0-19-6-4c
+    runs-on: dagger-g3-v0-19-7-4c
     steps:
       # Configure credentials to clone dagger modules
       - uses: de-vri-es/setup-git-credentials@v2


### PR DESCRIPTION
In my last attempt I grep'd for 0.19.6 and fixed those, but that missed places where the string in question is 0-19-6....

Didn't notice in the PR because publish only runs on main. So one more bump.