### PR TITLE
fix invalid gorelease config

### DIFF
--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -4,6 +4,7 @@ project_name: dagger
 
 builds:
   - builder: prebuilt
+    id: dagger-linux
     binary: ./dagger
     goos:
       - linux
@@ -18,6 +19,7 @@ builds:
       path: build/dagger_{{ .Env.ENGINE_VERSION }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}_v{{ . }}{{ end }}/dagger
 
   - builder: prebuilt
+    id: dagger-desktop
     binary: ./dagger
     goos:
       - windows


### PR DESCRIPTION
Previous attempt to remove windows/armv7 builds of CLI wasn't quite right because the goreleaser config had a duplicate name in it. I ran with --dry-run at the time but apparently that skipped goreleaser. CI also only runs goreleaser on main, so missed there too.

Fixed the problem, this time I tricked goreleaser into actually running (without actually uploading anything), so more confident in the fix this time around.

Will need this before next release