### PR TITLE
workaround dev engine telemetry import issue

### DIFF
--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -1815,6 +1815,7 @@ func Foo() *dagger.Directory {
 // `querybuilder` package and use that changes in the go generated files.
 // If so, please disable that test until the release is done then re enable it.
 func (GoSuite) TestReleaseLibraryInModule(ctx context.Context, t *testctx.T) {
+	t.Skip("broken, see line 523 of core/sdk/go_sdk.go")
 	versions := []string{"v0.19.10", "v0.19.5"}
 
 	for _, version := range versions {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5585,8 +5585,6 @@ func (t *Test) IgnoreDirButKeepFileInSubdir(
 			require.Equal(t, strings.Join([]string{
 				"dagger/",
 				"foo/",
-				"querybuilder/",
-				"telemetry/",
 			}, "\n"), strings.TrimSpace(out))
 		})
 

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -520,18 +520,12 @@ func (sdk *goSDK) baseWithCodegen(
 		codegenArgs = append(codegenArgs, "--is-init")
 	}
 
-	var engineVersion dagql.String
-	if err := dag.Select(ctx, dag.Root(), &engineVersion,
-		dagql.Selector{
-			Field: "version",
-		},
-	); err != nil {
-		return ctr, fmt.Errorf("failed to get engine version: %w", err)
+	/* FIXME: dev version handling is broken because it requires changing imports in code
+	if !engine.IsDevVersion(engine.Version) {
+		codegenArgs = append(codegenArgs, "--lib-version", dagql.String(engine.Version))
 	}
-
-	if !engine.IsDevVersion(engineVersion.String()) {
-		codegenArgs = append(codegenArgs, "--lib-version", engineVersion)
-	}
+	*/
+	codegenArgs = append(codegenArgs, "--lib-version", dagql.String("v0.19.11"))
 
 	selectors := []dagql.Selector{
 		{


### PR DESCRIPTION
The change to telemetry imports doesn't work in dev engines because it ends up requiring import statements change.

Fixing this will require more significant work, just adding a temporary workaround in the meantime to unblock our local dev.

cc @TomChv 