### PR TITLE
fix: handle deeply nested directories in cache size calculation

### DIFF
--- a/internal/buildkit/cache/refs.go
+++ b/internal/buildkit/cache/refs.go
@@ -78,10 +78,11 @@ func safeDiskUsage(ctx context.Context, root string) (int64, error) {
 			return filepath.SkipDir
 		}
 
-		// Get file info to check for circular references
-		info, err := d.Info()
-		if err != nil {
-			return nil // Skip entries we can't stat
+		// Get file info to check for circular references and size.
+		// Skip entries we can't stat rather than failing the entire walk.
+		info, _ := d.Info()
+		if info == nil {
+			return nil
 		}
 
 		// Check for circular references using inode number


### PR DESCRIPTION
Fixes #11609

## Changes

Adds safe filesystem walker with protections against deeply nested/circular directory structures that cause ENAMETOOLONG errors during cache size calculation.

**New functions:**
- `safeDiskUsage()` - walks filesystem with max depth (1024), inode tracking for circular refs, ENAMETOOLONG handling
- `safeSnapshotUsage()` - calculates usage from snapshot mounts using safe walker
- `isFileNameTooLongError()` - detects ENAMETOOLONG errors

**Modified:**
- `size()` method in `refs.go` - falls back to safe calculation when snapshotter.Usage() fails with ENAMETOOLONG

## Behavior

- Normal snapshots: no change, uses regular snapshotter.Usage()
- Problematic snapshots: detects ENAMETOOLONG, automatically uses safe walker
- Returns actual size instead of 0
- Logs warnings when circular refs or max depth hit

## Testing

- Code builds successfully
- Needs runtime testing with actual deeply nested snapshots

**Files changed:** `internal/buildkit/cache/refs.go`