### PR TITLE
helm: add shareProcessNamespace option for sidecar process access

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -49,6 +49,9 @@ spec:
         runAsGroup: 1001
         fsGroup: 1001
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.engine.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       serviceAccountName: {{ include "dagger.serviceAccountName" . }}
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -56,6 +56,9 @@ spec:
         runAsGroup: 1001
         fsGroup: 1001
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.engine.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       serviceAccountName: {{ include "dagger.serviceAccountName" . }}
       {{- if .Values.engine.priorityClassName }}
       priorityClassName: {{ .Values.engine.priorityClassName }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -130,6 +130,11 @@ engine:
   ### Set runtimeClassName to use a custom runtimeClass
   runtimeClassName: ""
 
+  ### Share process namespace with sidecars for monitoring and observability
+  # Enables sidecar containers to see processes in the main engine container
+  # Useful for monitoring tools like Datadog, security scanners, and log collectors
+  shareProcessNamespace: false
+
   readinessProbeSettings:
     initialDelaySeconds: 5
     timeoutSeconds: 14


### PR DESCRIPTION
Add configurable engine.shareProcessNamespace option to enable process namespace sharing between containers. This allows sidecar containers (e.g., Datadog agents, security scanners) to access processes running in the main engine container for monitoring and observability.

Defaults to false for backward compatibility.

Fixes: https://github.com/dagger/dagger/issues/11676