### PR TITLE
fix(idtui): show subprocess output on error in dagger run

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -2168,7 +2168,13 @@ func (fe *frontendPretty) hasShownRootError() bool {
 	if fe.err == nil {
 		return false
 	}
-	for _, origin := range telemetry.ParseErrorOrigins(fe.err.Error()) {
+	origins := telemetry.ParseErrorOrigins(fe.err.Error())
+	if len(origins) == 0 {
+		// No error origins means the error didn't come from a specific span,
+		// so it can't have been shown in the progress output.
+		return false
+	}
+	for _, origin := range origins {
 		if !origin.IsValid() {
 			return false
 		}


### PR DESCRIPTION
fixes #11907

Signed-off-by: Alex Suraci <alex@dagger.io>
