### PR TITLE
[chore] convert container export to dagop

### DIFF
--- a/util/containerutil/annotation.go
+++ b/util/containerutil/annotation.go
@@ -1,0 +1,6 @@
+package containerutil
+
+type ContainerAnnotation struct {
+	Key   string
+	Value string
+}


### PR DESCRIPTION
This reworks the container publish and export functions, so that an `ImmutableRef` is passed to the exporting code, rather than performing a buildkit solve during the export phase.