### PR TITLE
core: add Check.Source to return the module source where the check is defined

### DIFF
--- a/core/checks.go
+++ b/core/checks.go
@@ -22,11 +22,12 @@ import (
 
 // Check represents a validation check with its result
 type Check struct {
-	Path        []string `field:"true" doc:"The path of the check within its module"`
-	Description string   `field:"true" doc:"The description of the check"`
-	Completed   bool     `field:"true" doc:"Whether the check completed"`
-	Passed      bool     `field:"true" doc:"Whether the check passed"`
-	Module      *Module
+	Path        []string      `field:"true" doc:"The path of the check within its module"`
+	Description string        `field:"true" doc:"The description of the check"`
+	Completed   bool          `field:"true" doc:"Whether the check completed"`
+	Passed      bool          `field:"true" doc:"Whether the check passed"`
+	Source      *ModuleSource `field:"true" doc:"The module source where the check is defined (i.e., toolchains)"`
+	Module      *Module       `field:"false" doc:"The module where the check is run"`
 }
 
 func (*Check) Type() *ast.Type {
@@ -219,6 +220,7 @@ func (c *Check) Name() string {
 func (c *Check) Clone() *Check {
 	cp := *c
 	cp.Module = c.Module.Clone()
+	cp.Source = c.Source.Clone()
 	return &cp
 }
 

--- a/core/module.go
+++ b/core/module.go
@@ -151,6 +151,8 @@ func (mod *Module) Checks(ctx context.Context, include []string) (*CheckGroup, e
 				// Prepend the toolchain name to the check path
 				check.Path = append([]string{gqlFieldName(tcMod.NameField)}, check.Path...)
 
+				check.Source = tcMod.GetSource()
+
 				match, err := check.Match(include)
 				if err != nil {
 					return nil, err
@@ -166,6 +168,10 @@ func (mod *Module) Checks(ctx context.Context, include []string) (*CheckGroup, e
 	// mod and any toolchain mods
 	for _, check := range group.Checks {
 		check.Module = mod
+		// if toolchains didn't set ModuleSource, then the check is defined in mod.
+		if check.Source == nil {
+			check.Source = mod.GetSource()
+		}
 	}
 	return group, nil
 }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -266,6 +266,9 @@ type Check {
 
   """Execute the check"""
   run: Check!
+
+  """The module source where the check is defined (i.e., toolchains)"""
+  source: ModuleSource!
 }
 
 type CheckGroup {

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -5212,6 +5212,10 @@
                         <td data-property-name=""><a class="property-name" id="Check-run" href="#Check-run"><code>run</code></a> - <span class="property-type"><a href="#definition-Check"><code>Check!</code></a></span> </td>
                         <td> Execute the check </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Check-source" href="#Check-source"><code>source</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> The module source where the check is defined (i.e., toolchains) </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/docs/static/reference/php/Dagger/Check.html
+++ b/docs/static/reference/php/Dagger/Check.html
@@ -219,6 +219,16 @@
                                             <p><p>Execute the check</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_source">source</a>()
+        
+                                            <p><p>The module source where the check is defined (i.e., toolchains)</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -559,6 +569,38 @@
                     <table class="table table-condensed">
         <tr>
             <td><a href="../Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_source">
+        <div class="location">at line 88</div>
+        <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+    <strong>source</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The module source where the check is defined (i.e., toolchains)</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1095,7 +1095,9 @@
 <abbr title="Dagger\Address">Address</abbr>::socket</a>() &mdash; <em>Method in class <a href="Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a></em></dt>
                     <dd><p>Load a local socket from the address.</p></dd><dt><a href="Dagger/Changeset.html#method_sync">
 <abbr title="Dagger\Changeset">Changeset</abbr>::sync</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
-                    <dd><p>Force evaluation in the engine.</p></dd><dt><a href="Dagger/Client.html#method_secret">
+                    <dd><p>Force evaluation in the engine.</p></dd><dt><a href="Dagger/Check.html#method_source">
+<abbr title="Dagger\Check">Check</abbr>::source</a>() &mdash; <em>Method in class <a href="Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a></em></dt>
+                    <dd><p>The module source where the check is defined (i.e., toolchains)</p></dd><dt><a href="Dagger/Client.html#method_secret">
 <abbr title="Dagger\Client">Client</abbr>::secret</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Creates a new secret.</p></dd><dt><a href="Dagger/Client.html#method_setSecret">
 <abbr title="Dagger\Client">Client</abbr>::setSecret</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1707,6 +1707,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Check::source",
+			"p": "Dagger/Check.html#method_source",
+			"d": "<p>The module source where the check is defined (i.e., toolchains)</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\CheckGroup::id",
 			"p": "Dagger/CheckGroup.html#method_id",
 			"d": "<p>A unique identifier for this CheckGroup.</p>"

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1225,6 +1225,15 @@ func (r *Check) Run() *Check {
 	}
 }
 
+// The module source where the check is defined (i.e., toolchains)
+func (r *Check) Source() *ModuleSource {
+	q := r.query.Select("source")
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
 type CheckGroup struct {
 	query *querybuilder.Selection
 

--- a/sdk/php/generated/Check.php
+++ b/sdk/php/generated/Check.php
@@ -81,4 +81,13 @@ class Check extends Client\AbstractObject implements Client\IdAble
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('run');
         return new \Dagger\Check($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
+
+    /**
+     * The module source where the check is defined (i.e., toolchains)
+     */
+    public function source(): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('source');
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1306,6 +1306,12 @@ class Check(Type):
         _ctx = self._select("run", _args)
         return Check(_ctx)
 
+    def source(self) -> "ModuleSource":
+        """The module source where the check is defined (i.e., toolchains)"""
+        _args: list[Arg] = []
+        _ctx = self._select("source", _args)
+        return ModuleSource(_ctx)
+
     def with_(self, cb: Callable[["Check"], "Check"]) -> "Check":
         """Call the provided callable with current Check.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2485,6 +2485,15 @@ impl Check {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// The module source where the check is defined (i.e., toolchains)
+    pub fn source(&self) -> ModuleSource {
+        let query = self.selection.select("source");
+        ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
 }
 #[derive(Clone)]
 pub struct CheckGroup {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3212,6 +3212,14 @@ export class Check extends BaseClient {
   }
 
   /**
+   * The module source where the check is defined (i.e., toolchains)
+   */
+  source = (): ModuleSource => {
+    const ctx = this._ctx.select("source")
+    return new ModuleSource(ctx)
+  }
+
+  /**
    * Call the provided function with current Check.
    *
    * This is useful for reusability and readability by not breaking the calling chain.


### PR DESCRIPTION
For toolchains, this returns the source of the toolchain where the check is defined.
Otherwise, it coincides with the source of the module where the check is being run in.

Check has a private Module field, but this commit adds an exported Source field.