### PR TITLE
fix(typescript): avoid ts-introspector crash on empty nested src dirs

### DIFF
--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -159,6 +159,22 @@ func (TypescriptSuite) TestInit(ctx context.Context, t *testctx.T) {
 		require.JSONEq(t, `{"existingSource":{"helloWorld":{"stdout":"hello\n"}}}`, out)
 	})
 
+	t.Run("handles empty directory in src", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--source=.", "--name=emptyDir", "--sdk=typescript")).
+			WithDirectory("/work/src/empty-dir", c.Directory())
+
+		out, err := modGen.
+			With(daggerQuery(`{emptyDir{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"emptyDir":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
 	t.Run("with source", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 

--- a/sdk/typescript/src/module/entrypoint/introspection_entrypoint.ts
+++ b/sdk/typescript/src/module/entrypoint/introspection_entrypoint.ts
@@ -30,7 +30,7 @@ function getTsSourceCodeFiles(dir: string): string[] {
 
       return []
     })
-    .reduce((p, c) => [...c, ...p])
+    .reduce((p, c) => [...c, ...p], [])
 }
 
 async function main() {


### PR DESCRIPTION
Fixes #11904 

### Problem 
A user reporting getting this module init failure:

```markdown
failed to get type defs json during module sdk codegen
TypeError: reduce of empty array with no initial value
```

#### Root cause

`getTsSourceCodeFiles` recursively scans `src/`, and each level reduces `readdirSync(dir).map(...)` without an initial accumulator.

To trigger the error, the module does not need to be empty: any empty nested directory under `src/` can trigger this panic.

#### Solution

This failure occurs during module typedef introspection (`ts-introspector`, Bun path), so forcing `"dagger.runtime": "node@..."` does not change it.

The fix is to seed the reduce with `[]` + I added a regression coverage in `TestTypescript/TestInit/handles_empty_directory_in_src`.