### PR TITLE
cli: add DAGGER_NO_UPDATE_CHECK to suppress update notifications

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -285,6 +285,10 @@ func findSuggestions(c *cobra.Command, arg string) string {
 }
 
 func checkForUpdates(ctx context.Context, w io.Writer) {
+	if os.Getenv("DAGGER_NO_UPDATE_CHECK") != "" {
+		return
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	updateCh := make(chan string)


### PR DESCRIPTION
Fixes #11979

## Summary

- Adds support for the `DAGGER_NO_UPDATE_CHECK` environment variable to suppress the CLI update notification that runs on every invocation
- When set to any non-empty value (e.g., `DAGGER_NO_UPDATE_CHECK=1`), the automatic version check is skipped entirely, avoiding both the network request and the stderr output
- This is useful in CI environments and automated scripts where CLI versions are pinned and managed externally

## Details

The change is a 4-line early return in `checkForUpdates()` in `cmd/dagger/main.go`. It checks `os.Getenv("DAGGER_NO_UPDATE_CHECK")` and returns immediately if the variable is set, following the same pattern already used for other Dagger environment variables like `DAGGER_QUIET`, `DAGGER_REVEAL`, and `DAGGER_NO_NAG`.

This pattern is consistent with other CLI tools:
- GitHub CLI: `GH_NO_UPDATE_NOTIFIER` (already used in this repo at `toolchains/release/gh/main.go`)
- Terraform / HashiCorp: `CHECKPOINT_DISABLE`
- npm: `NO_UPDATE_NOTIFIER`

## Usage

```bash
# Suppress update check
export DAGGER_NO_UPDATE_CHECK=1
dagger call my-function

# Or inline
DAGGER_NO_UPDATE_CHECK=1 dagger call my-function
```

## Test plan

- [ ] Verify `dagger version` without the env var still shows update notification when an update is available
- [ ] Verify `DAGGER_NO_UPDATE_CHECK=1 dagger version` suppresses the update notification
- [ ] Verify `dagger version --check` still works regardless of the env var (it uses a separate code path via `forceVersionCheck`)