### PR TITLE
fix: generate sdk typescript if node_modules

### DIFF
--- a/toolchains/typescript-sdk-dev/ts-sdk.dang
+++ b/toolchains/typescript-sdk-dev/ts-sdk.dang
@@ -10,6 +10,7 @@ type TypescriptSdkDev {
     @ignorePatterns(patterns: [
       "*",
       "!sdk/typescript",
+      "sdk/typescript/node_modules",
     ])
 
   pub sourcePath: String! = "sdk/typescript"


### PR DESCRIPTION
In case node_modules directory is present, the generate function might fail with an error like:

    get patch: file size 134250496 exceeds limit 134217728

Ignoring the directory is enough to fix the issue.