### PR TITLE
cmd/dagger: hint that module ref is overridden on errors

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1237,10 +1237,10 @@ func localModuleErrorf(format string, err error) error {
 
 	wrapped := fmt.Errorf(format, err)
 	if moduleURL != "" {
-		return fmt.Errorf("%w\nhint: module source came from --mod=%q. If you intended local, pass --mod .", wrapped, moduleURL)
+		return fmt.Errorf("%w\nhint: module source came from --mod=%q; if you intended local, pass `--mod .`", wrapped, moduleURL)
 	}
 	if envRef, ok := os.LookupEnv("DAGGER_MODULE"); ok {
-		return fmt.Errorf("%w\nhint: module source came from DAGGER_MODULE=%q. If you intended local, pass --mod .", wrapped, envRef)
+		return fmt.Errorf("%w\nhint: module source came from DAGGER_MODULE=%q; if you intended local, pass `--mod .`", wrapped, envRef)
 	}
 	return wrapped
 }

--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -608,7 +608,7 @@ func (ToolchainSuite) TestToolchainLocalModuleHints(ctx context.Context, t *test
 			Sync(ctx)
 		requireErrOut(t, err, `module source "github.com/dagger/dagger@main" kind must be "local", got "git"`)
 		requireErrOut(t, err, `hint: module source came from DAGGER_MODULE="github.com/dagger/dagger@main"`)
-		requireErrOut(t, err, "pass --mod .")
+		requireErrOut(t, err, "pass `--mod .`")
 
 		out, err := modGen.
 			WithEnvVariable("DAGGER_MODULE", "github.com/dagger/dagger@main").
@@ -628,6 +628,6 @@ func (ToolchainSuite) TestToolchainLocalModuleHints(ctx context.Context, t *test
 			Sync(ctx)
 		requireErrOut(t, err, `module source "github.com/dagger/dagger@main" kind must be "local", got "git"`)
 		requireErrOut(t, err, `hint: module source came from --mod="github.com/dagger/dagger@main"`)
-		requireErrOut(t, err, "pass --mod .")
+		requireErrOut(t, err, "pass `--mod .`")
 	})
 }


### PR DESCRIPTION
### Context
@nipuna-perera  [hit a Jenkins-only failure](https://discord.com/channels/707636530424053791/1469434064732819587) on `dagger toolchain install`.

The command was resolving the module from `DAGGER_MODULE` (remote git ref) instead of the local workspace. For local-mutating commands (`dagger toolchain` for example), that leads to: `kind must be "local", got "git"`.

### Problem
The error did not explain where the module ref came from, so the fix path was unclear.

### Approach
Keep behavior unchanged, improve diagnostics only:
- If module source came from `--mod`, say that explicitly
- If module source came from `DAGGER_MODULE`, say that explicitly
- Provide a concrete local fallback: `--mod .`

No heuristics, no resolution logic changes.

**Testing**
Added integration coverage for:
- `DAGGER_MODULE` override hint
- `--mod` override hint
- `--mod .` bypass
