### PR TITLE
chores: move archive to moby/go-archive and idtools to moby/sys/user

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,7 @@ linters:
 
       - linters:
           - staticcheck
-        text: "idtools.IdentityMapping"
+        text: "user.IdentityMapping"
 
       - linters:
           - gocyclo

--- a/core/container_emulator.go
+++ b/core/container_emulator.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/archutil"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	copy "github.com/dagger/dagger/internal/fsutil/copy"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -35,7 +35,7 @@ var qemuArchMap = map[string]string{
 
 type emulator struct {
 	path  string
-	idmap *idtools.IdentityMapping
+	idmap *user.IdentityMapping
 }
 
 func (e *emulator) Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error) {
@@ -44,7 +44,7 @@ func (e *emulator) Mount(ctx context.Context, readonly bool) (snapshot.Mountable
 
 type staticEmulatorMount struct {
 	path  string
-	idmap *idtools.IdentityMapping
+	idmap *user.IdentityMapping
 }
 
 func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
@@ -61,9 +61,7 @@ func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
 
 	var uid, gid int
 	if m.idmap != nil {
-		root := m.idmap.RootPair()
-		uid = root.UID
-		gid = root.GID
+		uid, gid = m.idmap.RootPair()
 	}
 	if err := copy.Copy(context.TODO(), filepath.Dir(m.path), filepath.Base(m.path), tmpdir, buildkit.BuildkitQemuEmulatorMountPoint, func(ci *copy.CopyInfo) {
 		m := 0555
@@ -82,7 +80,7 @@ func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
 		}, nil
 }
 
-func (m *staticEmulatorMount) IdentityMapping() *idtools.IdentityMapping {
+func (m *staticEmulatorMount) IdentityMapping() *user.IdentityMapping {
 	return m.idmap
 }
 

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -35,7 +35,6 @@ import (
 	bknetwork "github.com/dagger/dagger/internal/buildkit/util/network"
 	"github.com/dagger/dagger/internal/buildkit/util/overlay"
 	"github.com/dagger/dagger/util/cleanups"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/google/uuid"
 	"github.com/moby/sys/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -329,7 +328,7 @@ func (m hostBindMountRef) Mount() ([]mount.Mount, func() error, error) {
 	}}, func() error { return nil }, nil
 }
 
-func (m hostBindMountRef) IdentityMapping() *idtools.IdentityMapping {
+func (m hostBindMountRef) IdentityMapping() *user.IdentityMapping {
 	return nil
 }
 

--- a/engine/buildkit/worker.go
+++ b/engine/buildkit/worker.go
@@ -20,7 +20,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/network"
 	"github.com/dagger/dagger/internal/buildkit/worker"
 	"github.com/dagger/dagger/internal/buildkit/worker/base"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/semaphore"
 )
@@ -54,7 +54,7 @@ type sharedWorkerState struct {
 	cgroupParent     string
 	networkProviders map[pb.NetMode]network.Provider
 	processMode      oci.ProcessMode
-	idmap            *idtools.IdentityMapping
+	idmap            *user.IdentityMapping
 	dns              *oci.DNSConfig
 	apparmorProfile  string
 	selinux          bool
@@ -89,7 +89,7 @@ type NewWorkerOpts struct {
 	Runc                *runc.Runc
 	DefaultCgroupParent string
 	ProcessMode         oci.ProcessMode
-	IDMapping           *idtools.IdentityMapping
+	IDMapping           *user.IdentityMapping
 	DNSConfig           *oci.DNSConfig
 	ApparmorProfile     string
 	SELinux             bool

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.5.1+incompatible
 	github.com/docker/docker v28.5.1+incompatible
+	github.com/docker/docker-credential-helpers v0.9.3
 	github.com/docker/go-connections v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/dschmidt/go-layerfs v0.2.0
@@ -105,6 +106,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/docker-image-spec v1.3.1
+	github.com/moby/go-archive v0.1.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/sys/mount v0.3.4
@@ -158,6 +160,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.57.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
@@ -249,7 +252,6 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -296,7 +298,6 @@ require (
 	github.com/mattn/goveralls v0.0.12 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/profiles/seccomp v0.1.0 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
@@ -340,7 +341,6 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	google.golang.org/api v0.239.0 // indirect

--- a/internal/buildkit/cache/manager.go
+++ b/internal/buildkit/cache/manager.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/disk"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/dagger/dagger/internal/buildkit/util/progress"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	digest "github.com/opencontainers/go-digest"
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -62,7 +62,7 @@ type Accessor interface {
 
 	New(ctx context.Context, parent ImmutableRef, s session.Group, opts ...RefOption) (MutableRef, error)
 	GetMutable(ctx context.Context, id string, opts ...RefOption) (MutableRef, error) // Rebase?
-	IdentityMapping() *idtools.IdentityMapping
+	IdentityMapping() *user.IdentityMapping
 	Merge(ctx context.Context, parents []ImmutableRef, pg progress.Controller, opts ...RefOption) (ImmutableRef, error)
 	Diff(ctx context.Context, lower, upper ImmutableRef, pg progress.Controller, opts ...RefOption) (ImmutableRef, error)
 }
@@ -359,7 +359,7 @@ func (cm *cacheManager) init(ctx context.Context) error {
 }
 
 // IdentityMapping returns the userns remapping used for refs
-func (cm *cacheManager) IdentityMapping() *idtools.IdentityMapping {
+func (cm *cacheManager) IdentityMapping() *user.IdentityMapping {
 	return cm.Snapshotter.IdentityMapping()
 }
 

--- a/internal/buildkit/cache/refs.go
+++ b/internal/buildkit/cache/refs.go
@@ -32,9 +32,9 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/progress"
 	rootlessmountopts "github.com/dagger/dagger/internal/buildkit/util/rootless/mountopts"
 	"github.com/dagger/dagger/internal/buildkit/util/winlayers"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/sys/mountinfo"
+	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -50,7 +50,7 @@ type Ref interface {
 	Mountable
 	RefMetadata
 	Release(context.Context) error
-	IdentityMapping() *idtools.IdentityMapping
+	IdentityMapping() *user.IdentityMapping
 	DescHandler(digest.Digest) *DescHandler
 }
 
@@ -325,7 +325,7 @@ func (cr *cacheRecord) isLazy(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (cr *cacheRecord) IdentityMapping() *idtools.IdentityMapping {
+func (cr *cacheRecord) IdentityMapping() *user.IdentityMapping {
 	return cr.cm.IdentityMapping()
 }
 

--- a/internal/buildkit/executor/executor.go
+++ b/internal/buildkit/executor/executor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	resourcestypes "github.com/dagger/dagger/internal/buildkit/executor/resources/types"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 )
 
 type Meta struct {
@@ -32,7 +32,7 @@ type Meta struct {
 
 type MountableRef interface {
 	Mount() ([]mount.Mount, func() error, error)
-	IdentityMapping() *idtools.IdentityMapping
+	IdentityMapping() *user.IdentityMapping
 }
 
 type Mountable interface {

--- a/internal/buildkit/executor/oci/resolvconf.go
+++ b/internal/buildkit/executor/oci/resolvconf.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/docker/docker/libnetwork/resolvconf"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"github.com/pkg/errors"
 )
 
@@ -36,7 +36,7 @@ type DNSConfig struct {
 	SearchDomains []string
 }
 
-func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.IdentityMapping, dns *DNSConfig, netMode pb.NetMode) (string, error) {
+func GetResolvConf(ctx context.Context, stateDir string, idmap *user.IdentityMapping, dns *DNSConfig, netMode pb.NetMode) (string, error) {
 	p := filepath.Join(stateDir, "resolv.conf")
 	if netMode == pb.NetMode_HOST {
 		p = filepath.Join(stateDir, "resolv-host.conf")
@@ -116,8 +116,8 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 		}
 
 		if idmap != nil {
-			root := idmap.RootPair()
-			if err := os.Chown(tmpPath, root.UID, root.GID); err != nil {
+			uid, gid := idmap.RootPair()
+			if err := os.Chown(tmpPath, uid, gid); err != nil {
 				return struct{}{}, errors.WithStack(err)
 			}
 		}

--- a/internal/buildkit/executor/oci/spec.go
+++ b/internal/buildkit/executor/oci/spec.go
@@ -18,8 +18,8 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/network"
 	rootlessmountopts "github.com/dagger/dagger/internal/buildkit/util/rootless/mountopts"
 	traceexec "github.com/dagger/dagger/internal/buildkit/util/tracing/exec"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/mitchellh/hashstructure/v2"
+	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -59,7 +59,7 @@ func (pm ProcessMode) String() string {
 
 // GenerateSpec generates spec using containerd functionality.
 // opts are ignored for s.Process, s.Hostname, and s.Mounts .
-func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, cgroupParent string, processMode ProcessMode, idmap *idtools.IdentityMapping, apparmorProfile string, selinuxB bool, tracingSocket string, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
+func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, cgroupParent string, processMode ProcessMode, idmap *user.IdentityMapping, apparmorProfile string, selinuxB bool, tracingSocket string, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
 	c := &containers.Container{
 		ID: id,
 	}

--- a/internal/buildkit/executor/oci/spec_darwin.go
+++ b/internal/buildkit/executor/oci/spec_darwin.go
@@ -5,7 +5,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -26,7 +26,7 @@ func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 
-func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+func generateIDmapOpts(idmap *user.IdentityMapping) ([]oci.SpecOpts, error) {
 	if idmap == nil {
 		return nil, nil
 	}

--- a/internal/buildkit/executor/oci/spec_freebsd.go
+++ b/internal/buildkit/executor/oci/spec_freebsd.go
@@ -5,7 +5,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -34,7 +34,7 @@ func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 
-func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+func generateIDmapOpts(idmap *user.IdentityMapping) ([]oci.SpecOpts, error) {
 	if idmap == nil {
 		return nil, nil
 	}

--- a/internal/buildkit/executor/oci/spec_linux.go
+++ b/internal/buildkit/executor/oci/spec_linux.go
@@ -16,8 +16,8 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/snapshot"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/entitlements/security"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/profiles/seccomp"
+	"github.com/moby/sys/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -98,7 +98,7 @@ func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 
-func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+func generateIDmapOpts(idmap *user.IdentityMapping) ([]oci.SpecOpts, error) {
 	if idmap == nil {
 		return nil, nil
 	}
@@ -107,13 +107,13 @@ func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
 	}, nil
 }
 
-func specMapping(s []idtools.IDMap) []specs.LinuxIDMapping {
+func specMapping(s []user.IDMap) []specs.LinuxIDMapping {
 	var ids []specs.LinuxIDMapping
 	for _, item := range s {
 		ids = append(ids, specs.LinuxIDMapping{
-			HostID:      uint32(item.HostID),
-			ContainerID: uint32(item.ContainerID),
-			Size:        uint32(item.Size),
+			HostID:      uint32(item.ParentID),
+			ContainerID: uint32(item.ID),
+			Size:        uint32(item.Count),
 		})
 	}
 	return ids

--- a/internal/buildkit/executor/oci/spec_windows.go
+++ b/internal/buildkit/executor/oci/spec_windows.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -73,7 +73,7 @@ func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 
-func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+func generateIDmapOpts(idmap *user.IdentityMapping) ([]oci.SpecOpts, error) {
 	if idmap == nil {
 		return nil, nil
 	}

--- a/internal/buildkit/frontend/gateway/gateway.go
+++ b/internal/buildkit/frontend/gateway/gateway.go
@@ -45,12 +45,12 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/tracing"
 	"github.com/dagger/dagger/internal/buildkit/worker"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/gogo/googleapis/google/rpc"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/ptypes/any"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/sys/signal"
+	"github.com/moby/sys/user"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -406,7 +406,7 @@ func (b *bindMount) Mount() ([]mount.Mount, func() error, error) {
 		Options: []string{"bind", "ro", "nosuid", "nodev", "noexec"},
 	}}, func() error { return nil }, nil
 }
-func (b *bindMount) IdentityMapping() *idtools.IdentityMapping {
+func (b *bindMount) IdentityMapping() *user.IdentityMapping {
 	return nil
 }
 

--- a/internal/buildkit/snapshot/containerd/snapshotter.go
+++ b/internal/buildkit/snapshot/containerd/snapshotter.go
@@ -7,11 +7,11 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/dagger/dagger/internal/buildkit/snapshot"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"github.com/pkg/errors"
 )
 
-func NewSnapshotter(name string, snapshotter snapshots.Snapshotter, ns string, idmap *idtools.IdentityMapping) snapshot.Snapshotter {
+func NewSnapshotter(name string, snapshotter snapshots.Snapshotter, ns string, idmap *user.IdentityMapping) snapshot.Snapshotter {
 	return snapshot.FromContainerdSnapshotter(name, &nsSnapshotter{ns, snapshotter}, idmap)
 }
 

--- a/internal/buildkit/snapshot/snapshotter.go
+++ b/internal/buildkit/snapshot/snapshotter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/dagger/dagger/internal/buildkit/executor"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
 	"github.com/pkg/errors"
 )
@@ -30,17 +30,17 @@ type Snapshotter interface {
 	Remove(ctx context.Context, key string) error
 	Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error
 	Close() error
-	IdentityMapping() *idtools.IdentityMapping
+	IdentityMapping() *user.IdentityMapping
 }
 
-func FromContainerdSnapshotter(name string, s snapshots.Snapshotter, idmap *idtools.IdentityMapping) Snapshotter {
+func FromContainerdSnapshotter(name string, s snapshots.Snapshotter, idmap *user.IdentityMapping) Snapshotter {
 	return &fromContainerd{name: name, Snapshotter: s, idmap: idmap}
 }
 
 type fromContainerd struct {
 	name string
 	snapshots.Snapshotter
-	idmap *idtools.IdentityMapping
+	idmap *user.IdentityMapping
 }
 
 func (s *fromContainerd) Name() string {
@@ -66,7 +66,7 @@ func (s *fromContainerd) View(ctx context.Context, key, parent string, opts ...s
 	}
 	return &staticMountable{mounts: mounts, idmap: s.idmap, id: key}, nil
 }
-func (s *fromContainerd) IdentityMapping() *idtools.IdentityMapping {
+func (s *fromContainerd) IdentityMapping() *user.IdentityMapping {
 	return s.idmap
 }
 

--- a/internal/buildkit/snapshot/staticmountable.go
+++ b/internal/buildkit/snapshot/staticmountable.go
@@ -5,14 +5,14 @@ import (
 	"sync/atomic"
 
 	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 )
 
 type staticMountable struct {
 	count  int32
 	id     string
 	mounts []mount.Mount
-	idmap  *idtools.IdentityMapping
+	idmap  *user.IdentityMapping
 }
 
 func (cm *staticMountable) Mount() ([]mount.Mount, func() error, error) {
@@ -36,6 +36,6 @@ func (cm *staticMountable) Mount() ([]mount.Mount, func() error, error) {
 	}, nil
 }
 
-func (cm *staticMountable) IdentityMapping() *idtools.IdentityMapping {
+func (cm *staticMountable) IdentityMapping() *user.IdentityMapping {
 	return cm.idmap
 }

--- a/internal/buildkit/solver/llbsolver/file/backend.go
+++ b/internal/buildkit/solver/llbsolver/file/backend.go
@@ -15,7 +15,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/system"
 	copy "github.com/dagger/dagger/internal/fsutil/copy"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 	"github.com/pkg/errors"
 )
 
@@ -27,7 +27,7 @@ func timestampToTime(ts int64) *time.Time {
 	return &tm
 }
 
-func mkdir(d string, action pb.FileActionMkDir, user *copy.User, idmap *idtools.IdentityMapping) (err error) {
+func mkdir(d string, action pb.FileActionMkDir, user *copy.User, idmap *user.IdentityMapping) (err error) {
 	defer func() {
 		var osErr *os.PathError
 		if errors.As(err, &osErr) {
@@ -67,7 +67,7 @@ func mkdir(d string, action pb.FileActionMkDir, user *copy.User, idmap *idtools.
 	return nil
 }
 
-func mkfile(d string, action pb.FileActionMkFile, user *copy.User, idmap *idtools.IdentityMapping) (err error) {
+func mkfile(d string, action pb.FileActionMkFile, user *copy.User, idmap *user.IdentityMapping) (err error) {
 	defer func() {
 		var osErr *os.PathError
 		if errors.As(err, &osErr) {
@@ -155,7 +155,7 @@ func rmPath(root, src string, allowNotFound bool) error {
 	return errors.WithStack(os.RemoveAll(p))
 }
 
-func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *copy.User, idmap *idtools.IdentityMapping) (err error) {
+func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *copy.User, idmap *user.IdentityMapping) (err error) {
 	srcPath, err := cleanPath(action.Src)
 	if err != nil {
 		return errors.Wrap(err, "cleaning source path")

--- a/internal/buildkit/solver/llbsolver/file/backend_windows.go
+++ b/internal/buildkit/solver/llbsolver/file/backend_windows.go
@@ -1,16 +1,17 @@
 package file
 
 import (
+	"github.com/dagger/dagger/internal/buildkit/util/windows"
 	copy "github.com/dagger/dagger/internal/fsutil/copy"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/sys/user"
 )
 
-func mapUserToChowner(user *copy.User, _ *idtools.IdentityMapping) (copy.Chowner, error) {
+func mapUserToChowner(user *copy.User, _ *user.IdentityMapping) (copy.Chowner, error) {
 	if user == nil || user.SID == "" {
 		return func(old *copy.User) (*copy.User, error) {
 			if old == nil || old.SID == "" {
 				old = &copy.User{
-					SID: idtools.ContainerAdministratorSidString,
+					SID: windows.ContainerAdministratorSidString,
 				}
 			}
 			return old, nil

--- a/internal/buildkit/solver/llbsolver/file/unpack.go
+++ b/internal/buildkit/solver/llbsolver/file/unpack.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/containerd/continuity/fs"
 	copy "github.com/dagger/dagger/internal/fsutil/copy"
-	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/chrootarchive"
-	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/chrootarchive"
+	"github.com/moby/sys/user"
 )
 
-func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Chowner, tm *time.Time, idmap *idtools.IdentityMapping) (bool, error) {
+func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Chowner, tm *time.Time, idmap *user.IdentityMapping) (bool, error) {
 	src, err := fs.RootPath(srcRoot, src)
 	if err != nil {
 		return false, err

--- a/internal/buildkit/source/git/source.go
+++ b/internal/buildkit/source/git/source.go
@@ -627,9 +627,9 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 	}
 
 	if idmap := mount.IdentityMapping(); idmap != nil {
-		u := idmap.RootPair()
+		uid, gid := idmap.RootPair()
 		err := filepath.WalkDir(gitDir, func(p string, _ os.DirEntry, _ error) error {
-			return os.Lchown(p, u.UID, u.GID)
+			return os.Lchown(p, uid, gid)
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to remap git checkout")

--- a/internal/buildkit/source/http/source.go
+++ b/internal/buildkit/source/http/source.go
@@ -25,7 +25,6 @@ import (
 	srctypes "github.com/dagger/dagger/internal/buildkit/source/types"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/tracing"
-	"github.com/docker/docker/pkg/idtools"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -362,15 +361,10 @@ func (hs *httpSourceHandler) save(ctx context.Context, resp *http.Response, s se
 	uid := hs.src.UID
 	gid := hs.src.GID
 	if idmap := mount.IdentityMapping(); idmap != nil {
-		identity, err := idmap.ToHost(idtools.Identity{
-			UID: int(uid),
-			GID: int(gid),
-		})
+		uid, gid, err = idmap.ToHost(int(uid), int(gid))
 		if err != nil {
 			return nil, "", err
 		}
-		uid = identity.UID
-		gid = identity.GID
 	}
 
 	if gid != 0 || uid != 0 {

--- a/internal/buildkit/util/system/getuserinfo/userinfo_windows.go
+++ b/internal/buildkit/util/system/getuserinfo/userinfo_windows.go
@@ -7,7 +7,6 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/reexec"
 )
 
@@ -31,9 +30,10 @@ func userInfoMain() {
 		os.Exit(3)
 	}
 
-	ident := idtools.Identity{
-		SID: sid.String(),
+	var ident struct {
+		SID string
 	}
+	ident.SID = sid.String()
 
 	asJSON, err := json.Marshal(ident)
 	if err != nil {

--- a/internal/buildkit/util/windows/util_windows.go
+++ b/internal/buildkit/util/windows/util_windows.go
@@ -1,0 +1,9 @@
+package windows
+
+// Constants for well-known SIDs in the Windows container.
+// These are currently undocumented.
+// See https://github.com/moby/buildkit/pull/5791#discussion_r1976652227 for more information.
+const (
+	ContainerAdministratorSidString = "S-1-5-93-2-1"
+	ContainerUserSidString          = "S-1-5-93-2-2"
+)

--- a/internal/buildkit/worker/base/worker.go
+++ b/internal/buildkit/worker/base/worker.go
@@ -45,8 +45,8 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/network"
 	"github.com/dagger/dagger/internal/buildkit/util/progress"
 	"github.com/dagger/dagger/internal/buildkit/util/progress/controller"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
+	"github.com/moby/sys/user"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -75,7 +75,7 @@ type WorkerOpt struct {
 	Differ           diff.Comparer
 	ImageStore       images.Store // optional
 	RegistryHosts    docker.RegistryHosts
-	IdentityMapping  *idtools.IdentityMapping
+	IdentityMapping  *user.IdentityMapping
 	LeaseManager     *leaseutil.Manager
 	GarbageCollect   func(context.Context) (gc.Stats, error)
 	ParallelismSem   *semaphore.Weighted


### PR DESCRIPTION
Package `github.com/docker/docker/pkg/archive` and `github.com/docker/docker/pkg/chrootarchive` have been removed and moved to `github.com/moby/go-archive` and `github.com/moby/go-archive/chrootarchive`.

Similar for idtools