### PR TITLE
telemetry: avoid O(n^2) space usage in published telemetry

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -66,14 +66,8 @@ func AroundFunc(
 		"digest", id.Digest().String(),
 	)
 
-	callAttr, err := id.Call().Encode()
-	if err != nil {
-		slog.WarnContext(ctx, "failed to encode call", "id", id.DisplaySelf(), "err", err)
-		return ctx, dagql.NoopDone
-	}
 	attrs := []attribute.KeyValue{
 		attribute.String(telemetry.DagDigestAttr, id.Digest().String()),
-		attribute.String(telemetry.DagCallAttr, callAttr),
 	}
 
 	// if inside a module call, add call trace metadata. this is useful


### PR DESCRIPTION
Every call made in the engine is sent back to the client (and from there forwarded to cloud). Each call also was including the entire ID payload of the call.

That takes total O(n^2) space, where n is the size of the DAG, due to the fact that each call payload duplicates the parts of the DAG already sent in earlier call payloads.

e.g. for a very simple DAG like A->B->C, the telemetry sent would be
1. ID for A
2. ID for A->B
3. ID for A->B->C

We don't seem to be using the payload at all anywhere I can see, so this change just removes sending it entirely for now. If it's needed in the future, we could instead send incremental calls that reference the inputs by digest.

The hope is to improve:
1. Amount of telemetry saturating connection back to client
2. Amount of memory usage in the client
3. Amount our cloud has to store