### PR TITLE
codegen: include internal/telemetry/

### DIFF
--- a/cmd/codegen/generator/go/generate_typedefs.go
+++ b/cmd/codegen/generator/go/generate_typedefs.go
@@ -35,6 +35,7 @@ func (g *GoGenerator) GenerateTypeDefs(ctx context.Context, schema *introspectio
 	var overlay fs.FS = layerfs.New(
 		mfs,
 		&MountedFS{FS: dagger.QueryBuilder, Name: filepath.Join(outDir, "internal")},
+		&MountedFS{FS: dagger.Telemetry, Name: filepath.Join(outDir, "internal")},
 	)
 
 	res := &generator.GeneratedState{


### PR DESCRIPTION
Currently `loadPackage` fails with `no packages found in .` when we make changes to `go.mod` in the root of the repo. To debug, I added a `go mod tidy` immediately before the `packages.Load`, suspecting that it's silently failing. `go mod tidy` revealed that the module's generated code was referring to
`github.com/dagger/dagger/modules/go/internal/telemetry` which indeed did not exist. Including it in this spot fixes the issue, but it's still a bit mysterious as to how it's been working up until this point.