### PR TITLE
fix: avoid fatal git config error when CLI runs inside mounted worktrees

### DIFF
--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -652,8 +652,11 @@ func (c *Client) GetGitConfig(ctx context.Context) ([]*git.GitConfigEntry, error
 	case *git.GitConfigResponse_Config:
 		return result.Config.Entries, nil
 	case *git.GitConfigResponse_Error:
-		// if git is not found, ignore that error
-		if result.Error.Type == git.NOT_FOUND {
+		// Git config is best-effort: it provides url.*.insteadOf mappings
+		// but is not required for normal operation. Ignore errors from
+		// missing git or failed config retrieval (e.g. broken .git
+		// pointers inside containers with mounted worktrees).
+		if result.Error.Type == git.NOT_FOUND || result.Error.Type == git.CONFIG_RETRIEVAL_FAILED {
 			return []*git.GitConfigEntry{}, nil
 		}
 

--- a/engine/session/git/git_config.go
+++ b/engine/session/git/git_config.go
@@ -55,6 +55,12 @@ func (s GitAttachable) GetConfig(ctx context.Context, req *GitConfigRequest) (*G
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
 
+	// Run from a temp directory to avoid reading local repo config.
+	// We only need system/global config (e.g. url.*.insteadOf), and running
+	// inside a git repo can fail fatally if the .git pointer is invalid
+	// (e.g. a mounted git worktree whose gitdir target doesn't exist).
+	cmd.Dir = os.TempDir()
+
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
 		"SSH_ASKPASS=echo",


### PR DESCRIPTION
Running `git config -l -z` from a directory with a broken .git pointer (e.g. a git worktree mounted into a container) causes a fatal exit 128. Fix by running from a temp directory so only system/global config is read, and treat CONFIG_RETRIEVAL_FAILED as non-fatal since git config forwarding is best-effort (only used for url.*.insteadOf mappings).