### PR TITLE
test(sdk/python): use dagger/pytest to run tests with telemetry

### DIFF
--- a/toolchains/python-sdk-dev/dagger.json
+++ b/toolchains/python-sdk-dev/dagger.json
@@ -13,12 +13,17 @@
   ],
   "dependencies": [
     {
+      "name": "dagger-engine",
+      "source": "../engine-dev"
+    },
+    {
       "name": "dockerd",
       "source": "dockerd"
     },
     {
-      "name": "dagger-engine",
-      "source": "../engine-dev"
+      "name": "pytest",
+      "source": "github.com/dagger/pytest@main",
+      "pin": "0b5189aa215d2203857573ca36741e87c4a36b9d"
     },
     {
       "name": "wolfi",

--- a/toolchains/python-sdk-dev/main.go
+++ b/toolchains/python-sdk-dev/main.go
@@ -142,10 +142,8 @@ func (t PythonSdkDev) Test(ctx context.Context) error {
 	jobs := parallel.New()
 	for _, version := range supportedVersions {
 		jobs = jobs.WithJob("test with python version "+version, func(ctx context.Context) error {
-			_, err := t.TestSuite(version, false).
-				Default().
-				Sync(ctx)
-			return err
+			return t.TestSuite(version, false).
+				RunDefault(ctx)
 		})
 	}
 	return jobs.Run(ctx)

--- a/toolchains/python-sdk-dev/test.go
+++ b/toolchains/python-sdk-dev/test.go
@@ -23,27 +23,27 @@ type TestSuite struct {
 
 // Run the pytest command.
 func (t *TestSuite) Run(
+	ctx context.Context,
 	// Arguments to pass to pytest
 	args []string,
-) *dagger.Container {
-	cmd := []string{"uv", "run"}
-	if t.Version != "" {
-		cmd = append(cmd, "-p", t.Version)
-	}
-	return t.Container.
-		WithExec(
-			append(append(cmd, "pytest"), args...),
-			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true})
+) error {
+	return dag.Pytest(dagger.PytestOpts{
+		Container: t.Container,
+		Source:    t.Container.Directory("/src/sdk/python"),
+	}).Test(ctx, dagger.PytestTestOpts{
+		Version: t.Version,
+		Args:    args,
+	})
 }
 
 // Run python tests.
-func (t *TestSuite) Default() *dagger.Container {
-	return t.Run([]string{"-Wd", "-l", "-m", "not provision"})
+func (t *TestSuite) RunDefault(ctx context.Context) error {
+	return t.Run(ctx, []string{"-Wd", "-l", "-m", "not provision"})
 }
 
 // Run unit tests.
-func (t *TestSuite) Unit() *dagger.Container {
-	return t.Run([]string{"-m", "not slow and not provision"})
+func (t *TestSuite) RunUnit(ctx context.Context) error {
+	return t.Run(ctx, []string{"-m", "not slow and not provision"})
 }
 
 // Test provisioning.


### PR DESCRIPTION
Use our own [dagger/pytest](https://github.com/dagger/pytest) test integration library to run the python sdk tests. This will send telemetry for all tests that are running.