### PR TITLE
fix: TypeScript cache setting type error.

### DIFF
--- a/sdk/typescript/src/module/decorators.ts
+++ b/sdk/typescript/src/module/decorators.ts
@@ -15,6 +15,7 @@ export const object = registry.object
  * class' method that must be exposed to the Dagger API.
  *
  * @param alias The alias to use for the field when exposed on the API.
+ * @param cache The cache setting to use for that function.
  */
 export const func = registry.func
 

--- a/sdk/typescript/src/module/registry.ts
+++ b/sdk/typescript/src/module/registry.ts
@@ -47,7 +47,7 @@ export type FunctionOptions = {
    * A duration string (e.g., "5m", "1h") means persistent caching for that duration.
    * By default, caching is enabled with a long default set by the engine.
    */
-  cache?: string
+  cache?: "never" | "session" | string
 
   /**
    * An optional alias to use for the function when exposed on the API.
@@ -112,7 +112,7 @@ export class Registry {
    * class' method that must be exposed to the Dagger API.
    */
   func = (
-    alias?: string,
+    opts?: FunctionOptions | string,
   ): ((
     target: object,
     propertyKey: string | symbol,


### PR DESCRIPTION
Fixes an error raised on Discord:
https://discord.com/channels/707636530424053791/1157515934597136404/1446582727230095510

This PR updates the types so it will correctly annotate decorators.