### PR TITLE
feat(sdk/elixir): check support

### DIFF
--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -333,6 +333,46 @@ func (ElixirSuite) TestReqAdapter(ctx context.Context, t *testctx.T) {
 	require.Equal(t, "hello-from-req-adapter\n", out)
 }
 
+func (ElixirSuite) TestCheck(ctx context.Context, t *testctx.T) {
+	t.Run("list checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "failing-check")
+		require.Contains(t, out, "passing-container")
+		require.Contains(t, out, "failing-container")
+	})
+
+	t.Run("run passing checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExec("--progress=report", "check", "passing*")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.Regexp(t, `passing-container.*OK`, out)
+	})
+
+	t.Run("run failing checks", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := elixirModule(t, c, "hello-with-checks").
+			With(daggerExecFail("--progress=report", "check", "failing*")).
+			CombinedOutput(ctx)
+
+		require.NoError(t, err)
+		require.Regexp(t, `failing-check.*ERROR`, out)
+		require.Regexp(t, `failing-container.*ERROR`, out)
+	})
+}
+
 func elixirModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/elixir", moduleName))

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.formatter.exs
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:dagger],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.gitattributes
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.gitattributes
@@ -1,0 +1,1 @@
+/dagger_sdk/** linguist-generated

--- a/core/integration/testdata/modules/elixir/hello-with-checks/.gitignore
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/.gitignore
@@ -1,0 +1,9 @@
+/dagger_sdk
+/_build
+/cover
+/deps
+/doc
+/erl_crash.dump
+/*.ez
+/template-*.tar
+/tmp

--- a/core/integration/testdata/modules/elixir/hello-with-checks/dagger.json
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "hello-with-checks",
+  "engineVersion": "v0.19.8",
+  "sdk": {
+    "source": "../../sdk/elixir"
+  }
+}

--- a/core/integration/testdata/modules/elixir/hello-with-checks/lib/hello_with_checks.ex
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/lib/hello_with_checks.ex
@@ -1,0 +1,31 @@
+defmodule HelloWithChecks do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "HelloWithChecks"
+
+  @check true
+  defn passing_check() :: Dagger.Void.t() do
+    :ok
+  end
+
+  @check true
+  defn failing_check() :: Dagger.Void.t() do
+    raise "this check always fails"
+  end
+
+  @check true
+  defn passing_container() :: Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("alpine:3")
+    |> Dagger.Container.with_exec(["sh", "-c", "exit 0"])
+  end
+
+  @check true
+  defn failing_container() :: Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("alpine:3")
+    |> Dagger.Container.with_exec(["sh", "-c", "exit 1"])
+  end
+end

--- a/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/mix.exs
@@ -1,0 +1,25 @@
+defmodule HelloWithChecks.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :hello_with_checks,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:dagger, path: "./dagger_sdk"}
+    ]
+  end
+end

--- a/core/integration/testdata/modules/elixir/hello-with-checks/mix.lock
+++ b/core/integration/testdata/modules/elixir/hello-with-checks/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nestru": {:hex, :nestru, "1.0.1", "f02321db91b898da3d598c274f2ccba2c41ec5c50c942eabe900474dbfe4bce3", [:mix], [], "hexpm", "e4fbbd6d64b1c8cb37ef590a891f0b6b17b0b880c1c5ce2ac98de02c0ad7417e"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}

--- a/sdk/elixir/.changes/unreleased/Added-20260219-144151.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20260219-144151.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: '[Dagger Check](https://docs.dagger.io/core-concepts/checks/) support'
+time: 2026-02-19T14:41:51.422679+07:00
+custom:
+    Author: wingyplus
+    PR: "11881"

--- a/sdk/elixir/lib/dagger/mod/object.ex
+++ b/sdk/elixir/lib/dagger/mod/object.ex
@@ -198,6 +198,7 @@ defmodule Dagger.Mod.Object do
       Module.register_attribute(__MODULE__, :function, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :field, accumulate: true, persist: true)
       Module.register_attribute(__MODULE__, :cache, accumulate: false, persist: true)
+      Module.register_attribute(__MODULE__, :check, accumulate: false, persist: true)
 
       @before_compile Dagger.Mod.Object
 
@@ -239,10 +240,17 @@ defmodule Dagger.Mod.Object do
       cache_attr =
         Module.get_attribute(__MODULE__, :cache)
 
+      check_attr =
+        Module.get_attribute(__MODULE__, :check)
+
+      Module.put_attribute(__MODULE__, :cache, nil)
+      Module.put_attribute(__MODULE__, :check, nil)
+
       @function {unquote(name),
                  %Dagger.Mod.Object.FunctionDef{
                    self: unquote(has_self?),
                    cache_policy: cache_attr,
+                   check: check_attr,
                    args: unquote(arg_defs),
                    return: unquote(return_def)
                  }}

--- a/sdk/elixir/lib/dagger/mod/object/function_def.ex
+++ b/sdk/elixir/lib/dagger/mod/object/function_def.ex
@@ -4,7 +4,7 @@ defmodule Dagger.Mod.Object.FunctionDef do
   # A function declaration from `Dagger.Mod.Object.defn/2`.
 
   @enforce_keys [:self, :args, :return]
-  defstruct @enforce_keys ++ [:cache_policy]
+  defstruct @enforce_keys ++ [:cache_policy, :check]
 
   @doc """
   Convert a `fun_def` into Dagger Function.
@@ -19,6 +19,7 @@ defmodule Dagger.Mod.Object.FunctionDef do
     |> maybe_with_description(Dagger.Mod.Object.get_function_doc(module, name))
     |> maybe_with_cache_policy(Dagger.Mod.Object.get_function_cache_policy(fun_def))
     |> maybe_with_deprecated(Dagger.Mod.Object.get_function_deprecated(module, name))
+    |> maybe_with_check(fun_def.check)
     |> with_args(fun_def.args, dag)
   end
 
@@ -40,6 +41,9 @@ defmodule Dagger.Mod.Object.FunctionDef do
 
   defp maybe_with_deprecated(function, {:deprecated, reason}),
     do: Dagger.Function.with_deprecated(function, reason: reason)
+
+  defp maybe_with_check(function, nil), do: function
+  defp maybe_with_check(function, true), do: Dagger.Function.with_check(function)
 
   defp maybe_with_cache_policy(function, nil), do: function
 

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -49,6 +49,8 @@ defmodule Dagger.ClientTest do
     assert ["## What is Dagger?" | _] = String.split(readme, "\n")
   end
 
+  # 2 minutes
+  @tag timeout: 180_000
   test "container build", %{dag: dag} do
     repo =
       dag

--- a/sdk/elixir/test/dagger/mod/object_test.exs
+++ b/sdk/elixir/test/dagger/mod/object_test.exs
@@ -306,6 +306,23 @@ defmodule Dagger.Mod.ObjectTest do
              ]
     end
 
+    test "check attribute" do
+      assert CheckAttribute.__object__(:functions) == [
+               checked_function: %FunctionDef{
+                 self: false,
+                 args: [],
+                 return: Dagger.Void,
+                 check: true
+               },
+               unchecked_function: %FunctionDef{
+                 self: false,
+                 args: [],
+                 return: Dagger.Void,
+                 check: nil
+               }
+             ]
+    end
+
     test "cache policy" do
       assert CacheAttribute.__object__(:functions) == [
                never_cached: %FunctionDef{

--- a/sdk/elixir/test/support/object_mod.ex
+++ b/sdk/elixir/test/support/object_mod.ex
@@ -152,6 +152,20 @@ defmodule CacheAttribute do
   end
 end
 
+defmodule CheckAttribute do
+  @moduledoc false
+  use Dagger.Mod.Object, name: "CheckAttribute"
+
+  @check true
+  defn checked_function() :: Dagger.Void.t() do
+    :ok
+  end
+
+  defn unchecked_function() :: Dagger.Void.t() do
+    :ok
+  end
+end
+
 defmodule ReturnVoid do
   @moduledoc false
   use Dagger.Mod.Object, name: "ReturnVoid"


### PR DESCRIPTION
Support `@check true` before a defn function to register it as a Dagger
check via Dagger.Function.with_check/1. Follows the same pattern as the
existing `@cache` attribute.