### PR TITLE
bug: fixes incorrect file caching

### DIFF
--- a/.changes/unreleased/Fixed-20251215-145337.yaml
+++ b/.changes/unreleased/Fixed-20251215-145337.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix incorrect file contents caching race condition bug
+time: 2025-12-15T14:53:37.378560538-08:00
+custom:
+    Author: alexcb
+    PR: "11575"

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -673,14 +673,6 @@ type WithFileArgs struct {
 
 var _ core.Inputs = WithFileArgs{}
 
-func (args WithFileArgs) Digest() (digest.Digest, error) {
-	var inputs []string
-
-	inputs = append(inputs, args.Path)
-
-	return hashutil.HashStrings(inputs...), nil
-}
-
 func (args WithFileArgs) Inputs(ctx context.Context) ([]llb.State, error) {
 	deps := []llb.State{}
 	srv, err := core.CurrentDagqlServer(ctx)


### PR DESCRIPTION
This fixes a file caching bug, reported in #11552, which resulted from an incorrect Digest() override, which ignored the file Source (contents).

Removing the override will cause the digest to use the entire args struct, which includes the Source field, which contains a digest of the file being copied in, e.g. `Source:File@xxh3:97e0aa643fe2496b`