### PR TITLE
default to ignoring xattr copy failures

### DIFF
--- a/internal/fsutil/copy/copy.go
+++ b/internal/fsutil/copy/copy.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/internal/fsutil"
 	"github.com/dagger/dagger/util/fsxutil"
 	"github.com/moby/patternmatcher"
@@ -297,7 +298,8 @@ type parentDir struct {
 func newCopier(destRoot string, chown Chowner, tm *time.Time, mode *int, xeh XAttrErrorHandler, only map[string]struct{}, includePatterns, excludePatterns []string, useGitignore bool, alwaysReplaceExistingDestPaths bool, enableHardlinkOptimization bool, sourcePathResolver, destPathResolver PathResolver, changeFunc fsutil.ChangeFunc) (*copier, error) {
 	if xeh == nil {
 		xeh = func(dst, src, key string, err error) error {
-			return err
+			slog.Warn("xattr copy failed", "src", src, "dst", dst, "err", err, "xattr", key)
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Some systems do not allow the engine to set SELinux xattrs when copying a file. The engine ignores these in many places, but it's easy to miss. This change updates the default behavior of copying to be ignoring these errors so we don't have to squash it everywhere all the time.