### PR TITLE
core: use content digests for secrets+sockets; fix git SSH caching

### DIFF
--- a/.changes/unreleased/Fixed-20260209-143945.yaml
+++ b/.changes/unreleased/Fixed-20260209-143945.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix git SSH socket not found errors when different clients use different SSH
+  auth sock paths on the same repo.
+time: 2026-02-09T14:39:45.018427027-08:00
+custom:
+  Author: sipsma
+  PR: "11828"

--- a/core/container.go
+++ b/core/container.go
@@ -647,15 +647,16 @@ func (container *Container) Build(
 
 	secretNameToLLBID := make(map[string]string)
 	for _, secret := range secrets {
-		secretName, ok := secretStore.GetSecretName(secret.ID().Digest())
+		secretDgst := SecretIDDigest(secret.ID())
+		secretName, ok := secretStore.GetSecretName(secretDgst)
 		if !ok {
-			return nil, fmt.Errorf("secret not found: %s", secret.ID().Digest())
+			return nil, fmt.Errorf("secret not found: %s", secretDgst)
 		}
 		container.Secrets = append(container.Secrets, ContainerSecret{
 			Secret:    secret,
 			MountPath: fmt.Sprintf("/run/secrets/%s", secretName),
 		})
-		secretNameToLLBID[secretName] = secret.ID().Digest().String()
+		secretNameToLLBID[secretName] = secretDgst.String()
 	}
 
 	// set image ref to empty string

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -202,7 +202,7 @@ func (container *Container) secretEnvs() (secretEnvs []*pb.SecretEnv) {
 	for _, secret := range container.Secrets {
 		if secret.EnvName != "" {
 			secretEnvs = append(secretEnvs, &pb.SecretEnv{
-				ID:   secret.Secret.ID().Digest().String(),
+				ID:   SecretIDDigest(secret.Secret.ID()).String(),
 				Name: secret.EnvName,
 			})
 		}

--- a/core/dagop.go
+++ b/core/dagop.go
@@ -782,7 +782,7 @@ func getAllContainerMounts(ctx context.Context, container *Container) (
 			Dest:      secret.MountPath,
 			MountType: pb.MountType_SECRET,
 			SecretOpt: &pb.SecretOpt{
-				ID:   secret.Secret.ID().Digest().String(),
+				ID:   SecretIDDigest(secret.Secret.ID()).String(),
 				Uid:  uint32(uid),
 				Gid:  uint32(gid),
 				Mode: uint32(secret.Mode),

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -144,16 +144,16 @@ func (repo *RemoteGitRepository) remoteCacheKey(ctx context.Context) (string, er
 func (repo *RemoteGitRepository) remoteCacheScope() []string {
 	scope := make([]string, 0, 4)
 	if token := repo.AuthToken; token.Self() != nil && token.ID() != nil {
-		scope = append(scope, "token:"+token.ID().Digest().String())
+		scope = append(scope, "token:"+SecretIDDigest(token.ID()).String())
 	}
 	if header := repo.AuthHeader; header.Self() != nil && header.ID() != nil {
-		scope = append(scope, "header:"+header.ID().Digest().String())
+		scope = append(scope, "header:"+SecretIDDigest(header.ID()).String())
 	}
 	if repo.AuthUsername != "" {
 		scope = append(scope, "username:"+repo.AuthUsername)
 	}
 	if sshSock := repo.SSHAuthSocket; sshSock.Self() != nil {
-		scope = append(scope, "ssh-sock:"+sshSock.Self().IDDigest.String())
+		scope = append(scope, "ssh-auth-scope:"+sshSock.Self().IDDigest.String())
 	}
 	return scope
 }
@@ -257,7 +257,7 @@ func (repo *RemoteGitRepository) setup(ctx context.Context) (_ *gitutil.GitCLI, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get secret store: %w", err)
 		}
-		password, err := secretStore.GetSecretPlaintext(ctx, repo.AuthToken.ID().Digest())
+		password, err := secretStore.GetSecretPlaintext(ctx, SecretIDDigest(repo.AuthToken.ID()))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -267,7 +267,7 @@ func (repo *RemoteGitRepository) setup(ctx context.Context) (_ *gitutil.GitCLI, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get secret store: %w", err)
 		}
-		byteAuthHeader, err := secretStore.GetSecretPlaintext(ctx, repo.AuthHeader.ID().Digest())
+		byteAuthHeader, err := secretStore.GetSecretPlaintext(ctx, SecretIDDigest(repo.AuthHeader.ID()))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	fscopy "github.com/dagger/dagger/internal/fsutil/copy"
 	"github.com/dagger/dagger/internal/testutil"
@@ -1931,4 +1932,32 @@ func (*Test) Fn(ctx context.Context, sock *dagger.Socket, msg string) (string, e
 	}](c2, t, `{test{fn(sock: "`+string(sockID2)+`", msg: "omg")}}`, nil)
 	require.NoError(t, err)
 	require.Equal(t, "omg", res2b.Test.Fn)
+}
+
+func (ModuleSuite) TestCrossSessionGitSockets(ctx context.Context, t *testctx.T) {
+	tc := getVCSTestCase(t, "git@bitbucket.org:dagger-modules/private-modules-test.git")
+	url := tc.gitTestRepoRef
+	ref := tc.gitTestRepoCommit
+
+	agentSockPath1, cleanup1 := setupPrivateRepoSSHAgent(t)
+	c1 := connect(ctx, t, dagger.WithEnvironmentVariable("SSH_AUTH_SOCK", agentSockPath1))
+	ref1ID, err := c1.Git(url).Commit(ref).ID(ctx)
+	require.NoError(t, err)
+	var id1 call.ID
+	err = id1.Decode(string(ref1ID))
+	require.NoError(t, err)
+
+	agentSockPath2, _ := setupPrivateRepoSSHAgent(t)
+	c2 := connect(ctx, t, dagger.WithEnvironmentVariable("SSH_AUTH_SOCK", agentSockPath2))
+	ref2ID, err := c2.Git(url).Commit(ref).ID(ctx)
+	require.NoError(t, err)
+	var id2 call.ID
+	err = id2.Decode(string(ref2ID))
+	require.NoError(t, err)
+
+	cleanup1()
+	require.NoError(t, c1.Close())
+
+	_, err = c2.LoadGitRefFromID(ref2ID).Tree().Sync(ctx)
+	require.NoError(t, err)
 }

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1703,7 +1703,7 @@ func (m *Test) Secrets() []*dagger.Secret {
 				Stdout(ctx)
 
 			require.NoError(t, err)
-			require.Regexp(t, `Secret@xxh3:[a-f0-9]{16}`, out)
+			require.Regexp(t, `Secret@[a-z0-9]{25}`, out)
 		})
 
 		t.Run("multiple", func(ctx context.Context, t *testctx.T) {
@@ -1712,7 +1712,7 @@ func (m *Test) Secrets() []*dagger.Secret {
 				Stdout(ctx)
 
 			require.NoError(t, err)
-			require.Regexp(t, strings.Repeat(`- Secret@xxh3:[a-f0-9]{16}\n`, 2), out)
+			require.Regexp(t, strings.Repeat(`- Secret@[a-z0-9]{25}\n`, 2), out)
 		})
 	})
 

--- a/core/postcall.go
+++ b/core/postcall.go
@@ -15,25 +15,31 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
+//nolint:gocyclo
 func ResourceTransferPostCall(
 	ctx context.Context,
 	query *Query,
 	sourceClientID string,
 	ids ...*resource.ID,
-) (func(context.Context) error, error) {
+) (func(context.Context) error, bool, error) {
 	secretsByDgst := map[digest.Digest]dagql.ID[*Secret]{}
+	socketsByDgst := map[digest.Digest]dagql.ID[*Socket]{}
 	for _, id := range ids {
 		walked, err := dagql.WalkID(&id.ID, false)
 		if err != nil {
-			return nil, fmt.Errorf("failed to walk ID: %w", err)
+			return nil, false, fmt.Errorf("failed to walk ID: %w", err)
 		}
 		secretIDs := dagql.WalkedIDs[*Secret](walked)
 		for _, secretID := range secretIDs {
-			secretsByDgst[secretID.ID().Digest()] = secretID
+			secretsByDgst[SecretIDDigest(secretID.ID())] = secretID
+		}
+		socketIDs := dagql.WalkedIDs[*Socket](walked)
+		for _, socketID := range socketIDs {
+			socketsByDgst[SocketIDDigest(socketID.ID())] = socketID
 		}
 	}
-	if len(secretsByDgst) == 0 {
-		return nil, nil
+	if len(secretsByDgst) == 0 && len(socketsByDgst) == 0 {
+		return nil, false, nil
 	}
 
 	var secretIDs []dagql.ID[*Secret]
@@ -42,13 +48,21 @@ func ResourceTransferPostCall(
 	}
 	// just in case order matters for caching somehow someday
 	slices.SortFunc(secretIDs, func(a, b dagql.ID[*Secret]) int {
-		return strings.Compare(a.ID().Digest().String(), b.ID().Digest().String())
+		return strings.Compare(SecretIDDigest(a.ID()).String(), SecretIDDigest(b.ID()).String())
+	})
+	var socketIDs []dagql.ID[*Socket]
+	for _, socketID := range socketsByDgst {
+		socketIDs = append(socketIDs, socketID)
+	}
+	// just in case order matters for caching somehow someday
+	slices.SortFunc(socketIDs, func(a, b dagql.ID[*Socket]) int {
+		return strings.Compare(SocketIDDigest(a.ID()).String(), SocketIDDigest(b.ID()).String())
 	})
 
 	// ensure that when we load secrets, we are doing so from the source client
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get source client metadata: %w", err)
+		return nil, false, fmt.Errorf("failed to get source client metadata: %w", err)
 	}
 	srcClientCtx := engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
 		ClientID:  sourceClientID,
@@ -62,16 +76,22 @@ func ResourceTransferPostCall(
 		// like ModuleRuntime. In this case, the only secrets involved are any related to pulling the module
 		// source (like a git auth token). These secrets are already known by the caller and the secret transfer
 		// is thus not needed.
-		return nil, nil //nolint:nilerr
+		return nil, false, nil //nolint:nilerr
+	}
+	srcSocketStore, err := query.Sockets(srcClientCtx)
+	if err != nil {
+		// see rationale above for secrets lookup; socket transfer can be skipped for
+		// this same source-client-missing case.
+		return nil, false, nil //nolint:nilerr
 	}
 	srcDag, err := query.Server.Server(srcClientCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get source client dagql server: %w", err)
+		return nil, false, fmt.Errorf("failed to get source client dagql server: %w", err)
 	}
 
 	secrets, err := dagql.LoadIDResults(srcClientCtx, srcDag, secretIDs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load secret instances: %w", err)
+		return nil, false, fmt.Errorf("failed to load secret instances: %w", err)
 	}
 
 	type secretWithPlaintext struct {
@@ -84,7 +104,8 @@ func ResourceTransferPostCall(
 		if !isNamed {
 			continue
 		}
-		plaintext, err := srcSecretStore.GetSecretPlaintext(ctx, secret.ID().Digest())
+		secretDigest := SecretDigest(secret)
+		plaintext, err := srcSecretStore.GetSecretPlaintext(ctx, secretDigest)
 		if err != nil {
 			// It's possible to hit secrets not found in the store when there's a cross-session cache hit
 			// on content-hashed values (like git tree directories). The value returned from cache may be
@@ -95,7 +116,7 @@ func ResourceTransferPostCall(
 			// Log this for now though in case it ever arises in unexpected cases. If that happens, the error
 			// will just be deferred and can be traced back to this log.
 			slog.Warn("failed to get secret plaintext",
-				"secret", secret.ID().Digest(),
+				"secret", secretDigest,
 				"err", err,
 				"sourceClientID", sourceClientID,
 			)
@@ -104,8 +125,23 @@ func ResourceTransferPostCall(
 		namedSecrets = append(namedSecrets, secretWithPlaintext{inst: secret, plaintext: plaintext})
 	}
 
-	if len(namedSecrets) == 0 {
-		return nil, nil
+	var sockets []dagql.ObjectResult[*Socket]
+	if len(socketIDs) > 0 {
+		socketResults, err := dagql.LoadIDResults(srcClientCtx, srcDag, socketIDs)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to load socket instances: %w", err)
+		}
+		for _, socket := range socketResults {
+			if socket.Self() == nil {
+				continue
+			}
+			sockets = append(sockets, socket)
+		}
+	}
+
+	hasNamedSecrets := len(namedSecrets) > 0
+	if len(namedSecrets) == 0 && len(sockets) == 0 {
+		return nil, false, nil
 	}
 
 	callerClientMemo := sync.Map{}
@@ -124,44 +160,80 @@ func ResourceTransferPostCall(
 			return nil
 		}
 
-		destClientSecretStore, err := query.Secrets(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get destination client secret store: %w", err)
-		}
 		destDag, err := query.Server.Server(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get destination client dagql server: %w", err)
 		}
-		for _, secret := range namedSecrets {
-			if err := destClientSecretStore.AddSecret(secret.inst); err != nil {
-				return fmt.Errorf("failed to add secret: %w", err)
-			}
-			// Ensure this secret is in the cache. This is necessary for now because of a corner case like:
-			// 1. Client A does a new function call, returns some type that references a SetSecret
-			// 2. Client B does the same function call, gets a cache hit
-			// 3. Client A disconnects *before Client B has reached this PostCall*
-			// 4. Client B tries to access the secret, but it's not in the cache
-			// The longer term fix for this type of issue is to have more dagql awareness of edges between
-			// cache results such that a function call return value result inherently results in any referenced
-			// secrets also staying in cache.
-			cacheKey := cache.CacheKey[dagql.CacheKeyType]{
-				CallKey: string(secret.inst.ID().Digest()),
-			}
-			_, err = destDag.Cache.GetOrInitializeWithCallbacks(ctx, cacheKey,
-				func(ctx context.Context) (*dagql.CacheValWithCallbacks, error) {
-					return &dagql.CacheValWithCallbacks{
-						Value:    secret.inst,
-						PostCall: postCall,
-					}, nil
-				},
-			)
+		if len(namedSecrets) > 0 {
+			destClientSecretStore, err := query.Secrets(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to cache secret: %w", err)
+				return fmt.Errorf("failed to get destination client secret store: %w", err)
+			}
+			for _, secret := range namedSecrets {
+				if err := destClientSecretStore.AddSecret(secret.inst); err != nil {
+					return fmt.Errorf("failed to add secret: %w", err)
+				}
+				// Ensure this secret is in the cache. This is necessary for now because of a corner case like:
+				// 1. Client A does a new function call, returns some type that references a SetSecret
+				// 2. Client B does the same function call, gets a cache hit
+				// 3. Client A disconnects *before Client B has reached this PostCall*
+				// 4. Client B tries to access the secret, but it's not in the cache
+				// The longer term fix for this type of issue is to have more dagql awareness of edges between
+				// cache results such that a function call return value result inherently results in any referenced
+				// secrets also staying in cache.
+				secretDigest := SecretDigest(secret.inst)
+				cacheKey := cache.CacheKey[dagql.CacheKeyType]{
+					CallKey: string(secretDigest),
+				}
+				_, err = destDag.Cache.GetOrInitializeWithCallbacks(ctx, cacheKey,
+					func(ctx context.Context) (*dagql.CacheValWithCallbacks, error) {
+						return &dagql.CacheValWithCallbacks{
+							Value:            secret.inst,
+							PostCall:         postCall,
+							ContentDigestKey: string(secretDigest),
+							ResultCallKey:    string(secret.inst.ID().Digest()),
+						}, nil
+					},
+				)
+				if err != nil {
+					return fmt.Errorf("failed to cache secret: %w", err)
+				}
+			}
+		}
+		if len(sockets) > 0 {
+			destClientSocketStore, err := query.Sockets(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get destination client socket store: %w", err)
+			}
+			for _, socket := range sockets {
+				socketDigest := socket.Self().IDDigest
+				if socketDigest == "" {
+					socketDigest = SocketIDDigest(socket.ID())
+				}
+				if socketDigest == "" {
+					slog.Warn("skipping socket transfer with empty digest",
+						"sourceClientID", sourceClientID,
+					)
+					continue
+				}
+				if destClientSocketStore.HasSocket(socketDigest) {
+					// Keep destination-local mapping when present; avoid replacing a
+					// potentially fresher local socket with one imported from another client.
+					continue
+				}
+				if err := destClientSocketStore.AddSocketFromOtherStore(socket.Self(), srcSocketStore); err != nil {
+					slog.Warn("failed to add socket from other store",
+						"socket", socketDigest,
+						"err", err,
+						"sourceClientID", sourceClientID,
+					)
+					continue
+				}
 			}
 		}
 
 		return nil
 	}
 
-	return postCall, nil
+	return postCall, hasNamedSecrets, nil
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -2473,7 +2473,7 @@ func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Con
 	if err != nil {
 		return nil, err
 	}
-	secretBytes, err := secretStore.GetSecretPlaintext(ctx, secret.ID().Digest())
+	secretBytes, err := secretStore.GetSecretPlaintext(ctx, core.SecretIDDigest(secret.ID()))
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -177,6 +177,12 @@ func (s *hostSchema) Install(srv *dagql.Server) {
 				dagql.Arg("path").Doc(`Location of the Unix socket (e.g., "/var/run/docker.sock").`),
 			),
 
+		dagql.NodeFuncWithCacheKey("_sshAuthSocket", s.sshAuthSocket, dagql.CachePerCall).
+			Doc(`Accesses the SSH auth socket on the host and returns a socket scoped to SSH identities.`).
+			Args(
+				dagql.Arg("source").Doc(`Optional source socket to scope. If not set, uses the caller's SSH_AUTH_SOCK.`),
+			),
+
 		dagql.Func("__internalSocket", s.internalSocket).
 			Doc(`(Internal-only) Accesses a socket on the host (unix or ip) with the given internal client resource name.`),
 
@@ -354,15 +360,6 @@ func (s *hostSchema) socket(ctx context.Context, host dagql.ObjectResult[*core.H
 		return inst, err
 	}
 
-	socketStore, err := query.Sockets(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get socket store: %w", err)
-	}
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get client metadata: %w", err)
-	}
-
 	accessor, err := core.GetClientResourceAccessor(ctx, query, args.Path)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get client resource name: %w", err)
@@ -374,12 +371,162 @@ func (s *hostSchema) socket(ctx context.Context, host dagql.ObjectResult[*core.H
 	if err != nil {
 		return inst, fmt.Errorf("failed to create instance: %w", err)
 	}
-	inst = inst.WithDigest(dgst)
-	if err := socketStore.AddUnixSocket(sock, clientMetadata.ClientID, args.Path); err != nil {
-		return inst, fmt.Errorf("failed to add unix socket to store: %w", err)
+	inst = inst.WithContentDigest(dgst)
+
+	upsertSocket := func(ctx context.Context) error {
+		callerClientMetadata, err := engine.ClientMetadataFromContext(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get client metadata: %w", err)
+		}
+		callerSocketStore, err := query.Sockets(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get socket store: %w", err)
+		}
+		nonModuleParentClientMetadata, err := query.NonModuleParentClientMetadata(ctx)
+		if err == nil && nonModuleParentClientMetadata.ClientID != callerClientMetadata.ClientID {
+			// In nested module contexts, preserve any pre-imported socket mapping (e.g. an explicitly
+			// passed socket argument) instead of clobbering it with the nested client's session.
+			if callerSocketStore.HasSocket(sock.IDDigest) {
+				return nil
+			}
+		}
+		if err := callerSocketStore.AddUnixSocket(sock, callerClientMetadata.ClientID, args.Path); err != nil {
+			return fmt.Errorf("failed to add unix socket to store: %w", err)
+		}
+		return nil
+	}
+	if err := upsertSocket(ctx); err != nil {
+		return inst, err
 	}
 
-	return inst, nil
+	return inst.ResultWithPostCall(upsertSocket), nil
+}
+
+type hostSSHAuthSocketArgs struct {
+	Source dagql.Optional[core.SocketID] `name:"source"`
+}
+
+func (s *hostSchema) sshAuthSocket(ctx context.Context, host dagql.ObjectResult[*core.Host], args hostSSHAuthSocketArgs) (inst dagql.Result[*core.Socket], err error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	socketStore, err := query.Sockets(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get socket store: %w", err)
+	}
+
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get client metadata: %w", err)
+	}
+
+	var sourceSocket *core.Socket
+	if args.Source.Valid {
+		sourceInst, err := args.Source.Value.Load(ctx, srv)
+		if err != nil {
+			return inst, fmt.Errorf("failed to load source socket: %w", err)
+		}
+		sourceSocket = sourceInst.Self()
+		if sourceSocket == nil {
+			return inst, errors.New("source socket is nil")
+		}
+		if !socketStore.HasSocket(sourceSocket.IDDigest) {
+			return inst, fmt.Errorf("source socket %s not found in socket store", sourceSocket.IDDigest)
+		}
+	} else {
+		if clientMetadata.SSHAuthSocketPath == "" {
+			return inst, errors.New("SSH_AUTH_SOCK is not set")
+		}
+		accessor, err := core.GetClientResourceAccessor(ctx, query, clientMetadata.SSHAuthSocketPath)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get client resource accessor: %w", err)
+		}
+		sourceSocket = &core.Socket{
+			IDDigest: hashutil.HashStrings(accessor),
+		}
+		if err := socketStore.AddUnixSocket(sourceSocket, clientMetadata.ClientID, clientMetadata.SSHAuthSocketPath); err != nil {
+			return inst, fmt.Errorf("failed to register source SSH auth socket: %w", err)
+		}
+	}
+
+	scopedDigest, err := core.ScopedSSHAuthSocketDigestFromStore(ctx, query, socketStore, sourceSocket.IDDigest)
+	if err != nil {
+		return inst, fmt.Errorf("failed to scope SSH auth socket from agent identities: %w", err)
+	}
+
+	scopedSocket := &core.Socket{IDDigest: scopedDigest}
+	inst, err = dagql.NewResultForCurrentID(ctx, scopedSocket)
+	if err != nil {
+		return inst, fmt.Errorf("failed to create instance: %w", err)
+	}
+	inst = inst.WithContentDigest(scopedDigest)
+
+	if err := upsertScopedSSHAuthSocket(ctx, query, args.Source.Valid, scopedSocket, sourceSocket); err != nil {
+		return inst, err
+	}
+
+	// This postcall may run for different callers that hit the same cached
+	// Host._sshAuthSocket result. Resolve caller-specific SSH auth socket metadata
+	// at postcall execution time to avoid leaking a previous caller's session/path
+	// into a different caller's socket store.
+	return inst.ResultWithPostCall(func(ctx context.Context) error {
+		return upsertScopedSSHAuthSocket(ctx, query, args.Source.Valid, scopedSocket, sourceSocket)
+	}), nil
+}
+
+// upsertScopedSSHAuthSocket persists the scoped socket mapping in the caller store.
+// If a source socket was provided, it aliases scoped -> source. Otherwise it registers
+// the scoped socket as a unix socket using the caller SSH auth socket session/path.
+func upsertScopedSSHAuthSocket(
+	ctx context.Context,
+	query *core.Query,
+	hasSource bool,
+	scopedSocket *core.Socket,
+	sourceSocket *core.Socket,
+) error {
+	callerSocketStore, err := query.Sockets(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get caller socket store: %w", err)
+	}
+
+	if hasSource {
+		if err := callerSocketStore.AddSocketAlias(scopedSocket, sourceSocket.IDDigest); err != nil {
+			return fmt.Errorf("failed to alias scoped SSH auth socket: %w", err)
+		}
+		return nil
+	}
+
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get client metadata: %w", err)
+	}
+	if clientMetadata.SSHAuthSocketPath == "" {
+		// Cached post-call replay can happen in contexts that don't expose
+		// SSH_AUTH_SOCK (for example when loading IDs to transfer client
+		// resources). Treat this as a no-op so replay doesn't fail; direct
+		// Host._sshAuthSocket calls still fail earlier in the resolver.
+		return nil
+	}
+
+	nonModuleParentClientMetadata, err := query.NonModuleParentClientMetadata(ctx)
+	if err == nil && nonModuleParentClientMetadata.ClientID != clientMetadata.ClientID {
+		// In nested module contexts, keep an existing scoped socket mapping from the
+		// parent caller (for example an explicitly passed socket arg) instead of
+		// clobbering it with this nested client's own session/path.
+		if callerSocketStore.HasSocket(scopedSocket.IDDigest) {
+			return nil
+		}
+	}
+
+	if err := callerSocketStore.AddUnixSocket(scopedSocket, clientMetadata.ClientID, clientMetadata.SSHAuthSocketPath); err != nil {
+		return fmt.Errorf("failed to register scoped SSH auth socket: %w", err)
+	}
+	return nil
 }
 
 type hostFileArgs struct {
@@ -728,9 +875,15 @@ type hostInternalSocketArgs struct {
 	Accessor string
 }
 
-func (s *hostSchema) internalSocket(ctx context.Context, host *core.Host, args hostInternalSocketArgs) (*core.Socket, error) {
+func (s *hostSchema) internalSocket(ctx context.Context, host *core.Host, args hostInternalSocketArgs) (inst dagql.Result[*core.Socket], err error) {
 	if args.Accessor == "" {
-		return nil, errors.New("socket accessor must be provided")
+		return inst, errors.New("socket accessor must be provided")
 	}
-	return &core.Socket{IDDigest: dagql.CurrentID(ctx).Digest()}, nil
+	dgst := hashutil.HashStrings(args.Accessor)
+	sock := &core.Socket{IDDigest: dgst}
+	inst, err = dagql.NewResultForCurrentID(ctx, sock)
+	if err != nil {
+		return inst, fmt.Errorf("failed to create instance: %w", err)
+	}
+	return inst.WithContentDigest(dgst), nil
 }

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -96,7 +96,7 @@ func (s *httpSchema) http(ctx context.Context, parent dagql.ObjectResult[*core.Q
 		if err != nil {
 			return inst, fmt.Errorf("failed to get secret store: %w", err)
 		}
-		authHeaderRaw, err := secretStore.GetSecretPlaintext(ctx, secret.ID().Digest())
+		authHeaderRaw, err := secretStore.GetSecretPlaintext(ctx, core.SecretIDDigest(secret.ID()))
 		if err != nil {
 			return inst, err
 		}

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -854,13 +854,7 @@ func (sdk *goSDK) getUnixSocketSelector(ctx context.Context) ([]dagql.Selector, 
 			Field: "host",
 		},
 		dagql.Selector{
-			Field: "unixSocket",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "path",
-					Value: dagql.NewString(clientMetadata.SSHAuthSocketPath),
-				},
-			},
+			Field: "_sshAuthSocket",
 		},
 	); err != nil {
 		return nil, nil, fmt.Errorf("failed to select internal socket: %w", err)

--- a/core/ssh_auth_socket.go
+++ b/core/ssh_auth_socket.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"slices"
+
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	sshAuthSocketDigestVersion = "ssh-auth-socket-v1"
+)
+
+func ScopedSSHAuthSocketDigest(secretSalt []byte, fingerprints []string) digest.Digest {
+	slices.Sort(fingerprints)
+
+	mac := hmac.New(sha256.New, secretSalt)
+	mac.Write([]byte(sshAuthSocketDigestVersion))
+	mac.Write([]byte{0})
+	for _, fingerprint := range fingerprints {
+		mac.Write([]byte(fingerprint))
+		mac.Write([]byte{0})
+	}
+	return digest.NewDigestFromBytes(digest.SHA256, mac.Sum(nil))
+}
+
+func ScopedSSHAuthSocketDigestFromStore(
+	ctx context.Context,
+	query *Query,
+	socketStore *SocketStore,
+	sourceSocketDigest digest.Digest,
+) (digest.Digest, error) {
+	fingerprints, err := socketStore.AgentFingerprints(ctx, sourceSocketDigest)
+	if err != nil {
+		return "", err
+	}
+	return ScopedSSHAuthSocketDigest(query.SecretSalt(), fingerprints), nil
+}


### PR DESCRIPTION
Fixes #11765 

Couple of interrelated high-level goals here.

---

One goal is to reduce usage of "custom recipe digests" and replace them with content digests. This is important for the dagql cache upgrades as recipe digests will be changed to always be purely "recipe", with any additional digests (content, "semantic", etc.) modeled as separate digests. That in turn makes the whole system much simpler algorithmically and makes digests less opaque ("is this a true recipe digest or a custom one? 🤷‍♂️" won't be a thing after this change a couple other out of scope of this PR).

Secrets and sockets were still using custom recipe digests, but their usage better fits a content digest. The changes here implement that. It's a bit trickier than just swapping out the digest since the digest is intertwined with Secret/Socket stores and client resource access.

---

Another goal is to fix long-standing issues with the caching of git SSH sockets. The sockets were digested essentially by their path, which led to a number of weird caching situations where clients either didn't get a cache hit they expected due to a path changing or hit a bug where a socket wasn't found because the path used was cached and ended up in a different client's DAG.

Users have often had to resort to ensuring their clients all used the same SSH socket path to avoid this.

The change here fixes this by adding a dedicated API for SSH auth sockets, separate from the more generic "Host.unixSocket" api. This enables a couple things:
1. Not being attached to a single path for a socket, more generically pointing to "the main client's SSH auth socket, whatever path it may be"
2. Caching SSH auth sockets based on key fingerprints they have loaded rather than client-specific paths.

The integ test added here repro's the previous bug, it passes now and thus fixes #11765 