### PR TITLE
fetch git tags before checking for version

### DIFF
--- a/version/main.go
+++ b/version/main.go
@@ -222,6 +222,7 @@ func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, err
 		From("alpine/git:latest").
 		WithWorkdir("/src").
 		WithMountedDirectory(".git", v.GitDir).
+		WithExec([]string{"git", "fetch", "--tags"}).
 		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
 		Stdout(ctx)
 	if err != nil {


### PR DESCRIPTION
given the recent changes in the `git` operation in the engine, we now
need to fetch the tags beforehand so we can get the correct version

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
