### PR TITLE
Add cache to python overrides

### DIFF
--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -650,6 +650,7 @@ class Module:
         *,
         name: APIName | None = None,
         doc: str | None = None,
+        cache: str | None = None,
         deprecated: str | None = None,
     ) -> Func[P, R]: ...
 
@@ -659,6 +660,7 @@ class Module:
         *,
         name: APIName | None = None,
         doc: str | None = None,
+        cache: str | None = None,
         deprecated: str | None = None,
     ) -> Callable[[Func[P, R]], Func[P, R]]: ...
 


### PR DESCRIPTION
When using the python SDK, the cache parameters exposed in the 0.19.4 release are not visible in the python type overrides. https://docs.dagger.io/extending/function-caching/ says the cache ought to be exposed but the way the overrides are written it isn't according to pyright.