### PR TITLE
engine: fix +ignore pragma for constructors

### DIFF
--- a/core/interface.go
+++ b/core/interface.go
@@ -323,10 +323,11 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 				}
 
 				res, err := callable.Call(ctx, &CallOpts{
-					Inputs:       callInputs,
-					ParentTyped:  self,
-					ParentFields: runtimeVal.Fields,
-					Server:       dag,
+					Inputs:         callInputs,
+					ParentTyped:    self,
+					ParentFields:   runtimeVal.Fields,
+					Server:         dag,
+					ContextualArgs: dagql.ContextualArgsFromContext(ctx),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to call interface function %s.%s: %w", ifaceName, fieldDef.Name, err)

--- a/core/object.go
+++ b/core/object.go
@@ -339,10 +339,11 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 				})
 			}
 			return fn.Call(ctx, &CallOpts{
-				Inputs:       callInput,
-				ParentTyped:  nil,
-				ParentFields: nil,
-				Server:       dag,
+				Inputs:         callInput,
+				ParentTyped:    nil,
+				ParentFields:   nil,
+				Server:         dag,
+				ContextualArgs: dagql.ContextualArgsFromContext(ctx),
 			})
 		},
 	)
@@ -463,6 +464,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 				ParentFields:   obj.Self().Fields,
 				SkipSelfSchema: false,
 				Server:         dag,
+				ContextualArgs: dagql.ContextualArgsFromContext(ctx),
 			}
 			for name, val := range args {
 				opts.Inputs = append(opts.Inputs, CallInput{

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -888,6 +888,17 @@ func CurrentDagqlServer(ctx context.Context) *Server {
 	return val.(*Server)
 }
 
+type contextualArgsCtx struct{}
+
+func WithContextualArgs(ctx context.Context, args map[string]struct{}) context.Context {
+	return context.WithValue(ctx, contextualArgsCtx{}, args)
+}
+
+func ContextualArgsFromContext(ctx context.Context) map[string]struct{} {
+	val, _ := ctx.Value(contextualArgsCtx{}).(map[string]struct{})
+	return val
+}
+
 // NewResultForCurrentID creates a new Result that's set to the current ID from
 // the given self value.
 func NewResultForCurrentID[T Typed](


### PR DESCRIPTION
Fixes #11750.

---

The issue is caused by a check on `setCallInputs`:
```go
if len(arg.metadata.Ignore) > 0 && !arg.metadata.isContextual() { // contextual args already have ignore applied
```

In this context an argument is considered contextual if either the `DefaultPath` or `DefaultAddress` is set. If it is then `setCallInputs` will not go through the ignore process of directories. The problem: arguments that are contextual (they have a default path) but a user specified a value will **not** be loaded as part of the contextual loading and will also be ignored in this check. This means `applyIgnoreOnDir` will never run for them.

Looking into the code I found two potential fixes:
1. Remove the `isContextual` check and apply ignore on all arguments. Great for simplicity, but it means we are going to run the `applyIgnoreOnDir` functions on truly contextual arguments twice.
2. Mark contextual arguments only when they are 100% coming from the context directory and not from user inputs.

I went with the second option even though it required more code changes. I'm not 100% sure on the performance impact of running `applyIgnoreOnDir` twice for contextual args, but it felt wasteful.

As for the test: I created a separate test even though we already have a `TestIgnore`. This was mainly to keep the existing test clean given that it tests a wide range of cases but for function arguments only. Happy to merge them and look into potential improvements for them.

Tested the change with a dev engine and a module with the following code:
```go
// ...
func New(
	// +defaultPath="."
	// +ignore=["**", "!dagger.json"]
	source *dagger.Directory,
) *NewMod {
	return &NewMod{
		Source: source,
	}
}

func (m *NewMod) TestSource(
	ctx context.Context,
) (string, error) {
	return dag.Container().
		From("alpine:latest").
		WithDirectory("/source", m.Source).
		WithExec([]string{"ls", "-lh", "/source"}).
		Stdout(ctx)
}

```

Specifying the arg using a dev engine vs v0.19.11:
<img width="1152" height="1122" alt="2026-02-10_11-19" src="https://github.com/user-attachments/assets/f1821eb4-ba48-44fe-983f-df1a08a78c98" />

Not specifying the arg (using the context):
<img width="1339" height="1019" alt="2026-02-10_11-21" src="https://github.com/user-attachments/assets/ba8ffdca-e54f-47e7-aaed-f13d17461c73" />

---

### AI disclosure

We don't really do or require this in the project, but given the buzz in social media I thought it would be worth disclosing the use of AI for this PR.

I used it as a guide to look into the code and it helped me understand how arguments are considered contextual, at which point they are loaded and ignored and what is the difference between constructor and function args. Once we found the bug, the code changes were also AI assisted but not vibe coded.