### PR TITLE
TUI prints name of module being loaded

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1290,10 +1290,12 @@ func optionalModCmdWrapper(
 			}
 			switch {
 			case configExists:
+				serveCtx, span := Tracer().Start(ctx, "load module: "+modRef)
 				mod := modSrc.AsModule()
-				err := mod.Serve(ctx, dagger.ModuleServeOpts{IncludeDependencies: true})
-				if err != nil {
-					return fmt.Errorf("failed to serve module: %w", err)
+				serveErr := mod.Serve(serveCtx, dagger.ModuleServeOpts{IncludeDependencies: true})
+				telemetry.EndWithCause(span, &serveErr)
+				if serveErr != nil {
+					return fmt.Errorf("failed to serve module: %w", serveErr)
 				}
 				return fn(ctx, engineClient, mod, cmd, cmdArgs)
 			case explicitModRefSet:


### PR DESCRIPTION
When DAGGER_MODULE is set, the module is silently loaded with no visible
indication in the TUI.

This PR fixes that by always displaying the name of the module being loaded.
