### PR TITLE
Optimize PHP SDK dev toolchain

### DIFF
--- a/toolchains/php-sdk-dev/main.go
+++ b/toolchains/php-sdk-dev/main.go
@@ -17,7 +17,7 @@ const (
 	phpSDKDigest        = "sha256:e4ffe0a17a6814009b5f0713a5444634a9c5b688ee34b8399e7d4f2db312c3b4"
 	phpSDKComposerImage = "composer/composer:2.8-bin" +
 		"@sha256:c735b6a52ea118693178babc601984dbbbd07f1d31ec87eaa881173622b467ed"
-	phpSDKVersionFile   = "src/Connection/version.php"
+	phpSDKVersionFile = "src/Connection/version.php"
 
 	phpDoctumVersion = "5.5.4"
 )


### PR DESCRIPTION
A small, _low-hanging fruit_ optimization.

This optimization has already been done in the PHP SDK.

Both the official and community image are maintained by the same person. But the community image is almost 74Mb smaller and designed specifically for copying the binary. 

https://hub.docker.com/_/composer
https://hub.docker.com/r/composer/composer