### PR TITLE
Vault: add non-standard approle auth method

### DIFF
--- a/docs/current_docs/extending/modules/arguments.mdx
+++ b/docs/current_docs/extending/modules/arguments.mdx
@@ -844,7 +844,7 @@ dagger call github-api --token=op://infra/github/credential
 Vault can be authenticated with either token or AppRole methods.
 The Vault host can be specified by setting the environment variable `VAULT_ADDR`.
 For token authentication, set the environment variable `VAULT_TOKEN`.
-For AppRole authentication, set the environment variables `VAULT_APPROLE_ROLE_ID` and `VAULT_APPROLE_SECRET_ID` (and optionally the variable `VAULT_APPROLE_AUTH_METHOD`, otherwise the default value will be used - `approle`).
+For AppRole authentication, set the environment variables `VAULT_APPROLE_ROLE_ID` and `VAULT_APPROLE_SECRET_ID` (and optionally the variable `VAULT_APPROLE_MOUNT_PATH`, otherwise the default value will be used - `approle`).
 Additional client configuration can be specified by the default environment variables accepted by Vault.
 
 Vault KvV2 secrets are accessed with the scheme `vault://PATH/TO/SECRET.ITEM`. If your KvV2 is not mounted at `/secret`, specify the mount location with the environment variable `VAULT_PATH_PREFIX`. Here is an example:

--- a/engine/client/secretprovider/vault.go
+++ b/engine/client/secretprovider/vault.go
@@ -131,11 +131,13 @@ func vaultConfigureClient(ctx context.Context) error {
 	if roleID != "" {
 		var opts []auth.LoginOption
 
-		authMethod := os.Getenv("VAULT_APPROLE_AUTH_METHOD")
+		// Sets auth mount path. Default is "approle"
+		authMethod := os.Getenv("VAULT_APPROLE_MOUNT_PATH")
 		if authMethod != "" {
 			opts = append(opts, auth.WithMountPath(authMethod))
 		}
 
+		// Get SecretID
 		secretID := &auth.SecretID{FromEnv: "VAULT_APPROLE_SECRET_ID"}
 
 		// Authenticate


### PR DESCRIPTION
Added `VAULT_APPROLE_MOUNT_PATH` env variable for authenticating to non-standard approle auth method in Vault

Resolves #11468