### PR TITLE
fix: file.WithName causing file not found error

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -1223,7 +1223,7 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, dest string, permiss
 		if err != nil {
 			return err
 		}
-		return RestoreErrPath(os.MkdirAll(resolvedDir, permissions), dest)
+		return TrimErrPathPrefix(os.MkdirAll(resolvedDir, permissions), root)
 	}, withSavedSnapshot("withNewDirectory %s", dest))
 }
 
@@ -1592,7 +1592,7 @@ func (dir *Directory) Stat(ctx context.Context, srv *dagql.Server, targetPath st
 			return err
 		}
 		fileInfo, err = osStatFunc(resolvedPath)
-		return RestoreErrPath(err, targetPath)
+		return TrimErrPathPrefix(err, root)
 	})
 	if err != nil {
 		return nil, err

--- a/core/file.go
+++ b/core/file.go
@@ -486,7 +486,7 @@ func (file *File) Stat(ctx context.Context) (*Stat, error) {
 			return err
 		}
 		fileInfo, err = osStatFunc(resolvedPath)
-		return RestoreErrPath(err, file.File)
+		return TrimErrPathPrefix(err, root)
 	})
 	if err != nil {
 		return nil, err
@@ -505,26 +505,22 @@ func (file *File) Stat(ctx context.Context) (*Stat, error) {
 }
 
 func (file *File) WithName(ctx context.Context, filename string) (*File, error) {
-	// Clone the file
 	file = file.Clone()
-
-	st, err := file.State()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new file with the new name
-	newFile := llb.Scratch().File(llb.Copy(st, file.File, filepath.Base(filename)))
-
-	def, err := newFile.Marshal(ctx, llb.Platform(file.Platform.Spec()))
-	if err != nil {
-		return nil, err
-	}
-
-	file.LLB = def.ToPB()
-	file.File = filepath.Base(filename)
-
-	return file, nil
+	return execInMount(ctx, file, func(root string) error {
+		src, err := RootPathWithoutFinalSymlink(root, file.File)
+		if err != nil {
+			return err
+		}
+		dst, err := RootPathWithoutFinalSymlink(root, filename)
+		if err != nil {
+			return err
+		}
+		err = os.Rename(src, dst)
+		if err != nil {
+			return TrimErrPathPrefix(err, root)
+		}
+		return nil
+	}, withSavedSnapshot("withName %s", filename))
 }
 
 func (file *File) WithTimestamps(ctx context.Context, unix int) (*File, error) {

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -217,6 +217,14 @@ func (FileSuite) TestWithName(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "content", mountedFileNameContent)
 	})
+
+	// regression test for https://github.com/dagger/dagger/issues/11660
+	t.Run("contents", func(ctx context.Context, t *testctx.T) {
+		f := c.File("test", "hello").WithName("tset")
+		s, err := f.Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello", s)
+	})
 }
 
 func (FileSuite) TestExport(ctx context.Context, t *testctx.T) {

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -49,7 +49,7 @@ func (s *fileSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("excludeMetadata").Doc(`If true, exclude metadata from the digest.`),
 			),
-		dagql.Func("withName", s.withName).
+		dagql.NodeFunc("withName", DagOpFileWrapper(srv, s.withName, WithPathFn(fileWithNamePath))).
 			Doc(`Retrieves this file with its name set to the given name.`).
 			Args(
 				dagql.Arg("name").Doc(`Name to set file to.`),
@@ -160,10 +160,26 @@ func (s *fileSchema) digest(ctx context.Context, file *core.File, args fileDiges
 
 type fileWithNameArgs struct {
 	Name string
+
+	FSDagOpInternalArgs
 }
 
-func (s *fileSchema) withName(ctx context.Context, parent *core.File, args fileWithNameArgs) (*core.File, error) {
-	return parent.WithName(ctx, args.Name)
+func fileWithNamePath(ctx context.Context, val *core.File, args fileWithNameArgs) (string, error) {
+	return args.Name, nil
+}
+
+func (s *fileSchema) withName(ctx context.Context, parent dagql.ObjectResult[*core.File], args fileWithNameArgs) (inst dagql.ObjectResult[*core.File], err error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+
+	file, err := parent.Self().WithName(ctx, args.Name)
+	if err != nil {
+		return inst, err
+	}
+
+	return dagql.NewObjectResultForCurrentID(ctx, srv, file)
 }
 
 type fileExportArgs struct {

--- a/core/util.go
+++ b/core/util.go
@@ -563,11 +563,26 @@ func mountObj[T fileOrDirectory](ctx context.Context, obj T, optFns ...mountObjO
 }
 
 // RestoreErrPath will restore the path of an error, which is useful for both removing buildkit mount root paths and referencing uncleaned paths
+// Note: TrimErrPathPrefix should be used instead when a root prefix is known
 func RestoreErrPath(err error, path string) error {
 	if pe, ok := err.(*os.PathError); ok {
 		pe.Path = path
 	} else if err != nil {
 		slog.Warn("RestorePathErr: unhandled type", "type", fmt.Sprintf("%T", err))
+	}
+	return err
+}
+
+// TrimErrPathPrefix will trim a prefix from the path of an error, which is useful for both removing buildkit mount root paths and referencing uncleaned paths
+func TrimErrPathPrefix(err error, prefix string) error {
+	switch e := err.(type) {
+	case *os.PathError:
+		e.Path = strings.TrimPrefix(e.Path, prefix)
+	case *os.LinkError:
+		e.Old = strings.TrimPrefix(e.Old, prefix)
+		e.New = strings.TrimPrefix(e.New, prefix)
+	default:
+		slog.Warn("TrimErrPathPrefix: unhandled type", "type", fmt.Sprintf("%T", err))
 	}
 	return err
 }


### PR DESCRIPTION
This converts file.WithName to dagop, and additionally fixes #11660