### PR TITLE
workspace: switch to absolute paths

### DIFF
--- a/core/integration/workspace_test.go
+++ b/core/integration/workspace_test.go
@@ -92,7 +92,7 @@ type Greeter {
 }
 
 // TestWorkspaceFindUp verifies that Workspace.findUp searches up from the
-// start path and stops at the repository root.
+// start path and stops at the workspace access boundary.
 func (WorkspaceSuite) TestFindUp(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -153,7 +153,7 @@ type Finder {
 }
 
 // TestWorkspaceRootIsRepoRoot verifies that Workspace.root resolves to the
-// repository root, not the caller's nested working directory.
+// workspace access boundary, not the caller's nested working directory.
 func (WorkspaceSuite) TestRootIsRepoRoot(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -402,7 +402,7 @@ type Subdir {
 }
 
 // TestWorkspacePathTraversal verifies that, by default, a module cannot use
-// Workspace to access arbitrary host paths outside the workspace repository.
+// Workspace to access arbitrary host paths outside the workspace access boundary.
 func (WorkspaceSuite) TestWorkspacePathTraversal(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -469,7 +469,7 @@ type EscapeFindup {
 		requireErrOut(t, err, "must be absolute")
 	})
 
-	t.Run("absolute path outside repo is rejected", func(ctx context.Context, t *testctx.T) {
+	t.Run("absolute path outside access boundary is rejected", func(ctx context.Context, t *testctx.T) {
 		ctr := base.
 			WithNewFile("sub/inner.txt", "inner").
 			With(initDangModule("abs-rel", `
@@ -488,7 +488,7 @@ type AbsRel {
 `))
 		_, err := ctr.With(daggerCall("abs-rel", "ls")).Stdout(ctx)
 		require.Error(t, err)
-		requireErrOut(t, err, "outside workspace repository root")
+		requireErrOut(t, err, "outside workspace access boundary")
 	})
 
 	t.Run("absolute path inside repo is allowed", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -34,9 +34,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			), dagql.CachePerClient).
 			Doc(`Returns a Directory from the workspace.`,
 				`Path must be absolute in host/repo context.`,
-				`By default, paths outside the workspace repository root are rejected.`).
+				`By default, paths outside the workspace access boundary are rejected.`).
 			Args(
-				dagql.Arg("path").Doc(`Absolute location of the directory to retrieve in host/repo context.`),
+				dagql.Arg("path").Doc(`Location of the directory to retrieve. Must be an absolute path.`),
 				dagql.Arg("exclude").Doc(`Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`),
 				dagql.Arg("include").Doc(`Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
 				dagql.Arg("gitignore").Doc(`Apply .gitignore filter rules inside the directory.`),
@@ -44,14 +44,14 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 		dagql.NodeFuncWithCacheKey("file", s.file, dagql.CachePerClient).
 			Doc(`Returns a File from the workspace.`,
 				`Path must be absolute in host/repo context.`,
-				`By default, paths outside the workspace repository root are rejected.`).
+				`By default, paths outside the workspace access boundary are rejected.`).
 			Args(
 				dagql.Arg("path").Doc(`Absolute location of the file to retrieve in host/repo context.`),
 			),
 		dagql.NodeFuncWithCacheKey("findUp", s.findUp, dagql.CachePerClient).
 			Doc(`Search for a file or directory by walking up from the start path within the workspace.`,
 				`Returns the absolute path if found, or null if not found.`,
-				`The search stops at the workspace repository root and will not traverse above it.`).
+				`The search stops at the workspace access boundary and will not traverse above it.`).
 			Args(
 				dagql.Arg("name").Doc(`The name of the file or directory to search for.`),
 				dagql.Arg("from").Doc(`Absolute path to start the search from in host/repo context.`),
@@ -83,14 +83,14 @@ func (s *workspaceSchema) currentWorkspace(
 	cwd = normalizeWorkspacePath(cwd)
 
 	statFS := core.NewCallerStatFS(bk)
-	repoRoot, found, err := core.Host{}.FindUp(ctx, statFS, cwd, ".git")
+	boundaryRoot, found, err := core.Host{}.FindUp(ctx, statFS, cwd, ".git")
 	if err != nil {
 		return nil, fmt.Errorf("workspace detection: %w", err)
 	}
 	if !found {
-		repoRoot = cwd
+		boundaryRoot = cwd
 	}
-	repoRoot = normalizeWorkspacePath(repoRoot)
+	boundaryRoot = normalizeWorkspacePath(boundaryRoot)
 
 	// Capture the current client ID so that when this workspace is passed to
 	// a module function, the directory/file resolvers can route host filesystem
@@ -101,8 +101,7 @@ func (s *workspaceSchema) currentWorkspace(
 	}
 
 	result := &core.Workspace{
-		Root:     repoRoot,
-		RepoRoot: repoRoot,
+		Root:     boundaryRoot,
 		ClientID: clientMetadata.ClientID,
 	}
 
@@ -164,20 +163,21 @@ func isPathWithinPrefix(targetPath, prefix string) bool {
 	return strings.HasPrefix(targetPath, prefix+"/")
 }
 
-func (s *workspaceSchema) enforceRepoBoundary(ws *core.Workspace, absPath string) error {
-	repoRoot := ws.RepoRoot
-	if repoRoot == "" {
-		repoRoot = ws.Root
-	}
-	if repoRoot == "" {
+func workspaceAccessBoundary(ws *core.Workspace) string {
+	return normalizeWorkspacePath(ws.Root)
+}
+
+func (s *workspaceSchema) enforceAccessBoundary(ws *core.Workspace, absPath string) error {
+	accessBoundary := workspaceAccessBoundary(ws)
+	if accessBoundary == "" || accessBoundary == "." {
 		return nil
 	}
 
-	if isPathWithinPrefix(absPath, repoRoot) {
+	if isPathWithinPrefix(absPath, accessBoundary) {
 		return nil
 	}
 
-	return fmt.Errorf("path %q is outside workspace repository root %q", absPath, repoRoot)
+	return fmt.Errorf("path %q is outside workspace access boundary %q", absPath, accessBoundary)
 }
 
 func (s *workspaceSchema) directory(ctx context.Context, parent dagql.ObjectResult[*core.Workspace], args workspaceDirectoryArgs) (inst dagql.ObjectResult[*core.Directory], _ error) {
@@ -201,7 +201,7 @@ func (s *workspaceSchema) directory(ctx context.Context, parent dagql.ObjectResu
 	if err != nil {
 		return inst, err
 	}
-	if err := s.enforceRepoBoundary(ws, absPath); err != nil {
+	if err := s.enforceAccessBoundary(ws, absPath); err != nil {
 		return inst, err
 	}
 
@@ -223,10 +223,7 @@ func (s *workspaceSchema) directory(ctx context.Context, parent dagql.ObjectResu
 		dirArgs = append(dirArgs, dagql.NamedInput{Name: "exclude", Value: excludes})
 	}
 	if args.Gitignore {
-		gitIgnoreRoot := ws.RepoRoot
-		if gitIgnoreRoot == "" {
-			gitIgnoreRoot = ws.Root
-		}
+		gitIgnoreRoot := workspaceAccessBoundary(ws)
 		dirArgs = append(dirArgs,
 			dagql.NamedInput{Name: "gitignore", Value: dagql.NewBoolean(true)},
 			dagql.NamedInput{Name: "gitIgnoreRoot", Value: dagql.NewString(gitIgnoreRoot)},
@@ -269,7 +266,7 @@ func (s *workspaceSchema) file(ctx context.Context, parent dagql.ObjectResult[*c
 	if err != nil {
 		return inst, err
 	}
-	if err := s.enforceRepoBoundary(ws, absPath); err != nil {
+	if err := s.enforceAccessBoundary(ws, absPath); err != nil {
 		return inst, err
 	}
 	fileDir, fileName := path.Split(absPath)
@@ -327,17 +324,14 @@ func (s *workspaceSchema) findUp(ctx context.Context, parent dagql.ObjectResult[
 	if err != nil {
 		return none, err
 	}
-	if err := s.enforceRepoBoundary(ws, absStart); err != nil {
+	if err := s.enforceAccessBoundary(ws, absStart); err != nil {
 		return none, err
 	}
 
 	statFS := core.NewCallerStatFS(bk)
-	cleanRepoRoot := path.Clean(ws.RepoRoot)
-	if cleanRepoRoot == "" {
-		cleanRepoRoot = path.Clean(ws.Root)
-	}
+	cleanAccessBoundary := path.Clean(workspaceAccessBoundary(ws))
 
-	// Walk up from absStart, stopping at repository root.
+	// Walk up from absStart, stopping at workspace access boundary.
 	curDir := absStart
 	for {
 		candidate := path.Join(curDir, args.Name)
@@ -346,8 +340,8 @@ func (s *workspaceSchema) findUp(ctx context.Context, parent dagql.ObjectResult[
 			return dagql.NonNull(dagql.NewString(normalizeWorkspacePath(candidate))), nil
 		}
 
-		// Stop at repository root.
-		if path.Clean(curDir) == cleanRepoRoot {
+		// Stop at workspace access boundary.
+		if path.Clean(curDir) == cleanAccessBoundary {
 			break
 		}
 

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -6,10 +6,6 @@ import "github.com/vektah/gqlparser/v2/ast"
 type Workspace struct {
 	Root string `field:"true" doc:"Absolute path to the workspace root directory."`
 
-	// RepoRoot is the absolute path to the repository root that contains this
-	// workspace. Paths outside this root are rejected by default.
-	RepoRoot string
-
 	// ClientID is the ID of the client that created this workspace.
 	// Used to route host filesystem operations through the correct session
 	// when the workspace is passed to a module function.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5738,10 +5738,10 @@ type Workspace {
 
   Path must be absolute in host/repo context.
 
-  By default, paths outside the workspace repository root are rejected.
+  By default, paths outside the workspace access boundary are rejected.
   """
   directory(
-    """Absolute location of the directory to retrieve in host/repo context."""
+    """Location of the directory to retrieve. Must be an absolute path."""
     path: String!
 
     """
@@ -5763,7 +5763,7 @@ type Workspace {
 
   Path must be absolute in host/repo context.
 
-  By default, paths outside the workspace repository root are rejected.
+  By default, paths outside the workspace access boundary are rejected.
   """
   file(
     """Absolute location of the file to retrieve in host/repo context."""
@@ -5775,7 +5775,7 @@ type Workspace {
 
   Returns the absolute path if found, or null if not found.
 
-  The search stops at the workspace repository root and will not traverse above it.
+  The search stops at the workspace access boundary and will not traverse above it.
   """
   findUp(
     """The name of the file or directory to search for."""
@@ -5796,5 +5796,4 @@ type Workspace {
 The `WorkspaceID` scalar type represents an identifier for an object of type Workspace.
 """
 scalar WorkspaceID
-
 

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -15731,7 +15731,7 @@
                         <td>
                           <p>Returns a Directory from the workspace.</p>
                           <p>Path must be absolute in host/repo context.</p>
-                          <p>By default, paths outside the workspace repository root are rejected.</p>
+                          <p>By default, paths outside the workspace access boundary are rejected.</p>
                         </td>
                       </tr>
                       <tr class="row-field-arguments">
@@ -15741,7 +15741,7 @@
                             <div class="field-argument-list">
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
-                                <p>Absolute location of the directory to retrieve in host/repo context.</p>
+                                <p>Location of the directory to retrieve. Must be an absolute path.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>exclude</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
@@ -15764,7 +15764,7 @@
                         <td>
                           <p>Returns a File from the workspace.</p>
                           <p>Path must be absolute in host/repo context.</p>
-                          <p>By default, paths outside the workspace repository root are rejected.</p>
+                          <p>By default, paths outside the workspace access boundary are rejected.</p>
                         </td>
                       </tr>
                       <tr class="row-field-arguments">
@@ -15785,7 +15785,7 @@
                         <td>
                           <p>Search for a file or directory by walking up from the start path within the workspace.</p>
                           <p>Returns the absolute path if found, or null if not found.</p>
-                          <p>The search stops at the workspace repository root and will not traverse above it.</p>
+                          <p>The search stops at the workspace access boundary and will not traverse above it.</p>
                         </td>
                       </tr>
                       <tr class="row-field-arguments">

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -14275,7 +14275,7 @@ type WorkspaceDirectoryOpts struct {
 //
 // Path must be absolute in host/repo context.
 //
-// By default, paths outside the workspace repository root are rejected.
+// By default, paths outside the workspace access boundary are rejected.
 func (r *Workspace) Directory(path string, opts ...WorkspaceDirectoryOpts) *Directory {
 	q := r.query.Select("directory")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -14303,7 +14303,7 @@ func (r *Workspace) Directory(path string, opts ...WorkspaceDirectoryOpts) *Dire
 //
 // Path must be absolute in host/repo context.
 //
-// By default, paths outside the workspace repository root are rejected.
+// By default, paths outside the workspace access boundary are rejected.
 func (r *Workspace) File(path string) *File {
 	q := r.query.Select("file")
 	q = q.Arg("path", path)
@@ -14317,7 +14317,7 @@ func (r *Workspace) File(path string) *File {
 //
 // Returns the absolute path if found, or null if not found.
 //
-// The search stops at the workspace repository root and will not traverse above it.
+// The search stops at the workspace access boundary and will not traverse above it.
 func (r *Workspace) FindUp(ctx context.Context, name string, from string) (string, error) {
 	if r.findUp != nil {
 		return *r.findUp, nil

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -27,7 +27,7 @@ class Workspace extends Client\AbstractObject implements Client\IdAble
      *
      * Path must be absolute in host/repo context.
      *
-     * By default, paths outside the workspace repository root are rejected.
+     * By default, paths outside the workspace access boundary are rejected.
      */
     public function directory(
         string $path,
@@ -54,7 +54,7 @@ class Workspace extends Client\AbstractObject implements Client\IdAble
      *
      * Path must be absolute in host/repo context.
      *
-     * By default, paths outside the workspace repository root are rejected.
+     * By default, paths outside the workspace access boundary are rejected.
      */
     public function file(string $path): File
     {
@@ -68,7 +68,7 @@ class Workspace extends Client\AbstractObject implements Client\IdAble
      *
      * Returns the absolute path if found, or null if not found.
      *
-     * The search stops at the workspace repository root and will not traverse above it.
+     * The search stops at the workspace access boundary and will not traverse above it.
      */
     public function findUp(string $name, string $from): string
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -14191,13 +14191,12 @@ class Workspace(Type):
 
         Path must be absolute in host/repo context.
 
-        By default, paths outside the workspace repository root are rejected.
+        By default, paths outside the workspace access boundary are rejected.
 
         Parameters
         ----------
         path:
-            Absolute location of the directory to retrieve in host/repo
-            context.
+            Location of the directory to retrieve. Must be an absolute path.
         exclude:
             Exclude artifacts that match the given pattern (e.g.,
             ["node_modules/", ".git*"]).
@@ -14221,7 +14220,7 @@ class Workspace(Type):
 
         Path must be absolute in host/repo context.
 
-        By default, paths outside the workspace repository root are rejected.
+        By default, paths outside the workspace access boundary are rejected.
 
         Parameters
         ----------
@@ -14240,7 +14239,7 @@ class Workspace(Type):
 
         Returns the absolute path if found, or null if not found.
 
-        The search stops at the workspace repository root and will not
+        The search stops at the workspace access boundary and will not
         traverse above it.
 
         Parameters

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -14643,11 +14643,11 @@ impl Workspace {
     }
     /// Returns a Directory from the workspace.
     /// Path must be absolute in host/repo context.
-    /// By default, paths outside the workspace repository root are rejected.
+    /// By default, paths outside the workspace access boundary are rejected.
     ///
     /// # Arguments
     ///
-    /// * `path` - Absolute location of the directory to retrieve in host/repo context.
+    /// * `path` - Location of the directory to retrieve. Must be an absolute path.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
@@ -14660,11 +14660,11 @@ impl Workspace {
     }
     /// Returns a Directory from the workspace.
     /// Path must be absolute in host/repo context.
-    /// By default, paths outside the workspace repository root are rejected.
+    /// By default, paths outside the workspace access boundary are rejected.
     ///
     /// # Arguments
     ///
-    /// * `path` - Absolute location of the directory to retrieve in host/repo context.
+    /// * `path` - Location of the directory to retrieve. Must be an absolute path.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts<'a>(
         &self,
@@ -14690,7 +14690,7 @@ impl Workspace {
     }
     /// Returns a File from the workspace.
     /// Path must be absolute in host/repo context.
-    /// By default, paths outside the workspace repository root are rejected.
+    /// By default, paths outside the workspace access boundary are rejected.
     ///
     /// # Arguments
     ///
@@ -14706,7 +14706,7 @@ impl Workspace {
     }
     /// Search for a file or directory by walking up from the start path within the workspace.
     /// Returns the absolute path if found, or null if not found.
-    /// The search stops at the workspace repository root and will not traverse above it.
+    /// The search stops at the workspace access boundary and will not traverse above it.
     ///
     /// # Arguments
     ///

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -13740,8 +13740,8 @@ export class Workspace extends BaseClient {
    *
    * Path must be absolute in host/repo context.
    *
-   * By default, paths outside the workspace repository root are rejected.
-   * @param path Absolute location of the directory to retrieve in host/repo context.
+   * By default, paths outside the workspace access boundary are rejected.
+   * @param path Location of the directory to retrieve. Must be an absolute path.
    * @param opts.exclude Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
    * @param opts.include Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
    * @param opts.gitignore Apply .gitignore filter rules inside the directory.
@@ -13756,7 +13756,7 @@ export class Workspace extends BaseClient {
    *
    * Path must be absolute in host/repo context.
    *
-   * By default, paths outside the workspace repository root are rejected.
+   * By default, paths outside the workspace access boundary are rejected.
    * @param path Absolute location of the file to retrieve in host/repo context.
    */
   file = (path: string): File => {
@@ -13769,7 +13769,7 @@ export class Workspace extends BaseClient {
    *
    * Returns the absolute path if found, or null if not found.
    *
-   * The search stops at the workspace repository root and will not traverse above it.
+   * The search stops at the workspace access boundary and will not traverse above it.
    * @param name The name of the file or directory to search for.
    * @param from Absolute path to start the search from in host/repo context.
    */

--- a/spec/workspace-api.md
+++ b/spec/workspace-api.md
@@ -26,6 +26,9 @@ This spec describes the desired behavior of the Workspace API.
   - Resolve to absolute path.
   - Walk up to nearest ancestor containing `.git`; if none, use the starting directory.
   - Workspace context can be local host filesystem or remote git repository context.
+- Workspace access boundary:
+  - If a git repository is detected, the boundary is the repository root.
+  - If no repository is detected, the boundary is the starting directory (caller CWD).
 - Workspace identity:
   - `Workspace` stores both `root` and `clientId`.
   - `Workspace.root` returns the absolute workspace root locator.
@@ -38,10 +41,10 @@ This spec describes the desired behavior of the Workspace API.
   - Paths resolve directly in the workspace's underlying context (host filesystem for local workspaces, repository tree for remote git workspaces).
   - All workspace path arguments (`directory.path`, `file.path`, `findUp.from`) must be absolute.
   - Relative path arguments are rejected.
-  - By default, path resolution outside the workspace git repository fails.
+  - By default, path resolution outside the workspace access boundary fails.
 - `findUp`:
   - Searches upward from `from`.
-  - Stops at workspace repository root.
+  - Stops at workspace access boundary.
   - Returns an absolute path or `null`.
 
 ### Path Contract
@@ -57,8 +60,8 @@ This spec describes the desired behavior of the Workspace API.
 ### Failure Behavior
 
 - Relative workspace path arguments fail with an error (e.g. `path "." must be absolute`).
-- Absolute paths outside the workspace repository root fail with an error (e.g. `outside workspace repository root`).
-- `findUp` returns `null` when no match is found before repository root.
+- Absolute paths outside the workspace access boundary fail with an error (e.g. `outside workspace access boundary`).
+- `findUp` returns `null` when no match is found before the access boundary.
 
 ### Conformance Check
 


### PR DESCRIPTION
## Summary

Replace the Workspace API's implicit relative-path sandbox with explicit absolute paths and git repo-boundary enforcement.

**Before:** `directory("src")`, `file("go.mod")`, `findUp(from: ".")` — all paths were relative to the workspace root and silently rewritten to absolute paths internally. Callers couldn't tell what host path was actually resolved.

**After:** `directory("/home/bob/myproject/src")`, `file("/home/bob/myproject/go.mod")`, `findUp(from: "/home/bob/myproject")` — all paths must be absolute. The path you pass is the path that gets resolved. Paths outside the git repository root are rejected.

### What changed

- **Absolute paths required**: `directory()`, `file()`, and `findUp()` now reject relative paths with a clear error. No implicit path rewriting.
- **Repo-boundary enforcement**: paths outside the git repository root are rejected (e.g. `/etc/passwd` fails, `/home/bob/myproject/src` succeeds). This replaces the old sandbox model.
- **New `RepoRoot` field**: separates the workspace root (cwd at session start) from the git repo root (security boundary), so `.gitignore` rules and `findUp` walking use the correct root.
- **`findUp` returns absolute paths**: previously returned relative paths like `config/go.mod`, now returns `/home/bob/myproject/config/go.mod`.
- **Removed `allowOutsideRepo`**: dropped for now to keep the security model simple.
- **Formal spec**: added `spec/workspace-api.md` documenting the full API surface, path semantics, caching model, and workspace detection behavior.
- **Regenerated SDK bindings** for Go, Python, TypeScript, PHP, Rust, and GraphQL schema.

## Test plan

```
dagger --progress=plain -m ./toolchains/engine-dev call test \
  --pkg=./core/integration \
  --run='TestWorkspace/(TestFindUp|TestRootIsRepoRoot|TestNoWorkspaceRootSandbox|TestWorkspacePathTraversal)' \
  --count=1 --timeout=30m --test-verbose
```