### PR TITLE
feat: typescript SDK add live telemetry

### DIFF
--- a/sdk/typescript/src/telemetry/live_processor.ts
+++ b/sdk/typescript/src/telemetry/live_processor.ts
@@ -1,0 +1,15 @@
+import type { Context } from "@opentelemetry/api"
+import { BatchSpanProcessor, type Span } from "@opentelemetry/sdk-trace-base"
+
+/**
+ * Live span processor implementation.
+ *
+ * It's a BatchSpanProcessor whose on_start calls on_end on the underlying
+ * SpanProcessor in order to send live telemetry.
+ */
+export class LiveProcessor extends BatchSpanProcessor {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override onStart(_span: Span, _parentContext: Context): void {
+    this.onEnd(_span)
+  }
+}


### PR DESCRIPTION
Use `LiveSpanProcessor` if live trace is enabled in ts sdk telemetry.