### PR TITLE
fix: python provision tests after 3.14 python upgrade

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,7 +167,7 @@ jobs:
 
       - uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.8.14"
+          uv-version: "0.10.3"
       - name: "Test Python SDK"
         run: |
           cd sdk/python
@@ -335,7 +335,7 @@ jobs:
         shell: bash
       - uses: yezz123/setup-uv@v4
         with:
-          uv-version: "0.8.14"
+          uv-version: "0.10.3"
       - name: "Test Python SDK"
         run: |
           cd sdk/python


### PR DESCRIPTION
This is a guess, but the error https://github.com/dagger/dagger/actions/runs/22108534795/job/63905196975 is related to a change with `3.14` and it started to failed after bumping python to 3.14 in https://github.com/dagger/dagger/pull/11868
I also bumped `uv` at that time but forgot those github actions.

At least it can't hurt to update those.