### PR TITLE
feat: use HEALTHCHECK commands with services

### DIFF
--- a/.changes/unreleased/Changed-20260304-092004.yaml
+++ b/.changes/unreleased/Changed-20260304-092004.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Service containers will now use docker HEALTHCHECK commands to determine when a service is ready. If no DockerHealthcheck is defined, then it will fallback to checking the ports defined with WithExposedPort()
+time: 2026-03-04T09:20:04.254894404-08:00
+custom:
+    Author: alexcb
+    PR: "11951"

--- a/core/healthcheck.go
+++ b/core/healthcheck.go
@@ -2,16 +2,20 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/otel/trace"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/internal/buildkit/executor"
+	gwpb "github.com/dagger/dagger/internal/buildkit/frontend/gateway/pb"
 )
 
 type portHealthChecker struct {
@@ -21,7 +25,7 @@ type portHealthChecker struct {
 	ports []Port
 }
 
-func newHealth(bk *buildkit.Client, ns buildkit.Namespaced, host string, ports []Port) *portHealthChecker {
+func newPortHealth(bk *buildkit.Client, ns buildkit.Namespaced, host string, ports []Port) *portHealthChecker {
 	return &portHealthChecker{
 		bk:    bk,
 		ns:    ns,
@@ -84,5 +88,130 @@ func (d *portHealthChecker) Check(ctx context.Context) (rerr error) {
 		slog.Info("port is healthy", "endpoint", endpoint)
 	}
 
+	return nil
+}
+
+type dockerHealthcheck struct {
+	args    []string
+	creator trace.SpanContext
+	ctr     *Container
+	exec    executor.Executor
+	svcID   string
+}
+
+func newDockerHealthcheck(exec executor.Executor, svcID string, ctr *Container, creator trace.SpanContext) (*dockerHealthcheck, error) {
+	if ctr == nil || ctr.Config.Healthcheck == nil || len(ctr.Config.Healthcheck.Test) == 0 || ctr.Config.Healthcheck.Test[0] == "NONE" {
+		return nil, fmt.Errorf("container does not have a healthcheck command")
+	}
+
+	var args []string
+	switch ctr.Config.Healthcheck.Test[0] {
+	case "CMD":
+		if len(ctr.Config.Healthcheck.Test) < 2 {
+			return nil, fmt.Errorf("healthcheck command should have at least 2 elements: %v", ctr.Config.Healthcheck.Test)
+		}
+		args = ctr.Config.Healthcheck.Test[1:]
+	case "CMD-SHELL":
+		if len(ctr.Config.Healthcheck.Test) != 2 {
+			return nil, fmt.Errorf("healthcheck shell command should have exactly 2 elements: %v", ctr.Config.Healthcheck.Test)
+		}
+		if len(ctr.Config.Shell) > 0 {
+			args = append([]string{}, ctr.Config.Shell...)
+		} else {
+			args = []string{"/bin/sh", "-c"}
+		}
+		args = append(args, ctr.Config.Healthcheck.Test[1:]...)
+	default:
+		return nil, fmt.Errorf("malformed healthcheck command: %v", ctr.Config.Healthcheck.Test)
+	}
+
+	return &dockerHealthcheck{
+		args:    args,
+		creator: creator,
+		ctr:     ctr,
+		exec:    exec,
+		svcID:   svcID,
+	}, nil
+}
+
+func (chk *dockerHealthcheck) durationBetweenRetries() time.Duration {
+	if chk.ctr.Config.Healthcheck.StartInterval > 0 {
+		return chk.ctr.Config.Healthcheck.StartInterval
+	}
+	if chk.ctr.Config.Healthcheck.Interval > 0 {
+		return chk.ctr.Config.Healthcheck.Interval
+	}
+	return time.Second * 5
+}
+
+func (chk *dockerHealthcheck) Check(ctx context.Context) error {
+	sleepDuration := chk.durationBetweenRetries()
+
+	allowFailuresUntil := time.Now()
+	if chk.ctr.Config.Healthcheck.StartPeriod > 0 {
+		allowFailuresUntil = allowFailuresUntil.Add(chk.ctr.Config.Healthcheck.StartPeriod)
+	}
+
+	numRetries := 3
+	if chk.ctr.Config.Healthcheck.Retries > 0 {
+		numRetries = chk.ctr.Config.Healthcheck.Retries
+	}
+	var numFailures int
+	for {
+		err := chk.check(ctx)
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(allowFailuresUntil) {
+			numFailures++
+		}
+		if numFailures == numRetries {
+			return err
+		}
+		// sleep before retrying
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleepDuration):
+			break
+		}
+	}
+}
+
+func (chk *dockerHealthcheck) check(ctx context.Context) error {
+	healthcheckMeta, err := chk.ctr.metaSpec(ctx, ContainerExecOpts{
+		Args: chk.args,
+	})
+	if err != nil {
+		return err
+	}
+
+	stdoutBuf := new(strings.Builder)
+	stderrBuf := new(strings.Builder)
+	// buffer stdout/stderr so we can return a nice error
+	outBufWC := discardOnClose(stdoutBuf)
+	errBufWC := discardOnClose(stderrBuf)
+	// stop buffering service logs once it's started
+	defer outBufWC.Close()
+	defer errBufWC.Close()
+
+	err = chk.exec.Exec(ctx, chk.svcID, executor.ProcessInfo{
+		Meta:   *healthcheckMeta,
+		Stdout: outBufWC,
+		Stderr: errBufWC,
+	})
+	if err != nil {
+		var gwErr *gwpb.ExitError
+		if errors.As(err, &gwErr) {
+			return &buildkit.ExecError{
+				Err:      telemetry.TrackOrigin(gwErr, chk.creator),
+				Cmd:      healthcheckMeta.Args,
+				ExitCode: int(gwErr.ExitCode),
+				Stdout:   stdoutBuf.String(),
+				Stderr:   stderrBuf.String(),
+			}
+		}
+		return err
+	}
 	return nil
 }

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -2591,3 +2591,115 @@ func calculateNestingLimit(ctx context.Context, c *dagger.Client, t *testctx.T) 
 
 	return calculatedNestingLimit
 }
+
+func (ServiceSuite) TestHealthcheckCommand(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	maingo := `package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	http.HandleFunc("/test-file-was-created", func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 10; i++ {
+			f, err := os.Open("/the-check-was-run")
+			if err != nil {
+				time.Sleep(time.Second)
+				continue
+			}
+			_ = f.Close()
+			fmt.Fprintf(w, "OK")
+			return
+		}
+		fmt.Fprintf(w, "FAIL")
+	})
+
+	fmt.Println(http.ListenAndServe(":8080", nil))
+}`
+	buildctr := c.Container().
+		From(golangImage).
+		WithWorkdir("/work").
+		WithNewFile("/work/main.go", maingo).
+		WithExec([]string{"go", "build", "-o=app", "main.go"})
+
+	for _, tt := range []struct {
+		name    string
+		shell   bool
+		command []string
+	}{
+		{
+			name:    "shell",
+			shell:   true,
+			command: []string{"touch /the-check-was-run"},
+		},
+		{
+			name:    "cmd",
+			shell:   false,
+			command: []string{"/bin/touch", "/the-check-was-run"},
+		},
+	} {
+		t.Run(tt.name, func(ctx context.Context, t *testctx.T) {
+			binctr := c.Container().
+				From(alpineImage).
+				WithFile("/bin/app", buildctr.File("/work/app")).
+				WithEntrypoint([]string{"/bin/app", "via-entrypoint"}).
+				WithDefaultArgs([]string{"/bin/app", "via-default-args"}).
+				WithDockerHealthcheck(tt.command, dagger.ContainerWithDockerHealthcheckOpts{
+					Shell:         tt.shell,
+					Interval:      "1s",
+					Timeout:       "3s",
+					StartPeriod:   "10s",
+					StartInterval: "1s",
+					Retries:       1,
+				}).
+				WithExposedPort(8080)
+
+			curlctr := c.Container().
+				From(alpineImage).
+				WithExec([]string{"sh", "-c", "apk add curl"})
+
+			output, err := curlctr.
+				WithServiceBinding("myapp", binctr.AsService()).
+				WithExec([]string{"sh", "-c", "curl -vXGET 'http://myapp:8080/test-file-was-created'"}).
+				Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "OK", output)
+		})
+	}
+}
+
+func (ServiceSuite) TestServiceHealthcheckFailure(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	srv := c.Container().
+		From("python").
+		WithDefaultArgs([]string{"python", "-m", "http.server", "8080"}).
+		WithExposedPort(8080).
+		WithDockerHealthcheck([]string{"sh", "-c", "echo 'check said no' && echo 'eek an error' >&2 && exit 42"}).
+		AsService()
+
+	host, err := srv.Hostname(ctx)
+	require.NoError(t, err)
+
+	client := c.Container().
+		From(alpineImage).
+		WithServiceBinding("www", srv).
+		WithExec([]string{"wget", "http://www:8080"})
+
+	_, err = client.Sync(ctx)
+	require.Error(t, err)
+	requireErrOut(t, err, "start "+host+" (aliased as www): health check errored: exit code:")
+
+	var execErr *dagger.ExecError
+	require.True(t, errors.As(err, &execErr), "expected error to be an ExecError, got %T", err)
+
+	// Verify the ExecError contains expected information
+	require.Equal(t, "check said no\n", execErr.Stdout)
+	require.Equal(t, "eek an error\n", execErr.Stderr)
+	require.Equal(t, []string{"sh", "-c", "echo 'check said no' && echo 'eek an error' >&2 && exit 42"}, execErr.Cmd)
+}

--- a/core/service.go
+++ b/core/service.go
@@ -568,9 +568,20 @@ func (svc *Service) startContainer(
 	}
 
 	checked := make(chan error, 1)
-	go func() {
-		checked <- newHealth(bk, buildkit.NewDirectNS(svcID), fullHost, ctr.Ports).Check(ctx)
-	}()
+
+	if ctr.Config.Healthcheck != nil {
+		dockerHealthcheck, err := newDockerHealthcheck(exec, svcID, ctr, svc.Creator)
+		if err != nil {
+			return nil, fmt.Errorf("failed to setup docker healthcheck: %w", err)
+		}
+		go func() {
+			checked <- dockerHealthcheck.Check(ctx)
+		}()
+	} else {
+		go func() {
+			checked <- newPortHealth(bk, buildkit.NewDirectNS(svcID), fullHost, ctr.Ports).Check(ctx)
+		}()
+	}
 
 	var stopped atomic.Bool
 
@@ -945,7 +956,7 @@ func (svc *Service) startReverseTunnel(ctx context.Context, id *call.ID) (runnin
 
 	checked := make(chan error, 1)
 	go func() {
-		checked <- newHealth(bk, netNS, fullHost, checkPorts).Check(svcCtx)
+		checked <- newPortHealth(bk, netNS, fullHost, checkPorts).Check(svcCtx)
 	}()
 
 	select {


### PR DESCRIPTION
If a docker healthcheck command is defined (either from a Dockerfile `HEALTHCHECK` command, or by using the `WithDockerHealthcheck()` api), it will be used instead of the exposed ports to determine when a service is ready.

e.g.

```
	srv := c.Container().
		From("python").
		WithDefaultArgs([]string{"python", "-m", "http.server", "8080"}).
		WithHealthcheck([]string{"sh", "-c", "curl -s localhost:8080 >/dev/null",
			dagger.ContainerWithDockerHealthcheckOpts{
				Timeout:       "3s",
				StartPeriod:   "10s",
				StartInterval: "1s",
				Retries:       5,
			}).
		AsService()
```

To revert to the old behavior of using the exposed ports, one can use the `WithoutDockerHealthcheck()` call before defining a service.

e.g.

```
srv := c.Container().
    From("some-image-with-a-healthcheck").
    WithExposedPort(8080).
    WithoutDockerHealthcheck().
    AsService()
```

This fixes #5472, #6238 and #8037