### PR TITLE
make go codegen deterministic

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -517,6 +517,11 @@ func (ps *parseState) fillObjectFunctionCases(type_ types.Type, cases map[string
 		return nil
 	}
 
+	// Sort methods alphabetically to ensure deterministic codegen output
+	sort.Slice(methods, func(i, j int) bool {
+		return methods[i].fn.Name() < methods[j].fn.Name()
+	})
+
 	for _, method := range methods {
 		fnName, sig := method.fn.Name(), method.fn.Type().(*types.Signature)
 		if err := ps.fillObjectFunctionCase(objName, fnName, fnName, sig, method.paramSpecs, cases); err != nil {


### PR DESCRIPTION
This basically needs to get released before https://github.com/dagger/dagger/pull/11515 is able to get merged.

Currently modules with dependencies do not have deterministic codegen, which means we cant commit generated files without a healthy amount of pain and regret.

This adds a sort to the codegen and a test to make sure running codegen twice produces the same result.