### PR TITLE
(updated+fixed) support kernels without legacy xtables (6.17+) 

### DIFF
--- a/.changes/unreleased/Fixed-20260121-214039.yaml
+++ b/.changes/unreleased/Fixed-20260121-214039.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  support kernels without legacy xtables (Linux 6.17+ and older ones with iptables disabled)
+time: 2026-01-21T21:40:39.097979296-08:00
+custom:
+  Author: shepherdjerred + sipsma
+  PR: "11731"

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -901,6 +901,10 @@ func setupNetwork(ctx context.Context, netName, netCIDR string) (*networkConfig,
 		return nil, fmt.Errorf("bridge from cidr: %w", err)
 	}
 
+	if err := netinst.EnsureIptablesSymlinks(ctx); err != nil {
+		return nil, fmt.Errorf("ensure iptables symlinks: %w", err)
+	}
+
 	// NB: this is needed for the Dagger shim worker at the moment for host alias
 	// resolution
 	err = netinst.InstallResolvconf(netName, bridge.String())
@@ -913,7 +917,7 @@ func setupNetwork(ctx context.Context, netName, netCIDR string) (*networkConfig,
 		return nil, fmt.Errorf("install dnsmasq: %w", err)
 	}
 
-	cniConfigPath, err := netinst.InstallCNIConfig(netName, netCIDR)
+	cniConfigPath, err := netinst.InstallCNIConfig(ctx, netName, netCIDR)
 	if err != nil {
 		return nil, fmt.Errorf("install cni: %w", err)
 	}

--- a/internal/buildkit/util/network/cniprovider/bridge.go
+++ b/internal/buildkit/util/network/cniprovider/bridge.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	cni "github.com/containerd/go-cni"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
@@ -17,28 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 )
-
-// detectIPMasqBackend determines whether to use iptables or nftables for IP masquerading.
-// On kernels without CONFIG_NETFILTER_XTABLES_LEGACY (6.17+), legacy iptables fails.
-// Returns "nftables" if legacy xtables is unavailable, empty string to use default.
-func detectIPMasqBackend() string {
-	// /proc/net/ip_tables_names only exists when legacy iptables kernel modules are available
-	if _, err := os.Stat("/proc/net/ip_tables_names"); os.IsNotExist(err) {
-		bklog.L.Debugf("legacy xtables not available (/proc/net/ip_tables_names missing), using nftables backend for ipMasq")
-		return "nftables"
-	}
-
-	// Double-check by probing the nat table
-	cmd := exec.Command("iptables", "-t", "nat", "-L", "-n")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		if strings.Contains(string(output), "Table does not exist") {
-			bklog.L.Debugf("legacy xtables nat table unavailable, using nftables backend for ipMasq")
-			return "nftables"
-		}
-	}
-
-	return "" // Use default (iptables)
-}
 
 func NewBridge(opt Opt) (network.Provider, error) {
 	cniOptions := []cni.Opt{cni.WithInterfacePrefix("eth")}
@@ -110,13 +87,6 @@ func NewBridge(opt Opt) (network.Provider, error) {
 		firewallBackend = "iptables"
 	}
 
-	// Detect if we need nftables backend for IP masquerading
-	// On kernels without CONFIG_NETFILTER_XTABLES_LEGACY (6.17+), legacy iptables fails
-	var ipMasqBackendConfig string
-	if ipMasqBackend := detectIPMasqBackend(); ipMasqBackend != "" {
-		ipMasqBackendConfig = fmt.Sprintf(`"ipMasqBackend": "%s",`, ipMasqBackend)
-	}
-
 	cniOptions = append(cniOptions, cni.WithConfListBytes([]byte(fmt.Sprintf(`{
 		"cniVersion": "1.0.0",
 		"name": "buildkit",
@@ -129,7 +99,7 @@ func NewBridge(opt Opt) (network.Provider, error) {
 				"bridge": "%s",
 				"isDefaultGateway": true,
 				"ipMasq": true,
-				%s
+				"ipMasqBackend": "nftables",
 				"ipam": {
 				  "type": "%s",
 				  "ranges": [
@@ -145,7 +115,7 @@ func NewBridge(opt Opt) (network.Provider, error) {
 				"ingressPolicy": "same-bridge"
 			}
 		]
-		}`, loopbackBinName, bridgeBinName, opt.BridgeName, ipMasqBackendConfig, hostLocalBinName, opt.BridgeSubnet, firewallBinName, firewallBackend))))
+		}`, loopbackBinName, bridgeBinName, opt.BridgeName, hostLocalBinName, opt.BridgeSubnet, firewallBinName, firewallBackend))))
 
 	unlock, err := initLock()
 	if err != nil {

--- a/network/netinst/iptables.go
+++ b/network/netinst/iptables.go
@@ -1,0 +1,99 @@
+package netinst
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/dagger/dagger/internal/buildkit/util/bklog"
+)
+
+const iptablesBinDir = "/usr/bin"
+
+var iptablesSymlinkOnce sync.Once
+var iptablesSymlinkErr error
+
+// EnsureIptablesSymlinks makes sure iptables/ip6tables resolve to the right backend.
+func EnsureIptablesSymlinks(ctx context.Context) error {
+	iptablesSymlinkOnce.Do(func() {
+		iptablesSymlinkErr = ensureIptablesSymlinks(ctx)
+	})
+	return iptablesSymlinkErr
+}
+
+func ensureIptablesSymlinks(ctx context.Context) error {
+	backend, target, err := pickIptablesTarget()
+	if err != nil {
+		return err
+	}
+
+	bklog.G(ctx).Infof("configuring iptables backend: %s", backend)
+
+	for _, name := range []string{
+		"iptables",
+		"iptables-save",
+		"iptables-restore",
+		"ip6tables",
+		"ip6tables-save",
+		"ip6tables-restore",
+	} {
+		path := filepath.Join(iptablesBinDir, name)
+		if err := ensureSymlink(path, target); err != nil {
+			return fmt.Errorf("ensure %s: %w", path, err)
+		}
+		bklog.G(ctx).Infof("set %s -> %s", path, target)
+	}
+
+	return nil
+}
+
+func pickIptablesTarget() (string, string, error) {
+	legacyTarget := filepath.Join(iptablesBinDir, "xtables-legacy-multi")
+	nftTarget := filepath.Join(iptablesBinDir, "xtables-nft-multi")
+
+	backend := "nft"
+	target := nftTarget
+	if legacyXtablesAvailable() {
+		backend = "legacy"
+		target = legacyTarget
+	}
+
+	if _, err := os.Stat(target); err != nil {
+		return "", "", fmt.Errorf("%s missing: %w", target, err)
+	}
+	return backend, target, nil
+}
+
+func ensureSymlink(path, target string) error {
+	if path == "" || target == "" {
+		return fmt.Errorf("invalid symlink target")
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("path is a directory: %s", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+
+	return os.Symlink(target, path)
+}
+
+func legacyXtablesAvailable() bool {
+	// /proc/net/ip_tables_names only exists when legacy iptables kernel modules are available.
+	if _, err := os.Stat("/proc/net/ip_tables_names"); err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	}
+	return false
+}

--- a/toolchains/engine-dev/build/builder.go
+++ b/toolchains/engine-dev/build/builder.go
@@ -113,7 +113,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		// for compression/decompression, containerd prefers igzip from the isa-l package as it's fastest
 		"isa-l", "pigz", "xz",
 		// for CNI (use nft variants for compatibility with kernels lacking legacy xtables)
-		"iptables-nft", "dnsmasq",
+		"nftables", "iptables-legacy", "dnsmasq",
 		// for Kata Containers integration
 		"e2fsprogs",
 		// for Directory.search

--- a/toolchains/engine-dev/consts/consts.go
+++ b/toolchains/engine-dev/consts/consts.go
@@ -16,7 +16,7 @@ const (
 	UbuntuVersion = "22.04"
 
 	RuncVersion  = "v1.3.3"
-	CniVersion   = "v1.5.0"
+	CniVersion   = "v1.9.0"
 	QemuBinImage = "tonistiigi/binfmt@sha256:e06789462ac7e2e096b53bfd9e607412426850227afeb1d0f5dfa48a731e0ba5"
 
 	XxImage = "tonistiigi/xx:1.2.1"


### PR DESCRIPTION
This is an update to the reverted https://github.com/dagger/dagger/pull/11608 which fixes the performance regression that introduced.

After investigation, the previous PR was fine except that it removed the `ip6tables` package.

When I run `TestModule` (pretty heavy integ test suite):
* With the previous PR: 7m39s
* With the previous PR ***but leave in ip6tables***: 5m56s

These numbers are pretty consistent on my laptop, not noise.

It's not 100% clear to me yet why that is, but may be related to the fact that even when we don't use ipv6, CNI binaries attempt to do some ipv6 related setup that ends up going through a slower path when ip6tables isn't around.

I haven't yet tested this on a 6.17+ kernel or one with legacy iptables disabled, so I can't yet be sure leaving in ip6tables works on those machines. cc @shepherdjerred @Kernald @ReillyBrogan @ezynda3 in case any of you have time to test it quick. Otherwise we'll try to do a test before the next release.

---

Left your commit in place @shepherdjerred with an extra on top, so you'll still get credit, appreciate the original PR!

---

Fixes #11694 