### PR TITLE
sdk(python): fix annotations with `from __future__ import annotations`

### DIFF
--- a/sdk/python/tests/mod/test_future_annotations.py
+++ b/sdk/python/tests/mod/test_future_annotations.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
+from typing_extensions import Doc
+
 import dagger
 from dagger import DefaultPath, Deprecated, Ignore, Name
 from dagger.mod import Module
-from typing_extensions import Doc
 
 
 def test_default_path_with_future_annotations():


### PR DESCRIPTION
Fixes #11554

## Context
When `from __future__ import annotations` (PEP 563) is enabled, `param.annotation` becomes a string instead of an actual type object. This causes all metadata extraction (`DefaultPath`, `Doc`, `Name`, `Ignore`, `Deprecated`) to fail silently: the annotations are simply ignored.

### Fix
The fix uses `get_type_hints(..., include_extras=True)` to resolve string annotations back to actual types while preserving `Annotated` metadata.

### To test

```sh
dagger call python-sdk test-suite run --args="tests/mod/test_future_annotations.py" --args="-v"
```