### PR TITLE
test: ability to call a java module using a git ref

### DIFF
--- a/core/integration/module_java_test.go
+++ b/core/integration/module_java_test.go
@@ -367,6 +367,15 @@ func (JavaSuite) TestEnum(_ context.Context, t *testctx.T) {
 	})
 }
 
+func (JavaSuite) TestGitRef(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	out, err := goGitBase(t, c).
+		With(daggerExec("functions", "-m", "github.com/dagger/dagger-test-modules/java-module")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "container-echo")
+}
+
 func javaModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/java", moduleName))


### PR DESCRIPTION
This is a follow up to #11570 adding a test to ensure we can call a Java module using a git ref.

The test requires https://github.com/eunomie/dagger/pull/new/test-java-module-git to be merged before