### PR TITLE
engine-dev: replace alpine with wolfi

### DIFF
--- a/toolchains/engine-dev/build/builder.go
+++ b/toolchains/engine-dev/build/builder.go
@@ -339,11 +339,10 @@ func (build *Builder) verifyPlatform(ctx context.Context, bin *dagger.File) erro
 	}
 	mntPath := filepath.Join("/mnt", name)
 	out, err := dag.
-		Alpine(dagger.AlpineOpts{
-			Branch:   consts.AlpineVersion,
+		Wolfi().
+		Container(dagger.WolfiContainerOpts{
 			Packages: []string{"file"},
 		}).
-		Container().
 		WithMountedFile(mntPath, bin).
 		WithExec([]string{"file", mntPath}).
 		Stdout(ctx)

--- a/toolchains/engine-dev/build/sdk.go
+++ b/toolchains/engine-dev/build/sdk.go
@@ -252,9 +252,7 @@ func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
 
 func unpackTar(tarball *dagger.File) *dagger.Directory {
 	return dag.
-		Alpine(dagger.AlpineOpts{
-			Branch: consts.AlpineVersion,
-		}).
+		Wolfi().
 		Container().
 		WithMountedDirectory("/out", dag.Directory()).
 		WithMountedFile("/target.tar", tarball).

--- a/toolchains/engine-dev/main.go
+++ b/toolchains/engine-dev/main.go
@@ -117,7 +117,7 @@ func (dev *EngineDev) Playground(
 ) (*dagger.Container, error) {
 	ctr := base
 	if ctr == nil {
-		ctr = dag.Alpine().Container().WithEnvVariable("HOME", "/root")
+		ctr = dag.Wolfi().Container().WithEnvVariable("HOME", "/root")
 	}
 	ctr = ctr.WithWorkdir("$HOME", dagger.ContainerWithWorkdirOpts{Expand: true})
 	svc, err := dev.Service(
@@ -298,7 +298,7 @@ func (dev *EngineDev) InstallClient(
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliPath, dag.DaggerCli().Binary()).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliPath).
-		WithExec([]string{"ln", "-s", cliPath, "/usr/local/bin/dagger"})
+		WithSymlink(cliPath, "/usr/local/bin/dagger")
 	if cfg := dev.ClientDockerConfig; cfg != nil {
 		client = client.WithMountedSecret(
 			"${HOME}/.docker/config.json",


### PR DESCRIPTION
I've had trouble running `dagger call generate` and `dagger call engine-dev introspection-json as-json contents` with an amd64 engine due to possible Alpine issues.

```
load http(url: "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/libcrypto3-3.5.4-r0.apk", refID: "qbyaq3p936rlfmt7shw4nbi3z"): invalid response status 404 Not Found
```

I'm not exactly sure what happened: https://dagger.cloud/tiborvass/traces/22fa61bd3737d64e844dad167bd733c5?listen=5f98acc260801256&listen=0a627df8013f68cd&listen=f86b388a509b75ae&listen=8ec8afe6b07dcb10#4cb90657d7dd6fad

but using wolfi solves the problem.