### PR TITLE
feat(helm): add liveness probe

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -134,6 +134,16 @@ spec:
             {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -exc
+                - |-
+                  dagger core version
+            {{- if .Values.engine.livenessProbeSettings }}
+            {{- toYaml .Values.engine.livenessProbeSettings | nindent 12 }}
+            {{- end }}
           {{- if .Values.engine.lifecycle }}
           lifecycle:
             {{- if .Values.engine.lifecycle.preStop }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -145,6 +145,16 @@ spec:
             {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -exc
+                - |-
+                  dagger core version
+            {{- if .Values.engine.livenessProbeSettings }}
+            {{- toYaml .Values.engine.livenessProbeSettings | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/dagger

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -96,7 +96,7 @@ engine:
 
   image:
     ### Set a ref if you want to use a custom Dagger image
-    #   NOTE: you will need to ensure that a compatible dagger CLI is embedded in the image, otherwise readiness probes will fail
+    #   NOTE: you will need to ensure that a compatible dagger CLI is embedded in the image, otherwise readiness and liveness probes will fail
     #   In the example below, we are configuring the latest, unreleased bleeding edge version
     #
     # ref: registry.dagger.io/engine:main
@@ -141,6 +141,14 @@ engine:
     periodSeconds: 15
     successThreshold: 1
     failureThreshold: 10
+
+  livenessProbeSettings:
+    initialDelaySeconds: 5
+    timeoutSeconds: 29
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 20
+    terminationGracePeriodSeconds: 30
 
   ### The Engine may need to finish operations in flight, or sync its state to a remote destination.
   #   We give it ample time by setting this value to 5 mins by default.


### PR DESCRIPTION
This PR adds a liveness probe in the same way we already have a readiness probe. 

I've set the defaults to be more forgiving than the readiness checks. 

This should help with engines that get into an unrecoverable state and need to be restarted.