### PR TITLE
Allow dagger modules on non-default SSH port

### DIFF
--- a/.changes/unreleased/Fixed-20260106-093754.yaml
+++ b/.changes/unreleased/Fixed-20260106-093754.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix parsing of module SSH URLs using non-default ports.
+time: 2026-01-06T09:37:54.926726777+01:00
+custom:
+    Author: Wytse Vellema
+    PR: "11628"

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -358,6 +358,22 @@ func TestParseRefString(t *testing.T) {
 				},
 			},
 		},
+		// Gerrit codereview on custom port
+		{
+			urlStr: "ssh://someuser@golang.org:29418/x/review/git-codereview",
+			want: &ParsedRefString{
+				Kind: ModuleSourceKindGit,
+				Git: &ParsedGitRefString{
+					modPath:        "golang.org/x/review/git-codereview",
+					RepoRoot:       &vcs.RepoRoot{Root: "golang.org/x/review", Repo: "https://go.googlesource.com/review"},
+					scheme:         SchemeSSH,
+					RepoRootSubdir: "git-codereview",
+					sourceUser:     "someuser",
+					cloneRef:       "ssh://someuser@golang.org:29418/x/review",
+					SourceCloneRef: "ssh://someuser@golang.org:29418/x/review",
+				},
+			},
+		},
 	} {
 		t.Run(tc.urlStr, func(t *testing.T) {
 			t.Parallel()
@@ -384,6 +400,14 @@ func TestParseRefString(t *testing.T) {
 			require.Equal(t, tc.want.Git.RepoRootSubdir, parsed.Git.RepoRootSubdir)
 			require.Equal(t, tc.want.Git.scheme, parsed.Git.scheme)
 			require.Equal(t, tc.want.Git.sourceUser, parsed.Git.sourceUser)
+
+			if tc.want.Git.SourceCloneRef != "" {
+				require.Equal(t, tc.want.Git.SourceCloneRef, parsed.Git.SourceCloneRef)
+			}
+
+			if tc.want.Git.cloneRef != "" {
+				require.Equal(t, tc.want.Git.cloneRef, parsed.Git.cloneRef)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes: #8638

I've added a test that passes the `RepoRootForImportDynamic` for  `vcs.RepoRootForImportPath`. I don't know if this is acceptable in this way but this was the only way for me to make this testable.