### PR TITLE
top level ignoreChecks

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -164,6 +164,135 @@ func (ChecksSuite) TestChecksAsBlueprint(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ChecksSuite) TestChecksIgnoreChecksTopLevel(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	t.Run("ignore checks on the module itself using top-level ignoreChecks", func(ctx context.Context, t *testctx.T) {
+		// Set up test environment with checks test data
+		modGen := checksTestEnv(t, c).
+			WithWorkdir("hello-with-checks")
+
+		// Verify all checks are visible by default
+		out, err := modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "failing-check")
+		require.Contains(t, out, "passing-container")
+		require.Contains(t, out, "failing-container")
+
+		// Now add top-level ignoreChecks configuration to filter out failing checks
+		modGen = modGen.WithNewFile("dagger.json", `{
+  "name": "hello-with-checks",
+  "sdk": "go",
+  "engineVersion": "v0.16.0",
+  "ignoreChecks": [
+    "failing-check",
+    "failing-container"
+  ]
+}`)
+
+		// List checks again - should only show passing checks
+		out, err = modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "passing-container")
+		require.NotContains(t, out, "failing-check")
+		require.NotContains(t, out, "failing-container")
+
+		// Run all checks - should only run passing checks (and succeed)
+		out, err = modGen.
+			With(daggerExec("--progress=report", "check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passingCheck.*OK`, out)
+		require.Regexp(t, `passingContainer.*OK`, out)
+		require.NotContains(t, out, "failingCheck")
+		require.NotContains(t, out, "failingContainer")
+	})
+
+	t.Run("ignore checks with glob patterns", func(ctx context.Context, t *testctx.T) {
+		// Set up test environment
+		modGen := checksTestEnv(t, c).
+			WithWorkdir("hello-with-checks")
+
+		// Add top-level ignoreChecks with wildcard patterns
+		modGen = modGen.WithNewFile("dagger.json", `{
+  "name": "hello-with-checks",
+  "sdk": "go",
+  "engineVersion": "v0.16.0",
+  "ignoreChecks": [
+    "failing-*"
+  ]
+}`)
+
+		// List checks - should only show passing checks
+		out, err := modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "passing-container")
+		require.NotContains(t, out, "failing-check")
+		require.NotContains(t, out, "failing-container")
+
+		// Run all checks - should succeed since only passing checks run
+		out, err = modGen.
+			With(daggerExec("--progress=report", "check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passingCheck.*OK`, out)
+		require.Regexp(t, `passingContainer.*OK`, out)
+	})
+
+	t.Run("ignoreChecks only applies to module itself, not when installed as toolchain", func(ctx context.Context, t *testctx.T) {
+		// First, modify hello-with-checks to have top-level ignoreChecks
+		modWithIgnore := checksTestEnv(t, c).
+			WithWorkdir("hello-with-checks").
+			WithNewFile("dagger.json", `{
+  "name": "hello-with-checks",
+  "sdk": "go",
+  "engineVersion": "v0.16.0",
+  "ignoreChecks": [
+    "failing-check",
+    "failing-container"
+  ]
+}`)
+
+		// Verify that ignoreChecks works when running checks directly on the module
+		out, err := modWithIgnore.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.NotContains(t, out, "failing-check")
+
+		// Now install this module as a toolchain in another module
+		// The ignoreChecks should NOT be honored
+		modGen := checksTestEnv(t, c).
+			WithWorkdir("app").
+			With(daggerExec("init"))
+
+		// Copy the modified hello-with-checks into a temp location and install it
+		modGen = modGen.
+			WithDirectory("../hello-with-checks-modified", modWithIgnore.Directory(".")).
+			With(daggerExec("toolchain", "install", "../hello-with-checks-modified"))
+
+		// Verify that ALL checks from the toolchain are visible (ignoreChecks NOT honored)
+		// Note: The toolchain name is "hello-with-checks" from dagger.json, not the directory name
+		out, err = modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello-with-checks:passing-check")
+		require.Contains(t, out, "hello-with-checks:failing-check")
+		require.Contains(t, out, "hello-with-checks:passing-container")
+		require.Contains(t, out, "hello-with-checks:failing-container")
+	})
+}
+
 func (ChecksSuite) TestChecksAsToolchain(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	t.Run("run checks from a toolchain (Go)", func(ctx context.Context, t *testctx.T) {

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -84,6 +84,11 @@ type ModuleConfig struct {
 	// If true, disable the new default function caching behavior for this module. Functions will
 	// instead default to the old behavior of per-session caching.
 	DisableDefaultFunctionCaching *bool `json:"disableDefaultFunctionCaching,omitempty"`
+
+	// IgnoreChecks is a list of check patterns to exclude from this module.
+	// Patterns can use glob syntax to match check names.
+	// Note: This only applies to the module itself, not when it's installed as a toolchain.
+	IgnoreChecks []string `json:"ignoreChecks,omitempty"`
 }
 
 type ModuleConfigUserFields struct {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -170,6 +170,9 @@ type ModuleSource struct {
 	ConfigToolchains []*modules.ModuleConfigDependency
 	Toolchains       dagql.ObjectResultArray[*ModuleSource] `field:"true" name:"toolchains" doc:"The toolchains referenced by the module source."`
 
+	// IgnoreChecks are the check patterns to ignore for this module (from dagger.json)
+	IgnoreChecks []string
+
 	UserDefaults *EnvFile `field:"true" name:"userDefaults" doc:"User-defined defaults read from local .env files"`
 	// Clients are the clients generated for the module.
 	ConfigClients []*modules.ModuleConfigClient `field:"true" name:"configClients" doc:"The clients generated for the module."`
@@ -231,6 +234,10 @@ func (src ModuleSource) Clone() *ModuleSource {
 	origToolchains := src.Toolchains
 	src.Toolchains = make([]dagql.ObjectResult[*ModuleSource], len(origToolchains))
 	copy(src.Toolchains, origToolchains)
+
+	origIgnoreChecks := src.IgnoreChecks
+	src.IgnoreChecks = make([]string, len(origIgnoreChecks))
+	copy(src.IgnoreChecks, origIgnoreChecks)
 
 	if src.Local != nil {
 		src.Local = src.Local.Clone()

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1028,6 +1028,7 @@ func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.Mod
 	src.ConfigBlueprint = modCfg.Blueprint
 	src.ConfigToolchains = modCfg.Toolchains
 	src.ConfigClients = modCfg.Clients
+	src.IgnoreChecks = modCfg.IgnoreChecks
 
 	engineVersion := modCfg.EngineVersion
 	switch engineVersion {
@@ -2892,6 +2893,7 @@ func (s *moduleSourceSchema) createBaseModule(
 		ToolchainModules:              make(map[string]*core.Module),
 		ToolchainArgumentConfigs:      make(map[string][]*modules.ModuleConfigArgument),
 		ToolchainIgnoreChecks:         make(map[string][]string),
+		IgnoreChecks:                  tcCtx.originalSrc.Self().IgnoreChecks,
 	}
 
 	// Load toolchain argument configurations from the original source


### PR DESCRIPTION
We have `ignoreChecks` available within the toolchains configuration in dagger.json, however @TomChv and I discovered the need for a top level one: when you're developing a toolchain that provides checks, but those checks dont make sense to run in the toolchain's own CI. I think thats basically the only use case for this but it is important