### PR TITLE
Revert "fix plain output to filter unwanted spans in default verbosity"

### DIFF
--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -281,24 +281,6 @@ func (fe plainSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.Re
 	}
 
 	for _, span := range spans {
-		id := dagui.SpanID{SpanID: span.SpanContext().SpanID()}
-		dbSpan := fe.db.Spans.Map[id]
-		if dbSpan == nil {
-			continue
-		}
-
-		var skip bool
-		for p := range dbSpan.Parents {
-			if !fe.Opts().ShouldShow(fe.db, p) {
-				skip = true
-				break
-			}
-		}
-
-		if skip {
-			continue
-		}
-
 		spanID := dagui.SpanID{SpanID: span.SpanContext().SpanID()}
 
 		spanDt, ok := fe.data[spanID]

--- a/docs/current_docs/reference/configuration/custom-runner.mdx
+++ b/docs/current_docs/reference/configuration/custom-runner.mdx
@@ -61,10 +61,10 @@ then the CLI will instead connect to the endpoint specified there. This
 environment variable currently accepts values in the following format:
 
 1. `container://<container name>` - Connect to the runner inside the given host container.
-    - Requires a local [container runtime](/reference/container-runtimes/).
+    - Requires a local [container runtime](../../container-runtimes/).
     - Can force a specific container runtime using `container+<runtime>://<container name>`, e.g. `container+podman://dagger-engine`.
 1. `image://<container image reference>` - Start the runner in Docker using the provided container image, pulling it locally if needed
-    - Requires a local [container runtime](/reference/container-runtimes/).
+    - Requires a local [container runtime](../../container-runtimes/).
     - Can force a specific container runtime using `image+<runtime>://<container image reference>`, e.g. `image+podman://registry.dagger.io/engine:latest`.
 1. `kube-pod://<podname>?context=<context>&namespace=<namespace>&container=<container>` - Connect to the runner inside the given Kubernetes pod.
     - Query strings params like context and namespace are optional.


### PR DESCRIPTION
Reverts dagger/dagger#11612 (un-fixing #11604)

Breaks `test-split:test-interface`: https://dagger.cloud/dagger/traces/f5a8ab7949cf0eb527bd0e39f8fa5662?span=0820bcd428347e20

I think we need to handle this elsewhere, not at span ingestion time