### PR TITLE
Keep stringArg type as string, even if it decodes to numeric

### DIFF
--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -257,6 +257,50 @@ func (ToolchainSuite) TestToolchainsWithConfiguration(ctx context.Context, t *te
 		require.Contains(t, out, "hola from blueprint")
 	})
 
+	t.Run("override function default argument with numerical-looking string", func(ctx context.Context, t *testctx.T) {
+		// Reproduces https://github.com/dagger/dagger/issues/11882
+		modGen := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithWorkdir("/work").
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			// Create toolchain with default Go SDK template (provides ContainerEcho(stringArg string))
+			WithWorkdir("/work/toolchains/test-toolchain").
+			With(daggerExec("init", "--sdk=go", "--name=test-toolchain")).
+			// Create main module
+			WithWorkdir("/work").
+			With(daggerExec("init", "--sdk=go")).
+			WithNewFile("dagger.json", `
+{
+  "name": "numerical-toolchain-argument",
+  "engineVersion": "v0.19.4",
+  "sdk": {
+    "source": "go"
+  },
+  "toolchains": [
+    {
+      "name": "test-toolchain",
+      "source": "toolchains/test-toolchain",
+      "customizations": [
+        {
+          "function": ["ContainerEcho"],
+          "argument": "stringArg",
+          "default": "8.0"
+        }
+      ]
+    }
+  ]
+}
+					`)
+		// verify the module loads and the numerical-looking string default works
+		out, err := modGen.
+			With(daggerExec("call", "test-toolchain", "container-echo", "stdout")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "8.0")
+	})
+
 	t.Run("override constructor defaultPath argument", func(ctx context.Context, t *testctx.T) {
 		modGen := toolchainTestEnv(t, c).
 			WithWorkdir("app").

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3157,6 +3157,15 @@ func applyArgumentConfigToFunction(fn *core.Function, argConfigs []*modules.Modu
 						defaultValue = argCfg.Default
 					}
 
+					// If the JSON parsed as a non-string type (e.g. number) but
+					// the argument expects a string, use the raw config value
+					// as-is. See https://github.com/dagger/dagger/issues/11882
+					if _, isString := defaultValue.(string); !isString {
+						if _, err := arg.TypeDef.ToInput().Decoder().DecodeInput(defaultValue); err != nil {
+							defaultValue = argCfg.Default
+						}
+					}
+
 					// Validate the type matches the argument type
 					_, err := arg.TypeDef.ToInput().Decoder().DecodeInput(defaultValue)
 					if err != nil {


### PR DESCRIPTION
This PR will prevent conversion of numeric-looking string default argument to numeric when parsing a module configuration.

Assisted by Claude Code

Resolves: #11882 