### PR TITLE
codegen: close telemetry after init

### DIFF
--- a/cmd/codegen/generate_client.go
+++ b/cmd/codegen/generate_client.go
@@ -32,6 +32,7 @@ var generateClientCmd = &cobra.Command{
 func GenerateClient(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	ctx = telemetry.InitEmbedded(ctx, nil)
+	defer telemetry.Close()
 
 	cfg, err := getGlobalConfig(ctx, false)
 	if err != nil {

--- a/cmd/codegen/generate_library.go
+++ b/cmd/codegen/generate_library.go
@@ -22,6 +22,7 @@ var generateLibraryCmd = &cobra.Command{
 func GenerateLibrary(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	ctx = telemetry.InitEmbedded(ctx, nil)
+	defer telemetry.Close()
 
 	cfg, err := getGlobalConfig(ctx, false)
 	if err != nil {

--- a/cmd/codegen/generate_module.go
+++ b/cmd/codegen/generate_module.go
@@ -29,6 +29,7 @@ var generateModuleCmd = &cobra.Command{
 func GenerateModule(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	ctx = telemetry.InitEmbedded(ctx, nil)
+	defer telemetry.Close()
 
 	cfg, err := getGlobalConfig(ctx, false)
 	if err != nil {

--- a/cmd/codegen/generate_typedef.go
+++ b/cmd/codegen/generate_typedef.go
@@ -21,6 +21,7 @@ var generateTypeDefsCmd = &cobra.Command{
 func GenerateTypeDefs(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	ctx = telemetry.InitEmbedded(ctx, nil)
+	defer telemetry.Close()
 
 	cfg, err := getGlobalConfig(ctx, true)
 	if err != nil {


### PR DESCRIPTION
Noticed telemetry.Close() calls were missing after the InitEmbedded call. Not clear if this was actively harming anything, but worth a quick fix.