### PR TITLE
let local-cache prune use explicit space limits

### DIFF
--- a/.changes/unreleased/Added-20260209-143626.yaml
+++ b/.changes/unreleased/Added-20260209-143626.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add support for individual gc settings in `engine local-cache prune`.
+time: 2026-02-09T14:36:26.453867904-08:00
+custom:
+  Author: sipsma
+  PR: "11830"

--- a/core/engine.go
+++ b/core/engine.go
@@ -29,6 +29,14 @@ type EngineCache struct {
 	MinFreeSpace  int `field:"true" doc:"The target amount of free disk space the garbage collector will attempt to leave."`
 }
 
+type EngineCachePruneOptions struct {
+	UseDefaultPolicy bool
+	MaxUsedSpace     string
+	ReservedSpace    string
+	MinFreeSpace     string
+	TargetSpace      string
+}
+
 func (*EngineCache) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "EngineCache",

--- a/core/query.go
+++ b/core/query.go
@@ -113,9 +113,10 @@ type Server interface {
 	// Return all the cache entries in the local cache. No support for filtering yet.
 	EngineLocalCacheEntries(context.Context) (*EngineCacheEntrySet, error)
 
-	// Prune the local cache of releaseable entries. If useDefaultPolicy is true, use the engine-wide default pruning policy,
-	// otherwise prune the whole cache of any releasable entries.
-	PruneEngineLocalCacheEntries(context.Context, bool) (*EngineCacheEntrySet, error)
+	// Prune the local cache of releaseable entries. If UseDefaultPolicy is true,
+	// use the engine-wide default pruning policy, otherwise prune the whole cache
+	// of any releasable entries.
+	PruneEngineLocalCacheEntries(context.Context, EngineCachePruneOptions) (*EngineCacheEntrySet, error)
 
 	// The default local cache policy to use for automatic local cache GC.
 	EngineLocalCachePolicy() *bkclient.PruneInfo

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -101,7 +101,7 @@ func (ms *mockServer) EngineLocalCacheEntries(context.Context) (*EngineCacheEntr
 	return nil, nil
 }
 
-func (ms *mockServer) PruneEngineLocalCacheEntries(context.Context, bool) (*EngineCacheEntrySet, error) {
+func (ms *mockServer) PruneEngineLocalCacheEntries(context.Context, EngineCachePruneOptions) (*EngineCacheEntrySet, error) {
 	return nil, nil
 }
 func (ms *mockServer) EngineLocalCachePolicy() *bkclient.PruneInfo { return nil }

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2114,6 +2114,26 @@ type EngineCache {
     Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
     """
     useDefaultPolicy: Boolean = false
+
+    """
+    Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
+    """
+    maxUsedSpace: String = ""
+
+    """
+    Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
+    """
+    reservedSpace: String = ""
+
+    """
+    Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
+    """
+    minFreeSpace: String = ""
+
+    """
+    Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
+    """
+    targetSpace: String = ""
   ): Void
 
   """The minimum amount of disk space this policy is guaranteed to retain."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -8197,6 +8197,22 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>useDefaultPolicy</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>maxUsedSpace</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>Override the maximum disk space to keep before pruning (e.g. &quot;200GB&quot; or &quot;80%&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>reservedSpace</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>Override the minimum disk space to retain during pruning (e.g. &quot;500GB&quot; or &quot;10%&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>minFreeSpace</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>Override the minimum free disk space target during pruning (e.g. &quot;20GB&quot; or &quot;20%&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>targetSpace</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>Override the target disk space to keep after pruning (e.g. &quot;200GB&quot; or &quot;50%&quot;).</p>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/docs/static/reference/php/Dagger/EngineCache.html
+++ b/docs/static/reference/php/Dagger/EngineCache.html
@@ -186,7 +186,7 @@
                     void
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_prune">prune</a>(bool|null $useDefaultPolicy = false)
+                    <a href="#method_prune">prune</a>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;)
         
                                             <p><p>Prune the cache of releaseable entries</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -448,7 +448,7 @@
                     <h3 id="method_prune">
         <div class="location">at line 58</div>
         <code>                    void
-    <strong>prune</strong>(bool|null $useDefaultPolicy = false)
+    <strong>prune</strong>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;)
         </code>
     </h3>
     <div class="details">    
@@ -465,6 +465,26 @@
                     <tr>
                 <td>bool|null</td>
                 <td>$useDefaultPolicy</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$maxUsedSpace</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$reservedSpace</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$minFreeSpace</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$targetSpace</td>
                 <td></td>
             </tr>
             </table>
@@ -488,7 +508,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_reservedSpace">
-        <div class="location">at line 70</div>
+        <div class="location">at line 87</div>
         <code>                    int
     <strong>reservedSpace</strong>()
         </code>
@@ -520,7 +540,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_targetSpace">
-        <div class="location">at line 79</div>
+        <div class="location">at line 96</div>
         <code>                    int
     <strong>targetSpace</strong>()
         </code>

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	bkclient "github.com/dagger/dagger/internal/buildkit/client"
+	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
+	"github.com/dagger/dagger/internal/buildkit/util/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEngineLocalCachePruneOptionsUseDefaultPolicyFalse(t *testing.T) {
+	dstat := disk.DiskStat{Total: 100 * 1e9}
+	defaultPolicy := []bkclient.PruneInfo{
+		{
+			All:           false,
+			MaxUsedSpace:  11,
+			ReservedSpace: 22,
+			MinFreeSpace:  33,
+			TargetSpace:   44,
+		},
+	}
+
+	opts := core.EngineCachePruneOptions{
+		UseDefaultPolicy: false,
+		MaxUsedSpace:     "3GB",
+		ReservedSpace:    "500MB",
+		MinFreeSpace:     "10%",
+		TargetSpace:      "2GB",
+	}
+
+	pruneOpts, err := resolveEngineLocalCachePruneOptions(defaultPolicy, opts, dstat)
+	require.NoError(t, err)
+	require.Len(t, pruneOpts, 1)
+	require.True(t, pruneOpts[0].All)
+	require.Equal(t, mustParseDiskSpace(t, opts.MaxUsedSpace, dstat), pruneOpts[0].MaxUsedSpace)
+	require.Equal(t, mustParseDiskSpace(t, opts.ReservedSpace, dstat), pruneOpts[0].ReservedSpace)
+	require.Equal(t, mustParseDiskSpace(t, opts.MinFreeSpace, dstat), pruneOpts[0].MinFreeSpace)
+	require.Equal(t, mustParseDiskSpace(t, opts.TargetSpace, dstat), pruneOpts[0].TargetSpace)
+}
+
+func TestResolveEngineLocalCachePruneOptionsOverridesReservedAndMinFree(t *testing.T) {
+	dstat := disk.DiskStat{Total: 50 * 1e9}
+	defaultPolicy := []bkclient.PruneInfo{
+		{
+			All:           false,
+			MaxUsedSpace:  100,
+			ReservedSpace: 200,
+			MinFreeSpace:  300,
+			TargetSpace:   400,
+		},
+		{
+			All:           true,
+			MaxUsedSpace:  500,
+			ReservedSpace: 600,
+			MinFreeSpace:  700,
+			TargetSpace:   800,
+		},
+	}
+	originalPolicy := append([]bkclient.PruneInfo(nil), defaultPolicy...)
+
+	opts := core.EngineCachePruneOptions{
+		UseDefaultPolicy: true,
+		ReservedSpace:    "123MB",
+		MinFreeSpace:     "5%",
+	}
+
+	pruneOpts, err := resolveEngineLocalCachePruneOptions(defaultPolicy, opts, dstat)
+	require.NoError(t, err)
+	require.Len(t, pruneOpts, len(defaultPolicy))
+
+	wantReserved := mustParseDiskSpace(t, opts.ReservedSpace, dstat)
+	wantMinFree := mustParseDiskSpace(t, opts.MinFreeSpace, dstat)
+	for i := range pruneOpts {
+		require.Equal(t, wantReserved, pruneOpts[i].ReservedSpace)
+		require.Equal(t, wantMinFree, pruneOpts[i].MinFreeSpace)
+		require.Equal(t, defaultPolicy[i].MaxUsedSpace, pruneOpts[i].MaxUsedSpace)
+		require.Equal(t, defaultPolicy[i].TargetSpace, pruneOpts[i].TargetSpace)
+	}
+
+	// Ensure default policy was not mutated by per-call overrides.
+	require.Equal(t, originalPolicy, defaultPolicy)
+}
+
+func TestResolveEngineLocalCachePruneOptionsInvalidSpaceValue(t *testing.T) {
+	dstat := disk.DiskStat{Total: 100 * 1e9}
+
+	_, err := resolveEngineLocalCachePruneOptions(nil, core.EngineCachePruneOptions{
+		UseDefaultPolicy: false,
+		ReservedSpace:    "not-a-size",
+	}, dstat)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid reservedSpace value")
+}
+
+func mustParseDiskSpace(t *testing.T, value string, dstat disk.DiskStat) int64 {
+	t.Helper()
+	var parsed bkconfig.DiskSpace
+	require.NoError(t, parsed.UnmarshalText([]byte(value)))
+	return parsed.AsBytes(dstat)
+}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4580,6 +4580,14 @@ func (r *EngineCache) MinFreeSpace(ctx context.Context) (int, error) {
 type EngineCachePruneOpts struct {
 	// Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
 	UseDefaultPolicy bool
+	// Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
+	MaxUsedSpace string
+	// Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
+	ReservedSpace string
+	// Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
+	MinFreeSpace string
+	// Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
+	TargetSpace string
 }
 
 // Prune the cache of releaseable entries
@@ -4592,6 +4600,22 @@ func (r *EngineCache) Prune(ctx context.Context, opts ...EngineCachePruneOpts) e
 		// `useDefaultPolicy` optional argument
 		if !querybuilder.IsZeroValue(opts[i].UseDefaultPolicy) {
 			q = q.Arg("useDefaultPolicy", opts[i].UseDefaultPolicy)
+		}
+		// `maxUsedSpace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MaxUsedSpace) {
+			q = q.Arg("maxUsedSpace", opts[i].MaxUsedSpace)
+		}
+		// `reservedSpace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ReservedSpace) {
+			q = q.Arg("reservedSpace", opts[i].ReservedSpace)
+		}
+		// `minFreeSpace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MinFreeSpace) {
+			q = q.Arg("minFreeSpace", opts[i].MinFreeSpace)
+		}
+		// `targetSpace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].TargetSpace) {
+			q = q.Arg("targetSpace", opts[i].TargetSpace)
 		}
 	}
 

--- a/sdk/php/generated/EngineCache.php
+++ b/sdk/php/generated/EngineCache.php
@@ -55,11 +55,28 @@ class EngineCache extends Client\AbstractObject implements Client\IdAble
     /**
      * Prune the cache of releaseable entries
      */
-    public function prune(?bool $useDefaultPolicy = false): void
-    {
+    public function prune(
+        ?bool $useDefaultPolicy = false,
+        ?string $maxUsedSpace = '',
+        ?string $reservedSpace = '',
+        ?string $minFreeSpace = '',
+        ?string $targetSpace = '',
+    ): void {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('prune');
         if (null !== $useDefaultPolicy) {
         $leafQueryBuilder->setArgument('useDefaultPolicy', $useDefaultPolicy);
+        }
+        if (null !== $maxUsedSpace) {
+        $leafQueryBuilder->setArgument('maxUsedSpace', $maxUsedSpace);
+        }
+        if (null !== $reservedSpace) {
+        $leafQueryBuilder->setArgument('reservedSpace', $reservedSpace);
+        }
+        if (null !== $minFreeSpace) {
+        $leafQueryBuilder->setArgument('minFreeSpace', $minFreeSpace);
+        }
+        if (null !== $targetSpace) {
+        $leafQueryBuilder->setArgument('targetSpace', $targetSpace);
         }
         $this->queryLeaf($leafQueryBuilder, 'prune');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4786,6 +4786,10 @@ class EngineCache(Type):
         self,
         *,
         use_default_policy: bool | None = False,
+        max_used_space: str | None = "",
+        reserved_space: str | None = "",
+        min_free_space: str | None = "",
+        target_space: str | None = "",
     ) -> Void | None:
         """Prune the cache of releaseable entries
 
@@ -4794,6 +4798,18 @@ class EngineCache(Type):
         use_default_policy:
             Use the engine-wide default pruning policy if true, otherwise
             prune the whole cache of any releasable entries.
+        max_used_space:
+            Override the maximum disk space to keep before pruning (e.g.
+            "200GB" or "80%").
+        reserved_space:
+            Override the minimum disk space to retain during pruning (e.g.
+            "500GB" or "10%").
+        min_free_space:
+            Override the minimum free disk space target during pruning (e.g.
+            "20GB" or "20%").
+        target_space:
+            Override the target disk space to keep after pruning (e.g. "200GB"
+            or "50%").
 
         Returns
         -------
@@ -4810,6 +4826,10 @@ class EngineCache(Type):
         """
         _args = [
             Arg("useDefaultPolicy", use_default_policy, False),
+            Arg("maxUsedSpace", max_used_space, ""),
+            Arg("reservedSpace", reserved_space, ""),
+            Arg("minFreeSpace", min_free_space, ""),
+            Arg("targetSpace", target_space, ""),
         ]
         _ctx = self._select("prune", _args)
         await _ctx.execute()

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1176,6 +1176,26 @@ export type EngineCachePruneOpts = {
    * Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
    */
   useDefaultPolicy?: boolean
+
+  /**
+   * Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
+   */
+  maxUsedSpace?: string
+
+  /**
+   * Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
+   */
+  reservedSpace?: string
+
+  /**
+   * Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
+   */
+  minFreeSpace?: string
+
+  /**
+   * Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
+   */
+  targetSpace?: string
 }
 
 /**
@@ -5699,6 +5719,10 @@ export class EngineCache extends BaseClient {
   /**
    * Prune the cache of releaseable entries
    * @param opts.useDefaultPolicy Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+   * @param opts.maxUsedSpace Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
+   * @param opts.reservedSpace Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
+   * @param opts.minFreeSpace Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
+   * @param opts.targetSpace Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
    */
   prune = async (opts?: EngineCachePruneOpts): Promise<void> => {
     if (this._prune) {


### PR DESCRIPTION
Before this change, manual local-cache pruning only accepted `useDefaultPolicy`, so teams running with `gc=false `could not reuse their configured space thresholds and had to choose between all-or-nothing pruning behavior.

After this change, engine.localCache.prune accepts explicit space overrides and applies them per call, enabling controlled manual pruning windows without re-enabling automatic GC.

Added test coverage in core/integration/localcache_test.go, test case `TestLocalCachePruneSpaceOverrides`.