### PR TITLE
python-sdk-dev: split tests by py version and type

### DIFF
--- a/toolchains/python-sdk-dev/test.go
+++ b/toolchains/python-sdk-dev/test.go
@@ -2,27 +2,33 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"runtime"
 
 	"dagger/python-sdk-dev/internal/dagger"
 )
 
-// Run the test suite.
-type TestSuite struct {
+type TestForPythonVersion struct {
 	// The base container to run the tests
 	// +private
 	Container *dagger.Container
 	// The python version to test against
 	// +private
 	Version string
-	// Disable nested execution for the test runs
-	// +private
-	DisableNestedExec bool
+}
+
+// Run python slow tests
+// +check
+func (t *TestForPythonVersion) Slow(ctx context.Context) error {
+	return t.Run(ctx, []string{"-Wd", "-l", "-m", "slow and not provision"})
+}
+
+// Run python unit tests
+// +check
+func (t *TestForPythonVersion) Unit(ctx context.Context) error {
+	return t.Run(ctx, []string{"-m", "not slow and not provision"})
 }
 
 // Run the pytest command.
-func (t *TestSuite) Run(
+func (t *TestForPythonVersion) Run(
 	ctx context.Context,
 	// Arguments to pass to pytest
 	args []string,
@@ -34,81 +40,4 @@ func (t *TestSuite) Run(
 		Version: t.Version,
 		Args:    args,
 	})
-}
-
-// Run python tests.
-func (t *TestSuite) RunDefault(ctx context.Context) error {
-	return t.Run(ctx, []string{"-Wd", "-l", "-m", "not provision"})
-}
-
-// Run unit tests.
-func (t *TestSuite) Unit(ctx context.Context) error {
-	return t.Run(ctx, []string{"-m", "not slow and not provision"})
-}
-
-// Test provisioning.
-//
-// This publishes a cli binary in an ephemeral http server and checks
-// if the SDK can download, extract and run it.
-func (t *TestSuite) Provision(
-	ctx context.Context,
-	// Dagger binary to use for test
-	cliBin *dagger.File,
-	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
-	// +optional
-	runnerHost string,
-) (*dagger.Container, error) {
-	archiveName := fmt.Sprintf("dagger_v0.x.y_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
-	checksumsName := "checksums.txt"
-
-	httpServer := t.Container.
-		WithMountedFile("/src/dagger", cliBin).
-		WithWorkdir("/work").
-		WithExec([]string{"tar", "cvzf", archiveName, "-C", "/src", "dagger"}).
-		WithExec(
-			[]string{"sha256sum", archiveName},
-			dagger.ContainerWithExecOpts{RedirectStdout: checksumsName}).
-		WithExec([]string{"python", "-m", "http.server"}).
-		WithExposedPort(8000).
-		AsService()
-
-	httpServerURL, err := httpServer.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "http"})
-	if err != nil {
-		return nil, err
-	}
-	archiveURL := fmt.Sprintf("%s/%s", httpServerURL, archiveName)
-	checksumsURL := fmt.Sprintf("%s/%s", archiveURL, checksumsName)
-
-	dockerVersion := "24.0.7"
-
-	ctr := dag.Dockerd().Attach(
-		t.Container.WithMountedFile(
-			"/opt/docker.tgz",
-			dag.HTTP(fmt.Sprintf("https://download.docker.com/linux/static/stable/%s/docker-%s.tgz", runtime.GOARCH, dockerVersion)),
-			dagger.ContainerWithMountedFileOpts{Owner: "root"}).
-			WithExec([]string{
-				"tar",
-				"xzvf",
-				"/opt/docker.tgz",
-				"--strip-components=1",
-				"-C",
-				"/usr/local/bin",
-				"docker/docker",
-			}),
-		dagger.DockerdAttachOpts{DockerVersion: dockerVersion})
-
-	if runnerHost != "" {
-		ctr = ctr.WithEnvVariable(
-			"_EXPERIMENTAL_DAGGER_RUNNER_HOST",
-			runnerHost)
-	}
-
-	return ctr.
-			WithServiceBinding("http_server", httpServer).
-			WithEnvVariable("_INTERNAL_DAGGER_TEST_CLI_URL", archiveURL).
-			WithEnvVariable("_INTERNAL_DAGGER_TEST_CLI_CHECKSUMS_URL", checksumsURL).
-			WithExec(
-				[]string{"pytest", "-m", "provision"},
-				dagger.ContainerWithExecOpts{InsecureRootCapabilities: true}),
-		nil
 }


### PR DESCRIPTION
Introduce a specific object type exposing `unit` and `slow` check function executing tests.
Instead of relying on the python version matrix and handling the parallelism when calling the tests, use the built-in `check` behaviour. All the check functions will be run in parallel.

This change gives more visibility and more control to the developer to run python sdk tests.

Previously only one single check was available regarding those tests:

    $ dagger check -l
    ...
    python-sdk:test
    ...

By using `dagger check` it's only possible to run all the tests against all the different python versions. But when iterating on a python feature it could be better to simply run against one specific version, and only the unit tests for instance.

This is doable by switching to `dagger call`:

    $ dagger call python-sdk test-suite --version 3.14 unit

But it's sad we have to use two different types of calling dagger functions to do that.

A new function, named `python-PYTHON_VERSION` returns a new instance of the `TestForPythonVersion` object with the PYTHON_VERSION. This object contains the two checks.
One function is created for each python version of the test matrix. The check list become:

    $ dagger check -l
    ...
    python-sdk:python-310:slow            Run python slow tests
    python-sdk:python-310:unit            Run python unit tests
    python-sdk:python-311:slow            Run python slow tests
    python-sdk:python-311:unit            Run python unit tests
    python-sdk:python-312:slow            Run python slow tests
    python-sdk:python-312:unit            Run python unit tests
    python-sdk:python-313:slow            Run python slow tests
    python-sdk:python-313:unit            Run python unit tests
    python-sdk:python-314:slow            Run python slow tests
    python-sdk:python-314:unit            Run python unit tests
    ...

When `dagger check` will be run, all the tests will run, as expected. But we can now benefit from the path matching to do more things, and keeping a call to check:

For instance, to run unit tests against python 3.14 just use the check path

    $ dagger check python-sdk:python-314:unit

To run unit tests against all python versions

    $ dagger check python-sdk:**:unit

To run all tests for a specific python version

    $ dagger check python-sdk:python-314

To run all tests against all python versions

    $ dagger check python-sdk:python-*

This gives more control, more granularity and a more explicit way to run python tests.