### PR TITLE
drivers: add TLS driver for engine clients

### DIFF
--- a/.changes/unreleased/Added-20260226-110408.yaml
+++ b/.changes/unreleased/Added-20260226-110408.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'drivers: add TLS driver for engine clients'
+time: 2026-02-26T11:04:08.481790308-03:00
+custom:
+    Author: matipan
+    PR: "11916"

--- a/engine/client/drivers/dial.go
+++ b/engine/client/drivers/dial.go
@@ -18,6 +18,7 @@ func init() {
 	register("unix", &dialDriver{})
 	register("ssh", &dialDriver{connhSSH.Helper, nil})
 	register("kube-pod", &dialDriver{connhKube.Helper, nil})
+	register("tls", &dialDriver{connhTLS, nil})
 }
 
 // dialDriver uses the buildkit connhelpers to directly connect

--- a/engine/client/drivers/tls.go
+++ b/engine/client/drivers/tls.go
@@ -1,0 +1,114 @@
+package drivers
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/dagger/dagger/internal/buildkit/client/connhelper"
+)
+
+const (
+	TLSDialTimeout = 10 * time.Second
+)
+
+func connhTLS(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	host := u.Hostname()
+	port := u.Port()
+
+	if host == "" {
+		return nil, fmt.Errorf("TLS driver requires a host in the URL")
+	}
+
+	if port == "" {
+		port = "443"
+	}
+
+	tlsConfig, err := buildTLSConfig(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	serverAddr := net.JoinHostPort(host, port)
+
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			dialer := net.Dialer{Timeout: TLSDialTimeout}
+			rawConn, err := dialer.DialContext(ctx, "tcp", serverAddr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to dial TCP to %s: %w", serverAddr, err)
+			}
+
+			tlsConn := tls.Client(rawConn, tlsConfig)
+
+			handshakeCtx, cancel := context.WithTimeout(ctx, TLSHandshakeTimeout)
+			defer cancel()
+
+			if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+				rawConn.Close()
+				return nil, fmt.Errorf("TLS handshake failed with %s: %w", serverAddr, err)
+			}
+
+			return tlsConn, nil
+		},
+	}, nil
+}
+
+func buildTLSConfig(target *url.URL) (*tls.Config, error) {
+	query := target.Query()
+
+	certPath := query.Get("cert_path")
+	keyPath := query.Get("key_path")
+	caPath := query.Get("ca_path")
+
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: false,
+	}
+
+	if target.Hostname() != "" {
+		tlsConfig.ServerName = target.Hostname()
+	}
+
+	if certPath != "" && keyPath != "" {
+		certPEM, err := os.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read client certificate from %s: %w", certPath, err)
+		}
+
+		keyPEM, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read client key from %s: %w", keyPath, err)
+		}
+
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	} else if certPath != "" || keyPath != "" {
+		return nil, fmt.Errorf("both cert_path and key_path must be provided for client authentication")
+	}
+
+	if caPath != "" {
+		caCert, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate from %s: %w", caPath, err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %s", caPath)
+		}
+
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	return tlsConfig, nil
+}


### PR DESCRIPTION
Adds a TLS driver for clients behind a new `tls://` protocol for _EXPERIMENTAL_DAGGER_RUNNER_HOST.

Main motivation for this change was in the context of Native CI. We've been debating for more direct ways to send smart information to our scheduler that do not require going through the CLI with custom cloud-only parameters. Connecting to a cloud engine today requires a TLS certificate, and we are already doing that in the Cloud driver. So I thought: easier to just provision the engine, get the connection details on the API and then use a TLS driver to connect directly to the cloud engine.

There's other approaches we debated with @marcosnils, like re-using the existing tcp driver and adding TLS parameters to it, similar to how Docker does it. But we thought a new driver was a more consistent approach. Here is how a client would use the driver:
```sh
export _EXPERIMENTAL_DAGGER_RUNNER_HOST='tls://host:port?cert_path=cert.pem&key_path=key.pem'
```

Setting the location of the certificates in the URL does feel a bit odd but we liked the idea of not adding new parameters. Happy to look into other alternatives though!