### PR TITLE
remove Windows ARM v7 from GoReleaser

### DIFF
--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -7,14 +7,24 @@ builds:
     binary: ./dagger
     goos:
       - linux
-      - windows
-      - darwin
     goarch:
       - amd64
       - arm64
       - arm
     goarm:
       - "7"
+
+    prebuilt:
+      path: build/dagger_{{ .Env.ENGINE_VERSION }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}_v{{ . }}{{ end }}/dagger
+
+  - builder: prebuilt
+    binary: ./dagger
+    goos:
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
 
     prebuilt:
       path: build/dagger_{{ .Env.ENGINE_VERSION }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}_v{{ . }}{{ end }}/dagger


### PR DESCRIPTION
we can no longer build the CLI for Windows ARMv7 after upgrading to Go 1.26. So we just need to remove it from the release process too.