### PR TITLE
fix: correct spelling in withAnnotation doc

### DIFF
--- a/.changes/unreleased/Fixed-20251227-105607.yaml
+++ b/.changes/unreleased/Fixed-20251227-105607.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correct spelling in withAnnotation doc
+time: 2025-12-27T10:56:07.667333-06:00
+custom:
+  Author: hugginsio
+  PR: "11598"

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -539,7 +539,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.Func("withAnnotation", s.withAnnotation).
-			Doc(`Retrieves this container plus the given OCI anotation.`).
+			Doc(`Retrieves this container plus the given OCI annotation.`).
 			Args(
 				dagql.Arg("name").Doc(`The name of the annotation.`),
 				dagql.Arg("value").Doc(`The value of the annotation.`),

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -765,7 +765,7 @@ type Container {
   """Retrieves the user to be set for all commands."""
   user: String!
 
-  """Retrieves this container plus the given OCI anotation."""
+  """Retrieves this container plus the given OCI annotation."""
   withAnnotation(
     """The name of the annotation."""
     name: String!

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -5888,7 +5888,7 @@
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-withAnnotation" href="#Container-withAnnotation"><code>withAnnotation</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
-                        <td> Retrieves this container plus the given OCI anotation. </td>
+                        <td> Retrieves this container plus the given OCI annotation. </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -478,7 +478,7 @@
                 <div class="col-md-8">
                     <a href="#method_withAnnotation">withAnnotation</a>(string $name, string $value)
         
-                                            <p><p>Retrieves this container plus the given OCI anotation.</p></p>                </div>
+                                            <p><p>Retrieves this container plus the given OCI annotation.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -2386,7 +2386,7 @@
             
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus the given OCI anotation.</p></p>                        
+                            <p><p>Retrieves this container plus the given OCI annotation.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1297,7 +1297,7 @@
                     <dd><p>The specified version of the git repo this source points to.</p></dd>        </dl><h2 id="letterW">W</h2>
         <dl id="indexW"><dt><a href="Dagger/Container.html#method_withAnnotation">
 <abbr title="Dagger\Container">Container</abbr>::withAnnotation</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves this container plus the given OCI anotation.</p></dd><dt><a href="Dagger/Container.html#method_withDefaultArgs">
+                    <dd><p>Retrieves this container plus the given OCI annotation.</p></dd><dt><a href="Dagger/Container.html#method_withDefaultArgs">
 <abbr title="Dagger\Container">Container</abbr>::withDefaultArgs</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Configures default arguments for future commands. Like CMD in Dockerfile.</p></dd><dt><a href="Dagger/Container.html#method_withDefaultTerminalCmd">
 <abbr title="Dagger\Container">Container</abbr>::withDefaultTerminalCmd</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2549,7 +2549,7 @@
 			"t": "M",
 			"n": "Dagger\\Container::withAnnotation",
 			"p": "Dagger/Container.html#method_withAnnotation",
-			"d": "<p>Retrieves this container plus the given OCI anotation.</p>"
+			"d": "<p>Retrieves this container plus the given OCI annotation.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -2272,7 +2272,7 @@ func (r *Container) User(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
-// Retrieves this container plus the given OCI anotation.
+// Retrieves this container plus the given OCI annotation.
 func (r *Container) WithAnnotation(name string, value string) *Container {
 	q := r.query.Select("withAnnotation")
 	q = q.Arg("name", name)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -496,7 +496,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Retrieves this container plus the given OCI anotation.
+     * Retrieves this container plus the given OCI annotation.
      */
     public function withAnnotation(string $name, string $value): Container
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2349,7 +2349,7 @@ class Container(Type):
         return await _ctx.execute(str)
 
     def with_annotation(self, name: str, value: str) -> Self:
-        """Retrieves this container plus the given OCI anotation.
+        """Retrieves this container plus the given OCI annotation.
 
         Parameters
         ----------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3617,7 +3617,7 @@ impl Container {
         let query = self.selection.select("user");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Retrieves this container plus the given OCI anotation.
+    /// Retrieves this container plus the given OCI annotation.
     ///
     /// # Arguments
     ///

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3986,7 +3986,7 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Retrieves this container plus the given OCI anotation.
+   * Retrieves this container plus the given OCI annotation.
    * @param name The name of the annotation.
    * @param value The value of the annotation.
    */


### PR DESCRIPTION
Fixes #11597.

I used `dagger call generate` to propogate the changes from `core/schema/container.go` to the rest of the codebase. However, I was not able to run the linting and testing commands from the contribution documentation.

I've added a `changie` entry since the generated documentation is user-facing. If this is unnecessary, I am happy to remove it.