### PR TITLE
engine: use igzip for faster image decompression

### DIFF
--- a/toolchains/engine-dev/build/builder.go
+++ b/toolchains/engine-dev/build/builder.go
@@ -110,8 +110,8 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		"mount", "umount", "posix-libc-utils", "coreutils",
 		// for git
 		"git", "openssh-client",
-		// for decompression
-		"pigz", "xz",
+		// for compression/decompression, containerd prefers igzip from the isa-l package as it's fastest
+		"isa-l", "pigz", "xz",
 		// for CNI
 		"iptables", "ip6tables", "dnsmasq",
 		// for Kata Containers integration


### PR DESCRIPTION
[Apparently containerd added support for igzip](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md#intel-isa-ls-igzip-support) to decompress image layers as it's multiple times faster than pigz.

It is made by Intel and heavily uses specialized CPU instructions, but it does exist for aarch64? Not sure if the perf optimizations carry over entirely to arm yet.