### PR TITLE
fix: retrieve checks and generate from objects

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -67,6 +67,8 @@ func (ChecksSuite) TestChecksDirectSDK(ctx context.Context, t *testctx.T) {
 			require.Contains(t, out, "failing-check")
 			require.Contains(t, out, "passing-container")
 			require.Contains(t, out, "failing-container")
+			require.Contains(t, out, "test:lint")
+			require.Contains(t, out, "test:unit")
 			// run a specific passing check
 			out, err = modGen.
 				With(daggerExec("--progress=report", "check", "passing*")).

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -43,6 +43,7 @@ func (GeneratorsSuite) TestGeneratorsDirectSDK(ctx context.Context, t *testctx.T
 				require.Contains(t, out, "generate-other-files")
 				require.Contains(t, out, "empty-changeset")
 				require.Contains(t, out, "changeset-failure")
+				require.Contains(t, out, "other-generators:gen-things")
 			})
 
 			t.Run("generate single", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/testdata/checks/hello-with-checks-java/src/main/java/io/dagger/modules/hellowithchecksjava/HelloWithChecksJava.java
+++ b/core/integration/testdata/checks/hello-with-checks-java/src/main/java/io/dagger/modules/hellowithchecksjava/HelloWithChecksJava.java
@@ -52,4 +52,9 @@ public class HelloWithChecksJava {
       .from("alpine:3")
       .withExec(List.of("sh", "-c", "exit 1"));
   }
+
+  @Function
+  public Test test() {
+    return new Test();
+  }
 }

--- a/core/integration/testdata/checks/hello-with-checks-java/src/main/java/io/dagger/modules/hellowithchecksjava/Test.java
+++ b/core/integration/testdata/checks/hello-with-checks-java/src/main/java/io/dagger/modules/hellowithchecksjava/Test.java
@@ -1,0 +1,32 @@
+package io.dagger.modules.hellowithchecksjava;
+
+import io.dagger.client.Container;
+import io.dagger.client.Dagger;
+import io.dagger.module.annotation.Check;
+import io.dagger.module.annotation.Function;
+import io.dagger.module.annotation.Object;
+import java.util.List;
+
+@Object
+public class Test {
+
+  @Function
+  @Check
+  public void lint() throws Exception {
+    Container container = Dagger.dag()
+      .container()
+      .from("alpine")
+      .withExec(List.of("sh", "-c", "exit 0"));
+    container.sync();
+  }
+
+  @Function
+  @Check
+  public void unit() throws Exception {
+    Container container = Dagger.dag()
+      .container()
+      .from("alpine")
+      .withExec(List.of("sh", "-c", "exit 0"));
+    container.sync();
+  }
+}

--- a/core/integration/testdata/checks/hello-with-checks-py/src/hello_with_checks_py/main.py
+++ b/core/integration/testdata/checks/hello-with-checks-py/src/hello_with_checks_py/main.py
@@ -5,6 +5,19 @@ from dagger import check, dag, function, object_type
 
 
 @object_type
+class Test:
+    @function
+    @check
+    async def lint(self) -> None:
+        await dag.container().from_("alpine").with_exec(["sh", "-c", "exit 0"]).sync()
+
+    @function
+    @check
+    async def unit(self) -> None:
+        await dag.container().from_("alpine").with_exec(["sh", "-c", "exit 0"]).sync()
+
+
+@object_type
 class HelloWithChecksPy:
     baseImage: str = "alpine:3"
 
@@ -41,3 +54,7 @@ class HelloWithChecksPy:
     def failing_container(self) -> dagger.Container:
         """Returns a container which runs as a failing check"""
         return dag.container().from_(self.baseImage).with_exec(["sh", "-c", "exit 1"])
+
+    @function
+    def test(self) -> Test:
+        return Test()

--- a/core/integration/testdata/checks/hello-with-checks-ts/src/index.ts
+++ b/core/integration/testdata/checks/hello-with-checks-ts/src/index.ts
@@ -61,4 +61,32 @@ class HelloWithChecksTs {
       .from(this.baseImage)
       .withExec(["sh", "-c", "exit 1"]);
   }
+
+  @func()
+  test(): Test {
+    return new Test();
+  }
+}
+
+@object()
+class Test {
+  @func()
+  @check()
+  async lint(): Promise<void> {
+    await dag
+      .container()
+      .from("alpine")
+      .withExec(["sh", "-c", "exit 0"])
+      .sync();
+  }
+
+  @func()
+  @check()
+  async unit(): Promise<void> {
+    await dag
+      .container()
+      .from("alpine")
+      .withExec(["sh", "-c", "exit 0"])
+      .sync();
+  }
 }

--- a/core/integration/testdata/checks/hello-with-checks/main.go
+++ b/core/integration/testdata/checks/hello-with-checks/main.go
@@ -64,3 +64,22 @@ func (m *HelloWithChecks) CurrentEnvChecks(ctx context.Context) ([]string, error
 	sort.Strings(names)
 	return names, nil
 }
+
+func (m *HelloWithChecks) Test() *Test {
+	return &Test{}
+}
+
+type Test struct {
+}
+
+// +check
+func (t *Test) Lint(ctx context.Context) error {
+	_, err := dag.Container().From("alpine").WithExec([]string{"sh", "-c", "exit 0"}).Sync(ctx)
+	return err
+}
+
+// +check
+func (t *Test) Unit(ctx context.Context) error {
+	_, err := dag.Container().From("alpine").WithExec([]string{"sh", "-c", "exit 0"}).Sync(ctx)
+	return err
+}

--- a/core/integration/testdata/generators/hello-with-generators-py/src/hello_with_generators_py/main.py
+++ b/core/integration/testdata/generators/hello-with-generators-py/src/hello_with_generators_py/main.py
@@ -5,6 +5,18 @@ from dagger import dag, function, generate, object_type
 
 
 @object_type
+class MetaGen:
+    @function
+    @generate
+    def gen_things(self) -> dagger.Changeset:
+        return (
+            dag.directory()
+            .with_new_file("meta-gen", "generated")
+            .changes(dag.directory())
+        )
+
+
+@object_type
 class HelloWithGeneratorsPy:
     @function
     @generate
@@ -29,3 +41,7 @@ class HelloWithGeneratorsPy:
     def changeset_failure(self) -> dagger.Changeset:
         """Return an error"""
         raise Exception("could not generate the changeset")
+
+    @function
+    def other_generators(self) -> MetaGen:
+        return MetaGen()

--- a/core/integration/testdata/generators/hello-with-generators-ts/src/index.ts
+++ b/core/integration/testdata/generators/hello-with-generators-ts/src/index.ts
@@ -37,4 +37,21 @@ export class HelloWithGeneratorsTs {
   changesetFailure(): Changeset {
     throw "could not generate the changeset";
   }
+
+  @func()
+  otherGenerators(): MetaGen {
+    return new MetaGen();
+  }
+}
+
+@object()
+class MetaGen {
+  @func()
+  @generate()
+  genThings(): Changeset {
+    return dag
+      .directory()
+      .withNewFile("meta-gen", "generated")
+      .changes(dag.directory());
+  }
 }

--- a/core/integration/testdata/generators/hello-with-generators/main.go
+++ b/core/integration/testdata/generators/hello-with-generators/main.go
@@ -34,3 +34,16 @@ func (m *HelloWithGenerators) EmptyChangeset() *dagger.Changeset {
 func (m *HelloWithGenerators) ChangesetFailure() (*dagger.Changeset, error) {
 	return nil, errors.New("could not generate the changeset")
 }
+
+type MetaGen struct{}
+
+func (m *HelloWithGenerators) OtherGenerators() *MetaGen {
+	return &MetaGen{}
+}
+
+// +generate
+func (mg *MetaGen) GenThings() *dagger.Changeset {
+	return dag.Directory().
+		WithNewFile("meta-gen", "generated").
+		Changes(dag.Directory())
+}

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -568,6 +568,23 @@ func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
 				IsGenerator: fn.IsGenerator,
 				Description: fn.Description,
 			})
+			// if the type returned by the function is an object, check the children of the return type
+			if returnsObject := fn.ReturnType.AsObject.Valid; returnsObject &&
+				// avoid cycles (X.withFoo: X)
+				fn.ReturnType.ToType().Name() != node.Type.Type().Name() {
+				if subObj, ok := node.Module.ObjectByName(fn.ReturnType.ToType().Name()); ok {
+					children = append(children, &ModTreeNode{
+						Parent:      node,
+						Name:        fn.Name, // use the name of the function and not the name of the type as we want the chain
+						DagqlServer: node.DagqlServer,
+						Module:      node.Module,
+						Type:        &TypeDef{AsObject: dagql.NonNull(subObj)},
+						IsCheck:     false,
+						IsGenerator: false,
+						Description: subObj.Description,
+					})
+				}
+			}
 		}
 		for _, field := range objType.Fields {
 			children = append(children, &ModTreeNode{


### PR DESCRIPTION
When a function return an object that defines check or generat functions, those should appear when we list and be run when needed.

This behaviour has been removed during the migration from the previous checks code to the new ModTree.

fixes #11811