### PR TITLE
feat: engine client docker driver proxy env handling

### DIFF
--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -71,7 +71,7 @@ func (d docker) ContainerRun(ctx context.Context, name string, opts runOpts) err
 		args = append(args, "-v", volume)
 	}
 
-	envs := os.Environ()
+	envs := os.Environ()		
 
 	for _, env := range opts.env {
 		k, _, ok := strings.Cut(env, "=")

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	// Registries configures custom registry mirrors, root CAs, and
 	// insecure/HTTP access.
 	Registries map[string]RegistryConfig `json:"registries,omitempty"`
+
+	Proxy *Proxy `json:"proxy,omitempty"`
 }
 
 type LogLevel string
@@ -228,3 +230,13 @@ type Security struct {
 	// privileged, and is a basic form of security hardening.
 	InsecureRootCapabilities *bool `json:"insecureRootCapabilities,omitempty"`
 }
+
+
+type Proxy struct {
+	HTTPProxy string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy []string `json:"noProxy,omitempty"`
+	AllProxy string `json:"allProxy,omitempty"`
+	FTPProxy string `json:"ftpProxy,omitempty"`
+}
+


### PR DESCRIPTION
allows Dagger to "just work" with its default configuration on machines that need http(s) proxies e.g.

```sh
HTTPS_PROXY=http://localhost:8080 dagger
```

will spawn an engine container with `HTTPS_PROXY=http://host.docker.internal:8080` when using the `docker` backend

on my work machine, for instance, this keeps me from needing to manage my own engine container with these env vars

for `nerdctl` we could use [`host.lima.internal`](https://github.com/containerd/nerdctl/issues/747#issuecomment-1065705918) if we are comfortable assuming that most `nerdctl` users are using it via Lima. it also looks like we could use [`host.finch.internal`](https://github.com/runfinch/finch/pull/1085) for `finch` if we are comfortable assuming that most `finch` users are on macOS

fixes #11553 (in a different way than requested)

EDIT: I noticed that CI doesn't seem to run the tests for `github.com/dagger/dagger/engine/client/drivers`, so here's the output of me running it for `podman` and `docker` on my machine:

```
$ DRIVER_TEST=1 go test ./engine/client/drivers/...
ok  	github.com/dagger/dagger/engine/client/drivers	(cached)
```

EDIT: implementation changed to pass config to engine via `~/.config/dagger/engine.json`