### PR TITLE
ci: bump daggerverse preview runner to v0.20.1

### DIFF
--- a/.github/workflows/daggerverse-preview.yml
+++ b/.github/workflows/daggerverse-preview.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     runs-on:
       - ${{ github.repository == 'dagger/dagger' && 'nscloud-ubuntu-24.04-amd64-4x8' || 'ubuntu-24.04' }}
-      - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.20.0' || 'ubuntu-24.04' }}
+      - ${{ github.repository == 'dagger/dagger' && 'namespace-experiments:dagger.integration=enabled;dagger.version=0.20.1' || 'ubuntu-24.04' }}
     name: deploy
     steps:
       - name: Checkout


### PR DESCRIPTION
The Namespace runner was still pinned to v0.20.0 while the daggerverse module requires v0.20.1. This was missed during the v0.20.1 post-release bump.

PS: as i'm pushing from my fork, it's expected to fail 
PS.1: A [user was hitting it](https://github.com/dagger/dagger/pull/12012) upon _wrongfully_ changing some `.changes/` files