### PR TITLE
fix case where cache mounts become unmountable after restart

### DIFF
--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -805,7 +805,6 @@ func (srv *Server) Close() error {
 	// the server should be shutdown first
 	srv.daggerSessionsMu.Lock()
 	daggerSessions := srv.daggerSessions
-	srv.daggerSessions = nil
 	srv.daggerSessionsMu.Unlock()
 
 	for _, s := range daggerSessions {


### PR DESCRIPTION
When the engine started, it was checking mutable mounts for any leftover volatile dirs. The way it did this resulted in the "shared" mount pool needed by overlay cache mounts being skipped. This also ended up being saved as the mounts to use for that ref going forward, which meant any concurrent use of the overlay cache mount would be invalid due to duplicate work/upper dirs and also fail due to volatile existing.

Fix is to just ensure the shared mount pool is correctly used in all cases.