### PR TITLE
core: support content-hashable function results

### DIFF
--- a/core/enum.go
+++ b/core/enum.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine/server/resource"
 	"github.com/dagger/dagger/engine/slog"
-	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -87,8 +85,11 @@ func (m *ModuleEnumType) ConvertToSDKInput(ctx context.Context, value dagql.Type
 	return enum.memberTypedef().Name, nil
 }
 
-func (m *ModuleEnumType) CollectCoreIDs(ctx context.Context, value dagql.AnyResult, ids map[digest.Digest]*resource.ID) error {
-	return nil
+func (m *ModuleEnumType) CollectContent(_ context.Context, value dagql.AnyResult, content *CollectedContent) error {
+	if value == nil {
+		return content.CollectJSONable(nil)
+	}
+	return content.CollectJSONable(value.Unwrap())
 }
 
 func (m *ModuleEnumType) getEnum(ctx context.Context) (*ModuleEnum, error) {

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -718,9 +718,11 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 		if !ok {
 			return nil, fmt.Errorf("find mod type for parent %q", fn.objDef.Name)
 		}
-		if err := parentModType.CollectCoreIDs(ctx, opts.ParentTyped, execMD.ParentIDs); err != nil {
+		parentContent := NewCollectedContent()
+		if err := parentModType.CollectContent(ctx, opts.ParentTyped, parentContent); err != nil {
 			return nil, fmt.Errorf("collect IDs from parent fields: %w", err)
 		}
+		execMD.ParentIDs = parentContent.IDs
 	}
 
 	if mod.ResultID != nil {
@@ -867,15 +869,15 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 
 		// If the function returned anything that's isolated per-client, this caller client should
 		// have access to it now since it was returned to them (i.e. secrets/sockets/etc).
-		returnedIDs := map[digest.Digest]*resource.ID{}
-		if err := fn.returnType.CollectCoreIDs(ctx, returnValue, returnedIDs); err != nil {
-			return nil, fmt.Errorf("collect IDs: %w", err)
+		returnedContent := NewCollectedContent()
+		if err := fn.returnType.CollectContent(ctx, returnValue, returnedContent); err != nil {
+			return nil, fmt.Errorf("collect content: %w", err)
 		}
 
 		// Function calls are cached per-session, but every client caller needs to add
 		// secret/socket/etc. resources from the result to their store.
-		returnedIDsList := make([]*resource.ID, 0, len(returnedIDs))
-		for _, id := range returnedIDs {
+		returnedIDsList := make([]*resource.ID, 0, len(returnedContent.IDs))
+		for _, id := range returnedContent.IDs {
 			returnedIDsList = append(returnedIDsList, id)
 		}
 		resourceTransferPostCall, hasNamedSecrets, err := ResourceTransferPostCall(ctx, query, clientID, returnedIDsList...)
@@ -889,12 +891,31 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 		}
 
 		returnValue = returnValue.WithPostCall(resourceTransferPostCall)
+
+		// If this function accepts Workspace args, set a content digest on the
+		// result derived from all content it returned — both core object IDs
+		// (Directory, File, etc.) and primitive scalar values (String, Int, etc.).
+		// This ensures downstream calls that reference this result get a different
+		// cache key when the underlying content changes.
+		if fn.hasWorkspaceArgs() {
+			returnValue = returnValue.WithContentDigestAny(returnedContent.Digest())
+		}
 	}
 	if returnValue != nil {
 		returnValue = returnValue.WithSafeToPersistCache(safeToPersistCache)
 	}
 
 	return returnValue, nil
+}
+
+// hasWorkspaceArgs returns true if any of the function's arguments are of type Workspace.
+func (fn *ModuleFunction) hasWorkspaceArgs() bool {
+	// for _, arg := range fn.metadata.Args {
+	// 	if arg.IsWorkspace() {
+	// 		return true
+	// 	}
+	// }
+	return false
 }
 
 func extractError(ctx context.Context, client *buildkit.Client, baseErr error) (dagql.ID[*Error], bool, error) {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -509,6 +509,12 @@ func (r Result[T]) WithContentDigest(customDigest digest.Digest) Result[T] {
 	return r
 }
 
+// WithContentDigestAny is WithContentDigest but returns an AnyResult, required
+// for polymorphic code paths like module function call plumbing.
+func (r Result[T]) WithContentDigestAny(customDigest digest.Digest) AnyResult {
+	return r.WithContentDigest(customDigest)
+}
+
 // String returns the instance in Class@sha256:... format.
 func (r Result[T]) String() string {
 	typ := r.Type()

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"golang.org/x/exp/constraints"
 
@@ -96,6 +97,9 @@ type AnyResult interface {
 
 	// WithSafeToPersistCache returns a new AnyResult with the given safe-to-persist-cache flag.
 	WithSafeToPersistCache(safe bool) AnyResult
+
+	// WithContentDigest returns a new AnyResult with the given content digest.
+	WithContentDigestAny(digest.Digest) AnyResult
 
 	HitCache() bool
 	HitContentDigestCache() bool


### PR DESCRIPTION
Splitting this out of #11812 so I can get a clean test of it in isolation to make sure the accompanied refactor didn't break anything.