### PR TITLE
fix missing 0.19.8->0.19.9 bumps

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.19.8"
+    default: "v0.19.9"
     required: false
 
   dev-engine:

--- a/.github/workflows/_dagger_on_depot_remote_engine.yml
+++ b/.github/workflows/_dagger_on_depot_remote_engine.yml
@@ -15,7 +15,7 @@ on:
       dagger:
         description: "Dagger version"
         type: string
-        default: "0.19.8"
+        default: "0.19.9"
         required: false
       ubuntu:
         description: "Ubuntu version"

--- a/.github/workflows/benchmark-engine.yml
+++ b/.github/workflows/benchmark-engine.yml
@@ -23,7 +23,7 @@ jobs:
   benchdev:
     if: ${{ github.repository == 'dagger/dagger' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')) }}
     runs-on:
-        - 'dagger-g3-v0-19-8-16c-st-benchmark'
+        - 'dagger-g3-v0-19-9-16c-st-benchmark'
     timeout-minutes: 10
     steps:
       - name: Checkout repo

--- a/.github/workflows/daggerverse-preview.yml
+++ b/.github/workflows/daggerverse-preview.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     runs-on:
       - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
-      - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.8' || 'ubuntu-24.04' }}
+      - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.19.9' || 'ubuntu-24.04' }}
     name: deploy
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
           call: --github-token=env:RELEASE_DAGGER_CI_TOKEN deploy-preview-with-dagger-main --target ${{ github.event.number }} --github-assignee $GITHUB_ACTOR
           cloud-token: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
           module: modules/daggerverse
-          version: v0.19.8
+          version: v0.19.9
         env:
           RELEASE_DAGGER_CI_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
     timeout-minutes: 20

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -29,7 +29,7 @@ jobs:
           call: --allow-llm all check
           cloud-token: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
           module: github.com/${{ github.repository }}/modules/evals@${{ github.sha }}
-          version: v0.19.8
+          version: v0.19.9
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     timeout-minutes: 20
@@ -48,7 +48,7 @@ jobs:
           call: --allow-llm all test specific --env-file file://.env --pkg ./cmd/dagger --run CMD/LLM
           cloud-token: dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw
           module: github.com/${{ github.repository }}@${{ github.sha }}
-          version: v0.19.8
+          version: v0.19.9
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     timeout-minutes: 20

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
-    runs-on: dagger-g3-v0-19-8-16c-st
+    runs-on: dagger-g3-v0-19-9-16c-st
     steps:
       - uses: actions/checkout@v4
       - name: "Publish"
@@ -90,7 +90,7 @@ jobs:
   dagger-io-bump-dagger:
     needs: publish
     if: github.ref_name != 'main'
-    runs-on: dagger-g3-v0-19-8-4c
+    runs-on: dagger-g3-v0-19-9-4c
     steps:
       # Configure credentials to clone dagger modules
       - uses: de-vri-es/setup-git-credentials@v2


### PR DESCRIPTION
In the confusion of https://github.com/dagger/dagger/pull/11648 needing a new workflow to bump CI runners for most workflows, I missed a couple that still needed bumps in the few remaining yamls here