### PR TITLE
Go SDK toolchain: fix typo in release()

### DIFF
--- a/toolchains/go-sdk-dev/main.dang
+++ b/toolchains/go-sdk-dev/main.dang
@@ -89,7 +89,7 @@ type GoSdkDev {
     """Target git remote to release to"""
     destRemote: String! = "https://github.com/dagger/dagger-go-sdk.git",
     githubToken: Secret,
-    callback: File! @defaultPath(path:"./go-git-filter-callback.py"),
+    callback: File! @defaultPath(path:"./git-filter-callback.py"),
   ): Void {
     let version = sourceTag.trimPrefix(sourcePath)
     gitReleaser().release(


### PR DESCRIPTION
This fixes the failed "dev release" CI job on main.

[Example trace](https://dagger.cloud/dagger/traces/22b1a0e5b3e15bfb0089fd22e03fb582)
