### PR TITLE
Disable Github Actions for pull requests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,12 +4,13 @@ name: Checks
     branches:
       - main
       - releases/**
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # commeting to enable native-ci
+  #pull_request:
+  #types:
+  #- opened
+  #- reopened
+  #- synchronize
+  #- ready_for_review
   workflow_dispatch: {}
 permissions:
   contents: read


### PR DESCRIPTION
We're moving off Github Actions, in favor of a pure Dagger-native CI stack.