### PR TITLE
refactor toolchain proxying

### DIFF
--- a/core/checks.go
+++ b/core/checks.go
@@ -468,9 +468,11 @@ func dagForCheck(ctx context.Context, mod *Module) (*dagql.Server, error) {
 			return nil, fmt.Errorf("run checks for module %q: serve core schema: %w", mod.Name(), err)
 		}
 	}
-	for _, tcMod := range mod.ToolchainModules {
-		if err := tcMod.Install(ctx, dag); err != nil {
-			return nil, fmt.Errorf("run checks for module %q: serve toolchain module %q: %w", mod.Name(), tcMod.Name(), err)
+	if mod.Toolchains != nil {
+		for _, entry := range mod.Toolchains.Entries() {
+			if err := entry.Module.Install(ctx, dag); err != nil {
+				return nil, fmt.Errorf("run checks for module %q: serve toolchain module %q: %w", mod.Name(), entry.Module.Name(), err)
+			}
 		}
 	}
 	if err := mod.Install(ctx, dag); err != nil {

--- a/core/module.go
+++ b/core/module.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 
-	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/buildkit"
@@ -64,15 +63,8 @@ type Module struct {
 	// Toolchain modules are allowed to share types with the modules that depend on them.
 	IsToolchain bool
 
-	// ToolchainModules stores references to toolchain module instances by their field name
-	// This enables proxy field resolution to route calls to the toolchain's runtime
-	ToolchainModules map[string]*Module
-
-	// ToolchainArgumentConfigs stores argument configuration overrides for toolchains by their original name
-	ToolchainArgumentConfigs map[string][]*modules.ModuleConfigArgument
-
-	// ToolchainIgnoreChecks stores check patterns to ignore for each toolchain by their original name
-	ToolchainIgnoreChecks map[string][]string
+	// Toolchains manages all toolchain modules and their configuration.
+	Toolchains *ToolchainRegistry
 
 	// ResultID is the ID of the initialized module.
 	ResultID *call.ID
@@ -99,6 +91,13 @@ func (mod *Module) Name() string {
 	return mod.NameField
 }
 
+// isToolchainModule checks if a Mod is a toolchain Module.
+// This centralizes the validation logic that was scattered across the codebase.
+func isToolchainModule(m Mod) bool {
+	tcMod, ok := m.(*Module)
+	return ok && tcMod.IsToolchain
+}
+
 func (mod *Module) Checks(ctx context.Context, include []string) (*CheckGroup, error) {
 	mainObj, ok := mod.MainObject()
 	if !ok {
@@ -116,53 +115,14 @@ func (mod *Module) Checks(ctx context.Context, include []string) (*CheckGroup, e
 			group.Checks = append(group.Checks, check)
 		}
 	}
-	// 2. Walk toolchain modules for checks
-	for _, dep := range mod.Deps.Mods {
-		if tcMod, ok := dep.(*Module); ok && tcMod.IsToolchain {
-			tcMainObj, ok := tcMod.MainObject()
-			if !ok {
-				continue // skip toolchains without a main object
-			}
-			// Get the ignore patterns for this toolchain
-			ignorePatterns := mod.ToolchainIgnoreChecks[tcMod.OriginalName]
 
-			// Walk the toolchain module's checks
-			for _, check := range tcMod.walkObjectChecks(ctx, tcMainObj, objChecksCache) {
-				// Check if this check should be ignored (before prepending toolchain name)
-				// This allows ignoreChecks patterns to be scoped to the toolchain without needing the prefix
-				ignored := false
-				if len(ignorePatterns) > 0 {
-					// Check against ignore patterns using the check path WITHOUT the toolchain prefix
-					for _, ignorePattern := range ignorePatterns {
-						checkMatch, err := check.Match([]string{ignorePattern})
-						if err != nil {
-							return nil, err
-						}
-						if checkMatch {
-							ignored = true
-							break
-						}
-					}
-				}
-
-				if ignored {
-					continue // Skip this check
-				}
-
-				// Prepend the toolchain name to the check path
-				check.Path = append([]string{gqlFieldName(tcMod.NameField)}, check.Path...)
-
-				check.Source = tcMod.GetSource()
-
-				match, err := check.Match(include)
-				if err != nil {
-					return nil, err
-				}
-				if match {
-					group.Checks = append(group.Checks, check)
-				}
-			}
+	// 2. Delegate toolchain checks to registry
+	if mod.Toolchains != nil {
+		tcChecks, err := mod.Toolchains.WalkChecks(ctx, include)
+		if err != nil {
+			return nil, err
 		}
+		group.Checks = append(group.Checks, tcChecks...)
 	}
 
 	// set individual check Module field now so it's a consistent value between this
@@ -723,7 +683,7 @@ func (mod *Module) validateObjectTypeDef(ctx context.Context, typeDef *TypeDef) 
 			// other modules (unless the source module is a toolchain)
 			if sourceMod != nil && sourceMod.Name() != ModuleName && sourceMod != mod {
 				// Allow types from toolchain modules
-				if tcMod, ok := sourceMod.(*Module); !ok || !tcMod.IsToolchain {
+				if !isToolchainModule(sourceMod) {
 					return fmt.Errorf("object %q field %q cannot reference external type from dependency module %q",
 						obj.OriginalName,
 						field.OriginalName,
@@ -749,7 +709,7 @@ func (mod *Module) validateObjectTypeDef(ctx context.Context, typeDef *TypeDef) 
 		if ok {
 			if sourceMod := retType.SourceMod(); sourceMod != nil && sourceMod.Name() != ModuleName && sourceMod != mod {
 				// Allow types from toolchain modules
-				if tcMod, ok := sourceMod.(*Module); !ok || !tcMod.IsToolchain {
+				if !isToolchainModule(sourceMod) {
 					return fmt.Errorf("object %q function %q cannot return external type from dependency module %q",
 						obj.OriginalName,
 						fn.OriginalName,
@@ -770,7 +730,7 @@ func (mod *Module) validateObjectTypeDef(ctx context.Context, typeDef *TypeDef) 
 			if ok {
 				if sourceMod := argType.SourceMod(); sourceMod != nil && sourceMod.Name() != ModuleName && sourceMod != mod {
 					// Allow types from toolchain modules
-					if tcMod, ok := sourceMod.(*Module); !ok || !tcMod.IsToolchain {
+					if !isToolchainModule(sourceMod) {
 						return fmt.Errorf("object %q function %q arg %q cannot reference external type from dependency module %q",
 							obj.OriginalName,
 							fn.OriginalName,

--- a/core/toolchain.go
+++ b/core/toolchain.go
@@ -1,0 +1,226 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+)
+
+// ToolchainRegistry manages toolchain modules for a parent module.
+// It consolidates all toolchain-related state and logic into a single,
+// testable abstraction, replacing the scattered maps and special-case
+// checks throughout the codebase.
+type ToolchainRegistry struct {
+	entries map[string]*ToolchainEntry
+	parent  *Module
+}
+
+// ToolchainEntry represents a single toolchain module with its configuration.
+type ToolchainEntry struct {
+	Module          *Module
+	FieldName       string
+	ArgumentConfigs []*modules.ModuleConfigArgument
+	IgnoreChecks    []string
+}
+
+// NewToolchainRegistry creates a new registry for the given parent module.
+func NewToolchainRegistry(parent *Module) *ToolchainRegistry {
+	return &ToolchainRegistry{
+		entries: make(map[string]*ToolchainEntry),
+		parent:  parent,
+	}
+}
+
+// Register adds a toolchain to the registry.
+// originalName is the toolchain's original name (with hyphens)
+// fieldName is the camelCase GraphQL field name
+func (r *ToolchainRegistry) Register(originalName, fieldName string, mod *Module) {
+	r.entries[originalName] = &ToolchainEntry{
+		Module:    mod,
+		FieldName: fieldName,
+	}
+}
+
+// Get retrieves a toolchain entry by its original name.
+func (r *ToolchainRegistry) Get(originalName string) (*ToolchainEntry, bool) {
+	entry, ok := r.entries[originalName]
+	return entry, ok
+}
+
+// GetByFieldName retrieves a toolchain entry by its GraphQL field name.
+func (r *ToolchainRegistry) GetByFieldName(fieldName string) (*ToolchainEntry, bool) {
+	for _, entry := range r.entries {
+		if entry.FieldName == fieldName {
+			return entry, true
+		}
+	}
+	return nil, false
+}
+
+// Entries returns all toolchain entries in the registry.
+func (r *ToolchainRegistry) Entries() []*ToolchainEntry {
+	entries := make([]*ToolchainEntry, 0, len(r.entries))
+	for _, entry := range r.entries {
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// WalkChecks walks all toolchain modules for checks, applying ignore patterns
+// and prepending the toolchain name to check paths.
+func (r *ToolchainRegistry) WalkChecks(ctx context.Context, include []string) ([]*Check, error) {
+	var checks []*Check
+	objChecksCache := map[string][]*Check{}
+
+	// Walk each toolchain module's checks
+	for _, entry := range r.entries {
+		tcMod := entry.Module
+		tcMainObj, ok := tcMod.MainObject()
+		if !ok {
+			continue // skip toolchains without a main object
+		}
+
+		// Walk the toolchain module's checks
+		for _, check := range tcMod.walkObjectChecks(ctx, tcMainObj, objChecksCache) {
+			// Check if this check should be ignored (before prepending toolchain name)
+			// This allows ignoreChecks patterns to be scoped to the toolchain without needing the prefix
+			ignored := false
+			if len(entry.IgnoreChecks) > 0 {
+				// Check against ignore patterns using the check path WITHOUT the toolchain prefix
+				for _, ignorePattern := range entry.IgnoreChecks {
+					checkMatch, err := check.Match([]string{ignorePattern})
+					if err != nil {
+						return nil, err
+					}
+					if checkMatch {
+						ignored = true
+						break
+					}
+				}
+			}
+
+			if ignored {
+				continue // Skip this check
+			}
+
+			// Prepend the toolchain name to the check path
+			check.Path = append([]string{gqlFieldName(tcMod.NameField)}, check.Path...)
+
+			// Set the check's source
+			check.Source = tcMod.GetSource()
+
+			match, err := check.Match(include)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				checks = append(checks, check)
+			}
+		}
+	}
+
+	return checks, nil
+}
+
+// CreateProxyField creates a dagql.Field that proxies calls to a toolchain module.
+// This consolidates the toolchainProxyFunction logic from object.go.
+func (entry *ToolchainEntry) CreateProxyField(ctx context.Context, parentMod *Module, fun *Function, dag *dagql.Server) (dagql.Field[*ModuleObject], error) {
+	tcMod := entry.Module
+
+	// Find the toolchain's main object type
+	if len(tcMod.ObjectDefs) == 0 {
+		return dagql.Field[*ModuleObject]{}, fmt.Errorf("toolchain module %q has no objects", tcMod.Name())
+	}
+
+	var mainObjDef *ObjectTypeDef
+	for _, objDef := range tcMod.ObjectDefs {
+		if objDef.AsObject.Valid && gqlObjectName(objDef.AsObject.Value.OriginalName) == gqlObjectName(tcMod.OriginalName) {
+			mainObjDef = objDef.AsObject.Value
+			break
+		}
+	}
+	if mainObjDef == nil {
+		return dagql.Field[*ModuleObject]{}, fmt.Errorf("toolchain module %q has no main object", tcMod.Name())
+	}
+
+	// Check if toolchain has a constructor
+	hasConstructor := mainObjDef.Constructor.Valid
+
+	if !hasConstructor {
+		// No constructor - treat as a zero-argument function that returns an uninitialized object
+		spec, err := fun.FieldSpec(ctx, parentMod)
+		if err != nil {
+			return dagql.Field[*ModuleObject]{}, fmt.Errorf("failed to get field spec for toolchain: %w", err)
+		}
+		spec.Module = parentMod.IDModule()
+		spec.GetCacheConfig = parentMod.CacheConfigForCall
+
+		return dagql.Field[*ModuleObject]{
+			Spec: &spec,
+			Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+				// Return an instance of the toolchain's main object with empty fields
+				// The toolchain module's own resolvers will handle function calls on this object
+				return dagql.NewResultForCurrentID(ctx, &ModuleObject{
+					Module:  tcMod,
+					TypeDef: mainObjDef,
+					Fields:  map[string]any{}, // empty fields, functions will be called on the toolchain's runtime
+				})
+			},
+		}, nil
+	}
+
+	// Has constructor - create a ModFunction for it and use its spec
+	constructor := mainObjDef.Constructor.Value
+
+	modFun, err := NewModFunction(
+		ctx,
+		tcMod,
+		mainObjDef,
+		constructor,
+	)
+	if err != nil {
+		return dagql.Field[*ModuleObject]{}, fmt.Errorf("failed to create toolchain constructor function %q: %w", fun.Name, err)
+	}
+
+	// Apply local user defaults
+	if err := modFun.mergeUserDefaultsTypeDefs(ctx); err != nil {
+		return dagql.Field[*ModuleObject]{}, fmt.Errorf("failed to merge user defaults for toolchain constructor %q: %w", fun.Name, err)
+	}
+
+	// Get the constructor's spec, which includes its arguments
+	spec, err := constructor.FieldSpec(ctx, tcMod)
+	if err != nil {
+		return dagql.Field[*ModuleObject]{}, fmt.Errorf("failed to get field spec for toolchain constructor: %w", err)
+	}
+	// But use the toolchain name from the parent module
+	spec.Name = fun.Name
+	spec.Module = parentMod.IDModule()
+	spec.GetCacheConfig = modFun.CacheConfigForCall
+
+	return dagql.Field[*ModuleObject]{
+		Spec: &spec,
+		Func: func(ctx context.Context, obj dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+			opts := &CallOpts{
+				ParentTyped:    obj,
+				ParentFields:   nil,
+				SkipSelfSchema: false,
+				Server:         dag,
+			}
+			for name, val := range args {
+				opts.Inputs = append(opts.Inputs, CallInput{
+					Name:  name,
+					Value: val,
+				})
+			}
+			// NB: ensure deterministic order
+			sort.Slice(opts.Inputs, func(i, j int) bool {
+				return opts.Inputs[i].Name < opts.Inputs[j].Name
+			})
+			return modFun.Call(ctx, opts)
+		},
+	}, nil
+}


### PR DESCRIPTION
This refactors/simplifies toolchain proxying. I've felt like the original proxying was too hacky, especially if we're going to lean on toolchains even more. This can all potentially go away if we solve contextual Envs (@shykes @vito ), but in the current implementation this refactor seems like a more straightforward approach