### PR TITLE
feat: Add service to helm chart

### DIFF
--- a/helm/dagger/templates/service.yaml
+++ b/helm/dagger/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.engine.port }}
+{{- if or .Values.engine.containerPorts .Values.engine.port }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/dagger/templates/service.yaml
+++ b/helm/dagger/templates/service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.engine.port }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dagger.fullname" . }}
+  labels:
+    {{- include "dagger.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- if .Values.engine.containerPorts }}
+    {{- range .Values.engine.containerPorts }}
+    - name: {{ .name | default "dagger" }}
+      port: {{ .containerPort | default $.Values.engine.port }}
+      targetPort: {{ .name | default "dagger" }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}
+    {{- else }}
+    - name: dagger
+      port: {{ .Values.engine.port }}
+      targetPort: dagger
+      protocol: TCP
+    {{- end }}
+  selector:
+    {{- include "dagger.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -67,13 +67,12 @@ engine:
   # port: 1234 # The container port that the Dagger Engine will listen on.
 
   ### Configure multiple ports for the Dagger Engine
-  # This allows defining all ports in a structured way
+  # If not defined, defaults to engine.port with name "dagger" and protocol "TCP"
   # Example configuration:
   # containerPorts:
   #   - name: dagger
-  #     containerPort: 1234 # Needs to be the same as engine.port if both are set
-  #     protocol: TCP
-  #     hostPort: 1234  # Optional: Expose the engine port directly on the host node
+  #     containerPort: 1234 # Defaults to engine.port if not specified
+  #     protocol: TCP # Defaults to TCP if not specified
   #   - name: metrics
   #     containerPort: 8080
   #     protocol: TCP
@@ -236,3 +235,15 @@ magicache:
   ### If secretName is set, a new secret will NOT be created
   #
   # secretName: EXISTING_SECRET_NAME
+
+service:
+  ### Kubernetes Service is created automatically when engine.port is defined
+  #
+  ### Service type (ClusterIP, NodePort, LoadBalancer)
+  type: ClusterIP
+
+  ### Additional service annotations
+  annotations: {}
+
+  ### Additional service labels
+  labels: {}


### PR DESCRIPTION
## Summary
Introduce the first official Kubernetes _Service_ manifest to the Dagger Helm chart so users no longer need to port-forward or handcraft their own Service just to reach the engine.

## Details

Before this feature, the chart launched engine pods with whatever ports you configured but left exposure up to the operator, forcing ad-hoc Services or kubectl port-forward

This change adds the missing _Service_ and renders it whenever any engine port is defined: either the single `engine.port` or custom entries in `engine.containerPorts`.