### PR TITLE
Fix case where disk full prevents client DB open

### DIFF
--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -223,6 +223,9 @@ func (db *DB) Begin() (*sql.Tx, error) {
 }
 
 func (db *DB) Close() (rerr error) {
+	if db == nil {
+		return nil
+	}
 	lg := slog.Default().With("clientID", db.clientID)
 	db.dbs.perDBLock.Lock(db.clientID)
 	defer db.dbs.perDBLock.Unlock(db.clientID)

--- a/engine/clientdb/dbs_test.go
+++ b/engine/clientdb/dbs_test.go
@@ -1,6 +1,7 @@
 package clientdb
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,4 +69,19 @@ func TestDBRefCount(t *testing.T) {
 	require.Nil(t, d2a.inner)
 	require.Nil(t, d2a.Queries)
 	require.Equal(t, d2a.refCount, 0)
+}
+
+func TestDBCloseNil(t *testing.T) {
+	var db *DB
+	require.NoError(t, db.Close())
+}
+
+func TestOpenWithNonDirRoot(t *testing.T) {
+	root := t.TempDir()
+	blocker := root + "/not-a-dir"
+	require.NoError(t, os.WriteFile(blocker, []byte("nope"), 0600))
+
+	dbs := NewDBs(blocker)
+	_, err := dbs.Open(t.Context(), "client1")
+	require.Error(t, err)
 }


### PR DESCRIPTION
When storage fills up, opening the client telemetry DB can fail, but aborting the session prevents telemetry from flushing or cleanup from progressing — a catch-22 where the engine can’t proceed to recover.

This change logs and continue on keepalive DB open errors, so clients are at least not stuck waiting for a clientdb prune.

There's probably a lot more we could do here, but this seems like a reasonable start.

discord ref: https://discord.com/channels/707636530424053791/1468006633304101017