### PR TITLE
feat: make dagger develop applying a changeset 

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -743,11 +743,14 @@ This command is idempotent: you can run it at any time, any number of times. It 
 					if err != nil {
 						return localModuleErrorf("failed to get local context directory path: %w", err)
 					}
-					_, err = modSrc.
-						GeneratedContextDirectory().
-						Export(ctx, contextDirPath)
+
+					cs, err := modSrc.GeneratedContextChangeset().Sync(ctx)
 					if err != nil {
 						return fmt.Errorf("failed to generate code: %w", err)
+					}
+
+					if _, err := cs.Export(ctx, contextDirPath); err != nil {
+						return fmt.Errorf("failed to apply generated code: %w", err)
 					}
 
 					// If no license has been created yet, and SDK is set, we should create one.

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -212,6 +212,9 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 		dagql.NodeFunc("generatedContextDirectory", s.moduleSourceGeneratedContextDirectory).
 			Doc(`The generated files and directories made on top of the module source's context directory.`),
 
+		dagql.NodeFunc("generatedContextChangeset", s.moduleSourceGeneratedContextChangeset).
+			Doc(`The generated files and directories made on top of the module source's context directory, returned as a Changeset.`),
+
 		dagql.Func("asString", s.moduleSourceAsString).
 			Doc(`A human readable ref string representation of this module source.`),
 
@@ -2765,28 +2768,32 @@ func (s *moduleSourceSchema) runClientGenerator(
 	return genDirInst, nil
 }
 
-func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
+// runGeneratedContext runs codegen, client generation, and dagger.json writing for the given
+// module source, returning the original context directory and the fully-generated context
+// directory. Callers can use these two directories to produce either a diff or a Changeset.
+func (s *moduleSourceSchema) runGeneratedContext(
 	ctx context.Context,
 	srcInst dagql.ObjectResult[*core.ModuleSource],
-	args struct{},
-) (res dagql.ObjectResult[*core.Directory], _ error) {
+) (originalCtxDir dagql.ObjectResult[*core.Directory], genDirInst dagql.ObjectResult[*core.Directory], _ error) {
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return res, fmt.Errorf("failed to get dag server: %w", err)
+		return originalCtxDir, genDirInst, fmt.Errorf("failed to get dag server: %w", err)
 	}
 
 	modCfg, err := s.loadModuleSourceConfig(srcInst.Self())
 	if err != nil {
-		return res, fmt.Errorf("failed to load module source config: %w", err)
+		return originalCtxDir, genDirInst, fmt.Errorf("failed to load module source config: %w", err)
 	}
 
+	originalCtxDir = srcInst.Self().ContextDirectory
+
 	// run codegen too if we have a name and SDK
-	genDirInst := srcInst.Self().ContextDirectory
+	genDirInst = originalCtxDir
 	if modCfg.Name != "" && modCfg.SDK != nil && modCfg.SDK.Source != "" {
 		updatedGenDirInst, err := s.runCodegen(ctx, srcInst)
 		var missingImplErr ErrSDKCodegenNotImplemented
 		if err != nil && !errors.As(err, &missingImplErr) {
-			return res, fmt.Errorf("failed to run codegen: %w", err)
+			return originalCtxDir, genDirInst, fmt.Errorf("failed to run codegen: %w", err)
 		}
 		if err == nil {
 			genDirInst = updatedGenDirInst
@@ -2797,14 +2804,14 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
 	for _, client := range modCfg.Clients {
 		genDirInst, err = s.runClientGenerator(ctx, srcInst, genDirInst, client)
 		if err != nil {
-			return res, fmt.Errorf("failed to generate client %s: %w", client.Generator, err)
+			return originalCtxDir, genDirInst, fmt.Errorf("failed to generate client %s: %w", client.Generator, err)
 		}
 	}
 
 	// write dagger.json to the generated context directory
 	modCfgBytes, err := json.MarshalIndent(modCfg, "", "  ")
 	if err != nil {
-		return res, fmt.Errorf("failed to encode module config: %w", err)
+		return originalCtxDir, genDirInst, fmt.Errorf("failed to encode module config: %w", err)
 	}
 	modCfgBytes = append(modCfgBytes, '\n')
 	modCfgPath := filepath.Join(srcInst.Self().SourceRootSubpath, modules.Filename)
@@ -2819,11 +2826,29 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
 		},
 	)
 	if err != nil {
-		return res, fmt.Errorf("failed to add updated dagger.json to context dir: %w", err)
+		return originalCtxDir, genDirInst, fmt.Errorf("failed to add updated dagger.json to context dir: %w", err)
+	}
+
+	return originalCtxDir, genDirInst, nil
+}
+
+func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
+	ctx context.Context,
+	srcInst dagql.ObjectResult[*core.ModuleSource],
+	args struct{},
+) (res dagql.ObjectResult[*core.Directory], _ error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	originalCtxDir, genDirInst, err := s.runGeneratedContext(ctx, srcInst)
+	if err != nil {
+		return res, err
 	}
 
 	// return just the diff of what we generated relative to the original context directory
-	err = dag.Select(ctx, srcInst.Self().ContextDirectory, &genDirInst,
+	err = dag.Select(ctx, originalCtxDir, &res,
 		dagql.Selector{
 			Field: "diff",
 			Args: []dagql.NamedInput{
@@ -2835,7 +2860,37 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextDirectory(
 		return res, fmt.Errorf("failed to get context dir diff: %w", err)
 	}
 
-	return genDirInst, nil
+	return res, nil
+}
+
+func (s *moduleSourceSchema) moduleSourceGeneratedContextChangeset(
+	ctx context.Context,
+	srcInst dagql.ObjectResult[*core.ModuleSource],
+	args struct{},
+) (res dagql.ObjectResult[*core.Changeset], _ error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	originalCtxDir, genDirInst, err := s.runGeneratedContext(ctx, srcInst)
+	if err != nil {
+		return res, err
+	}
+
+	// Build the changeset: genDirInst.Changes(originalCtxDir).
+	if err := dag.Select(ctx, genDirInst, &res,
+		dagql.Selector{
+			Field: "changes",
+			Args: []dagql.NamedInput{
+				{Name: "from", Value: dagql.NewID[*core.Directory](originalCtxDir.ID())},
+			},
+		},
+	); err != nil {
+		return res, fmt.Errorf("failed to compute changeset: %w", err)
+	}
+
+	return res, nil
 }
 
 func (s *moduleSourceSchema) runModuleDefInSDK(ctx context.Context, src, srcInstContentHashed dagql.ObjectResult[*core.ModuleSource], mod *core.Module) (*core.Module, error) {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -4299,6 +4299,11 @@ type ModuleSource {
   engineVersion: String!
 
   """
+  The generated files and directories made on top of the module source's context directory, returned as a Changeset.
+  """
+  generatedContextChangeset: Changeset!
+
+  """
   The generated files and directories made on top of the module source's context directory.
   """
   generatedContextDirectory: Directory!

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -13404,6 +13404,10 @@
                         <td> The engine version of the module. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="ModuleSource-generatedContextChangeset" href="#ModuleSource-generatedContextChangeset"><code>generatedContextChangeset</code></a> - <span class="property-type"><a href="#definition-Changeset"><code>Changeset!</code></a></span> </td>
+                        <td> The generated files and directories made on top of the module source's context directory, returned as a Changeset. </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="ModuleSource-generatedContextDirectory" href="#ModuleSource-generatedContextDirectory"><code>generatedContextDirectory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td> The generated files and directories made on top of the module source's context directory. </td>
                       </tr>

--- a/docs/static/reference/php/Dagger/ModuleSource.html
+++ b/docs/static/reference/php/Dagger/ModuleSource.html
@@ -263,6 +263,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_generatedContextChangeset">generatedContextChangeset</a>()
+        
+                                            <p><p>The generated files and directories made on top of the module source's context directory, returned as a Changeset.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -1131,8 +1141,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_generatedContextDirectory">
+                    <h3 id="method_generatedContextChangeset">
         <div class="location">at line 128</div>
+        <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
+    <strong>generatedContextChangeset</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The generated files and directories made on top of the module source's context directory, returned as a Changeset.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_generatedContextDirectory">
+        <div class="location">at line 137</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>generatedContextDirectory</strong>()
         </code>
@@ -1164,7 +1206,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_htmlRepoURL">
-        <div class="location">at line 137</div>
+        <div class="location">at line 146</div>
         <code>                    string
     <strong>htmlRepoURL</strong>()
         </code>
@@ -1196,7 +1238,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_htmlURL">
-        <div class="location">at line 146</div>
+        <div class="location">at line 155</div>
         <code>                    string
     <strong>htmlURL</strong>()
         </code>
@@ -1228,7 +1270,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 155</div>
+        <div class="location">at line 164</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1260,7 +1302,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_introspectionSchemaJSON">
-        <div class="location">at line 168</div>
+        <div class="location">at line 177</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>introspectionSchemaJSON</strong>()
         </code>
@@ -1293,7 +1335,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_kind">
-        <div class="location">at line 177</div>
+        <div class="location">at line 186</div>
         <code>                    <abbr title="Dagger\ModuleSourceKind">ModuleSourceKind</abbr>
     <strong>kind</strong>()
         </code>
@@ -1325,7 +1367,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_localContextDirectoryPath">
-        <div class="location">at line 186</div>
+        <div class="location">at line 195</div>
         <code>                    string
     <strong>localContextDirectoryPath</strong>()
         </code>
@@ -1357,7 +1399,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleName">
-        <div class="location">at line 195</div>
+        <div class="location">at line 204</div>
         <code>                    string
     <strong>moduleName</strong>()
         </code>
@@ -1389,7 +1431,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleOriginalName">
-        <div class="location">at line 204</div>
+        <div class="location">at line 213</div>
         <code>                    string
     <strong>moduleOriginalName</strong>()
         </code>
@@ -1421,7 +1463,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_originalSubpath">
-        <div class="location">at line 213</div>
+        <div class="location">at line 222</div>
         <code>                    string
     <strong>originalSubpath</strong>()
         </code>
@@ -1453,7 +1495,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_pin">
-        <div class="location">at line 222</div>
+        <div class="location">at line 231</div>
         <code>                    string
     <strong>pin</strong>()
         </code>
@@ -1485,7 +1527,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_repoRootPath">
-        <div class="location">at line 231</div>
+        <div class="location">at line 240</div>
         <code>                    string
     <strong>repoRootPath</strong>()
         </code>
@@ -1517,7 +1559,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 240</div>
+        <div class="location">at line 249</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>sdk</strong>()
         </code>
@@ -1549,7 +1591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceRootSubpath">
-        <div class="location">at line 249</div>
+        <div class="location">at line 258</div>
         <code>                    string
     <strong>sourceRootSubpath</strong>()
         </code>
@@ -1581,7 +1623,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceSubpath">
-        <div class="location">at line 258</div>
+        <div class="location">at line 267</div>
         <code>                    string
     <strong>sourceSubpath</strong>()
         </code>
@@ -1613,7 +1655,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 267</div>
+        <div class="location">at line 276</div>
         <code>                    <a href="../Dagger/ModuleSourceId.html"><abbr title="Dagger\ModuleSourceId">ModuleSourceId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1645,7 +1687,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_toolchains">
-        <div class="location">at line 276</div>
+        <div class="location">at line 285</div>
         <code>                    array
     <strong>toolchains</strong>()
         </code>
@@ -1677,7 +1719,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 285</div>
+        <div class="location">at line 294</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -1709,7 +1751,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 294</div>
+        <div class="location">at line 303</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -1741,7 +1783,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withBlueprint">
-        <div class="location">at line 303</div>
+        <div class="location">at line 312</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withBlueprint</strong>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $blueprint)
         </code>
@@ -1783,7 +1825,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withClient">
-        <div class="location">at line 313</div>
+        <div class="location">at line 322</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withClient</strong>(string $generator, string $outputDir)
         </code>
@@ -1830,7 +1872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDependencies">
-        <div class="location">at line 324</div>
+        <div class="location">at line 333</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withDependencies</strong>(array $dependencies)
         </code>
@@ -1872,7 +1914,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEngineVersion">
-        <div class="location">at line 334</div>
+        <div class="location">at line 343</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withEngineVersion</strong>(string $version)
         </code>
@@ -1914,7 +1956,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExperimentalFeatures">
-        <div class="location">at line 344</div>
+        <div class="location">at line 353</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withExperimentalFeatures</strong>(array $features)
         </code>
@@ -1956,7 +1998,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withIncludes">
-        <div class="location">at line 354</div>
+        <div class="location">at line 363</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withIncludes</strong>(array $patterns)
         </code>
@@ -1998,7 +2040,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withName">
-        <div class="location">at line 364</div>
+        <div class="location">at line 373</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withName</strong>(string $name)
         </code>
@@ -2040,7 +2082,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 374</div>
+        <div class="location">at line 383</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSDK</strong>(string $source)
         </code>
@@ -2082,7 +2124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSourceSubpath">
-        <div class="location">at line 384</div>
+        <div class="location">at line 393</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSourceSubpath</strong>(string $path)
         </code>
@@ -2124,7 +2166,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withToolchains">
-        <div class="location">at line 394</div>
+        <div class="location">at line 403</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withToolchains</strong>(array $toolchains)
         </code>
@@ -2166,7 +2208,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateBlueprint">
-        <div class="location">at line 404</div>
+        <div class="location">at line 413</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateBlueprint</strong>()
         </code>
@@ -2198,7 +2240,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateDependencies">
-        <div class="location">at line 413</div>
+        <div class="location">at line 422</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateDependencies</strong>(array $dependencies)
         </code>
@@ -2240,7 +2282,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateToolchains">
-        <div class="location">at line 423</div>
+        <div class="location">at line 432</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateToolchains</strong>(array $toolchains)
         </code>
@@ -2282,7 +2324,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedClients">
-        <div class="location">at line 433</div>
+        <div class="location">at line 442</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdatedClients</strong>(array $clients)
         </code>
@@ -2324,7 +2366,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutBlueprint">
-        <div class="location">at line 443</div>
+        <div class="location">at line 452</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutBlueprint</strong>()
         </code>
@@ -2356,7 +2398,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutClient">
-        <div class="location">at line 452</div>
+        <div class="location">at line 461</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutClient</strong>(string $path)
         </code>
@@ -2398,7 +2440,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDependencies">
-        <div class="location">at line 462</div>
+        <div class="location">at line 471</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutDependencies</strong>(array $dependencies)
         </code>
@@ -2440,7 +2482,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExperimentalFeatures">
-        <div class="location">at line 472</div>
+        <div class="location">at line 481</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutExperimentalFeatures</strong>(array $features)
         </code>
@@ -2482,7 +2524,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutToolchains">
-        <div class="location">at line 482</div>
+        <div class="location">at line 491</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutToolchains</strong>(array $toolchains)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -628,7 +628,9 @@
 <abbr title="Dagger\Module">Module</abbr>::generators</a>() &mdash; <em>Method in class <a href="Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a></em></dt>
                     <dd><p>Return all generators defined by the module</p></dd><dt><a href="Dagger/ModuleConfigClient.html#method_generator">
 <abbr title="Dagger\ModuleConfigClient">ModuleConfigClient</abbr>::generator</a>() &mdash; <em>Method in class <a href="Dagger/ModuleConfigClient.html"><abbr title="Dagger\ModuleConfigClient">ModuleConfigClient</abbr></a></em></dt>
-                    <dd><p>The generator to use</p></dd><dt><a href="Dagger/ModuleSource.html#method_generatedContextDirectory">
+                    <dd><p>The generator to use</p></dd><dt><a href="Dagger/ModuleSource.html#method_generatedContextChangeset">
+<abbr title="Dagger\ModuleSource">ModuleSource</abbr>::generatedContextChangeset</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
+                    <dd><p>The generated files and directories made on top of the module source's context directory, returned as a Changeset.</p></dd><dt><a href="Dagger/ModuleSource.html#method_generatedContextDirectory">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::generatedContextDirectory</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
                     <dd><p>The generated files and directories made on top of the module source's context directory.</p></dd>        </dl><h2 id="letterH">H</h2>
         <dl id="indexH"><dt><a href="Dagger/Client.html#method_host">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -5109,6 +5109,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\ModuleSource::generatedContextChangeset",
+			"p": "Dagger/ModuleSource.html#method_generatedContextChangeset",
+			"d": "<p>The generated files and directories made on top of the module source's context directory, returned as a Changeset.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\ModuleSource::generatedContextDirectory",
 			"p": "Dagger/ModuleSource.html#method_generatedContextDirectory",
 			"d": "<p>The generated files and directories made on top of the module source's context directory.</p>"

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -10539,6 +10539,15 @@ func (r *ModuleSource) EngineVersion(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// The generated files and directories made on top of the module source's context directory, returned as a Changeset.
+func (r *ModuleSource) GeneratedContextChangeset() *Changeset {
+	q := r.query.Select("generatedContextChangeset")
+
+	return &Changeset{
+		query: q,
+	}
+}
+
 // The generated files and directories made on top of the module source's context directory.
 func (r *ModuleSource) GeneratedContextDirectory() *Directory {
 	q := r.query.Select("generatedContextDirectory")

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -123,6 +123,15 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The generated files and directories made on top of the module source's context directory, returned as a Changeset.
+     */
+    public function generatedContextChangeset(): Changeset
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedContextChangeset');
+        return new \Dagger\Changeset($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * The generated files and directories made on top of the module source's context directory.
      */
     public function generatedContextDirectory(): Directory

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -10657,6 +10657,14 @@ class ModuleSource(Type):
         _ctx = self._select("engineVersion", _args)
         return await _ctx.execute(str)
 
+    def generated_context_changeset(self) -> Changeset:
+        """The generated files and directories made on top of the module source's
+        context directory, returned as a Changeset.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("generatedContextChangeset", _args)
+        return Changeset(_ctx)
+
     def generated_context_directory(self) -> Directory:
         """The generated files and directories made on top of the module source's
         context directory.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -11256,6 +11256,15 @@ impl ModuleSource {
         let query = self.selection.select("engineVersion");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The generated files and directories made on top of the module source's context directory, returned as a Changeset.
+    pub fn generated_context_changeset(&self) -> Changeset {
+        let query = self.selection.select("generatedContextChangeset");
+        Changeset {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// The generated files and directories made on top of the module source's context directory.
     pub fn generated_context_directory(&self) -> Directory {
         let query = self.selection.select("generatedContextDirectory");

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -10731,6 +10731,14 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
+   * The generated files and directories made on top of the module source's context directory, returned as a Changeset.
+   */
+  generatedContextChangeset = (): Changeset => {
+    const ctx = this._ctx.select("generatedContextChangeset")
+    return new Changeset(ctx)
+  }
+
+  /**
    * The generated files and directories made on top of the module source's context directory.
    */
   generatedContextDirectory = (): Directory => {


### PR DESCRIPTION
Add `moduleSource.GeneratedContextChangeset` so it acts exactly as `generatedContextDirectory` 
but it returns a changeset.
Use that new endpoint when running dagger develop.

The goal is that once we generated one file for each dependency, we will be able to remove 
the dependency file if that dependency is uninstalled.