### PR TITLE
feat: add -m flag to dagger generate command

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -139,6 +139,7 @@ func init() {
 	moduleAddFlags(shellCmd, shellCmd.PersistentFlags(), true)
 	shellAddFlags(shellCmd)
 	moduleAddFlags(checksCmd, checksCmd.PersistentFlags(), false)
+	moduleAddFlags(generateCmd, generateCmd.PersistentFlags(), false)
 	moduleAddFlags(rootCmd, rootCmd.Flags(), true)
 	shellAddFlags(rootCmd)
 


### PR DESCRIPTION
Add the --mod/-m flag to the dagger generate command, allowing users to specify which module to generate code for. This brings generate in line with dagger call and dagger check which already support this flag.

The fix is a one-line addition to register moduleAddFlags on generateCmd, since loadModule() already reads the module reference via getExplicitModuleSourceRef().