### PR TITLE
engine: fix safeToPersistCache propagation for nullables

### DIFF
--- a/.changes/unreleased/Fixed-20260212-105644.yaml
+++ b/.changes/unreleased/Fixed-20260212-105644.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix nullable function return types incorrectly being skipped for persistent
+  cache
+time: 2026-02-12T10:56:44.641350269-08:00
+custom:
+  Author: sipsma
+  PR: "11855"


### PR DESCRIPTION
Nullable return types from functions weren't propagating from the Nullable-wrapped result to the de-ref'd un-null result.

This meant nullable return types from functions would not get cached. It seems most SDKs end up using Non-nullable types for the most part in practice, but we just hit this in Dang where you can easily specify a type as Nullable.

Along the way I noticed a quirk with the sqlite db TTL checks in that we were always following the "TTL expired" branch even when there actually was no hit at all. Funnily, this actually ended up behaving totally fine in practice, but worth a fix for clarity if nothing else.