### PR TITLE
test: use github.com/dagger/pytest for python-sdk

### DIFF
--- a/toolchains/python-sdk-dev/dagger.json
+++ b/toolchains/python-sdk-dev/dagger.json
@@ -13,12 +13,17 @@
   ],
   "dependencies": [
     {
+      "name": "dagger-engine",
+      "source": "../engine-dev"
+    },
+    {
       "name": "dockerd",
       "source": "dockerd"
     },
     {
-      "name": "dagger-engine",
-      "source": "../engine-dev"
+      "name": "pytest",
+      "source": "github.com/dagger/pytest@main",
+      "pin": "821da5888b0c2e66d33a7c9b59351f92b53492f9"
     },
     {
       "name": "wolfi",

--- a/toolchains/python-sdk-dev/go.mod
+++ b/toolchains/python-sdk-dev/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	dagger.io/dagger v0.19.11
-	github.com/99designs/gqlgen v0.17.81
+	github.com/99designs/gqlgen v0.17.81 // indirect
 	github.com/Khan/genqlient v0.8.1
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -26,27 +26,27 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.30
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.2 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
-	go.opentelemetry.io/otel/log v0.14.0
-	go.opentelemetry.io/otel/metric v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.38.0
-	go.opentelemetry.io/otel/sdk/log v0.14.0
-	go.opentelemetry.io/otel/sdk/metric v1.38.0
+	go.opentelemetry.io/otel/sdk/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0
-	go.opentelemetry.io/proto/otlp v1.8.0
+	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
 	golang.org/x/net v0.46.0 // indirect
-	golang.org/x/sync v0.17.0
+	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
-	google.golang.org/grpc v1.76.0
+	google.golang.org/grpc v1.76.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 

--- a/toolchains/python-sdk-dev/main.go
+++ b/toolchains/python-sdk-dev/main.go
@@ -138,10 +138,7 @@ func (t PythonSdkDev) Test(ctx context.Context) error {
 	jobs := parallel.New()
 	for _, version := range supportedVersions {
 		jobs = jobs.WithJob("test with python version "+version, func(ctx context.Context) error {
-			_, err := t.TestSuite(version, false).
-				Default().
-				Sync(ctx)
-			return err
+			return t.TestSuite(version, false).RunDefault(ctx)
 		})
 	}
 	return jobs.Run(ctx)


### PR DESCRIPTION
This adds telemetry to Python SDK tests so we can see each individual test passing in the traces/cloud.