### PR TITLE
docs-dev: fix +ignore pragma with `**/*`

### DIFF
--- a/toolchains/docs-dev/main.go
+++ b/toolchains/docs-dev/main.go
@@ -77,6 +77,7 @@ func (d DocsDev) LintMarkdown(
 	ctx context.Context,
 	// +defaultPath="/"
 	// +ignore=[
+	// "**/*",
 	// "!**/README.md",
 	// "!docs/**/*.md",
 	// "!**/.markdownlint.*",


### PR DESCRIPTION
Maybe `**/*` should become optional if users omit this too often ?