### PR TITLE
fix(cache): do not cache function errors in a single dagger session

### DIFF
--- a/dagql/session_cache_test.go
+++ b/dagql/session_cache_test.go
@@ -2,6 +2,7 @@ package dagql
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -90,4 +91,65 @@ func TestSessionCacheReleaseAndClose(t *testing.T) {
 
 		require.Equal(t, 0, c.Size())
 	})
+}
+
+func TestSessionCacheErrorThenSuccessIsCached(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	base, err := cache.NewCache[CacheKeyType, AnyResult](ctx, "")
+	require.NoError(t, err)
+
+	sc := NewSessionCache(base)
+	key := cache.CacheKey[CacheKeyType]{CallKey: "session-cache-error-then-success"}
+
+	// We simulate this sequence for a single CallKey:
+	//  1) error
+	//  2) error
+	//  3) success
+	//  4) (must be served from cache, NOT call the underlying fn)
+	type step struct {
+		err error
+	}
+	steps := []step{
+		{err: fmt.Errorf("boom 1")},
+		{err: fmt.Errorf("boom 2")},
+		{err: nil}, // first success
+		{err: fmt.Errorf("should never be used if caching works")},
+	}
+
+	callCount := 0
+	fn := func(ctx context.Context) (*CacheValWithCallbacks, error) {
+		require.Less(t, callCount, len(steps), "underlying fn called too many times")
+		s := steps[callCount]
+		callCount++
+		if s.err != nil {
+			return nil, s.err
+		}
+		// Successful call: we don't care about the actual value for this test,
+		// only that the SessionCache / engine cache will reuse it.
+		return &CacheValWithCallbacks{Value: nil}, nil
+	}
+
+	// 1) First call: error, underlying fn must run once.
+	_, err = sc.GetOrInitializeWithCallbacks(ctx, key, fn)
+	require.Error(t, err)
+	require.Equal(t, 1, callCount)
+
+	// 2) Second call: another error, underlying fn must run again.
+	_, err = sc.GetOrInitializeWithCallbacks(ctx, key, fn)
+	require.Error(t, err)
+	require.Equal(t, 2, callCount)
+
+	// 3) Third call: first success, underlying fn must run a third time.
+	_, err = sc.GetOrInitializeWithCallbacks(ctx, key, fn)
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount)
+
+	// 4) Fourth call: MUST hit cache, not run fn again.
+	// If caching is broken, this call will increment
+	// callCount to 4 and return an error.
+	_, err = sc.GetOrInitializeWithCallbacks(ctx, key, fn)
+	require.NoError(t, err, "after a successful call for a key, subsequent calls must reuse the cached success")
+	require.Equal(t, 3, callCount, "underlying fn should not be called again after success is cached")
 }


### PR DESCRIPTION
Fixes #11465

### Problem

In a long-lived engine session (interactive shell), function calls that previously failed were incorrectly replayed when invoked again with the same inputs.

The correct behavior should be:
	•	Failed calls should never be cached.
	•	Subsequent identical calls should rerun and, upon success, then be cached.

This issue did not affect the Dagger CLI (dagger call) because each invocation runs with a fresh session.

###  Solution

To resolve this, after a forced `DoNotCache=true` call successfully completes, we explicitly re-insert the successful result into the cache using the original key. This ensures subsequent calls correctly retrieve the successful outcome from the cache.

A boolean flag, `forcedDoNotCache`, was introduced to clearly distinguish cases:
- Set internally due to previous errors (eligible for recaching).
- Explicitly set by callers for intentionally non-cacheable operations (ineligible for recaching).

This fix effectively addresses the caching issue without needing the more complex approach of directly invalidating BuildKit’s cache entries.


## Manual repro

Given this test module: 

```shell
import dagger
import random
from dagger import dag, function, object_type


@object_type
class Test:
    @function(cache="session") 
    async def test_cache(self, low: int, high: float, limit: float) -> float:

        data =  random.uniform( low,high)
        if data < limit: 
            # if i hit this i dont want caching to occu
            raise ValueError( f"{data} < {limit}")
        return data
```

You can run, in a single session, these commands: `test | test-cache 0 10 4` (you can increase the `4` to `8` or `9`, so that the errors are more common) all the failed runs shall rerun and once a successful run is hit, it should be cached for th e next runs