### PR TITLE
fix(test): pin jest toolchain commits to prevent transient CI failures

### DIFF
--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -479,13 +479,13 @@ func (ToolchainSuite) TestToolchainMultipleVersions(ctx context.Context, t *test
 		// Install first commit
 		modGen = modGen.With(daggerExec(
 			"toolchain", "install",
-			"github.com/dagger/jest@9ad6b0b9811b93bf2293a9f3eb0ffcae4d10919d",
+			"github.com/dagger/jest@b19aca4e39448291f65ad96f0eea3005ea1cf356",
 		))
 
 		// will fail at name deduplication (both named "jest")
 		_, err := modGen.With(daggerExec(
 			"toolchain", "install",
-			"github.com/dagger/jest@7e9d82b267c73bdb09dbc5e70a79e2cd020f7cc2",
+			"github.com/dagger/jest@1484257689c618ed314f5acefd1d712d80cda2dc",
 		)).CombinedOutput(ctx)
 
 		// this should error with "duplicate toolchain name"
@@ -502,13 +502,13 @@ func (ToolchainSuite) TestToolchainMultipleVersions(ctx context.Context, t *test
 		// Install first commit
 		modGen = modGen.With(daggerExec(
 			"toolchain", "install", "--name", "jest-old",
-			"github.com/dagger/jest@9ad6b0b9811b93bf2293a9f3eb0ffcae4d10919d",
+			"github.com/dagger/jest@b19aca4e39448291f65ad96f0eea3005ea1cf356",
 		))
 
 		// will fail at name deduplication (both named "jest")
 		modGen = modGen.With(daggerExec(
 			"toolchain", "install", "--name", "jest-new",
-			"github.com/dagger/jest@7e9d82b267c73bdb09dbc5e70a79e2cd020f7cc2",
+			"github.com/dagger/jest@1484257689c618ed314f5acefd1d712d80cda2dc",
 		))
 
 		// This should work if we use different names


### PR DESCRIPTION
The jest module's dang SDK source was unpinned, resolving to whatever main pointed to at fetch time.

Yesterday, a breaking change in `vito/dang` (`e5942b3`) caused a ~2h window where any CI run fetching the SDK got a compile error. This was fixed upstream (dagger/jest#7), and these test refs now point to commits that include the pinned SDK.