### PR TITLE
bump dagger/pytest so it doesn't use dagger/dagger/modules/wolfi

### DIFF
--- a/toolchains/python-sdk-dev/dagger.json
+++ b/toolchains/python-sdk-dev/dagger.json
@@ -23,7 +23,7 @@
     {
       "name": "pytest",
       "source": "github.com/dagger/pytest@main",
-      "pin": "9d1757d125a8fd3d7f0caef2d2cb3c3115f886b0"
+      "pin": "8ecbf6650d1c3c9eaf0fa92bb57c9c15987c932b"
     },
     {
       "name": "wolfi",


### PR DESCRIPTION
This was causing a pull of dagger/dagger because dagger/pytest had the wolfi module as a dependency. But this was only used to have a container with uv installed inside. dagger/pytest now has alpine by default. And in our specific case we are giving a dev container anyway.