### PR TITLE
uv: Use dependency-groups.dev instead of tool.uv-dev-dependencies

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
 "Community" = "https://discord.gg/ufnyBtc8uY"
 "Twitter" = "https://twitter.com/dagger_io"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "codegen",
     # lint
     "ruff>=0.3.4",


### PR DESCRIPTION
The previous format was deprecated, which led to a warning during module loading. See:
https://docs.astral.sh/uv/concepts/projects/dependencies/#legacy-dev-dependencies