### PR TITLE
util/parallel: disable 'reveal' by default

### DIFF
--- a/util/parallel/parallel.go
+++ b/util/parallel/parallel.go
@@ -14,7 +14,8 @@ import (
 func New() parallelJobs {
 	return parallelJobs{
 		Internal: false,
-		Reveal:   true,
+		Reveal:   false, // this used to be 'true', but it caused too many "hiding noisy spans" in web trace view
+
 		// Don't use the contextual tracer by default: this breaks in Dagger *clients* (including modules),
 		// because a freshly connected client does not have
 		ContextualTracer: false,


### PR DESCRIPTION
This should fix the issue in web trace view, where too many spans are hidden by default with "hiding noisy spans"

