### PR TITLE
Load context dir using per-session Module metadata

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5694,6 +5694,182 @@ func (t *Test) GetFileContext(
 	})
 }
 
+func (ModuleSuite) TestContextParallel(ctx context.Context, t *testctx.T) {
+	src := `package main
+
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+func (z *Test) Fn(
+	ctx context.Context,
+	rand string,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!analytics"
+	// ]
+	a *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!auth"
+	// ]
+	b *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!bin"
+	// ]
+	c *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!cmd"
+	// ]
+	d *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!core"
+	// ]
+	e *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!dagql"
+	// ]
+	f *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!docs"
+	// ]
+	g *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!engine"
+	// ]
+	h *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!evals"
+	// ]
+	i *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!hack"
+	// ]
+	j *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!helm"
+	// ]
+	k *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!internal"
+	// ]
+	l *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!modules"
+	// ]
+	m *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!network"
+	// ]
+	n *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!sdk"
+	// ]
+	o *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!toolchains"
+	// ]
+	p *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!util"
+	// ]
+	q *dagger.Directory,
+
+	// +defaultPath="/"
+  // +ignore=[
+	// "**",
+	// "!version"
+	// ]
+	r *dagger.Directory,
+) (string, error) {
+	for _, dir := range [](*dagger.Directory){a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r} {
+		if _, err := dir.Entries(ctx); err != nil {
+			return "", err
+		}
+	}
+	return "woo", nil
+}
+`
+
+	c1 := connect(ctx, t)
+	c2 := connect(ctx, t)
+
+	getCtr := func(c *dagger.Client, r string) *dagger.Container {
+		workdir := "/" + r
+		return goGitBase(t, c).
+			WithMountedDirectory(workdir, c.Host().Directory("../..")).
+			WithWorkdir(workdir).
+			WithoutDirectory(filepath.Join(workdir, ".dagger")).
+			WithoutFile(filepath.Join(workdir, "dagger.json")).
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.dagger")).
+			WithNewFile(filepath.Join(workdir, ".dagger/main.go"), src)
+	}
+
+	rand1 := rand.Text()
+	ctr1 := getCtr(c1, rand1)
+	out, err := ctr1.With(daggerCall("fn", "--rand", rand1)).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "woo", out)
+
+	rand2 := rand.Text()
+	ctr2 := getCtr(c2, rand2)
+	out, err = ctr2.With(daggerCall("fn", "--rand", rand2)).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "woo", out)
+}
+
 func (ModuleSuite) TestFloat(ctx context.Context, t *testctx.T) {
 	depSrc := `package main
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3494,11 +3494,8 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	}
 
 	// save a result for the final module based on its content hash, currently used in the _contextDirectory API
-	contentCacheKey := mod.ContentDigestCacheKey()
-	contentHashedInst := inst.WithObjectDigest(digest.Digest(contentCacheKey.CallKey))
-	_, err = dag.Cache.GetOrInitializeValue(ctx, contentCacheKey, contentHashedInst)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get or initialize instance: %w", err)
+	if err := core.CacheModuleByContentDigest(ctx, dag, inst); err != nil {
+		return inst, fmt.Errorf("failed to cache module by content digest: %w", err)
 	}
 
 	return inst, nil


### PR DESCRIPTION
(scoped this back a bit from the original more general goal of multiple cache keys per result, there was more stuff to figure out but this ended up being needed ASAP to fix a problem a user was hitting)

This fixes an issue where cache hits from content digest overlaps resulted in a client from one session attempting to load a directory using a path from another one, specifically for contextual dirs.

See the included integ test for a consistent repro.

This ends up being mostly a follow-up to https://github.com/dagger/dagger/pull/11350. We essentially need to ensure that we not only load modules based on content hashes, but also specifically the module object with session specific data from the current session. Otherwise the case that can happen is:
1. Client A on one machine loads a module X from local path `/1`
2. Client B on another machine loads the same module X from local path `/2`

Client B can then end up hitting cache on the module X that Client A loaded, but there the local path references /1, which Client B didn't know about. Just ensuring that module objects are session specific fixes this.