### PR TITLE
feat(cmd/dagger): support path filters (include, exclude, gitignore) for dagger.Directory arguments

### DIFF
--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -182,7 +182,11 @@ func (s *addressSchema) directory(
 			})
 		}
 	} else {
-		q = queryLocalDirectory(addr, args.CopyFilter)
+		if path, err := parsePathWithFilter(addr, &args.CopyFilter); err != nil {
+			return inst, err
+		} else {
+			q = queryLocalDirectory(path, args.CopyFilter)
+		}
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
@@ -230,6 +234,48 @@ func queryRemoteGitRoot(gitURL *gitutil.GitURL) []dagql.Selector {
 func getLocalPath(path string) string {
 	// file://PATH -> PATH
 	return strings.TrimPrefix(path, "file://")
+}
+
+// Parse directories with filters:
+// - /path/to/monorepo?include=apps/app1,libs/lib1,libs/lib2&exclude=libs/lib1/testdata
+func parsePathWithFilter(pathWithFilter string, copyFiler *core.CopyFilter) (string, error) {
+	path := pathWithFilter
+	if i := strings.Index(pathWithFilter, "?"); i > 0 {
+		// this will support something like
+		// "--path-arg=.?include=cmd,internal&exclude=docs&gitignore=true"
+
+		pathArgs := strings.Split(pathWithFilter[i+1:], "&")
+		path = pathWithFilter[:i]
+		for _, pathArg := range pathArgs {
+			if j := strings.Index(pathArg, "="); j > 0 {
+				argName := pathArg[:j]
+				argValue := pathArg[j+1:]
+				switch argName {
+				case "include":
+					copyFiler.Include = append(copyFiler.Include, strings.Split(argValue, ",")...)
+				case "exclude":
+					copyFiler.Exclude = append(copyFiler.Exclude, strings.Split(argValue, ",")...)
+				case "gitignore":
+					if bVal, err := strconv.ParseBool(argValue); err == nil {
+						copyFiler.Gitignore = bVal
+					} else {
+						return "", fmt.Errorf("invalid option %s=%s in %q: %w", argName, argValue, pathWithFilter, err)
+					}
+				default:
+					return "", fmt.Errorf("unknown option %q in %q", argName, pathWithFilter)
+				}
+			} else {
+				argName := pathArg
+				switch argName {
+				case "gitignore":
+					copyFiler.Gitignore = true
+				default:
+					return "", fmt.Errorf("unknown option %q in %q", argName, pathWithFilter)
+				}
+			}
+		}
+	}
+	return path, nil
 }
 
 func (s *addressSchema) container(

--- a/core/schema/address_test.go
+++ b/core/schema/address_test.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/core"
+)
+
+func TestParsePathWithFilters(t *testing.T) {
+	var emptyFilter core.CopyFilter
+	parse := func(value string, cf core.CopyFilter) (string, core.CopyFilter, error) {
+		path, err := parsePathWithFilter(value, &cf)
+		return path, cf, err
+	}
+
+	path, cf, err := parse("path", emptyFilter)
+	require.NoError(t, err)
+	require.Equal(t, "path", path)
+	require.True(t, cf.IsEmpty(), "filter should be empty")
+
+	path, cf, err = parse("path?include=a,b,c&exclude=x,y,z&gitignore", emptyFilter)
+	require.NoError(t, err)
+	require.Equal(t, "path", path)
+	require.Equal(t, cf.Include, []string{"a", "b", "c"})
+	require.Equal(t, cf.Exclude, []string{"x", "y", "z"})
+	require.True(t, cf.Gitignore)
+
+	path, cf, err = parse("path?include=d", cf)
+	require.NoError(t, err)
+	require.Equal(t, "path", path)
+	require.Equal(t, cf.Include, []string{"a", "b", "c", "d"})
+	require.Equal(t, cf.Exclude, []string{"x", "y", "z"})
+	require.True(t, cf.Gitignore)
+
+	_, cf, err = parse("path?gitignore=false", cf)
+	require.NoError(t, err)
+	require.False(t, cf.Gitignore)
+
+	_, _, err = parse("path?", emptyFilter)
+	require.Error(t, err)
+
+	_, _, err = parse("path?gitignore=badvalue", emptyFilter)
+	require.Error(t, err)
+
+	_, _, err = parse("path?badoption=1", emptyFilter)
+	require.Error(t, err)
+
+	_, _, err = parse("path?badoption_with_novalue", emptyFilter)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This is a simple client-side feature to complement the more comprehensive [server-side dynamic filtering](https://github.com/dagger/dagger/issues/11287).

It will allow specifying include/exclude options for arguments of type `dagger.Directory` using a url-like format.
For example: 
```/path/to/monorepo?include=apps/app1,libs/lib1,libs/lib2&exclude=libs/lib1/testdata```

Can be useful for builds that need a subset of directories.
For example a `golang` build, with `replace` support.

Works for command line args, as well as user defaults.

Unlike the dynamic filtering proposal this would most likely require a script to compute the includes/excludes prior to invoking dagger.
I have at least one use-case where this is actually preferable (includes are computed by an native executable).