### PR TITLE
engine: harden BoltDB settings to avoid page-freed panics under NoSync

### DIFF
--- a/.changes/unreleased/Fixed-20260211-182802.yaml
+++ b/.changes/unreleased/Fixed-20260211-182802.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Update internal bbolt db configuration to do less syncing and possibly avoid
+  an upstream bug causing crashes
+time: 2026-02-11T18:28:02.858189627-08:00
+custom:
+  Author: sipsma
+  PR: "11850"

--- a/internal/buildkit/cache/metadata/metadata.go
+++ b/internal/buildkit/cache/metadata/metadata.go
@@ -28,7 +28,11 @@ type Store struct {
 }
 
 func NewStore(dbPath string) (*Store, error) {
-	db, err := boltutil.Open(dbPath, 0600, &bbolt.Options{NoSync: true})
+	db, err := boltutil.Open(dbPath, 0600, &bbolt.Options{
+		NoSync:         true,
+		NoFreelistSync: true,
+		NoGrowSync:     true,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open database file %s", dbPath)
 	}

--- a/internal/buildkit/solver/bboltcachestorage/storage.go
+++ b/internal/buildkit/solver/bboltcachestorage/storage.go
@@ -29,7 +29,9 @@ type Store struct {
 
 func NewStore(dbPath string) (*Store, error) {
 	db, err := safeOpenDB(dbPath, &bolt.Options{
-		NoSync: true,
+		NoSync:         true,
+		NoFreelistSync: true,
+		NoGrowSync:     true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before this change, several engine BoltDBs ran with `NoSync` only, and crashy/shutdown-edge cases could still surface bbolt corruption panics like `page ... already freed`.

After this change, every BoltDB in this tree that already uses `NoSync` also sets `NoFreelistSync` and `NoGrowSync`, aligning the option set across all DB open paths and matching the mitigation pattern used in containerd.

This updates all four relevant init points: snapshotter metadata store options, containerd metadata DB open, worker cache metadata store open, and solver cache store open. It also updates the `GracefulStop` comment to reflect the full option set.

---

Gonna give CI a ton of re-rolls to see if that panic pops up again (it was quite rare though, so won't be definitive).