### PR TITLE
fix: dockerfile RUN heredoc fails

### DIFF
--- a/.changes/unreleased/Fixed-20260318-050000.yaml
+++ b/.changes/unreleased/Fixed-20260318-050000.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Fix Dockerfile RUN heredoc failing with "command not found" (exit 127) by preserving /dev/pipes/ mounts in the OCI spec.
+time: 2026-03-18T05:00:00.000000000+08:00
+custom:
+  Author: majiayu000
+  PR: "12020"

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -183,6 +183,32 @@ CMD echo "stage2"
 		require.NotContains(t, output, "stage2\n")
 	})
 
+	t.Run("with heredoc", func(ctx context.Context, t *testctx.T) {
+		dockerfile := `FROM ` + alpineImage + `
+RUN <<EOF
+#!/bin/sh
+echo "hello from heredoc" > /heredoc-output
+EOF
+CMD cat /heredoc-output
+`
+
+		t.Run("builtin frontend", func(ctx context.Context, t *testctx.T) {
+			dir := baseDir.WithNewFile("Dockerfile", dockerfile)
+
+			stdout, err := dir.DockerBuild().WithExec(nil).Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, stdout, "hello from heredoc")
+		})
+
+		t.Run("remote frontend", func(ctx context.Context, t *testctx.T) {
+			dir := baseDir.WithNewFile("Dockerfile", "#syntax=docker/dockerfile:1\n"+dockerfile)
+
+			stdout, err := dir.DockerBuild().WithExec(nil).Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, stdout, "hello from heredoc")
+		})
+	})
+
 	t.Run("with build secrets", func(ctx context.Context, t *testctx.T) {
 		sec := c.SetSecret("my-secret", "barbar")
 

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -452,9 +452,11 @@ func (w *Worker) setupRootfs(ctx context.Context, state *execState) error {
 		case mnt.Destination == MetaMountDestPath:
 			metaMount = &mnt
 
-		case mnt.Destination == BuildkitQemuEmulatorMountPoint:
-			// buildkit puts the qemu emulator under /dev, which we aren't mounting now, so just
-			// leave it be
+		case mnt.Destination == BuildkitQemuEmulatorMountPoint,
+			strings.HasPrefix(mnt.Destination, "/dev/pipes/"):
+			// Keep specific sub-mounts of /dev in the OCI spec so that runc processes
+			// them after the /dev tmpfs mount. The qemu emulator is at
+			// /dev/.buildkit_qemu_emulator and /dev/pipes/ is used by heredoc processing.
 			filteredMounts = append(filteredMounts, mnt)
 
 		case containerfs.IsSpecialMountType(mnt.Type):


### PR DESCRIPTION
Fixes #12865 (originally #11972)

Dockerfile heredoc syntax fails with exit 127 because the `/dev/pipes/` bind mount used by BuildKit for heredoc processing gets pre-applied to the rootfs, then shadowed when runc mounts `/dev` as tmpfs. Fix by keeping `/dev/pipes/` mounts in the OCI spec alongside the existing qemu emulator case, so runc processes them after the `/dev` tmpfs mount.

Added integration test covering both builtin and remote Dockerfile frontends.