### PR TITLE
speed up module loading in large monorepos

### DIFF
--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -300,6 +300,12 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 			continue
 		}
 		include = filepath.Join(relPathFromRoot, include)
+		if include == "." {
+			// we were told to include the directory itself, but include
+			// filters seem to ignore ".", so we replace it with the intention
+			// of "*"
+			include = "*"
+		}
 		if negative {
 			include = "!" + include
 		}
@@ -313,6 +319,12 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 			continue
 		}
 		exclude = filepath.Join(relPathFromRoot, exclude)
+		if exclude == "." {
+			// we were told to exclude the directory itself, but exclude
+			// filters seem to ignore ".", so we replace it with the intention
+			// of "*"
+			exclude = "*"
+		}
 		if negative {
 			exclude = "!" + exclude
 		}

--- a/engine/filesync/localfs.go
+++ b/engine/filesync/localfs.go
@@ -267,8 +267,11 @@ func (local *localFS) Sync( //nolint:gocyclo
 				only[path] = struct{}{}
 				cachedResultsMu.Unlock()
 
-				path, ok := strings.CutPrefix(path, local.copyPath)
-				if cacheCtx != nil && ok {
+				doHandle := cacheCtx != nil
+				if local.copyPath != "" {
+					path, doHandle = strings.CutPrefix(path, local.copyPath)
+				}
+				if doHandle {
 					relPathFound = true
 					if err := cacheCtx.HandleChange(appliedChange.Result().kind, path, appliedChange.Result().stat, nil); err != nil {
 						return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -293,8 +296,11 @@ func (local *localFS) Sync( //nolint:gocyclo
 				only[path] = struct{}{}
 				cachedResultsMu.Unlock()
 
-				path, ok := strings.CutPrefix(path, local.copyPath)
-				if cacheCtx != nil && ok {
+				doHandle := cacheCtx != nil
+				if local.copyPath != "" {
+					path, doHandle = strings.CutPrefix(path, local.copyPath)
+				}
+				if doHandle {
 					relPathFound = true
 					if err := cacheCtx.HandleChange(appliedChange.Result().kind, path, appliedChange.Result().stat, nil); err != nil {
 						return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -355,8 +361,11 @@ func (local *localFS) Sync( //nolint:gocyclo
 					only[path] = struct{}{}
 					cachedResultsMu.Unlock()
 
-					path, ok := strings.CutPrefix(path, local.copyPath)
-					if cacheCtx != nil && ok {
+					doHandle := cacheCtx != nil
+					if local.copyPath != "" {
+						path, doHandle = strings.CutPrefix(path, local.copyPath)
+					}
+					if doHandle {
 						relPathFound = true
 						if err := cacheCtx.HandleChange(appliedChange.Result().kind, path, appliedChange.Result().stat, nil); err != nil {
 							return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -407,8 +416,11 @@ func (local *localFS) Sync( //nolint:gocyclo
 			only[path] = struct{}{}
 			cachedResultsMu.Unlock()
 
-			path, ok := strings.CutPrefix(path, local.copyPath)
-			if cacheCtx != nil && ok {
+			doHandle := cacheCtx != nil
+			if local.copyPath != "" {
+				path, doHandle = strings.CutPrefix(path, local.copyPath)
+			}
+			if doHandle {
 				relPathFound = true
 				if err := cacheCtx.HandleChange(appliedChange.Result().kind, path, appliedChange.Result().stat, nil); err != nil {
 					return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -435,8 +447,12 @@ func (local *localFS) Sync( //nolint:gocyclo
 		only[hardlink.path] = struct{}{}
 		cachedResultsMu.Unlock()
 
-		path, ok := strings.CutPrefix(hardlink.path, local.copyPath)
-		if cacheCtx != nil && ok {
+		doHandle := cacheCtx != nil
+		path := hardlink.path
+		if local.copyPath != "" {
+			path, doHandle = strings.CutPrefix(path, local.copyPath)
+		}
+		if doHandle {
 			relPathFound = true
 			if err := cacheCtx.HandleChange(appliedChange.Result().kind, path, appliedChange.Result().stat, nil); err != nil {
 				return nil, fmt.Errorf("failed to handle change in content hasher: %w", err)


### PR DESCRIPTION
Module loading was specifying an include that had a `**/*` appended, which appears to create a huge slowdown in monorepos with large directory trees in terms of number of files/dirs.

This specifically applies to a case like:
1. Big monorepo
2. A dagger module subdir that has relatively few files

Before this change, the `**/*` pattern seemed to be possibly be resulting in walks/checks of the full tree. I didn't take time yet to diagnose why exactly that happens and if it's expected or not.

Dropping the `**/*` fixes this entirely and brings module loading time down to a few seconds on empty cache and less than 1 second afterwards (for a simple go sdk module).

It's not entirely clear why the `**/*` was there; I have a vague memory of it being strictly necessary in ancient iterations of module loading but was probably cargo-culted since then even when not needed anymore.