### PR TITLE
feat(sdk/python): AST based analysis to introspect

### DIFF
--- a/sdk/python/src/dagger/mod/_analyzer/__init__.py
+++ b/sdk/python/src/dagger/mod/_analyzer/__init__.py
@@ -1,0 +1,40 @@
+"""AST-based type analysis for Dagger modules.
+
+This module provides static analysis of Python source code to extract
+type information without importing the module. This is critical when
+dependencies may not be available at analysis time.
+
+Usage:
+    from dagger.mod._analyzer import analyze_module
+
+    metadata = analyze_module(
+        source_files=["src/mymodule/__init__.py"],
+        main_object_name="MyModule",
+    )
+"""
+
+from dagger.mod._analyzer.analyze import analyze_module
+from dagger.mod._analyzer.metadata import (
+    EnumMemberMetadata,
+    EnumTypeMetadata,
+    FieldMetadata,
+    FunctionMetadata,
+    LocationMetadata,
+    ModuleMetadata,
+    ObjectTypeMetadata,
+    ParameterMetadata,
+    ResolvedType,
+)
+
+__all__ = [
+    "EnumMemberMetadata",
+    "EnumTypeMetadata",
+    "FieldMetadata",
+    "FunctionMetadata",
+    "LocationMetadata",
+    "ModuleMetadata",
+    "ObjectTypeMetadata",
+    "ParameterMetadata",
+    "ResolvedType",
+    "analyze_module",
+]

--- a/sdk/python/src/dagger/mod/_analyzer/analyze.py
+++ b/sdk/python/src/dagger/mod/_analyzer/analyze.py
@@ -1,0 +1,143 @@
+"""Main entry point for AST-based module analysis.
+
+This module provides the analyze_module() function that performs
+static analysis of Python source files to extract type information
+without importing the module.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+
+from dagger.mod._analyzer.errors import AnalysisError, ValidationError
+from dagger.mod._analyzer.metadata import ModuleMetadata
+from dagger.mod._analyzer.parser import ModuleParser
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_module(
+    source_files: list[str | Path],
+    main_object_name: str,
+    *,
+    module_name: str | None = None,
+) -> ModuleMetadata:
+    """Analyze Python source files and extract module metadata.
+
+    This is the main entry point for AST-based type analysis. It parses
+    the source files, extracts decorated classes and functions, resolves
+    type annotations, and returns structured metadata.
+    """
+    if not source_files:
+        msg = "No source files provided"
+        raise AnalysisError(msg)
+
+    # Convert to paths
+    paths = [Path(f) for f in source_files]
+
+    # Validate files exist
+    for path in paths:
+        if not path.exists():
+            msg = f"Source file not found: {path}"
+            raise AnalysisError(msg)
+        if not path.is_file():
+            msg = f"Not a file: {path}"
+            raise AnalysisError(msg)
+
+    logger.debug(
+        "Analyzing module: main_object=%s, files=%s",
+        main_object_name,
+        [str(p) for p in paths],
+    )
+
+    # Parse all files
+    parser = ModuleParser(
+        source_files=paths,
+        main_object_name=main_object_name,
+    )
+
+    objects, enums = parser.parse()
+
+    # Validate main object exists
+    if main_object_name not in objects:
+        available = list(objects.keys())
+        msg = (
+            f"Main object '{main_object_name}' not found. "
+            f"Available objects: {available}. "
+            "Ensure the main class is decorated with @dagger.object_type."
+        )
+        raise ValidationError(msg)
+
+    # Extract module documentation from main object's module
+    module_doc = _extract_module_doc(paths)
+
+    # Build metadata
+    metadata = ModuleMetadata(
+        module_name=module_name or main_object_name,
+        main_object=main_object_name,
+        doc=module_doc,
+        objects=objects,
+        enums=enums,
+    )
+
+    logger.debug(
+        "Analysis complete: objects=%d, enums=%d",
+        len(objects),
+        len(enums),
+    )
+
+    return metadata
+
+
+def _extract_module_doc(source_files: list[Path]) -> str | None:
+    """Extract module-level docstring from the first source file."""
+    # Prefer __init__.py
+    init_files = [f for f in source_files if f.name == "__init__.py"]
+    if init_files:
+        target = init_files[0]
+    elif source_files:
+        target = source_files[0]
+    else:
+        return None
+
+    try:
+        source = target.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        return ast.get_docstring(tree)
+    except (OSError, SyntaxError):
+        return None
+
+
+def analyze_source_string(
+    source: str,
+    main_object_name: str,
+    *,
+    module_name: str | None = None,
+) -> ModuleMetadata:
+    """Analyze Python source code from a string.
+
+    This is useful for testing or when source is not in a file.
+    """
+    import tempfile
+
+    # Write to a temporary file
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+        encoding="utf-8",
+    ) as f:
+        f.write(source)
+        temp_path = f.name
+
+    try:
+        return analyze_module(
+            source_files=[temp_path],
+            main_object_name=main_object_name,
+            module_name=module_name,
+        )
+    finally:
+        # Clean up temp file
+        Path(temp_path).unlink(missing_ok=True)

--- a/sdk/python/src/dagger/mod/_analyzer/analyze.py
+++ b/sdk/python/src/dagger/mod/_analyzer/analyze.py
@@ -29,6 +29,26 @@ def analyze_module(
     This is the main entry point for AST-based type analysis. It parses
     the source files, extracts decorated classes and functions, resolves
     type annotations, and returns structured metadata.
+
+    Args:
+        source_files: Paths to Python source files making up the module.
+            At least one file is required.
+        main_object_name: Name of the class decorated with
+            ``@dagger.object_type`` that represents the module's root.
+        module_name: Name recorded on the resulting ``ModuleMetadata``.
+            Defaults to ``main_object_name`` when not provided.
+
+    Returns
+    -------
+        Structured metadata describing the module's types and functions.
+
+    Raises
+    ------
+        AnalysisError: If ``source_files`` is empty or any listed path
+            is missing or not a file.
+        ParseError: If any source file has a Python syntax error.
+        ValidationError: If ``main_object_name`` is not a class decorated
+            with ``@dagger.object_type`` in the analyzed sources.
     """
     if not source_files:
         msg = "No source files provided"
@@ -123,7 +143,24 @@ def analyze_source_string(
 ) -> ModuleMetadata:
     """Analyze Python source code from a string.
 
-    This is useful for testing or when source is not in a file.
+    This is useful for testing or when source is not in a file. The
+    source is written to a temporary file and passed through
+    ``analyze_module``.
+
+    Args:
+        source: Python source code to analyze.
+        main_object_name: Name of the root ``@dagger.object_type`` class.
+        module_name: Name recorded on the resulting ``ModuleMetadata``.
+
+    Returns
+    -------
+        Structured metadata describing the module's types and functions.
+
+    Raises
+    ------
+        AnalysisError: See ``analyze_module``.
+        ParseError: If the source has a Python syntax error.
+        ValidationError: If ``main_object_name`` is not found.
     """
     import tempfile
 

--- a/sdk/python/src/dagger/mod/_analyzer/analyze.py
+++ b/sdk/python/src/dagger/mod/_analyzer/analyze.py
@@ -92,15 +92,20 @@ def analyze_module(
 
 
 def _extract_module_doc(source_files: list[Path]) -> str | None:
-    """Extract module-level docstring from the first source file."""
-    # Prefer __init__.py
+    """Extract module-level docstring, preferring the root package."""
+
+    def _depth(path: Path) -> int:
+        # Include the path itself but ignore the synthetic root ('/' or drive).
+        return len(path.parts)
+
+    if not source_files:
+        return None
+
     init_files = [f for f in source_files if f.name == "__init__.py"]
     if init_files:
-        target = init_files[0]
-    elif source_files:
-        target = source_files[0]
+        target = min(init_files, key=_depth)
     else:
-        return None
+        target = min(source_files, key=_depth)
 
     try:
         source = target.read_text(encoding="utf-8")

--- a/sdk/python/src/dagger/mod/_analyzer/errors.py
+++ b/sdk/python/src/dagger/mod/_analyzer/errors.py
@@ -1,0 +1,73 @@
+"""AST analysis error classes.
+
+All errors include source location for clear error messages.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dagger.mod._exceptions import ModuleError
+
+if TYPE_CHECKING:
+    from dagger.mod._analyzer.metadata import LocationMetadata
+
+
+class AnalysisError(ModuleError):
+    """Base class for AST analysis errors."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        location: LocationMetadata | None = None,
+        extra: dict | None = None,
+    ):
+        self.location = location
+        if location:
+            message = f"{location}: {message}"
+        super().__init__(message, extra=extra)
+
+
+class ParseError(AnalysisError):
+    """Error parsing Python source code."""
+
+
+class DeclarationError(AnalysisError):
+    """Error extracting declarations from AST."""
+
+
+class TypeResolutionError(AnalysisError):
+    """Error resolving type annotations."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        annotation: str | None = None,
+        location: LocationMetadata | None = None,
+        extra: dict | None = None,
+    ):
+        if annotation:
+            message = f"{message}\n  annotation: {annotation}"
+        super().__init__(message, location=location, extra=extra)
+
+
+class ValidationError(AnalysisError):
+    """Error validating module structure or usage patterns."""
+
+
+class DecoratorError(AnalysisError):
+    """Error processing decorator."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        decorator_name: str | None = None,
+        location: LocationMetadata | None = None,
+        extra: dict | None = None,
+    ):
+        if decorator_name:
+            message = f"@{decorator_name}: {message}"
+        super().__init__(message, location=location, extra=extra)

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -1,0 +1,451 @@
+"""Metadata dataclasses for AST analysis results.
+
+These classes represent the structured output of AST analysis,
+serving as the single source of truth for type information.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class LocationMetadata:
+    """Source location for error messages and debugging."""
+
+    file: str
+    line: int
+    column: int
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}:{self.column}"
+
+
+@dataclasses.dataclass(slots=True)
+class ResolvedType:
+    """Resolved type information.
+
+    This represents a fully resolved type that can be converted to a TypeDef.
+    """
+
+    kind: str  # "primitive", "list", "object", "enum", "interface", "scalar", "void"
+    name: str  # Type name (e.g., "str", "Container", "MyObject")
+    is_optional: bool = False  # Whether type is T | None
+    element_type: ResolvedType | None = None  # For list types
+    is_self: bool = False  # Whether this was typing.Self
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "kind": self.kind,
+            "name": self.name,
+            "is_optional": self.is_optional,
+            "is_self": self.is_self,
+        }
+        if self.element_type is not None:
+            result["element_type"] = self.element_type.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResolvedType:
+        """Create from dictionary."""
+        element_type = None
+        if data.get("element_type"):
+            element_type = cls.from_dict(data["element_type"])
+        return cls(
+            kind=data["kind"],
+            name=data["name"],
+            is_optional=data.get("is_optional", False),
+            element_type=element_type,
+            is_self=data.get("is_self", False),
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class ParameterMetadata:
+    """Metadata for a function parameter extracted from AST."""
+
+    # Names
+    python_name: str  # Original Python parameter name
+    api_name: str  # API name (after normalization, e.g., from_ -> from)
+
+    # Type information
+    type_annotation: str  # String representation of the annotation
+    resolved_type: ResolvedType  # Resolved type structure
+
+    # Optional/default handling
+    is_nullable: bool  # Whether type is T | None
+    has_default: bool  # Whether parameter has a default value
+    default_value: Any | None = None  # The default value if extractable
+
+    # Metadata from Annotated[T, ...]
+    doc: str | None = None  # From Doc()
+    ignore: list[str] | None = None  # From Ignore()
+    default_path: str | None = None  # From DefaultPath()
+    default_address: str | None = None  # From DefaultAddress()
+    deprecated: str | None = None  # From Deprecated()
+    alt_name: str | None = None  # From Name() - used to set api_name
+
+    # Source location
+    location: LocationMetadata | None = None
+
+    @property
+    def is_optional(self) -> bool:
+        """Whether this parameter is optional in the API."""
+        return any(
+            [
+                self.has_default,
+                self.default_path is not None,
+                self.default_address is not None,
+                self.is_nullable,
+            ]
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "python_name": self.python_name,
+            "api_name": self.api_name,
+            "type_annotation": self.type_annotation,
+            "resolved_type": self.resolved_type.to_dict(),
+            "is_nullable": self.is_nullable,
+            "has_default": self.has_default,
+            "default_value": self.default_value,
+            "doc": self.doc,
+            "ignore": self.ignore,
+            "default_path": self.default_path,
+            "default_address": self.default_address,
+            "deprecated": self.deprecated,
+            "alt_name": self.alt_name,
+            "location": dataclasses.asdict(self.location) if self.location else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ParameterMetadata:
+        """Create from dictionary."""
+        location = None
+        if data.get("location"):
+            location = LocationMetadata(**data["location"])
+        return cls(
+            python_name=data["python_name"],
+            api_name=data["api_name"],
+            type_annotation=data["type_annotation"],
+            resolved_type=ResolvedType.from_dict(data["resolved_type"]),
+            is_nullable=data["is_nullable"],
+            has_default=data["has_default"],
+            default_value=data.get("default_value"),
+            doc=data.get("doc"),
+            ignore=data.get("ignore"),
+            default_path=data.get("default_path"),
+            default_address=data.get("default_address"),
+            deprecated=data.get("deprecated"),
+            alt_name=data.get("alt_name"),
+            location=location,
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class FunctionMetadata:
+    """Metadata for a @function decorated method."""
+
+    # Names
+    python_name: str  # Original method name
+    api_name: str  # API name (after normalization)
+
+    # Return type
+    return_type_annotation: str  # String representation
+    resolved_return_type: ResolvedType  # Resolved type structure
+
+    # Parameters (excluding self)
+    parameters: list[ParameterMetadata] = dataclasses.field(default_factory=list)
+
+    # Decorator metadata
+    doc: str | None = None
+    deprecated: str | None = None
+    cache_policy: str | None = None
+    is_check: bool = False
+
+    # Function characteristics
+    is_async: bool = False
+    is_classmethod: bool = False
+    is_constructor: bool = False  # True for __init__ or create() classmethod
+
+    # Source location
+    location: LocationMetadata | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "python_name": self.python_name,
+            "api_name": self.api_name,
+            "return_type_annotation": self.return_type_annotation,
+            "resolved_return_type": self.resolved_return_type.to_dict(),
+            "parameters": [p.to_dict() for p in self.parameters],
+            "doc": self.doc,
+            "deprecated": self.deprecated,
+            "cache_policy": self.cache_policy,
+            "is_check": self.is_check,
+            "is_async": self.is_async,
+            "is_classmethod": self.is_classmethod,
+            "is_constructor": self.is_constructor,
+            "location": dataclasses.asdict(self.location) if self.location else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FunctionMetadata:
+        """Create from dictionary."""
+        location = None
+        if data.get("location"):
+            location = LocationMetadata(**data["location"])
+        return cls(
+            python_name=data["python_name"],
+            api_name=data["api_name"],
+            return_type_annotation=data["return_type_annotation"],
+            resolved_return_type=ResolvedType.from_dict(data["resolved_return_type"]),
+            parameters=[
+                ParameterMetadata.from_dict(p) for p in data.get("parameters", [])
+            ],
+            doc=data.get("doc"),
+            deprecated=data.get("deprecated"),
+            cache_policy=data.get("cache_policy"),
+            is_check=data.get("is_check", False),
+            is_async=data.get("is_async", False),
+            is_classmethod=data.get("is_classmethod", False),
+            is_constructor=data.get("is_constructor", False),
+            location=location,
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class FieldMetadata:
+    """Metadata for a field() declared attribute."""
+
+    # Names
+    python_name: str  # Original field name
+    api_name: str  # API name (after normalization)
+
+    # Type information
+    type_annotation: str  # String representation
+    resolved_type: ResolvedType  # Resolved type structure
+
+    # Field options
+    has_default: bool
+    default_value: Any | None = None
+    deprecated: str | None = None
+    init: bool = True  # Whether field is in constructor
+    doc: str | None = None
+
+    # Source location
+    location: LocationMetadata | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "python_name": self.python_name,
+            "api_name": self.api_name,
+            "type_annotation": self.type_annotation,
+            "resolved_type": self.resolved_type.to_dict(),
+            "has_default": self.has_default,
+            "default_value": self.default_value,
+            "deprecated": self.deprecated,
+            "init": self.init,
+            "doc": self.doc,
+            "location": dataclasses.asdict(self.location) if self.location else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FieldMetadata:
+        """Create from dictionary."""
+        location = None
+        if data.get("location"):
+            location = LocationMetadata(**data["location"])
+        return cls(
+            python_name=data["python_name"],
+            api_name=data["api_name"],
+            type_annotation=data["type_annotation"],
+            resolved_type=ResolvedType.from_dict(data["resolved_type"]),
+            has_default=data["has_default"],
+            default_value=data.get("default_value"),
+            deprecated=data.get("deprecated"),
+            init=data.get("init", True),
+            doc=data.get("doc"),
+            location=location,
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class ObjectTypeMetadata:
+    """Metadata for an @object_type or @interface decorated class."""
+
+    # Name
+    name: str  # Class name
+
+    # Type flags
+    is_interface: bool = False
+
+    # Class metadata
+    doc: str | None = None
+    deprecated: str | None = None
+
+    # Members
+    fields: list[FieldMetadata] = dataclasses.field(default_factory=list)
+    functions: list[FunctionMetadata] = dataclasses.field(default_factory=list)
+    constructor: FunctionMetadata | None = None
+
+    # Source location
+    location: LocationMetadata | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "is_interface": self.is_interface,
+            "doc": self.doc,
+            "deprecated": self.deprecated,
+            "fields": [f.to_dict() for f in self.fields],
+            "functions": [f.to_dict() for f in self.functions],
+            "constructor": self.constructor.to_dict() if self.constructor else None,
+            "location": dataclasses.asdict(self.location) if self.location else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ObjectTypeMetadata:
+        """Create from dictionary."""
+        location = None
+        if data.get("location"):
+            location = LocationMetadata(**data["location"])
+        constructor = None
+        if data.get("constructor"):
+            constructor = FunctionMetadata.from_dict(data["constructor"])
+        return cls(
+            name=data["name"],
+            is_interface=data.get("is_interface", False),
+            doc=data.get("doc"),
+            deprecated=data.get("deprecated"),
+            fields=[FieldMetadata.from_dict(f) for f in data.get("fields", [])],
+            functions=[
+                FunctionMetadata.from_dict(f) for f in data.get("functions", [])
+            ],
+            constructor=constructor,
+            location=location,
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class EnumMemberMetadata:
+    """Metadata for an enum member."""
+
+    name: str
+    value: str
+    doc: str | None = None
+    deprecated: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "value": self.value,
+            "doc": self.doc,
+            "deprecated": self.deprecated,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnumMemberMetadata:
+        """Create from dictionary."""
+        return cls(
+            name=data["name"],
+            value=data["value"],
+            doc=data.get("doc"),
+            deprecated=data.get("deprecated"),
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class EnumTypeMetadata:
+    """Metadata for an @enum_type decorated enum."""
+
+    name: str
+    doc: str | None = None
+    members: list[EnumMemberMetadata] = dataclasses.field(default_factory=list)
+    location: LocationMetadata | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "doc": self.doc,
+            "members": [m.to_dict() for m in self.members],
+            "location": dataclasses.asdict(self.location) if self.location else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnumTypeMetadata:
+        """Create from dictionary."""
+        location = None
+        if data.get("location"):
+            location = LocationMetadata(**data["location"])
+        return cls(
+            name=data["name"],
+            doc=data.get("doc"),
+            members=[EnumMemberMetadata.from_dict(m) for m in data.get("members", [])],
+            location=location,
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class ModuleMetadata:
+    """Complete module metadata - single source of truth.
+
+    This is the root structure returned by analyze_module() and contains
+    all type information needed for registration.
+    """
+
+    # Module identification
+    module_name: str
+    main_object: str
+
+    # Module-level documentation
+    doc: str | None = None
+
+    # Type definitions
+    objects: dict[str, ObjectTypeMetadata] = dataclasses.field(default_factory=dict)
+    enums: dict[str, EnumTypeMetadata] = dataclasses.field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Serialize to JSON for file storage."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "module_name": self.module_name,
+            "main_object": self.main_object,
+            "doc": self.doc,
+            "objects": {k: v.to_dict() for k, v in self.objects.items()},
+            "enums": {k: v.to_dict() for k, v in self.enums.items()},
+        }
+
+    @classmethod
+    def from_json(cls, data: str) -> ModuleMetadata:
+        """Deserialize from JSON."""
+        return cls.from_dict(json.loads(data))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModuleMetadata:
+        """Create from dictionary."""
+        objects = {
+            k: ObjectTypeMetadata.from_dict(v)
+            for k, v in data.get("objects", {}).items()
+        }
+        enums = {
+            k: EnumTypeMetadata.from_dict(v) for k, v in data.get("enums", {}).items()
+        }
+        return cls(
+            module_name=data["module_name"],
+            main_object=data["main_object"],
+            doc=data.get("doc"),
+            objects=objects,
+            enums=enums,
+        )

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -166,6 +166,7 @@ class FunctionMetadata:
     deprecated: str | None = None
     cache_policy: str | None = None
     is_check: bool = False
+    is_generate: bool = False
 
     # Function characteristics
     is_async: bool = False
@@ -187,6 +188,7 @@ class FunctionMetadata:
             "deprecated": self.deprecated,
             "cache_policy": self.cache_policy,
             "is_check": self.is_check,
+            "is_generate": self.is_generate,
             "is_async": self.is_async,
             "is_classmethod": self.is_classmethod,
             "is_constructor": self.is_constructor,
@@ -211,6 +213,7 @@ class FunctionMetadata:
             deprecated=data.get("deprecated"),
             cache_policy=data.get("cache_policy"),
             is_check=data.get("is_check", False),
+            is_generate=data.get("is_generate", False),
             is_async=data.get("is_async", False),
             is_classmethod=data.get("is_classmethod", False),
             is_constructor=data.get("is_constructor", False),

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -21,8 +21,8 @@ ResolvedTypeKind = Literal[
 ]
 
 _LIST_KIND: ResolvedTypeKind = "list"
-_NAMED_KINDS: frozenset[ResolvedTypeKind] = frozenset(
-    {"object", "enum", "interface", "scalar"}
+_VALID_KINDS: frozenset[str] = frozenset(
+    {"primitive", "list", "object", "enum", "interface", "scalar", "void"}
 )
 
 
@@ -58,6 +58,12 @@ class ResolvedType:
     is_self: bool = False  # Whether this was typing.Self
 
     def __post_init__(self) -> None:
+        if self.kind not in _VALID_KINDS:
+            msg = (
+                f"ResolvedType.kind must be one of {sorted(_VALID_KINDS)}, "
+                f"got {self.kind!r}"
+            )
+            raise ValueError(msg)
         if self.kind == _LIST_KIND and self.element_type is None:
             msg = "ResolvedType(kind='list') requires an element_type"
             raise ValueError(msg)

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -8,7 +8,22 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import Any
+from typing import Any, Literal
+
+ResolvedTypeKind = Literal[
+    "primitive",
+    "list",
+    "object",
+    "enum",
+    "interface",
+    "scalar",
+    "void",
+]
+
+_LIST_KIND: ResolvedTypeKind = "list"
+_NAMED_KINDS: frozenset[ResolvedTypeKind] = frozenset(
+    {"object", "enum", "interface", "scalar"}
+)
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -28,13 +43,35 @@ class ResolvedType:
     """Resolved type information.
 
     This represents a fully resolved type that can be converted to a TypeDef.
+
+    Invariants enforced in ``__post_init__``:
+
+    - ``kind`` must be one of the values in ``ResolvedTypeKind``.
+    - ``element_type`` is set if and only if ``kind == "list"``.
+    - ``is_self`` is only meaningful for object/interface kinds.
     """
 
-    kind: str  # "primitive", "list", "object", "enum", "interface", "scalar", "void"
+    kind: ResolvedTypeKind
     name: str  # Type name (e.g., "str", "Container", "MyObject")
     is_optional: bool = False  # Whether type is T | None
     element_type: ResolvedType | None = None  # For list types
     is_self: bool = False  # Whether this was typing.Self
+
+    def __post_init__(self) -> None:
+        if self.kind == _LIST_KIND and self.element_type is None:
+            msg = "ResolvedType(kind='list') requires an element_type"
+            raise ValueError(msg)
+        if self.kind != _LIST_KIND and self.element_type is not None:
+            msg = (
+                f"ResolvedType(kind={self.kind!r}) must not carry an element_type"
+            )
+            raise ValueError(msg)
+        if self.is_self and self.kind not in ("object", "interface"):
+            msg = (
+                f"ResolvedType(is_self=True) is only valid for object/interface "
+                f"kinds, got kind={self.kind!r}"
+            )
+            raise ValueError(msg)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -167,6 +167,7 @@ class FunctionMetadata:
     cache_policy: str | None = None
     is_check: bool = False
     is_generate: bool = False
+    is_service: bool = False
 
     # Function characteristics
     is_async: bool = False
@@ -189,6 +190,7 @@ class FunctionMetadata:
             "cache_policy": self.cache_policy,
             "is_check": self.is_check,
             "is_generate": self.is_generate,
+            "is_service": self.is_service,
             "is_async": self.is_async,
             "is_classmethod": self.is_classmethod,
             "is_constructor": self.is_constructor,
@@ -214,6 +216,7 @@ class FunctionMetadata:
             cache_policy=data.get("cache_policy"),
             is_check=data.get("is_check", False),
             is_generate=data.get("is_generate", False),
+            is_service=data.get("is_service", False),
             is_async=data.get("is_async", False),
             is_classmethod=data.get("is_classmethod", False),
             is_constructor=data.get("is_constructor", False),

--- a/sdk/python/src/dagger/mod/_analyzer/metadata.py
+++ b/sdk/python/src/dagger/mod/_analyzer/metadata.py
@@ -68,9 +68,7 @@ class ResolvedType:
             msg = "ResolvedType(kind='list') requires an element_type"
             raise ValueError(msg)
         if self.kind != _LIST_KIND and self.element_type is not None:
-            msg = (
-                f"ResolvedType(kind={self.kind!r}) must not carry an element_type"
-            )
+            msg = f"ResolvedType(kind={self.kind!r}) must not carry an element_type"
             raise ValueError(msg)
         if self.is_self and self.kind not in ("object", "interface"):
             msg = (

--- a/sdk/python/src/dagger/mod/_analyzer/namespace.py
+++ b/sdk/python/src/dagger/mod/_analyzer/namespace.py
@@ -159,7 +159,7 @@ class StubNamespace:
             name: The module or attribute name to import.
             alias: Optional alias for the import.
         """
-        key = alias or name.split(".")[-1]
+        key = alias or name.rsplit(".", maxsplit=1)[-1]
 
         # Try to actually import it
         try:

--- a/sdk/python/src/dagger/mod/_analyzer/namespace.py
+++ b/sdk/python/src/dagger/mod/_analyzer/namespace.py
@@ -1,0 +1,308 @@
+"""Stub namespace for evaluating type annotations.
+
+This module provides a safe namespace for evaluating stringified
+type annotations (from `from __future__ import annotations`) without
+requiring all imports to be available.
+"""
+
+from __future__ import annotations
+
+import ast
+import typing
+from typing import Any
+
+import typing_extensions
+
+from dagger.mod._analyzer.errors import TypeResolutionError
+from dagger.mod._analyzer.metadata import LocationMetadata
+
+
+class StubType:
+    """A stub type for unavailable imports.
+
+    This allows type annotations to be parsed even when the actual
+    type is not importable.
+    """
+
+    def __init__(self, name: str, module: str | None = None):
+        self.__name__ = name
+        self.__module__ = module or "stub"
+        self._is_stub = True
+
+    def __repr__(self) -> str:
+        if self.__module__ and self.__module__ != "stub":
+            return f"<StubType {self.__module__}.{self.__name__}>"
+        return f"<StubType {self.__name__}>"
+
+    def __getitem__(self, item):
+        """Support generic subscripting like StubType[T]."""
+        return self
+
+    def __or__(self, other):
+        """Support union syntax like StubType | None."""
+        return typing.Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other):
+        """Support reverse union syntax like None | StubType."""
+        return typing.Union[other, self]  # noqa: UP007
+
+
+def is_stub_type(t: Any) -> bool:
+    """Check if a type is a stub type."""
+    return getattr(t, "_is_stub", False)
+
+
+class StubNamespace:
+    """A namespace for evaluating type annotations.
+
+    Provides built-in types, typing module types, and stubs for
+    unavailable imports.
+    """
+
+    def __init__(self):
+        self._namespace: dict[str, Any] = self._build_base_namespace()
+        self._declared_types: set[str] = set()
+
+    def _build_base_namespace(self) -> dict[str, Any]:
+        """Build the base namespace with built-in and typing types."""
+        ns: dict[str, Any] = {
+            # Built-in types
+            "str": str,
+            "int": int,
+            "float": float,
+            "bool": bool,
+            "bytes": bytes,
+            "None": type(None),
+            "type": type,
+            "list": list,
+            "dict": dict,
+            "tuple": tuple,
+            "set": set,
+            "frozenset": frozenset,
+            # typing module - commonly used
+            "Any": typing.Any,
+            "Union": typing.Union,
+            "Optional": typing.Optional,
+            "List": list,
+            "Dict": dict,
+            "Tuple": tuple,
+            "Set": set,
+            "FrozenSet": frozenset,
+            "Sequence": typing.Sequence,
+            "Mapping": typing.Mapping,
+            "Iterable": typing.Iterable,
+            "Iterator": typing.Iterator,
+            "Callable": typing.Callable,
+            "Type": type,
+            "ClassVar": typing.ClassVar,
+            "Final": typing.Final,
+            "Literal": typing.Literal,
+            "TypeVar": typing.TypeVar,
+            "Generic": typing.Generic,
+            "Protocol": typing.Protocol,
+            "Annotated": typing.Annotated,
+            # typing_extensions
+            "Self": typing_extensions.Self,
+            "Doc": typing_extensions.Doc,
+            # Make typing module available
+            "typing": typing,
+            "typing_extensions": typing_extensions,
+        }
+
+        # Add dagger types
+        try:
+            import dagger
+            from dagger.mod._arguments import (
+                DefaultAddress,
+                DefaultPath,
+                Deprecated,
+                Ignore,
+                Name,
+            )
+
+            ns["dagger"] = dagger
+            ns["DefaultPath"] = DefaultPath
+            ns["DefaultAddress"] = DefaultAddress
+            ns["Ignore"] = Ignore
+            ns["Name"] = Name
+            ns["Deprecated"] = Deprecated
+
+            # Add common dagger types directly
+            for name in [
+                "Container",
+                "Directory",
+                "File",
+                "Secret",
+                "Service",
+                "CacheVolume",
+                "Socket",
+                "ModuleSource",
+                "Module",
+                "Platform",
+                "JSON",
+                "GitRepository",
+                "GitRef",
+            ]:
+                if hasattr(dagger, name):
+                    ns[name] = getattr(dagger, name)
+
+        except ImportError:
+            # dagger module not available, create stubs
+            ns["dagger"] = StubType("dagger")
+
+        return ns
+
+    def add_import(self, name: str, alias: str | None = None) -> None:
+        """Add an import to the namespace.
+
+        Args:
+            name: The module or attribute name to import.
+            alias: Optional alias for the import.
+        """
+        key = alias or name.split(".")[-1]
+
+        # Try to actually import it
+        try:
+            import importlib
+
+            parts = name.split(".")
+            if len(parts) == 1:
+                module = importlib.import_module(name)
+                self._namespace[key] = module
+            else:
+                # Handle dotted imports (e.g., "foo.bar")
+                module_name = ".".join(parts[:-1])
+                attr_name = parts[-1]
+                module = importlib.import_module(module_name)
+                self._namespace[key] = getattr(module, attr_name)
+        except (ImportError, AttributeError):
+            # Create a stub type for unavailable imports
+            self._namespace[key] = StubType(key, name)
+
+    def add_from_import(self, module: str, name: str, alias: str | None = None) -> None:
+        """Add a from-import to the namespace.
+
+        Args:
+            module: The module to import from.
+            name: The name to import.
+            alias: Optional alias for the import.
+        """
+        key = alias or name
+
+        # Try to actually import it
+        try:
+            import importlib
+
+            mod = importlib.import_module(module)
+            self._namespace[key] = getattr(mod, name)
+        except (ImportError, AttributeError):
+            # Create a stub type
+            self._namespace[key] = StubType(name, module)
+
+    def add_declared_type(self, name: str) -> None:
+        """Register a type declared in the module being analyzed.
+
+        This creates a forward reference placeholder.
+        """
+        self._declared_types.add(name)
+        # Create a stub that can be used in annotations
+        self._namespace[name] = StubType(name, "module")
+
+    def get_namespace(self) -> dict[str, Any]:
+        """Get the complete namespace for evaluation."""
+        return self._namespace.copy()
+
+    def eval_annotation(
+        self,
+        annotation: str | ast.expr,
+        *,
+        location: LocationMetadata | None = None,
+    ) -> Any:
+        """Evaluate a type annotation in this namespace.
+
+        Args:
+            annotation: The annotation string or AST node.
+            location: Source location for error messages.
+
+        Returns
+        -------
+            The evaluated type.
+
+        Raises
+        ------
+            TypeResolutionError: If the annotation cannot be evaluated.
+        """
+        if isinstance(annotation, ast.expr):
+            annotation_str = ast.unparse(annotation)
+        else:
+            annotation_str = annotation
+
+        try:
+            # Use eval with our controlled namespace
+            return eval(annotation_str, {"__builtins__": {}}, self._namespace)  # noqa: S307
+        except Exception as e:
+            msg = f"Failed to evaluate type annotation: {e}"
+            raise TypeResolutionError(
+                msg,
+                annotation=annotation_str,
+                location=location,
+            ) from e
+
+
+def extract_imports_from_ast(tree: ast.Module) -> list[tuple[str, str, str | None]]:
+    """Extract import statements from an AST.
+
+    Returns
+    -------
+        List of tuples: (import_type, name, alias)
+        - import_type: "import" or "from"
+        - name: full dotted name or "module.name" for from imports
+        - alias: optional alias
+    """
+    imports: list[tuple[str, str, str | None]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(("import", alias.name, alias.asname) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            imports.extend(
+                (
+                    "from",
+                    f"{module}.{alias.name}" if module else alias.name,
+                    alias.asname,
+                )
+                for alias in node.names
+                if alias.name != "*"
+            )
+
+    return imports
+
+
+def build_namespace_from_ast(tree: ast.Module) -> StubNamespace:
+    """Build a namespace from an AST module.
+
+    This extracts imports and creates appropriate stubs for
+    unavailable modules.
+    """
+    namespace = StubNamespace()
+
+    # Extract and add imports
+    for import_type, name, alias in extract_imports_from_ast(tree):
+        if import_type == "import":
+            namespace.add_import(name, alias)
+        else:
+            # from X.Y import Z - name is "X.Y.Z"
+            parts = name.rsplit(".", 1)
+            if "." in name:
+                module, attr = parts
+                namespace.add_from_import(module, attr, alias)
+            else:
+                namespace.add_import(name, alias)
+
+    # Find declared classes to use as forward references
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            namespace.add_declared_type(node.name)
+
+    return namespace

--- a/sdk/python/src/dagger/mod/_analyzer/namespace.py
+++ b/sdk/python/src/dagger/mod/_analyzer/namespace.py
@@ -8,6 +8,7 @@ requiring all imports to be available.
 from __future__ import annotations
 
 import ast
+import logging
 import typing
 from typing import Any
 
@@ -15,6 +16,8 @@ import typing_extensions
 
 from dagger.mod._analyzer.errors import TypeResolutionError
 from dagger.mod._analyzer.metadata import LocationMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class StubType:
@@ -146,8 +149,15 @@ class StubNamespace:
                 if hasattr(dagger, name):
                     ns[name] = getattr(dagger, name)
 
-        except ImportError:
-            # dagger module not available, create stubs
+        except ImportError as e:
+            # Failing to import dagger itself means every dagger.* annotation
+            # will resolve to a stub; surface this loudly so the user doesn't
+            # silently get nonsense TypeDefs in their module.
+            logger.warning(
+                "Failed to import the dagger package during AST analysis (%s); "
+                "dagger.* type annotations will resolve to stubs.",
+                e,
+            )
             ns["dagger"] = StubType("dagger")
 
         return ns
@@ -175,8 +185,22 @@ class StubNamespace:
                 attr_name = parts[-1]
                 module = importlib.import_module(module_name)
                 self._namespace[key] = getattr(module, attr_name)
-        except (ImportError, AttributeError):
-            # Create a stub type for unavailable imports
+        except ImportError as e:
+            logger.debug(
+                "Import %r unavailable during AST analysis; using stub: %s",
+                name,
+                e,
+            )
+            self._namespace[key] = StubType(key, name)
+        except AttributeError as e:
+            # The module imported fine but the attribute does not exist — this
+            # is almost always a user typo, not a missing dependency.
+            logger.warning(
+                "Attribute %r missing on %r during AST analysis (%s); using stub.",
+                parts[-1] if len(parts) > 1 else name,
+                parts[0],
+                e,
+            )
             self._namespace[key] = StubType(key, name)
 
     def add_from_import(self, module: str, name: str, alias: str | None = None) -> None:
@@ -195,8 +219,22 @@ class StubNamespace:
 
             mod = importlib.import_module(module)
             self._namespace[key] = getattr(mod, name)
-        except (ImportError, AttributeError):
-            # Create a stub type
+        except ImportError as e:
+            logger.debug(
+                "from %s import %s unavailable during AST analysis; using stub: %s",
+                module,
+                name,
+                e,
+            )
+            self._namespace[key] = StubType(name, module)
+        except AttributeError as e:
+            logger.warning(
+                "from %s import %s: attribute missing during AST analysis (%s); "
+                "using stub — check for a typo in the import.",
+                module,
+                name,
+                e,
+            )
             self._namespace[key] = StubType(name, module)
 
     def add_declared_type(self, name: str) -> None:

--- a/sdk/python/src/dagger/mod/_analyzer/namespace.py
+++ b/sdk/python/src/dagger/mod/_analyzer/namespace.py
@@ -52,7 +52,7 @@ class StubType:
 
 def is_stub_type(t: Any) -> bool:
     """Check if a type is a stub type."""
-    return getattr(t, "_is_stub", False)
+    return isinstance(t, StubType)
 
 
 class StubNamespace:

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -509,7 +509,7 @@ class ModuleParser:
             all_args.extend(args.kwonlyargs)
 
         # Get defaults
-        defaults_offset = len(all_args) - len(args.defaults)
+        defaults_offset = len(args.args) - len(args.defaults)
         kw_defaults = {
             arg.arg: default
             for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False)
@@ -579,7 +579,9 @@ class ModuleParser:
                     resolved_type=resolved_type,
                     is_nullable=resolved_type.is_optional,
                     has_default=has_default,
-                    default_value=self._serialize_default(default_value),
+                    default_value=(
+                        self._serialize_default(default_value) if has_default else None
+                    ),
                     doc=meta_doc,
                     ignore=meta_ignore,
                     default_path=meta_default_path,

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -1,0 +1,686 @@
+"""AST parser for extracting module declarations.
+
+This module parses Python source files and extracts decorated
+classes, functions, and fields for Dagger module registration.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+from dagger.mod._analyzer.errors import ParseError
+from dagger.mod._analyzer.metadata import (
+    EnumMemberMetadata,
+    EnumTypeMetadata,
+    FieldMetadata,
+    FunctionMetadata,
+    LocationMetadata,
+    ObjectTypeMetadata,
+    ParameterMetadata,
+    ResolvedType,
+)
+from dagger.mod._analyzer.namespace import StubNamespace
+from dagger.mod._analyzer.resolver import TypeResolver
+from dagger.mod._analyzer.visitors.annotations import (
+    extract_annotated_metadata,
+    get_annotation_string,
+)
+from dagger.mod._analyzer.visitors.decorators import (
+    extract_decorator_info,
+    find_decorator,
+    has_decorator,
+    is_classmethod,
+)
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a Python name for API usage.
+
+    Removes trailing underscore used for reserved word avoidance.
+    """
+    is_trailing_underscore = (
+        name.endswith("_")
+        and len(name) > 1
+        and name[-2] != "_"
+        and not name.startswith("_")
+    )
+    if is_trailing_underscore:
+        return name[:-1]
+    return name
+
+
+def get_location(node: ast.AST, file_path: str) -> LocationMetadata:
+    """Get source location from an AST node."""
+    return LocationMetadata(
+        file=file_path,
+        line=getattr(node, "lineno", 0),
+        column=getattr(node, "col_offset", 0),
+    )
+
+
+def get_docstring(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef | ast.Module,
+) -> str | None:
+    """Extract docstring from a node."""
+    return ast.get_docstring(node)
+
+
+class ModuleParser:
+    """Parser for extracting declarations from Python source files.
+
+    This parser reads Python source, builds an AST, and extracts
+    all Dagger-decorated classes, functions, and fields.
+    """
+
+    def __init__(self, source_files: list[str | Path], main_object_name: str):
+        """Initialize the parser.
+
+        Args:
+            source_files: List of Python source files to parse.
+            main_object_name: Name of the main object class.
+        """
+        self.source_files = [Path(f) for f in source_files]
+        self.main_object_name = main_object_name
+
+        # Parsed data
+        self._asts: dict[Path, ast.Module] = {}
+        self._namespace: StubNamespace | None = None
+        self._resolver: TypeResolver | None = None
+
+        # Collected declarations
+        self._objects: dict[str, ObjectTypeMetadata] = {}
+        self._enums: dict[str, EnumTypeMetadata] = {}
+
+        # Track what types are declared (for resolver)
+        self._declared_objects: set[str] = set()
+        self._declared_enums: set[str] = set()
+        self._declared_interfaces: set[str] = set()
+
+    def parse(
+        self,
+    ) -> tuple[dict[str, ObjectTypeMetadata], dict[str, EnumTypeMetadata]]:
+        """Parse all source files and extract declarations.
+
+        Returns
+        -------
+            Tuple of (objects, enums) dictionaries.
+        """
+        # Phase 1: Parse all files
+        self._parse_files()
+
+        # Phase 2: Collect declaration names (for forward references)
+        self._collect_declaration_names()
+
+        # Phase 3: Build namespace and resolver
+        self._build_namespace()
+
+        # Phase 4: Extract full declarations
+        self._extract_declarations()
+
+        return self._objects, self._enums
+
+    def _parse_files(self) -> None:
+        """Parse all source files into ASTs."""
+        for file_path in self.source_files:
+            try:
+                source = file_path.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=str(file_path))
+                self._asts[file_path] = tree
+            except SyntaxError as e:  # noqa: PERF203
+                msg = f"Syntax error in {file_path}: {e.msg}"
+                location = LocationMetadata(
+                    file=str(file_path),
+                    line=e.lineno or 0,
+                    column=e.offset or 0,
+                )
+                raise ParseError(msg, location=location) from e
+            except OSError as e:
+                msg = f"Failed to read {file_path}: {e}"
+                raise ParseError(msg) from e
+
+    def _collect_declaration_names(self) -> None:
+        """Collect names of decorated classes for forward reference resolution."""
+        for tree in self._asts.values():
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    if has_decorator(node, "object_type"):
+                        self._declared_objects.add(node.name)
+                    elif has_decorator(node, "interface"):
+                        self._declared_interfaces.add(node.name)
+                    elif has_decorator(node, "enum_type") or self._is_enum_subclass(
+                        node
+                    ):
+                        self._declared_enums.add(node.name)
+
+    def _is_enum_subclass(self, node: ast.ClassDef) -> bool:
+        """Check if a class inherits from enum.Enum."""
+        for base in node.bases:
+            if isinstance(base, ast.Attribute) and base.attr == "Enum":
+                return True
+            if isinstance(base, ast.Name) and base.id == "Enum":
+                return True
+        return False
+
+    def _build_namespace(self) -> None:
+        """Build the namespace for type resolution."""
+        # Combine all ASTs for namespace building
+        self._namespace = StubNamespace()
+
+        for tree in self._asts.values():
+            self._add_imports_from_tree(tree)
+
+        # Add declared types
+        all_declared = (
+            self._declared_objects | self._declared_interfaces | self._declared_enums
+        )
+        for name in all_declared:
+            self._namespace.add_declared_type(name)
+
+        # Create resolver
+        self._resolver = TypeResolver(
+            namespace=self._namespace,
+            declared_objects=self._declared_objects,
+            declared_enums=self._declared_enums,
+            declared_interfaces=self._declared_interfaces,
+        )
+
+    def _add_imports_from_tree(self, tree: ast.Module) -> None:
+        """Extract imports from an AST tree and add to namespace."""
+        assert self._namespace is not None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self._namespace.add_import(alias.name, alias.asname)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                for alias in node.names:
+                    if alias.name != "*":
+                        self._namespace.add_from_import(
+                            module, alias.name, alias.asname
+                        )
+
+    def _extract_declarations(self) -> None:
+        """Extract full declarations from all ASTs."""
+        for file_path, tree in self._asts.items():
+            for node in ast.iter_child_nodes(tree):
+                if isinstance(node, ast.ClassDef):
+                    self._extract_class(node, file_path)
+
+    def _extract_class(self, node: ast.ClassDef, file_path: Path) -> None:
+        """Extract a class declaration."""
+        # Check for @object_type
+        if has_decorator(node, "object_type"):
+            obj = self._parse_object_type(node, file_path, is_interface=False)
+            self._objects[obj.name] = obj
+            return
+
+        # Check for @interface
+        if has_decorator(node, "interface"):
+            obj = self._parse_object_type(node, file_path, is_interface=True)
+            self._objects[obj.name] = obj
+            return
+
+        # Check for @enum_type or enum.Enum subclass
+        if has_decorator(node, "enum_type") or self._is_enum_subclass(node):
+            enum = self._parse_enum_type(node, file_path)
+            self._enums[enum.name] = enum
+
+    def _parse_object_type(
+        self,
+        node: ast.ClassDef,
+        file_path: Path,
+        is_interface: bool,
+    ) -> ObjectTypeMetadata:
+        """Parse an @object_type or @interface decorated class."""
+        assert self._resolver is not None
+
+        self._resolver.set_current_class(node.name)
+
+        # Get decorator info for metadata
+        decorator_type = "interface" if is_interface else "object_type"
+        decorator = find_decorator(node, decorator_type)
+        decorator_info = extract_decorator_info(decorator) if decorator else None
+
+        # Extract deprecation
+        deprecated = None
+        if decorator_info and "deprecated" in decorator_info.kwargs:
+            deprecated = decorator_info.kwargs["deprecated"]
+
+        # Extract fields and functions
+        fields: list[FieldMetadata] = []
+        functions: list[FunctionMetadata] = []
+        constructor: FunctionMetadata | None = None
+
+        # Track field names for type hints resolution
+        field_annotations: dict[str, ast.expr] = {}
+
+        for item in node.body:
+            # Extract annotated assignments (field declarations)
+            if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                field_annotations[item.target.id] = item.annotation
+                field = self._parse_field(item, file_path, node.name)
+                if field is not None:
+                    fields.append(field)
+
+            # Extract methods
+            elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                # Check for @classmethod create() - alternative constructor
+                if item.name == "create" and is_classmethod(item):
+                    constructor = self._parse_constructor(item, file_path, node.name)
+                elif has_decorator(item, "function"):
+                    func = self._parse_function(item, file_path, node.name)
+                    functions.append(func)
+
+        # If no alternative constructor, create one from __init__
+        if constructor is None and not is_interface:
+            constructor = self._create_default_constructor(node, fields, file_path)
+
+        self._resolver.set_current_class(None)
+
+        return ObjectTypeMetadata(
+            name=node.name,
+            is_interface=is_interface,
+            doc=get_docstring(node),
+            deprecated=deprecated,
+            fields=fields,
+            functions=functions,
+            constructor=constructor,
+            location=get_location(node, str(file_path)),
+        )
+
+    def _parse_field(
+        self,
+        node: ast.AnnAssign,
+        file_path: Path,
+        class_name: str,
+    ) -> FieldMetadata | None:
+        """Parse a field declaration.
+
+        Only returns a FieldMetadata if the field uses dagger.field().
+        """
+        assert self._resolver is not None
+        assert isinstance(node.target, ast.Name)
+
+        python_name = node.target.id
+
+        # Check if this is a dagger.field() call
+        has_field_decorator = False
+        field_kwargs: dict[str, Any] = {}
+
+        if node.value is not None and isinstance(node.value, ast.Call):
+            func = node.value.func
+            # Check for field(), dagger.field(), mod.field()
+            is_name_field = isinstance(func, ast.Name) and func.id == "field"
+            is_attr_field = isinstance(func, ast.Attribute) and func.attr == "field"
+            is_field_call = is_name_field or is_attr_field
+
+            if is_field_call:
+                has_field_decorator = True
+                # Extract field() arguments
+                for keyword in node.value.keywords:
+                    if keyword.arg is not None:
+                        value = self._eval_constant(keyword.value)
+                        field_kwargs[keyword.arg] = value
+
+        if not has_field_decorator:
+            return None
+
+        # Resolve type
+        location = get_location(node, str(file_path))
+        resolved_type = self._resolver.resolve(node.annotation, location=location)
+
+        # Extract Annotated metadata
+        annotated_meta = extract_annotated_metadata(node.annotation)
+
+        # Get API name
+        api_name = field_kwargs.get("name") or normalize_name(python_name)
+
+        # Get default value
+        has_default = "default" in field_kwargs or "default_factory" in field_kwargs
+        default_value = field_kwargs.get("default")
+
+        return FieldMetadata(
+            python_name=python_name,
+            api_name=api_name,
+            type_annotation=get_annotation_string(node.annotation),
+            resolved_type=resolved_type,
+            has_default=has_default,
+            default_value=self._serialize_default(default_value),
+            deprecated=field_kwargs.get("deprecated"),
+            init=field_kwargs.get("init", True),
+            doc=annotated_meta.doc,
+            location=location,
+        )
+
+    def _parse_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        file_path: Path,
+        class_name: str,
+    ) -> FunctionMetadata:
+        """Parse a @function decorated method."""
+        assert self._resolver is not None
+
+        # Get decorator info
+        decorator = find_decorator(node, "function")
+        decorator_info = extract_decorator_info(decorator) if decorator else None
+
+        # Check for @check decorator
+        is_check = has_decorator(node, "check")
+
+        # Extract decorator kwargs
+        func_kwargs: dict[str, Any] = {}
+        if decorator_info:
+            func_kwargs = decorator_info.kwargs
+
+        # Get API name
+        python_name = node.name
+        api_name = func_kwargs.get("name") or normalize_name(python_name)
+
+        # Parse return type
+        location = get_location(node, str(file_path))
+        if node.returns:
+            return_annotation = get_annotation_string(node.returns)
+            resolved_return = self._resolver.resolve(node.returns, location=location)
+        else:
+            return_annotation = "None"
+            resolved_return = ResolvedType(kind="void", name="None", is_optional=True)
+
+        # Parse parameters
+        parameters = self._parse_parameters(node, file_path)
+
+        return FunctionMetadata(
+            python_name=python_name,
+            api_name=api_name,
+            return_type_annotation=return_annotation,
+            resolved_return_type=resolved_return,
+            parameters=parameters,
+            doc=func_kwargs.get("doc") or get_docstring(node),
+            deprecated=func_kwargs.get("deprecated"),
+            cache_policy=func_kwargs.get("cache"),
+            is_check=is_check,
+            is_async=isinstance(node, ast.AsyncFunctionDef),
+            is_classmethod=is_classmethod(node),
+            is_constructor=False,
+            location=location,
+        )
+
+    def _parse_constructor(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        file_path: Path,
+        class_name: str,
+    ) -> FunctionMetadata:
+        """Parse an alternative constructor (classmethod create)."""
+        assert self._resolver is not None
+
+        location = get_location(node, str(file_path))
+
+        # Parse return type (should be Self or the class name)
+        if node.returns:
+            return_annotation = get_annotation_string(node.returns)
+            resolved_return = self._resolver.resolve(node.returns, location=location)
+        else:
+            return_annotation = class_name
+            resolved_return = ResolvedType(kind="object", name=class_name)
+
+        # Parse parameters (skip cls for classmethod)
+        parameters = self._parse_parameters(node, file_path, skip_first=True)
+
+        return FunctionMetadata(
+            python_name=node.name,
+            api_name="",  # Constructor has empty API name
+            return_type_annotation=return_annotation,
+            resolved_return_type=resolved_return,
+            parameters=parameters,
+            doc=get_docstring(node),
+            deprecated=None,
+            cache_policy=None,
+            is_check=False,
+            is_async=isinstance(node, ast.AsyncFunctionDef),
+            is_classmethod=True,
+            is_constructor=True,
+            location=location,
+        )
+
+    def _create_default_constructor(
+        self,
+        node: ast.ClassDef,
+        fields: list[FieldMetadata],
+        file_path: Path,
+    ) -> FunctionMetadata:
+        """Create a default constructor from dataclass-style fields."""
+        assert self._resolver is not None
+
+        # Convert fields to constructor parameters
+        parameters: list[ParameterMetadata] = [
+            ParameterMetadata(
+                python_name=field.python_name,
+                api_name=field.api_name,
+                type_annotation=field.type_annotation,
+                resolved_type=field.resolved_type,
+                is_nullable=field.resolved_type.is_optional,
+                has_default=field.has_default,
+                default_value=field.default_value,
+                doc=field.doc,
+                deprecated=field.deprecated,
+                location=field.location,
+            )
+            for field in fields
+            if field.init
+        ]
+
+        return FunctionMetadata(
+            python_name="__init__",
+            api_name="",  # Constructor has empty API name
+            return_type_annotation=node.name,
+            resolved_return_type=ResolvedType(kind="object", name=node.name),
+            parameters=parameters,
+            doc=get_docstring(node),
+            deprecated=None,
+            cache_policy=None,
+            is_check=False,
+            is_async=False,
+            is_classmethod=False,
+            is_constructor=True,
+            location=get_location(node, str(file_path)),
+        )
+
+    def _parse_parameters(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        file_path: Path,
+        skip_first: bool = True,  # Skip 'self' or 'cls'
+    ) -> list[ParameterMetadata]:
+        """Parse function parameters."""
+        assert self._resolver is not None
+
+        parameters: list[ParameterMetadata] = []
+        args = node.args
+
+        # Combine all parameter types
+        all_args = list(args.args)
+        if args.kwonlyargs:
+            all_args.extend(args.kwonlyargs)
+
+        # Get defaults
+        defaults_offset = len(all_args) - len(args.defaults)
+        kw_defaults = {
+            arg.arg: default
+            for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False)
+            if default
+        }
+
+        for i, arg in enumerate(all_args):
+            # Skip self/cls
+            if skip_first and i == 0 and arg.arg in ("self", "cls"):
+                continue
+
+            python_name = arg.arg
+            location = get_location(arg, str(file_path))
+
+            # Get annotation
+            if arg.annotation:
+                annotation = arg.annotation
+                annotation_str = get_annotation_string(annotation)
+
+                # Extract Annotated metadata
+                annotated_meta = extract_annotated_metadata(annotation)
+
+                # Resolve type
+                resolved_type = self._resolver.resolve(annotation, location=location)
+            else:
+                annotation_str = "Any"
+                annotated_meta = None
+                resolved_type = ResolvedType(kind="primitive", name="Any")
+
+            # Get default value
+            has_default = False
+            default_value = None
+
+            # Check positional defaults
+            if i >= defaults_offset and i - defaults_offset < len(args.defaults):
+                has_default = True
+                default_node = args.defaults[i - defaults_offset]
+                default_value = self._eval_constant(default_node)
+
+            # Check keyword-only defaults
+            if arg.arg in kw_defaults:
+                has_default = True
+                default_value = self._eval_constant(kw_defaults[arg.arg])
+
+            # Get API name (from Name() annotation or normalized)
+            api_name = normalize_name(python_name)
+            if annotated_meta and annotated_meta.name:
+                api_name = annotated_meta.name
+
+            # Extract optional metadata values
+            if annotated_meta:
+                meta_doc = annotated_meta.doc
+                meta_ignore = annotated_meta.ignore
+                meta_default_path = annotated_meta.default_path
+                meta_default_addr = annotated_meta.default_address
+                meta_deprecated = annotated_meta.deprecated
+                meta_alt_name = annotated_meta.name
+            else:
+                meta_doc = meta_ignore = meta_default_path = None
+                meta_default_addr = meta_deprecated = meta_alt_name = None
+
+            parameters.append(
+                ParameterMetadata(
+                    python_name=python_name,
+                    api_name=api_name,
+                    type_annotation=annotation_str,
+                    resolved_type=resolved_type,
+                    is_nullable=resolved_type.is_optional,
+                    has_default=has_default,
+                    default_value=self._serialize_default(default_value),
+                    doc=meta_doc,
+                    ignore=meta_ignore,
+                    default_path=meta_default_path,
+                    default_address=meta_default_addr,
+                    deprecated=meta_deprecated,
+                    alt_name=meta_alt_name,
+                    location=location,
+                )
+            )
+
+        return parameters
+
+    def _parse_enum_type(
+        self,
+        node: ast.ClassDef,
+        file_path: Path,
+    ) -> EnumTypeMetadata:
+        """Parse an enum type declaration."""
+        members: list[EnumMemberMetadata] = []
+
+        # Extract enum members
+        for i, item in enumerate(node.body):
+            if isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        member_name = target.id
+                        # Get value
+                        if isinstance(item.value, ast.Constant):
+                            value = str(item.value.value)
+                        else:
+                            value = member_name
+
+                        # Check for docstring following assignment
+                        doc = None
+                        next_idx = i + 1
+                        if next_idx < len(node.body):
+                            next_item = node.body[next_idx]
+                            if (
+                                isinstance(next_item, ast.Expr)
+                                and isinstance(next_item.value, ast.Constant)
+                                and isinstance(next_item.value.value, str)
+                            ):
+                                doc = next_item.value.value.strip()
+
+                        members.append(
+                            EnumMemberMetadata(
+                                name=member_name,
+                                value=value,
+                                doc=doc,
+                            )
+                        )
+
+        return EnumTypeMetadata(
+            name=node.name,
+            doc=get_docstring(node),
+            members=members,
+            location=get_location(node, str(file_path)),
+        )
+
+    def _eval_constant(self, node: ast.expr | None) -> Any:  # noqa: PLR0911, C901
+        """Evaluate a constant expression to a Python value."""
+        if node is None:
+            return None
+
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id == "True":
+                return True
+            if node.id == "False":
+                return False
+            if node.id == "None":
+                return None
+            return node.id  # Return as string
+        if isinstance(node, ast.List):
+            return [self._eval_constant(el) for el in node.elts]
+        if isinstance(node, ast.Tuple):
+            return tuple(self._eval_constant(el) for el in node.elts)
+        if isinstance(node, ast.Dict):
+            return {
+                self._eval_constant(k) if k else None: self._eval_constant(v)
+                for k, v in zip(node.keys, node.values, strict=False)
+            }
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            val = self._eval_constant(node.operand)
+            if isinstance(val, (int, float)):
+                return -val
+
+        # Can't evaluate - return None (will be handled at runtime)
+        return None
+
+    def _serialize_default(self, value: Any) -> Any:
+        """Serialize a default value for JSON storage.
+
+        Complex values that can't be serialized are returned as None.
+        """
+        if value is None:
+            return None
+
+        # Try to serialize to JSON
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            return None
+        else:
+            return value

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -368,8 +368,9 @@ class ModuleParser:
         decorator = find_decorator(node, "function")
         decorator_info = extract_decorator_info(decorator) if decorator else None
 
-        # Check for @check decorator
+        # Check for @check and @generate decorators
         is_check = has_decorator(node, "check")
+        is_generate = has_decorator(node, "generate")
 
         # Extract decorator kwargs
         func_kwargs: dict[str, Any] = {}
@@ -402,6 +403,7 @@ class ModuleParser:
             deprecated=func_kwargs.get("deprecated"),
             cache_policy=func_kwargs.get("cache"),
             is_check=is_check,
+            is_generate=is_generate,
             is_async=isinstance(node, ast.AsyncFunctionDef),
             is_classmethod=is_classmethod(node),
             is_constructor=False,

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -721,9 +721,10 @@ class ModuleParser:
         decorator = find_decorator(node, "function")
         decorator_info = extract_decorator_info(decorator) if decorator else None
 
-        # Check for @check and @generate decorators
+        # Check for decorator flags
         is_check = has_decorator(node, "check")
         is_generate = has_decorator(node, "generate")
+        is_service = has_decorator(node, "up")
 
         # Extract decorator kwargs
         func_kwargs: dict[str, Any] = {}
@@ -757,6 +758,7 @@ class ModuleParser:
             cache_policy=func_kwargs.get("cache"),
             is_check=is_check,
             is_generate=is_generate,
+            is_service=is_service,
             is_async=isinstance(node, ast.AsyncFunctionDef),
             is_classmethod=is_classmethod(node),
             is_constructor=False,

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -369,28 +369,25 @@ class ModuleParser:
         """Parse an @object_type or @interface decorated class."""
         assert self._resolver is not None
 
-        self._resolver.set_current_class(node.name)
+        with self._resolver.in_class(node.name):
+            # Get decorator info for metadata
+            decorator_type = "interface" if is_interface else "object_type"
+            decorator = find_decorator(node, decorator_type)
+            decorator_info = extract_decorator_info(decorator) if decorator else None
 
-        # Get decorator info for metadata
-        decorator_type = "interface" if is_interface else "object_type"
-        decorator = find_decorator(node, decorator_type)
-        decorator_info = extract_decorator_info(decorator) if decorator else None
+            # Extract deprecation
+            deprecated = None
+            if decorator_info and "deprecated" in decorator_info.kwargs:
+                deprecated = decorator_info.kwargs["deprecated"]
 
-        # Extract deprecation
-        deprecated = None
-        if decorator_info and "deprecated" in decorator_info.kwargs:
-            deprecated = decorator_info.kwargs["deprecated"]
+            # Extract fields, functions, and constructor
+            fields, functions, init_params, constructor = self._extract_class_members(
+                node, file_path
+            )
 
-        # Extract fields, functions, and constructor
-        fields, functions, init_params, constructor = self._extract_class_members(
-            node, file_path
-        )
-
-        # Resolve constructor
-        if constructor is None and not is_interface:
-            constructor = self._resolve_constructor(node, file_path, init_params)
-
-        self._resolver.set_current_class(None)
+            # Resolve constructor
+            if constructor is None and not is_interface:
+                constructor = self._resolve_constructor(node, file_path, init_params)
 
         return ObjectTypeMetadata(
             name=node.name,

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -125,6 +125,11 @@ class ModuleParser:
         # ``dagger.field`` from ``dataclasses.field`` when called unqualified.
         self._file_field_origin: dict[Path, str | None] = {}
 
+        # Module-level constants collected for default value resolution.
+        # Initialized here so ``_eval_constant`` can rely on it existing even
+        # when called before ``_collect_module_constants`` has run.
+        self._module_constants: dict[str, ast.expr] = {}
+
     def parse(
         self,
     ) -> tuple[dict[str, ObjectTypeMetadata], dict[str, EnumTypeMetadata]]:
@@ -211,7 +216,6 @@ class ModuleParser:
         This allows resolving references like ``FAVES`` when used as
         default values in function signatures.
         """
-        self._module_constants: dict[str, ast.expr] = {}
         for tree in self._asts.values():
             for node in ast.iter_child_nodes(tree):
                 if isinstance(node, ast.Assign):
@@ -1126,9 +1130,15 @@ class ModuleParser:
             if node.id in name_map:
                 return name_map[node.id]
             # Try resolving module-level constants
-            if hasattr(self, "_module_constants") and node.id in self._module_constants:
+            if node.id in self._module_constants:
                 return self._eval_constant(self._module_constants[node.id])
-            return node.id  # Return as string
+            logger.warning(
+                "Unresolved name %r used in a constant expression at line %d; "
+                "falling back to the literal string.",
+                node.id,
+                getattr(node, "lineno", 0),
+            )
+            return node.id
         if isinstance(node, ast.Attribute):
             # Handle enum member references like Status.INACTIVE → "INACTIVE"
             return node.attr

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -249,34 +249,14 @@ class ModuleParser:
         if decorator_info and "deprecated" in decorator_info.kwargs:
             deprecated = decorator_info.kwargs["deprecated"]
 
-        # Extract fields and functions
-        fields: list[FieldMetadata] = []
-        functions: list[FunctionMetadata] = []
-        constructor: FunctionMetadata | None = None
+        # Extract fields, functions, and constructor
+        fields, functions, init_params, constructor = self._extract_class_members(
+            node, file_path
+        )
 
-        # Track field names for type hints resolution
-        field_annotations: dict[str, ast.expr] = {}
-
-        for item in node.body:
-            # Extract annotated assignments (field declarations)
-            if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
-                field_annotations[item.target.id] = item.annotation
-                field = self._parse_field(item, file_path, node.name)
-                if field is not None:
-                    fields.append(field)
-
-            # Extract methods
-            elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                # Check for @classmethod create() - alternative constructor
-                if item.name == "create" and is_classmethod(item):
-                    constructor = self._parse_constructor(item, file_path, node.name)
-                elif has_decorator(item, "function"):
-                    func = self._parse_function(item, file_path, node.name)
-                    functions.append(func)
-
-        # If no alternative constructor, create one from __init__
+        # Resolve constructor
         if constructor is None and not is_interface:
-            constructor = self._create_default_constructor(node, fields, file_path)
+            constructor = self._resolve_constructor(node, file_path, init_params)
 
         self._resolver.set_current_class(None)
 
@@ -288,6 +268,89 @@ class ModuleParser:
             fields=fields,
             functions=functions,
             constructor=constructor,
+            location=get_location(node, str(file_path)),
+        )
+
+    def _extract_class_members(
+        self,
+        node: ast.ClassDef,
+        file_path: Path,
+    ) -> tuple[
+        list[FieldMetadata],
+        list[FunctionMetadata],
+        list[ParameterMetadata],
+        FunctionMetadata | None,
+    ]:
+        """Extract fields, functions, init params, and constructor from a class body."""
+        fields: list[FieldMetadata] = []
+        functions: list[FunctionMetadata] = []
+        init_params: list[ParameterMetadata] = []
+        constructor: FunctionMetadata | None = None
+
+        for item in node.body:
+            if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                self._process_annotated_assign(
+                    item, file_path, node.name, fields, init_params
+                )
+            elif isinstance(item, ast.Assign):
+                ext_func = self._parse_external_constructor(item, file_path, node.name)
+                if ext_func is not None:
+                    functions.append(ext_func)
+            elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if item.name == "create" and is_classmethod(item):
+                    constructor = self._parse_constructor(item, file_path, node.name)
+                elif has_decorator(item, "function"):
+                    func = self._parse_function(item, file_path, node.name)
+                    functions.append(func)
+
+        return fields, functions, init_params, constructor
+
+    def _process_annotated_assign(
+        self,
+        item: ast.AnnAssign,
+        file_path: Path,
+        class_name: str,
+        fields: list[FieldMetadata],
+        init_params: list[ParameterMetadata],
+    ) -> None:
+        """Process an annotated assignment for both field and constructor param."""
+        is_initvar = self._is_initvar_annotation(item.annotation)
+
+        if not is_initvar:
+            field = self._parse_field(item, file_path, class_name)
+            if field is not None:
+                fields.append(field)
+
+        param = self._parse_class_assignment_as_param(
+            item, file_path, class_name, is_initvar=is_initvar
+        )
+        if param is not None:
+            init_params.append(param)
+
+    def _resolve_constructor(
+        self,
+        node: ast.ClassDef,
+        file_path: Path,
+        init_params: list[ParameterMetadata],
+    ) -> FunctionMetadata:
+        """Resolve the constructor: inherited or default from init params."""
+        inherited = self._find_inherited_constructor(node, file_path)
+        if inherited is not None:
+            return inherited
+
+        return FunctionMetadata(
+            python_name="__init__",
+            api_name="",
+            return_type_annotation=node.name,
+            resolved_return_type=ResolvedType(kind="object", name=node.name),
+            parameters=init_params,
+            doc=get_docstring(node),
+            deprecated=None,
+            cache_policy=None,
+            is_check=False,
+            is_async=False,
+            is_classmethod=False,
+            is_constructor=True,
             location=get_location(node, str(file_path)),
         )
 
@@ -341,6 +404,10 @@ class ModuleParser:
         # Get default value
         has_default = "default" in field_kwargs or "default_factory" in field_kwargs
         default_value = field_kwargs.get("default")
+        if default_value is None and "default_factory" in field_kwargs:
+            # default_factory is a callable; use its result as the default
+            # (e.g., default_factory=list → [])
+            default_value = field_kwargs["default_factory"]
 
         return FieldMetadata(
             python_name=python_name,
@@ -354,6 +421,240 @@ class ModuleParser:
             doc=annotated_meta.doc,
             location=location,
         )
+
+    def _is_initvar_annotation(self, annotation: ast.expr) -> bool:
+        """Check if annotation is ``dataclasses.InitVar[T]`` or ``InitVar[T]``."""
+        if not isinstance(annotation, ast.Subscript):
+            return False
+        value = annotation.value
+        if isinstance(value, ast.Attribute):
+            return value.attr == "InitVar"
+        return isinstance(value, ast.Name) and value.id == "InitVar"
+
+    def _unwrap_initvar(self, annotation: ast.expr) -> ast.expr:
+        """Unwrap InitVar[T] to get the inner type T."""
+        if self._is_initvar_annotation(annotation):
+            return annotation.slice  # type: ignore[return-value]
+        return annotation
+
+    def _parse_class_assignment_as_param(
+        self,
+        node: ast.AnnAssign,
+        file_path: Path,
+        class_name: str,
+        *,
+        is_initvar: bool = False,
+    ) -> ParameterMetadata | None:
+        """Parse an annotated class assignment as a potential constructor parameter.
+
+        Handles all class-level annotated assignments including:
+        - dagger.field() with init=True (default)
+        - dataclasses.InitVar[T] declarations
+        - Simple annotated assignments (e.g., name: str = "default")
+
+        Returns None if the assignment has init=False.
+        """
+        assert self._resolver is not None
+        assert isinstance(node.target, ast.Name)
+
+        python_name = node.target.id
+
+        # Get effective annotation (unwrap InitVar if needed)
+        annotation = (
+            self._unwrap_initvar(node.annotation) if is_initvar else node.annotation
+        )
+
+        # Determine init eligibility and default value
+        has_default = False
+        default_value = None
+
+        if node.value is not None:
+            if isinstance(node.value, ast.Call):
+                # Extract kwargs from any field-like call
+                call_kwargs: dict[str, Any] = {}
+                for keyword in node.value.keywords:
+                    if keyword.arg is not None:
+                        call_kwargs[keyword.arg] = self._eval_constant(keyword.value)
+
+                # If init=False, this is not a constructor parameter
+                if call_kwargs.get("init") is False:
+                    return None
+
+                # Extract default value from the call
+                if "default" in call_kwargs:
+                    has_default = True
+                    default_value = call_kwargs["default"]
+                elif "default_factory" in call_kwargs:
+                    has_default = True
+                    default_value = call_kwargs["default_factory"]
+            else:
+                # Simple expression as default value
+                has_default = True
+                default_value = self._eval_constant(node.value)
+
+        # Resolve type
+        location = get_location(node, str(file_path))
+        resolved_type = self._resolver.resolve(annotation, location=location)
+
+        # Extract Annotated metadata
+        annotated_meta = extract_annotated_metadata(annotation)
+
+        # Build parameter
+        api_name = normalize_name(python_name)
+        if annotated_meta and annotated_meta.name:
+            api_name = annotated_meta.name
+
+        return ParameterMetadata(
+            python_name=python_name,
+            api_name=api_name,
+            type_annotation=get_annotation_string(annotation),
+            resolved_type=resolved_type,
+            is_nullable=resolved_type.is_optional,
+            has_default=has_default,
+            default_value=(
+                self._serialize_default(default_value) if has_default else None
+            ),
+            doc=annotated_meta.doc if annotated_meta else None,
+            ignore=annotated_meta.ignore if annotated_meta else None,
+            default_path=annotated_meta.default_path if annotated_meta else None,
+            default_address=annotated_meta.default_address if annotated_meta else None,
+            deprecated=annotated_meta.deprecated if annotated_meta else None,
+            alt_name=annotated_meta.name if annotated_meta else None,
+            location=location,
+        )
+
+    def _parse_external_constructor(
+        self,
+        node: ast.Assign,
+        file_path: Path,
+        class_name: str,
+    ) -> FunctionMetadata | None:
+        """Parse external constructor pattern: ``name = function(ClassName)``.
+
+        Handles:
+        - ``external = function(External)``
+        - ``alternative = function(doc="...")(External)``
+        """
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            return None
+
+        call_node = node.value
+        if not isinstance(call_node, ast.Call):
+            return None
+
+        match = self._match_function_constructor(call_node)
+        if match is None:
+            return None
+        target_class_name, func_kwargs = match
+
+        target_obj = self._objects.get(target_class_name)
+        if target_obj is None:
+            return None
+
+        ctor = target_obj.constructor
+        doc = func_kwargs.get("doc")
+        if doc is None and ctor:
+            doc = ctor.doc
+        if doc is None:
+            doc = target_obj.doc
+
+        return FunctionMetadata(
+            python_name=node.targets[0].id,
+            api_name=normalize_name(node.targets[0].id),
+            return_type_annotation=target_class_name,
+            resolved_return_type=ResolvedType(kind="object", name=target_class_name),
+            parameters=list(ctor.parameters) if ctor else [],
+            doc=doc,
+            deprecated=func_kwargs.get("deprecated"),
+            cache_policy=func_kwargs.get("cache"),
+            is_check=False,
+            is_async=False,
+            is_classmethod=False,
+            is_constructor=False,
+            location=get_location(node, str(file_path)),
+        )
+
+    def _match_function_constructor(
+        self,
+        call_node: ast.Call,
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Match ``function(Cls)`` or ``function(doc="...")(Cls)`` patterns.
+
+        Returns (target_class_name, kwargs) or None.
+        """
+        if self._is_function_ref(call_node.func):
+            return self._extract_function_call_target(call_node, call_node)
+        if (
+            isinstance(call_node.func, ast.Call)
+            and self._is_function_ref(call_node.func.func)
+            and call_node.args
+            and isinstance(call_node.args[0], ast.Name)
+        ):
+            return self._extract_function_call_target(call_node, call_node.func)
+        return None
+
+    def _extract_function_call_target(
+        self,
+        args_node: ast.Call,
+        kwargs_node: ast.Call,
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Extract target class name and kwargs from a function() call."""
+        if not args_node.args or not isinstance(args_node.args[0], ast.Name):
+            return None
+        target = args_node.args[0].id
+        kwargs: dict[str, Any] = {}
+        for kw in kwargs_node.keywords:
+            if kw.arg is not None:
+                kwargs[kw.arg] = self._eval_constant(kw.value)
+        return target, kwargs
+
+    def _is_function_ref(self, node: ast.expr) -> bool:
+        """Check if a node references 'function' or 'dagger.function'."""
+        if isinstance(node, ast.Name):
+            return node.id == "function"
+        if isinstance(node, ast.Attribute):
+            return node.attr == "function"
+        return False
+
+    def _find_inherited_constructor(
+        self,
+        node: ast.ClassDef,
+        file_path: Path,
+    ) -> FunctionMetadata | None:
+        """Look for an alternative constructor (create classmethod) in base classes."""
+        for base in node.bases:
+            base_name = None
+            if isinstance(base, ast.Name):
+                base_name = base.id
+            elif isinstance(base, ast.Attribute):
+                base_name = base.attr
+
+            if base_name is None:
+                continue
+
+            # Search for the base class definition in all parsed ASTs
+            base_class = self._find_class_def(base_name)
+            if base_class is None:
+                continue
+
+            # Check for create classmethod in the base class
+            for item in base_class.body:
+                if (
+                    isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and item.name == "create"
+                    and is_classmethod(item)
+                ):
+                    return self._parse_constructor(item, file_path, node.name)
+
+        return None
+
+    def _find_class_def(self, class_name: str) -> ast.ClassDef | None:
+        """Find a class definition by name in all parsed ASTs."""
+        for tree in self._asts.values():
+            for ast_node in ast.iter_child_nodes(tree):
+                if isinstance(ast_node, ast.ClassDef) and ast_node.name == class_name:
+                    return ast_node
+        return None
 
     def _parse_function(
         self,
@@ -446,49 +747,6 @@ class ModuleParser:
             is_classmethod=True,
             is_constructor=True,
             location=location,
-        )
-
-    def _create_default_constructor(
-        self,
-        node: ast.ClassDef,
-        fields: list[FieldMetadata],
-        file_path: Path,
-    ) -> FunctionMetadata:
-        """Create a default constructor from dataclass-style fields."""
-        assert self._resolver is not None
-
-        # Convert fields to constructor parameters
-        parameters: list[ParameterMetadata] = [
-            ParameterMetadata(
-                python_name=field.python_name,
-                api_name=field.api_name,
-                type_annotation=field.type_annotation,
-                resolved_type=field.resolved_type,
-                is_nullable=field.resolved_type.is_optional,
-                has_default=field.has_default,
-                default_value=field.default_value,
-                doc=field.doc,
-                deprecated=field.deprecated,
-                location=field.location,
-            )
-            for field in fields
-            if field.init
-        ]
-
-        return FunctionMetadata(
-            python_name="__init__",
-            api_name="",  # Constructor has empty API name
-            return_type_annotation=node.name,
-            resolved_return_type=ResolvedType(kind="object", name=node.name),
-            parameters=parameters,
-            doc=get_docstring(node),
-            deprecated=None,
-            cache_policy=None,
-            is_check=False,
-            is_async=False,
-            is_classmethod=False,
-            is_constructor=True,
-            location=get_location(node, str(file_path)),
         )
 
     def _parse_parameters(
@@ -641,7 +899,7 @@ class ModuleParser:
             location=get_location(node, str(file_path)),
         )
 
-    def _eval_constant(self, node: ast.expr | None) -> Any:  # noqa: PLR0911, C901
+    def _eval_constant(self, node: ast.expr | None) -> Any:  # noqa: PLR0911
         """Evaluate a constant expression to a Python value."""
         if node is None:
             return None
@@ -649,12 +907,16 @@ class ModuleParser:
         if isinstance(node, ast.Constant):
             return node.value
         if isinstance(node, ast.Name):
-            if node.id == "True":
-                return True
-            if node.id == "False":
-                return False
-            if node.id == "None":
-                return None
+            name_map = {
+                "True": True,
+                "False": False,
+                "None": None,
+                # Callable defaults used as default_factory in fields
+                "list": [],
+                "dict": {},
+            }
+            if node.id in name_map:
+                return name_map[node.id]
             return node.id  # Return as string
         if isinstance(node, ast.List):
             return [self._eval_constant(el) for el in node.elts]

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -331,6 +331,8 @@ class ModuleParser:
 
         for item in node.body:
             if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                if self._is_non_field_annotation(item.annotation):
+                    continue
                 self._process_annotated_assign(
                     item, file_path, node.name, fields, init_params
                 )
@@ -482,6 +484,27 @@ class ModuleParser:
         if isinstance(value, ast.Attribute):
             return value.attr == "InitVar"
         return isinstance(value, ast.Name) and value.id == "InitVar"
+
+    def _is_non_field_annotation(self, annotation: ast.expr) -> bool:
+        """True for annotations that don't declare a field or init parameter.
+
+        Covers ``ClassVar[...]`` and ``Final[...]`` (plus ``typing.`` prefixed
+        forms). These mark class-level constants, not Dagger fields.
+        """
+        names = {"ClassVar", "Final"}
+
+        def _matches(node: ast.expr) -> bool:
+            if isinstance(node, ast.Name):
+                return node.id in names
+            if isinstance(node, ast.Attribute):
+                return node.attr in names
+            return False
+
+        if _matches(annotation):
+            return True
+        if isinstance(annotation, ast.Subscript) and _matches(annotation.value):
+            return True
+        return False
 
     def _unwrap_initvar(self, annotation: ast.expr) -> ast.expr:
         """Unwrap InitVar[T] to get the inner type T."""

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,8 @@ from dagger.mod._analyzer.visitors.decorators import (
     has_decorator,
     is_classmethod,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_name(name: str) -> str:
@@ -943,8 +946,16 @@ class ModuleParser:
         }
 
         for i, arg in enumerate(all_args):
-            # Skip self/cls
-            if skip_first and i == 0 and arg.arg in ("self", "cls"):
+            # Skip the receiver (first positional) of a method/classmethod.
+            # Don't key this on the name — some users write ``this``/``mcs``,
+            # and the receiver should never leak into the Dagger API schema.
+            if skip_first and i == 0 and positional_args:
+                if arg.arg not in ("self", "cls"):
+                    logger.warning(
+                        "First parameter of method is named %r (expected "
+                        "'self' or 'cls'); skipping it as the receiver.",
+                        arg.arg,
+                    )
                 continue
 
             python_name = arg.arg

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -143,9 +143,7 @@ class ModuleParser:
         # Deferred external-constructor declarations, resolved in a second
         # pass after every class has been parsed so the lookup does not
         # depend on file/class iteration order.
-        self._pending_external_constructors: list[
-            tuple[str, ast.Assign, Path]
-        ] = []
+        self._pending_external_constructors: list[tuple[str, ast.Assign, Path]] = []
 
     def parse(
         self,
@@ -296,9 +294,7 @@ class ModuleParser:
                             module, alias.name, alias.asname
                         )
 
-    _NON_DAGGER_FIELD_MODULES = frozenset(
-        {"dataclasses", "attrs", "attr", "pydantic"}
-    )
+    _NON_DAGGER_FIELD_MODULES = frozenset({"dataclasses", "attrs", "attr", "pydantic"})
 
     def _bare_field_is_dagger(self, file_path: Path) -> bool:
         """Return True when bare ``field`` in a file refers to dagger.field.

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -125,10 +125,14 @@ class ModuleParser:
         # ``dagger.field`` from ``dataclasses.field`` when called unqualified.
         self._file_field_origin: dict[Path, str | None] = {}
 
-        # Module-level constants collected for default value resolution.
+        # Module-level constants per source file, keyed by (file, name).
         # Initialized here so ``_eval_constant`` can rely on it existing even
         # when called before ``_collect_module_constants`` has run.
-        self._module_constants: dict[str, ast.expr] = {}
+        self._module_constants: dict[Path, dict[str, ast.expr]] = {}
+
+        # File currently being extracted. Set by ``_extract_declarations`` so
+        # ``_eval_constant`` can scope name lookups to the containing file.
+        self._current_file: Path | None = None
 
     def parse(
         self,
@@ -214,20 +218,23 @@ class ModuleParser:
         """Collect module-level constant assignments for default value resolution.
 
         This allows resolving references like ``FAVES`` when used as
-        default values in function signatures.
+        default values in function signatures. Constants are scoped per
+        file so two files defining ``DEFAULT = ...`` with different values
+        don't silently overwrite one another.
         """
-        for tree in self._asts.values():
+        for file_path, tree in self._asts.items():
+            constants = self._module_constants.setdefault(file_path, {})
             for node in ast.iter_child_nodes(tree):
                 if isinstance(node, ast.Assign):
                     for target in node.targets:
                         if isinstance(target, ast.Name):
-                            self._module_constants[target.id] = node.value
+                            constants[target.id] = node.value
                 elif (
                     isinstance(node, ast.AnnAssign)
                     and isinstance(node.target, ast.Name)
                     and node.value is not None
                 ):
-                    self._module_constants[node.target.id] = node.value
+                    constants[node.target.id] = node.value
 
     def _build_namespace(self) -> None:
         """Build the namespace for type resolution."""
@@ -310,9 +317,13 @@ class ModuleParser:
     def _extract_declarations(self) -> None:
         """Extract full declarations from all ASTs."""
         for file_path, tree in self._asts.items():
-            for node in ast.iter_child_nodes(tree):
-                if isinstance(node, ast.ClassDef):
-                    self._extract_class(node, file_path)
+            self._current_file = file_path
+            try:
+                for node in ast.iter_child_nodes(tree):
+                    if isinstance(node, ast.ClassDef):
+                        self._extract_class(node, file_path)
+            finally:
+                self._current_file = None
 
     def _extract_class(self, node: ast.ClassDef, file_path: Path) -> None:
         """Extract a class declaration."""
@@ -1129,9 +1140,14 @@ class ModuleParser:
             }
             if node.id in name_map:
                 return name_map[node.id]
-            # Try resolving module-level constants
-            if node.id in self._module_constants:
-                return self._eval_constant(self._module_constants[node.id])
+            # Try resolving module-level constants (scoped to current file)
+            file_constants = (
+                self._module_constants.get(self._current_file, {})
+                if self._current_file is not None
+                else {}
+            )
+            if node.id in file_constants:
+                return self._eval_constant(file_constants[node.id])
             logger.warning(
                 "Unresolved name %r used in a constant expression at line %d; "
                 "falling back to the literal string.",

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -118,6 +118,10 @@ class ModuleParser:
         self._declared_enums: set[str] = set()
         self._declared_interfaces: set[str] = set()
 
+        # Per-file origin of the bare name ``field``; used to disambiguate
+        # ``dagger.field`` from ``dataclasses.field`` when called unqualified.
+        self._file_field_origin: dict[Path, str | None] = {}
+
     def parse(
         self,
     ) -> tuple[dict[str, ObjectTypeMetadata], dict[str, EnumTypeMetadata]]:
@@ -135,6 +139,9 @@ class ModuleParser:
 
         # Phase 2.5: Collect module-level constants for default resolution
         self._collect_module_constants()
+
+        # Record per-file origin of the unqualified ``field`` name.
+        self._track_field_origins()
 
         # Phase 3: Build namespace and resolver
         self._build_namespace()
@@ -252,6 +259,46 @@ class ModuleParser:
                         self._namespace.add_from_import(
                             module, alias.name, alias.asname
                         )
+
+    _NON_DAGGER_FIELD_MODULES = frozenset(
+        {"dataclasses", "attrs", "attr", "pydantic"}
+    )
+
+    def _bare_field_is_dagger(self, file_path: Path) -> bool:
+        """Return True when bare ``field`` in a file refers to dagger.field.
+
+        Defaults to True (dagger) when no import of ``field`` is found in the
+        file: that matches the common pattern of importing ``dagger`` as a
+        module and using ``dagger.field(...)`` elsewhere while declaring
+        ``field: Something = field()`` inline. Falls back to False only when
+        the file explicitly imports ``field`` from a non-dagger module.
+        """
+        origin = self._file_field_origin.get(file_path)
+        if origin is None:
+            return True
+        top = origin.split(".", 1)[0]
+        return top not in self._NON_DAGGER_FIELD_MODULES
+
+    def _track_field_origins(self) -> None:
+        """Record which module the unqualified ``field`` name came from.
+
+        A file that does ``from dataclasses import field`` (or from attrs,
+        pydantic, etc.) must not treat ``field(...)`` calls as dagger.field.
+        """
+        for file_path, tree in self._asts.items():
+            origin: str | None = None
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                module = node.module or ""
+                for alias in node.names:
+                    bound = alias.asname or alias.name
+                    if bound == "field":
+                        origin = module
+                        break
+                if origin is not None:
+                    break
+            self._file_field_origin[file_path] = origin
 
     def _extract_declarations(self) -> None:
         """Extract full declarations from all ASTs."""
@@ -434,7 +481,11 @@ class ModuleParser:
             func = node.value.func
             # Check for field(), dagger.field(), mod.field()
             # but NOT dataclasses.field() or other non-dagger field() calls
-            is_name_field = isinstance(func, ast.Name) and func.id == "field"
+            is_name_field = (
+                isinstance(func, ast.Name)
+                and func.id == "field"
+                and self._bare_field_is_dagger(file_path)
+            )
             is_attr_field = (
                 isinstance(func, ast.Attribute)
                 and func.attr == "field"

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -605,9 +605,7 @@ class ModuleParser:
 
         if _matches(annotation):
             return True
-        if isinstance(annotation, ast.Subscript) and _matches(annotation.value):
-            return True
-        return False
+        return isinstance(annotation, ast.Subscript) and _matches(annotation.value)
 
     def _unwrap_initvar(self, annotation: ast.expr) -> ast.expr:
         """Unwrap InitVar[T] to get the inner type T."""

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -847,13 +847,12 @@ class ModuleParser:
         parameters: list[ParameterMetadata] = []
         args = node.args
 
-        # Combine all parameter types
-        all_args = list(args.args)
-        if args.kwonlyargs:
-            all_args.extend(args.kwonlyargs)
+        # Positional-only come before regular positional; defaults in args.defaults
+        # are right-aligned against the combined sequence.
+        positional_args = list(args.posonlyargs) + list(args.args)
+        all_args = positional_args + list(args.kwonlyargs)
 
-        # Get defaults
-        defaults_offset = len(args.args) - len(args.defaults)
+        defaults_offset = len(positional_args) - len(args.defaults)
         kw_defaults = {
             arg.arg: default
             for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False)

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -855,7 +855,7 @@ class ModuleParser:
         kw_defaults = {
             arg.arg: default
             for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False)
-            if default
+            if default is not None
         }
 
         for i, arg in enumerate(all_args):

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -134,6 +134,13 @@ class ModuleParser:
         # ``_eval_constant`` can scope name lookups to the containing file.
         self._current_file: Path | None = None
 
+        # Deferred external-constructor declarations, resolved in a second
+        # pass after every class has been parsed so the lookup does not
+        # depend on file/class iteration order.
+        self._pending_external_constructors: list[
+            tuple[str, ast.Assign, Path]
+        ] = []
+
     def parse(
         self,
     ) -> tuple[dict[str, ObjectTypeMetadata], dict[str, EnumTypeMetadata]]:
@@ -161,6 +168,9 @@ class ModuleParser:
         # Phase 4: Extract full declarations
         self._extract_declarations()
 
+        # Phase 5: Resolve external constructors once every class is known
+        self._resolve_external_constructors()
+
         return self._objects, self._enums
 
     def _parse_files(self) -> None:
@@ -183,18 +193,24 @@ class ModuleParser:
                 raise ParseError(msg) from e
 
     def _collect_declaration_names(self) -> None:
-        """Collect names of decorated classes for forward reference resolution."""
+        """Collect names of decorated top-level classes for forward references.
+
+        Only considers top-level classes: the module's public API surface lives
+        at module scope, and ``_extract_declarations`` is also top-level-only.
+        Previously this phase used ``ast.walk`` and would register nested
+        decorated classes that were never actually emitted as metadata,
+        leaving dangling type references.
+        """
         for tree in self._asts.values():
-            for node in ast.walk(tree):
-                if isinstance(node, ast.ClassDef):
-                    if has_decorator(node, "object_type"):
-                        self._declared_objects.add(node.name)
-                    elif has_decorator(node, "interface"):
-                        self._declared_interfaces.add(node.name)
-                    elif has_decorator(node, "enum_type") or self._is_enum_subclass(
-                        node
-                    ):
-                        self._declared_enums.add(node.name)
+            for node in ast.iter_child_nodes(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                if has_decorator(node, "object_type"):
+                    self._declared_objects.add(node.name)
+                elif has_decorator(node, "interface"):
+                    self._declared_interfaces.add(node.name)
+                elif has_decorator(node, "enum_type") or self._is_enum_subclass(node):
+                    self._declared_enums.add(node.name)
 
     _ENUM_BASE_NAMES = frozenset(
         {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum"}
@@ -411,9 +427,13 @@ class ModuleParser:
                     item, file_path, node.name, fields, init_params
                 )
             elif isinstance(item, ast.Assign):
-                ext_func = self._parse_external_constructor(item, file_path, node.name)
-                if ext_func is not None:
-                    functions.append(ext_func)
+                # Only defer assignments that look like external-constructor
+                # declarations. Everything else (plain class-level constants)
+                # is ignored at class scope.
+                if self._looks_like_external_constructor(item):
+                    self._pending_external_constructors.append(
+                        (node.name, item, file_path)
+                    )
             elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 if item.name == "create" and is_classmethod(item):
                     constructor = self._parse_constructor(item, file_path, node.name)
@@ -675,6 +695,53 @@ class ModuleParser:
             alt_name=annotated_meta.name if annotated_meta else None,
             location=location,
         )
+
+    def _looks_like_external_constructor(self, node: ast.Assign) -> bool:
+        """Cheap pre-check for ``name = function(...)`` shape at class scope."""
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            return False
+        return isinstance(node.value, ast.Call)
+
+    def _resolve_external_constructors(self) -> None:
+        """Resolve deferred external-constructor declarations.
+
+        Runs after every class has been parsed, so a ``foo = function(Bar)``
+        in class A can reference a class Bar declared later in the file or
+        in a different source file without depending on iteration order.
+        """
+        for class_name, assign_node, file_path in self._pending_external_constructors:
+            owner = self._objects.get(class_name)
+            if owner is None:
+                continue
+            self._current_file = file_path
+            try:
+                func = self._parse_external_constructor(
+                    assign_node, file_path, class_name
+                )
+            finally:
+                self._current_file = None
+            if func is None:
+                target_name = self._external_constructor_target(assign_node)
+                logger.warning(
+                    "External constructor %r in %r references unknown target "
+                    "%r; skipping (is the target decorated with @object_type?).",
+                    assign_node.targets[0].id
+                    if isinstance(assign_node.targets[0], ast.Name)
+                    else "?",
+                    class_name,
+                    target_name or "?",
+                )
+                continue
+            owner.functions.append(func)
+
+    def _external_constructor_target(self, node: ast.Assign) -> str | None:
+        """Best-effort extraction of the target class name for logging."""
+        if not isinstance(node.value, ast.Call):
+            return None
+        match = self._match_function_constructor(node.value)
+        if match is None:
+            return None
+        return match[0]
 
     def _parse_external_constructor(
         self,

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -74,9 +74,15 @@ def get_docstring(
 def _parse_docstring_deprecated(raw_doc: str) -> tuple[str | None, str | None]:
     """Parse a docstring that may contain a ``.. deprecated::`` directive.
 
-    Returns (doc, deprecated) where:
-    - doc is the non-deprecated portion (or None if only deprecation)
-    - deprecated is the deprecation message (or None if not deprecated)
+    Returns ``(doc, deprecated)`` with three-state semantics for
+    ``deprecated``:
+
+    - ``None`` when the docstring has no ``.. deprecated::`` directive.
+    - ``""`` when the directive is present but carries no message.
+    - The stripped message otherwise.
+
+    ``doc`` is the non-deprecated portion of the docstring (or None if
+    only the deprecation directive was present).
     """
     import re
 
@@ -554,8 +560,10 @@ class ModuleParser:
         has_default = "default" in field_kwargs or "default_factory" in field_kwargs
         default_value = field_kwargs.get("default")
         if default_value is None and "default_factory" in field_kwargs:
-            # default_factory is a callable; use its result as the default
-            # (e.g., default_factory=list → [])
+            # We don't invoke the factory; whatever _eval_constant returned
+            # becomes the static default. The name_map hard-codes list → []
+            # and dict → {}; other factories fall through to None and the
+            # parameter is registered as optional-without-default.
             default_value = field_kwargs["default_factory"]
 
         return FieldMetadata(

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -177,12 +177,21 @@ class ModuleParser:
                     ):
                         self._declared_enums.add(node.name)
 
+    _ENUM_BASE_NAMES = frozenset(
+        {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum"}
+    )
+
     def _is_enum_subclass(self, node: ast.ClassDef) -> bool:
-        """Check if a class inherits from enum.Enum."""
+        """Check if a class inherits from a stdlib enum base.
+
+        Covers ``Enum`` as well as ``IntEnum``, ``StrEnum``, ``Flag``,
+        ``IntFlag`` and ``ReprEnum`` (all valid Dagger enum shapes),
+        whether imported bare or via ``enum.``.
+        """
         for base in node.bases:
-            if isinstance(base, ast.Attribute) and base.attr == "Enum":
+            if isinstance(base, ast.Attribute) and base.attr in self._ENUM_BASE_NAMES:
                 return True
-            if isinstance(base, ast.Name) and base.id == "Enum":
+            if isinstance(base, ast.Name) and base.id in self._ENUM_BASE_NAMES:
                 return True
         return False
 

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -68,6 +68,25 @@ def get_docstring(
     return ast.get_docstring(node)
 
 
+def _parse_docstring_deprecated(raw_doc: str) -> tuple[str | None, str | None]:
+    """Parse a docstring that may contain a ``.. deprecated::`` directive.
+
+    Returns (doc, deprecated) where:
+    - doc is the non-deprecated portion (or None if only deprecation)
+    - deprecated is the deprecation message (or None if not deprecated)
+    """
+    import re
+
+    match = re.search(r"\.\.\s+deprecated::\s*(.*)", raw_doc, re.IGNORECASE)
+    if not match:
+        return raw_doc, None
+
+    deprecated_msg = match.group(1).strip()
+    # Get the doc portion before the deprecated directive
+    doc_part = raw_doc[: match.start()].strip()
+    return doc_part or None, deprecated_msg or ""
+
+
 class ModuleParser:
     """Parser for extracting declarations from Python source files.
 
@@ -113,6 +132,9 @@ class ModuleParser:
 
         # Phase 2: Collect declaration names (for forward references)
         self._collect_declaration_names()
+
+        # Phase 2.5: Collect module-level constants for default resolution
+        self._collect_module_constants()
 
         # Phase 3: Build namespace and resolver
         self._build_namespace()
@@ -163,6 +185,26 @@ class ModuleParser:
             if isinstance(base, ast.Name) and base.id == "Enum":
                 return True
         return False
+
+    def _collect_module_constants(self) -> None:
+        """Collect module-level constant assignments for default value resolution.
+
+        This allows resolving references like ``FAVES`` when used as
+        default values in function signatures.
+        """
+        self._module_constants: dict[str, ast.expr] = {}
+        for tree in self._asts.values():
+            for node in ast.iter_child_nodes(tree):
+                if isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            self._module_constants[target.id] = node.value
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.value is not None
+                ):
+                    self._module_constants[node.target.id] = node.value
 
     def _build_namespace(self) -> None:
         """Build the namespace for type resolution."""
@@ -299,6 +341,10 @@ class ModuleParser:
             elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 if item.name == "create" and is_classmethod(item):
                     constructor = self._parse_constructor(item, file_path, node.name)
+                elif item.name == "__init__":
+                    constructor = self._parse_init_constructor(
+                        item, file_path, node.name
+                    )
                 elif has_decorator(item, "function"):
                     func = self._parse_function(item, file_path, node.name)
                     functions.append(func)
@@ -376,8 +422,14 @@ class ModuleParser:
         if node.value is not None and isinstance(node.value, ast.Call):
             func = node.value.func
             # Check for field(), dagger.field(), mod.field()
+            # but NOT dataclasses.field() or other non-dagger field() calls
             is_name_field = isinstance(func, ast.Name) and func.id == "field"
-            is_attr_field = isinstance(func, ast.Attribute) and func.attr == "field"
+            is_attr_field = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "field"
+                and isinstance(func.value, ast.Name)
+                and func.value.id not in ("dataclasses", "attrs", "attr", "pydantic")
+            )
             is_field_call = is_name_field or is_attr_field
 
             if is_field_call:
@@ -749,6 +801,38 @@ class ModuleParser:
             location=location,
         )
 
+    def _parse_init_constructor(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        file_path: Path,
+        class_name: str,
+    ) -> FunctionMetadata:
+        """Parse an explicit __init__ method as a constructor.
+
+        When __init__ is defined explicitly, its parameters override
+        the auto-generated parameters from field declarations.
+        """
+        location = get_location(node, str(file_path))
+
+        # Parse parameters (skip self)
+        parameters = self._parse_parameters(node, file_path, skip_first=True)
+
+        return FunctionMetadata(
+            python_name="__init__",
+            api_name="",
+            return_type_annotation=class_name,
+            resolved_return_type=ResolvedType(kind="object", name=class_name),
+            parameters=parameters,
+            doc=get_docstring(node),
+            deprecated=None,
+            cache_policy=None,
+            is_check=False,
+            is_async=False,
+            is_classmethod=False,
+            is_constructor=True,
+            location=location,
+        )
+
     def _parse_parameters(
         self,
         node: ast.FunctionDef | ast.AsyncFunctionDef,
@@ -866,14 +950,13 @@ class ModuleParser:
                 for target in item.targets:
                     if isinstance(target, ast.Name):
                         member_name = target.id
-                        # Get value
-                        if isinstance(item.value, ast.Constant):
-                            value = str(item.value.value)
-                        else:
-                            value = member_name
+                        value, inline_doc = self._extract_enum_member_value(
+                            item.value, member_name
+                        )
 
                         # Check for docstring following assignment
-                        doc = None
+                        doc = inline_doc
+                        deprecated = None
                         next_idx = i + 1
                         if next_idx < len(node.body):
                             next_item = node.body[next_idx]
@@ -882,13 +965,15 @@ class ModuleParser:
                                 and isinstance(next_item.value, ast.Constant)
                                 and isinstance(next_item.value.value, str)
                             ):
-                                doc = next_item.value.value.strip()
+                                raw_doc = next_item.value.value.strip()
+                                doc, deprecated = _parse_docstring_deprecated(raw_doc)
 
                         members.append(
                             EnumMemberMetadata(
                                 name=member_name,
                                 value=value,
                                 doc=doc,
+                                deprecated=deprecated,
                             )
                         )
 
@@ -899,7 +984,35 @@ class ModuleParser:
             location=get_location(node, str(file_path)),
         )
 
-    def _eval_constant(self, node: ast.expr | None) -> Any:  # noqa: PLR0911
+    def _extract_enum_member_value(
+        self,
+        value_node: ast.expr,
+        member_name: str,
+    ) -> tuple[str, str | None]:
+        """Extract value and optional inline doc from an enum member assignment.
+
+        Handles:
+        - Simple string: ``ACTIVE = "ACTIVE value"`` → ("ACTIVE value", None)
+        - Tuple (legacy): ``ACTIVE = "here", "doc"`` → ("here", "doc")
+        - Other: uses member name as value
+        """
+        if isinstance(value_node, ast.Constant):
+            return str(value_node.value), None
+
+        # Legacy dagger.Enum pattern: MEMBER = "value", "description"
+        if isinstance(value_node, ast.Tuple) and len(value_node.elts) >= 1:
+            first = value_node.elts[0]
+            value = str(first.value) if isinstance(first, ast.Constant) else member_name
+            doc = None
+            if len(value_node.elts) > 1:
+                second = value_node.elts[1]
+                if isinstance(second, ast.Constant) and isinstance(second.value, str):
+                    doc = second.value
+            return value, doc
+
+        return member_name, None
+
+    def _eval_constant(self, node: ast.expr | None) -> Any:  # noqa: PLR0911, C901
         """Evaluate a constant expression to a Python value."""
         if node is None:
             return None
@@ -917,7 +1030,13 @@ class ModuleParser:
             }
             if node.id in name_map:
                 return name_map[node.id]
+            # Try resolving module-level constants
+            if hasattr(self, "_module_constants") and node.id in self._module_constants:
+                return self._eval_constant(self._module_constants[node.id])
             return node.id  # Return as string
+        if isinstance(node, ast.Attribute):
+            # Handle enum member references like Status.INACTIVE → "INACTIVE"
+            return node.attr
         if isinstance(node, ast.List):
             return [self._eval_constant(el) for el in node.elts]
         if isinstance(node, ast.Tuple):

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -567,7 +567,7 @@ class ModuleParser:
             type_annotation=get_annotation_string(node.annotation),
             resolved_type=resolved_type,
             has_default=has_default,
-            default_value=self._serialize_default(default_value),
+            default_value=self._serialize_default(default_value, name=python_name),
             deprecated=field_kwargs.get("deprecated"),
             init=field_kwargs.get("init", True),
             doc=annotated_meta.doc,
@@ -685,7 +685,9 @@ class ModuleParser:
             is_nullable=resolved_type.is_optional,
             has_default=has_default,
             default_value=(
-                self._serialize_default(default_value) if has_default else None
+                self._serialize_default(default_value, name=python_name)
+                if has_default
+                else None
             ),
             doc=annotated_meta.doc if annotated_meta else None,
             ignore=annotated_meta.ignore if annotated_meta else None,
@@ -1099,7 +1101,9 @@ class ModuleParser:
                     is_nullable=resolved_type.is_optional,
                     has_default=has_default,
                     default_value=(
-                        self._serialize_default(default_value) if has_default else None
+                        self._serialize_default(default_value, name=python_name)
+                        if has_default
+                        else None
                     ),
                     doc=meta_doc,
                     ignore=meta_ignore,
@@ -1242,18 +1246,23 @@ class ModuleParser:
         # Can't evaluate - return None (will be handled at runtime)
         return None
 
-    def _serialize_default(self, value: Any) -> Any:
+    def _serialize_default(self, value: Any, *, name: str = "") -> Any:
         """Serialize a default value for JSON storage.
 
-        Complex values that can't be serialized are returned as None.
+        Returns None for values that cannot be represented in JSON, with a
+        warning so the user sees why the default didn't reach the engine.
         """
         if value is None:
             return None
 
-        # Try to serialize to JSON
         try:
             json.dumps(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Default value for %r cannot be serialized to JSON (%s); "
+                "the parameter will behave as if no default were set.",
+                name or "<unknown>",
+                exc,
+            )
             return None
-        else:
-            return value
+        return value

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -122,6 +122,9 @@ def _build_function_def(func_meta: FunctionMetadata) -> dagger.Function:
     if func_meta.is_check:
         func_def = func_def.with_check()
 
+    if func_meta.is_generate:
+        func_def = func_def.with_generator()
+
     # Handle cache policy
     if func_meta.cache_policy is not None:
         if func_meta.cache_policy == "never":
@@ -147,9 +150,8 @@ def _add_parameter(
     """Add a parameter to a function definition."""
     arg_typedef = _resolved_type_to_typedef(param_meta.resolved_type)
 
-    # Mark optional if nullable
-    if param_meta.is_nullable:
-        arg_typedef = arg_typedef.with_optional(True)
+    # Note: optionality from type (T | None) is already handled by
+    # _resolved_type_to_typedef via resolved.is_optional.
 
     # Convert default value to JSON if present
     default_value = None

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -1,0 +1,237 @@
+"""Registration adapter for converting AST metadata to Dagger TypeDefs.
+
+This module provides the bridge between AST analysis results and
+the Dagger engine registration API.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dagger
+from dagger import dag
+from dagger.mod._analyzer.errors import AnalysisError
+from dagger.mod._analyzer.metadata import (
+    EnumTypeMetadata,
+    FunctionMetadata,
+    ModuleMetadata,
+    ObjectTypeMetadata,
+    ParameterMetadata,
+    ResolvedType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def register_from_metadata(metadata: ModuleMetadata) -> dagger.ModuleID:
+    """Register a module with the Dagger engine using AST metadata.
+
+    This is the equivalent of Module._typedefs() but uses pre-analyzed
+    metadata instead of runtime introspection.
+
+    Args:
+        metadata: The module metadata from AST analysis.
+
+    Returns
+    -------
+        The registered module ID.
+    """
+    mod = dag.module()
+
+    # Set module description
+    if metadata.doc:
+        mod = mod.with_description(metadata.doc)
+
+    # Register object types
+    for obj_meta in metadata.objects.values():
+        type_def = _build_object_typedef(obj_meta)
+
+        if obj_meta.is_interface:
+            mod = mod.with_interface(type_def)
+        else:
+            mod = mod.with_object(type_def)
+
+    # Register enum types
+    for enum_meta in metadata.enums.values():
+        enum_def = _build_enum_typedef(enum_meta)
+        mod = mod.with_enum(enum_def)
+
+    return await mod.id()
+
+
+def _build_object_typedef(obj_meta: ObjectTypeMetadata) -> dagger.TypeDef:
+    """Build a TypeDef for an object or interface."""
+    type_def = dag.type_def()
+
+    if obj_meta.is_interface:
+        type_def = type_def.with_interface(
+            obj_meta.name,
+            description=obj_meta.doc,
+        )
+    else:
+        type_def = type_def.with_object(
+            obj_meta.name,
+            description=obj_meta.doc,
+            deprecated=obj_meta.deprecated,
+        )
+
+    # Add fields (only for objects, not interfaces)
+    if not obj_meta.is_interface:
+        for field_meta in obj_meta.fields:
+            field_typedef = _resolved_type_to_typedef(field_meta.resolved_type)
+            type_def = type_def.with_field(
+                field_meta.api_name,
+                field_typedef,
+                description=field_meta.doc,
+                deprecated=field_meta.deprecated,
+            )
+
+    # Add functions
+    for func_meta in obj_meta.functions:
+        func_def = _build_function_def(func_meta)
+        type_def = type_def.with_function(func_def)
+
+    # Add constructor (for objects only)
+    has_constructor = (
+        obj_meta.constructor
+        and not obj_meta.is_interface
+        and obj_meta.constructor.parameters
+    )
+    if has_constructor:
+        ctor_def = _build_function_def(obj_meta.constructor)  # type: ignore[arg-type]
+        type_def = type_def.with_constructor(ctor_def)
+
+    return type_def
+
+
+def _build_function_def(func_meta: FunctionMetadata) -> dagger.Function:
+    """Build a Function definition."""
+    return_typedef = _resolved_type_to_typedef(func_meta.resolved_return_type)
+
+    func_def = dag.function(
+        func_meta.api_name,
+        return_typedef,
+    )
+
+    if func_meta.doc:
+        func_def = func_def.with_description(func_meta.doc)
+
+    if func_meta.deprecated:
+        func_def = func_def.with_deprecated(reason=func_meta.deprecated)
+
+    if func_meta.is_check:
+        func_def = func_def.with_check()
+
+    # Handle cache policy
+    if func_meta.cache_policy is not None:
+        if func_meta.cache_policy == "never":
+            func_def = func_def.with_cache_policy(dagger.FunctionCachePolicy.Never)
+        elif func_meta.cache_policy == "session":
+            func_def = func_def.with_cache_policy(dagger.FunctionCachePolicy.PerSession)
+        elif func_meta.cache_policy != "":
+            func_def = func_def.with_cache_policy(
+                dagger.FunctionCachePolicy.Default,
+                time_to_live=func_meta.cache_policy,
+            )
+
+    # Add parameters
+    for param_meta in func_meta.parameters:
+        func_def = _add_parameter(func_def, param_meta)
+
+    return func_def
+
+
+def _add_parameter(
+    func_def: dagger.Function, param_meta: ParameterMetadata
+) -> dagger.Function:
+    """Add a parameter to a function definition."""
+    arg_typedef = _resolved_type_to_typedef(param_meta.resolved_type)
+
+    # Mark optional if nullable
+    if param_meta.is_nullable:
+        arg_typedef = arg_typedef.with_optional(True)
+
+    # Convert default value to JSON if present
+    default_value = None
+    if param_meta.default_value is not None:
+        import contextlib
+        import json
+
+        with contextlib.suppress(TypeError, ValueError):
+            default_value = dagger.JSON(json.dumps(param_meta.default_value))
+
+    return func_def.with_arg(
+        param_meta.api_name,
+        arg_typedef,
+        description=param_meta.doc,
+        default_value=default_value,
+        default_path=param_meta.default_path,
+        default_address=param_meta.default_address,
+        ignore=param_meta.ignore,
+        deprecated=param_meta.deprecated,
+    )
+
+
+def _build_enum_typedef(enum_meta: EnumTypeMetadata) -> dagger.TypeDef:
+    """Build a TypeDef for an enum."""
+    enum_def = dag.type_def().with_enum(
+        enum_meta.name,
+        description=enum_meta.doc,
+    )
+
+    for member in enum_meta.members:
+        enum_def = enum_def.with_enum_member(
+            member.name,
+            value=member.value,
+            description=member.doc,
+            deprecated=member.deprecated,
+        )
+
+    return enum_def
+
+
+def _resolved_type_to_typedef(resolved: ResolvedType) -> dagger.TypeDef:  # noqa: PLR0911
+    """Convert a ResolvedType to a Dagger TypeDef."""
+    td = dag.type_def()
+
+    # Handle optional
+    if resolved.is_optional:
+        td = td.with_optional(True)
+
+    # Handle different kinds
+    if resolved.kind == "primitive":
+        kind_map = {
+            "str": dagger.TypeDefKind.STRING_KIND,
+            "int": dagger.TypeDefKind.INTEGER_KIND,
+            "float": dagger.TypeDefKind.FLOAT_KIND,
+            "bool": dagger.TypeDefKind.BOOLEAN_KIND,
+            "bytes": dagger.TypeDefKind.STRING_KIND,  # bytes as string
+            "Any": dagger.TypeDefKind.STRING_KIND,  # Any as string fallback
+        }
+        type_kind = kind_map.get(resolved.name, dagger.TypeDefKind.STRING_KIND)
+        return td.with_kind(type_kind)
+
+    if resolved.kind == "void":
+        return td.with_kind(dagger.TypeDefKind.VOID_KIND)
+
+    if resolved.kind == "list":
+        if resolved.element_type:
+            element_td = _resolved_type_to_typedef(resolved.element_type)
+            return td.with_list_of(element_td)
+        # List without element type - fallback to string
+        return td.with_list_of(dag.type_def().with_kind(dagger.TypeDefKind.STRING_KIND))
+
+    if resolved.kind == "object":
+        return td.with_object(resolved.name)
+
+    if resolved.kind == "interface":
+        return td.with_interface(resolved.name)
+
+    if resolved.kind == "enum":
+        return td.with_enum(resolved.name)
+
+    if resolved.kind == "scalar":
+        return td.with_scalar(resolved.name)
+
+    msg = f"Unknown type kind: {resolved.kind}"
+    raise AnalysisError(msg)

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -155,12 +155,15 @@ def _add_parameter(
 
     # Convert default value to JSON if present
     default_value = None
-    if param_meta.default_value is not None:
+    if param_meta.has_default:
         import contextlib
         import json
 
-        with contextlib.suppress(TypeError, ValueError):
-            default_value = dagger.JSON(json.dumps(param_meta.default_value))
+        if param_meta.default_value is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                default_value = dagger.JSON(json.dumps(param_meta.default_value))
+        else:
+            default_value = dagger.JSON("null")
 
     return func_def.with_arg(
         param_meta.api_name,

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -92,10 +92,16 @@ def _build_object_typedef(obj_meta: ObjectTypeMetadata) -> dagger.TypeDef:
         type_def = type_def.with_function(func_def)
 
     # Add constructor (for objects only)
+    # Register when: explicit method (create/init), or has params/doc
     has_constructor = (
         obj_meta.constructor
         and not obj_meta.is_interface
-        and (obj_meta.constructor.parameters or obj_meta.constructor.doc)
+        and (
+            obj_meta.constructor.is_classmethod  # explicit create() classmethod
+            or obj_meta.constructor.python_name == "__init__"  # explicit __init__
+            or obj_meta.constructor.parameters
+            or obj_meta.constructor.doc
+        )
     )
     if has_constructor:
         ctor_def = _build_function_def(obj_meta.constructor)  # type: ignore[arg-type]
@@ -145,9 +151,18 @@ def _build_function_def(func_meta: FunctionMetadata) -> dagger.Function:
 
 
 def _add_parameter(
-    func_def: dagger.Function, param_meta: ParameterMetadata
+    func_def: dagger.Function,
+    param_meta: ParameterMetadata,
 ) -> dagger.Function:
     """Add a parameter to a function definition."""
+    # Validate: deprecated parameters must be optional
+    if param_meta.deprecated and not param_meta.is_optional:
+        msg = (
+            f"Can't deprecate required parameter '{param_meta.python_name}'. "
+            "Mark it optional or provide a default value."
+        )
+        raise AnalysisError(msg)
+
     arg_typedef = _resolved_type_to_typedef(param_meta.resolved_type)
 
     # Note: optionality from type (T | None) is already handled by
@@ -162,8 +177,15 @@ def _add_parameter(
         if param_meta.default_value is not None:
             with contextlib.suppress(TypeError, ValueError):
                 default_value = dagger.JSON(json.dumps(param_meta.default_value))
-        else:
+        elif param_meta.resolved_type.is_optional:
+            # Type is already nullable, send explicit null
             default_value = dagger.JSON("null")
+        else:
+            # Dynamic default (callable factory) for non-nullable type.
+            # Make the type optional so the engine accepts omission.
+            # Do NOT send a default value — the engine will omit this
+            # param from inputs, and the runtime will use default_factory.
+            arg_typedef = arg_typedef.with_optional(True)
 
     return func_def.with_arg(
         param_meta.api_name,

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -119,6 +119,19 @@ def _build_function_def(func_meta: FunctionMetadata) -> dagger.Function:
         return_typedef,
     )
 
+    func_def = _apply_function_metadata(func_def, func_meta)
+
+    for param_meta in func_meta.parameters:
+        func_def = _add_parameter(func_def, param_meta)
+
+    return func_def
+
+
+def _apply_function_metadata(
+    func_def: dagger.Function,
+    func_meta: FunctionMetadata,
+) -> dagger.Function:
+    """Apply metadata flags and cache policy to a function definition."""
     if func_meta.doc:
         func_def = func_def.with_description(func_meta.doc)
 
@@ -131,22 +144,30 @@ def _build_function_def(func_meta: FunctionMetadata) -> dagger.Function:
     if func_meta.is_generate:
         func_def = func_def.with_generator()
 
-    # Handle cache policy
-    if func_meta.cache_policy is not None:
-        if func_meta.cache_policy == "never":
-            func_def = func_def.with_cache_policy(dagger.FunctionCachePolicy.Never)
-        elif func_meta.cache_policy == "session":
-            func_def = func_def.with_cache_policy(dagger.FunctionCachePolicy.PerSession)
-        elif func_meta.cache_policy != "":
-            func_def = func_def.with_cache_policy(
-                dagger.FunctionCachePolicy.Default,
-                time_to_live=func_meta.cache_policy,
-            )
+    if func_meta.is_service:
+        func_def = func_def.with_up()
 
-    # Add parameters
-    for param_meta in func_meta.parameters:
-        func_def = _add_parameter(func_def, param_meta)
+    cache_policy = func_meta.cache_policy
+    if cache_policy is not None:
+        func_def = _apply_cache_policy(func_def, cache_policy)
 
+    return func_def
+
+
+def _apply_cache_policy(
+    func_def: dagger.Function,
+    cache_policy: str,
+) -> dagger.Function:
+    """Apply cache policy to a function definition."""
+    if cache_policy == "never":
+        return func_def.with_cache_policy(dagger.FunctionCachePolicy.Never)
+    if cache_policy == "session":
+        return func_def.with_cache_policy(dagger.FunctionCachePolicy.PerSession)
+    if cache_policy != "":
+        return func_def.with_cache_policy(
+            dagger.FunctionCachePolicy.Default,
+            time_to_live=cache_policy,
+        )
     return func_def
 
 

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -95,7 +95,7 @@ def _build_object_typedef(obj_meta: ObjectTypeMetadata) -> dagger.TypeDef:
     has_constructor = (
         obj_meta.constructor
         and not obj_meta.is_interface
-        and obj_meta.constructor.parameters
+        and (obj_meta.constructor.parameters or obj_meta.constructor.doc)
     )
     if has_constructor:
         ctor_def = _build_function_def(obj_meta.constructor)  # type: ignore[arg-type]

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -189,15 +189,15 @@ def _add_parameter(
     # Note: optionality from type (T | None) is already handled by
     # _resolved_type_to_typedef via resolved.is_optional.
 
-    # Convert default value to JSON if present
+    # Convert default value to JSON if present. The parser already validated
+    # that non-None defaults are JSON-serializable (and warned otherwise), so
+    # a JSON failure here indicates a parser bug and must not be suppressed.
     default_value = None
     if param_meta.has_default:
-        import contextlib
         import json
 
         if param_meta.default_value is not None:
-            with contextlib.suppress(TypeError, ValueError):
-                default_value = dagger.JSON(json.dumps(param_meta.default_value))
+            default_value = dagger.JSON(json.dumps(param_meta.default_value))
         elif param_meta.resolved_type.is_optional:
             # Type is already nullable, send explicit null
             default_value = dagger.JSON("null")

--- a/sdk/python/src/dagger/mod/_analyzer/registration.py
+++ b/sdk/python/src/dagger/mod/_analyzer/registration.py
@@ -24,10 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 async def register_from_metadata(metadata: ModuleMetadata) -> dagger.ModuleID:
-    """Register a module with the Dagger engine using AST metadata.
-
-    This is the equivalent of Module._typedefs() but uses pre-analyzed
-    metadata instead of runtime introspection.
+    """Register a module with the Dagger engine from AST-derived metadata.
 
     Args:
         metadata: The module metadata from AST analysis.

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -1,0 +1,523 @@
+"""Type resolver for converting AST annotations to ResolvedType.
+
+This module handles:
+- Forward references ("Foo" -> Foo)
+- Self type resolution
+- Union types (T | None)
+- Generic types (list[T])
+- Dagger types (Container, Directory, etc.)
+"""
+
+from __future__ import annotations
+
+import ast
+import types
+import typing
+from typing import Any, get_args, get_origin
+
+import typing_extensions
+
+from dagger.mod._analyzer.errors import TypeResolutionError
+from dagger.mod._analyzer.metadata import LocationMetadata, ResolvedType
+from dagger.mod._analyzer.namespace import StubNamespace, is_stub_type
+from dagger.mod._analyzer.visitors.annotations import unwrap_annotated
+
+# Known Dagger types from the API
+DAGGER_OBJECT_TYPES = {
+    "Container",
+    "Directory",
+    "File",
+    "Secret",
+    "Service",
+    "CacheVolume",
+    "Socket",
+    "ModuleSource",
+    "Module",
+    "GitRepository",
+    "GitRef",
+    "Terminal",
+    "Host",
+    "Client",
+}
+
+# Dagger scalar types
+DAGGER_SCALAR_TYPES = {
+    "Platform",
+    "JSON",
+    "ContainerID",
+    "DirectoryID",
+    "FileID",
+    "SecretID",
+    "ServiceID",
+    "CacheVolumeID",
+    "SocketID",
+    "ModuleSourceID",
+    "ModuleID",
+    "GitRepositoryID",
+    "GitRefID",
+    "TerminalID",
+}
+
+# Primitive type mapping
+PRIMITIVE_TYPES = {
+    "str": "str",
+    "int": "int",
+    "float": "float",
+    "bool": "bool",
+    "bytes": "bytes",
+}
+
+
+class TypeResolver:
+    """Resolves AST type annotations to ResolvedType structures.
+
+    This handles the complex task of converting Python type annotations
+    (which may include forward references, Self, Union types, etc.)
+    into a normalized ResolvedType that can be used for registration.
+    """
+
+    def __init__(
+        self,
+        namespace: StubNamespace,
+        declared_objects: set[str] | None = None,
+        declared_enums: set[str] | None = None,
+        declared_interfaces: set[str] | None = None,
+    ):
+        """Initialize the resolver.
+
+        Args:
+            namespace: The namespace for evaluating annotations.
+            declared_objects: Names of @object_type classes in this module.
+            declared_enums: Names of @enum_type enums in this module.
+            declared_interfaces: Names of @interface classes in this module.
+        """
+        self.namespace = namespace
+        self.declared_objects = declared_objects or set()
+        self.declared_enums = declared_enums or set()
+        self.declared_interfaces = declared_interfaces or set()
+        self._current_class: str | None = None
+
+    def set_current_class(self, class_name: str | None) -> None:
+        """Set the current class context for Self resolution."""
+        self._current_class = class_name
+
+    def resolve(
+        self,
+        annotation: ast.expr | str | Any,
+        *,
+        location: LocationMetadata | None = None,
+    ) -> ResolvedType:
+        """Resolve a type annotation to a ResolvedType.
+
+        Args:
+            annotation: AST expression, string, or evaluated type.
+            location: Source location for error messages.
+
+        Returns
+        -------
+            A ResolvedType representing the annotation.
+        """
+        try:
+            return self._resolve_impl(annotation, location)
+        except TypeResolutionError:
+            raise
+        except Exception as e:
+            if isinstance(annotation, ast.expr):
+                annotation_str = ast.unparse(annotation)
+            else:
+                annotation_str = str(annotation)
+            msg = f"Failed to resolve type: {e}"
+            raise TypeResolutionError(
+                msg,
+                annotation=annotation_str,
+                location=location,
+            ) from e
+
+    def _resolve_impl(
+        self,
+        annotation: ast.expr | str | Any,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Internal implementation of resolve."""
+        # Handle AST nodes
+        if isinstance(annotation, ast.expr):
+            return self._resolve_ast(annotation, location)
+
+        # Handle string annotations (from __future__ annotations)
+        if isinstance(annotation, str):
+            # Try to parse as AST
+            try:
+                node = ast.parse(annotation, mode="eval").body
+                return self._resolve_ast(node, location)
+            except SyntaxError:
+                # Try to evaluate in namespace
+                evaled = self.namespace.eval_annotation(annotation, location=location)
+                return self._resolve_evaluated(evaled, location)
+
+        # Handle already-evaluated types
+        return self._resolve_evaluated(annotation, location)
+
+    def _resolve_ast(  # noqa: PLR0911
+        self,
+        node: ast.expr,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve an AST node to ResolvedType."""
+        # Handle Annotated - unwrap and resolve base type
+        unwrapped = unwrap_annotated(node)
+        if unwrapped is not node:
+            return self._resolve_ast(unwrapped, location)
+
+        # Handle None
+        if isinstance(node, ast.Constant) and node.value is None:
+            return ResolvedType(kind="void", name="None", is_optional=True)
+
+        # Handle simple names
+        if isinstance(node, ast.Name):
+            return self._resolve_name(node.id, location)
+
+        # Handle attribute access (e.g., typing.Self, dagger.Container)
+        if isinstance(node, ast.Attribute):
+            return self._resolve_attribute(node, location)
+
+        # Handle subscripts (generics like list[str], Optional[T])
+        if isinstance(node, ast.Subscript):
+            return self._resolve_subscript(node, location)
+
+        # Handle binary operations (T | None)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            return self._resolve_union(node, location)
+
+        # Handle string constant (forward reference)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return self._resolve_name(node.value, location)
+
+        # Fallback: try to evaluate
+        try:
+            evaled = self.namespace.eval_annotation(node, location=location)
+            return self._resolve_evaluated(evaled, location)
+        except TypeResolutionError:
+            annotation_str = ast.unparse(node)
+            msg = "Unable to resolve type annotation"
+            raise TypeResolutionError(
+                msg, annotation=annotation_str, location=location
+            ) from None
+
+    def _resolve_name(  # noqa: PLR0911, C901
+        self,
+        name: str,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve a simple name to ResolvedType."""
+        # Check for None/void
+        if name in ("None", "NoneType"):
+            return ResolvedType(kind="void", name="None")
+
+        # Check for Self
+        if name == "Self":
+            if self._current_class:
+                return ResolvedType(
+                    kind="object",
+                    name=self._current_class,
+                    is_self=True,
+                )
+            msg = "Self used outside of class context"
+            raise TypeResolutionError(msg, annotation=name, location=location)
+
+        # Check for primitives
+        if name in PRIMITIVE_TYPES:
+            return ResolvedType(kind="primitive", name=name)
+
+        # Check for module-declared types
+        if name in self.declared_objects:
+            return ResolvedType(kind="object", name=name)
+        if name in self.declared_enums:
+            return ResolvedType(kind="enum", name=name)
+        if name in self.declared_interfaces:
+            return ResolvedType(kind="interface", name=name)
+
+        # Check for dagger types
+        if name in DAGGER_OBJECT_TYPES:
+            return ResolvedType(kind="object", name=name)
+        if name in DAGGER_SCALAR_TYPES:
+            return ResolvedType(kind="scalar", name=name)
+
+        # Try to resolve from namespace
+        try:
+            evaled = self.namespace.eval_annotation(name, location=location)
+            return self._resolve_evaluated(evaled, location)
+        except TypeResolutionError:
+            # Unknown type - might be a forward reference or stub
+            # Assume it's an object type
+            return ResolvedType(kind="object", name=name)
+
+    def _resolve_attribute(
+        self,
+        node: ast.Attribute,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve an attribute access like typing.Self or dagger.Container."""
+        attr_name = node.attr
+
+        # Handle typing.Self or typing_extensions.Self
+        if attr_name == "Self":
+            if self._current_class:
+                return ResolvedType(
+                    kind="object",
+                    name=self._current_class,
+                    is_self=True,
+                )
+            msg = "Self used outside of class context"
+            raise TypeResolutionError(
+                msg, annotation=ast.unparse(node), location=location
+            )
+
+        # Handle dagger.X
+        if isinstance(node.value, ast.Name) and node.value.id == "dagger":
+            if attr_name in DAGGER_OBJECT_TYPES:
+                return ResolvedType(kind="object", name=attr_name)
+            if attr_name in DAGGER_SCALAR_TYPES:
+                return ResolvedType(kind="scalar", name=attr_name)
+
+        # Try to resolve by attribute name
+        return self._resolve_name(attr_name, location)
+
+    def _resolve_subscript(  # noqa: PLR0911
+        self,
+        node: ast.Subscript,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve a subscript like list[str], Optional[T], Union[A, B]."""
+        value = node.value
+        slice_val = node.slice
+
+        # Get the base type name
+        if isinstance(value, ast.Name):
+            base_name = value.id
+        elif isinstance(value, ast.Attribute):
+            base_name = value.attr
+        else:
+            # Try to evaluate
+            try:
+                evaled = self.namespace.eval_annotation(node, location=location)
+                return self._resolve_evaluated(evaled, location)
+            except TypeResolutionError:
+                annotation_str = ast.unparse(node)
+                msg = "Unable to resolve subscripted type"
+                raise TypeResolutionError(
+                    msg, annotation=annotation_str, location=location
+                ) from None
+
+        # Handle list[T]
+        if base_name in ("list", "List", "Sequence"):
+            element_type = self._get_single_subscript_arg(slice_val, location)
+            return ResolvedType(
+                kind="list",
+                name="list",
+                element_type=element_type,
+            )
+
+        # Handle Optional[T]
+        if base_name == "Optional":
+            inner_type = self._get_single_subscript_arg(slice_val, location)
+            inner_type.is_optional = True
+            return inner_type
+
+        # Handle Union[A, B, ...]
+        if base_name == "Union":
+            return self._resolve_union_subscript(slice_val, location)
+
+        # Handle Annotated[T, ...] - extract base type
+        is_annotated = base_name == "Annotated"
+        if is_annotated and isinstance(slice_val, ast.Tuple) and slice_val.elts:
+            return self._resolve_ast(slice_val.elts[0], location)
+
+        # Unknown generic - try to evaluate
+        try:
+            evaled = self.namespace.eval_annotation(node, location=location)
+            return self._resolve_evaluated(evaled, location)
+        except TypeResolutionError:
+            # Fallback to treating as object
+            return ResolvedType(kind="object", name=base_name)
+
+    def _resolve_union(
+        self,
+        node: ast.BinOp,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve a union type like T | None."""
+        left = self._resolve_ast(node.left, location)
+        right = self._resolve_ast(node.right, location)
+
+        # Handle T | None -> make T optional
+        if right.kind == "void" or right.name == "None":
+            left.is_optional = True
+            return left
+        if left.kind == "void" or left.name == "None":
+            right.is_optional = True
+            return right
+
+        # General union - not supported in Dagger, take first non-None type
+        msg = "Union types (other than T | None) are not supported in Dagger"
+        raise TypeResolutionError(msg, annotation=ast.unparse(node), location=location)
+
+    def _resolve_union_subscript(
+        self,
+        slice_val: ast.expr,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve Union[A, B, ...] subscript."""
+        args = slice_val.elts if isinstance(slice_val, ast.Tuple) else [slice_val]
+
+        non_none_types = []
+        has_none = False
+
+        for arg in args:
+            is_none_const = isinstance(arg, ast.Constant) and arg.value is None
+            is_none_name = isinstance(arg, ast.Name) and arg.id in ("None", "NoneType")
+            if is_none_const or is_none_name:
+                has_none = True
+            else:
+                non_none_types.append(arg)
+
+        if not non_none_types:
+            return ResolvedType(kind="void", name="None")
+
+        if len(non_none_types) == 1:
+            resolved = self._resolve_ast(non_none_types[0], location)
+            resolved.is_optional = has_none
+            return resolved
+
+        # Multiple non-None types - not supported
+        msg = "Union types (other than Optional[T]) are not supported in Dagger"
+        annotation_str = f"Union[{', '.join(ast.unparse(t) for t in args)}]"
+        raise TypeResolutionError(msg, annotation=annotation_str, location=location)
+
+    def _get_single_subscript_arg(
+        self,
+        slice_val: ast.expr,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Get the single type argument from a subscript like list[T]."""
+        if isinstance(slice_val, ast.Tuple) and slice_val.elts:
+            return self._resolve_ast(slice_val.elts[0], location)
+        return self._resolve_ast(slice_val, location)
+
+    def _resolve_evaluated(  # noqa: PLR0911, PLR0912, C901
+        self,
+        t: Any,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve an already-evaluated type."""
+        # Handle None
+        if t is None or t is type(None):
+            return ResolvedType(kind="void", name="None")
+
+        # Handle Self
+        if t is typing_extensions.Self:
+            if self._current_class:
+                return ResolvedType(
+                    kind="object",
+                    name=self._current_class,
+                    is_self=True,
+                )
+            msg = "Self used outside of class context"
+            raise TypeResolutionError(msg, location=location)
+
+        # Handle stub types
+        if is_stub_type(t):
+            return ResolvedType(kind="object", name=t.__name__)
+
+        # Handle primitives
+        if t in (str, int, float, bool, bytes):
+            return ResolvedType(kind="primitive", name=t.__name__)
+
+        # Handle new-style unions (Python 3.10+)
+        if isinstance(t, types.UnionType):
+            return self._resolve_union_type(t, location)
+
+        # Handle typing special forms
+        origin = get_origin(t)
+        args = get_args(t)
+
+        if origin is not None:
+            # Handle Union
+            if origin is typing.Union:
+                return self._resolve_union_args(args, location)
+
+            # Handle list, List, Sequence
+            if origin in (list, list) or (
+                hasattr(typing, "Sequence") and origin is typing.Sequence
+            ):
+                if args:
+                    element_type = self._resolve_evaluated(args[0], location)
+                    return ResolvedType(
+                        kind="list",
+                        name="list",
+                        element_type=element_type,
+                    )
+                return ResolvedType(kind="list", name="list")
+
+            # Handle Annotated
+            if origin is typing.Annotated and args:
+                return self._resolve_evaluated(args[0], location)
+
+        # Handle classes
+        if isinstance(t, type):
+            name = t.__name__
+
+            # Check module-declared types
+            if name in self.declared_objects:
+                return ResolvedType(kind="object", name=name)
+            if name in self.declared_enums:
+                return ResolvedType(kind="enum", name=name)
+            if name in self.declared_interfaces:
+                return ResolvedType(kind="interface", name=name)
+
+            # Check dagger types
+            if name in DAGGER_OBJECT_TYPES:
+                return ResolvedType(kind="object", name=name)
+            if name in DAGGER_SCALAR_TYPES:
+                return ResolvedType(kind="scalar", name=name)
+
+            # Assume it's an object type
+            return ResolvedType(kind="object", name=name)
+
+        # Fallback
+        return ResolvedType(kind="object", name=str(t))
+
+    def _resolve_union_type(
+        self,
+        t: types.UnionType,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve a Python 3.10+ union type."""
+        args = t.__args__
+        return self._resolve_union_args(args, location)
+
+    def _resolve_union_args(
+        self,
+        args: tuple,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve union arguments."""
+        non_none_types = []
+        has_none = False
+
+        for arg in args:
+            if arg is None or arg is type(None):
+                has_none = True
+            else:
+                non_none_types.append(arg)
+
+        if not non_none_types:
+            return ResolvedType(kind="void", name="None")
+
+        if len(non_none_types) == 1:
+            resolved = self._resolve_evaluated(non_none_types[0], location)
+            resolved.is_optional = has_none
+            return resolved
+
+        # Multiple non-None types - not supported
+        msg = f"Union types (other than Optional[T]) are not supported: Union[{args}]"
+        raise TypeResolutionError(msg, location=location)

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import ast
 import collections.abc
 import enum
+import logging
 import types
 import typing
 from typing import Any, get_args, get_origin
@@ -23,6 +24,8 @@ from dagger.mod._analyzer.errors import TypeResolutionError
 from dagger.mod._analyzer.metadata import LocationMetadata, ResolvedType
 from dagger.mod._analyzer.namespace import StubNamespace, is_stub_type
 from dagger.mod._analyzer.visitors.annotations import unwrap_annotated
+
+logger = logging.getLogger(__name__)
 
 # Known Dagger types from the API
 DAGGER_OBJECT_TYPES = {
@@ -272,8 +275,16 @@ class TypeResolver:
             evaled = self.namespace.eval_annotation(name, location=location)
             return self._resolve_evaluated(evaled, location)
         except TypeResolutionError:
-            # Unknown type - might be a forward reference or stub
-            # Assume it's an object type
+            # Unknown type - might be a forward reference or a user typo.
+            # Keep the permissive fallback so forward refs still work, but
+            # warn so that typos don't silently produce garbage TypeDefs.
+            logger.warning(
+                "Unresolved type %r%s; assuming it is an object type. If "
+                "this is a typo or a missing import, the engine will fail "
+                "at runtime.",
+                name,
+                f" at {location.file}:{location.line}" if location else "",
+            )
             return ResolvedType(kind="object", name=name)
 
     def _resolve_attribute(
@@ -350,6 +361,12 @@ class TypeResolver:
             evaled = self.namespace.eval_annotation(node, location=location)
             return self._resolve_evaluated(evaled, location)
         except TypeResolutionError:
+            logger.warning(
+                "Unsupported generic type %r%s; element types are lost. "
+                "Dagger supports list[T], Optional[T] and Union[T, None].",
+                ast.unparse(node),
+                f" at {location.file}:{location.line}" if location else "",
+            )
             return ResolvedType(kind="object", name=base_name)
 
     def _get_subscript_base_name(

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -216,8 +216,12 @@ class TypeResolver:
         # Check for Self
         if name == "Self":
             if self._current_class:
+                if self._current_class in self.declared_interfaces:
+                    kind = "interface"
+                else:
+                    kind = "object"
                 return ResolvedType(
-                    kind="object",
+                    kind=kind,
                     name=self._current_class,
                     is_self=True,
                 )
@@ -262,8 +266,12 @@ class TypeResolver:
         # Handle typing.Self or typing_extensions.Self
         if attr_name == "Self":
             if self._current_class:
+                if self._current_class in self.declared_interfaces:
+                    kind = "interface"
+                else:
+                    kind = "object"
                 return ResolvedType(
-                    kind="object",
+                    kind=kind,
                     name=self._current_class,
                     is_self=True,
                 )
@@ -288,48 +296,30 @@ class TypeResolver:
         location: LocationMetadata | None,
     ) -> ResolvedType:
         """Resolve a subscript like list[str], Optional[T], Union[A, B]."""
-        value = node.value
         slice_val = node.slice
 
         # Get the base type name
-        if isinstance(value, ast.Name):
-            base_name = value.id
-        elif isinstance(value, ast.Attribute):
-            base_name = value.attr
-        else:
-            # Try to evaluate
-            try:
-                evaled = self.namespace.eval_annotation(node, location=location)
-                return self._resolve_evaluated(evaled, location)
-            except TypeResolutionError:
-                annotation_str = ast.unparse(node)
-                msg = "Unable to resolve subscripted type"
-                raise TypeResolutionError(
-                    msg, annotation=annotation_str, location=location
-                ) from None
+        base_name = self._get_subscript_base_name(node, location)
+        if base_name is None:
+            evaled = self.namespace.eval_annotation(node, location=location)
+            return self._resolve_evaluated(evaled, location)
 
-        # Handle list[T]
-        if base_name in ("list", "List", "Sequence"):
-            element_type = self._get_single_subscript_arg(slice_val, location)
-            return ResolvedType(
-                kind="list",
-                name="list",
-                element_type=element_type,
-            )
+        if base_name in ("list", "List", "Sequence", "tuple", "Tuple"):
+            return self._resolve_sequence_subscript(base_name, slice_val, location)
 
-        # Handle Optional[T]
         if base_name == "Optional":
             inner_type = self._get_single_subscript_arg(slice_val, location)
             inner_type.is_optional = True
             return inner_type
 
-        # Handle Union[A, B, ...]
         if base_name == "Union":
             return self._resolve_union_subscript(slice_val, location)
 
-        # Handle Annotated[T, ...] - extract base type
-        is_annotated = base_name == "Annotated"
-        if is_annotated and isinstance(slice_val, ast.Tuple) and slice_val.elts:
+        if (
+            base_name == "Annotated"
+            and isinstance(slice_val, ast.Tuple)
+            and slice_val.elts
+        ):
             return self._resolve_ast(slice_val.elts[0], location)
 
         # Unknown generic - try to evaluate
@@ -337,8 +327,54 @@ class TypeResolver:
             evaled = self.namespace.eval_annotation(node, location=location)
             return self._resolve_evaluated(evaled, location)
         except TypeResolutionError:
-            # Fallback to treating as object
             return ResolvedType(kind="object", name=base_name)
+
+    def _get_subscript_base_name(
+        self,
+        node: ast.Subscript,
+        location: LocationMetadata | None,
+    ) -> str | None:
+        """Extract the base name from a subscript, or None if unresolvable."""
+        value = node.value
+        if isinstance(value, ast.Name):
+            return value.id
+        if isinstance(value, ast.Attribute):
+            return value.attr
+        # Try to evaluate; raise if that also fails
+        try:
+            self.namespace.eval_annotation(node, location=location)
+        except TypeResolutionError:
+            annotation_str = ast.unparse(node)
+            msg = "Unable to resolve subscripted type"
+            raise TypeResolutionError(
+                msg, annotation=annotation_str, location=location
+            ) from None
+        return None
+
+    def _resolve_sequence_subscript(
+        self,
+        base_name: str,
+        slice_val: ast.expr,
+        location: LocationMetadata | None,
+    ) -> ResolvedType:
+        """Resolve list[T], tuple[T, ...], or Sequence[T]."""
+        if base_name in ("tuple", "Tuple") and isinstance(slice_val, ast.Tuple):
+            non_ellipsis = [
+                el
+                for el in slice_val.elts
+                if not (isinstance(el, ast.Constant) and el.value is ...)
+            ]
+            if non_ellipsis:
+                element_type = self._resolve_ast(non_ellipsis[0], location)
+            else:
+                element_type = ResolvedType(kind="primitive", name="Any")
+        else:
+            element_type = self._get_single_subscript_arg(slice_val, location)
+        return ResolvedType(
+            kind="list",
+            name="list",
+            element_type=element_type,
+        )
 
     def _resolve_union(
         self,
@@ -416,8 +452,12 @@ class TypeResolver:
         # Handle Self
         if t is typing_extensions.Self:
             if self._current_class:
+                if self._current_class in self.declared_interfaces:
+                    kind = "interface"
+                else:
+                    kind = "object"
                 return ResolvedType(
-                    kind="object",
+                    kind=kind,
                     name=self._current_class,
                     is_self=True,
                 )

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -452,7 +452,7 @@ class TypeResolver:
             right.is_optional = True
             return right
 
-        # General union - not supported in Dagger, take first non-None type
+        # General union - not supported in Dagger
         msg = "Union types (other than T | None) are not supported in Dagger"
         raise TypeResolutionError(msg, annotation=ast.unparse(node), location=location)
 

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -11,6 +11,7 @@ This module handles:
 from __future__ import annotations
 
 import ast
+import enum
 import types
 import typing
 from typing import Any, get_args, get_origin
@@ -56,6 +57,23 @@ DAGGER_SCALAR_TYPES = {
     "GitRepositoryID",
     "GitRefID",
     "TerminalID",
+}
+
+# Dagger enum types from the API
+DAGGER_ENUM_TYPES = {
+    "CacheSharingMode",
+    "ChangesetMergeConflict",
+    "ChangesetsMergeConflict",
+    "ExistsType",
+    "FileType",
+    "FunctionCachePolicy",
+    "ImageLayerCompression",
+    "ImageMediaTypes",
+    "ModuleSourceExperimentalFeature",
+    "ModuleSourceKind",
+    "NetworkProtocol",
+    "ReturnType",
+    "TypeDefKind",
 }
 
 # Primitive type mapping
@@ -203,7 +221,7 @@ class TypeResolver:
                 msg, annotation=annotation_str, location=location
             ) from None
 
-    def _resolve_name(  # noqa: PLR0911, C901
+    def _resolve_name(  # noqa: PLR0911, PLR0912, C901
         self,
         name: str,
         location: LocationMetadata | None,
@@ -245,6 +263,8 @@ class TypeResolver:
             return ResolvedType(kind="object", name=name)
         if name in DAGGER_SCALAR_TYPES:
             return ResolvedType(kind="scalar", name=name)
+        if name in DAGGER_ENUM_TYPES:
+            return ResolvedType(kind="enum", name=name)
 
         # Try to resolve from namespace
         try:
@@ -286,6 +306,8 @@ class TypeResolver:
                 return ResolvedType(kind="object", name=attr_name)
             if attr_name in DAGGER_SCALAR_TYPES:
                 return ResolvedType(kind="scalar", name=attr_name)
+            if attr_name in DAGGER_ENUM_TYPES:
+                return ResolvedType(kind="enum", name=attr_name)
 
         # Try to resolve by attribute name
         return self._resolve_name(attr_name, location)
@@ -519,6 +541,12 @@ class TypeResolver:
                 return ResolvedType(kind="object", name=name)
             if name in DAGGER_SCALAR_TYPES:
                 return ResolvedType(kind="scalar", name=name)
+            if name in DAGGER_ENUM_TYPES:
+                return ResolvedType(kind="enum", name=name)
+
+            # Check if it's an enum subclass (e.g., dependency enums)
+            if issubclass(t, enum.Enum):
+                return ResolvedType(kind="enum", name=name)
 
             # Assume it's an object type
             return ResolvedType(kind="object", name=name)

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 import ast
 import collections.abc
+import contextlib
 import enum
 import logging
 import types
 import typing
-from typing import Any, get_args, get_origin
+from typing import Any, Iterator, get_args, get_origin
 
 import typing_extensions
 
@@ -120,8 +121,26 @@ class TypeResolver:
         self._current_class: str | None = None
 
     def set_current_class(self, class_name: str | None) -> None:
-        """Set the current class context for Self resolution."""
+        """Set the current class context for Self resolution.
+
+        Prefer ``in_class`` which scopes the change and restores the
+        previous value automatically.
+        """
         self._current_class = class_name
+
+    @contextlib.contextmanager
+    def in_class(self, class_name: str | None) -> Iterator[None]:
+        """Scope ``Self`` resolution to a class for the duration of the block.
+
+        Save-and-restore keeps nested or recursive usage safe and guarantees
+        the resolver returns to its prior state even if the body raises.
+        """
+        previous = self._current_class
+        self._current_class = class_name
+        try:
+            yield
+        finally:
+            self._current_class = previous
 
     def resolve(
         self,

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -11,6 +11,7 @@ This module handles:
 from __future__ import annotations
 
 import ast
+import collections.abc
 import enum
 import types
 import typing
@@ -507,9 +508,12 @@ class TypeResolver:
             if origin is typing.Union:
                 return self._resolve_union_args(args, location)
 
-            # Handle list, List, Sequence
-            if origin in (list, list) or (
-                hasattr(typing, "Sequence") and origin is typing.Sequence
+            # Handle list, Sequence, Iterable (typing.Sequence[T] yields
+            # collections.abc.Sequence as its origin, not typing.Sequence).
+            if origin in (
+                list,
+                collections.abc.Sequence,
+                collections.abc.Iterable,
             ):
                 if args:
                     element_type = self._resolve_evaluated(args[0], location)

--- a/sdk/python/src/dagger/mod/_analyzer/resolver.py
+++ b/sdk/python/src/dagger/mod/_analyzer/resolver.py
@@ -17,7 +17,8 @@ import enum
 import logging
 import types
 import typing
-from typing import Any, Iterator, get_args, get_origin
+from collections.abc import Iterator
+from typing import Any, get_args, get_origin
 
 import typing_extensions
 

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/__init__.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/__init__.py
@@ -1,0 +1,21 @@
+"""AST visitors for extracting specific patterns."""
+
+from dagger.mod._analyzer.visitors.annotations import (
+    AnnotatedMetadata,
+    extract_annotated_metadata,
+)
+from dagger.mod._analyzer.visitors.decorators import (
+    DecoratorInfo,
+    extract_decorator_info,
+    find_decorator,
+    has_decorator,
+)
+
+__all__ = [
+    "AnnotatedMetadata",
+    "DecoratorInfo",
+    "extract_annotated_metadata",
+    "extract_decorator_info",
+    "find_decorator",
+    "has_decorator",
+]

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/annotations.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/annotations.py
@@ -1,0 +1,216 @@
+"""Visitor for extracting Annotated metadata from type annotations."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+
+
+@dataclasses.dataclass
+class AnnotatedMetadata:
+    """Metadata extracted from Annotated[T, ...] type."""
+
+    base_type: ast.expr  # The base type T
+    doc: str | None = None  # From Doc()
+    name: str | None = None  # From Name()
+    default_path: str | None = None  # From DefaultPath()
+    default_address: str | None = None  # From DefaultAddress()
+    ignore: list[str] | None = None  # From Ignore()
+    deprecated: str | None = None  # From Deprecated()
+
+
+def is_annotated_type(annotation: ast.expr) -> bool:
+    """Check if an annotation is Annotated[T, ...].
+
+    Handles:
+    - Annotated[T, ...]
+    - typing.Annotated[T, ...]
+    - typing_extensions.Annotated[T, ...]
+    """
+    if not isinstance(annotation, ast.Subscript):
+        return False
+
+    value = annotation.value
+    if isinstance(value, ast.Name):
+        return value.id == "Annotated"
+    if isinstance(value, ast.Attribute):
+        return value.attr == "Annotated"
+
+    return False
+
+
+def extract_annotated_metadata(annotation: ast.expr) -> AnnotatedMetadata:
+    """Extract metadata from an Annotated[T, ...] type annotation.
+
+    Args:
+        annotation: An AST node representing an Annotated type.
+
+    Returns
+    -------
+        AnnotatedMetadata with the base type and extracted metadata.
+    """
+    if not is_annotated_type(annotation):
+        return AnnotatedMetadata(base_type=annotation)
+
+    # Get the subscript slice (the contents of Annotated[...])
+    subscript = annotation.slice  # type: ignore[attr-defined]
+
+    # Handle different Python versions / AST structures
+    if isinstance(subscript, ast.Tuple):
+        elements = subscript.elts
+    elif isinstance(subscript, ast.Index):
+        # Python 3.8 compatibility
+        if isinstance(subscript.value, ast.Tuple):  # type: ignore[attr-defined]
+            elements = subscript.value.elts  # type: ignore[attr-defined]
+        else:
+            elements = [subscript.value]  # type: ignore[attr-defined]
+    else:
+        # Single element (shouldn't happen for valid Annotated)
+        return AnnotatedMetadata(base_type=subscript)
+
+    if not elements:
+        return AnnotatedMetadata(base_type=annotation)
+
+    # First element is the base type
+    base_type = elements[0]
+
+    # Remaining elements are metadata
+    metadata = AnnotatedMetadata(base_type=base_type)
+
+    for meta_node in elements[1:]:
+        _extract_single_metadata(meta_node, metadata)
+
+    return metadata
+
+
+def _extract_single_metadata(node: ast.expr, metadata: AnnotatedMetadata) -> None:
+    """Extract a single metadata item and update the metadata object.
+
+    Handles:
+    - Doc("description")
+    - Name("api_name")
+    - DefaultPath("path")
+    - DefaultAddress("address")
+    - Ignore(["pattern1", "pattern2"])
+    - Deprecated("reason")
+    """
+    if not isinstance(node, ast.Call):
+        return
+
+    # Get the function name being called
+    func_name = _get_call_name(node)
+    if not func_name:
+        return
+
+    # Map known metadata types to extraction
+    if func_name in ("Doc", "typing_extensions.Doc"):
+        metadata.doc = _extract_string_arg(node)
+    elif func_name in ("Name", "dagger.Name"):
+        metadata.name = _extract_string_arg(node)
+    elif func_name in ("DefaultPath", "dagger.DefaultPath"):
+        metadata.default_path = _extract_string_arg(node)
+    elif func_name in ("DefaultAddress", "dagger.DefaultAddress"):
+        metadata.default_address = _extract_string_arg(node)
+    elif func_name in ("Ignore", "dagger.Ignore"):
+        metadata.ignore = _extract_list_arg(node)
+    elif func_name in ("Deprecated", "dagger.Deprecated"):
+        metadata.deprecated = _extract_string_arg(node, default="")
+
+
+def _get_call_name(node: ast.Call) -> str | None:
+    """Get the name of a Call node's function.
+
+    Handles:
+    - Doc(...) -> "Doc"
+    - typing_extensions.Doc(...) -> "typing_extensions.Doc"
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        if isinstance(func.value, ast.Name):
+            return f"{func.value.id}.{func.attr}"
+        return func.attr
+    return None
+
+
+def _extract_string_arg(node: ast.Call, default: str | None = None) -> str | None:
+    """Extract a string argument from a Call node.
+
+    Looks for:
+    - First positional argument: Doc("value")
+    - Keyword argument with specific names: Doc(documentation="value")
+    """
+    # Check positional arguments
+    if node.args:
+        first_arg = node.args[0]
+        if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+            return first_arg.value
+
+    # Check keyword arguments
+    for keyword in node.keywords:
+        if isinstance(keyword.value, ast.Constant) and isinstance(
+            keyword.value.value, str
+        ):
+            return keyword.value.value
+
+    return default
+
+
+def _extract_list_arg(node: ast.Call) -> list[str] | None:
+    """Extract a list of strings argument from a Call node.
+
+    Looks for:
+    - First positional argument: Ignore(["a", "b"])
+    - Keyword argument: Ignore(patterns=["a", "b"])
+    """
+    target_node: ast.expr | None = None
+
+    # Check positional arguments
+    if node.args:
+        target_node = node.args[0]
+    else:
+        # Check keyword arguments
+        for keyword in node.keywords:
+            target_node = keyword.value
+            break
+
+    if target_node is None:
+        return None
+
+    # Extract list elements
+    if isinstance(target_node, ast.List):
+        result = [
+            el.value
+            for el in target_node.elts
+            if isinstance(el, ast.Constant) and isinstance(el.value, str)
+        ]
+        return result if result else None
+
+    return None
+
+
+def unwrap_annotated(annotation: ast.expr) -> ast.expr:
+    """Remove Annotated wrapper and return the base type.
+
+    If the annotation is not Annotated, returns it unchanged.
+    """
+    if not is_annotated_type(annotation):
+        return annotation
+
+    subscript = annotation.slice  # type: ignore[attr-defined]
+
+    if isinstance(subscript, ast.Tuple):
+        return subscript.elts[0]
+    if isinstance(subscript, ast.Index):
+        inner = subscript.value  # type: ignore[attr-defined]
+        if isinstance(inner, ast.Tuple):
+            return inner.elts[0]
+        return inner
+
+    return annotation
+
+
+def get_annotation_string(annotation: ast.expr) -> str:
+    """Get a string representation of an annotation."""
+    return ast.unparse(annotation)

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/annotations.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/annotations.py
@@ -185,7 +185,7 @@ def _extract_list_arg(node: ast.Call) -> list[str] | None:
             for el in target_node.elts
             if isinstance(el, ast.Constant) and isinstance(el.value, str)
         ]
-        return result if result else None
+        return result or None
 
     return None
 

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
@@ -1,0 +1,192 @@
+"""Visitor for extracting decorator information from AST."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass
+class DecoratorInfo:
+    """Information extracted from a decorator."""
+
+    name: str  # e.g., "function", "object_type", "dagger.function"
+    args: list[Any] = dataclasses.field(default_factory=list)
+    kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    node: ast.expr | None = None  # The original AST node
+
+
+# Known Dagger decorators and their possible names
+DAGGER_DECORATORS = {
+    # @dagger.object_type or @mod.object_type or @object_type
+    "object_type": {"object_type", "dagger.object_type", "mod.object_type"},
+    # @dagger.function or @mod.function or @function
+    "function": {"function", "dagger.function", "mod.function"},
+    # @dagger.field or @mod.field or @field
+    "field": {"field", "dagger.field", "mod.field"},
+    # @dagger.interface or @mod.interface or @interface
+    "interface": {"interface", "dagger.interface", "mod.interface"},
+    # @dagger.enum_type or @mod.enum_type or @enum_type
+    "enum_type": {"enum_type", "dagger.enum_type", "mod.enum_type"},
+    # @dagger.check or @mod.check or @check
+    "check": {"check", "dagger.check", "mod.check"},
+}
+
+
+def get_decorator_name(decorator: ast.expr) -> str:
+    """Get the name of a decorator.
+
+    Handles:
+    - Simple names: @foo
+    - Attribute access: @mod.foo
+    - Call expressions: @foo() or @mod.foo()
+    """
+    if isinstance(decorator, ast.Call):
+        return get_decorator_name(decorator.func)
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    if isinstance(decorator, ast.Attribute):
+        # e.g., mod.function -> "mod.function"
+        value_name = get_decorator_name(decorator.value)
+        return f"{value_name}.{decorator.attr}"
+    return ""
+
+
+def has_decorator(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+    decorator_type: str,
+) -> bool:
+    """Check if a node has a specific Dagger decorator.
+
+    Args:
+        node: The AST node to check.
+        decorator_type: One of "object_type", "function", "field", etc.
+
+    Returns
+    -------
+        True if the node has the decorator.
+    """
+    if decorator_type not in DAGGER_DECORATORS:
+        return False
+
+    valid_names = DAGGER_DECORATORS[decorator_type]
+
+    for decorator in node.decorator_list:
+        name = get_decorator_name(decorator)
+        if name in valid_names:
+            return True
+
+    return False
+
+
+def find_decorator(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef, decorator_type: str
+) -> ast.expr | None:
+    """Find a specific Dagger decorator on a node.
+
+    Args:
+        node: The AST node to check.
+        decorator_type: One of "object_type", "function", "field", etc.
+
+    Returns
+    -------
+        The decorator AST node, or None if not found.
+    """
+    if decorator_type not in DAGGER_DECORATORS:
+        return None
+
+    valid_names = DAGGER_DECORATORS[decorator_type]
+
+    for decorator in node.decorator_list:
+        name = get_decorator_name(decorator)
+        if name in valid_names:
+            return decorator
+
+    return None
+
+
+def extract_decorator_info(decorator: ast.expr) -> DecoratorInfo:
+    """Extract information from a decorator AST node.
+
+    Handles:
+    - @decorator
+    - @decorator()
+    - @decorator(arg1, arg2)
+    - @decorator(key=value)
+    """
+    name = get_decorator_name(decorator)
+    args: list[Any] = []
+    kwargs: dict[str, Any] = {}
+
+    if isinstance(decorator, ast.Call):
+        # Extract positional arguments
+        args = [_eval_decorator_arg(arg) for arg in decorator.args]
+
+        # Extract keyword arguments
+        kwargs = {
+            keyword.arg: _eval_decorator_arg(keyword.value)
+            for keyword in decorator.keywords
+            if keyword.arg is not None
+        }
+
+    return DecoratorInfo(name=name, args=args, kwargs=kwargs, node=decorator)
+
+
+def _eval_decorator_arg(node: ast.expr) -> Any:  # noqa: PLR0911
+    """Evaluate a decorator argument to a Python value.
+
+    Only handles simple literal values. Complex expressions
+    are returned as strings.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    if isinstance(node, ast.Name):
+        name_map = {"True": True, "False": False, "None": None}
+        return name_map.get(node.id, node.id)
+
+    if isinstance(node, ast.List):
+        return [_eval_decorator_arg(el) for el in node.elts]
+
+    if isinstance(node, ast.Tuple):
+        return tuple(_eval_decorator_arg(el) for el in node.elts)
+
+    if isinstance(node, ast.Dict):
+        return {
+            _eval_decorator_arg(k) if k else None: _eval_decorator_arg(v)
+            for k, v in zip(node.keys, node.values, strict=False)
+        }
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        val = _eval_decorator_arg(node.operand)
+        if isinstance(val, (int, float)):
+            return -val
+
+    # For complex expressions, return the source code
+    return ast.unparse(node)
+
+
+def is_classmethod(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Check if a function has @classmethod decorator."""
+    for decorator in node.decorator_list:
+        name = get_decorator_name(decorator)
+        if name == "classmethod":
+            return True
+    return False
+
+
+def is_staticmethod(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Check if a function has @staticmethod decorator."""
+    for decorator in node.decorator_list:
+        name = get_decorator_name(decorator)
+        if name == "staticmethod":
+            return True
+    return False
+
+
+def get_function_decorators(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[DecoratorInfo]:
+    """Get all decorator info for a function."""
+    return [extract_decorator_info(d) for d in node.decorator_list]

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
@@ -31,6 +31,8 @@ DAGGER_DECORATORS = {
     "enum_type": {"enum_type", "dagger.enum_type", "mod.enum_type"},
     # @dagger.check or @mod.check or @check
     "check": {"check", "dagger.check", "mod.check"},
+    # @dagger.generate or @mod.generate or @generate
+    "generate": {"generate", "dagger.generate", "mod.generate"},
 }
 
 

--- a/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
+++ b/sdk/python/src/dagger/mod/_analyzer/visitors/decorators.py
@@ -33,6 +33,8 @@ DAGGER_DECORATORS = {
     "check": {"check", "dagger.check", "mod.check"},
     # @dagger.generate or @mod.generate or @generate
     "generate": {"generate", "dagger.generate", "mod.generate"},
+    # @dagger.up or @mod.up or @up
+    "up": {"up", "dagger.up", "mod.up"},
 }
 
 

--- a/sdk/python/src/dagger/mod/_discovery.py
+++ b/sdk/python/src/dagger/mod/_discovery.py
@@ -1,0 +1,112 @@
+"""Module discovery and AST-based registration utilities.
+
+Provides functions to locate Python source files for a Dagger module
+and register module types using AST analysis.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import importlib.util
+import logging
+import os
+import typing
+from pathlib import Path
+
+import dagger
+
+IMPORT_PKG: typing.Final[str] = os.getenv("DAGGER_DEFAULT_PYTHON_PACKAGE", "main")
+
+logger = logging.getLogger(__name__)
+
+
+async def ast_register(
+    main_object_name: str,
+    module_name: str,
+) -> dagger.ModuleID:
+    """Analyze source files and register module types with the Dagger engine.
+
+    This is the shared pipeline used by both the CLI registration path
+    and the Module._typedefs() path.
+    """
+    from dagger.mod._analyzer import analyze_module
+    from dagger.mod._analyzer.registration import register_from_metadata
+
+    source_files = find_source_files()
+    if not source_files:
+        msg = (
+            "No Python source files found for module. "
+            f"Looking for package: {IMPORT_PKG}"
+        )
+        raise RuntimeError(msg)
+
+    logger.debug("Found source files: %s", source_files)
+
+    metadata = analyze_module(
+        source_files=source_files,
+        main_object_name=main_object_name,
+        module_name=module_name,
+    )
+
+    logger.debug(
+        "Analyzed module: %d objects, %d enums",
+        len(metadata.objects),
+        len(metadata.enums),
+    )
+
+    return await register_from_metadata(metadata)
+
+
+def find_source_files() -> list[str]:
+    """Find Python source files for the module.
+
+    Returns a list of .py files in the module package.
+    """
+    spec = _find_module_spec()
+
+    if spec is None:
+        return []
+
+    # Single-file module
+    if spec.submodule_search_locations is None:
+        if spec.origin and spec.origin.endswith(".py"):
+            return [spec.origin]
+        return []
+
+    # Package module — find all .py files
+    source_files: list[str] = []
+    for location in spec.submodule_search_locations:
+        pkg_path = Path(location)
+        if pkg_path.is_dir():
+            _collect_package_files(pkg_path, source_files)
+
+    return source_files
+
+
+def _find_module_spec() -> importlib.machinery.ModuleSpec | None:
+    """Find the module spec, falling back to 'main' package."""
+    spec = importlib.util.find_spec(IMPORT_PKG)
+    if spec is None:
+        spec = importlib.util.find_spec("main")
+    return spec
+
+
+def _collect_package_files(pkg_path: Path, source_files: list[str]) -> None:
+    """Collect .py files from a package directory into source_files."""
+    # Add __init__.py first if it exists
+    init_file = pkg_path / "__init__.py"
+    if init_file.exists():
+        source_files.append(str(init_file))
+
+    # Add other .py files
+    source_files.extend(
+        str(py_file)
+        for py_file in pkg_path.glob("*.py")
+        if py_file.name != "__init__.py"
+    )
+
+    # Add files from subdirectories (one level deep)
+    for subdir in pkg_path.iterdir():
+        if subdir.is_dir() and not subdir.name.startswith("_"):
+            source_files.extend(str(py_file) for py_file in subdir.glob("*.py"))

--- a/sdk/python/src/dagger/mod/_discovery.py
+++ b/sdk/python/src/dagger/mod/_discovery.py
@@ -93,13 +93,14 @@ def _find_module_spec() -> importlib.machinery.ModuleSpec | None:
 
 
 def _collect_package_files(pkg_path: Path, source_files: list[str]) -> None:
-    """Collect .py files from a package directory into source_files."""
-    # Add __init__.py first if it exists
-    init_file = pkg_path / "__init__.py"
-    if init_file.exists():
-        source_files.append(str(init_file))
+    """Collect .py files from a package directory into source_files.
 
-    # Add other .py files
+    __init__.py is added last so that any class definitions in it
+    take precedence over same-named classes in other files. This
+    matches Python's import semantics where ``import pkg`` loads
+    ``__init__.py`` as the primary module entry point.
+    """
+    # Add other .py files first
     source_files.extend(
         str(py_file)
         for py_file in pkg_path.glob("*.py")
@@ -110,3 +111,8 @@ def _collect_package_files(pkg_path: Path, source_files: list[str]) -> None:
     for subdir in pkg_path.iterdir():
         if subdir.is_dir() and not subdir.name.startswith("_"):
             source_files.extend(str(py_file) for py_file in subdir.glob("*.py"))
+
+    # Add __init__.py last so its definitions take precedence
+    init_file = pkg_path / "__init__.py"
+    if init_file.exists():
+        source_files.append(str(init_file))

--- a/sdk/python/src/dagger/mod/_discovery.py
+++ b/sdk/python/src/dagger/mod/_discovery.py
@@ -93,26 +93,21 @@ def _find_module_spec() -> importlib.machinery.ModuleSpec | None:
 
 
 def _collect_package_files(pkg_path: Path, source_files: list[str]) -> None:
-    """Collect .py files from a package directory into source_files.
+    """Collect .py files from a package directory, recursing into subpackages.
 
-    __init__.py is added last so that any class definitions in it
-    take precedence over same-named classes in other files. This
-    matches Python's import semantics where ``import pkg`` loads
-    ``__init__.py`` as the primary module entry point.
+    ``__init__.py`` is always added after the rest of the directory so that its
+    definitions take precedence, mirroring Python's import semantics.
     """
-    # Add other .py files first
-    source_files.extend(
-        str(py_file)
-        for py_file in pkg_path.glob("*.py")
-        if py_file.name != "__init__.py"
-    )
+    init_file: Path | None = None
+    for py_file in sorted(pkg_path.glob("*.py")):
+        if py_file.name == "__init__.py":
+            init_file = py_file
+        else:
+            source_files.append(str(py_file))
 
-    # Add files from subdirectories (one level deep)
-    for subdir in pkg_path.iterdir():
+    for subdir in sorted(pkg_path.iterdir()):
         if subdir.is_dir() and not subdir.name.startswith("_"):
-            source_files.extend(str(py_file) for py_file in subdir.glob("*.py"))
+            _collect_package_files(subdir, source_files)
 
-    # Add __init__.py last so its definitions take precedence
-    init_file = pkg_path / "__init__.py"
-    if init_file.exists():
+    if init_file and init_file.exists():
         source_files.append(str(init_file))

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -9,7 +9,6 @@ import typing
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, TypeVar, cast
 
-import anyio
 import cattrs
 import cattrs.gen
 from cattrs.preconf import is_primitive_enum
@@ -19,7 +18,7 @@ from typing_extensions import dataclass_transform, overload
 import dagger
 from dagger import dag
 from dagger.client._core import configure_converter_enum
-from dagger.mod._converter import make_converter, to_typedef
+from dagger.mod._converter import make_converter
 from dagger.mod._exceptions import (
     BadUsageError,
     FunctionError,
@@ -40,13 +39,7 @@ from dagger.mod._resolver import (
     R,
 )
 from dagger.mod._types import APIName, FieldDefinition, FunctionDefinition, PythonName
-from dagger.mod._utils import (
-    asyncify,
-    extract_enum_member_doc,
-    get_doc,
-    get_parent_module_doc,
-    is_annotated,
-)
+from dagger.mod._utils import asyncify, is_annotated
 
 logger = logging.getLogger(__package__)
 
@@ -113,162 +106,17 @@ class Module:
 
         await dag.current_function_call().return_value(dagger.JSON(output))
 
-    async def register(self):
-        """Register the module and its types with the Dagger API."""
+    async def _typedefs(self) -> dagger.ModuleID:
+        """Register the module types using AST-based analysis."""
+        from dagger.mod._discovery import ast_register
+
         try:
-            result = await self._typedefs()
-            output = json.dumps(result)
-        except TypeError as e:
-            raise RegistrationError(str(e), e) from e
-        await anyio.Path(TYPE_DEF_FILE).write_text(output)
-
-    async def _typedefs(self) -> dagger.ModuleID:  # noqa: C901, PLR0912, PLR0915
-        if not self._main_name:
-            msg = "Main object name can't be empty"
-            raise ValueError(msg)
-        try:
-            self.get_object(self._main_name)
-        except ObjectNotFoundError as e:
-            msg = (
-                f"Main object with name '{self._main_name}' not found or class not "
-                "decorated with '@dagger.object_type'\n"
-                f"If you believe the module name '{MODULE_NAME}' is incorrectly "
-                "being converted into PascalCase, please file a bug report."
+            return await ast_register(
+                main_object_name=self._main_name,
+                module_name=MODULE_NAME,
             )
-            raise ObjectNotFoundError(msg, extra=e.extra) from None
-
-        mod = dag.module()
-
-        # Object types
-        for obj_name, obj_type in self._objects.items():
-            if self.is_main(obj_type):
-                # Only the main object's constructor is needed.
-                # It's the entrypoint to the module.
-                obj_type.get_constructor(self._converter)
-
-                # Module description from main object's parent module
-                if desc := get_parent_module_doc(obj_type.cls):
-                    mod = mod.with_description(desc)
-
-            # Object/interface type
-            type_def = dag.type_def()
-            if obj_type.interface:
-                type_def = type_def.with_interface(
-                    obj_name,
-                    description=get_doc(obj_type.cls),
-                )
-            else:
-                type_def = type_def.with_object(
-                    obj_name,
-                    description=get_doc(obj_type.cls),
-                    deprecated=obj_type.deprecated,
-                )
-
-            # Object fields
-            if obj_type.fields:
-                types = typing.get_type_hints(obj_type.cls)
-
-                for field_name, field in obj_type.fields.items():
-                    ctx = f"type for field '{field.original_name}' in {obj_type}"
-                    type_def = type_def.with_field(
-                        field_name,
-                        to_typedef(types[field.original_name], ctx),
-                        description=get_doc(field.return_type),
-                        deprecated=field.meta.deprecated,
-                    )
-
-            # Object/interface functions
-            for func_name, func in obj_type.functions.items():
-                what = f"function '{func_name}'" if func_name else "constructor"
-
-                func_def = dag.function(
-                    func_name,
-                    to_typedef(
-                        func.return_type,
-                        f"return type for {what} in {obj_type}",
-                    ),
-                )
-
-                if doc := func.doc:
-                    func_def = func_def.with_description(doc)
-
-                if func.cache_policy is not None:
-                    if func.cache_policy == "never":
-                        func_def = func_def.with_cache_policy(
-                            dagger.FunctionCachePolicy.Never,
-                        )
-                    elif func.cache_policy == "session":
-                        func_def = func_def.with_cache_policy(
-                            dagger.FunctionCachePolicy.PerSession,
-                        )
-                    elif func.cache_policy != "":
-                        func_def = func_def.with_cache_policy(
-                            dagger.FunctionCachePolicy.Default,
-                            time_to_live=func.cache_policy,
-                        )
-                if deprecated := func.deprecated:
-                    func_def = func_def.with_deprecated(reason=deprecated)
-                if func.check:
-                    func_def = func_def.with_check()
-                if func.generate:
-                    func_def = func_def.with_generator()
-                if func.service:
-                    func_def = func_def.with_up()
-
-                for param in func.parameters.values():
-                    arg_def = to_typedef(
-                        param.resolved_type,
-                        f"parameter type for '{param.name}' in {what} and {obj_type}",
-                    )
-
-                    if param.is_nullable:
-                        arg_def = arg_def.with_optional(True)
-
-                    func_def = func_def.with_arg(
-                        param.name,
-                        arg_def,
-                        description=param.doc,
-                        default_value=param.default_value,
-                        default_path=param.default_path,
-                        default_address=param.default_address,
-                        ignore=param.ignore,
-                        deprecated=param.deprecated,
-                    )
-
-                type_def = (
-                    type_def.with_constructor(func_def)
-                    if func_name == ""
-                    else type_def.with_function(func_def)
-                )
-
-            # Add object/interface to module
-            mod = (
-                mod.with_interface(type_def)
-                if obj_type.interface
-                else mod.with_object(type_def)
-            )
-
-        # Enum types
-        for name, cls in self._enums.items():
-            enum_def = dag.type_def().with_enum(name, description=get_doc(cls))
-            member_docs = extract_enum_member_doc(cls)
-
-            for member in cls:
-                description = getattr(member, "description", None)
-                meta = member_docs.get(member.name)
-
-                if description is None and meta and meta.description is not None:
-                    description = meta.description
-
-                enum_def = enum_def.with_enum_member(
-                    member.name,
-                    value=str(member.value),
-                    description=description,
-                    deprecated=meta.deprecated if meta else None,
-                )
-            mod = mod.with_enum(enum_def)
-
-        return await mod.id()
+        except RuntimeError as e:
+            raise RegistrationError(str(e)) from e
 
     async def invoke(self) -> dagger.ModuleID:
         """Invoke a function and return its result.

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -107,7 +107,7 @@ class Module:
         await dag.current_function_call().return_value(dagger.JSON(output))
 
     async def _typedefs(self) -> dagger.ModuleID:
-        """Register the module types using AST-based analysis."""
+        """Delegate to AST-based registration, translating RuntimeError."""
         from dagger.mod._discovery import ast_register
 
         try:

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -781,13 +781,16 @@ class Foo:
 
 
 def test_ast_module_name():
-    metadata = _analyze("""
+    metadata = _analyze(
+        """
 import dagger
 
 @dagger.object_type
 class Foo:
     pass
-""", module_name="my-module")
+""",
+        module_name="my-module",
+    )
     assert metadata.module_name == "my-module"
     assert metadata.main_object == "Foo"
 
@@ -834,13 +837,16 @@ def test_ast_empty_source_files():
 
 def test_ast_main_object_not_found():
     with pytest.raises(ValidationError, match="Main object 'Missing' not found"):
-        _analyze("""
+        _analyze(
+            """
 import dagger
 
 @dagger.object_type
 class Foo:
     pass
-""", main="Missing")
+""",
+            main="Missing",
+        )
 
 
 def test_ast_syntax_error():

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1,0 +1,854 @@
+"""Tests for the AST-based module analyzer.
+
+These are the AST-path equivalents of the runtime tests in test_registration.py
+and test_future_annotations.py, verifying that analyze_source_string() extracts
+the same information the runtime Module() introspection does.
+"""
+
+import pytest
+
+from dagger.mod._analyzer.analyze import analyze_module, analyze_source_string
+from dagger.mod._analyzer.errors import AnalysisError, ParseError, ValidationError
+
+
+def _analyze(source: str, main: str = "Foo", **kwargs):
+    """Shorthand used throughout this file."""
+    return analyze_source_string(source, main, **kwargs)
+
+
+# -- Mirrors test_registration.py: test_object_type_resolvers ----------------
+
+
+def test_ast_object_type_resolvers():
+    """AST equivalent of test_object_type_resolvers."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    private_field: str
+    exposed_field: str = dagger.field()
+
+    def private_method(self) -> str: ...
+    @dagger.function
+    def exposed_method(self) -> str: ...
+""")
+
+    obj = metadata.objects["Foo"]
+    fields = [f.python_name for f in obj.fields]
+    functions = [f.python_name for f in obj.functions]
+    assert fields + functions == ["exposed_field", "exposed_method"]
+
+
+# -- Mirrors test_registration.py: test_func_doc ----------------------------
+
+
+def test_ast_func_doc():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn_with_doc(self):
+        \"\"\"Foo.\"\"\"
+""")
+    assert metadata.objects["Foo"].functions[0].doc == "Foo."
+
+
+# -- Mirrors test_registration.py: test_function_deprecated_metadata ---------
+
+
+def test_ast_function_deprecated_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function(deprecated="Use new method instead")
+    def legacy(self):
+        \"\"\"Legacy function.\"\"\"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.deprecated == "Use new method instead"
+
+
+# -- Mirrors test_registration.py: test_function_check_metadata --------------
+
+
+def test_ast_function_check_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    @dagger.check
+    def lint(self):
+        \"\"\"Check function.\"\"\"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_check is True
+
+
+def test_ast_function_check_default_false():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def regular(self):
+        \"\"\"Regular function.\"\"\"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_check is False
+
+
+def test_ast_check_decorator_order():
+    """@check works whether applied before or after @function."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.check
+    @dagger.function
+    def check_first(self):
+        \"\"\"Check applied before function.\"\"\"
+
+    @dagger.function
+    @dagger.check
+    def function_first(self):
+        \"\"\"Check applied after function.\"\"\"
+""")
+    fns = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert fns["check_first"].is_check is True
+    assert fns["function_first"].is_check is True
+
+
+# -- Mirrors test_registration.py: test_field_deprecated_metadata ------------
+
+
+def test_ast_field_deprecated_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    legacy: str = dagger.field(default="", deprecated="Use new field instead")
+""")
+    field = metadata.objects["Foo"].fields[0]
+    assert field.deprecated == "Use new field instead"
+
+
+# -- Mirrors test_registration.py: test_object_type_deprecated_metadata ------
+
+
+def test_ast_object_type_deprecated_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type(deprecated="Use NewFoo instead")
+class Foo:
+    pass
+""")
+    assert metadata.objects["Foo"].deprecated == "Use NewFoo instead"
+
+
+# -- Mirrors test_registration.py: test_void_return_type ---------------------
+
+
+def test_ast_void_return_type():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def void(self): ...
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.resolved_return_type.kind == "void"
+    assert fn.resolved_return_type.is_optional is True
+
+
+# -- Mirrors test_registration.py: test_self_return_type ---------------------
+
+
+def test_ast_self_return_type():
+    metadata = _analyze("""
+import dagger
+from typing_extensions import Self
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def iden(self) -> Self:
+        return self
+
+    @dagger.function
+    def seq(self) -> list[Self]:
+        return [self]
+""")
+    fns = {f.python_name: f for f in metadata.objects["Foo"].functions}
+
+    iden_ret = fns["iden"].resolved_return_type
+    assert iden_ret.kind == "object"
+    assert iden_ret.name == "Foo"
+    assert iden_ret.is_self is True
+
+    seq_ret = fns["seq"].resolved_return_type
+    assert seq_ret.kind == "list"
+    assert seq_ret.element_type.kind == "object"
+    assert seq_ret.element_type.name == "Foo"
+    assert seq_ret.element_type.is_self is True
+
+
+# -- Mirrors test_forward_reference.py --------------------------------------
+
+
+def test_ast_forward_reference():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def method1(self) -> "Foo": ...
+
+    @dagger.function
+    def get_bar(self) -> "Bar": ...
+
+@dagger.object_type
+class Bar:
+    pass
+""")
+    fns = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert fns["method1"].resolved_return_type.name == "Foo"
+    assert fns["get_bar"].resolved_return_type.name == "Bar"
+
+
+# -- Mirrors test_future_annotations.py -------------------------------------
+
+
+def test_ast_default_path_with_future_annotations():
+    metadata = _analyze("""
+from __future__ import annotations
+from typing import Annotated
+import dagger
+from dagger import DefaultPath
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(
+        self,
+        src: Annotated[dagger.Directory, DefaultPath(".")],
+    ) -> str:
+        return "ok"
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.default_path == "."
+
+
+def test_ast_doc_with_future_annotations():
+    metadata = _analyze("""
+from __future__ import annotations
+from typing import Annotated
+from typing_extensions import Doc
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(
+        self,
+        src: Annotated[str, Doc("Source directory")],
+    ) -> str:
+        return "ok"
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.doc == "Source directory"
+
+
+def test_ast_name_with_future_annotations():
+    metadata = _analyze("""
+from __future__ import annotations
+from typing import Annotated
+import dagger
+from dagger import Name
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(
+        self,
+        src: Annotated[str, Name("source")],
+    ) -> str:
+        return "ok"
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.api_name == "source"
+
+
+def test_ast_ignore_with_future_annotations():
+    metadata = _analyze("""
+from __future__ import annotations
+from typing import Annotated
+import dagger
+from dagger import Ignore
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(
+        self,
+        src: Annotated[dagger.Directory, Ignore(["*.tmp", ".git"])],
+    ) -> str:
+        return "ok"
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.ignore == ["*.tmp", ".git"]
+
+
+def test_ast_deprecated_with_future_annotations():
+    metadata = _analyze("""
+from __future__ import annotations
+from typing import Annotated
+import dagger
+from dagger import Deprecated
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(
+        self,
+        src: Annotated[str, Deprecated("Use new_src instead")] = "",
+    ) -> str:
+        return "ok"
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.deprecated == "Use new_src instead"
+
+
+# -- Mirrors test_interfaces.py: test_registered_functions -------------------
+
+
+def test_ast_interface_registered_functions():
+    metadata = _analyze("""
+import dagger
+from typing_extensions import Self
+
+@dagger.interface
+class Duck:
+    @dagger.function
+    def quack(self) -> str: ...
+
+    @dagger.function
+    def get_self(self) -> Self: ...
+
+    @dagger.function
+    def get_mob(self) -> list[Self]: ...
+
+    def get_private(self) -> bool: ...
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    duck = metadata.objects["Duck"]
+    assert duck.is_interface is True
+    func_names = [f.python_name for f in duck.functions]
+    assert "quack" in func_names
+    assert "get_self" in func_names
+    assert "get_mob" in func_names
+    assert "get_private" not in func_names
+    assert duck.constructor is None
+
+
+# -- Mirrors test_enum_docstrings.py -----------------------------------------
+
+
+def test_ast_enum_member_doc():
+    metadata = _analyze("""
+import enum
+import dagger
+
+@dagger.enum_type
+class ExampleEnum(enum.Enum):
+    FIRST = "first"
+    \"\"\"This is the first option\"\"\"
+
+    SECOND = "second"
+    \"\"\"This is the second option\"\"\"
+
+    THIRD = "third"
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    members = {m.name: m for m in metadata.enums["ExampleEnum"].members}
+    assert members["FIRST"].doc == "This is the first option"
+    assert members["SECOND"].doc == "This is the second option"
+    assert members["THIRD"].doc is None
+
+
+def test_ast_enum_no_docs():
+    metadata = _analyze("""
+import enum
+import dagger
+
+@dagger.enum_type
+class EmptyEnum(enum.Enum):
+    VALUE = "value"
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    assert metadata.enums["EmptyEnum"].members[0].doc is None
+
+
+# -- @generate decorator (no runtime equivalent yet) -------------------------
+
+
+def test_ast_function_generate_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    @dagger.generate
+    def codegen(self) -> dagger.Directory:
+        ...
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_generate is True
+
+
+def test_ast_function_generate_default_false():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def regular(self) -> str:
+        return "ok"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_generate is False
+
+
+# -- Type resolution ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected_kind", "expected_name"),
+    [
+        ("str", "primitive", "str"),
+        ("int", "primitive", "int"),
+        ("float", "primitive", "float"),
+        ("bool", "primitive", "bool"),
+    ],
+)
+def test_ast_primitive_type_resolution(annotation, expected_kind, expected_name):
+    metadata = _analyze(f"""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn(self, x: {annotation}) -> str:
+        return ""
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == expected_kind
+    assert param.resolved_type.name == expected_name
+
+
+def test_ast_optional_type():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn(self, name: str | None = None) -> str:
+        return name or ""
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "str"
+    assert param.resolved_type.is_optional is True
+    assert param.is_nullable is True
+
+
+def test_ast_list_type():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn(self, items: list[str]) -> list[int]:
+        return [len(s) for s in items]
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.parameters[0].resolved_type.kind == "list"
+    assert fn.parameters[0].resolved_type.element_type.name == "str"
+    assert fn.resolved_return_type.kind == "list"
+    assert fn.resolved_return_type.element_type.name == "int"
+
+
+@pytest.mark.parametrize(
+    ("type_name", "expected_kind"),
+    [
+        ("dagger.Container", "object"),
+        ("dagger.Directory", "object"),
+        ("dagger.File", "object"),
+        ("dagger.Secret", "object"),
+        ("dagger.Service", "object"),
+        ("dagger.Platform", "scalar"),
+    ],
+)
+def test_ast_dagger_type_resolution(type_name, expected_kind):
+    metadata = _analyze(f"""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn(self) -> {type_name}:
+        ...
+""")
+    ret = metadata.objects["Foo"].functions[0].resolved_return_type
+    assert ret.kind == expected_kind
+
+
+def test_ast_enum_type_resolution():
+    metadata = _analyze("""
+import enum
+import dagger
+
+@dagger.enum_type
+class Color(enum.Enum):
+    RED = "RED"
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def pick(self, color: Color) -> str:
+        return color.value
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "enum"
+    assert param.resolved_type.name == "Color"
+
+
+def test_ast_interface_type_resolution():
+    metadata = _analyze("""
+import dagger
+
+@dagger.interface
+class Buildable:
+    @dagger.function
+    def build(self) -> str: ...
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def get_buildable(self) -> Buildable:
+        ...
+""")
+    ret = metadata.objects["Foo"].functions[0].resolved_return_type
+    assert ret.kind == "interface"
+    assert ret.name == "Buildable"
+
+
+# -- Constructor handling ----------------------------------------------------
+
+
+def test_ast_default_constructor():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+    count: int = dagger.field(default=0)
+""")
+    ctor = metadata.objects["Foo"].constructor
+    assert ctor is not None
+    assert ctor.is_constructor is True
+    assert len(ctor.parameters) == 2
+    assert ctor.parameters[0].python_name == "name"
+    assert ctor.parameters[0].has_default is False
+    assert ctor.parameters[1].python_name == "count"
+    assert ctor.parameters[1].has_default is True
+
+
+def test_ast_field_init_false_excluded_from_constructor():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+    internal: str = dagger.field(init=False)
+""")
+    ctor = metadata.objects["Foo"].constructor
+    assert len(ctor.parameters) == 1
+    assert ctor.parameters[0].python_name == "name"
+
+
+def test_ast_alt_constructor():
+    metadata = _analyze("""
+import dagger
+from typing_extensions import Self
+
+@dagger.object_type
+class Foo:
+    @classmethod
+    def create(cls, bar: str = "bar") -> Self:
+        \"\"\"Constructor doc.\"\"\"
+        return cls()
+""")
+    ctor = metadata.objects["Foo"].constructor
+    assert ctor is not None
+    assert ctor.is_constructor is True
+    assert ctor.is_classmethod is True
+    assert ctor.doc == "Constructor doc."
+    assert len(ctor.parameters) == 1
+    assert ctor.parameters[0].python_name == "bar"
+    assert ctor.parameters[0].default_value == "bar"
+
+
+def test_ast_constructor_doc():
+    """Constructor inherits class docstring when auto-generated."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    \"\"\"Object doc.\"\"\"
+""")
+    assert metadata.objects["Foo"].constructor.doc == "Object doc."
+
+
+# -- Decorator naming conventions --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # @dagger.* prefix
+        """
+import dagger
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+
+    @dagger.function
+    def hello(self) -> str: ...
+""",
+        # bare imports
+        """
+from dagger import object_type, function, field
+
+@object_type
+class Foo:
+    name: str = field()
+
+    @function
+    def hello(self) -> str: ...
+""",
+        # @mod.* prefix
+        """
+import dagger
+from dagger.mod import Module
+
+mod = Module()
+
+@mod.object_type
+class Foo:
+    name: str = mod.field()
+
+    @mod.function
+    def hello(self) -> str: ...
+""",
+    ],
+    ids=["dagger_prefix", "bare_import", "mod_prefix"],
+)
+def test_ast_decorator_naming(source):
+    metadata = _analyze(source)
+    obj = metadata.objects["Foo"]
+    assert len(obj.fields) == 1
+    assert len(obj.functions) == 1
+
+
+# -- Name normalization (mirrors test_utils.py: test_normalize_name) ---------
+
+
+@pytest.mark.parametrize(
+    ("python_name", "expected_api_name"),
+    [
+        ("with_", "with"),
+        ("from_", "from"),
+    ],
+)
+def test_ast_trailing_underscore_normalization(python_name, expected_api_name):
+    metadata = _analyze(f"""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def {python_name}(self) -> str: ...
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.python_name == python_name
+    assert fn.api_name == expected_api_name
+
+
+# -- Cache policy ------------------------------------------------------------
+
+
+def test_ast_cache_policy():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function(cache="never")
+    def no_cache(self) -> str: ...
+
+    @dagger.function(cache="session")
+    def session_cache(self) -> str: ...
+
+    @dagger.function(cache="30s")
+    def ttl_cache(self) -> str: ...
+""")
+    fns = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert fns["no_cache"].cache_policy == "never"
+    assert fns["session_cache"].cache_policy == "session"
+    assert fns["ttl_cache"].cache_policy == "30s"
+
+
+# -- Async functions ---------------------------------------------------------
+
+
+def test_ast_async_function():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    async def bar(self) -> str:
+        return "bar"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_async is True
+
+
+# -- Keyword-only arguments --------------------------------------------------
+
+
+def test_ast_kwonly_parameters():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(self, *, name: str, count: int = 1) -> str:
+        return name * count
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert len(fn.parameters) == 2
+    assert fn.parameters[0].python_name == "name"
+    assert fn.parameters[1].python_name == "count"
+    assert fn.parameters[1].has_default is True
+    assert fn.parameters[1].default_value == 1
+
+
+# -- Module metadata ---------------------------------------------------------
+
+
+def test_ast_module_name():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    pass
+""", module_name="my-module")
+    assert metadata.module_name == "my-module"
+    assert metadata.main_object == "Foo"
+
+
+def test_ast_module_name_defaults_to_main_object():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    assert metadata.module_name == "Foo"
+
+
+def test_ast_metadata_json_roundtrip():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+
+    @dagger.function
+    def hello(self, greeting: str = "hi") -> str:
+        return greeting
+""")
+    restored = metadata.from_json(metadata.to_json())
+
+    assert restored.module_name == metadata.module_name
+    assert restored.main_object == metadata.main_object
+    assert "Foo" in restored.objects
+    assert len(restored.objects["Foo"].fields) == 1
+    assert len(restored.objects["Foo"].functions) == 1
+
+
+# -- Error handling ----------------------------------------------------------
+
+
+def test_ast_empty_source_files():
+    with pytest.raises(AnalysisError, match="No source files provided"):
+        analyze_module([], "Foo")
+
+
+def test_ast_main_object_not_found():
+    with pytest.raises(ValidationError, match="Main object 'Missing' not found"):
+        _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    pass
+""", main="Missing")
+
+
+def test_ast_syntax_error():
+    with pytest.raises(ParseError):
+        _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo
+    pass
+""")

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -777,6 +777,27 @@ class Foo:
     assert fn.parameters[1].default_value == 1
 
 
+def test_ast_kwonly_falsey_defaults():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(self, *, enabled: bool = False, retries: int = 0) -> bool:
+        return enabled
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert len(fn.parameters) == 2
+    enabled, retries = fn.parameters
+    assert enabled.python_name == "enabled"
+    assert enabled.has_default is True
+    assert enabled.default_value is False
+    assert retries.python_name == "retries"
+    assert retries.has_default is True
+    assert retries.default_value == 0
+
+
 # -- Module metadata ---------------------------------------------------------
 
 

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -443,6 +443,38 @@ class Foo:
     assert fn.is_generate is False
 
 
+# -- @up decorator -----------------------------------------------------------
+
+
+def test_ast_function_up_metadata():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    @dagger.up
+    def web(self) -> dagger.Service:
+        ...
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_service is True
+
+
+def test_ast_function_up_default_false():
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def regular(self) -> str:
+        return "ok"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.is_service is False
+
+
 # -- Type resolution ---------------------------------------------------------
 
 

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -911,3 +911,381 @@ import dagger
 class Foo
     pass
 """)
+
+
+# -- Regression tests for constructor / inheritance / enum fix commits -------
+
+
+def test_ast_initvar_not_exposed_as_field():
+    """``InitVar[T]`` must be a constructor param, never a field."""
+    metadata = _analyze("""
+import dagger
+from dataclasses import InitVar
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+    secret: InitVar[str]
+""")
+    obj = metadata.objects["Foo"]
+    field_names = [f.python_name for f in obj.fields]
+    param_names = [p.python_name for p in obj.constructor.parameters]
+    assert field_names == ["name"]
+    assert "secret" in param_names
+
+
+def test_ast_initvar_dotted_form():
+    """``dataclasses.InitVar[T]`` (dotted form) is recognized."""
+    metadata = _analyze("""
+import dagger
+import dataclasses
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+    token: dataclasses.InitVar[str]
+""")
+    obj = metadata.objects["Foo"]
+    assert [f.python_name for f in obj.fields] == ["name"]
+    assert "token" in [p.python_name for p in obj.constructor.parameters]
+
+
+def test_ast_explicit_init_overrides_autoderived():
+    """An explicit ``__init__`` supersedes field-derived constructor params."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    name: str = dagger.field()
+    count: int = dagger.field(default=0)
+
+    def __init__(self, name: str, *, flag: bool = False) -> None:
+        self.name = name
+        self.count = 0
+""")
+    ctor = metadata.objects["Foo"].constructor
+    names = [p.python_name for p in ctor.parameters]
+    assert names == ["name", "flag"]
+    assert ctor.is_constructor is True
+
+
+def test_ast_inherited_create_from_base_class():
+    """A ``create`` classmethod on a base class is used as the constructor."""
+    metadata = _analyze("""
+import dagger
+from typing import Self
+
+class Base:
+    @classmethod
+    def create(cls, name: str) -> Self:
+        return cls()
+
+@dagger.object_type
+class Foo(Base):
+    pass
+""")
+    ctor = metadata.objects["Foo"].constructor
+    assert [p.python_name for p in ctor.parameters] == ["name"]
+    assert ctor.is_constructor is True
+
+
+def test_ast_external_constructor_simple():
+    """``alt = function(Other)`` copies the target's constructor signature."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Other:
+    name: str = dagger.field(default="other")
+
+@dagger.object_type
+class Foo:
+    alt = dagger.function(Other)
+""")
+    funcs = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert "alt" in funcs
+    assert funcs["alt"].resolved_return_type.name == "Other"
+    assert [p.python_name for p in funcs["alt"].parameters] == ["name"]
+
+
+def test_ast_external_constructor_with_kwargs():
+    """``alt = function(doc=...)(Other)`` propagates kwargs."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Other:
+    name: str = dagger.field(default="other")
+
+@dagger.object_type
+class Foo:
+    alt = dagger.function(doc="custom doc")(Other)
+""")
+    funcs = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert "alt" in funcs
+    assert funcs["alt"].doc == "custom doc"
+
+
+def test_ast_external_constructor_forward_reference():
+    """``alt = function(Later)`` works when Later is declared afterward."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    alt = dagger.function(Later)
+
+@dagger.object_type
+class Later:
+    name: str = dagger.field(default="later")
+""")
+    funcs = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert "alt" in funcs
+    assert funcs["alt"].resolved_return_type.name == "Later"
+
+
+def test_ast_legacy_enum_tuple_value_with_doc():
+    """``MEMBER = "value", "doc"`` sets both value and member doc."""
+    metadata = _analyze("""
+import dagger
+
+class Status(dagger.Enum):
+    ACTIVE = "A", "Active description"
+    INACTIVE = "I", "Inactive description"
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    members = {m.name: m for m in metadata.enums["Status"].members}
+    assert members["ACTIVE"].value == "A"
+    assert members["ACTIVE"].doc == "Active description"
+    assert members["INACTIVE"].value == "I"
+
+
+def test_ast_legacy_enum_one_tuple_value():
+    """``MEMBER = "value",`` (1-tuple) sets value, no doc."""
+    metadata = _analyze("""
+import dagger
+
+class Status(dagger.Enum):
+    ACTIVE = "A",
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    active = metadata.enums["Status"].members[0]
+    assert active.value == "A"
+    assert active.doc is None
+
+
+# -- Error paths covered by resolver raise sites -----------------------------
+
+
+def test_ast_general_union_is_rejected():
+    """``int | str`` is not a supported Dagger type."""
+    from dagger.mod._analyzer.errors import TypeResolutionError
+
+    with pytest.raises(TypeResolutionError):
+        _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def fn(self, x: int | str) -> str:
+        return str(x)
+""")
+
+
+# -- Advanced defaults -------------------------------------------------------
+
+
+def test_ast_default_factory_list():
+    """``default_factory=list`` yields an empty list as the static default."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    tags: list[str] = dagger.field(default_factory=list)
+""")
+    field = metadata.objects["Foo"].fields[0]
+    assert field.python_name == "tags"
+    assert field.has_default is True
+    assert field.default_value == []
+
+
+def test_ast_module_level_constant_default():
+    """A module-level constant used as a default is resolved to its value."""
+    metadata = _analyze("""
+import dagger
+
+DEFAULT_NAME = "alice"
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def greet(self, name: str = DEFAULT_NAME) -> str:
+        return name
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    param = fn.parameters[0]
+    assert param.python_name == "name"
+    assert param.default_value == "alice"
+
+
+def test_ast_annassigned_constant_default():
+    """Annotated module-level constants also resolve."""
+    metadata = _analyze("""
+import dagger
+
+DEFAULT_COUNT: int = 5
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def count(self, n: int = DEFAULT_COUNT) -> int:
+        return n
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.parameters[0].default_value == 5
+
+
+# -- New fixes in this review round ------------------------------------------
+
+
+def test_ast_positional_only_parameter():
+    """Parameters before ``/`` must be extracted, not silently dropped."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def build(self, name: str, /, count: int = 0) -> str:
+        return f"{name}:{count}"
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    names = [p.python_name for p in fn.parameters]
+    assert names == ["name", "count"]
+
+
+def test_ast_classvar_annotation_is_ignored():
+    """``ClassVar[...]`` at class scope is a class constant, not a field."""
+    metadata = _analyze("""
+import dagger
+from typing import ClassVar
+
+@dagger.object_type
+class Foo:
+    VERSION: ClassVar[int] = 1
+    name: str = dagger.field()
+""")
+    obj = metadata.objects["Foo"]
+    assert [f.python_name for f in obj.fields] == ["name"]
+    ctor_names = [p.python_name for p in obj.constructor.parameters]
+    assert "VERSION" not in ctor_names
+
+
+def test_ast_final_annotation_is_ignored():
+    """``Final[...]`` at class scope is skipped as well."""
+    metadata = _analyze("""
+import dagger
+from typing import Final
+
+@dagger.object_type
+class Foo:
+    MAX: Final[int] = 99
+    name: str = dagger.field()
+""")
+    obj = metadata.objects["Foo"]
+    assert [f.python_name for f in obj.fields] == ["name"]
+    assert "MAX" not in [p.python_name for p in obj.constructor.parameters]
+
+
+def test_ast_intenum_is_detected():
+    """``IntEnum`` subclasses are registered alongside plain ``Enum``."""
+    metadata = _analyze("""
+import dagger
+from enum import IntEnum
+
+class Priority(IntEnum):
+    LOW = 1
+    HIGH = 2
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    assert "Priority" in metadata.enums
+    names = {m.name for m in metadata.enums["Priority"].members}
+    assert names == {"LOW", "HIGH"}
+
+
+def test_ast_strenum_is_detected():
+    """``StrEnum`` subclasses are registered alongside plain ``Enum``."""
+    metadata = _analyze("""
+import dagger
+from enum import StrEnum
+
+class Color(StrEnum):
+    RED = "red"
+    BLUE = "blue"
+
+@dagger.object_type
+class Foo:
+    pass
+""")
+    assert "Color" in metadata.enums
+
+
+def test_ast_sequence_resolves_as_list():
+    """``Sequence[T]`` resolves to list kind, not a bare object."""
+    metadata = _analyze("""
+import dagger
+from collections.abc import Sequence
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def sum(self, xs: Sequence[int]) -> int:
+        return sum(xs)
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "list"
+    assert param.resolved_type.element_type.name == "int"
+
+
+def test_ast_dataclasses_field_is_not_dagger_field():
+    """Bare ``field()`` from ``dataclasses`` must not register a Dagger field."""
+    metadata = _analyze("""
+import dagger
+from dataclasses import field
+
+@dagger.object_type
+class Foo:
+    items: list[str] = field(default_factory=list)
+    name: str = dagger.field()
+""")
+    obj = metadata.objects["Foo"]
+    field_names = [f.python_name for f in obj.fields]
+    assert field_names == ["name"]
+
+
+def test_ast_first_method_param_skipped_by_position():
+    """The receiver is skipped by position, not by name match."""
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def call(this, x: int) -> int:
+        return x
+""")
+    fn = metadata.objects["Foo"].functions[0]
+    names = [p.python_name for p in fn.parameters]
+    assert names == ["x"]

--- a/sdk/python/tests/mod/test_discovery.py
+++ b/sdk/python/tests/mod/test_discovery.py
@@ -1,0 +1,55 @@
+"""Tests for module discovery and AST registration integration."""
+
+from __future__ import annotations
+
+import importlib
+import textwrap
+
+from dagger.mod import _discovery
+from dagger.mod._analyzer import analyze_module
+
+
+def _write(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def test_nested_packages_are_discovered(tmp_path, monkeypatch):
+    pkg = tmp_path / "samplepkg"
+    _write(pkg / "__init__.py", '"""Root package doc."""\n')
+    _write(
+        pkg / "root.py",
+        """
+        import dagger
+
+        @dagger.object_type
+        class Root:
+            pass
+        """,
+    )
+    _write(pkg / "features" / "__init__.py", '"""Nested doc."""\n')
+    _write(
+        pkg / "features" / "nested" / "service.py",
+        """
+        import dagger
+
+        @dagger.object_type
+        class Nested:
+            pass
+        """,
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("DAGGER_DEFAULT_PYTHON_PACKAGE", "samplepkg")
+    monkeypatch.setattr(_discovery, "IMPORT_PKG", "samplepkg", raising=False)
+    importlib.invalidate_caches()
+
+    source_files = _discovery.find_source_files()
+    metadata = analyze_module(
+        source_files=source_files,
+        main_object_name="Root",
+        module_name="samplepkg",
+    )
+
+    assert "Nested" in metadata.objects
+    assert metadata.doc == "Root package doc."


### PR DESCRIPTION
This PR replaces the runtime analysis for the Python SDK to an AST based one.

Context: when the Python SDK wants to run a Python module, it starts by analysing the user module source code. This allows to find the types and functions exposed by the module, that is used in two different phases:
- to register those types to the engine (so the schema is extended by them, allowing them to be called)
- when a function is called so the python SDK knows the types to instanciate, functions to call, values to send back, etc

Right now, this happen at runtime, by loading the module code. The module code is loaded, and it will be analysed.

The problem is this analysis must happen _without_ to load the code. This is required to allow self calls. Self calls means the code must be able to call itself. There's a chicken and egg issue there, where the code must used generated code based... on the code.

To make it clearer, look at this self call code in Go (as it doesn't yet exist in python):

```go
type Test struct{}

func (m *Test) ContainerEcho(stringArg string) *dagger.Container {
	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
}

func (m *Test) Print(ctx context.Context, stringArg string) (string, error) {
	return dag.Test().ContainerEcho(stringArg).Stdout(ctx)
}
```

In the `Print` function it calls `dag.Test()` (that is "self") and then the `ContainerEcho()` function.
To generate this binding, the SDK must know `ContainerEcho` is a thing. This means this code is valid only if it knows the function exposed.

In python, the equivalent code should be something like that:

```python
@object_type
class Test:
    @function
    def container_echo(self, string_arg: str) -> dagger.Container:
        return dag.container().from_("alpine:latest").with_exec(["echo", string_arg])

    @function
    def print(self, string_arg: str) -> str:
        return dag.test().container_echo(string_arg).stdout()
```

With the current python implementation, this will break as the code is loaded. But at the time the code is loaded, it doesn't know `dag.test()` is a thing.
We need to do:
- first analyse the code to find `test` object with `container_echo` and `print` functions
- generate the code exposed by the engine based on those types
- load the code when needed to call the functions

All that to say we _must_ analyse the code before it's loaded.

And to do that, we need to completely change the way the code is analysed, moving to an AST based analysis instead of loading the code and looking at it. That's what this PR is doing.

This is a big one. And one way to ensure this is good is to rely on the extensive test suite we have. As everything is green on this side, we could be quite confident on the result.

> [!NOTE]
> Next step will be to plug that into the `moduleTypes` of the SDK, preparing the work for self calls