### PR TITLE
Revert "fix: support kernels without legacy xtables (6.17+) (#11608)"

### DIFF
--- a/internal/buildkit/util/network/cniprovider/bridge.go
+++ b/internal/buildkit/util/network/cniprovider/bridge.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	cni "github.com/containerd/go-cni"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
@@ -17,28 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 )
-
-// detectIPMasqBackend determines whether to use iptables or nftables for IP masquerading.
-// On kernels without CONFIG_NETFILTER_XTABLES_LEGACY (6.17+), legacy iptables fails.
-// Returns "nftables" if legacy xtables is unavailable, empty string to use default.
-func detectIPMasqBackend() string {
-	// /proc/net/ip_tables_names only exists when legacy iptables kernel modules are available
-	if _, err := os.Stat("/proc/net/ip_tables_names"); os.IsNotExist(err) {
-		bklog.L.Debugf("legacy xtables not available (/proc/net/ip_tables_names missing), using nftables backend for ipMasq")
-		return "nftables"
-	}
-
-	// Double-check by probing the nat table
-	cmd := exec.Command("iptables", "-t", "nat", "-L", "-n")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		if strings.Contains(string(output), "Table does not exist") {
-			bklog.L.Debugf("legacy xtables nat table unavailable, using nftables backend for ipMasq")
-			return "nftables"
-		}
-	}
-
-	return "" // Use default (iptables)
-}
 
 func NewBridge(opt Opt) (network.Provider, error) {
 	cniOptions := []cni.Opt{cni.WithInterfacePrefix("eth")}
@@ -110,13 +87,6 @@ func NewBridge(opt Opt) (network.Provider, error) {
 		firewallBackend = "iptables"
 	}
 
-	// Detect if we need nftables backend for IP masquerading
-	// On kernels without CONFIG_NETFILTER_XTABLES_LEGACY (6.17+), legacy iptables fails
-	var ipMasqBackendConfig string
-	if ipMasqBackend := detectIPMasqBackend(); ipMasqBackend != "" {
-		ipMasqBackendConfig = fmt.Sprintf(`"ipMasqBackend": "%s",`, ipMasqBackend)
-	}
-
 	cniOptions = append(cniOptions, cni.WithConfListBytes([]byte(fmt.Sprintf(`{
 		"cniVersion": "1.0.0",
 		"name": "buildkit",
@@ -129,7 +99,6 @@ func NewBridge(opt Opt) (network.Provider, error) {
 				"bridge": "%s",
 				"isDefaultGateway": true,
 				"ipMasq": true,
-				%s
 				"ipam": {
 				  "type": "%s",
 				  "ranges": [
@@ -145,7 +114,7 @@ func NewBridge(opt Opt) (network.Provider, error) {
 				"ingressPolicy": "same-bridge"
 			}
 		]
-		}`, loopbackBinName, bridgeBinName, opt.BridgeName, ipMasqBackendConfig, hostLocalBinName, opt.BridgeSubnet, firewallBinName, firewallBackend))))
+		}`, loopbackBinName, bridgeBinName, opt.BridgeName, hostLocalBinName, opt.BridgeSubnet, firewallBinName, firewallBackend))))
 
 	unlock, err := initLock()
 	if err != nil {

--- a/toolchains/engine-dev/build/builder.go
+++ b/toolchains/engine-dev/build/builder.go
@@ -111,8 +111,8 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		"git", "openssh-client",
 		// for decompression
 		"pigz", "xz",
-		// for CNI (use nft variants for compatibility with kernels lacking legacy xtables)
-		"iptables-nft", "dnsmasq",
+		// for CNI
+		"iptables", "ip6tables", "dnsmasq",
 		// for Kata Containers integration
 		"e2fsprogs",
 		// for Directory.search


### PR DESCRIPTION
This reverts commit 79c2341d21f7499269a4667d093bb7f32e1d157d.

I saw some strange slowness in https://github.com/dagger/dagger/pull/11608 but *thought* it went away after re-runs. However, I did some more testing before starting the release and realized it actually is quite noticeably slower. It's hard to tell in CI since our infra is quite noisy, but my laptop is much more consistent and is consistently several minutes slower to run `TestModules` with the nftables change vs. without it.

We should revisit this but it's not worth the performance hit for now