### PR TITLE
fix: allow non local module sources

### DIFF
--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -391,9 +391,14 @@ func (m *JavaSdk) setModuleConfig(ctx context.Context, modSource *dagger.ModuleS
 	if err != nil {
 		return err
 	}
-	dirPath, err := modSource.LocalContextDirectoryPath(ctx)
-	if err != nil {
+	var dirPath string
+	if kind, err := modSource.Kind(ctx); err != nil {
 		return err
+	} else if kind == dagger.ModuleSourceKindLocal {
+		dirPath, err = modSource.LocalContextDirectoryPath(ctx)
+		if err != nil {
+			return err
+		}
 	}
 	m.moduleConfig = moduleConfig{
 		name:    modName,


### PR DESCRIPTION
Allow to use non local module sources (like git).

Before:

```console
$ dagger -m github.com/eunomie/daggerverse/java-module functions
✔ connect 0.2s
✘ load module: github.com/eunomie/daggerverse/java-module 2.0s ERROR
┇ initializing module › ModuleSource.asModule › module SDK: load runtime › JavaSdk.moduleRuntime(
  ┆ modSource: no(digest: "xxh3:3dd78c6074651c8d")
  ┆ introspectionJson: no(
  ┆ ┆ digest: "sha256:43b0a4f1c4c794521babdba89f153bfb899a9b1bafd1311b475ca76dc44e97e2"
  ┆ )
  ) ›
✘ ModuleSource.localContextDirectoryPath: String! 0.0s ERROR
! module source is not local
```

After:

```console
$ dagger -m github.com/eunomie/daggerverse/java-module functions
✔ connect 0.2s
✔ load module: github.com/eunomie/daggerverse/java-module 1.3s

Name             Description
container-echo   Returns a container that echoes whatever string argument is provided
grep-dir         Returns lines that match a pattern in the files of the provided Directory
```

I don't think I have a very nice way to test it for now: what matters here is the `runtime` of the module. And this runtime is not embedded in the engine, it's translated to a git ref pointing to `github.com/dagger/dagger/sdk/java`.
So to test we need a remote module (as what we want to test is the ability to use it) but the module requires the new sdk runtime. So it means it needs to be hardcoded in the `dagger.json` of this runtime.

My proposal is the following: merge it as it for now. The change is pretty small, has no impact in case of a local module source, and has an impact on non local module sources. Non local module sources don't work for now. So this impact is either better than current situation or nothing.
Once it's merged, I can open a follow up PR that will test using the default ref. At least it ensures that works. I means the test will always test one merge behind, but at least it covers that without to do crazy stuff and without to change the way we reference the Java SDK.