### PR TITLE
chore: bump trivy 0.68.2 → 0.69.3

### DIFF
--- a/toolchains/security/main.dang
+++ b/toolchains/security/main.dang
@@ -2,7 +2,7 @@ pub description = "A toolchain for supply chain security of the Dagger project"
 
 type Security {
   let trivyBase = container
-    .from("aquasec/trivy:0.68.2@sha256:05d0126976bdedcd0782a0336f77832dbea1c81b9cc5e4b3a5ea5d2ec863aca7")
+    .from("aquasec/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c")
     .withMountedCache(
       path: "/root/.cache",
       cache: cacheVolume("trivy-cache"),


### PR DESCRIPTION
The `security:scan-engine-container` CI check fails because Trivy `0.68.2` is outdated (`0.69.3` available). Bump to the latest release to unblock the pipeline.                                 

To verify the digest:                                                                           
- `docker pull aquasec/trivy:0.69.3`                                                            
- `docker inspect aquasec/trivy:0.69.3 --format='{{index .RepoDigests 0}}'` 