### PR TITLE
re-export core types in generated clients

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/client.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/client.go.tmpl
@@ -9,6 +9,12 @@ type Client struct {
 // ClientOpt holds a client option
 type ClientOpt = dagger.ClientOpt
 
+// Request contains all the values required to build queries executed by the graphql.Client
+type Request = dagger.Request
+
+// Response contains data returned by the GraphQL API
+type Response = dagger.Response
+
 // WithWorkdir sets the engine workdir
 var WithWorkdir = dagger.WithWorkdir
 
@@ -66,7 +72,7 @@ func (c *Client) QueryBuilder() *querybuilder.Selection {
 }
 
 // Do executes a raw GraphQL request using the client's session
-func (c *Client) Do(ctx context.Context, req *dagger.Request, resp *dagger.Response) error {
+func (c *Client) Do(ctx context.Context, req *Request, resp *Response) error {
 	return c.dag.Do(ctx, req, resp)
 }
 

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -2043,13 +2043,15 @@ func (ClientGeneratorTest) TestClientParity(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 	require.Contains(t, genCode, "func (c *Client) GraphQLClient() graphql.Client", "generated client should have GraphQLClient method")
 	require.Contains(t, genCode, "func (c *Client) QueryBuilder() *querybuilder.Selection", "generated client should have QueryBuilder method")
-	require.Contains(t, genCode, "func (c *Client) Do(ctx context.Context, req *dagger.Request, resp *dagger.Response) error", "generated client should have Do method")
 	require.Contains(t, genCode, "func (c *Client) Close() error", "generated client should have Close method")
 
 	// Verify ClientOpt and With* functions are re-exported
 	require.Contains(t, genCode, "type ClientOpt = dagger.ClientOpt", "generated client should re-export ClientOpt type")
+	require.Contains(t, genCode, "type Request = dagger.Request", "generated client should re-export Request type")
+	require.Contains(t, genCode, "type Response = dagger.Response", "generated client should re-export Response type")
 	require.Contains(t, genCode, "var WithWorkdir = dagger.WithWorkdir", "generated client should re-export WithWorkdir")
 	require.Contains(t, genCode, "var WithLogOutput = dagger.WithLogOutput", "generated client should re-export WithLogOutput")
 	require.Contains(t, genCode, "var WithConn = dagger.WithConn", "generated client should re-export WithConn")
 	require.Contains(t, genCode, "func Connect(ctx context.Context, opts ...ClientOpt)", "Connect should accept local ClientOpt type")
+	require.Contains(t, genCode, "func (c *Client) Do(ctx context.Context, req *Request, resp *Response) error", "Do should use local Request/Response types")
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/11798

This re-exports core types and some functions we were missing in generated clients. Without this, users would have to import their generated client _and_ the published library