### PR TITLE
dagui: fix Chained across different depths

### DIFF
--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -108,7 +108,7 @@ func (db *DB) RowsView(opts FrontendOpts) *RowsView {
 	return view
 }
 
-func (db *DB) WalkSpans(opts FrontendOpts, spans iter.Seq[*Span], f func(*TraceTree)) {
+func (db *DB) WalkSpans(opts FrontendOpts, spans iter.Seq[*Span], f func(*TraceTree)) { //nolint:gocyclo
 	var lastTree *TraceTree
 	var lastCall *TraceTree
 	seen := make(map[SpanID]bool)


### PR DESCRIPTION
Fixes a tiny UI quirk that causes the UI to render `.foo` instead of `Parent.foo` when the `Parent` was actually beneath another span preceding `foo` (like "load Parent").