### PR TITLE
ui: add boundary span wrapping user telemetry

### DIFF
--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -76,7 +76,7 @@ func loadModule(ctx context.Context, dag *dagger.Client) (*dagger.Module, error)
 	if modRef == "" {
 		modRef = moduleURLDefault
 	}
-	ctx, span := Tracer().Start(ctx, "load "+modRef)
+	ctx, span := Tracer().Start(ctx, "load "+modRef, telemetry.Encapsulate())
 	defer span.End()
 	return dag.ModuleSource(modRef).AsModule().Sync(ctx)
 }

--- a/core/service.go
+++ b/core/service.go
@@ -497,6 +497,7 @@ func (svc *Service) startContainer(
 		ctx,
 		// Match naming scheme of normal exec span.
 		fmt.Sprintf("exec %s", strings.Join(svc.Args, " ")),
+		// TODO: user boundaries?
 		// This span continues the original withExec, by linking to it.
 		telemetry.Resume(trace.ContextWithSpanContext(ctx, svc.Creator)),
 	)

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -61,10 +61,17 @@ func AroundFunc(
 		attribute.String(telemetry.DagCallAttr, callAttr),
 	}
 
+	if id.Call().Module == nil && id.Call().Field == "withExec" {
+		// TODO: better way to flag this
+		attrs = append(attrs, attribute.Bool(telemetry.UserBoundaryAttr, true))
+	}
+
 	// if inside a module call, add call trace metadata. this is useful
 	// since within a single span, we can correlate the caller's and callee's
 	// module and functions calls
 	if q, err := CurrentQuery(ctx); id.Call().Module != nil && err == nil {
+		attrs = append(attrs, attribute.Bool(telemetry.UserBoundaryAttr, true))
+
 		callerRef, calleeRef := parseCallerCalleeRefs(ctx, q, id)
 
 		if callerRef != nil && calleeRef != nil {

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -61,14 +61,21 @@ func AroundFunc(
 		attribute.String(telemetry.DagCallAttr, callAttr),
 	}
 
-	if isUserBoundary(id) {
-		attrs = append(attrs, attribute.Bool(telemetry.UserBoundaryAttr, true))
+	q, err := CurrentQuery(ctx)
+	if err != nil {
+		// should never happen, just getting it out of the way
+		slog.Error("no current query for telemetry", "id", id.DisplaySelf())
+		return ctx, dagql.NoopDone
+	}
+
+	if boundary, ok := extractUserBoundary(ctx, q, id); ok {
+		attrs = append(attrs, attribute.String(telemetry.UserBoundaryAttr, boundary))
 	}
 
 	// if inside a module call, add call trace metadata. this is useful
 	// since within a single span, we can correlate the caller's and callee's
 	// module and functions calls
-	if q, err := CurrentQuery(ctx); id.Call().Module != nil && err == nil {
+	if id.Call().Module != nil {
 		callerRef, calleeRef := parseCallerCalleeRefs(ctx, q, id)
 
 		if callerRef != nil && calleeRef != nil {
@@ -392,19 +399,23 @@ func isMeta(id *call.ID) bool {
 	}
 }
 
-// isUserBoundary returns true if telemetry beneath this call comes from user
+// extractUserBoundary returns true if telemetry beneath this call comes from user
 // code, i.e. produced from a container exec's native OTel integration, or from
 // a module function call.
-func isUserBoundary(id *call.ID) bool {
+func extractUserBoundary(ctx context.Context, q *Query, id *call.ID) (string, bool) {
 	if id.Call().Module != nil {
-		return true
+		return id.Call().Module.Ref, true
 	}
 	if id.Receiver() != nil &&
 		id.Receiver().Type().NamedType() == "Container" &&
 		id.Field() == "withExec" {
-		return true
+		if fc, err := q.CurrentModule(ctx); err == nil {
+			// allow withExec calls to inherit the caller's boundary
+			return fc.GetSource().AsString(), true
+		}
+		return "<native>", true
 	}
-	return false
+	return "", false
 }
 
 func isDagOp(id *call.ID) bool {

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -368,6 +368,7 @@ func (db *DB) newSpan(spanID SpanID) *Span {
 		ChildSpans:      NewSpanSet(),
 		RunningSpans:    NewSpanSet(),
 		RevealedSpans:   NewSpanSet(),
+		UserSpans:       NewSpanSet(),
 		FailedLinks:     NewSpanSet(),
 		CanceledLinks:   NewSpanSet(),
 		ErrorOrigins:    NewSpanSet(),

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -71,6 +71,7 @@ const (
 	HideErrorsVerbosity       = -1
 	HideCompletedVerbosity    = 0
 	ShowCompletedVerbosity    = 1
+	ShowFullTraceVerbosity    = 2
 	ShowInternalVerbosity     = 3
 	ShowEncapsulatedVerbosity = 3
 	ShowSpammyVerbosity       = 4

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -80,10 +80,7 @@ const (
 )
 
 func (opts FrontendOpts) ShouldShow(db *DB, span *Span) bool {
-	verbosity := opts.Verbosity
-	if v, ok := opts.SpanVerbosity[span.ID]; ok {
-		verbosity = v
-	}
+	verbosity := span.Verbosity(opts)
 	if opts.Debug {
 		// debug reveals all
 		return true

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -94,6 +94,7 @@ type Span struct {
 	FailedLinks   SpanSet `json:"-"`
 	CanceledLinks SpanSet `json:"-"`
 	RevealedSpans SpanSet `json:"-"`
+	UserSpans     SpanSet `json:"-"`
 	ErrorOrigins  SpanSet `json:"-"`
 
 	callCache *callpbv1.Call
@@ -470,7 +471,7 @@ func (span *Span) PropagateStatusToParentsAndLinks() {
 	if span.ParentSpan.UserBoundary {
 		for parent := range span.Parents {
 			// TODO
-			parent.RevealedSpans.Add(span)
+			parent.UserSpans.Add(span)
 		}
 	}
 

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -468,7 +468,7 @@ func (span *Span) PropagateStatusToParentsAndLinks() {
 		}
 	}
 
-	if span.ParentSpan.UserBoundary {
+	if span.ParentSpan.UserBoundary && span.Call() == nil && !span.Passthrough {
 		for parent := range span.Parents {
 			// TODO
 			parent.UserSpans.Add(span)

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -78,7 +78,7 @@ func (db *DB) RowsView(opts FrontendOpts) *RowsView {
 	}
 	var spans iter.Seq[*Span]
 	if view.Zoomed != nil {
-		if len(view.Zoomed.UserSpans.Order) > 0 {
+		if len(view.Zoomed.UserSpans.Order) > 0 && opts.Verbosity < ShowFullTraceVerbosity {
 			spans = view.Zoomed.UserSpans.Iter()
 		} else if len(view.Zoomed.RevealedSpans.Order) > 0 &&
 			// Revealed spans bubble up all the way to the root span. By default, we

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -78,7 +78,9 @@ func (db *DB) RowsView(opts FrontendOpts) *RowsView {
 	}
 	var spans iter.Seq[*Span]
 	if view.Zoomed != nil {
-		if len(view.Zoomed.RevealedSpans.Order) > 0 &&
+		if len(view.Zoomed.UserSpans.Order) > 0 {
+			spans = view.Zoomed.UserSpans.Iter()
+		} else if len(view.Zoomed.RevealedSpans.Order) > 0 &&
 			// Revealed spans bubble up all the way to the root span. By default, we
 			// want to preserve the top-level context (i.e. spans immediately beneath
 			// root). So, we only prioritize revealed spans if the zoomed span is also

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -259,30 +259,16 @@ func (lv *RowsView) Rows(opts FrontendOpts) *Rows {
 		if row.Expanded {
 			var lastChild *TraceRow
 
-			if tree.shouldShowRevealedSpans(opts) {
-				// Show revealed spans directly, finding their TraceTrees
-				for _, revealedSpan := range tree.Span.RevealedSpans.Order {
-					if revealedTree, ok := lv.BySpan[revealedSpan.ID]; ok {
-						childRow := walk(revealedTree, row, depth+1)
-						if lastChild != nil {
-							childRow.Previous = lastChild
-							lastChild.Next = childRow
-						}
-						lastChild = childRow
-					}
+			for child := range lv.VisibleChildren(tree, opts) {
+				childRow := walk(child, row, depth+1)
+				if lastChild != nil {
+					childRow.Previous = lastChild
+					lastChild.Next = childRow
 				}
-			} else {
-				// Show direct children
-				for _, child := range tree.Children {
-					childRow := walk(child, row, depth+1)
-					if lastChild != nil {
-						childRow.Previous = lastChild
-						lastChild.Next = childRow
-					}
-					lastChild = childRow
-				}
+				lastChild = childRow
 			}
-			row.ShowingChildren = row.HasChildren
+
+			row.ShowingChildren = lastChild != nil
 		}
 		return row
 	}
@@ -298,12 +284,39 @@ func (lv *RowsView) Rows(opts FrontendOpts) *Rows {
 	return rows
 }
 
-func (row *TraceTree) shouldShowRevealedSpans(opts FrontendOpts) bool {
-	verbosity := opts.Verbosity
-	if v, ok := opts.SpanVerbosity[row.Span.ID]; ok {
-		verbosity = v
+func (lv *RowsView) VisibleChildren(tree *TraceTree, opts FrontendOpts) iter.Seq[*TraceTree] {
+	return func(yield func(*TraceTree) bool) {
+		if tree.shouldShowRevealedSpans(opts) {
+			for _, revealedSpan := range tree.Span.RevealedSpans.Order {
+				if child, ok := lv.BySpan[revealedSpan.ID]; ok {
+					if !yield(child) {
+						break
+					}
+				}
+			}
+		} else if len(tree.Span.UserSpans.Order) > 0 &&
+			tree.Span.Verbosity(opts) < ShowFullTraceVerbosity {
+			for _, revealedSpan := range tree.Span.UserSpans.Order {
+				if child, ok := lv.BySpan[revealedSpan.ID]; ok {
+					if !yield(child) {
+						break
+					}
+				}
+			}
+		} else {
+			for _, child := range tree.Children {
+				if !yield(child) {
+					break
+				}
+			}
+		}
 	}
-	return row.RevealedChildren && !opts.RevealNoisySpans && verbosity < ShowSpammyVerbosity
+}
+
+func (row *TraceTree) shouldShowRevealedSpans(opts FrontendOpts) bool {
+	return row.RevealedChildren &&
+		!opts.RevealNoisySpans &&
+		row.Span.Verbosity(opts) < ShowSpammyVerbosity
 }
 
 func (row *TraceTree) hasVisibleChildren(opts FrontendOpts) bool {

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -722,17 +722,6 @@ func (w *Worker) setupOTel(ctx context.Context, state *execState) error {
 		ctx = trace.ContextWithSpanContext(ctx, w.causeCtx)
 	}
 
-	ctx, span := Tracer(ctx).Start(ctx, "[user telemetry boundary]",
-		trace.WithAttributes(
-			attribute.Bool(telemetry.UserBoundaryAttr, true),
-			// attribute.Bool(telemetry.UIPassthroughAttr, true),
-		),
-	)
-	state.cleanups.Add("end user telemetry boundary span", func() error {
-		span.End()
-		return nil
-	})
-
 	var destSession string
 	var destClientID string
 	if w.execMD != nil && w.execMD.SessionID != "" {

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -722,6 +722,17 @@ func (w *Worker) setupOTel(ctx context.Context, state *execState) error {
 		ctx = trace.ContextWithSpanContext(ctx, w.causeCtx)
 	}
 
+	ctx, span := Tracer(ctx).Start(ctx, "[user telemetry boundary]",
+		trace.WithAttributes(
+			attribute.Bool(telemetry.UserBoundaryAttr, true),
+			// attribute.Bool(telemetry.UIPassthroughAttr, true),
+		),
+	)
+	state.cleanups.Add("end user telemetry boundary span", func() error {
+		span.End()
+		return nil
+	})
+
 	var destSession string
 	var destClientID string
 	if w.execMD != nil && w.execMD.SessionID != "" {

--- a/internal/testutil/middleware.go
+++ b/internal/testutil/middleware.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/testctx"
@@ -27,11 +26,6 @@ func SpanOpts[T testctx.Runner[T]](w *testctx.W[T]) []trace.SpanStartOption {
 		attribute.String(testctxTypeAttr, fmt.Sprintf("%T", t)),
 		// Prevent revealed/rolled-up stuff bubbling up through test spans.
 		attribute.Bool(telemetry.UIBoundaryAttr, true),
-	}
-	if strings.Count(w.Name(), "/") == 0 {
-		// Only reveal top-level test suites; we don't need to automatically see
-		// every single one.
-		attrs = append(attrs, attribute.Bool(telemetry.UIRevealAttr, true))
 	}
 	if isPrewarm() {
 		attrs = append(attrs, attribute.Bool(testctxPrewarmAttr, true))

--- a/sdk/go/telemetry/attrs.go
+++ b/sdk/go/telemetry/attrs.go
@@ -44,6 +44,11 @@ const (
 	// this span.
 	UIBoundaryAttr = "dagger.io/ui.boundary"
 
+	// Indicate that any telemetry beneath this span is user-supplied. Allows us
+	// to distinguish user's "custom spans" from regular spans without having to
+	// add an attribute to all of them.
+	UserBoundaryAttr = "dagger.io/user.boundary"
+
 	// An emoji representing the conceptual source of the span.
 	//
 	// Example: 🧑, 🤖


### PR DESCRIPTION
Trying a theory: we can identify which spans are 'user spans' by wrapping all points where we exec something, since that will cover both module function calls _and_ any telemetry produced by a `withExec` (e.g. test spans).