### PR TITLE
cmd/dagger: batch `generate -l` fetch and drop noisy query subtree tracing

### DIFF
--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -82,34 +82,39 @@ func loadModule(ctx context.Context, dag *dagger.Client) (*dagger.Module, error)
 	return dag.ModuleSource(modRef).AsModule().Sync(ctx)
 }
 
-func loadCheckGroupInfo(ctx context.Context, dag *dagger.Client, checkgroup *dagger.CheckGroup) (*CheckGroupInfo, error) {
-	ctx, span := Tracer().Start(ctx, "fetch check information")
+// loadGroupListDetails fetches name+description for every item in a group
+// using a single batch GraphQL query, with tracing suppressed to avoid
+// per-item span noise in list mode.
+func loadGroupListDetails(
+	ctx context.Context,
+	dag *dagger.Client,
+	spanName string,
+	getID func(context.Context) (any, error),
+	query string,
+	opName string,
+) ([]groupListItem, error) {
+	ctx, span := Tracer().Start(ctx, spanName)
 	defer span.End()
 
-	// Intentionally execute the list query subtree without tracing to avoid
-	// per-check name/description span noise in "dagger check -l".
 	noTraceCtx := trace.ContextWithSpan(ctx, trace.SpanFromContext(context.Background()))
 
-	id, err := checkgroup.ID(noTraceCtx)
+	id, err := getID(noTraceCtx)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	var res struct {
-		CheckGroup struct {
-			List []struct {
-				Name        string
-				Description string
-			}
+		Group struct {
+			List []groupListItem
 		}
 	}
 
 	err = dag.Do(noTraceCtx, &dagger.Request{
-		Query:  loadChecksQuery,
-		OpName: "CheckGroupListDetails",
+		Query:  query,
+		OpName: opName,
 		Variables: map[string]any{
-			"checkGroup": id,
+			"id": id,
 		},
 	}, &dagger.Response{
 		Data: &res,
@@ -119,13 +124,28 @@ func loadCheckGroupInfo(ctx context.Context, dag *dagger.Client, checkgroup *dag
 		return nil, err
 	}
 
-	info := &CheckGroupInfo{Checks: make([]*CheckInfo, 0, len(res.CheckGroup.List))}
-	for _, check := range res.CheckGroup.List {
-		checkInfo := &CheckInfo{
-			Name:        cliName(check.Name),
-			Description: check.Description,
-		}
-		info.Checks = append(info.Checks, checkInfo)
+	return res.Group.List, nil
+}
+
+type groupListItem struct {
+	Name        string
+	Description string
+}
+
+func loadCheckGroupInfo(ctx context.Context, dag *dagger.Client, checkgroup *dagger.CheckGroup) (*CheckGroupInfo, error) {
+	items, err := loadGroupListDetails(ctx, dag, "fetch check information",
+		func(ctx context.Context) (any, error) { return checkgroup.ID(ctx) },
+		loadChecksQuery, "CheckGroupListDetails",
+	)
+	if err != nil {
+		return nil, err
+	}
+	info := &CheckGroupInfo{Checks: make([]*CheckInfo, 0, len(items))}
+	for _, item := range items {
+		info.Checks = append(info.Checks, &CheckInfo{
+			Name:        cliName(item.Name),
+			Description: item.Description,
+		})
 	}
 	return info, nil
 }

--- a/cmd/dagger/checks.graphql
+++ b/cmd/dagger/checks.graphql
@@ -1,5 +1,5 @@
-query CheckGroupListDetails($checkGroup: CheckGroupID!) {
-  checkGroup: loadCheckGroupFromID(id: $checkGroup) {
+query CheckGroupListDetails($id: CheckGroupID!) {
+  group: loadCheckGroupFromID(id: $id) {
     list {
       name
       description

--- a/cmd/dagger/generators.go
+++ b/cmd/dagger/generators.go
@@ -2,23 +2,27 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strings"
+
+	"github.com/juju/ansiterm/tabwriter"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
 
 	"dagger.io/dagger"
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/slog"
-	"github.com/juju/ansiterm/tabwriter"
-	"github.com/muesli/termenv"
-	"github.com/spf13/cobra"
-	"go.opentelemetry.io/otel/codes"
 )
 
 var (
 	generateListMode bool
 )
+
+//go:embed generators.graphql
+var loadGeneratorsQuery string
 
 func init() {
 	generateCmd.Flags().BoolVarP(&generateListMode, "list", "l", false, "List available generators")
@@ -55,7 +59,7 @@ Examples:
 					generators = mod.Generators()
 				}
 				if generateListMode {
-					return listGenerators(ctx, generators, cmd)
+					return listGenerators(ctx, dag, generators, cmd)
 				} else {
 					return runGenerators(ctx, dag, generators, cmd)
 				}
@@ -64,33 +68,20 @@ Examples:
 	},
 }
 
-func loadGeneratorGroupInfo(ctx context.Context, generatorGroup *dagger.GeneratorGroup) (*GeneratorGroupInfo, error) {
-	ctx, span := Tracer().Start(ctx, "fetch generator information")
-	defer span.End()
-
-	generators, err := generatorGroup.List(ctx)
+func loadGeneratorGroupInfo(ctx context.Context, dag *dagger.Client, generatorGroup *dagger.GeneratorGroup) (*GeneratorGroupInfo, error) {
+	items, err := loadGroupListDetails(ctx, dag, "fetch generator information",
+		func(ctx context.Context) (any, error) { return generatorGroup.ID(ctx) },
+		loadGeneratorsQuery, "GeneratorGroupListDetails",
+	)
 	if err != nil {
 		return nil, err
 	}
-	info := &GeneratorGroupInfo{}
-	for _, generator := range generators {
-		generatorInfo := &GeneratorInfo{}
-
-		name, err := generator.Name(ctx)
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-			return nil, err
-		}
-		generatorInfo.Name = cliName(name)
-
-		description, err := generator.Description(ctx)
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-			return nil, err
-		}
-		generatorInfo.Description = description
-
-		info.Generators = append(info.Generators, generatorInfo)
+	info := &GeneratorGroupInfo{Generators: make([]*GeneratorInfo, 0, len(items))}
+	for _, item := range items {
+		info.Generators = append(info.Generators, &GeneratorInfo{
+			Name:        cliName(item.Name),
+			Description: item.Description,
+		})
 	}
 	return info, nil
 }
@@ -105,8 +96,8 @@ type GeneratorInfo struct {
 }
 
 // 'dagger generators -l'
-func listGenerators(ctx context.Context, generatorGroup *dagger.GeneratorGroup, cmd *cobra.Command) error {
-	info, err := loadGeneratorGroupInfo(ctx, generatorGroup)
+func listGenerators(ctx context.Context, dag *dagger.Client, generatorGroup *dagger.GeneratorGroup, cmd *cobra.Command) error {
+	info, err := loadGeneratorGroupInfo(ctx, dag, generatorGroup)
 	if err != nil {
 		return err
 	}

--- a/cmd/dagger/generators.graphql
+++ b/cmd/dagger/generators.graphql
@@ -1,0 +1,8 @@
+query GeneratorGroupListDetails($id: GeneratorGroupID!) {
+  group: loadGeneratorGroupFromID(id: $id) {
+    list {
+      name
+      description
+    }
+  }
+}


### PR DESCRIPTION
Switch `dagger generate -l` to a single bulk GraphQL request (`dag.Do` with `GeneratorGroupListDetails`) instead of per-generator field fetches.

Run that list-query subtree with a discarded tracing context so per-generator `name`/`description` spans are not emitted, while keeping CLI behavior/output unchanged.

This is a follow up to https://github.com/dagger/dagger/pull/11946 that did it for `dagger check -l`