### PR TITLE
Fix typo in referece overview

### DIFF
--- a/docs/current_docs/reference/index.mdx
+++ b/docs/current_docs/reference/index.mdx
@@ -41,7 +41,7 @@ Access Dagger programmatically through various interfaces:
 Dagger supports various container runtimes:
 
 - [Container runtimes overview](./container-runtimes/index.mdx) - Overview of supported container runtimes
-- [Docker](./container-runtimes/docker.mdx) - Using Dagger with Podman
+- [Docker](./container-runtimes/docker.mdx) - Using Dagger with Docker
 - [Podman](./container-runtimes/podman.mdx) - Using Dagger with Podman
 - [Nerdctl](./container-runtimes/nerdctl.mdx) - Working with Nerdctl
 - [Apple Container](./container-runtimes/apple-container.mdx) - Using Apple's container runtime


### PR DESCRIPTION
Fix typo.

Podman => Docker