### PR TITLE
ref(sdk/python): migrate python code analysis from runtime to ast-based

### DIFF
--- a/sdk/python/ruff.toml
+++ b/sdk/python/ruff.toml
@@ -104,6 +104,23 @@ ignore = [
 "**/__init__.py" = ["PLC0414"]
 # Allow some patterns to redefine imports in __init__.
 "./src/**/__init__.py" = ["I001", "F403"]
+# AST parsing code has inherent complexity - allow higher complexity and return counts.
+"src/dagger/mod/_ast_visitor.py" = [
+    "C901",    # Too complex
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "SIM102",  # Nested if statements are clearer for AST parsing
+    "PERF401", # Allow for loops in list comprehension contexts
+]
+"src/dagger/mod/_ast_resolver.py" = [
+    "C901",    # Too complex
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLW0603", # Global statement for lazy loading cache
+]
+"src/dagger/mod/_analyzer.py" = [
+    "PERF203", # Try-except in loop is needed for error collection
+]
 
 [lint.isort]
 known-first-party = ["dagger", "codegen"]

--- a/sdk/python/src/dagger/mod/_analyzer.py
+++ b/sdk/python/src/dagger/mod/_analyzer.py
@@ -1,0 +1,244 @@
+"""Python module analyzer using AST parsing.
+
+This module provides the main entry point for analyzing Dagger Python modules
+without executing the code. It parses Python source files, extracts decorated
+types, and builds an intermediate representation.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+from dagger.mod._ast_visitor import get_module_docstring, parse_file
+from dagger.mod._exceptions import ModuleLoadError
+from dagger.mod._ir import ModuleIR, ObjectTypeIR
+from dagger.mod._utils import to_pascal_case
+
+
+class PythonModuleAnalyzer:
+    """Analyzes Python modules for Dagger types using AST parsing.
+
+    This analyzer parses Python source files without executing them,
+    extracting decorated classes (@object_type, @function, etc.) and
+    building an intermediate representation (IR) that can be converted
+    to Dagger TypeDefs.
+    """
+
+    def __init__(
+        self,
+        source_paths: Sequence[Path],
+        main_object_name: str | None = None,
+    ):
+        """Initialize the analyzer.
+
+        Args:
+            source_paths: Python files to analyze
+            main_object_name: Expected main object name (PascalCase).
+                If not provided, will be inferred from environment or
+                module structure.
+        """
+        self.source_paths = list(source_paths)
+        self.main_object_name = main_object_name
+
+    def analyze(self) -> ModuleIR:
+        """Analyze all source files and build module IR.
+
+        Returns
+        -------
+            ModuleIR containing all discovered types
+
+        Raises
+        ------
+            ModuleLoadError: If main object not found or analysis fails
+            SyntaxError: If source files contain invalid Python syntax
+        """
+        all_objects: list[ObjectTypeIR] = []
+        errors: list[str] = []
+
+        for source_path in self.source_paths:
+            try:
+                objects = parse_file(source_path)
+                all_objects.extend(objects)
+            except SyntaxError as e:
+                errors.append(f"Syntax error in {source_path}: {e}")
+            except OSError as e:
+                errors.append(f"Failed to read {source_path}: {e}")
+
+        if errors:
+            msg = "Failed to analyze module:\n" + "\n".join(errors)
+            raise ModuleLoadError(msg)
+
+        # Infer main object if not provided
+        if self.main_object_name is None:
+            self.main_object_name = self._infer_main_object(all_objects)
+
+        # Validate main object exists
+        main_obj = next(
+            (obj for obj in all_objects if obj.name == self.main_object_name),
+            None,
+        )
+        if main_obj is None:
+            found_names = [obj.name for obj in all_objects]
+            msg = (
+                f"Main object '{self.main_object_name}' not found. "
+                f"Found objects: {found_names}"
+            )
+            raise ModuleLoadError(msg)
+
+        # Extract module-level docstring from first source file
+        module_doc = None
+        if self.source_paths:
+            module_doc = get_module_docstring(self.source_paths[0])
+
+        return ModuleIR(
+            main_object_name=self.main_object_name,
+            objects=tuple(all_objects),
+            source_files=tuple(self.source_paths),
+            module_doc=module_doc,
+        )
+
+    def _infer_main_object(self, objects: list[ObjectTypeIR]) -> str:
+        """Infer main object name from environment or convention.
+
+        Priority:
+        1. DAGGER_MAIN_OBJECT environment variable
+        2. DAGGER_MODULE environment variable (converted to PascalCase)
+        3. Object named "Main"
+        4. Single object in module
+
+        Raises
+        ------
+            ModuleLoadError: If main object cannot be determined
+        """
+        # Check DAGGER_MAIN_OBJECT first
+        if env_name := os.getenv("DAGGER_MAIN_OBJECT"):
+            return env_name
+
+        # Check DAGGER_MODULE
+        if module_name := os.getenv("DAGGER_MODULE"):
+            return to_pascal_case(module_name)
+
+        # Check for "Main" convention
+        if any(obj.name == "Main" for obj in objects):
+            return "Main"
+
+        # If only one object, use it
+        if len(objects) == 1:
+            return objects[0].name
+
+        # Can't determine
+        found_names = [obj.name for obj in objects]
+        msg = (
+            "Could not determine main object. "
+            "Set DAGGER_MAIN_OBJECT or DAGGER_MODULE environment variable. "
+            f"Found objects: {found_names}"
+        )
+        raise ModuleLoadError(msg)
+
+
+def analyze_package(
+    package_path: Path,
+    main_object_name: str | None = None,
+    *,
+    recursive: bool = True,
+) -> ModuleIR:
+    """Analyze a Python package directory for Dagger types.
+
+    Args:
+        package_path: Directory containing Python files
+        main_object_name: Expected main object name
+        recursive: Whether to search subdirectories
+
+    Returns
+    -------
+        ModuleIR with all discovered types
+
+    Raises
+    ------
+        ModuleLoadError: If no Python files found or main object not found
+    """
+    if not package_path.is_dir():
+        # Single file
+        if package_path.suffix == ".py":
+            return PythonModuleAnalyzer([package_path], main_object_name).analyze()
+        msg = f"Not a Python file or directory: {package_path}"
+        raise ModuleLoadError(msg)
+
+    # Find Python files
+    pattern = "**/*.py" if recursive else "*.py"
+    python_files = sorted(package_path.glob(pattern))
+
+    # Filter out __pycache__ and hidden directories
+    python_files = [
+        f
+        for f in python_files
+        if "__pycache__" not in f.parts and not any(p.startswith(".") for p in f.parts)
+    ]
+
+    if not python_files:
+        msg = f"No Python files found in {package_path}"
+        raise ModuleLoadError(msg)
+
+    return PythonModuleAnalyzer(python_files, main_object_name).analyze()
+
+
+def analyze_source(
+    source_code: str,
+    filename: str = "<string>",
+    main_object_name: str | None = None,
+) -> ModuleIR:
+    """Analyze Python source code string for Dagger types.
+
+    Useful for testing and dynamic analysis.
+
+    Args:
+        source_code: Python source code
+        filename: Virtual filename for error messages
+        main_object_name: Expected main object name
+
+    Returns
+    -------
+        ModuleIR with all discovered types
+    """
+    import ast
+
+    from dagger.mod._ast_visitor import DaggerModuleVisitor
+
+    # Parse source
+    tree = ast.parse(source_code, filename=filename)
+
+    # Create a temporary path for the visitor
+    temp_path = Path(filename)
+
+    visitor = DaggerModuleVisitor(temp_path, source_code)
+    visitor.visit(tree)
+
+    objects = visitor.objects
+
+    # Infer main object
+    if main_object_name is None:
+        if len(objects) == 1:
+            main_object_name = objects[0].name
+        elif any(obj.name == "Main" for obj in objects):
+            main_object_name = "Main"
+        else:
+            found_names = [obj.name for obj in objects]
+            msg = f"Could not determine main object. Found: {found_names}"
+            raise ModuleLoadError(msg)
+    # Validate explicitly provided main object exists
+    elif not any(obj.name == main_object_name for obj in objects):
+        found_names = [obj.name for obj in objects]
+        msg = f"Main object '{main_object_name}' not found. Found: {found_names}"
+        raise ModuleLoadError(msg)
+
+    # Extract module docstring
+    module_doc = ast.get_docstring(tree)
+
+    return ModuleIR(
+        main_object_name=main_object_name,
+        objects=tuple(objects),
+        source_files=(temp_path,),
+        module_doc=module_doc,
+    )

--- a/sdk/python/src/dagger/mod/_ast_resolver.py
+++ b/sdk/python/src/dagger/mod/_ast_resolver.py
@@ -1,0 +1,415 @@
+"""Type resolution from AST IR to Dagger TypeDefs.
+
+This module converts parsed intermediate representations to Dagger API
+TypeDef objects using dag.type_def() and related builders.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import TYPE_CHECKING
+
+import dagger
+from dagger import dag
+from dagger.mod._ir import (
+    FieldIR,
+    FunctionIR,
+    ModuleIR,
+    ObjectTypeIR,
+    ParameterIR,
+    TypeAnnotation,
+)
+
+if TYPE_CHECKING:
+    from dagger import TypeDef
+
+
+# Core Dagger types from gen.py - loaded lazily
+_DAGGER_TYPES: set[str] | None = None
+
+
+def _get_dagger_types() -> set[str]:
+    """Load Dagger core types from gen.py."""
+    global _DAGGER_TYPES
+    if _DAGGER_TYPES is None:
+        try:
+            from dagger.client import gen
+
+            _DAGGER_TYPES = {
+                name
+                for name in dir(gen)
+                if not name.startswith("_") and name[0].isupper()
+            }
+        except ImportError:
+            _DAGGER_TYPES = set()
+    return _DAGGER_TYPES
+
+
+def _is_dagger_type(type_name: str) -> bool:
+    """Check if a type name is a Dagger core type."""
+    return type_name in _get_dagger_types()
+
+
+# Built-in Python type to TypeDefKind mapping
+BUILTIN_TYPE_MAP = {
+    "str": dagger.TypeDefKind.STRING_KIND,
+    "int": dagger.TypeDefKind.INTEGER_KIND,
+    "float": dagger.TypeDefKind.FLOAT_KIND,
+    "bool": dagger.TypeDefKind.BOOLEAN_KIND,
+    "None": dagger.TypeDefKind.VOID_KIND,
+    "NoneType": dagger.TypeDefKind.VOID_KIND,
+}
+
+
+def _extract_base_type(raw: str) -> str:
+    """Extract the base type name from a complex annotation string.
+
+    Strips away Optional[], Union[], Annotated[], list[], etc. to get
+    the core type name.
+    """
+    raw = raw.strip()
+
+    # Handle Annotated[T, ...]
+    if raw.startswith("Annotated["):
+        inner = raw[len("Annotated[") : -1]
+        parts = _split_type_args(inner)
+        if parts:
+            raw = parts[0].strip()
+
+    # Handle Optional[T]
+    if raw.startswith("Optional["):
+        raw = raw[len("Optional[") : -1].strip()
+
+    # Handle Union[T, None]
+    if raw.startswith("Union["):
+        inner = raw[len("Union[") : -1]
+        parts = _split_type_args(inner)
+        for part in parts:
+            if part.strip() not in ("None", "NoneType"):
+                raw = part.strip()
+                break
+
+    # Handle T | None
+    if " | " in raw:
+        parts = raw.split(" | ")
+        for part in parts:
+            if part.strip() not in ("None", "NoneType"):
+                raw = part.strip()
+                break
+
+    # Handle list[T], List[T], Sequence[T]
+    for prefix in ("list[", "List[", "Sequence[", "tuple[", "Tuple["):
+        if raw.startswith(prefix):
+            inner = raw[len(prefix) : -1]
+            parts = _split_type_args(inner)
+            if parts:
+                raw = parts[0].strip()
+            break
+
+    # Handle module-qualified names (e.g., dagger.Container)
+    if "." in raw:
+        raw = raw.split(".")[-1]
+
+    return raw
+
+
+def _split_type_args(args_str: str) -> list[str]:
+    """Split comma-separated type arguments, respecting brackets."""
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+
+    for char in args_str:
+        if char in "[({":
+            depth += 1
+        elif char in "])}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+
+    if current:
+        parts.append("".join(current))
+
+    return parts
+
+
+class TypeResolver:
+    """Resolves TypeAnnotation IR to Dagger TypeDef objects.
+
+    Handles mapping Python types to Dagger types:
+    - Built-in types (str, int, bool, float) -> TypeDefKind
+    - Dagger core types (Container, Directory) -> with_object()
+    - Module-defined types -> with_object(), with_interface(), with_enum()
+    - Lists -> with_list_of()
+    - Optional -> with_optional()
+    """
+
+    def __init__(self, module_ir: ModuleIR):
+        self.module_ir = module_ir
+        self._object_names = {obj.name for obj in module_ir.objects}
+
+    def resolve(self, annotation: TypeAnnotation) -> TypeDef:
+        """Convert TypeAnnotation to Dagger TypeDef."""
+        td = dag.type_def()
+
+        # Handle optional
+        if annotation.is_optional:
+            td = td.with_optional(True)
+
+        # Handle list types
+        if annotation.is_list and annotation.element_type:
+            element_annotation = TypeAnnotation(raw=annotation.element_type)
+            element_td = self.resolve(element_annotation)
+            return td.with_list_of(element_td)
+
+        # Extract and resolve base type
+        base_type = _extract_base_type(annotation.raw)
+
+        # Check built-in types
+        if base_type in BUILTIN_TYPE_MAP:
+            return td.with_kind(BUILTIN_TYPE_MAP[base_type])
+
+        # Check for Dagger core types
+        if _is_dagger_type(base_type):
+            return td.with_object(base_type)
+
+        # Check for module-defined types
+        obj = self.module_ir.get_object(base_type)
+        if obj is not None:
+            if obj.is_enum:
+                return td.with_enum(base_type)
+            if obj.is_interface:
+                return td.with_interface(base_type)
+            return td.with_object(base_type)
+
+        # Check if it's a known type name in our module
+        if base_type in self._object_names:
+            return td.with_object(base_type)
+
+        # Check for Self return type
+        if base_type == "Self":
+            # Will need to be resolved in context
+            return td.with_object("Self")
+
+        # Fallback: assume it's an object type
+        # This handles forward references
+        return td.with_object(base_type)
+
+    def resolve_return_type(
+        self, annotation: TypeAnnotation | None, context_type: str
+    ) -> TypeDef:
+        """Resolve return type, handling Self references."""
+        if annotation is None:
+            return dag.type_def().with_kind(dagger.TypeDefKind.VOID_KIND)
+
+        td = self.resolve(annotation)
+
+        # Replace Self with context type
+        base_type = _extract_base_type(annotation.raw)
+        if base_type == "Self":
+            return dag.type_def().with_object(context_type)
+
+        return td
+
+
+class IRToTypeDefConverter:
+    """Converts complete module IR to Dagger TypeDefs for registration."""
+
+    def __init__(self, module_ir: ModuleIR):
+        self.module_ir = module_ir
+        self.resolver = TypeResolver(module_ir)
+
+    async def convert(self) -> dagger.ModuleID:
+        """Convert module IR to Dagger Module and return its ID."""
+        mod = dag.module()
+
+        # Set module description
+        if self.module_ir.module_doc:
+            mod = mod.with_description(self.module_ir.module_doc)
+
+        # Process all object types
+        for obj in self.module_ir.get_object_types():
+            type_def = self._convert_object_type(obj)
+            mod = mod.with_object(type_def)
+
+        # Process interfaces
+        for obj in self.module_ir.get_interfaces():
+            type_def = self._convert_interface_type(obj)
+            mod = mod.with_interface(type_def)
+
+        # Process enums
+        for obj in self.module_ir.get_enums():
+            type_def = self._convert_enum_type(obj)
+            mod = mod.with_enum(type_def)
+
+        return await mod.id()
+
+    def _convert_object_type(self, obj: ObjectTypeIR) -> TypeDef:
+        """Convert object type IR to TypeDef."""
+        type_def = dag.type_def().with_object(
+            obj.name,
+            description=obj.doc,
+            deprecated=obj.deprecated,
+        )
+
+        # Add fields
+        for field in obj.fields:
+            type_def = self._add_field(type_def, field)
+
+        # Add functions
+        for func in obj.functions:
+            type_def = self._add_function(type_def, func, obj.name)
+
+        # Add constructor for main object if exists
+        if obj.name == self.module_ir.main_object_name and not any(
+            f.is_constructor for f in obj.functions
+        ):
+            # Add default constructor
+            type_def = self._add_default_constructor(type_def, obj)
+
+        return type_def
+
+    def _convert_interface_type(self, obj: ObjectTypeIR) -> TypeDef:
+        """Convert interface type IR to TypeDef."""
+        type_def = dag.type_def().with_interface(
+            obj.name,
+            description=obj.doc,
+        )
+
+        # Add functions
+        for func in obj.functions:
+            type_def = self._add_function(type_def, func, obj.name)
+
+        return type_def
+
+    def _convert_enum_type(self, obj: ObjectTypeIR) -> TypeDef:
+        """Convert enum type IR to TypeDef."""
+        type_def = dag.type_def().with_enum(
+            obj.name,
+            description=obj.doc,
+        )
+
+        for member in obj.enum_members:
+            type_def = type_def.with_enum_member(
+                member.name,
+                value=member.value,
+                description=member.doc,
+                deprecated=member.deprecated,
+            )
+
+        return type_def
+
+    def _add_field(self, type_def: TypeDef, field: FieldIR) -> TypeDef:
+        """Add a field to a type definition."""
+        field_td = self.resolver.resolve(field.annotation)
+        return type_def.with_field(
+            field.api_name,
+            field_td,
+            description=field.annotation.doc,
+            deprecated=field.deprecated,
+        )
+
+    def _add_function(
+        self, type_def: TypeDef, func: FunctionIR, context_type: str
+    ) -> TypeDef:
+        """Add a function to a type definition."""
+        # Build return type
+        return_td = self.resolver.resolve_return_type(
+            func.return_annotation, context_type
+        )
+
+        # Create function def
+        func_def = dag.function(func.api_name, return_td)
+
+        if func.doc:
+            func_def = func_def.with_description(func.doc.strip())
+
+        # Handle cache policy
+        if func.cache_policy is not None:
+            if func.cache_policy == "never":
+                func_def = func_def.with_cache_policy(dagger.FunctionCachePolicy.Never)
+            elif func.cache_policy == "session":
+                func_def = func_def.with_cache_policy(
+                    dagger.FunctionCachePolicy.PerSession
+                )
+            elif func.cache_policy:
+                func_def = func_def.with_cache_policy(
+                    dagger.FunctionCachePolicy.Default,
+                    time_to_live=func.cache_policy,
+                )
+
+        if func.deprecated:
+            func_def = func_def.with_deprecated(reason=func.deprecated)
+
+        if func.is_check:
+            func_def = func_def.with_check()
+
+        # Add parameters
+        for param in func.parameters:
+            func_def = self._add_parameter(func_def, param)
+
+        if func.is_constructor or func.api_name == "":
+            return type_def.with_constructor(func_def)
+        return type_def.with_function(func_def)
+
+    def _add_parameter(
+        self, func_def: dagger.Function, param: ParameterIR
+    ) -> dagger.Function:
+        """Add a parameter to a function definition."""
+        param_td = self.resolver.resolve(param.annotation)
+
+        # Handle nullable/optional
+        is_nullable = param.annotation.is_optional
+        if is_nullable or param.has_default or param.annotation.default_path:
+            param_td = param_td.with_optional(True)
+
+        # Build default value
+        default_value = None
+        if param.has_default and param.default_value is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                default_value = dagger.JSON(json.dumps(param.default_value))
+
+        return func_def.with_arg(
+            param.api_name,
+            param_td,
+            description=param.annotation.doc,
+            default_value=default_value,
+            default_path=param.annotation.default_path,
+            ignore=list(param.annotation.ignore) if param.annotation.ignore else None,
+            deprecated=param.annotation.deprecated,
+        )
+
+    def _add_default_constructor(self, type_def: TypeDef, obj: ObjectTypeIR) -> TypeDef:
+        """Add a default constructor from fields that have init=True."""
+        return_td = dag.type_def().with_object(obj.name)
+        func_def = dag.function("", return_td)
+
+        # Add parameters from init fields
+        for field in obj.fields:
+            if not field.init:
+                continue
+
+            param_td = self.resolver.resolve(field.annotation)
+
+            # Handle optional
+            if field.has_default or field.annotation.is_optional:
+                param_td = param_td.with_optional(True)
+
+            # Build default value
+            default_value = None
+            if field.has_default and field.default_value is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    default_value = dagger.JSON(json.dumps(field.default_value))
+
+            func_def = func_def.with_arg(
+                field.api_name,
+                param_td,
+                description=field.annotation.doc,
+                default_value=default_value,
+            )
+
+        return type_def.with_constructor(func_def)

--- a/sdk/python/src/dagger/mod/_ast_visitor.py
+++ b/sdk/python/src/dagger/mod/_ast_visitor.py
@@ -1,0 +1,691 @@
+"""AST visitor for extracting Dagger module definitions.
+
+This module provides the core AST parsing logic to extract decorated classes,
+functions, and fields from Python source code without executing it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from dagger.mod._ir import (
+    EnumMemberIR,
+    FieldIR,
+    FunctionIR,
+    ObjectTypeIR,
+    ParameterIR,
+    SourceLocation,
+    TypeAnnotation,
+)
+from dagger.mod._utils import normalize_name, to_camel_case
+
+# Decorator names recognized by the analyzer
+OBJECT_TYPE_DECORATORS = frozenset({"object_type"})
+INTERFACE_DECORATORS = frozenset({"interface"})
+ENUM_DECORATORS = frozenset({"enum_type"})
+FUNCTION_DECORATORS = frozenset({"function"})
+CHECK_DECORATORS = frozenset({"check"})
+FIELD_FUNCTION = "field"
+
+
+def _get_decorator_name(dec: ast.expr) -> str | None:
+    """Extract decorator name from AST node.
+
+    Handles:
+    - @decorator
+    - @module.decorator
+    - @decorator(args)
+    - @module.decorator(args)
+    """
+    if isinstance(dec, ast.Name):
+        return dec.id
+    if isinstance(dec, ast.Attribute):
+        return dec.attr
+    if isinstance(dec, ast.Call):
+        return _get_decorator_name(dec.func)
+    return None
+
+
+def _has_decorator(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef, names: frozenset[str]
+) -> bool:
+    """Check if node has any of the specified decorators."""
+    return any(_get_decorator_name(dec) in names for dec in node.decorator_list)
+
+
+def _get_decorator_kwargs(dec: ast.expr) -> dict[str, Any]:
+    """Extract keyword arguments from a decorator call."""
+    if not isinstance(dec, ast.Call):
+        return {}
+
+    result: dict[str, Any] = {}
+    for kw in dec.keywords:
+        if kw.arg is None:
+            continue
+        # Extract simple constant values
+        if isinstance(kw.value, ast.Constant):
+            result[kw.arg] = kw.value.value
+        elif isinstance(kw.value, (ast.List, ast.Tuple)):
+            # Handle list/tuple of constants
+            elements = []
+            for elt in kw.value.elts:
+                if isinstance(elt, ast.Constant):
+                    elements.append(elt.value)
+            result[kw.arg] = elements
+    return result
+
+
+def _find_decorator(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef, names: frozenset[str]
+) -> ast.expr | None:
+    """Find the first decorator matching the given names."""
+    for dec in node.decorator_list:
+        if _get_decorator_name(dec) in names:
+            return dec
+    return None
+
+
+class TypeAnnotationParser:
+    """Parses type annotations from AST nodes.
+
+    Extracts type structure (optional, list, element type) and metadata
+    from Annotated[] types (Doc, Name, DefaultPath, Ignore, Deprecated).
+    """
+
+    def __init__(self, source_file: Path):
+        self.source_file = source_file
+
+    def parse(self, node: ast.expr | None, location: SourceLocation) -> TypeAnnotation:
+        """Parse a type annotation AST node into TypeAnnotation IR."""
+        if node is None:
+            return TypeAnnotation(raw="Any", location=location)
+
+        raw = ast.unparse(node)
+
+        # Extract metadata from Annotated[] first
+        doc, name, default_path, ignore, deprecated = self._extract_annotated_metadata(
+            node
+        )
+
+        # Strip Annotated wrapper for type analysis
+        inner_node = self._strip_annotated(node)
+
+        # Analyze type structure
+        is_optional = self._is_optional_type(inner_node)
+        is_list, element_type = self._extract_list_type(inner_node)
+
+        return TypeAnnotation(
+            raw=raw,
+            location=location,
+            is_optional=is_optional,
+            is_list=is_list,
+            element_type=element_type,
+            doc=doc,
+            name=name,
+            default_path=default_path,
+            ignore=tuple(ignore) if ignore else None,
+            deprecated=deprecated,
+        )
+
+    def _strip_annotated(self, node: ast.expr) -> ast.expr:
+        """Remove Annotated[] wrapper to get the base type."""
+        if isinstance(node, ast.Subscript) and self._is_annotated(node.value):
+            # Annotated[T, ...] -> T
+            if isinstance(node.slice, ast.Tuple) and node.slice.elts:
+                return node.slice.elts[0]
+        return node
+
+    def _is_annotated(self, node: ast.expr) -> bool:
+        """Check if node is Annotated type."""
+        if isinstance(node, ast.Name):
+            return node.id == "Annotated"
+        if isinstance(node, ast.Attribute):
+            return node.attr == "Annotated"
+        return False
+
+    def _is_optional_type(self, node: ast.expr) -> bool:
+        """Check if type is Optional or Union with None."""
+        # Handle X | None (Python 3.10+ union syntax)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            return self._contains_none(node)
+
+        # Handle Optional[X] or Union[X, None]
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Name):
+                if node.value.id == "Optional":
+                    return True
+                if node.value.id == "Union":
+                    return self._union_contains_none(node.slice)
+            if isinstance(node.value, ast.Attribute):
+                if node.value.attr in ("Optional", "Union"):
+                    if node.value.attr == "Optional":
+                        return True
+                    return self._union_contains_none(node.slice)
+
+        return False
+
+    def _contains_none(self, node: ast.expr) -> bool:
+        """Check if a binary union contains None."""
+        if isinstance(node, ast.Constant) and node.value is None:
+            return True
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            return self._contains_none(node.left) or self._contains_none(node.right)
+        return False
+
+    def _union_contains_none(self, slice_node: ast.expr) -> bool:
+        """Check if Union[] type args contain None."""
+        if isinstance(slice_node, ast.Tuple):
+            return any(
+                isinstance(elt, ast.Constant) and elt.value is None
+                for elt in slice_node.elts
+            )
+        return isinstance(slice_node, ast.Constant) and slice_node.value is None
+
+    def _extract_list_type(self, node: ast.expr) -> tuple[bool, str | None]:
+        """Extract list/sequence type and element type."""
+        # Strip Optional wrapper first
+        inner = self._unwrap_optional(node)
+
+        if isinstance(inner, ast.Subscript):
+            type_name = None
+            if isinstance(inner.value, ast.Name):
+                type_name = inner.value.id
+            elif isinstance(inner.value, ast.Attribute):
+                type_name = inner.value.attr
+
+            if type_name in ("list", "List", "Sequence"):
+                element = ast.unparse(inner.slice)
+                return True, element
+
+        return False, None
+
+    def _unwrap_optional(self, node: ast.expr) -> ast.expr:
+        """Unwrap Optional[T] to T."""
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            # X | None -> X
+            if isinstance(node.right, ast.Constant) and node.right.value is None:
+                return node.left
+            if isinstance(node.left, ast.Constant) and node.left.value is None:
+                return node.right
+
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Name) and node.value.id == "Optional":
+                return node.slice
+            if isinstance(node.value, ast.Name) and node.value.id == "Union":
+                if isinstance(node.slice, ast.Tuple):
+                    # Return first non-None type
+                    for elt in node.slice.elts:
+                        if not (isinstance(elt, ast.Constant) and elt.value is None):
+                            return elt
+
+        return node
+
+    def _extract_annotated_metadata(
+        self, node: ast.expr
+    ) -> tuple[str | None, str | None, str | None, list[str] | None, str | None]:
+        """Extract metadata from Annotated[] type.
+
+        Returns (doc, name, default_path, ignore, deprecated)
+        """
+        if not isinstance(node, ast.Subscript):
+            return None, None, None, None, None
+
+        if not self._is_annotated(node.value):
+            return None, None, None, None, None
+
+        if not isinstance(node.slice, ast.Tuple):
+            return None, None, None, None, None
+
+        doc = None
+        name = None
+        default_path = None
+        ignore = None
+        deprecated = None
+
+        # Skip first element (the actual type), iterate metadata
+        for arg in node.slice.elts[1:]:
+            if isinstance(arg, ast.Call):
+                call_name = self._get_call_name(arg)
+
+                if call_name == "Doc" and arg.args:
+                    if isinstance(arg.args[0], ast.Constant):
+                        doc = arg.args[0].value
+
+                elif call_name == "Name" and arg.args:
+                    if isinstance(arg.args[0], ast.Constant):
+                        name = arg.args[0].value
+
+                elif call_name == "DefaultPath" and arg.args:
+                    if isinstance(arg.args[0], ast.Constant):
+                        default_path = arg.args[0].value
+
+                elif call_name == "Ignore" and arg.args:
+                    if isinstance(arg.args[0], (ast.List, ast.Tuple)):
+                        ignore = [
+                            elt.value
+                            for elt in arg.args[0].elts
+                            if isinstance(elt, ast.Constant)
+                        ]
+
+                elif call_name == "Deprecated":
+                    if arg.args and isinstance(arg.args[0], ast.Constant):
+                        deprecated = arg.args[0].value
+                    elif not arg.args:
+                        deprecated = ""
+
+        return doc, name, default_path, ignore, deprecated
+
+    def _get_call_name(self, node: ast.Call) -> str | None:
+        """Get the name of a function call."""
+        if isinstance(node.func, ast.Name):
+            return node.func.id
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr
+        return None
+
+
+class DaggerModuleVisitor(ast.NodeVisitor):
+    """AST visitor that extracts Dagger module definitions.
+
+    Visits class definitions and extracts decorated types (objects, interfaces,
+    enums) along with their fields and functions.
+    """
+
+    def __init__(self, source_file: Path, source_code: str):
+        self.source_file = source_file
+        self.source_code = source_code
+        self.source_lines = source_code.splitlines()
+
+        self.objects: list[ObjectTypeIR] = []
+        self.annotation_parser = TypeAnnotationParser(source_file)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Visit class definition and extract if decorated."""
+        is_object = _has_decorator(node, OBJECT_TYPE_DECORATORS)
+        is_interface = _has_decorator(node, INTERFACE_DECORATORS)
+        is_enum = _has_decorator(node, ENUM_DECORATORS)
+
+        if is_object or is_interface or is_enum:
+            obj_ir = self._extract_object_type(
+                node,
+                is_interface=is_interface,
+                is_enum=is_enum,
+            )
+            self.objects.append(obj_ir)
+
+    def _make_location(self, node: ast.AST) -> SourceLocation:
+        """Create source location from AST node."""
+        return SourceLocation(
+            file=self.source_file,
+            line=getattr(node, "lineno", 0),
+            column=getattr(node, "col_offset", 0),
+        )
+
+    def _extract_docstring(
+        self, node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> str | None:
+        """Extract docstring from class or function."""
+        return ast.get_docstring(node)
+
+    def _extract_object_type(
+        self,
+        node: ast.ClassDef,
+        *,
+        is_interface: bool,
+        is_enum: bool,
+    ) -> ObjectTypeIR:
+        """Extract object type from class definition."""
+        location = self._make_location(node)
+
+        # Extract deprecated from decorator
+        deprecated = None
+        if is_interface:
+            dec = _find_decorator(node, INTERFACE_DECORATORS)
+        elif is_enum:
+            dec = _find_decorator(node, ENUM_DECORATORS)
+        else:
+            dec = _find_decorator(node, OBJECT_TYPE_DECORATORS)
+        if dec:
+            kwargs = _get_decorator_kwargs(dec)
+            deprecated = kwargs.get("deprecated")
+
+        doc = self._extract_docstring(node)
+
+        if is_enum:
+            members = self._extract_enum_members(node)
+            return ObjectTypeIR(
+                name=node.name,
+                qualified_name=f"{self.source_file.stem}.{node.name}",
+                location=location,
+                module_path=self.source_file,
+                is_enum=True,
+                enum_members=tuple(members),
+                doc=doc,
+                deprecated=deprecated,
+            )
+
+        fields = self._extract_fields(node)
+        functions = self._extract_functions(node)
+
+        return ObjectTypeIR(
+            name=node.name,
+            qualified_name=f"{self.source_file.stem}.{node.name}",
+            location=location,
+            module_path=self.source_file,
+            is_interface=is_interface,
+            fields=tuple(fields),
+            functions=tuple(functions),
+            doc=doc,
+            deprecated=deprecated,
+        )
+
+    def _extract_fields(self, class_node: ast.ClassDef) -> list[FieldIR]:
+        """Extract fields from class body."""
+        fields: list[FieldIR] = []
+
+        for stmt in class_node.body:
+            if not isinstance(stmt, ast.AnnAssign):
+                continue
+            if not isinstance(stmt.target, ast.Name):
+                continue
+
+            # Check if it's a field() call
+            if stmt.value is None:
+                continue
+            if not isinstance(stmt.value, ast.Call):
+                continue
+
+            call_name = None
+            if isinstance(stmt.value.func, ast.Name):
+                call_name = stmt.value.func.id
+            elif isinstance(stmt.value.func, ast.Attribute):
+                call_name = stmt.value.func.attr
+
+            if call_name != FIELD_FUNCTION:
+                continue
+
+            field_ir = self._extract_field(stmt)
+            if field_ir:
+                fields.append(field_ir)
+
+        return fields
+
+    def _extract_field(self, node: ast.AnnAssign) -> FieldIR | None:
+        """Extract a single field from annotated assignment."""
+        if not isinstance(node.target, ast.Name):
+            return None
+
+        python_name = node.target.id
+        location = self._make_location(node)
+        annotation = self.annotation_parser.parse(node.annotation, location)
+
+        # Parse field() call arguments
+        deprecated = None
+        has_default = False
+        default_value = None
+        default_repr = None
+        init = True
+
+        if isinstance(node.value, ast.Call):
+            for kw in node.value.keywords:
+                if kw.arg == "deprecated" and isinstance(kw.value, ast.Constant):
+                    deprecated = kw.value.value
+                elif kw.arg == "default":
+                    has_default = True
+                    if isinstance(kw.value, ast.Constant):
+                        default_value = kw.value.value
+                    default_repr = ast.unparse(kw.value)
+                elif kw.arg == "default_factory":
+                    has_default = True
+                    default_repr = f"{ast.unparse(kw.value)}()"
+                elif kw.arg == "init" and isinstance(kw.value, ast.Constant):
+                    init = kw.value.value
+                elif kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    # Override API name from field() call
+                    if annotation.name is None:
+                        annotation = TypeAnnotation(
+                            raw=annotation.raw,
+                            location=annotation.location,
+                            is_optional=annotation.is_optional,
+                            is_list=annotation.is_list,
+                            element_type=annotation.element_type,
+                            doc=annotation.doc,
+                            name=kw.value.value,
+                            default_path=annotation.default_path,
+                            ignore=annotation.ignore,
+                            deprecated=annotation.deprecated,
+                        )
+
+        # Determine API name
+        api_name = annotation.name or to_camel_case(normalize_name(python_name))
+
+        return FieldIR(
+            python_name=python_name,
+            api_name=api_name,
+            annotation=annotation,
+            location=location,
+            has_default=has_default,
+            default_value=default_value,
+            default_repr=default_repr,
+            init=init,
+            deprecated=deprecated,
+        )
+
+    def _extract_functions(self, class_node: ast.ClassDef) -> list[FunctionIR]:
+        """Extract functions from class body."""
+        functions: list[FunctionIR] = []
+
+        for stmt in class_node.body:
+            if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            # Check for @function decorator
+            if not _has_decorator(stmt, FUNCTION_DECORATORS):
+                continue
+
+            func_ir = self._extract_function(stmt)
+            if func_ir:
+                functions.append(func_ir)
+
+        return functions
+
+    def _extract_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> FunctionIR | None:
+        """Extract a single function from method definition."""
+        location = self._make_location(node)
+
+        # Extract decorator metadata
+        is_check = _has_decorator(node, CHECK_DECORATORS)
+        cache_policy = None
+        deprecated = None
+        doc_override = None
+        name_override = None
+
+        func_dec = _find_decorator(node, FUNCTION_DECORATORS)
+        if func_dec:
+            kwargs = _get_decorator_kwargs(func_dec)
+            cache_policy = kwargs.get("cache")
+            deprecated = kwargs.get("deprecated")
+            doc_override = kwargs.get("doc")
+            name_override = kwargs.get("name")
+
+        # Extract parameters
+        parameters = self._extract_parameters(node)
+
+        # Extract return annotation
+        return_annotation = None
+        if node.returns:
+            return_annotation = self.annotation_parser.parse(
+                node.returns, self._make_location(node.returns)
+            )
+
+        # Extract docstring
+        doc = doc_override or self._extract_docstring(node)
+
+        # Determine API name
+        python_name = node.name
+        if name_override is not None:
+            api_name = name_override
+        else:
+            api_name = to_camel_case(normalize_name(python_name))
+
+        return FunctionIR(
+            python_name=python_name,
+            api_name=api_name,
+            parameters=tuple(parameters),
+            return_annotation=return_annotation,
+            location=location,
+            doc=doc,
+            is_check=is_check,
+            cache_policy=cache_policy,
+            deprecated=deprecated,
+            is_async=isinstance(node, ast.AsyncFunctionDef),
+        )
+
+    def _extract_parameters(
+        self, func_node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> list[ParameterIR]:
+        """Extract parameters from function definition."""
+        params: list[ParameterIR] = []
+
+        # Calculate default value positions
+        args = func_node.args
+        num_args = len(args.args)
+        num_defaults = len(args.defaults)
+        first_default_idx = num_args - num_defaults
+
+        for i, arg in enumerate(args.args):
+            # Skip 'self' and 'cls'
+            if arg.arg in ("self", "cls"):
+                continue
+
+            location = self._make_location(arg)
+            annotation = self.annotation_parser.parse(arg.annotation, location)
+
+            # Check for default value
+            has_default = False
+            default_value = None
+            default_repr = None
+
+            if i >= first_default_idx:
+                has_default = True
+                default_node = args.defaults[i - first_default_idx]
+                default_repr = ast.unparse(default_node)
+                if isinstance(default_node, ast.Constant):
+                    default_value = default_node.value
+
+            # Determine API name
+            api_name = annotation.name or to_camel_case(normalize_name(arg.arg))
+
+            params.append(
+                ParameterIR(
+                    python_name=arg.arg,
+                    api_name=api_name,
+                    annotation=annotation,
+                    location=location,
+                    has_default=has_default,
+                    default_value=default_value,
+                    default_repr=default_repr,
+                )
+            )
+
+        return params
+
+    def _extract_enum_members(self, class_node: ast.ClassDef) -> list[EnumMemberIR]:
+        """Extract enum members from class body."""
+        members: list[EnumMemberIR] = []
+
+        for i, stmt in enumerate(class_node.body):
+            if not isinstance(stmt, ast.Assign):
+                continue
+
+            for target in stmt.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+
+                member_name = target.id
+
+                # Skip private attributes
+                if member_name.startswith("_"):
+                    continue
+
+                # Get value
+                value = ""
+                if isinstance(stmt.value, ast.Constant):
+                    value = str(stmt.value.value)
+                else:
+                    value = ast.unparse(stmt.value)
+
+                # Extract docstring from next statement
+                doc = self._extract_doc_from_next_stmt(class_node.body, i)
+
+                # Parse deprecated directive from doc
+                deprecated = None
+                if doc and ".. deprecated::" in doc:
+                    parts = doc.split(".. deprecated::", 1)
+                    doc = parts[0].strip() or None
+                    deprecated = parts[1].strip()
+
+                location = self._make_location(stmt)
+
+                members.append(
+                    EnumMemberIR(
+                        name=member_name,
+                        value=value,
+                        doc=doc,
+                        deprecated=deprecated,
+                        location=location,
+                    )
+                )
+
+        return members
+
+    def _extract_doc_from_next_stmt(
+        self, body: list[ast.stmt], index: int
+    ) -> str | None:
+        """Extract documentation from statement following an assignment."""
+        next_idx = index + 1
+        if next_idx >= len(body):
+            return None
+
+        next_stmt = body[next_idx]
+        if (
+            isinstance(next_stmt, ast.Expr)
+            and isinstance(next_stmt.value, ast.Constant)
+            and isinstance(next_stmt.value.value, str)
+        ):
+            return next_stmt.value.value.strip()
+        return None
+
+
+def parse_file(source_path: Path) -> list[ObjectTypeIR]:
+    """Parse a single Python file and extract Dagger types.
+
+    Args:
+        source_path: Path to Python file
+
+    Returns
+    -------
+        List of extracted ObjectTypeIR
+
+    Raises
+    ------
+        SyntaxError: If file contains invalid Python syntax
+    """
+    source_code = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source_code, filename=str(source_path))
+
+    visitor = DaggerModuleVisitor(source_path, source_code)
+    visitor.visit(tree)
+
+    return visitor.objects
+
+
+def get_module_docstring(source_path: Path) -> str | None:
+    """Extract module-level docstring from Python file."""
+    source_code = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source_code)
+    return ast.get_docstring(tree)

--- a/sdk/python/src/dagger/mod/_ir.py
+++ b/sdk/python/src/dagger/mod/_ir.py
@@ -1,0 +1,186 @@
+"""Intermediate representation for AST-based module analysis.
+
+This module defines immutable dataclasses representing parsed Python module
+definitions. The IR serves as a contract between AST parsing and TypeDef
+generation, enabling static analysis without code execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SourceLocation:
+    """Source code location for error reporting."""
+
+    file: Path
+    line: int
+    column: int
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}:{self.column}"
+
+
+@dataclass(frozen=True, slots=True)
+class TypeAnnotation:
+    """Parsed type annotation from AST.
+
+    Represents a Python type annotation with extracted metadata from
+    Annotated[] types and optionality information.
+    """
+
+    raw: str  # Original annotation string (from ast.unparse)
+    location: SourceLocation | None = None
+
+    # Parsed type structure
+    is_optional: bool = False
+    is_list: bool = False
+    element_type: str | None = None  # For list[T], the T
+
+    # Metadata extracted from Annotated[]
+    doc: str | None = None
+    name: str | None = None  # From Name() - API name override
+    default_path: str | None = None  # From DefaultPath()
+    ignore: tuple[str, ...] | None = None  # From Ignore()
+    deprecated: str | None = None  # From Deprecated()
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterIR:
+    """Function parameter intermediate representation."""
+
+    python_name: str  # Original Python parameter name
+    api_name: str  # Converted API name (camelCase)
+    annotation: TypeAnnotation
+    location: SourceLocation | None = None
+
+    has_default: bool = False
+    default_value: Any = None  # Actual default value if simple constant
+    default_repr: str | None = None  # String representation for complex defaults
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionIR:
+    """Function/method intermediate representation."""
+
+    python_name: str  # Original Python method name
+    api_name: str  # Converted API name (camelCase, or "" for constructor)
+    parameters: tuple[ParameterIR, ...]
+    return_annotation: TypeAnnotation | None
+    location: SourceLocation
+
+    # Documentation
+    doc: str | None = None
+
+    # Decorator metadata
+    is_constructor: bool = False
+    is_check: bool = False
+    cache_policy: str | None = None  # "never", "session", or TTL duration
+    deprecated: str | None = None
+
+    # Method type
+    is_async: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class FieldIR:
+    """Field intermediate representation."""
+
+    python_name: str  # Original Python field name
+    api_name: str  # Converted API name (camelCase)
+    annotation: TypeAnnotation
+    location: SourceLocation
+
+    has_default: bool = False
+    default_value: Any = None
+    default_repr: str | None = None
+    init: bool = True  # Whether included in constructor
+    deprecated: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EnumMemberIR:
+    """Enum member intermediate representation."""
+
+    name: str  # Member name (UPPER_CASE typically)
+    value: str  # String representation of value
+    doc: str | None = None
+    deprecated: str | None = None
+    location: SourceLocation | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectTypeIR:
+    """Object type intermediate representation.
+
+    Represents a class decorated with @object_type, @interface, or @enum_type.
+    """
+
+    name: str  # Class name (PascalCase)
+    qualified_name: str  # module.path.ClassName
+    location: SourceLocation
+    module_path: Path
+
+    # Type classification
+    is_interface: bool = False
+    is_enum: bool = False
+
+    # Members (mutually exclusive based on type)
+    fields: tuple[FieldIR, ...] = field(default_factory=tuple)
+    functions: tuple[FunctionIR, ...] = field(default_factory=tuple)
+    enum_members: tuple[EnumMemberIR, ...] = field(default_factory=tuple)
+
+    # Metadata
+    doc: str | None = None
+    deprecated: str | None = None
+
+    def get_constructor(self) -> FunctionIR | None:
+        """Get the constructor function if defined."""
+        for func in self.functions:
+            if func.is_constructor:
+                return func
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleIR:
+    """Complete module intermediate representation.
+
+    Contains all parsed types from a Dagger Python module package.
+    """
+
+    main_object_name: str
+    objects: tuple[ObjectTypeIR, ...]
+    source_files: tuple[Path, ...] = field(default_factory=tuple)
+    module_doc: str | None = None
+
+    def get_main_object(self) -> ObjectTypeIR | None:
+        """Get the main object type."""
+        for obj in self.objects:
+            if obj.name == self.main_object_name:
+                return obj
+        return None
+
+    def get_object(self, name: str) -> ObjectTypeIR | None:
+        """Get an object type by name."""
+        for obj in self.objects:
+            if obj.name == name:
+                return obj
+        return None
+
+    def get_enums(self) -> tuple[ObjectTypeIR, ...]:
+        """Get all enum types."""
+        return tuple(obj for obj in self.objects if obj.is_enum)
+
+    def get_interfaces(self) -> tuple[ObjectTypeIR, ...]:
+        """Get all interface types."""
+        return tuple(obj for obj in self.objects if obj.is_interface)
+
+    def get_object_types(self) -> tuple[ObjectTypeIR, ...]:
+        """Get all object types (non-enum, non-interface)."""
+        return tuple(
+            obj for obj in self.objects if not obj.is_enum and not obj.is_interface
+        )

--- a/sdk/python/src/dagger/mod/cli.py
+++ b/sdk/python/src/dagger/mod/cli.py
@@ -6,6 +6,7 @@ import importlib.util
 import logging
 import os
 import typing
+from pathlib import Path
 
 import anyio
 
@@ -21,13 +22,132 @@ ENTRY_POINT_GROUP: typing.Final[str] = typing.cast(str, __package__)
 IMPORT_PKG: typing.Final[str] = os.getenv("DAGGER_DEFAULT_PYTHON_PACKAGE", "main")
 
 
-def app(mod: Module | None = None, register: bool = False) -> int | None:
-    """Entrypoint for a Python Dagger module."""
+def app(
+    mod: Module | None = None,
+    register: bool = False,
+    analyze: bool = False,
+) -> int | None:
+    """Entrypoint for a Python Dagger module.
+
+    Args:
+        mod: Pre-loaded Module instance (optional)
+        register: If True, register types and exit
+        analyze: If True, perform AST analysis without loading module
+    """
+    if analyze:
+        return analyze_standalone()
+
     telemetry.initialize()
     try:
         return anyio.run(main, mod, register)
     finally:
         telemetry.shutdown()
+
+
+def analyze_standalone() -> int:
+    """Perform standalone AST analysis without loading the module.
+
+    This analyzes Python source files using AST parsing to extract
+    Dagger type definitions without executing any user code.
+
+    Environment variables
+    ---------------------
+        DAGGER_SOURCE_DIR: Directory to analyze (default: current directory)
+        DAGGER_MAIN_OBJECT: Name of the main object class
+        DAGGER_MODULE: Module name (converted to PascalCase for main object)
+
+    Returns
+    -------
+        0 on success, non-zero on error
+    """
+    from dagger.mod._analyzer import analyze_package
+
+    try:
+        module_ir = _run_analysis(analyze_package)
+    except ModuleLoadError as e:
+        logger.warning("Module load error: %s", e)
+        return 2
+    except SyntaxError as e:
+        logger.warning("Syntax error: %s", e)
+        return 2
+    except Exception:
+        logger.exception("Unhandled exception during analysis")
+        return 1
+    else:
+        _log_analysis_summary(module_ir)
+        return 0
+
+
+def _run_analysis(analyze_package):
+    """Run the package analysis."""
+    source_dir = Path(os.getenv("DAGGER_SOURCE_DIR", "."))
+    main_object = os.getenv("DAGGER_MAIN_OBJECT")
+    return analyze_package(source_dir, main_object)
+
+
+def _log_analysis_summary(module_ir) -> None:
+    """Log a summary of the analyzed module."""
+    logger.info("Analyzed module: %s", module_ir.main_object_name)
+    logger.info("  Objects: %d", len(module_ir.get_object_types()))
+    logger.info("  Interfaces: %d", len(module_ir.get_interfaces()))
+    logger.info("  Enums: %d", len(module_ir.get_enums()))
+
+    for obj in module_ir.objects:
+        kind = _get_object_kind(obj)
+        logger.info("  - %s (%s)", obj.name, kind)
+        _log_functions(obj)
+        _log_fields(obj)
+        _log_enum_members(obj)
+
+
+def _get_object_kind(obj) -> str:
+    """Get the kind of object (enum, interface, or object)."""
+    if obj.is_enum:
+        return "enum"
+    if obj.is_interface:
+        return "interface"
+    return "object"
+
+
+def _log_functions(obj) -> None:
+    """Log function signatures for an object."""
+    for func in obj.functions:
+        params = ", ".join(p.api_name for p in func.parameters)
+        ret = func.return_annotation.raw if func.return_annotation else "None"
+        logger.info("      %s(%s) -> %s", func.api_name, params, ret)
+
+
+def _log_fields(obj) -> None:
+    """Log fields for an object."""
+    for field in obj.fields:
+        logger.info("      %s: %s", field.api_name, field.annotation.raw)
+
+
+def _log_enum_members(obj) -> None:
+    """Log enum members for an object."""
+    for member in obj.enum_members:
+        logger.info("      %s = %s", member.name, member.value)
+
+
+async def analyze_and_register() -> dagger.ModuleID:
+    """Analyze module using AST and register types with Dagger.
+
+    This is the new registration path that uses AST parsing instead of
+    runtime introspection.
+    """
+    from dagger.mod._analyzer import analyze_package
+    from dagger.mod._ast_resolver import IRToTypeDefConverter
+
+    # Get source directory
+    source_dir = Path(os.getenv("DAGGER_SOURCE_DIR", "."))
+    main_object = os.getenv("DAGGER_MAIN_OBJECT")
+
+    # Analyze module using AST
+    module_ir = analyze_package(source_dir, main_object)
+
+    # Convert IR to TypeDefs
+    converter = IRToTypeDefConverter(module_ir)
+    return await converter.convert()
 
 
 async def main(mod: Module | None = None, register: bool = False) -> int | None:

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1,0 +1,706 @@
+"""Tests for AST-based module analysis."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dagger.mod._analyzer import analyze_source
+from dagger.mod._ast_visitor import TypeAnnotationParser
+from dagger.mod._exceptions import ModuleLoadError
+from dagger.mod._ir import (
+    SourceLocation,
+    TypeAnnotation,
+)
+
+# =============================================================================
+# TypeAnnotation Tests
+# =============================================================================
+
+
+class TestTypeAnnotation:
+    """Tests for TypeAnnotation IR dataclass."""
+
+    def test_basic_annotation(self):
+        """Test creating a basic type annotation."""
+        annotation = TypeAnnotation(raw="str")
+        assert annotation.raw == "str"
+        assert not annotation.is_optional
+        assert not annotation.is_list
+        assert annotation.element_type is None
+
+    def test_optional_annotation(self):
+        """Test optional type annotation."""
+        annotation = TypeAnnotation(raw="str | None", is_optional=True)
+        assert annotation.is_optional
+
+    def test_list_annotation(self):
+        """Test list type annotation."""
+        annotation = TypeAnnotation(
+            raw="list[str]",
+            is_list=True,
+            element_type="str",
+        )
+        assert annotation.is_list
+        assert annotation.element_type == "str"
+
+    def test_annotation_with_metadata(self):
+        """Test annotation with Annotated metadata."""
+        annotation = TypeAnnotation(
+            raw='Annotated[str, Doc("A string")]',
+            doc="A string",
+            name="customName",
+            deprecated="Use other field",
+        )
+        assert annotation.doc == "A string"
+        assert annotation.name == "customName"
+        assert annotation.deprecated == "Use other field"
+
+
+# =============================================================================
+# TypeAnnotationParser Tests
+# =============================================================================
+
+
+class TestTypeAnnotationParser:
+    """Tests for TypeAnnotationParser AST parsing."""
+
+    @pytest.fixture
+    def parser(self, tmp_path: Path) -> TypeAnnotationParser:
+        return TypeAnnotationParser(tmp_path / "test.py")
+
+    @pytest.fixture
+    def location(self, tmp_path: Path) -> SourceLocation:
+        return SourceLocation(file=tmp_path / "test.py", line=1, column=0)
+
+    def _parse_annotation(
+        self,
+        parser: TypeAnnotationParser,
+        annotation_str: str,
+        location: SourceLocation,
+    ) -> TypeAnnotation:
+        """Helper to parse an annotation string."""
+        import ast
+
+        node = ast.parse(annotation_str, mode="eval").body
+        return parser.parse(node, location)
+
+    def test_parse_simple_types(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing simple built-in types."""
+        for type_str in ["str", "int", "float", "bool"]:
+            annotation = self._parse_annotation(parser, type_str, location)
+            assert annotation.raw == type_str
+            assert not annotation.is_optional
+            assert not annotation.is_list
+
+    def test_parse_optional_union_syntax(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Optional using union syntax."""
+        annotation = self._parse_annotation(parser, "str | None", location)
+        assert annotation.is_optional
+
+    def test_parse_optional_type(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Optional[T] type."""
+        annotation = self._parse_annotation(parser, "Optional[str]", location)
+        assert annotation.is_optional
+
+    def test_parse_list_type(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing list[T] type."""
+        annotation = self._parse_annotation(parser, "list[str]", location)
+        assert annotation.is_list
+        assert annotation.element_type == "str"
+
+    def test_parse_annotated_with_doc(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Annotated with Doc."""
+        annotation = self._parse_annotation(
+            parser,
+            'Annotated[str, Doc("A description")]',
+            location,
+        )
+        assert annotation.doc == "A description"
+
+    def test_parse_annotated_with_name(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Annotated with Name."""
+        annotation = self._parse_annotation(
+            parser,
+            'Annotated[str, Name("customName")]',
+            location,
+        )
+        assert annotation.name == "customName"
+
+    def test_parse_annotated_with_default_path(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Annotated with DefaultPath."""
+        annotation = self._parse_annotation(
+            parser,
+            'Annotated[Directory, DefaultPath("./src")]',
+            location,
+        )
+        assert annotation.default_path == "./src"
+
+    def test_parse_annotated_with_ignore(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Annotated with Ignore."""
+        annotation = self._parse_annotation(
+            parser,
+            'Annotated[Directory, Ignore([".git", "node_modules"])]',
+            location,
+        )
+        assert annotation.ignore == (".git", "node_modules")
+
+    def test_parse_annotated_with_deprecated(
+        self, parser: TypeAnnotationParser, location: SourceLocation
+    ):
+        """Test parsing Annotated with Deprecated."""
+        annotation = self._parse_annotation(
+            parser,
+            'Annotated[str, Deprecated("Use other param")]',
+            location,
+        )
+        assert annotation.deprecated == "Use other param"
+
+
+# =============================================================================
+# Module Analysis Tests
+# =============================================================================
+
+
+class TestAnalyzeSource:
+    """Tests for analyze_source function."""
+
+    def test_simple_object_type(self):
+        """Test analyzing a simple object type."""
+        source = textwrap.dedent('''
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                """Main module description."""
+                pass
+        ''')
+
+        module_ir = analyze_source(source, "test.py")
+
+        assert module_ir.main_object_name == "Main"
+        assert len(module_ir.objects) == 1
+
+        obj = module_ir.objects[0]
+        assert obj.name == "Main"
+        assert obj.doc == "Main module description."
+        assert not obj.is_interface
+        assert not obj.is_enum
+
+    def test_object_with_function(self):
+        """Test analyzing object type with a function."""
+        source = textwrap.dedent('''
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def hello(self, name: str) -> str:
+                    """Say hello."""
+                    return f"Hello, {name}!"
+        ''')
+
+        module_ir = analyze_source(source, "test.py")
+        obj = module_ir.objects[0]
+
+        assert len(obj.functions) == 1
+        func = obj.functions[0]
+
+        assert func.python_name == "hello"
+        assert func.api_name == "hello"
+        assert func.doc == "Say hello."
+        assert len(func.parameters) == 1
+
+        param = func.parameters[0]
+        assert param.python_name == "name"
+        assert param.api_name == "name"
+        assert param.annotation.raw == "str"
+
+        assert func.return_annotation is not None
+        assert func.return_annotation.raw == "str"
+
+    def test_function_with_default_parameter(self):
+        """Test analyzing function with default parameter."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def greet(self, name: str = "World") -> str:
+                    return f"Hello, {name}!"
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+        param = func.parameters[0]
+
+        assert param.has_default
+        assert param.default_value == "World"
+        # AST unparse uses single quotes
+        assert param.default_repr == "'World'"
+
+    def test_function_with_optional_type(self):
+        """Test analyzing function with optional type."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def process(self, data: str | None) -> str:
+                    return data or ""
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+        param = func.parameters[0]
+
+        assert param.annotation.is_optional
+
+    def test_object_with_field(self):
+        """Test analyzing object type with a field."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                name: str = dagger.field(default="default")
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        obj = module_ir.objects[0]
+
+        assert len(obj.fields) == 1
+        field = obj.fields[0]
+
+        assert field.python_name == "name"
+        assert field.api_name == "name"
+        assert field.has_default
+        assert field.default_value == "default"
+
+    def test_field_with_deprecation(self):
+        """Test analyzing deprecated field."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                old_name: str = dagger.field(default="", deprecated="Use new_name")
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        field = module_ir.objects[0].fields[0]
+
+        assert field.deprecated == "Use new_name"
+
+    def test_function_with_check_decorator(self):
+        """Test analyzing function with @check decorator."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                @dagger.check
+                def lint(self) -> str:
+                    return "OK"
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.is_check
+
+    def test_function_with_cache_policy(self):
+        """Test analyzing function with cache policy."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function(cache="never")
+                def no_cache(self) -> str:
+                    return "fresh"
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.cache_policy == "never"
+
+    def test_function_deprecated(self):
+        """Test analyzing deprecated function."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function(deprecated="Use new_method instead")
+                def old_method(self) -> str:
+                    return ""
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.deprecated == "Use new_method instead"
+
+    def test_async_function(self):
+        """Test analyzing async function."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                async def fetch(self) -> str:
+                    return ""
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.is_async
+
+    def test_interface_type(self):
+        """Test analyzing interface type."""
+        source = textwrap.dedent('''
+            import dagger
+            import typing
+
+            @dagger.interface
+            class Buildable(typing.Protocol):
+                """Interface for buildable objects."""
+
+                @dagger.function
+                def build(self) -> str:
+                    ...
+        ''')
+
+        module_ir = analyze_source(source, "test.py", main_object_name="Buildable")
+        obj = module_ir.objects[0]
+
+        assert obj.is_interface
+        assert obj.doc == "Interface for buildable objects."
+
+    def test_enum_type(self):
+        """Test analyzing enum type."""
+        source = textwrap.dedent('''
+            import enum
+            import dagger
+
+            @dagger.enum_type
+            class Status(enum.Enum):
+                """Status enumeration."""
+
+                PENDING = "pending"
+                """Waiting to start."""
+
+                DONE = "done"
+                """Completed."""
+
+            @dagger.object_type
+            class Main:
+                pass
+        ''')
+
+        module_ir = analyze_source(source, "test.py")
+
+        # Find enum
+        enum_obj = module_ir.get_object("Status")
+        assert enum_obj is not None
+        assert enum_obj.is_enum
+        assert enum_obj.doc == "Status enumeration."
+
+        assert len(enum_obj.enum_members) == 2
+
+        pending = enum_obj.enum_members[0]
+        assert pending.name == "PENDING"
+        # Value is the string content without enclosing quotes
+        assert pending.value == "pending"
+        assert pending.doc == "Waiting to start."
+
+        done = enum_obj.enum_members[1]
+        assert done.name == "DONE"
+        assert done.value == "done"
+        assert done.doc == "Completed."
+
+    def test_name_conversion(self):
+        """Test Python to API name conversion."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                my_field: str = dagger.field(default="")
+
+                @dagger.function
+                def my_function(self, some_param: str) -> str:
+                    return some_param
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        obj = module_ir.objects[0]
+
+        # snake_case preserved for API (camelCase conversion happens in TypeDef)
+        assert obj.fields[0].api_name == "myField"
+        assert obj.functions[0].api_name == "myFunction"
+        assert obj.functions[0].parameters[0].api_name == "someParam"
+
+    def test_trailing_underscore_normalization(self):
+        """Test that trailing underscores are normalized."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def from_(self, path: str) -> str:
+                    return path
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.api_name == "from"
+
+    def test_custom_api_name(self):
+        """Test custom API name via decorator."""
+        source = textwrap.dedent("""
+            import dagger
+            from typing import Annotated
+
+            @dagger.object_type
+            class Main:
+                @dagger.function(name="customName")
+                def original_name(self) -> str:
+                    return ""
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.python_name == "original_name"
+        assert func.api_name == "customName"
+
+    def test_explicit_constructor_empty_name(self):
+        """Test that @function(name="") creates a constructor."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function(name="")
+                def create(self) -> "Main":
+                    return Main()
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.python_name == "create"
+        assert func.api_name == ""  # Empty name = constructor
+
+    def test_multiple_objects(self):
+        """Test analyzing multiple object types."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def get_helper(self) -> "Helper":
+                    pass
+
+            @dagger.object_type
+            class Helper:
+                @dagger.function
+                def help(self) -> str:
+                    return "Helping!"
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+
+        assert len(module_ir.objects) == 2
+        assert {obj.name for obj in module_ir.objects} == {"Main", "Helper"}
+
+    def test_list_return_type(self):
+        """Test analyzing function with list return type."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def get_names(self) -> list[str]:
+                    return []
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+
+        assert func.return_annotation is not None
+        assert func.return_annotation.is_list
+        assert func.return_annotation.element_type == "str"
+
+    def test_annotated_parameter(self):
+        """Test analyzing parameter with Annotated metadata."""
+        source = textwrap.dedent("""
+            import dagger
+            from typing import Annotated
+            from typing_extensions import Doc
+
+            @dagger.object_type
+            class Main:
+                @dagger.function
+                def process(
+                    self,
+                    data: Annotated[str, Doc("Input data")],
+                ) -> str:
+                    return data
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        func = module_ir.objects[0].functions[0]
+        param = func.parameters[0]
+
+        assert param.annotation.doc == "Input data"
+
+    def test_missing_main_object_raises_error(self):
+        """Test that missing main object raises ModuleLoadError."""
+        source = textwrap.dedent("""
+            # No decorated classes, just a plain function
+            def helper():
+                pass
+        """)
+
+        with pytest.raises(ModuleLoadError, match="Main.*not found"):
+            analyze_source(source, "test.py", main_object_name="Main")
+
+    def test_object_deprecated(self):
+        """Test analyzing deprecated object type."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type(deprecated="Use NewMain instead")
+            class Main:
+                pass
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        obj = module_ir.objects[0]
+
+        assert obj.deprecated == "Use NewMain instead"
+
+
+class TestModuleIRHelpers:
+    """Tests for ModuleIR helper methods."""
+
+    def test_get_main_object(self):
+        """Test get_main_object method."""
+        source = textwrap.dedent("""
+            import dagger
+
+            @dagger.object_type
+            class Main:
+                pass
+
+            @dagger.object_type
+            class Helper:
+                pass
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        main = module_ir.get_main_object()
+
+        assert main is not None
+        assert main.name == "Main"
+
+    def test_get_enums(self):
+        """Test get_enums method."""
+        source = textwrap.dedent("""
+            import enum
+            import dagger
+
+            @dagger.enum_type
+            class Status(enum.Enum):
+                OK = "ok"
+
+            @dagger.object_type
+            class Main:
+                pass
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        enums = module_ir.get_enums()
+
+        assert len(enums) == 1
+        assert enums[0].name == "Status"
+
+    def test_get_interfaces(self):
+        """Test get_interfaces method."""
+        source = textwrap.dedent("""
+            import dagger
+            import typing
+
+            @dagger.interface
+            class Runnable(typing.Protocol):
+                pass
+
+            @dagger.object_type
+            class Main:
+                pass
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        interfaces = module_ir.get_interfaces()
+
+        assert len(interfaces) == 1
+        assert interfaces[0].name == "Runnable"
+
+    def test_get_object_types(self):
+        """Test get_object_types method excludes enums and interfaces."""
+        source = textwrap.dedent("""
+            import enum
+            import typing
+            import dagger
+
+            @dagger.enum_type
+            class Status(enum.Enum):
+                OK = "ok"
+
+            @dagger.interface
+            class Runnable(typing.Protocol):
+                pass
+
+            @dagger.object_type
+            class Main:
+                pass
+
+            @dagger.object_type
+            class Helper:
+                pass
+        """)
+
+        module_ir = analyze_source(source, "test.py")
+        objects = module_ir.get_object_types()
+
+        assert len(objects) == 2
+        assert {obj.name for obj in objects} == {"Main", "Helper"}


### PR DESCRIPTION
The Python SDK's code analysis has been migrated from runtime-based to AST-based analysis. This allows types to be available before dependencies are fetched, enabling static analysis without executing user code.

Files Created

| File                                       | Purpose                                                                                                                                        |
|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| sdk/python/src/dagger/mod/_ir.py           | Immutable dataclasses for intermediate representation (TypeAnnotation, ParameterIR, FunctionIR, FieldIR, EnumMemberIR, ObjectTypeIR, ModuleIR) |
| sdk/python/src/dagger/mod/_ast_visitor.py  | Core AST parsing with DaggerModuleVisitor class that extracts decorated types without executing code                                           |
| sdk/python/src/dagger/mod/_ast_resolver.py | TypeResolver and IRToTypeDefConverter classes to convert IR to Dagger TypeDefs                                                                 |
| sdk/python/src/dagger/mod/_analyzer.py     | Main entry points: PythonModuleAnalyzer, analyze_package(), analyze_source()                                                                   |
| sdk/python/tests/mod/test_ast_analyzer.py  | 38 comprehensive tests covering all components                                                                                                 |

Files Modified

| File                                 | Changes                                                                                                        |
|--------------------------------------|----------------------------------------------------------------------------------------------------------------|
| sdk/python/src/dagger/mod/cli.py     | Added analyze parameter to app(), analyze_standalone() function for CLI, analyze_and_register() async function |
| sdk/python/src/dagger/mod/_module.py | Added use_ast parameter to register(), _typedefs_from_ast() method                                             |
| sdk/python/ruff.toml                 | Added per-file ignores for AST complexity rules                                                                |

Key Features

1. Static Analysis: Parses Python source using ast module without importing/executing code
2. Full Decorator Support: @object_type, @function, @field, @enum_type, @interface, @check
3. Metadata Extraction: Handles Annotated[] with Doc, Name, DefaultPath, Ignore, Deprecated
4. Name Conversion: Automatic snake_case → camelCase, trailing underscore normalization
5. Type Resolution: Maps Python types to Dagger TypeDef (builtins, Dagger core types, module types)
6. Constructor Support: Default constructors from dataclass fields, explicit constructors via name=""
7. Package Analysis: Supports single files and full package directories with recursive scanning

Usage

    # Programmatic API
    from dagger.mod._analyzer import analyze_package, analyze_source

    # Analyze a package directory
    module_ir = analyze_package(Path("./src"), main_object="MyModule")

    # Analyze source code string
    module_ir = analyze_source(source_code, "test.py")

    # CLI standalone analysis
    python -m dagger --analyze  # Uses DAGGER_SOURCE_DIR env var

    # Integration with Module.register()
    await mod.register(use_ast=True)

Architecture

The implementation follows a clean separation of concerns:

Source Code → AST Visitor → IR Dataclasses → TypeDef Converter → Dagger API

This allows the parsing and type resolution to be tested independently and makes future extensions straightforward.