### PR TITLE
Add support for sockets in Directory.dockerBuild

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -641,6 +641,7 @@ func (container *Container) Build(
 	secrets []dagql.ObjectResult[*Secret],
 	secretStore *SecretStore,
 	noInit bool,
+	sshSocket *Socket,
 ) (*Container, error) {
 	container = container.Clone()
 
@@ -708,6 +709,12 @@ func (container *Container) Build(
 		return llbID, nil
 	})
 
+	if sshSocket != nil {
+		solveCtx = buildkit.WithSSHTranslator(solveCtx, func(id string, optional bool) (string, error) {
+			return sshSocket.LLBID(), nil
+		})
+	}
+
 	res, err := bk.Solve(solveCtx, bkgw.SolveRequest{
 		Frontend:       "dockerfile.v0",
 		FrontendOpt:    opts,
@@ -770,7 +777,6 @@ func (container *Container) Build(
 				buildkit.DaggerNoInitEnv+"=true",
 			)
 		}
-
 		dag.Metadata.Description = desc
 		return nil
 	}); err != nil {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -976,6 +976,7 @@ func (s *containerSchema) build(ctx context.Context, parent dagql.ObjectResult[*
 		secrets,
 		secretStore,
 		args.NoInit,
+		nil,
 	)
 }
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -222,6 +222,10 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 					`This should only be used if the user requires that their exec processes be the
 				pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
 				),
+				dagql.Arg("ssh").Doc(
+					`A socket to use for SSH authentication during the build`,
+					`(e.g., for Dockerfile RUN --mount=type=ssh instructions).`,
+					`Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.`),
 			),
 		dagql.NodeFunc("withTimestamps", DagOpDirectoryWrapper(srv, s.withTimestamps, WithPathFn(keepParentDir[dirWithTimestampsArgs]))).
 			Doc(`Retrieves this directory with all file/dir timestamps set to the given time.`).
@@ -1278,6 +1282,7 @@ type dirDockerBuildArgs struct {
 	BuildArgs  []dagql.InputObject[core.BuildArg] `default:"[]"`
 	Secrets    []core.SecretID                    `default:"[]"`
 	NoInit     bool                               `default:"false"`
+	SSH        dagql.Optional[core.SocketID]
 }
 
 func getDockerIgnoreFileContent(ctx context.Context, parent dagql.ObjectResult[*core.Directory], filename string) ([]byte, error) {
@@ -1374,6 +1379,15 @@ func (s *directorySchema) dockerBuild(ctx context.Context, parent dagql.ObjectRe
 		return nil, fmt.Errorf("failed to get secret store: %w", err)
 	}
 
+	var sshSocket *core.Socket
+	if args.SSH.Valid {
+		sshSocketResult, err := args.SSH.Value.Load(ctx, srv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load SSH socket: %w", err)
+		}
+		sshSocket = sshSocketResult.Self()
+	}
+
 	return ctr.Build(
 		ctx,
 		parent.Self(),
@@ -1384,6 +1398,7 @@ func (s *directorySchema) dockerBuild(ctx context.Context, parent dagql.ObjectRe
 		secrets,
 		secretStore,
 		args.NoInit,
+		sshSocket,
 	)
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1718,6 +1718,15 @@ type Directory {
     behavior.
     """
     noInit: Boolean = false
+
+    """
+    A socket to use for SSH authentication during the build
+
+    (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+
+    Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.
+    """
+    ssh: SocketID
   ): Container!
 
   """Returns a list of files and directories at the given path."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -7361,6 +7361,12 @@
                                 <p>If set, skip the automatic init process injected into containers created by RUN statements.</p>
                                 <p>This should only be used if the user requires that their exec processes be the pid 1 process in the container. Otherwise it may result in unexpected behavior.</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>ssh</code></span> - <span class="property-type"><a href="#definition-SocketID"><code>SocketID</code></a></span></h6>
+                                <p>A socket to use for SSH authentication during the build</p>
+                                <p>(e.g., for Dockerfile RUN --mount=type=ssh instructions).</p>
+                                <p>Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.</p>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -226,7 +226,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_dockerBuild">dockerBuild</a>(string|null $dockerfile = &#039;Dockerfile&#039;, <abbr title="Dagger\Dagger\Platform">Platform</abbr>|null $platform = null, array|null $buildArgs = null, string|null $target = &#039;&#039;, array|null $secrets = null, bool|null $noInit = false)
+                    <a href="#method_dockerBuild">dockerBuild</a>(string|null $dockerfile = &#039;Dockerfile&#039;, <abbr title="Dagger\Dagger\Platform">Platform</abbr>|null $platform = null, array|null $buildArgs = null, string|null $target = &#039;&#039;, array|null $secrets = null, bool|null $noInit = false, <abbr title="Dagger\Dagger\SocketId|Dagger\Socket|null">Socket|null</abbr> $ssh = null)
         
                                             <p><p>Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -921,7 +921,7 @@
                     <h3 id="method_dockerBuild">
         <div class="location">at line 104</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>dockerBuild</strong>(string|null $dockerfile = &#039;Dockerfile&#039;, <abbr title="Dagger\Dagger\Platform">Platform</abbr>|null $platform = null, array|null $buildArgs = null, string|null $target = &#039;&#039;, array|null $secrets = null, bool|null $noInit = false)
+    <strong>dockerBuild</strong>(string|null $dockerfile = &#039;Dockerfile&#039;, <abbr title="Dagger\Dagger\Platform">Platform</abbr>|null $platform = null, array|null $buildArgs = null, string|null $target = &#039;&#039;, array|null $secrets = null, bool|null $noInit = false, <abbr title="Dagger\Dagger\SocketId|Dagger\Socket|null">Socket|null</abbr> $ssh = null)
         </code>
     </h3>
     <div class="details">    
@@ -965,6 +965,11 @@
                 <td>$noInit</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td><abbr title="Dagger\Dagger\SocketId|Dagger\Socket|null">Socket|null</abbr></td>
+                <td>$ssh</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -986,7 +991,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_entries">
-        <div class="location">at line 137</div>
+        <div class="location">at line 141</div>
         <code>                    array
     <strong>entries</strong>(string|null $path = null)
         </code>
@@ -1028,7 +1033,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exists">
-        <div class="location">at line 149</div>
+        <div class="location">at line 153</div>
         <code>                    bool
     <strong>exists</strong>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -1080,7 +1085,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_export">
-        <div class="location">at line 165</div>
+        <div class="location">at line 169</div>
         <code>                    string
     <strong>export</strong>(string $path, bool|null $wipe = false)
         </code>
@@ -1127,7 +1132,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 178</div>
+        <div class="location">at line 182</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path)
         </code>
@@ -1169,7 +1174,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_filter">
-        <div class="location">at line 188</div>
+        <div class="location">at line 192</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>filter</strong>(array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         </code>
@@ -1221,7 +1226,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 206</div>
+        <div class="location">at line 210</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string $start)
         </code>
@@ -1268,7 +1273,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_glob">
-        <div class="location">at line 217</div>
+        <div class="location">at line 221</div>
         <code>                    array
     <strong>glob</strong>(string $pattern)
         </code>
@@ -1310,7 +1315,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 227</div>
+        <div class="location">at line 231</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1342,7 +1347,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 236</div>
+        <div class="location">at line 240</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -1374,7 +1379,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 247</div>
+        <div class="location">at line 251</div>
         <code>                    array
     <strong>search</strong>(string $pattern, array|null $paths = null, array|null $globs = null, bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1466,7 +1471,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stat">
-        <div class="location">at line 298</div>
+        <div class="location">at line 302</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -1513,7 +1518,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 311</div>
+        <div class="location">at line 315</div>
         <code>                    <a href="../Dagger/DirectoryId.html"><abbr title="Dagger\DirectoryId">DirectoryId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1545,7 +1550,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 320</div>
+        <div class="location">at line 324</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>terminal</strong>(<abbr title="Dagger\Dagger\ContainerId|Dagger\Container|null">Container|null</abbr> $container = null, array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -1602,7 +1607,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 345</div>
+        <div class="location">at line 349</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withChanges</strong>(<abbr title="Dagger\ChangesetId|Dagger\Changeset">Changeset</abbr> $changes)
         </code>
@@ -1644,7 +1649,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 355</div>
+        <div class="location">at line 359</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;)
         </code>
@@ -1711,7 +1716,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 384</div>
+        <div class="location">at line 388</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -1753,7 +1758,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 394</div>
+        <div class="location">at line 398</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1810,7 +1815,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 415</div>
+        <div class="location">at line 419</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null)
         </code>
@@ -1862,7 +1867,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 429</div>
+        <div class="location">at line 433</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewDirectory</strong>(string $path, int|null $permissions = 420)
         </code>
@@ -1909,7 +1914,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 442</div>
+        <div class="location">at line 446</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -1961,7 +1966,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatch">
-        <div class="location">at line 456</div>
+        <div class="location">at line 460</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatch</strong>(string $patch)
         </code>
@@ -2003,7 +2008,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatchFile">
-        <div class="location">at line 466</div>
+        <div class="location">at line 470</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatchFile</strong>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $patch)
         </code>
@@ -2045,7 +2050,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 476</div>
+        <div class="location">at line 480</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -2092,7 +2097,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 487</div>
+        <div class="location">at line 491</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -2134,7 +2139,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 497</div>
+        <div class="location">at line 501</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2176,7 +2181,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 507</div>
+        <div class="location">at line 511</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2218,7 +2223,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 517</div>
+        <div class="location">at line 521</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3665,6 +3665,12 @@ type DirectoryDockerBuildOpts struct {
 	//
 	// This should only be used if the user requires that their exec processes be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
 	NoInit bool
+	// A socket to use for SSH authentication during the build
+	//
+	// (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+	//
+	// Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.
+	SSH *Socket
 }
 
 // Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.
@@ -3694,6 +3700,10 @@ func (r *Directory) DockerBuild(opts ...DirectoryDockerBuildOpts) *Container {
 		// `noInit` optional argument
 		if !querybuilder.IsZeroValue(opts[i].NoInit) {
 			q = q.Arg("noInit", opts[i].NoInit)
+		}
+		// `ssh` optional argument
+		if !querybuilder.IsZeroValue(opts[i].SSH) {
+			q = q.Arg("ssh", opts[i].SSH)
 		}
 	}
 

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -108,6 +108,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble
         ?string $target = '',
         ?array $secrets = null,
         ?bool $noInit = false,
+        SocketId|Socket|null $ssh = null,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('dockerBuild');
         if (null !== $dockerfile) {
@@ -127,6 +128,9 @@ class Directory extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $noInit) {
         $innerQueryBuilder->setArgument('noInit', $noInit);
+        }
+        if (null !== $ssh) {
+        $innerQueryBuilder->setArgument('ssh', $ssh);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3837,6 +3837,7 @@ class Directory(Type):
         target: str | None = "",
         secrets: "list[Secret] | None" = None,
         no_init: bool | None = False,
+        ssh: "Socket | None" = None,
     ) -> Container:
         """Use Dockerfile compatibility to build a container from this directory.
         Only use this function for Dockerfile compatibility. Otherwise use the
@@ -3862,6 +3863,11 @@ class Directory(Type):
             This should only be used if the user requires that their exec
             processes be the pid 1 process in the container. Otherwise it may
             result in unexpected behavior.
+        ssh:
+            A socket to use for SSH authentication during the build
+            (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+            Typically obtained via host.unixSocket() pointing to the
+            SSH_AUTH_SOCK.
         """
         _args = [
             Arg("dockerfile", dockerfile, "Dockerfile"),
@@ -3870,6 +3876,7 @@ class Directory(Type):
             Arg("target", target, ""),
             Arg("secrets", [] if secrets is None else secrets, []),
             Arg("noInit", no_init, False),
+            Arg("ssh", ssh, None),
         ]
         _ctx = self._select("dockerBuild", _args)
         return Container(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5370,6 +5370,11 @@ pub struct DirectoryDockerBuildOpts<'a> {
     /// They will be mounted at /run/secrets/[secret-name].
     #[builder(setter(into, strip_option), default)]
     pub secrets: Option<Vec<SecretId>>,
+    /// A socket to use for SSH authentication during the build
+    /// (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+    /// Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.
+    #[builder(setter(into, strip_option), default)]
+    pub ssh: Option<SocketId>,
     /// Target build stage to build.
     #[builder(setter(into, strip_option), default)]
     pub target: Option<&'a str>,
@@ -5692,6 +5697,9 @@ impl Directory {
         }
         if let Some(no_init) = opts.no_init {
             query = query.arg("noInit", no_init);
+        }
+        if let Some(ssh) = opts.ssh {
+            query = query.arg("ssh", ssh);
         }
         Container {
             proc: self.proc.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -952,6 +952,15 @@ export type DirectoryDockerBuildOpts = {
    * This should only be used if the user requires that their exec processes be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
    */
   noInit?: boolean
+
+  /**
+   * A socket to use for SSH authentication during the build
+   *
+   * (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+   *
+   * Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.
+   */
+  ssh?: Socket
 }
 
 export type DirectoryEntriesOpts = {
@@ -5097,6 +5106,11 @@ export class Directory extends BaseClient {
    * @param opts.noInit If set, skip the automatic init process injected into containers created by RUN statements.
    *
    * This should only be used if the user requires that their exec processes be the pid 1 process in the container. Otherwise it may result in unexpected behavior.
+   * @param opts.ssh A socket to use for SSH authentication during the build
+   *
+   * (e.g., for Dockerfile RUN --mount=type=ssh instructions).
+   *
+   * Typically obtained via host.unixSocket() pointing to the SSH_AUTH_SOCK.
    */
   dockerBuild = (opts?: DirectoryDockerBuildOpts): Container => {
     const ctx = this._ctx.select("dockerBuild", { ...opts })


### PR DESCRIPTION
Sockets have to be explicitly provided as arguments to the API. If so, then `RUN --mount=type=ssh` will use that socket.

So if you want to have a function that does a DockerBuild with an SSH socket the code might be like:
```go
func (m *MyModule) DoDockerbuild(dir *dagger.Directory, sshSock *dagger.Socket) *dagger.Container {
  return dir.DockerBuild(dagger.DirectoryDockerBuildOpts{SSH: sshSock})
}
```

And can then be called like this (or similar):
```
dagger call do-dockerbuild --dir . --ssh-sock $SSH_AUTH_SOCK
```

Fixes https://github.com/dagger/dagger/issues/6736