### PR TITLE
less fsyncs via overlay volatile

### DIFF
--- a/internal/buildkit/snapshot/localmounter.go
+++ b/internal/buildkit/snapshot/localmounter.go
@@ -34,13 +34,14 @@ func LocalMounterWithMounts(mounts []mount.Mount, opts ...LocalMounterOpt) Mount
 }
 
 type localMounter struct {
-	mu           sync.Mutex
-	mounts       []mount.Mount
-	mountable    Mountable
-	target       string
-	release      func() error
-	forceRemount bool
-	tmpDir       string
+	mu                  sync.Mutex
+	mounts              []mount.Mount
+	mountable           Mountable
+	target              string
+	release             func() error
+	forceRemount        bool
+	tmpDir              string
+	overlayIncompatDirs []string
 }
 
 func ForceRemount() LocalMounterOpt {

--- a/internal/buildkit/util/overlay/overlay.go
+++ b/internal/buildkit/util/overlay/overlay.go
@@ -1,8 +1,74 @@
 package overlay
 
-import "github.com/containerd/containerd/v2/core/mount"
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/mount"
+)
 
 // IsOverlayMountType returns true if the mount type is overlay-based
 func IsOverlayMountType(mnt mount.Mount) bool {
 	return mnt.Type == "overlay"
+}
+
+/*
+We use the "volatile" overlayfs mount option to improve performance via less
+fsync'ing: https://docs.kernel.org/filesystems/overlayfs.html#volatile-mount
+
+This results in the kernel creating a `incompat` dir inside the overlay's
+workdir when the mount is created. That directory is *not* removed when the
+mount is unmounted. If the mount is remounted later and the incompat dir still
+exists, the mount syscall will error out. This is the kernel's attempt to tell
+us the mount might have not be fsync'd after use and thus have inconsistent data
+(i.e. in the case of a hard machine crash).
+
+However, we often mount+unmount the same overlay mount multiple times (e.g. cache
+mounts, mounts after an errored exec, etc.). Thus we need to find these incompat
+dirs and remove them by hand (as the kernel docs say we should).
+*/
+
+// VolatileIncompatDir returns the overlayfs incompat directory for a mount that
+// uses the "volatile" option. An empty string means the mount doesn't use
+// volatile overlayfs or doesn't include a workdir option.
+func VolatileIncompatDir(mnt mount.Mount) string {
+	if !IsOverlayMountType(mnt) {
+		return ""
+	}
+	var hasVolatile bool
+	var workDir string
+	for _, opt := range mnt.Options {
+		if opt == "volatile" {
+			hasVolatile = true
+			continue
+		}
+		if strings.HasPrefix(opt, "workdir=") {
+			workDir = strings.TrimPrefix(opt, "workdir=")
+			continue
+		}
+	}
+	if !hasVolatile || workDir == "" {
+		return ""
+	}
+	return filepath.Join(workDir, "work", "incompat")
+}
+
+// VolatileIncompatDirs returns de-duplicated incompat directories for mounts
+// that use the "volatile" option.
+func VolatileIncompatDirs(mounts []mount.Mount) []string {
+	if len(mounts) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 1)
+	for _, m := range mounts {
+		if dir := VolatileIncompatDir(m); dir != "" {
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			out = append(out, dir)
+		}
+	}
+	return out
 }

--- a/internal/buildkit/util/overlay/overlay_linux.go
+++ b/internal/buildkit/util/overlay/overlay_linux.go
@@ -94,7 +94,7 @@ func GetOverlayLayers(m mount.Mount) ([]string, error) {
 			for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
 				l[i], l[j] = l[j], l[i] // make l[0] = bottommost
 			}
-		} else if strings.HasPrefix(o, "workdir=") || o == "index=off" || o == "userxattr" || strings.HasPrefix(o, "redirect_dir=") {
+		} else if strings.HasPrefix(o, "workdir=") || o == "index=off" || o == "userxattr" || strings.HasPrefix(o, "redirect_dir=") || o == "volatile" {
 			// these options are possible to specfied by the snapshotter but not indicate dir locations.
 			continue
 		} else {


### PR DESCRIPTION
Looked into the [chown perf regression](https://github.com/dagger/dagger/issues/11556) with ebpf and found that each chown was causing overlay to call fsync on every file (within its copy-up internal functions), each of which took ~8ms on my laptop. 8ms isn't a lot to a human but when you are serially chowning 100k files it adds up quickly. Syscalls like this shouldn't be that slow generally, especially for the test case where each file is only 1 byte.

It's not entirely clear to me why overlay makes this so slow. I can repro the slowness outside of dagger with hand-crafted overlay mounts, but when I remove overlay from the equation and use the same underlying filesystem it's much much faster.
* This might be worth looking into separately. It may easily just be expected behavior I haven't encountered before, but smells slightly off...

This all reminded me of @marcosnils's effort a long time ago to upstream support for the overlay `volatile` option, which met a bunch of friction and didn't get merged. Thankfully, we no longer have those problems!

`volatile` skips the fsyncs overlay does and fixes the perf problem for me.

cc @grouville 

---

First run in CI is definitely quite fast, a couple of checks are several minutes faster than they were most recently on main:
1. [This PR
](https://dagger.cloud/dagger/ci?branch=chown-slow&minTimestamp=1765512047557&ref=b9a8e35c3d32b0583f5d69d327529535d2fadca7&repo=github.com%2Fdagger%2Fdagger)
2. [Main](https://dagger.cloud/dagger/ci?branch=main&minTimestamp=1765395967216&ref=fd2afa31d6b18742557d2248bbcb469ff7767e14&repo=github.com%2Fdagger%2Fdagger)