### PR TITLE
generate: workaround for panic

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -25,7 +25,7 @@ func (dev *DaggerDev) Generate(ctx context.Context,
 	// +optional
 	check bool,
 ) (*dagger.Changeset, error) {
-	var genDocs, genEngine, genChangelog, genGHA, genSDKs *dagger.Changeset
+	var genDocs, genEngine, genChangelog, genSDKs *dagger.Changeset
 	maybeCheck := func(ctx context.Context, changes *dagger.Changeset) error {
 		if !check {
 			return nil
@@ -77,7 +77,7 @@ func (dev *DaggerDev) Generate(ctx context.Context,
 	err = parallel.Run(ctx, "merge all changesets", func(ctx context.Context) error {
 		var err error
 		var gen []*dagger.Changeset
-		gen = append(gen, genDocs, genEngine, genChangelog, genGHA, genSDKs)
+		gen = append(gen, genDocs, genEngine, genChangelog, genSDKs)
 		result, err = changesetMerge(gen...).Sync(ctx)
 		return err
 	})

--- a/.dagger/util.go
+++ b/.dagger/util.go
@@ -15,6 +15,9 @@ import (
 func changesetMerge(changesets ...*dagger.Changeset) *dagger.Changeset {
 	before := dag.Directory()
 	for _, changeset := range changesets {
+		if changeset == nil {
+			continue
+		}
 		before = before.WithDirectory("", changeset.Before())
 	}
 	after := before


### PR DESCRIPTION
```
        panic: panic: runtime error: invalid memory address or nil pointer dereference
        stacktrace:
        goroutine 122 [running]:
        runtime/debug.Stack()
                /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
        github.com/sourcegraph/conc/panics.NewRecovered(0x1, {0xb9cb80, 0x12eb240})
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/panics/panics.go:59 +0x85
        github.com/sourcegraph/conc/panics.(*Catcher).tryRecover(0xc000284310)
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/panics/panics.go:28 +0x5f
        panic({0xb9cb80?, 0x12eb240?})
                /usr/local/go/src/runtime/panic.go:783 +0x132
        go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
                /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.38.0/trace/span.go:468 +0x25
        go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00028e000, {0x0, 0x0, 0xc00047c000?})
                /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.38.0/trace/span.go:517 +0xbf2
        panic({0xb9cb80?, 0x12eb240?})
                /usr/local/go/src/runtime/panic.go:783 +0x132
        github.com/dagger/dagger/.dagger/internal/dagger.(*Changeset).Before(...)
                /src/.dagger/internal/dagger/dagger.gen.go:1358
        main.changesetMerge({0xc0002900f0, 0x5, 0x0?})
                /src/.dagger/util.go:18 +0x117
        main.(*DaggerDev).Generate.func6({0xdb1bc0, 0xc0002900c0})
                /src/.dagger/main.go:81 +0x10a
        github.com/dagger/dagger/util/parallel.parallelJobs.Run.Job.Runner.func1()
                /src/util/parallel/parallel.go:140 +0xc2
        github.com/dagger/dagger/util/parallel.parallelJobs.Run.(*ErrorPool).Go.func2()
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/error_pool.go:30 +0x23
        github.com/sourcegraph/conc/pool.(*Pool).worker(0x0?)
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/pool/pool.go:154 +0x69
        github.com/sourcegraph/conc/panics.(*Catcher).Try(0x4283a0?, 0xc00017bdc0?)
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/panics/panics.go:23 +0x42
        github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:32 +0x4d
        created by github.com/sourcegraph/conc.(*WaitGroup).Go in goroutine 1
                /go/pkg/mod/github.com/sourcegraph/conc@v0.3.0/waitgroup.go:30 +0x73
        
```