### PR TITLE
Dagger lockfile

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client"
@@ -128,6 +129,12 @@ func withEngine(
 		params.Interactive = interactive
 		params.InteractiveCommand = interactiveCommandParsed
 
+		effectiveLockMode, err := resolveLockMode(params.LockMode, lockMode)
+		if err != nil {
+			return cleanup.Run, err
+		}
+		params.LockMode = effectiveLockMode
+
 		if hasTTY {
 			params.PromptHandler = Frontend
 		}
@@ -149,6 +156,22 @@ func withEngine(
 
 		return cleanup.Run, fn(ctx, sess)
 	})
+}
+
+func resolveLockMode(paramLockMode, globalLockMode string) (string, error) {
+	effective := paramLockMode
+	if effective == "" {
+		effective = globalLockMode
+	}
+	if effective == "" {
+		return "", nil
+	}
+
+	mode, err := workspace.ParseLockMode(effective)
+	if err != nil {
+		return "", err
+	}
+	return string(mode), nil
 }
 
 func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {

--- a/cmd/dagger/engine_lock_test.go
+++ b/cmd/dagger/engine_lock_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func TestResolveLockMode(t *testing.T) {
+	t.Run("both empty", func(t *testing.T) {
+		mode, err := resolveLockMode("", "")
+		if err != nil {
+			t.Fatalf("resolveLockMode returned unexpected error: %v", err)
+		}
+		if mode != "" {
+			t.Fatalf("expected empty mode, got %q", mode)
+		}
+	})
+
+	t.Run("uses global when param empty", func(t *testing.T) {
+		mode, err := resolveLockMode("", "frozen")
+		if err != nil {
+			t.Fatalf("resolveLockMode returned unexpected error: %v", err)
+		}
+		if mode != "frozen" {
+			t.Fatalf("expected frozen, got %q", mode)
+		}
+	})
+
+	t.Run("param takes precedence over global", func(t *testing.T) {
+		mode, err := resolveLockMode("live", "frozen")
+		if err != nil {
+			t.Fatalf("resolveLockMode returned unexpected error: %v", err)
+		}
+		if mode != "live" {
+			t.Fatalf("expected live, got %q", mode)
+		}
+	})
+
+	t.Run("explicit disabled is preserved", func(t *testing.T) {
+		mode, err := resolveLockMode("", "disabled")
+		if err != nil {
+			t.Fatalf("resolveLockMode returned unexpected error: %v", err)
+		}
+		if mode != "disabled" {
+			t.Fatalf("expected disabled, got %q", mode)
+		}
+	})
+
+	t.Run("invalid global mode", func(t *testing.T) {
+		_, err := resolveLockMode("", "weird")
+		if err == nil {
+			t.Fatalf("expected error for invalid global lock mode")
+		}
+	})
+
+	t.Run("invalid param mode", func(t *testing.T) {
+		_, err := resolveLockMode("weird", "pinned")
+		if err == nil {
+			t.Fatalf("expected error for invalid param lock mode")
+		}
+	})
+}

--- a/cmd/dagger/lock.go
+++ b/cmd/dagger/lock.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"io"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/engine/client"
+	"github.com/spf13/cobra"
+)
+
+const workspaceLockUpdateQuery = `query {
+  currentWorkspace {
+    update {
+      isEmpty
+      export(path: ".")
+    }
+  }
+}
+`
+
+type workspaceLockUpdateResponse struct {
+	CurrentWorkspace struct {
+		Update struct {
+			IsEmpty bool
+			Export  string
+		}
+	}
+}
+
+func init() {
+	lockCmd.AddCommand(lockUpdateCmd)
+}
+
+var lockCmd = &cobra.Command{
+	Use:   "lock",
+	Short: "Manage workspace lockfiles",
+	Annotations: map[string]string{
+		"experimental": "true",
+	},
+}
+
+var lockUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Refresh workspace lock entries",
+	Long: `Refresh workspace lock entries.
+
+Refresh entries already recorded in .dagger/lock.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
+			return updateWorkspaceLockfile(ctx, cmd.OutOrStdout(), engineClient.Dagger())
+		})
+	},
+}
+
+func updateWorkspaceLockfile(ctx context.Context, outWriter io.Writer, dag *dagger.Client) error {
+	var res workspaceLockUpdateResponse
+	if err := dag.Do(ctx, &dagger.Request{Query: workspaceLockUpdateQuery}, &dagger.Response{Data: &res}); err != nil {
+		return err
+	}
+
+	if res.CurrentWorkspace.Update.IsEmpty {
+		_, err := outWriter.Write([]byte("Lockfile already up to date\n"))
+		return err
+	}
+
+	_, err := outWriter.Write([]byte("Updated .dagger/lock\n"))
+	return err
+}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -63,6 +63,7 @@ var (
 	expandCompleted          = os.Getenv("DAGGER_EXPAND_COMPLETED") != ""
 	debugFlag                bool
 	progress                 string
+	lockMode                 string
 	interactive              bool
 	interactiveCommand       string
 	interactiveCommandParsed []string
@@ -139,6 +140,7 @@ func init() {
 		queryCmd,
 		runCmd,
 		traceCmd,
+		lockCmd,
 		configCmd,
 		checksCmd,
 		upCmd,
@@ -338,6 +340,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs)")
+	flags.StringVar(&lockMode, "lock", "", "Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -156,6 +156,7 @@ func (container *Container) execMeta(ctx context.Context, opts ContainerExecOpts
 	}
 	execMD.CallerClientID = clientMetadata.ClientID
 	execMD.SessionID = clientMetadata.SessionID
+	execMD.LockMode = clientMetadata.LockMode
 	execMD.AllowedLLMModules = clientMetadata.AllowedLLMModules
 
 	if execMD.Call == nil {

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -539,8 +539,8 @@ func (repo *RemoteGitRepository) initRemote(ctx context.Context, fn func(string)
 	if initializeRepo {
 		// Explicitly set the Git config 'init.defaultBranch' to the
 		// implied default to suppress "hint:" output about not having a
+		// default initial branch name set, which otherwise spams unit
 		// test logs.
-		// default initial branch name set which otherwise spams unit
 		if _, err := git.Run(ctx, "-c", "init.defaultBranch=main", "init", "--bare", "--quiet"); err != nil {
 			return fmt.Errorf("failed to init repo at %s: %w", dir, err)
 		}
@@ -563,17 +563,13 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 		return nil, fmt.Errorf("current call is nil")
 	}
 
-	// cacheKeyDigest, err := curCall.RecipeDigest(ctx)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("tree cache key: %w", err)
-	//} 
 	inputs := []string{
 		ref.Name,
 		ref.SHA,
 		ref.repo.URL.Remote(),
-		fmt.Sprintf("discard git: %b", discardGitDir),
+		fmt.Sprintf("discard git: %t", discardGitDir),
 		fmt.Sprintf("depth: %d", depth),
-		fmt.Sprintf("tags: %b", includeTags),
+		fmt.Sprintf("tags: %t", includeTags),
 	}
 	cacheKey := hashutil.HashStrings(inputs...).String()
 	cache := query.SnapshotManager()

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -562,11 +562,20 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 	if curCall == nil {
 		return nil, fmt.Errorf("current call is nil")
 	}
-	cacheKeyDigest, err := curCall.RecipeDigest(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("tree cache key: %w", err)
+
+	// cacheKeyDigest, err := curCall.RecipeDigest(ctx)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("tree cache key: %w", err)
+	//} 
+	inputs := []string{
+		ref.Name,
+		ref.SHA,
+		ref.repo.URL.Remote(),
+		fmt.Sprintf("discard git: %b", discardGitDir),
+		fmt.Sprintf("depth: %d", depth),
+		fmt.Sprintf("tags: %b", includeTags),
 	}
-	cacheKey := cacheKeyDigest.String()
+	cacheKey := hashutil.HashStrings(inputs...).String()
 	cache := query.SnapshotManager()
 	locker := query.Locker()
 	locker.Lock(indexGitSnapshot + cacheKey)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -1827,3 +1827,47 @@ func main() {
 		})
 	}
 }
+
+func (GitSuite) TestCaching(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("same commit should cache", func(ctx context.Context, t *testctx.T) {
+		dir1 := c.Git("https://github.com/dagger/dagger").Commit("7bed576fbc61fff0015f5bf9c85f17c43102a4a3").Tree()
+		s1, err := c.Container().
+			From(alpineImage).
+			WithDirectory("/src", dir1).
+			WithExec([]string{"sh", "-c", "head -c 102 /dev/urandom | base64 -w0"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+
+		dir2 := c.Git("https://github.com/dagger/dagger").Commit("7bed576fbc61fff0015f5bf9c85f17c43102a4a3").Tree()
+		s2, err := c.Container().
+			From(alpineImage).
+			WithDirectory("/src", dir2).
+			WithExec([]string{"sh", "-c", "head -c 102 /dev/urandom | base64 -w0"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, s1, s2)
+	})
+
+	t.Run("different commit should bust", func(ctx context.Context, t *testctx.T) {
+		dir1 := c.Git("https://github.com/dagger/dagger").Commit("7bed576fbc61fff0015f5bf9c85f17c43102a4a3").Tree()
+		s1, err := c.Container().
+			From(alpineImage).
+			WithDirectory("/src", dir1).
+			WithExec([]string{"sh", "-c", "head -c 102 /dev/urandom | base64 -w0"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+
+		dir2 := c.Git("https://github.com/dagger/dagger").Commit("36a3929f291bc03e2f48fd2687e5538a063c63ea").Tree()
+		s2, err := c.Container().
+			From(alpineImage).
+			WithDirectory("/src", dir2).
+			WithExec([]string{"sh", "-c", "head -c 102 /dev/urandom | base64 -w0"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+
+		require.NotEqual(t, s1, s2)
+	})
+}

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -1,0 +1,680 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/internal/buildkit/identity"
+	"github.com/dagger/dagger/util/lockfile"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+type LockfileSuite struct{}
+
+func TestLockfile(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(LockfileSuite{})
+}
+
+const containerFromQuery = `{
+  container {
+    from(address: "alpine:latest") {
+      file(path: "/etc/alpine-release") {
+        contents
+      }
+    }
+  }
+}
+`
+
+const (
+	lockTestGitRepoURL      = "https://github.com/dagger/dagger.git"
+	lockTestGitBranchName   = "main"
+	lockTestGitBranchCommit = "c80ac2c13df7d573a069938e01ca13f7a81f0345"
+	lockTestGitTagName      = "v0.18.2"
+	lockTestGitTagOldCommit = "9ea5ea7c848fef2a2c47cce0716d5fcb8d6bedeb"
+)
+
+const gitBranchCommitQuery = `{
+  git(url: "` + lockTestGitRepoURL + `") {
+    branch(name: "main") {
+      commit
+    }
+  }
+}
+`
+
+const gitBranchAndTagCommitQuery = `{
+  git(url: "` + lockTestGitRepoURL + `") {
+    branch(name: "main") {
+      commit
+    }
+    tag(name: "` + lockTestGitTagName + `") {
+      commit
+    }
+  }
+}
+`
+
+const workspaceUpdateQuery = `{
+  currentWorkspace {
+    update {
+      modifiedPaths
+    }
+  }
+}
+`
+
+const workspaceUpdateExportQuery = `{
+  currentWorkspace {
+    update {
+      export(path: ".")
+    }
+  }
+}
+`
+
+func (LockfileSuite) TestFromLockfileDisabledIgnoresEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+	lockPath, originalLock := writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=disabled", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.Equal(t, originalLock, string(lockBytes))
+}
+
+func (LockfileSuite) TestFromLockfileLiveRefreshesEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+	lockPath, originalLock := writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=live", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertContainerFromLockEntry(t, lockBytes, workspace.PolicyPin)
+}
+
+func (LockfileSuite) TestFromLockfilePinnedUsesPinEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, _ = writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=pinned", "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `invalid lock digest "not-a-digest"`)
+}
+
+func (LockfileSuite) TestFromLockfilePinnedRefreshesFloatEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+	lockPath, originalLock := writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyFloat)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=pinned", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertContainerFromLockEntry(t, lockBytes, workspace.PolicyFloat)
+}
+
+func (LockfileSuite) TestFromLockfileFrozenUsesFloatEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, _ = writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyFloat)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `invalid lock digest "not-a-digest"`)
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRequiresEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing lock entry for container.from")
+
+	_, err = os.Stat(filepath.Join(workdir, ".dagger", "lock"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func (LockfileSuite) TestGitBranchPinnedRefreshesFloatEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeQueryDoc(t, workdir, "git-branch.graphql", gitBranchCommitQuery)
+	lockPath, originalLock := writeGitRefLock(t, workdir, "git.branch", lockTestGitBranchName, lockTestGitBranchCommit, workspace.PolicyFloat)
+
+	t.Logf("lock path is %s\n", lockPath)
+	t.Logf("lock contents is %s\n", originalLock)
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=pinned", "query", "--doc", queryPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), lockTestGitBranchCommit)
+	// require.Equal(t, string(out), "weeeeeeeeeeeeeeeeeeeeeeee")
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertGitLockEntry(t, lockBytes, "git.branch", []any{lockTestGitRepoURL, lockTestGitBranchName}, workspace.PolicyFloat)
+}
+
+func (LockfileSuite) TestGitBranchFrozenUsesFloatEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeQueryDoc(t, workdir, "git-branch.graphql", gitBranchCommitQuery)
+
+	_, _ = writeGitRefLock(t, workdir, "git.branch", lockTestGitBranchName, lockTestGitBranchCommit, workspace.PolicyFloat)
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "query", "--doc", queryPath)
+	require.NoError(t, err)
+	require.Contains(t, string(out), lockTestGitBranchCommit)
+}
+
+func (LockfileSuite) TestLockUpdateRefreshesExistingEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	lockPath, originalLock := writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "sha256:"+strings.Repeat("0", 64), workspace.PolicyPin)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "lock", "update")
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertContainerFromLockEntry(t, lockBytes, workspace.PolicyPin)
+}
+
+func (LockfileSuite) TestLockUpdateRefreshesExistingGitEntry(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	lockPath, originalLock := writeGitRefLock(t, workdir, "git.branch", lockTestGitBranchName, lockTestGitBranchCommit, workspace.PolicyFloat)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "lock", "update")
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertGitLockEntry(t, lockBytes, "git.branch", []any{lockTestGitRepoURL, lockTestGitBranchName}, workspace.PolicyFloat)
+	require.NotContains(t, string(lockBytes), lockTestGitBranchCommit)
+}
+
+func (LockfileSuite) TestLiveDiscoversQueryEntries(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=live", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockPath := filepath.Join(workdir, ".dagger", "lock")
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assertContainerFromLockEntry(t, lockBytes, workspace.PolicyPin)
+}
+
+func (LockfileSuite) TestLiveDiscoversGitEntries(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	queryPath := writeQueryDoc(t, workdir, "git.graphql", gitBranchAndTagCommitQuery)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=live", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockPath := filepath.Join(workdir, ".dagger", "lock")
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assertGitLockEntry(t, lockBytes, "git.branch", []any{lockTestGitRepoURL, lockTestGitBranchName}, workspace.PolicyFloat)
+	assertGitLockEntry(t, lockBytes, "git.tag", []any{lockTestGitRepoURL, lockTestGitTagName}, workspace.PolicyPin)
+}
+
+func (LockfileSuite) TestLiveNestedQuery(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	updated := daggerCliBase(t, c).
+		WithNewFile("query.graphql", containerFromQuery).
+		With(daggerExec("--silent", "--lock=live", "query", "--doc", "query.graphql"))
+
+	s, err := updated.Stdout(ctx)
+	require.NoError(t, err)
+	t.Logf("%s", s)
+
+	lockContents, err := updated.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	assertContainerFromLockEntry(t, []byte(lockContents), workspace.PolicyPin)
+}
+
+func (LockfileSuite) TestLiveModuleCall(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceBase(t, c).
+		With(initStandaloneDangModule("lockmod", `
+type Lockmod {
+  pub release: String! {
+    Dagger.container.from("alpine:latest").file("/etc/alpine-release").contents
+  }
+}
+`))
+
+	updated := base.With(daggerExec("--silent", "--lock=live", "call", "release"))
+	out, err := updated.Stdout(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, strings.TrimSpace(out))
+
+	lockContents, err := updated.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	assertContainerFromLockEntry(t, []byte(lockContents), workspace.PolicyPin)
+
+	frozen := updated.With(daggerExec("--silent", "--lock=frozen", "call", "release"))
+	out, err = frozen.Stdout(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, strings.TrimSpace(out))
+
+	lockContentsAfter, err := frozen.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, lockContents, lockContentsAfter)
+}
+
+func (LockfileSuite) TestLiveDiscoversModuleSourceEntries(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	gitDaemon, source := startModuleResolveGitService(ctx, t, c)
+	updated := moduleResolveClientContainer(ctx, t, c, gitDaemon, source).
+		WithNewFile("query.graphql", moduleSourceCommitQuery(source)).
+		WithExec([]string{"dagger", "--silent", "--lock=live", "query", "--doc", "query.graphql"})
+
+	out, err := updated.Stdout(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, strings.TrimSpace(out))
+
+	lockContents, err := updated.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	assertModuleResolveLockEntry(t, []byte(lockContents), source, workspace.PolicyFloat)
+}
+
+func (LockfileSuite) TestModuleSourceFrozenUsesLockedEntry(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	gitDaemon, repoURL, source := startModuleResolveGitServiceWithRepo(ctx, t, c)
+	initialCommit := gitRepoHeadCommit(ctx, t, c, gitDaemon, repoURL)
+	newCommit := advanceGitRepo(ctx, t, c, gitDaemon, repoURL, "README.md", "second revision")
+	require.NotEqual(t, initialCommit, newCommit)
+
+	frozen := moduleResolveClientContainer(ctx, t, c, gitDaemon, source).
+		WithNewFile(".dagger/lock", mustMarshalModuleResolveLock(t, source, initialCommit, workspace.PolicyFloat)).
+		WithNewFile("query.graphql", moduleSourceCommitQuery(source)).
+		WithExec([]string{"dagger", "--silent", "--lock=frozen", "query", "--doc", "query.graphql"})
+
+	out, err := frozen.Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, initialCommit)
+	require.NotContains(t, out, newCommit)
+}
+
+func (LockfileSuite) TestLockUpdateRefreshesExistingModuleResolveEntry(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	gitDaemon, repoURL, source := startModuleResolveGitServiceWithRepo(ctx, t, c)
+	initialCommit := gitRepoHeadCommit(ctx, t, c, gitDaemon, repoURL)
+	newCommit := advanceGitRepo(ctx, t, c, gitDaemon, repoURL, "README.md", "second revision")
+	require.NotEqual(t, initialCommit, newCommit)
+
+	updated := moduleResolveClientContainer(ctx, t, c, gitDaemon, source).
+		WithNewFile(".dagger/lock", mustMarshalModuleResolveLock(t, source, initialCommit, workspace.PolicyFloat)).
+		WithExec([]string{"dagger", "--silent", "lock", "update"})
+
+	_, err := updated.Stdout(ctx)
+	require.NoError(t, err)
+
+	lockContents, err := updated.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	assertModuleResolveLockEntry(t, []byte(lockContents), source, workspace.PolicyFloat)
+	require.NotContains(t, lockContents, initialCommit)
+	require.Contains(t, lockContents, newCommit)
+}
+
+func (LockfileSuite) TestWorkspaceUpdate(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	lockPath, originalLock := writeContainerFromLock(t, workdir, lockTestPlatform(ctx, t), "sha256:"+strings.Repeat("0", 64), workspace.PolicyFloat)
+	updateQueryPath := writeQueryDoc(t, workdir, "update.graphql", workspaceUpdateQuery)
+	updateExportQueryPath := writeQueryDoc(t, workdir, "update-export.graphql", workspaceUpdateExportQuery)
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", updateQueryPath)
+	require.NoError(t, err)
+	require.Contains(t, string(out), ".dagger/lock")
+
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.Equal(t, originalLock, string(lockBytes))
+
+	_, err = hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", updateExportQueryPath)
+	require.NoError(t, err)
+
+	lockBytes, err = os.ReadFile(lockPath)
+	require.NoError(t, err)
+	require.NotEqual(t, originalLock, string(lockBytes))
+	assertContainerFromLockEntry(t, lockBytes, workspace.PolicyFloat)
+}
+
+func (LockfileSuite) TestWorkspaceUpdateRequiresLockfile(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	updateQueryPath := writeQueryDoc(t, workdir, "update.graphql", workspaceUpdateQuery)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", updateQueryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "workspace lockfile does not exist")
+}
+
+func (LockfileSuite) TestWorkspaceUpdateNestedQuery(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	staleLock := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), "sha256:"+strings.Repeat("1", 64), workspace.PolicyFloat)
+	updated := daggerCliBase(t, c).
+		WithNewFile(".dagger/lock", staleLock).
+		WithNewFile("update.graphql", workspaceUpdateExportQuery).
+		With(daggerExec("--silent", "query", "--doc", "update.graphql"))
+
+	_, err := updated.Stdout(ctx)
+	require.NoError(t, err)
+
+	lockContents, err := updated.File("/work/.dagger/lock").Contents(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, staleLock, lockContents)
+	assertContainerFromLockEntry(t, []byte(lockContents), workspace.PolicyFloat)
+}
+
+func writeContainerFromQuery(t *testctx.T, workdir string) string {
+	return writeQueryDoc(t, workdir, "query.graphql", containerFromQuery)
+}
+
+func writeQueryDoc(t *testctx.T, workdir, name, contents string) string {
+	t.Helper()
+
+	queryPath := filepath.Join(workdir, name)
+	require.NoError(t, os.WriteFile(queryPath, []byte(contents), 0o600))
+	return queryPath
+}
+
+func writeContainerFromLock(t *testctx.T, workdir, platform, digest string, policy workspace.LockPolicy) (string, string) {
+	t.Helper()
+
+	lockPath := filepath.Join(workdir, ".dagger", "lock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(lockPath), 0o755))
+
+	lockContents := mustMarshalContainerFromLock(t, platform, digest, policy)
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+	return lockPath, lockContents
+}
+
+func writeGitRefLock(t *testctx.T, workdir, operation, name, commit string, policy workspace.LockPolicy) (string, string) {
+	t.Helper()
+
+	lockPath := filepath.Join(workdir, ".dagger", "lock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(lockPath), 0o755))
+
+	lockContents := mustMarshalGitRefLock(t, operation, name, commit, policy)
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+	return lockPath, lockContents
+}
+
+func mustMarshalContainerFromLock(t *testctx.T, platform, digest string, policy workspace.LockPolicy) string {
+	t.Helper()
+
+	lock := workspace.NewLock()
+	require.NoError(t, lock.SetLookup("", "container.from", []any{"docker.io/library/alpine:latest", platform}, workspace.LookupResult{
+		Value:  digest,
+		Policy: policy,
+	}))
+
+	lockBytes, err := lock.Marshal()
+	require.NoError(t, err)
+	return string(lockBytes)
+}
+
+func mustMarshalGitRefLock(t *testctx.T, operation, name, commit string, policy workspace.LockPolicy) string {
+	t.Helper()
+
+	lock := workspace.NewLock()
+	inputs := []any{lockTestGitRepoURL}
+	if name != "" {
+		inputs = append(inputs, name)
+	}
+	require.NoError(t, lock.SetLookup("", operation, inputs, workspace.LookupResult{
+		Value:  commit,
+		Policy: policy,
+	}))
+
+	lockBytes, err := lock.Marshal()
+	require.NoError(t, err)
+	return string(lockBytes)
+}
+
+func mustMarshalModuleResolveLock(t *testctx.T, source, commit string, policy workspace.LockPolicy) string {
+	t.Helper()
+
+	lock := workspace.NewLock()
+	require.NoError(t, lock.SetModuleResolve(source, workspace.LookupResult{
+		Value:  commit,
+		Policy: policy,
+	}))
+
+	lockBytes, err := lock.Marshal()
+	require.NoError(t, err)
+	return string(lockBytes)
+}
+
+func lockTestPlatform(ctx context.Context, t *testctx.T) string {
+	t.Helper()
+
+	c := connect(ctx, t)
+	platform, err := c.DefaultPlatform(ctx)
+	require.NoError(t, err)
+	return string(platform)
+}
+
+func assertContainerFromLockEntry(t *testctx.T, lockBytes []byte, expectedPolicy workspace.LockPolicy) {
+	t.Helper()
+	parsed, err := lockfile.Parse(lockBytes)
+	require.NoError(t, err)
+
+	var found bool
+	for _, entry := range parsed.Entries() {
+		if entry.Namespace != "" || entry.Operation != "container.from" {
+			continue
+		}
+		found = true
+		require.Len(t, entry.Inputs, 2)
+
+		ref, ok := entry.Inputs[0].(string)
+		require.True(t, ok)
+		require.Contains(t, ref, "alpine:latest")
+
+		require.Equal(t, string(expectedPolicy), entry.Policy)
+
+		value, ok := entry.Value.(string)
+		require.True(t, ok)
+		require.True(t, strings.HasPrefix(value, "sha256:"))
+	}
+
+	require.True(t, found, "expected container.from entry in lockfile")
+}
+
+func assertGitLockEntry(t *testctx.T, lockBytes []byte, operation string, expectedInputs []any, expectedPolicy workspace.LockPolicy) {
+	t.Helper()
+	parsed, err := lockfile.Parse(lockBytes)
+	require.NoError(t, err)
+
+	var found bool
+	for _, entry := range parsed.Entries() {
+		if entry.Namespace != "" || entry.Operation != operation {
+			continue
+		}
+		if !equalLockInputs(entry.Inputs, expectedInputs) {
+			continue
+		}
+
+		found = true
+		require.Equal(t, string(expectedPolicy), entry.Policy)
+
+		value, ok := entry.Value.(string)
+		require.True(t, ok)
+		require.True(t, len(value) == 40 || strings.HasPrefix(value, "sha256:"))
+	}
+
+	require.True(t, found, "expected %s entry in lockfile", operation)
+}
+
+func assertModuleResolveLockEntry(t *testctx.T, lockBytes []byte, source string, expectedPolicy workspace.LockPolicy) {
+	t.Helper()
+	parsed, err := lockfile.Parse(lockBytes)
+	require.NoError(t, err)
+
+	var found bool
+	for _, entry := range parsed.Entries() {
+		if entry.Namespace != "" || entry.Operation != "modules.resolve" {
+			continue
+		}
+		if !equalLockInputs(entry.Inputs, []any{source}) {
+			continue
+		}
+
+		found = true
+		require.Equal(t, string(expectedPolicy), entry.Policy)
+
+		value, ok := entry.Value.(string)
+		require.True(t, ok)
+		require.Len(t, value, 40)
+	}
+
+	require.True(t, found, "expected modules.resolve entry in lockfile")
+}
+
+func equalLockInputs(actual, expected []any) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func startModuleResolveGitService(ctx context.Context, t *testctx.T, c *dagger.Client) (*dagger.Service, string) {
+	t.Helper()
+	gitDaemon, _, source := startModuleResolveGitServiceWithRepo(ctx, t, c)
+	return gitDaemon, source
+}
+
+func startModuleResolveGitServiceWithRepo(ctx context.Context, t *testctx.T, c *dagger.Client) (*dagger.Service, string, string) {
+	t.Helper()
+
+	content := c.Directory().
+		WithNewFile("dagger.json", `{"name":"lockmod","engineVersion":"latest"}`).
+		WithNewFile("README.md", "first revision")
+
+	gitDir := c.Container().
+		From(alpineImage).
+		WithExec([]string{"apk", "add", "git"}).
+		WithDirectory("/root/srv", makeGitDir(c, content, "main")).
+		WithExec([]string{"git", "config", "-f", "/root/srv/repo.git/config", "http.receivepack", "true"}).
+		Directory("/root/srv")
+
+	hostname := identity.NewID() + ".test"
+	gitDaemon, repoBaseURL := gitSmartHTTPServiceDirAuth(ctx, t, c, hostname, gitDir, "", nil)
+	repoURL := repoBaseURL + "/repo.git"
+	gitDaemon, err := gitDaemon.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := gitDaemon.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	return gitDaemon, repoURL, repoURL + "@main"
+}
+
+func moduleSourceCommitQuery(source string) string {
+	return fmt.Sprintf(`{
+  moduleSource(refString: %q) {
+    commit
+  }
+}
+`, source)
+}
+
+func moduleResolveClientContainer(
+	ctx context.Context,
+	t *testctx.T,
+	c *dagger.Client,
+	gitSvc *dagger.Service,
+	source string,
+) *dagger.Container {
+	t.Helper()
+
+	host := moduleResolveServiceHost(t, source)
+	devEngine := devEngineContainerAsService(devEngineContainer(c, func(ctr *dagger.Container) *dagger.Container {
+		return ctr.WithServiceBinding(host, gitSvc)
+	}))
+	return engineClientContainer(ctx, t, c, devEngine).WithWorkdir("/work")
+}
+
+func moduleResolveServiceHost(t *testctx.T, rawURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	host := parsed.Hostname()
+	require.NotEmpty(t, host)
+	return host
+}
+
+func gitRepoHeadCommit(ctx context.Context, t *testctx.T, c *dagger.Client, svc *dagger.Service, repoURL string) string {
+	t.Helper()
+
+	commit, err := c.Container().
+		From(alpineImage).
+		WithExec([]string{"apk", "add", "git"}).
+		WithServiceBinding(moduleResolveServiceHost(t, repoURL), svc).
+		WithWorkdir("/src").
+		WithExec([]string{"git", "clone", repoURL, "."}).
+		WithExec([]string{"git", "rev-parse", "HEAD"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	return strings.TrimSpace(commit)
+}
+
+func advanceGitRepo(ctx context.Context, t *testctx.T, c *dagger.Client, svc *dagger.Service, repoURL, path, contents string) string {
+	t.Helper()
+
+	commit, err := c.Container().
+		From(alpineImage).
+		WithExec([]string{"apk", "add", "git"}).
+		With(gitUserConfig).
+		WithServiceBinding(moduleResolveServiceHost(t, repoURL), svc).
+		WithWorkdir("/src").
+		WithExec([]string{"git", "clone", repoURL, "."}).
+		WithNewFile(path, contents).
+		WithExec([]string{"git", "add", path}).
+		WithExec([]string{"git", "commit", "-m", "update " + path}).
+		WithExec([]string{"git", "push", "origin", "main"}).
+		WithExec([]string{"git", "rev-parse", "HEAD"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	return strings.TrimSpace(commit)
+}

--- a/core/lockfile_update.go
+++ b/core/lockfile_update.go
@@ -1,0 +1,295 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/platforms"
+	"github.com/dagger/dagger/core/workspace"
+	serverresolver "github.com/dagger/dagger/engine/server/resolver"
+	"github.com/dagger/dagger/util/gitutil"
+	"github.com/distribution/reference"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	lockCoreNamespace           = ""
+	lockContainerFromOperation  = "container.from"
+	lockModulesResolveOperation = "modules.resolve"
+	lockGitHeadOperation        = "git.head"
+	lockGitRefOperation         = "git.ref"
+	lockGitBranchOperation      = "git.branch"
+	lockGitTagOperation         = "git.tag"
+)
+
+// UpdateWorkspaceLock refreshes the existing entries in a workspace lockfile in place.
+func UpdateWorkspaceLock(ctx context.Context, query *Query, lock *workspace.Lock) error {
+	entries, err := lock.Entries()
+	if err != nil {
+		return fmt.Errorf("read lock entries: %w", err)
+	}
+
+	for _, entry := range entries {
+		result, err := updateWorkspaceLockEntry(ctx, query, entry)
+		if err != nil {
+			return err
+		}
+		if err := lock.SetLookup(entry.Namespace, entry.Operation, entry.Inputs, result); err != nil {
+			return fmt.Errorf("rewrite lock entry for %s %v: %w", entry.Operation, entry.Inputs, err)
+		}
+	}
+
+	return nil
+}
+
+func updateWorkspaceLockEntry(ctx context.Context, query *Query, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	switch {
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockContainerFromOperation:
+		return updateContainerFromLockEntry(ctx, query, entry)
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockModulesResolveOperation:
+		return updateModuleResolveLockEntry(ctx, query, entry)
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockGitHeadOperation:
+		return updateGitHeadLockEntry(ctx, entry)
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockGitRefOperation:
+		return updateGitRefLockEntry(ctx, entry)
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockGitBranchOperation:
+		return updateGitBranchLockEntry(ctx, entry)
+	case entry.Namespace == lockCoreNamespace && entry.Operation == lockGitTagOperation:
+		return updateGitTagLockEntry(ctx, entry)
+	default:
+		return workspace.LookupResult{}, fmt.Errorf("unsupported lock entry %q %q", entry.Namespace, entry.Operation)
+	}
+}
+
+func updateContainerFromLockEntry(ctx context.Context, query *Query, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	if len(entry.Inputs) != 2 {
+		return workspace.LookupResult{}, fmt.Errorf("invalid container.from inputs %v", entry.Inputs)
+	}
+
+	ref, ok := entry.Inputs[0].(string)
+	if !ok || ref == "" {
+		return workspace.LookupResult{}, fmt.Errorf("invalid container.from ref %v", entry.Inputs[0])
+	}
+
+	platform, ok := entry.Inputs[1].(string)
+	if !ok || platform == "" {
+		return workspace.LookupResult{}, fmt.Errorf("invalid container.from platform %v", entry.Inputs[1])
+	}
+
+	digest, err := resolveContainerFromDigest(ctx, query, ref, platform)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+
+	return workspace.LookupResult{
+		Value:  digest,
+		Policy: entry.Result.Policy,
+	}, nil
+}
+
+func updateModuleResolveLockEntry(ctx context.Context, query *Query, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	if len(entry.Inputs) != 1 {
+		return workspace.LookupResult{}, fmt.Errorf("invalid %s inputs %v", lockModulesResolveOperation, entry.Inputs)
+	}
+
+	source, ok := entry.Inputs[0].(string)
+	if !ok || source == "" {
+		return workspace.LookupResult{}, fmt.Errorf("invalid %s source %v", lockModulesResolveOperation, entry.Inputs[0])
+	}
+
+	commit, err := resolveModuleSourceCommit(ctx, query, source)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+
+	return workspace.LookupResult{
+		Value:  commit,
+		Policy: entry.Result.Policy,
+	}, nil
+}
+
+func resolveContainerFromDigest(ctx context.Context, query *Query, refString, platformString string) (string, error) {
+	rslvr, err := query.RegistryResolver(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get registry resolver: %w", err)
+	}
+
+	refName, err := reference.ParseNormalizedNamed(refString)
+	if err != nil {
+		return "", fmt.Errorf("parse image address %q: %w", refString, err)
+	}
+	refName = reference.TagNameOnly(refName)
+
+	platform, err := platforms.Parse(platformString)
+	if err != nil {
+		return "", fmt.Errorf("parse platform %q: %w", platformString, err)
+	}
+
+	_, resolvedDigest, _, err := rslvr.ResolveImageConfig(ctx, refName.String(), serverresolver.ResolveImageConfigOpts{
+		Platform:    ptr(platform),
+		ResolveMode: serverresolver.ResolveModeDefault,
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve image %q (platform: %q): %w", refName.String(), platformString, err)
+	}
+
+	return resolvedDigest.String(), nil
+}
+
+func updateGitHeadLockEntry(ctx context.Context, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	if len(entry.Inputs) != 1 {
+		return workspace.LookupResult{}, fmt.Errorf("invalid git.head inputs %v", entry.Inputs)
+	}
+	remoteURL, ok := entry.Inputs[0].(string)
+	if !ok || remoteURL == "" {
+		return workspace.LookupResult{}, fmt.Errorf("invalid git.head remote %v", entry.Inputs[0])
+	}
+	commit, err := resolveGitRefCommit(ctx, remoteURL, "head", "")
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	return workspace.LookupResult{Value: commit, Policy: entry.Result.Policy}, nil
+}
+
+func updateGitRefLockEntry(ctx context.Context, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	remoteURL, name, err := parseGitLookupInputs("git.ref", entry.Inputs)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	commit, err := resolveGitRefCommit(ctx, remoteURL, "ref", name)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	return workspace.LookupResult{Value: commit, Policy: entry.Result.Policy}, nil
+}
+
+func updateGitBranchLockEntry(ctx context.Context, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	remoteURL, name, err := parseGitLookupInputs("git.branch", entry.Inputs)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	commit, err := resolveGitRefCommit(ctx, remoteURL, "branch", name)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	return workspace.LookupResult{Value: commit, Policy: entry.Result.Policy}, nil
+}
+
+func updateGitTagLockEntry(ctx context.Context, entry workspace.LookupEntry) (workspace.LookupResult, error) {
+	remoteURL, name, err := parseGitLookupInputs("git.tag", entry.Inputs)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	commit, err := resolveGitRefCommit(ctx, remoteURL, "tag", name)
+	if err != nil {
+		return workspace.LookupResult{}, err
+	}
+	return workspace.LookupResult{Value: commit, Policy: entry.Result.Policy}, nil
+}
+
+func resolveModuleSourceCommit(ctx context.Context, query *Query, source string) (string, error) {
+	bk, err := query.Engine(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get engine client: %w", err)
+	}
+
+	parsedRef, err := ParseRefString(ctx, NewCallerStatFS(bk), source, "")
+	if err != nil {
+		return "", fmt.Errorf("parse module source %q: %w", source, err)
+	}
+	if parsedRef.Kind != ModuleSourceKindGit {
+		return "", fmt.Errorf("module source %q is not a git source", source)
+	}
+
+	return resolveParsedGitRefCommit(ctx, parsedRef.Git, "")
+}
+
+func parseGitLookupInputs(operation string, inputs []any) (string, string, error) {
+	if len(inputs) != 2 {
+		return "", "", fmt.Errorf("invalid %s inputs %v", operation, inputs)
+	}
+	remoteURL, ok := inputs[0].(string)
+	if !ok || remoteURL == "" {
+		return "", "", fmt.Errorf("invalid %s remote %v", operation, inputs[0])
+	}
+	name, ok := inputs[1].(string)
+	if !ok || name == "" {
+		return "", "", fmt.Errorf("invalid %s name %v", operation, inputs[1])
+	}
+	return remoteURL, name, nil
+}
+
+func resolveGitRefCommit(ctx context.Context, remoteURL, field, name string) (string, error) {
+	remote, err := loadRemoteGitMetadata(ctx, remoteURL)
+	if err != nil {
+		return "", err
+	}
+
+	target := "HEAD"
+	switch field {
+	case "head":
+	case "ref", "branch", "tag":
+		target = name
+	default:
+		return "", fmt.Errorf("unsupported git lock field %q", field)
+	}
+
+	ref, err := remote.Lookup(target)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s %q for %q: %w", field, name, remoteURL, err)
+	}
+	return ref.SHA, nil
+}
+
+func resolveParsedGitRefCommit(ctx context.Context, parsed *ParsedGitRefString, pinCommitRef string) (string, error) {
+	remote, err := loadRemoteGitMetadata(ctx, parsed.cloneRef)
+	if err != nil {
+		return "", err
+	}
+
+	ref, err := resolveParsedGitRef(remote, parsed, pinCommitRef)
+	if err != nil {
+		return "", err
+	}
+	return ref.SHA, nil
+}
+
+func loadRemoteGitMetadata(ctx context.Context, remoteURL string) (*gitutil.Remote, error) {
+	gitURL, err := gitutil.ParseURL(remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse git URL %q: %w", remoteURL, err)
+	}
+
+	repo := &RemoteGitRepository{URL: gitURL}
+	remote, err := repo.Remote(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load git remote %q: %w", remoteURL, err)
+	}
+	return remote, nil
+}
+
+func resolveParsedGitRef(remote *gitutil.Remote, parsed *ParsedGitRefString, pinCommitRef string) (*gitutil.Ref, error) {
+	if gitutil.IsCommitSHA(pinCommitRef) {
+		return &gitutil.Ref{SHA: pinCommitRef}, nil
+	}
+
+	target := "HEAD"
+	switch {
+	case parsed.hasVersion && semver.IsValid(parsed.ModVersion):
+		matched, err := matchVersion(remote.Tags().ShortNames(), parsed.ModVersion, parsed.RepoRootSubdir)
+		if err != nil {
+			return nil, fmt.Errorf("matching version to tags: %w", err)
+		}
+		target = matched
+	case parsed.hasVersion:
+		target = parsed.ModVersion
+	case pinCommitRef != "":
+		target = pinCommitRef
+	}
+
+	ref, err := remote.Lookup(target)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git ref %q: %w", target, err)
+	}
+	return ref, nil
+}

--- a/core/lockfile_update.go
+++ b/core/lockfile_update.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/platforms"
@@ -255,17 +256,25 @@ func resolveParsedGitRefCommit(ctx context.Context, parsed *ParsedGitRefString, 
 }
 
 func loadRemoteGitMetadata(ctx context.Context, remoteURL string) (*gitutil.Remote, error) {
-	gitURL, err := gitutil.ParseURL(remoteURL)
+	candidates, err := gitutil.ParseCloneURL(remoteURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse git URL %q: %w", remoteURL, err)
 	}
 
-	repo := &RemoteGitRepository{URL: gitURL}
-	remote, err := repo.Remote(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("load git remote %q: %w", remoteURL, err)
+	var lastErr error
+	for _, gitURL := range candidates {
+		repo := &RemoteGitRepository{URL: gitURL}
+		remote, err := repo.Remote(ctx)
+		if err != nil {
+			if errors.Is(err, gitutil.ErrGitAuthFailed) {
+				lastErr = err
+				continue
+			}
+			return nil, fmt.Errorf("load git remote %q: %w", remoteURL, err)
+		}
+		return remote, nil
 	}
-	return remote, nil
+	return nil, fmt.Errorf("load git remote %q: %w", remoteURL, lastErr)
 }
 
 func resolveParsedGitRef(remote *gitutil.Remote, parsed *ParsedGitRefString, pinCommitRef string) (*gitutil.Ref, error) {

--- a/core/lockfile_update_test.go
+++ b/core/lockfile_update_test.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateWorkspaceLockEntry(t *testing.T) {
+	t.Parallel()
+
+	_, err := updateWorkspaceLockEntry(context.Background(), nil, workspace.LookupEntry{
+		Namespace: "acme",
+		Operation: "resolve",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `unsupported lock entry "acme" "resolve"`)
+}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -818,6 +818,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 		Call:              curCall,
 		ExecID:            identity.NewID(),
 		Internal:          true,
+		LockMode:          clientMetadata.LockMode,
 		AllowedLLMModules: clientMetadata.AllowedLLMModules,
 	}
 	if curCall != nil {

--- a/core/query.go
+++ b/core/query.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/dagger/dagger/auth"
+	workspacepkg "github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
@@ -35,7 +36,10 @@ type Query struct {
 	ConstructorArgs map[string]dagql.Input
 }
 
-var ErrNoCurrentModule = fmt.Errorf("no current module")
+var (
+	ErrNoCurrentModule    = fmt.Errorf("no current module")
+	ErrNoCurrentWorkspace = fmt.Errorf("no current workspace")
+)
 
 // APIs from the server+session+client that are needed by core APIs
 type Server interface {
@@ -74,6 +78,13 @@ type Server interface {
 
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
+
+	// A snapshot of the current workspace lockfile for ambient live locking.
+	// Returns ok=false when lock-backed workspace access is unavailable.
+	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)
+
+	// Stage a lockfile lookup result for the current workspace's live lock state.
+	SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error
 
 	// The Client metadata of a specific client ID within the same session as the
 	// current client.

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -21,9 +21,11 @@ import (
 	telemetry "github.com/dagger/otel-go"
 	"github.com/distribution/reference"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
+	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
@@ -914,6 +916,8 @@ type containerFromArgs struct {
 	Address string
 }
 
+const lockContainerFromOperation = "container.from"
+
 // if the image ref has a digest, then it's immutable and we don't need to scope it to the session. If it's just a tag, then
 // we scope to the session so that resolution of a tag->digest is cached within the session but not across.
 var fromSessionScopeInput = dagql.ImplicitInput{
@@ -1052,19 +1056,78 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		return inst, nil
 	}
 
-	// Doesn't have a digest, resolve that now and re-call this field using the canonical
-	// digested ref instead. This ensures the ID returned here is always stable w/ the
-	// digested image ref.
-	_, digest, _, err := rslvr.ResolveImageConfig(ctx, refName.String(), serverresolver.ResolveImageConfigOpts{
-		Platform:    ptr(platform.Spec()),
-		ResolveMode: serverresolver.ResolveModeDefault,
-	})
+	lockMode, err := currentLookupLockMode(ctx)
 	if err != nil {
-		return inst, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refName.String(), platform.Format(), err)
+		return inst, fmt.Errorf("container.from lock mode: %w", err)
 	}
-	refName, err = reference.WithDigest(refName, digest)
+
+	var lookupLock *workspaceLookupLock
+	var rawLock *workspace.Lock
+	if lockMode != workspace.LockModeDisabled {
+		lookupLock, err = loadWorkspaceLookupLock(ctx, query)
+		if err != nil {
+			return inst, fmt.Errorf("container.from lockfile: %w", err)
+		}
+		if lookupLock == nil {
+			return inst, fmt.Errorf("experimental lockfile support is local-only")
+		}
+		rawLock = lookupLock.lock
+	}
+
+	lockInputs := []any{refName.String(), platform.Format()}
+	lockResolution, err := resolveLookupFromLock(
+		lockMode,
+		rawLock,
+		lockContainerFromOperation,
+		lockInputs,
+		workspace.PolicyPin,
+	)
 	if err != nil {
-		return inst, fmt.Errorf("failed to set digest on image %s: %w", refName.String(), err)
+		return inst, fmt.Errorf("container.from lock resolution: %w", err)
+	}
+
+	if lockResolution.Pin != "" {
+		resolvedDigest, err := digest.Parse(lockResolution.Pin)
+		if err != nil {
+			return inst, fmt.Errorf("invalid lock digest %q for image %q: %w", lockResolution.Pin, refName.String(), err)
+		}
+		refName, err = reference.WithDigest(refName, resolvedDigest)
+		if err != nil {
+			return inst, fmt.Errorf("failed to apply lock digest on image %s: %w", refName.String(), err)
+		}
+	} else {
+		// Doesn't have a digest, resolve that now and re-call this field using the canonical
+		// digested ref instead. This ensures the ID returned here is always stable w/ the
+		// digested image ref.
+		rslvr, err := query.RegistryResolver(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get registry resolver: %w", err)
+		}
+		_, resolvedDigest, _, err := rslvr.ResolveImageConfig(ctx, refName.String(), serverresolver.ResolveImageConfigOpts{
+			Platform:    ptr(platform.Spec()),
+			ResolveMode: serverresolver.ResolveModeDefault,
+		})
+		if err != nil {
+			return inst, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refName.String(), platform.Format(), err)
+		}
+		refName, err = reference.WithDigest(refName, resolvedDigest)
+		if err != nil {
+			return inst, fmt.Errorf("failed to set digest on image %s: %w", refName.String(), err)
+		}
+
+		if lockResolution.ShouldWrite && lookupLock != nil {
+			if err := lookupLock.SetLookup(
+				lockCoreNamespace,
+				lockContainerFromOperation,
+				lockInputs,
+				workspace.LookupResult{
+					Value:  resolvedDigest.String(),
+					Policy: lockResolution.Policy,
+				},
+			); err != nil {
+				return inst, fmt.Errorf("set lock entry for container.from: %w", err)
+			}
+		}
 	}
 
 	ctx, span := core.Tracer(ctx).Start(ctx, fmt.Sprintf("from %s", refName),

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -14,12 +14,14 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/engine/sources/netconfhttp"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
+	"github.com/opencontainers/go-digest"
 	"golang.org/x/mod/semver"
 
 	"github.com/dagger/dagger/util/gitutil"
@@ -726,6 +728,11 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 		return inst, err
 	}
 
+	return inst, nil
+}
+
+func calcGitContentDigest(gitRef *core.GitRef) digest.Digest {
+	repo := gitRef.Repo.Self()
 	dgstInputs := []string{
 		// all details of the remote repo
 		repo.URL.Value.String(),
@@ -738,21 +745,18 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 		// a token but hits cache for a dir where a ssh sock was used)
 		// -> see below
 	}
-
-	if sshAuthSock.Self() != nil {
-		dgstInputs = append(dgstInputs, "sshAuthSock", string(sshAuthSock.Self().Handle))
+	if remoteRepo, ok := repo.Backend.(*core.RemoteGitRepository); ok {
+		if sshSock := remoteRepo.SSHAuthSocket.Self(); sshSock != nil {
+			dgstInputs = append(dgstInputs, "sshAuthSock", string(sshSock.Handle))
+		}
+		if remoteRepo.AuthToken.Self() != nil {
+			dgstInputs = append(dgstInputs, "authToken", "true")
+		}
+		if remoteRepo.AuthHeader.Self() != nil {
+			dgstInputs = append(dgstInputs, "authHeader", "true")
+		}
 	}
-	if httpAuthToken.Self() != nil {
-		dgstInputs = append(dgstInputs, "authToken", strconv.FormatBool(httpAuthToken.Self() != nil))
-	}
-	if httpAuthHeader.Self() != nil {
-		dgstInputs = append(dgstInputs, "authHeader", strconv.FormatBool(httpAuthHeader.Self() != nil))
-	}
-	inst, err = inst.WithContentDigest(ctx, hashutil.HashStrings(dgstInputs...))
-	if err != nil {
-		return inst, err
-	}
-	return inst, nil
+	return hashutil.HashStrings(dgstInputs...)
 }
 
 func IsRemotePublic(ctx context.Context, remote *gitutil.GitURL) (bool, error) {
@@ -777,23 +781,143 @@ func IsRemotePublic(ctx context.Context, remote *gitutil.GitURL) (bool, error) {
 }
 
 type refArgs struct {
-	Name   string
-	Commit string `default:"" internal:"true"`
+	Name          string
+	Commit        string `default:"" internal:"true"`
+	LockOperation string `default:"" internal:"true"`
+	LockPolicy    string `default:"" internal:"true"`
+	LockName      string `default:"" internal:"true"`
+	LockedName    string `default:"" internal:"true"`
+}
+
+const (
+	lockGitHeadOperation   = "git.head"
+	lockGitRefOperation    = "git.ref"
+	lockGitBranchOperation = "git.branch"
+	lockGitTagOperation    = "git.tag"
+)
+
+func gitLockInputs(repo *core.GitRepository, operation, name string) ([]any, error) {
+	remoteRepo, ok := repo.Backend.(*core.RemoteGitRepository)
+	if !ok {
+		return nil, fmt.Errorf("git locking only supports remote repositories")
+	}
+
+	switch operation {
+	case lockGitHeadOperation:
+		return []any{remoteRepo.URL.Remote()}, nil
+	case lockGitRefOperation, lockGitBranchOperation, lockGitTagOperation:
+		return []any{remoteRepo.URL.Remote(), name}, nil
+	default:
+		return nil, fmt.Errorf("unsupported git lock operation %q", operation)
+	}
+}
+
+func gitRefLockPolicy(ref *gitutil.Ref) workspace.LockPolicy {
+	if ref != nil && strings.HasPrefix(ref.Name, "refs/tags/") {
+		return workspace.PolicyPin
+	}
+	return workspace.PolicyFloat
 }
 
 func (s *gitSchema) ref(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], args refArgs) (inst dagql.Result[*core.GitRef], _ error) {
 	repo := parent.Self()
+	if args.Commit != "" && !gitutil.IsCommitSHA(args.Commit) {
+		return inst, fmt.Errorf("invalid commit SHA: %q", args.Commit)
+	}
+	if args.LockOperation == "" && args.Commit == "" && !gitutil.IsCommitSHA(args.Name) {
+		args.LockOperation = lockGitRefOperation
+		args.LockPolicy = string(workspace.PolicyFloat)
+		args.LockName = args.Name
+		if strings.HasPrefix(args.Name, "refs/") {
+			args.LockedName = args.Name
+		}
+	}
+	if args.LockOperation != "" {
+		if _, ok := repo.Backend.(*core.RemoteGitRepository); !ok {
+			args.LockOperation = ""
+		}
+	}
+
+	var (
+		lockResolution lookupLockResolution
+		lookupLock     *workspaceLookupLock
+	)
+	if args.Commit == "" && args.LockOperation != "" {
+		lockMode, err := currentLookupLockMode(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("%s lock mode: %w", args.LockOperation, err)
+		}
+		if lockMode != workspace.LockModeDisabled {
+			query, err := core.CurrentQuery(ctx)
+			if err != nil {
+				return inst, err
+			}
+			lookupLock, err = loadWorkspaceLookupLock(ctx, query)
+			if err != nil {
+				return inst, fmt.Errorf("%s lockfile: %w", args.LockOperation, err)
+			}
+			if lookupLock == nil {
+				return inst, fmt.Errorf("experimental lockfile support is local-only")
+			}
+			lockInputs, err := gitLockInputs(repo, args.LockOperation, args.LockName)
+			if err != nil {
+				return inst, fmt.Errorf("%s lock inputs: %w", args.LockOperation, err)
+			}
+			lockResolution, err = resolveLookupFromLock(
+				lockMode,
+				lookupLock.lock,
+				args.LockOperation,
+				lockInputs,
+				workspace.LockPolicy(args.LockPolicy),
+			)
+			if err != nil {
+				return inst, fmt.Errorf("%s lock resolution: %w", args.LockOperation, err)
+			}
+			if lockResolution.Pin != "" {
+				ref := &gitutil.Ref{
+					Name: args.LockedName,
+					SHA:  lockResolution.Pin,
+				}
+				return s.gitRefResult(ctx, parent, ref)
+			}
+		}
+	}
+
 	ref, err := repo.Remote.Lookup(args.Name)
 	if err != nil {
 		return inst, err
-	}
-	if args.Commit != "" && !gitutil.IsCommitSHA(args.Commit) {
-		return inst, fmt.Errorf("invalid commit SHA: %q", args.Commit)
 	}
 	if args.Commit != "" && args.Commit != ref.SHA {
 		ref.SHA = args.Commit
 	}
 
+	if args.Commit == "" && args.LockOperation != "" && lockResolution.ShouldWrite && lookupLock != nil {
+		policy := lockResolution.Policy
+		if !lockResolution.Found && args.LockOperation == lockGitRefOperation {
+			policy = gitRefLockPolicy(ref)
+		}
+		lockInputs, err := gitLockInputs(repo, args.LockOperation, args.LockName)
+		if err != nil {
+			return inst, fmt.Errorf("%s lock inputs: %w", args.LockOperation, err)
+		}
+		if err := lookupLock.SetLookup(
+			lockCoreNamespace,
+			args.LockOperation,
+			lockInputs,
+			workspace.LookupResult{
+				Value:  ref.SHA,
+				Policy: policy,
+			},
+		); err != nil {
+			return inst, fmt.Errorf("set lock entry for %s: %w", args.LockOperation, err)
+		}
+	}
+
+	return s.gitRefResult(ctx, parent, ref)
+}
+
+func (s *gitSchema) gitRefResult(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], ref *gitutil.Ref) (inst dagql.Result[*core.GitRef], _ error) {
+	repo := parent.Self()
 	refBackend, err := repo.Backend.Get(ctx, ref)
 	if err != nil {
 		return inst, err
@@ -837,7 +961,11 @@ func (s *gitSchema) ref(ctx context.Context, parent dagql.ObjectResult[*core.Git
 }
 
 func (s *gitSchema) head(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], args struct{}) (inst dagql.Result[*core.GitRef], _ error) {
-	return s.ref(ctx, parent, refArgs{Name: "HEAD"})
+	return s.ref(ctx, parent, refArgs{
+		Name:          "HEAD",
+		LockOperation: lockGitHeadOperation,
+		LockPolicy:    string(workspace.PolicyFloat),
+	})
 }
 
 func (s *gitSchema) latestVersion(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], args struct{}) (inst dagql.Result[*core.GitRef], _ error) {
@@ -872,19 +1000,35 @@ func (s *gitSchema) commit(ctx context.Context, parent dagql.ObjectResult[*core.
 type branchArgs refArgs
 
 func (s *gitSchema) branch(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], args branchArgs) (dagql.Result[*core.GitRef], error) {
+	lockName := args.Name
 	if supportsStrictRefs(ctx) {
 		args.Name = "refs/heads/" + strings.TrimPrefix(args.Name, "refs/heads/")
 	}
-	return s.ref(ctx, parent, refArgs(args))
+	return s.ref(ctx, parent, refArgs{
+		Name:          args.Name,
+		Commit:        args.Commit,
+		LockOperation: lockGitBranchOperation,
+		LockPolicy:    string(workspace.PolicyFloat),
+		LockName:      lockName,
+		LockedName:    args.Name,
+	})
 }
 
 type tagArgs refArgs
 
 func (s *gitSchema) tag(ctx context.Context, parent dagql.ObjectResult[*core.GitRepository], args tagArgs) (dagql.Result[*core.GitRef], error) {
+	lockName := args.Name
 	if supportsStrictRefs(ctx) {
 		args.Name = "refs/tags/" + strings.TrimPrefix(args.Name, "refs/tags/")
 	}
-	return s.ref(ctx, parent, refArgs(args))
+	return s.ref(ctx, parent, refArgs{
+		Name:          args.Name,
+		Commit:        args.Commit,
+		LockOperation: lockGitTagOperation,
+		LockPolicy:    string(workspace.PolicyPin),
+		LockName:      lockName,
+		LockedName:    args.Name,
+	})
 }
 
 type tagsArgs struct {
@@ -1104,6 +1248,11 @@ func (s *gitSchema) tree(ctx context.Context, parent dagql.ObjectResult[*core.Gi
 				return inst, err
 			}
 		}
+	}
+
+	inst, err = inst.WithContentDigest(ctx, calcGitContentDigest(parent.Self()))
+	if err != nil {
+		return inst, err
 	}
 
 	return inst, nil

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -238,13 +238,15 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 
 	remote, err := gitutil.ParseURL(args.URL)
 	if errors.Is(err, gitutil.ErrUnknownProtocol) {
-		try := [][]dagql.NamedInput{
-			{
-				{Name: "url", Value: dagql.NewString("https://" + args.URL)},
-			},
-			{
-				{Name: "url", Value: dagql.NewString("ssh://" + args.URL)},
-			},
+		candidates, candErr := gitutil.ParseCloneURL(args.URL)
+		if candErr != nil {
+			return inst, fmt.Errorf("failed to parse Git URL: %w", candErr)
+		}
+		try := make([][]dagql.NamedInput, 0, len(candidates))
+		for _, candidate := range candidates {
+			try = append(try, []dagql.NamedInput{
+				{Name: "url", Value: dagql.NewString(candidate.String())},
+			})
 		}
 		if args.Commit != "" {
 			for i := range try {

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -731,32 +731,50 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 	return inst, nil
 }
 
-func calcGitContentDigest(gitRef *core.GitRef) digest.Digest {
+func calcGitContentDigest(gitRef *core.GitRef, args treeArgs) (digest.Digest, error) {
+	if gitRef.Ref == nil {
+		return "", fmt.Errorf("cannot content-address remote git tree: missing ref")
+	}
+	if gitRef.Ref.SHA == "" {
+		return "", fmt.Errorf("cannot content-address remote git tree: ref %q has no resolved SHA", gitRef.Ref.Name)
+	}
+
 	repo := gitRef.Repo.Self()
+	remoteRepo, ok := repo.Backend.(*core.RemoteGitRepository)
+	if !ok {
+		return "", fmt.Errorf("cannot content-address non-remote git tree")
+	}
+
+	keepsGitDir := !(repo.DiscardGitDir || args.DiscardGitDir)
+
 	dgstInputs := []string{
-		// all details of the remote repo
-		repo.URL.Value.String(),
-		string(repo.Remote.Digest()),
-		// legacy args
-		strconv.FormatBool(repo.DiscardGitDir),
-		// also include what auth methods are used, currently we can't
-		// handle a cache hit where the result has a different auth
-		// method than the caller used (i.e. a git repo is pulled w/
-		// a token but hits cache for a dir where a ssh sock was used)
-		// -> see below
+		// A commit SHA only identifies an object inside a Git object database.
+		// The remote URL is part of the checkout source.
+		remoteRepo.URL.Remote(),
+
+		// The resolved commit selects the files to check out.
+		gitRef.Ref.SHA,
+
+		// The returned Directory may include or exclude .git based on both the
+		// repository keepGitDir option and tree(discardGitDir: ...).
+		strconv.FormatBool(keepsGitDir),
 	}
-	if remoteRepo, ok := repo.Backend.(*core.RemoteGitRepository); ok {
-		if sshSock := remoteRepo.SSHAuthSocket.Self(); sshSock != nil {
-			dgstInputs = append(dgstInputs, "sshAuthSock", string(sshSock.Handle))
-		}
-		if remoteRepo.AuthToken.Self() != nil {
-			dgstInputs = append(dgstInputs, "authToken", "true")
-		}
-		if remoteRepo.AuthHeader.Self() != nil {
-			dgstInputs = append(dgstInputs, "authHeader", "true")
-		}
+
+	if keepsGitDir {
+		dgstInputs = append(dgstInputs,
+			// Depth changes retained git history. For example, `git log` sees one
+			// commit at the default shallow depth but more with tree(depth: 5).
+			strconv.Itoa(args.Depth),
+
+			// includeTags changes which tag refs are populated under .git.
+			strconv.FormatBool(args.IncludeTags),
+
+			// ref.Name affects named-ref vs detached-SHA checkout metadata.
+			gitRef.Ref.Name,
+		)
 	}
-	return hashutil.HashStrings(dgstInputs...)
+
+	return hashutil.HashStrings(dgstInputs...), nil
 }
 
 func IsRemotePublic(ctx context.Context, remote *gitutil.GitURL) (bool, error) {
@@ -1217,42 +1235,15 @@ func (s *gitSchema) tree(ctx context.Context, parent dagql.ObjectResult[*core.Gi
 		return inst, err
 	}
 
-	remoteRepo, isRemoteRepo := parent.Self().Repo.Self().Backend.(*core.RemoteGitRepository)
-	if isRemoteRepo {
-		usedAuth := remoteRepo.AuthToken.Self() != nil ||
-			remoteRepo.AuthHeader.Self() != nil ||
-			remoteRepo.SSHAuthSocket.Self() != nil
-		if usedAuth {
-			// do a full hash of the actual files/dirs in the private git repo so
-			// that the cache key of the returned value can't be known unless the
-			// full contents are already known
-			if lazy := inst.Self().LazyEvalFunc(); lazy != nil {
-				if err := lazy(ctx); err != nil {
-					return inst, fmt.Errorf("failed to evaluate tree before hashing: %w", err)
-				}
-			}
-			snapshot, ok := inst.Self().Snapshot.Peek()
-			if !ok {
-				return inst, fmt.Errorf("failed to get tree snapshot: unset")
-			}
-			dirPath, ok := inst.Self().Dir.Peek()
-			if !ok {
-				return inst, fmt.Errorf("failed to get tree path: unset")
-			}
-			dgst, err := core.GetContentHashFromDirectory(ctx, snapshot, dirPath)
-			if err != nil {
-				return inst, fmt.Errorf("failed to get content hash: %w", err)
-			}
-			inst, err = inst.WithContentDigest(ctx, dgst)
-			if err != nil {
-				return inst, err
-			}
+	if _, ok := parent.Self().Repo.Self().Backend.(*core.RemoteGitRepository); ok {
+		dgst, err := calcGitContentDigest(parent.Self(), args)
+		if err != nil {
+			return inst, err
 		}
-	}
-
-	inst, err = inst.WithContentDigest(ctx, calcGitContentDigest(parent.Self()))
-	if err != nil {
-		return inst, err
+		inst, err = inst.WithContentDigest(ctx, dgst)
+		if err != nil {
+			return inst, err
+		}
 	}
 
 	return inst, nil

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -745,7 +745,7 @@ func calcGitContentDigest(gitRef *core.GitRef, args treeArgs) (digest.Digest, er
 		return "", fmt.Errorf("cannot content-address non-remote git tree")
 	}
 
-	keepsGitDir := !(repo.DiscardGitDir || args.DiscardGitDir)
+	keepsGitDir := !repo.DiscardGitDir && !args.DiscardGitDir
 
 	dgstInputs := []string{
 		// A commit SHA only identifies an object inside a Git object database.

--- a/core/schema/lockfile.go
+++ b/core/schema/lockfile.go
@@ -1,0 +1,169 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/engine"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	lockCoreNamespace           = ""
+	lockModulesResolveOperation = "modules.resolve"
+)
+
+type workspaceLookupLock struct {
+	ctx   context.Context
+	query *core.Query
+	lock  *workspace.Lock
+}
+
+func loadWorkspaceLookupLock(ctx context.Context, query *core.Query) (*workspaceLookupLock, error) {
+	lock, ok, err := query.CurrentWorkspaceLock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &workspaceLookupLock{
+		ctx:   ctx,
+		query: query,
+		lock:  lock,
+	}, nil
+}
+
+func (l *workspaceLookupLock) SetLookup(namespace, operation string, inputs []any, result workspace.LookupResult) error {
+	if l == nil {
+		return fmt.Errorf("workspace lock is required")
+	}
+	if err := l.query.SetCurrentWorkspaceLookup(l.ctx, namespace, operation, inputs, result); err != nil {
+		return err
+	}
+	if err := l.lock.SetLookup(namespace, operation, inputs, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func currentLookupLockMode(ctx context.Context) (workspace.LockMode, error) {
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("client metadata: %w", err)
+	}
+	return workspace.ResolveLockMode(clientMetadata.LockMode)
+}
+
+type lookupLockResolution struct {
+	Pin         string
+	Policy      workspace.LockPolicy
+	ShouldWrite bool
+	Found       bool
+}
+
+func resolveLookupFromLock(
+	lockMode workspace.LockMode,
+	lock *workspace.Lock,
+	operation string,
+	inputs []any,
+	requestedPolicy workspace.LockPolicy,
+) (lookupLockResolution, error) {
+	resolution := lookupLockResolution{
+		Policy: requestedPolicy,
+	}
+
+	if lockMode == workspace.LockModeDisabled {
+		return resolution, nil
+	}
+
+	if lock != nil {
+		if lockResult, ok, err := lock.GetLookup(lockCoreNamespace, operation, inputs); err != nil {
+			return resolution, fmt.Errorf("invalid lock entry for %s %v: %w", operation, inputs, err)
+		} else if ok {
+			resolution.Found = true
+			resolution.Policy = lockResult.Policy
+			switch lockMode {
+			case workspace.LockModeLive:
+				resolution.ShouldWrite = true
+				return resolution, nil
+			case workspace.LockModeFrozen:
+				resolution.Pin = lockResult.Value
+				return resolution, nil
+			case workspace.LockModePinned:
+				if resolution.Policy == workspace.PolicyPin {
+					resolution.Pin = lockResult.Value
+				} else {
+					resolution.ShouldWrite = true
+				}
+				return resolution, nil
+			default:
+				return resolution, fmt.Errorf("unsupported lock mode %q", lockMode)
+			}
+		}
+	}
+
+	switch lockMode {
+	case workspace.LockModeLive:
+		resolution.ShouldWrite = true
+		return resolution, nil
+	case workspace.LockModePinned:
+		resolution.ShouldWrite = true
+		return resolution, nil
+	case workspace.LockModeFrozen:
+		return resolution, fmt.Errorf("missing lock entry for %s %v", operation, inputs)
+	default:
+		return resolution, fmt.Errorf("unsupported lock mode %q", lockMode)
+	}
+}
+
+func lockHostPath(ws *core.Workspace) (string, error) {
+	if ws == nil {
+		return "", fmt.Errorf("workspace is required")
+	}
+	if ws.HostPath() == "" {
+		return "", fmt.Errorf("workspace has no host path")
+	}
+	return filepath.Join(ws.HostPath(), ws.Path, workspace.LockDirName, workspace.LockFileName), nil
+}
+
+func readWorkspaceLock(ctx context.Context, bk interface {
+	ReadCallerHostFile(ctx context.Context, path string) ([]byte, error)
+}, ws *core.Workspace) (*workspace.Lock, error) {
+	lock, _, err := readWorkspaceLockState(ctx, bk, ws)
+	return lock, err
+}
+
+func readWorkspaceLockState(ctx context.Context, bk interface {
+	ReadCallerHostFile(ctx context.Context, path string) ([]byte, error)
+}, ws *core.Workspace) (*workspace.Lock, bool, error) {
+	lockPath, err := lockHostPath(ws)
+	if err != nil {
+		return nil, false, err
+	}
+
+	data, err := bk.ReadCallerHostFile(ctx, lockPath)
+	if err != nil {
+		if isWorkspaceLockNotFound(err) {
+			return workspace.NewLock(), false, nil
+		}
+		return nil, false, fmt.Errorf("reading lock: %w", err)
+	}
+
+	lock, err := workspace.ParseLock(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing lock: %w", err)
+	}
+	return lock, true, nil
+}
+
+func isWorkspaceLockNotFound(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound
+}

--- a/core/schema/lockfile_test.go
+++ b/core/schema/lockfile_test.go
@@ -1,0 +1,224 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/engine"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWorkspaceLockReader struct {
+	data []byte
+	err  error
+}
+
+func (r fakeWorkspaceLockReader) ReadCallerHostFile(context.Context, string) ([]byte, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.data, nil
+}
+
+func TestResolveLookupFromLock(t *testing.T) {
+	t.Parallel()
+
+	const operation = "container.from"
+	inputs := []any{"alpine:latest", "linux/amd64"}
+
+	makeLock := func(t *testing.T, pin string, policy workspace.LockPolicy) *workspace.Lock {
+		t.Helper()
+		lock := workspace.NewLock()
+		require.NoError(t, lock.SetLookup(lockCoreNamespace, operation, inputs, workspace.LookupResult{
+			Value:  pin,
+			Policy: policy,
+		}))
+		return lock
+	}
+
+	t.Run("disabled ignores lockfile", func(t *testing.T) {
+		t.Parallel()
+		lock := makeLock(t, "sha256:abc123", workspace.PolicyPin)
+
+		res, err := resolveLookupFromLock(workspace.LockModeDisabled, lock, operation, inputs, workspace.PolicyFloat)
+		require.NoError(t, err)
+		require.Empty(t, res.Pin)
+		require.Equal(t, workspace.PolicyFloat, res.Policy)
+		require.False(t, res.ShouldWrite)
+	})
+
+	t.Run("live always resolves and writes", func(t *testing.T) {
+		t.Parallel()
+		lock := makeLock(t, "sha256:abc123", workspace.PolicyPin)
+
+		res, err := resolveLookupFromLock(workspace.LockModeLive, lock, operation, inputs, workspace.PolicyFloat)
+		require.NoError(t, err)
+		require.Empty(t, res.Pin)
+		require.Equal(t, workspace.PolicyPin, res.Policy)
+		require.True(t, res.ShouldWrite)
+	})
+
+	t.Run("existing pin entry", func(t *testing.T) {
+		t.Parallel()
+		lock := makeLock(t, "sha256:abc123", workspace.PolicyPin)
+
+		res, err := resolveLookupFromLock(workspace.LockModeFrozen, lock, operation, inputs, workspace.PolicyFloat)
+		require.NoError(t, err)
+		require.Equal(t, "sha256:abc123", res.Pin)
+		require.Equal(t, workspace.PolicyPin, res.Policy)
+		require.False(t, res.ShouldWrite)
+
+		res, err = resolveLookupFromLock(workspace.LockModePinned, lock, operation, inputs, workspace.PolicyFloat)
+		require.NoError(t, err)
+		require.Equal(t, "sha256:abc123", res.Pin)
+		require.Equal(t, workspace.PolicyPin, res.Policy)
+		require.False(t, res.ShouldWrite)
+	})
+
+	t.Run("existing float entry", func(t *testing.T) {
+		t.Parallel()
+		lock := makeLock(t, "sha256:def456", workspace.PolicyFloat)
+
+		res, err := resolveLookupFromLock(workspace.LockModeFrozen, lock, operation, inputs, workspace.PolicyPin)
+		require.NoError(t, err)
+		require.Equal(t, "sha256:def456", res.Pin)
+		require.Equal(t, workspace.PolicyFloat, res.Policy)
+		require.False(t, res.ShouldWrite)
+
+		res, err = resolveLookupFromLock(workspace.LockModePinned, lock, operation, inputs, workspace.PolicyPin)
+		require.NoError(t, err)
+		require.Empty(t, res.Pin)
+		require.Equal(t, workspace.PolicyFloat, res.Policy)
+		require.True(t, res.ShouldWrite)
+	})
+
+	t.Run("missing entry with requested pin policy", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := resolveLookupFromLock(workspace.LockModeFrozen, nil, operation, inputs, workspace.PolicyPin)
+		require.ErrorContains(t, err, "missing lock entry")
+		require.Equal(t, workspace.PolicyPin, res.Policy)
+
+		res, err = resolveLookupFromLock(workspace.LockModePinned, nil, operation, inputs, workspace.PolicyPin)
+		require.NoError(t, err)
+		require.Equal(t, workspace.PolicyPin, res.Policy)
+		require.Empty(t, res.Pin)
+		require.True(t, res.ShouldWrite)
+	})
+
+	t.Run("missing entry with requested float policy", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := resolveLookupFromLock(workspace.LockModeFrozen, nil, operation, inputs, workspace.PolicyFloat)
+		require.ErrorContains(t, err, "missing lock entry")
+		require.Equal(t, workspace.PolicyFloat, res.Policy)
+
+		res, err = resolveLookupFromLock(workspace.LockModePinned, nil, operation, inputs, workspace.PolicyFloat)
+		require.NoError(t, err)
+		require.Empty(t, res.Pin)
+		require.Equal(t, workspace.PolicyFloat, res.Policy)
+		require.True(t, res.ShouldWrite)
+	})
+
+	t.Run("invalid lock entry result", func(t *testing.T) {
+		t.Parallel()
+
+		data := strings.Join([]string{
+			`[["version","1"]]`,
+			`["","container.from",["alpine:latest","linux/amd64"],"sha256:abc123","invalid"]`,
+		}, "\n")
+		lock, err := workspace.ParseLock([]byte(data))
+		require.NoError(t, err)
+
+		_, err = resolveLookupFromLock(workspace.LockModePinned, lock, operation, inputs, workspace.PolicyFloat)
+		require.ErrorContains(t, err, "invalid lock entry")
+	})
+}
+
+func TestCurrentLookupLockMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to disabled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{})
+		mode, err := currentLookupLockMode(ctx)
+		require.NoError(t, err)
+		require.Equal(t, workspace.LockModeDisabled, mode)
+	})
+
+	t.Run("uses explicit mode", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+			LockMode: string(workspace.LockModeLive),
+		})
+		mode, err := currentLookupLockMode(ctx)
+		require.NoError(t, err)
+		require.Equal(t, workspace.LockModeLive, mode)
+	})
+}
+
+func TestLockHostPath(t *testing.T) {
+	t.Parallel()
+
+	ws := &core.Workspace{Path: filepath.Join("apps", "api")}
+	ws.SetHostPath("/repo")
+
+	lockPath, err := lockHostPath(ws)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("/repo", "apps", "api", ".dagger", "lock"), lockPath)
+}
+
+func TestReadWorkspaceLock(t *testing.T) {
+	t.Parallel()
+
+	makeWorkspace := func() *core.Workspace {
+		ws := &core.Workspace{Path: "."}
+		ws.SetHostPath("/repo")
+		return ws
+	}
+
+	t.Run("missing lockfile returns empty lock", func(t *testing.T) {
+		t.Parallel()
+
+		lock, err := readWorkspaceLock(context.Background(), fakeWorkspaceLockReader{
+			err: fmt.Errorf("failed to read file: %w", os.ErrNotExist),
+		}, makeWorkspace())
+		require.NoError(t, err)
+
+		lockBytes, err := lock.Marshal()
+		require.NoError(t, err)
+		require.Empty(t, lockBytes)
+	})
+
+	t.Run("invalid lockfile returns parse error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := readWorkspaceLock(context.Background(), fakeWorkspaceLockReader{
+			data: []byte("not-json"),
+		}, makeWorkspace())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "parsing lock")
+	})
+
+	t.Run("missing lockfile reports exists false", func(t *testing.T) {
+		t.Parallel()
+
+		lock, exists, err := readWorkspaceLockState(context.Background(), fakeWorkspaceLockReader{
+			err: fmt.Errorf("failed to read file: %w", os.ErrNotExist),
+		}, makeWorkspace())
+		require.NoError(t, err)
+		require.False(t, exists)
+
+		lockBytes, err := lock.Marshal()
+		require.NoError(t, err)
+		require.Empty(t, lockBytes)
+	})
+}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -14,18 +14,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dagger/dagger/engine/slog"
-	"github.com/dagger/dagger/util/parallel"
-
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/sdk"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/util/gitutil"
 	"github.com/dagger/dagger/util/hashutil"
+	"github.com/dagger/dagger/util/parallel"
 	telemetry "github.com/dagger/otel-go"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
@@ -322,7 +323,7 @@ func (s *moduleSourceSchema) moduleSource(
 			return inst, err
 		}
 	case core.ModuleSourceKindGit:
-		inst, err = s.gitModuleSource(ctx, query, parsedRef.Git, args.RefPin, !args.DisableFindUp)
+		inst, err = s.gitModuleSource(ctx, query, args.RefString, parsedRef.Git, args.RefPin, !args.DisableFindUp)
 		if err != nil {
 			return inst, err
 		}
@@ -411,7 +412,7 @@ func (s *moduleSourceSchema) localModuleSource(
 					depModPath := filepath.Join(defaultFindUpSourceRootDir, namedDep.Source)
 					return s.localModuleSource(ctx, query, bk, depModPath, false, allowNotExists)
 				case core.ModuleSourceKindGit:
-					return s.gitModuleSource(ctx, query, parsedRef.Git, namedDep.Pin, false)
+					return s.gitModuleSource(ctx, query, namedDep.Source, parsedRef.Git, namedDep.Pin, false)
 				}
 			}
 		}
@@ -569,9 +570,11 @@ func (s *moduleSourceSchema) localModuleSource(
 	return dagql.NewResultForCurrentCall(ctx, localSrc)
 }
 
+//nolint:gocyclo
 func (s *moduleSourceSchema) gitModuleSource(
 	ctx context.Context,
 	query dagql.ObjectResult[*core.Query],
+	source string,
 	parsed *core.ParsedGitRefString,
 	refPin string,
 	// whether to search up the directory tree for a dagger.json file
@@ -580,6 +583,37 @@ func (s *moduleSourceSchema) gitModuleSource(
 	dag, err := query.Self().Server.Server(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+
+	var (
+		lockResolution lookupLockResolution
+		lookupLock     *workspaceLookupLock
+	)
+	if refPin == "" {
+		lockMode, err := currentLookupLockMode(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("%s lock mode: %w", lockModulesResolveOperation, err)
+		}
+		if lockMode != workspace.LockModeDisabled {
+			lookupLock, err = loadWorkspaceLookupLock(ctx, query.Self())
+			if err != nil {
+				return inst, fmt.Errorf("%s lockfile: %w", lockModulesResolveOperation, err)
+			}
+			if lookupLock == nil {
+				return inst, fmt.Errorf("experimental lockfile support is local-only")
+			}
+			lockResolution, err = resolveLookupFromLock(
+				lockMode,
+				lookupLock.lock,
+				lockModulesResolveOperation,
+				[]any{source},
+				workspace.PolicyFloat,
+			)
+			if err != nil {
+				return inst, fmt.Errorf("%s lock resolution: %w", lockModulesResolveOperation, err)
+			}
+			refPin = lockResolution.Pin
+		}
 	}
 
 	gitRef, err := parsed.GitRef(ctx, dag, refPin)
@@ -722,12 +756,37 @@ func (s *moduleSourceSchema) gitModuleSource(
 		return inst, fmt.Errorf("load user defaults: %w", err)
 	}
 
+	if lockResolution.ShouldWrite && lookupLock != nil {
+		policy := lockResolution.Policy
+		if !lockResolution.Found {
+			policy = moduleResolveLockPolicy(gitRef.Self().Ref)
+		}
+		if err := lookupLock.SetLookup(
+			lockCoreNamespace,
+			lockModulesResolveOperation,
+			[]any{source},
+			workspace.LookupResult{
+				Value:  gitRef.Self().Ref.SHA,
+				Policy: policy,
+			},
+		); err != nil {
+			return inst, fmt.Errorf("set lock entry for %s: %w", lockModulesResolveOperation, err)
+		}
+	}
+
 	inst, err = dagql.NewResultForCurrentCall(ctx, gitSrc)
 	if err != nil {
 		return inst, fmt.Errorf("failed to create instance: %w", err)
 	}
 
 	return inst, nil
+}
+
+func moduleResolveLockPolicy(ref *gitutil.Ref) workspace.LockPolicy {
+	if ref != nil && (strings.HasPrefix(ref.Name, "refs/tags/") || gitutil.IsCommitSHA(ref.Name)) {
+		return workspace.PolicyPin
+	}
+	return workspace.PolicyFloat
 }
 
 func (s *moduleSourceSchema) loadBlueprintModule(

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/dagger/dagger/engine"
 )
 
-type currentTypeDefsTestServer struct {
-	deps *core.SchemaBuilder
-}
-
 func TestCoreModTypeDefs(t *testing.T) {
 	ctx := context.Background()
 	baseCache, err := dagql.NewCache(ctx, "", nil, nil)

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/dagger/dagger/auth"
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
@@ -21,6 +22,10 @@ import (
 	"github.com/moby/locker"
 	"google.golang.org/grpc"
 )
+
+type currentTypeDefsTestServer struct {
+	deps *core.SchemaBuilder
+}
 
 func (s *currentTypeDefsTestServer) ServeModule(context.Context, dagql.ObjectResult[*core.Module], bool, bool) error {
 	return nil
@@ -144,3 +149,11 @@ func (s *currentTypeDefsTestServer) CloudEngineClient(context.Context, string, s
 }
 
 func (s *currentTypeDefsTestServer) CleanMountNS() *os.File { return nil }
+
+func (s *currentTypeDefsTestServer) CurrentWorkspaceLock(context.Context) (*workspace.Lock, bool, error) {
+	return nil, false, nil
+}
+
+func (s *currentTypeDefsTestServer) SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspace.LookupResult) error {
+	return nil
+}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client/pathutil"
@@ -70,6 +71,10 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("include").Doc("Only include services matching the specified patterns"),
 			),
+		dagql.NodeFunc("update", s.update).
+			Doc("Refresh workspace-managed state and return the resulting changeset.",
+				"Currently this refreshes existing lockfile entries only.").
+			Experimental("Experimental workspace update API currently refreshes existing lockfile entries only."),
 	}.Install(srv)
 }
 
@@ -209,6 +214,9 @@ type workspaceFileArgs struct {
 	Path string
 }
 
+type workspaceUpdateArgs struct {
+}
+
 func (s *workspaceSchema) file(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
@@ -239,6 +247,91 @@ func (s *workspaceSchema) file(
 	}
 
 	return inst, nil
+}
+
+func (s *workspaceSchema) update(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceUpdateArgs,
+) (*core.Changeset, error) {
+	ws := parent.Self()
+	if ws.HostPath() == "" {
+		return nil, fmt.Errorf("workspace update is local-only")
+	}
+
+	workspaceCtx, err := s.withWorkspaceClientContext(ctx, ws)
+	if err != nil {
+		return nil, fmt.Errorf("workspace client context: %w", err)
+	}
+
+	query, err := core.CurrentQuery(workspaceCtx)
+	if err != nil {
+		return nil, err
+	}
+	bk, err := query.Engine(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get engine client: %w", err)
+	}
+
+	lock, exists, err := readWorkspaceLockState(workspaceCtx, bk, ws)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("workspace lockfile does not exist")
+	}
+
+	if err := core.UpdateWorkspaceLock(workspaceCtx, query, lock); err != nil {
+		return nil, fmt.Errorf("update workspace lock: %w", err)
+	}
+
+	lockBytes, err := lock.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal workspace lock: %w", err)
+	}
+
+	baseDir, err := s.resolveRootfs(ctx, ws, resolveWorkspacePath(".", ws.Path), core.CopyFilter{}, false)
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedDir dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, baseDir, &updatedDir,
+		dagql.Selector{
+			Field: "withNewFile",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.NewString(path.Join(workspace.LockDirName, workspace.LockFileName))},
+				{Name: "contents", Value: dagql.String(lockBytes)},
+				{Name: "permissions", Value: dagql.Int(0o644)},
+			},
+		},
+	); err != nil {
+		return nil, fmt.Errorf("workspace update lockfile: %w", err)
+	}
+
+	baseDirID, err := baseDir.ID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get baseDir ID: %w", err)
+	}
+
+	var changes dagql.ObjectResult[*core.Changeset]
+	if err := srv.Select(ctx, updatedDir, &changes,
+		dagql.Selector{
+			Field: "changes",
+			Args: []dagql.NamedInput{
+				{Name: "from", Value: dagql.NewID[*core.Directory](baseDirID)},
+			},
+		},
+	); err != nil {
+		return nil, fmt.Errorf("workspace update changeset: %w", err)
+	}
+
+	return changes.Self(), nil
 }
 
 // resolveWorkspacePath resolves a workspace API path into a boundary-relative path:

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -100,6 +100,7 @@ func (r *DangRuntime) Call(
 
 	execMD.CallerClientID = clientMetadata.ClientID
 	execMD.SessionID = clientMetadata.SessionID
+	execMD.LockMode = clientMetadata.LockMode
 	execMD.AllowedLLMModules = clientMetadata.AllowedLLMModules
 
 	if execMD.ExecID == "" {

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -310,6 +310,9 @@ func (sdk *goSDK) ModuleTypes(
 		}
 		execMD.CallDigest = callDigest
 	}
+	if clientMetadata, err := engine.ClientMetadataFromContext(ctx); err == nil {
+		execMD.LockMode = clientMetadata.LockMode
+	}
 	execMD.EncodedModuleID, err = currentModuleID.Encode()
 	if err != nil {
 		return inst, err

--- a/core/sdk/module_typedefs.go
+++ b/core/sdk/module_typedefs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	telemetry "github.com/dagger/otel-go"
@@ -70,6 +71,9 @@ func (sdk *moduleTypes) ModuleTypes(
 			return inst, fmt.Errorf("compute module types exec call digest: %w", err)
 		}
 		execMD.CallDigest = callDigest
+	}
+	if clientMetadata, err := engine.ClientMetadataFromContext(ctx); err == nil {
+		execMD.LockMode = clientMetadata.LockMode
 	}
 	execMD.EncodedModuleID, err = currentModuleID.Encode()
 	if err != nil {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/dagger/dagger/auth"
+	workspacepkg "github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
@@ -129,6 +130,14 @@ func (ms *mockServer) CurrentWorkspace(context.Context) (*Workspace, error) {
 
 func (ms *mockServer) SpecificClientAttachableConn(context.Context, string) (*grpc.ClientConn, error) {
 	return nil, nil
+}
+
+func (ms *mockServer) CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error) {
+	return nil, false, nil
+}
+
+func (ms *mockServer) SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error {
+	return nil
 }
 
 func (ms *mockServer) NonModuleParentClientMetadata(context.Context) (*engine.ClientMetadata, error) {

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -1,0 +1,239 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/dagger/dagger/util/lockfile"
+)
+
+const (
+	LockDirName  = ".dagger"
+	LockFileName = "lock"
+
+	lockModulesResolveOperation = "modules.resolve"
+)
+
+// LockMode controls where lookup results come from for a run.
+type LockMode string
+
+const (
+	LockModeDisabled LockMode = "disabled"
+	LockModeLive     LockMode = "live"
+	LockModePinned   LockMode = "pinned"
+	LockModeFrozen   LockMode = "frozen"
+
+	// Backward-compatible aliases for the previous experimental names.
+	LockModeAuto   = LockModePinned
+	LockModeStrict = LockModeFrozen
+
+	// DefaultLockMode is used when no mode is explicitly set.
+	DefaultLockMode = LockModeDisabled
+)
+
+// LockPolicy controls update intent for a lock entry.
+type LockPolicy string
+
+const (
+	PolicyPin   LockPolicy = "pin"
+	PolicyFloat LockPolicy = "float"
+)
+
+// LookupResult is the stored lock result for a lookup tuple.
+type LookupResult struct {
+	Value  string     `json:"value"`
+	Policy LockPolicy `json:"policy"`
+}
+
+// LookupEntry is a structured lockfile lookup tuple.
+type LookupEntry struct {
+	Namespace string
+	Operation string
+	Inputs    []any
+	Result    LookupResult
+}
+
+// Lock is the workspace lockfile wrapper.
+type Lock struct {
+	file *lockfile.Lockfile
+}
+
+// ParseLock parses .dagger/lock data.
+func ParseLock(data []byte) (*Lock, error) {
+	file, err := lockfile.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{file: file}, nil
+}
+
+// NewLock returns an empty workspace lock.
+func NewLock() *Lock {
+	return &Lock{file: lockfile.New()}
+}
+
+// Marshal serializes lock entries.
+func (l *Lock) Marshal() ([]byte, error) {
+	if l == nil || l.file == nil {
+		return nil, fmt.Errorf("nil lock")
+	}
+	return l.file.Marshal()
+}
+
+// Clone returns a deep copy of the lock.
+func (l *Lock) Clone() (*Lock, error) {
+	cloned := NewLock()
+	if l == nil || l.file == nil {
+		return cloned, nil
+	}
+	if err := cloned.Merge(l); err != nil {
+		return nil, err
+	}
+	return cloned, nil
+}
+
+// Merge applies all entries from other onto l.
+func (l *Lock) Merge(other *Lock) error {
+	if l == nil || l.file == nil {
+		return fmt.Errorf("nil lock")
+	}
+	if other == nil || other.file == nil {
+		return nil
+	}
+	entries, err := other.Entries()
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := l.SetLookup(entry.Namespace, entry.Operation, entry.Inputs, entry.Result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetModuleResolve retrieves the lock result for a module source lookup.
+func (l *Lock) GetModuleResolve(source string) (LookupResult, bool, error) {
+	return l.GetLookup("", lockModulesResolveOperation, moduleResolveInputs(source))
+}
+
+// SetModuleResolve sets the lock result for a module source lookup.
+func (l *Lock) SetModuleResolve(source string, result LookupResult) error {
+	if source == "" {
+		return fmt.Errorf("module source is required")
+	}
+	return l.SetLookup("", lockModulesResolveOperation, moduleResolveInputs(source), result)
+}
+
+// GetLookup retrieves the lock result for a generic lookup tuple.
+func (l *Lock) GetLookup(namespace, operation string, inputs []any) (LookupResult, bool, error) {
+	if l == nil || l.file == nil {
+		return LookupResult{}, false, nil
+	}
+	value, policy, ok := l.file.Get(namespace, operation, inputs)
+	if !ok {
+		return LookupResult{}, false, nil
+	}
+	result, err := parseLookupResult(value, policy)
+	if err != nil {
+		return LookupResult{}, false, err
+	}
+	return result, true, nil
+}
+
+// SetLookup sets the lock result for a generic lookup tuple.
+func (l *Lock) SetLookup(namespace, operation string, inputs []any, result LookupResult) error {
+	if l == nil || l.file == nil {
+		return fmt.Errorf("nil lock")
+	}
+	if result.Value == "" {
+		return fmt.Errorf("lookup value is required")
+	}
+	if !isValidLockPolicy(result.Policy) {
+		return fmt.Errorf("invalid lock policy %q", result.Policy)
+	}
+	return l.file.Set(namespace, operation, inputs, result.Value, string(result.Policy))
+}
+
+// DeleteLookup removes a generic lookup tuple entry.
+func (l *Lock) DeleteLookup(namespace, operation string, inputs []any) bool {
+	if l == nil || l.file == nil {
+		return false
+	}
+	return l.file.Delete(namespace, operation, inputs)
+}
+
+// Entries returns a deterministic snapshot of all lookup entries.
+func (l *Lock) Entries() ([]LookupEntry, error) {
+	if l == nil || l.file == nil {
+		return nil, nil
+	}
+
+	rawEntries := l.file.Entries()
+	entries := make([]LookupEntry, 0, len(rawEntries))
+	for _, entry := range rawEntries {
+		result, err := parseLookupResult(entry.Value, entry.Policy)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, LookupEntry{
+			Namespace: entry.Namespace,
+			Operation: entry.Operation,
+			Inputs:    entry.Inputs,
+			Result:    result,
+		})
+	}
+	return entries, nil
+}
+
+func parseLookupResult(value any, policy string) (LookupResult, error) {
+	resultValue, ok := value.(string)
+	if !ok || resultValue == "" {
+		return LookupResult{}, fmt.Errorf("value is required")
+	}
+	result := LookupResult{
+		Value:  resultValue,
+		Policy: LockPolicy(policy),
+	}
+	if !isValidLockPolicy(result.Policy) {
+		return LookupResult{}, fmt.Errorf("invalid policy %q", result.Policy)
+	}
+	return result, nil
+}
+
+func isValidLockPolicy(policy LockPolicy) bool {
+	return policy == PolicyPin || policy == PolicyFloat
+}
+
+func moduleResolveInputs(source string) []any {
+	return []any{source}
+}
+
+// ParseLockMode validates an explicitly configured lock mode.
+func ParseLockMode(mode string) (LockMode, error) {
+	switch mode {
+	case "update":
+		return LockModeLive, nil
+	case "auto":
+		return LockModePinned, nil
+	case "strict":
+		return LockModeFrozen, nil
+	}
+
+	lockMode := LockMode(mode)
+	if !isValidLockMode(lockMode) {
+		return "", fmt.Errorf("invalid lock mode %q", mode)
+	}
+	return lockMode, nil
+}
+
+// ResolveLockMode applies the branch default when the mode is unspecified.
+func ResolveLockMode(mode string) (LockMode, error) {
+	if mode == "" {
+		return DefaultLockMode, nil
+	}
+	return ParseLockMode(mode)
+}
+
+func isValidLockMode(mode LockMode) bool {
+	return mode == LockModeDisabled || mode == LockModeLive || mode == LockModePinned || mode == LockModeFrozen
+}

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -1,0 +1,194 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupSetGetDelete(t *testing.T) {
+	lock := NewLock()
+	inputs := []any{"alpine:latest", "linux/amd64"}
+
+	require.NoError(t, lock.SetLookup("", "container.from", inputs, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: PolicyFloat,
+	}))
+
+	result, ok, err := lock.GetLookup("", "container.from", inputs)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "sha256:deadbeef", result.Value)
+	require.Equal(t, PolicyFloat, result.Policy)
+
+	require.True(t, lock.DeleteLookup("", "container.from", inputs))
+	_, ok, err = lock.GetLookup("", "container.from", inputs)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestModuleResolveSetGet(t *testing.T) {
+	lock := NewLock()
+	source := "github.com/dagger/dagger@main"
+
+	require.NoError(t, lock.SetModuleResolve(source, LookupResult{
+		Value:  "0123456789abcdef0123456789abcdef01234567",
+		Policy: PolicyFloat,
+	}))
+
+	result, ok, err := lock.GetModuleResolve(source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "0123456789abcdef0123456789abcdef01234567", result.Value)
+	require.Equal(t, PolicyFloat, result.Policy)
+}
+
+func TestLookupSetValidation(t *testing.T) {
+	lock := NewLock()
+
+	err := lock.SetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"}, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: LockPolicy("weird"),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid lock policy")
+}
+
+func TestLookupGetValidation(t *testing.T) {
+	input := strings.Join([]string{
+		`[["version","1"]]`,
+		`["","container.from",["alpine:latest","linux/amd64"],"sha256:deadbeef","weird"]`,
+	}, "\n")
+
+	lock, err := ParseLock([]byte(input))
+	require.NoError(t, err)
+
+	_, _, err = lock.GetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"})
+	require.ErrorContains(t, err, "invalid policy")
+}
+
+func TestEntries(t *testing.T) {
+	lock := NewLock()
+	inputs := []any{"alpine:latest", "linux/amd64"}
+
+	require.NoError(t, lock.SetLookup("", "container.from", inputs, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: PolicyFloat,
+	}))
+
+	entries, err := lock.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, LookupEntry{
+		Namespace: "",
+		Operation: "container.from",
+		Inputs:    inputs,
+		Result: LookupResult{
+			Value:  "sha256:deadbeef",
+			Policy: PolicyFloat,
+		},
+	}, entries[0])
+}
+
+func TestClone(t *testing.T) {
+	lock := NewLock()
+	require.NoError(t, lock.SetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"}, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: PolicyPin,
+	}))
+
+	cloned, err := lock.Clone()
+	require.NoError(t, err)
+
+	require.NoError(t, cloned.SetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"}, LookupResult{
+		Value:  "0123456789abcdef0123456789abcdef01234567",
+		Policy: PolicyFloat,
+	}))
+
+	_, ok, err := lock.GetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"})
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestMerge(t *testing.T) {
+	base := NewLock()
+	require.NoError(t, base.SetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"}, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: PolicyPin,
+	}))
+
+	delta := NewLock()
+	require.NoError(t, delta.SetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"}, LookupResult{
+		Value:  "0123456789abcdef0123456789abcdef01234567",
+		Policy: PolicyFloat,
+	}))
+
+	require.NoError(t, base.Merge(delta))
+
+	result, ok, err := base.GetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, LookupResult{Value: "sha256:deadbeef", Policy: PolicyPin}, result)
+
+	result, ok, err = base.GetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, LookupResult{Value: "0123456789abcdef0123456789abcdef01234567", Policy: PolicyFloat}, result)
+}
+
+func TestParseLockMode(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		mode, err := ParseLockMode("disabled")
+		require.NoError(t, err)
+		require.Equal(t, LockModeDisabled, mode)
+	})
+
+	t.Run("live", func(t *testing.T) {
+		mode, err := ParseLockMode("live")
+		require.NoError(t, err)
+		require.Equal(t, LockModeLive, mode)
+	})
+
+	t.Run("pinned", func(t *testing.T) {
+		mode, err := ParseLockMode("pinned")
+		require.NoError(t, err)
+		require.Equal(t, LockModePinned, mode)
+	})
+
+	t.Run("frozen", func(t *testing.T) {
+		mode, err := ParseLockMode("frozen")
+		require.NoError(t, err)
+		require.Equal(t, LockModeFrozen, mode)
+	})
+
+	t.Run("legacy update alias", func(t *testing.T) {
+		mode, err := ParseLockMode("update")
+		require.NoError(t, err)
+		require.Equal(t, LockModeLive, mode)
+	})
+
+	t.Run("legacy auto alias", func(t *testing.T) {
+		mode, err := ParseLockMode("auto")
+		require.NoError(t, err)
+		require.Equal(t, LockModePinned, mode)
+	})
+
+	t.Run("legacy strict alias", func(t *testing.T) {
+		mode, err := ParseLockMode("strict")
+		require.NoError(t, err)
+		require.Equal(t, LockModeFrozen, mode)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := ParseLockMode("weird")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid lock mode")
+	})
+}
+
+func TestResolveLockMode(t *testing.T) {
+	mode, err := ResolveLockMode("")
+	require.NoError(t, err)
+	require.Equal(t, DefaultLockMode, mode)
+}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3171,6 +3171,8 @@ func (c *Cache) wait(
 		delete(c.ongoingCalls, oc.callConcurrencyKeys)
 		c.callsMu.Unlock()
 	})
+	// TODO there's a race condition here: thread one enters the .Do() above but hasn't finished calling initCompletedResult(....), the second thread will skip over the Do(),
+	// then check the err below before it's actually written to
 	if oc.initCompletedResultErr != nil {
 		c.callsMu.Lock()
 		oc.waiters--

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/git-readme
@@ -19,7 +19,7 @@ $ viztest: Viztest! X.Xs CACHED
 ✔ .gitReadme(remote: "https://github.com/dagger/dagger", version: "v0.18.6"): String! X.Xs
 ┃ ## What is Dagger?
 ├╴✔ git(url: "https://github.com/dagger/dagger"): GitRepository! X.Xs
-├╴$ .tag(name: "v0.18.6"): GitRef! X.Xs CACHED
+├╴✔ .tag(name: "v0.18.6"): GitRef! X.Xs
 ├╴$ .tree: Directory! X.Xs CACHED
 ├╴✔ .file(path: "README.md"): File! X.Xs
 ╰╴✔ .contents: String! X.Xs

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -22,6 +22,7 @@ dagger [options] [subcommand | file...]
       --eager-runtime                load module runtime eagerly
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -m, --mod string                   Module reference to load, either a local path or a remote git repo (defaults to current directory)
       --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
   -E, --no-exit                      Leave the TUI running after completion
@@ -42,6 +43,7 @@ dagger [options] [subcommand | file...]
 * [dagger functions](#dagger-functions)	 - List available functions
 * [dagger init](#dagger-init)	 - Initialize a new module
 * [dagger install](#dagger-install)	 - Install a dependency
+* [dagger lock](#dagger-lock)	 - Manage workspace lockfiles
 * [dagger login](#dagger-login)	 - Log in to Dagger Cloud
 * [dagger logout](#dagger-logout)	 - Log out from Dagger Cloud
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
@@ -77,6 +79,7 @@ dagger call [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -124,6 +127,7 @@ dagger config -m github.com/dagger/hello-dagger
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -158,6 +162,7 @@ dagger core [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -220,6 +225,7 @@ dagger develop [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -263,6 +269,7 @@ dagger functions [options] [function]...
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -327,6 +334,7 @@ dagger init --sdk=go
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -374,6 +382,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -385,6 +394,65 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### SEE ALSO
 
 * [dagger](#dagger)	 - A tool to run composable workflows in containers
+
+## dagger lock
+
+Manage workspace lockfiles
+
+### Options inherited from parent commands
+
+```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
+  -E, --no-exit                      Leave the TUI running after completion
+      --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
+* [dagger lock update](#dagger-lock-update)	 - Refresh workspace lock entries
+
+## dagger lock update
+
+Refresh workspace lock entries
+
+### Synopsis
+
+Refresh workspace lock entries.
+
+Refresh entries already recorded in .dagger/lock.
+
+```
+dagger lock update
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -d, --debug                        Show debug logs and full verbosity
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
+  -E, --no-exit                      Leave the TUI running after completion
+      --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
+```
+
+### SEE ALSO
+
+* [dagger lock](#dagger-lock)	 - Manage workspace lockfiles
 
 ## dagger login
 
@@ -401,6 +469,7 @@ dagger login [options] [org]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -428,6 +497,7 @@ dagger logout
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -494,6 +564,7 @@ EOF
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -554,6 +625,7 @@ dagger run python main.py
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -577,6 +649,7 @@ Manage toolchains
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -628,6 +701,7 @@ dagger toolchain install github.com/dagger/dagger/toolchains/go
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -673,6 +747,7 @@ dagger toolchain list
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -719,6 +794,7 @@ dagger toolchain uninstall mytoolchain
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -765,6 +841,7 @@ dagger toolchain update
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -811,6 +888,7 @@ dagger uninstall hello
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -862,6 +940,7 @@ dagger update [options] [<DEPENDENCY>...]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -895,6 +974,7 @@ dagger version
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)

--- a/docs/current_docs/reference/cli/lockfiles.mdx
+++ b/docs/current_docs/reference/cli/lockfiles.mdx
@@ -1,0 +1,122 @@
+---
+title: "Lockfiles"
+description: "How Dagger lock modes and lock policies work."
+slug: /reference/cli/lockfiles
+---
+
+Lockfiles let Dagger remember the exact result of selected lookups, so later runs can either reuse that recorded result or intentionally refresh it.
+
+There are two separate concepts:
+
+- A lock **mode** answers: "Where should this run read lookup results from?"
+- A lock **policy** answers: "When live resolution is allowed, should this entry stay fixed or be refreshed?"
+
+## Lock modes
+
+Lock mode is set for a run, typically with `--lock`.
+
+```bash
+dagger --lock=pinned call ...
+```
+
+Available modes:
+
+| Mode | Meaning |
+| --- | --- |
+| `disabled` | Ignore the lockfile completely. |
+| `live` | Resolve everything live and record the result. |
+| `pinned` | Reuse pinned entries, resolve everything else live, and record the result. |
+| `frozen` | Resolve only from the lockfile and fail on misses. |
+
+The easiest way to think about lock modes is:
+
+- `disabled`: feature off
+- `live`: refresh while running
+- `pinned`: prefer stable pins, refresh the rest
+- `frozen`: require a complete lockfile
+
+Typical uses:
+
+- `disabled`: opt out for this run
+- `live`: bootstrap or intentionally refresh while running a workflow
+- `pinned`: day-to-day development and most CI
+- `frozen`: reproducible, hermetic, or offline runs
+
+## Lock policies
+
+Lock policy is stored on each lock entry.
+
+Available policies:
+
+| Policy | Meaning |
+| --- | --- |
+| `pin` | Prefer the recorded value when the lock mode allows it. |
+| `float` | Prefer live resolution when the lock mode allows it. |
+
+The easiest way to think about lock policies is:
+
+- `pin`: stay on this exact resolved result
+- `float`: keep following the live reference when possible
+
+## How mode and policy work together
+
+Mode is chosen by the caller for the current run. Policy is remembered in the lockfile for each entry.
+
+That means:
+
+- mode controls the behavior of this run
+- policy controls whether an existing entry should be preferred or refreshed when live resolution is allowed
+
+For example, if a lock entry has policy `pin`:
+
+- `disabled` ignores it
+- `live` resolves live and rewrites it
+- `pinned` reuses it
+- `frozen` reuses it
+
+If a lock entry has policy `float`:
+
+- `disabled` ignores it
+- `live` resolves live and rewrites it
+- `pinned` resolves live and rewrites it
+- `frozen` reuses the recorded value as-is
+
+If an entry is missing:
+
+- `disabled` resolves live and does not write
+- `live` resolves live and writes
+- `pinned` resolves live and writes
+- `frozen` fails
+
+## Updating lockfiles
+
+Use `dagger lock update` when you want to rewrite lock entries on purpose.
+
+```bash
+dagger lock update
+```
+
+That refreshes entries already recorded in `.dagger/lock` using the current environment's normal ambient authentication.
+
+To refresh or discover entries encountered by a specific command, run that command with `--lock=live`:
+
+```bash
+dagger --lock=live call release
+dagger --lock=live query --doc query.graphql
+```
+
+It is your responsibility to run lock updates in an environment that can authenticate to any private registries or repositories those lookups require.
+
+## Lock-aware operations
+
+These operations currently record and resolve lock entries:
+
+| Operation | Inputs | Default policy |
+| --- | --- | --- |
+| `container.from` | `[imageRef, platform]` | `pin` |
+| `git.head` | `[remoteURL]` | `float` |
+| `git.branch` | `[remoteURL, branchName]` | `float` |
+| `git.tag` | `[remoteURL, tagName]` | `pin` |
+| `git.ref` | `[remoteURL, refName]` | `pin` for tags, `float` otherwise |
+
+`git.commit` is already pinned by its input and does not create lock entries.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6179,6 +6179,13 @@ type Workspace {
     """Only include services matching the specified patterns"""
     include: [String!]
   ): UpGroup!
+
+  """
+  Refresh workspace-managed state and return the resulting changeset.
+
+  Currently this refreshes existing lockfile entries only.
+  """
+  update: Changeset! @experimental(reason: "Experimental workspace update API currently refreshes existing lockfile entries only.")
 }
 
 """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -17013,6 +17013,13 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Workspace-update" href="#Workspace-update"><code>update</code></a> - <span class="property-type"><a href="#definition-Changeset"><code>Changeset!</code></a></span> </td>
+                        <td>
+                          <p>Refresh workspace-managed state and return the resulting changeset.</p>
+                          <p>Currently this refreshes existing lockfile entries only.</p>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -271,6 +271,16 @@
                                             <p><p>Return all services from modules loaded in the workspace.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_update">update</a>()
+        
+                                            <p><p>Refresh workspace-managed state and return the resulting changeset.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -858,6 +868,38 @@
                     <table class="table table-condensed">
         <tr>
             <td><a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_update">
+        <div class="location">at line 176</div>
+        <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
+    <strong>update</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Refresh workspace-managed state and return the resulting changeset.</p></p>                <p><p>Currently this refreshes existing lockfile entries only.</p></p>        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -881,7 +881,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_update">
-        <div class="location">at line 176</div>
+        <div class="location">at line 179</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>update</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1504,7 +1504,9 @@
                     <dd></dd><dt><a href="Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd></dd><dt><a href="Dagger/UpGroupId.html"><abbr title="Dagger\UpGroupId">UpGroupId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>UpGroupID</code> scalar type represents an identifier for an object of type UpGroup.</p></dd><dt><a href="Dagger/UpId.html"><abbr title="Dagger\UpId">UpId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
-                    <dd><p>The <code>UpID</code> scalar type represents an identifier for an object of type Up.</p></dd>        </dl><h2 id="letterV">V</h2>
+                    <dd><p>The <code>UpID</code> scalar type represents an identifier for an object of type Up.</p></dd><dt><a href="Dagger/Workspace.html#method_update">
+<abbr title="Dagger\Workspace">Workspace</abbr>::update</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Refresh workspace-managed state and return the resulting changeset.</p></dd>        </dl><h2 id="letterV">V</h2>
         <dl id="indexV"><dt><a href="Dagger/Address.html#method_value">
 <abbr title="Dagger\Address">Address</abbr>::value</a>() &mdash; <em>Method in class <a href="Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a></em></dt>
                     <dd><p>The address value</p></dd><dt><a href="Dagger/Client.html#method_version">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -6559,6 +6559,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Workspace::update",
+			"p": "Dagger/Workspace.html#method_update",
+			"d": "<p>Refresh workspace-managed state and return the resulting changeset.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Client\\IdAble::id",
 			"p": "Dagger/Client/IdAble.html#method_id",
 			"d": null

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -129,6 +129,10 @@ type Params struct {
 
 	SkipWorkspaceModules bool
 
+	// LockMode controls lockfile behavior for lookup resolution.
+	// Valid values: "disabled", "strict", "auto", "update".
+	LockMode string
+
 	// Workspace explicitly declares workspace binding for this client.
 	Workspace *string
 
@@ -1432,6 +1436,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		CloudAuth:                 c.CloudAuth,
 		EnableCloudScaleOut:       c.EnableCloudScaleOut,
 		CloudScaleOutEngineID:     remoteEngineID,
+		LockMode:                  c.LockMode,
 	}
 
 	if c.Module != "" {
@@ -1439,6 +1444,9 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 	}
 	if c.Module == "" && c.LoadWorkspaceModules {
 		md.LoadWorkspaceModules = true
+	}
+	if c.LockMode != "" {
+		md.LockMode = c.LockMode
 	}
 	if c.Workspace != nil {
 		md.Workspace = c.Workspace

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -46,6 +46,7 @@ type ExecutionMetadata struct {
 	SessionID   string
 	SecretToken string
 	Hostname    string
+	LockMode    string
 
 	// The "stable" ID of the client that is used to identify filesync cache refs
 	// across different clients running on the same host.

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -125,6 +125,11 @@ type ClientMetadata struct {
 	// use LoadWorkspaceModules instead.
 	SkipWorkspaceModules bool `json:"skip_workspace_modules,omitempty"`
 
+	// LockMode controls lockfile behavior for lookup resolution.
+	// Valid values: "live", "pinned", "frozen", "update".
+	// Legacy aliases "disabled", "auto", and "strict" are also accepted.
+	LockMode string `json:"lock_mode,omitempty"`
+
 	// Workspace explicitly declares the workspace binding for this client.
 	// When unset, the engine applies default workspace binding behavior.
 	Workspace *string `json:"workspace,omitempty"`

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"slices"
@@ -35,6 +36,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"resenje.org/singleflight"
 
 	"github.com/dagger/dagger/analytics"
@@ -42,6 +45,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/schema"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
@@ -99,6 +103,23 @@ type daggerSession struct {
 	interactiveCommand []string
 
 	allowedLLMModules []string
+
+	lockFiles  map[workspaceLockKey]*workspaceLockState
+	lockFileMu sync.RWMutex
+}
+
+type workspaceLockKey struct {
+	ownerClientID string
+	lockPath      string
+}
+
+type workspaceLockState struct {
+	ws       *core.Workspace
+	lockPath string
+	lock     *workspace.Lock
+	delta    *workspace.Lock
+	loaded   bool
+	dirty    bool
 }
 
 type daggerSessionState string
@@ -962,6 +983,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 	var loadWorkspaceModules bool
 	var eagerRuntime bool
 	var workspaceRef *string
+	var lockMode string
 	if md, _ := engine.ClientMetadataFromHTTPHeaders(r.Header); md != nil {
 		clientVersion = md.ClientVersion
 		allowedLLMModules = md.AllowedLLMModules
@@ -972,6 +994,11 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			ref := declaredWorkspace
 			workspaceRef = &ref
 		}
+		lockMode = md.LockMode
+	}
+
+	if lockMode == "" {
+		lockMode = srv.inheritedNestedClientLockMode(execMD)
 	}
 
 	httpHandlerFunc(srv.serveHTTPToClient, &ClientInitOpts{
@@ -988,6 +1015,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			ExtraModules:         extraModules,
 			LoadWorkspaceModules: loadWorkspaceModules,
 			EagerRuntime:         eagerRuntime,
+			LockMode:             lockMode,
 			Workspace:            workspaceRef,
 		},
 		Call:                   execMD.Call,
@@ -996,6 +1024,74 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 		EncodedContentModuleID: execMD.EncodedContentModuleID,
 		EncodedFunctionCall:    execMD.EncodedFunctionCall,
 	}).ServeHTTP(w, r)
+}
+
+func (srv *Server) inheritedNestedClientLockMode(execMD *engineutil.ExecutionMetadata) string {
+	if execMD == nil {
+		return ""
+	}
+	if execMD.LockMode != "" {
+		return execMD.LockMode
+	}
+	callerClient, err := srv.clientFromIDs(execMD.SessionID, execMD.CallerClientID)
+	if err != nil || callerClient == nil || callerClient.clientMetadata == nil {
+		return ""
+	}
+	if callerClient.clientMetadata.LockMode != "" {
+		return callerClient.clientMetadata.LockMode
+	}
+	for i := len(callerClient.parents) - 1; i >= 0; i-- {
+		parent := callerClient.parents[i]
+		if parent != nil && parent.clientMetadata != nil && parent.clientMetadata.LockMode != "" {
+			return parent.clientMetadata.LockMode
+		}
+	}
+	return ""
+}
+
+func nestedClientMetadata(execMD *engineutil.ExecutionMetadata, forwarded *engine.ClientMetadata, inheritedLockMode string) *engine.ClientMetadata {
+	clientVersion := execMD.ClientVersionOverride
+	if clientVersion == "" {
+		clientVersion = engine.Version
+	}
+
+	allowedLLMModules := execMD.AllowedLLMModules
+	var extraModules []engine.ExtraModule
+	var skipWorkspaceModules bool
+	lockMode := inheritedLockMode
+	var eagerRuntime bool
+	var workspaceRef *string
+	if forwarded != nil {
+		clientVersion = forwarded.ClientVersion
+		allowedLLMModules = forwarded.AllowedLLMModules
+		extraModules = forwarded.ExtraModules
+		skipWorkspaceModules = forwarded.SkipWorkspaceModules
+		if forwarded.LockMode != "" {
+			lockMode = forwarded.LockMode
+		}
+		eagerRuntime = forwarded.EagerRuntime
+		if declaredWorkspace, ok := workspaceRefFromClientMetadata(forwarded); ok {
+			ref := declaredWorkspace
+			workspaceRef = &ref
+		}
+	}
+
+	return &engine.ClientMetadata{
+		ClientID:             execMD.ClientID,
+		ClientVersion:        clientVersion,
+		ClientSecretToken:    execMD.SecretToken,
+		SessionID:            execMD.SessionID,
+		ClientHostname:       execMD.Hostname,
+		ClientStableID:       execMD.ClientStableID,
+		Labels:               map[string]string{},
+		SSHAuthSocketPath:    execMD.SSHAuthSocketPath,
+		AllowedLLMModules:    allowedLLMModules,
+		ExtraModules:         extraModules,
+		SkipWorkspaceModules: skipWorkspaceModules,
+		LockMode:             lockMode,
+		EagerRuntime:         eagerRuntime,
+		Workspace:            workspaceRef,
+	}
 }
 
 const InstrumentationLibrary = "dagger.io/engine.server"
@@ -1298,6 +1394,7 @@ func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *dag
 
 func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
 	ctx := r.Context()
+	var shutdownErr error
 
 	sess := client.daggerSession
 	slog := slog.With(
@@ -1311,6 +1408,13 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 
 	if client.clientID == sess.mainClientCallerID {
 		slog.Info("main client is shutting down")
+		flushCtx := context.WithoutCancel(ctx)
+		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
+			slog.Error("failed to flush workspace locks", "error", err)
+		}
+
+		// this must be done after lockfile flushing (since lockfiles make use of attachables to write data to host)
 		sess.beginClosing()
 
 		// Stop services, since the main client is going away, and we
@@ -1325,6 +1429,12 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 				close(sess.shutdownCh)
 			})
 		}()
+	} else {
+		flushCtx := context.WithoutCancel(ctx)
+		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
+			slog.Error("failed to flush workspace locks", "error", err)
+		}
 	}
 
 	// Flush telemetry across the entire session so that any child clients will
@@ -1332,13 +1442,14 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 	slog.ExtraDebug("flushing session telemetry")
 	if err := sess.FlushTelemetry(ctx); err != nil {
 		slog.Error("failed to flush telemetry", "error", err)
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush session telemetry: %w", err))
 	}
 
 	client.closeShutdownOnce.Do(func() {
 		close(client.shutdownCh)
 	})
 
-	return nil
+	return shutdownErr
 }
 
 // Stitch in the given module to the list being served to the current client.
@@ -1433,6 +1544,277 @@ func isSameModuleReference(a *core.ModuleSource, b *core.ModuleSource) bool {
 		return false
 	}
 	return a.Pin() == b.Pin()
+}
+func (srv *Server) CurrentWorkspaceLock(ctx context.Context) (*workspace.Lock, bool, error) {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ws, key, lockPath, ok, err := srv.currentWorkspaceLockBinding(client)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	sess := client.daggerSession
+
+	sess.lockFileMu.RLock()
+	if state, ok := sess.lockFiles[key]; ok && state.loaded {
+		cloned, err := state.lock.Clone()
+		sess.lockFileMu.RUnlock()
+		return cloned, true, err
+	}
+	sess.lockFileMu.RUnlock()
+
+	sess.lockFileMu.Lock()
+	defer sess.lockFileMu.Unlock()
+
+	state, err := srv.loadWorkspaceLockStateLocked(ctx, client, ws, key, lockPath)
+	if err != nil {
+		return nil, false, err
+	}
+	cloned, err := state.lock.Clone()
+	if err != nil {
+		return nil, false, err
+	}
+	return cloned, true, nil
+}
+
+func (srv *Server) SetCurrentWorkspaceLookup(
+	ctx context.Context,
+	namespace string,
+	operation string,
+	inputs []any,
+	result workspace.LookupResult,
+) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	ws, key, lockPath, ok, err := srv.currentWorkspaceLockBinding(client)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("workspace lock is not available")
+	}
+
+	sess := client.daggerSession
+	sess.lockFileMu.Lock()
+	defer sess.lockFileMu.Unlock()
+
+	state, err := srv.loadWorkspaceLockStateLocked(ctx, client, ws, key, lockPath)
+	if err != nil {
+		return err
+	}
+	if err := state.lock.SetLookup(namespace, operation, inputs, result); err != nil {
+		return err
+	}
+	if err := state.delta.SetLookup(namespace, operation, inputs, result); err != nil {
+		return err
+	}
+	state.dirty = true
+	return nil
+}
+
+func (srv *Server) currentWorkspaceLockBinding(client *daggerClient) (*core.Workspace, workspaceLockKey, string, bool, error) {
+	ws := client.workspace
+	if ws == nil || ws.HostPath() == "" {
+		return nil, workspaceLockKey{}, "", false, nil
+	}
+	lockPath, err := workspaceLockPath(ws)
+	if err != nil {
+		return nil, workspaceLockKey{}, "", false, err
+	}
+	return ws, workspaceLockKey{
+		ownerClientID: ws.ClientID,
+		lockPath:      lockPath,
+	}, lockPath, true, nil
+}
+
+func (srv *Server) loadWorkspaceLockStateLocked(
+	ctx context.Context,
+	client *daggerClient,
+	ws *core.Workspace,
+	key workspaceLockKey,
+	lockPath string,
+) (*workspaceLockState, error) {
+	sess := client.daggerSession
+	if sess.lockFiles == nil {
+		sess.lockFiles = make(map[workspaceLockKey]*workspaceLockState)
+	}
+	if state, ok := sess.lockFiles[key]; ok && state.loaded {
+		return state, nil
+	}
+
+	workspaceCtx, bk, err := srv.workspaceOwnerAccess(ctx, sess, ws)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := readWorkspaceLockState(workspaceCtx, bk, ws)
+	if err != nil {
+		return nil, err
+	}
+
+	state := &workspaceLockState{
+		ws:       ws.Clone(),
+		lockPath: lockPath,
+		lock:     lock,
+		delta:    workspace.NewLock(),
+		loaded:   true,
+	}
+	sess.lockFiles[key] = state
+	return state, nil
+}
+
+func (srv *Server) workspaceOwnerAccess(
+	ctx context.Context,
+	sess *daggerSession,
+	ws *core.Workspace,
+) (context.Context, *engineutil.Client, error) {
+	if ws.ClientID == "" {
+		return nil, nil, fmt.Errorf("workspace has no client ID")
+	}
+
+	ownerClient, err := srv.clientFromIDs(sess.sessionID, ws.ClientID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("workspace owner client: %w", err)
+	}
+	if ownerClient.clientMetadata == nil {
+		return nil, nil, fmt.Errorf("workspace owner client metadata not initialized")
+	}
+	if ownerClient.engineUtilClient == nil {
+		return nil, nil, fmt.Errorf("workspace owner buildkit client not initialized")
+	}
+
+	workspaceCtx := engine.ContextWithClientMetadata(ctx, ownerClient.clientMetadata)
+	return workspaceCtx, ownerClient.engineUtilClient, nil
+}
+
+func workspaceLockPath(ws *core.Workspace) (string, error) {
+	if ws == nil {
+		return "", fmt.Errorf("workspace is required")
+	}
+	if ws.HostPath() == "" {
+		return "", fmt.Errorf("workspace has no host path")
+	}
+	return filepath.Join(ws.HostPath(), ws.Path, workspace.LockDirName, workspace.LockFileName), nil
+}
+
+func readWorkspaceLockState(ctx context.Context, bk interface {
+	ReadCallerHostFile(ctx context.Context, path string) ([]byte, error)
+}, ws *core.Workspace) (*workspace.Lock, error) {
+	lockPath, err := workspaceLockPath(ws)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := bk.ReadCallerHostFile(ctx, lockPath)
+	if err != nil {
+		if isWorkspaceLockNotFound(err) {
+			return workspace.NewLock(), nil
+		}
+		return nil, fmt.Errorf("reading lock: %w", err)
+	}
+
+	lock, err := workspace.ParseLock(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing lock: %w", err)
+	}
+	return lock, nil
+}
+
+func isWorkspaceLockNotFound(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound
+}
+
+func exportWorkspaceLockToHost(ctx context.Context, bk *engineutil.Client, ws *core.Workspace, lock *workspace.Lock) error {
+	lockBytes, err := lock.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal lock: %w", err)
+	}
+
+	lockPath, err := workspaceLockPath(ws)
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp("", "workspace-lock-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(lockBytes); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := bk.LocalFileExport(ctx, tmpFile.Name(), workspace.LockFileName, lockPath, true); err != nil {
+		return fmt.Errorf("export lock: %w", err)
+	}
+	return nil
+}
+
+func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient) error {
+	sess := client.daggerSession
+
+	type pendingWorkspaceLockExport struct {
+		ws       *core.Workspace
+		lockPath string
+		delta    *workspace.Lock
+	}
+
+	var pending []pendingWorkspaceLockExport
+
+	sess.lockFileMu.RLock()
+	for _, state := range sess.lockFiles {
+		if state == nil || !state.loaded || !state.dirty {
+			continue
+		}
+		delta, err := state.delta.Clone()
+		if err != nil {
+			sess.lockFileMu.RUnlock()
+			return fmt.Errorf("clone workspace lock delta for %s: %w", state.lockPath, err)
+		}
+		if state.ws.ClientID == client.clientID {
+			pending = append(pending, pendingWorkspaceLockExport{
+				ws:       state.ws.Clone(),
+				lockPath: state.lockPath,
+				delta:    delta,
+			})
+		}
+	}
+	sess.lockFileMu.RUnlock()
+
+	var flushErr error
+	for _, export := range pending {
+		srv.locker.Lock(export.lockPath)
+
+		workspaceCtx, bk, err := srv.workspaceOwnerAccess(ctx, sess, export.ws)
+		if err == nil {
+			var latest *workspace.Lock
+			latest, err = readWorkspaceLockState(workspaceCtx, bk, export.ws)
+			if err == nil {
+				err = latest.Merge(export.delta)
+			}
+			if err == nil {
+				err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
+			}
+		}
+
+		srv.locker.Unlock(export.lockPath)
+
+		if err != nil {
+			flushErr = errors.Join(flushErr, fmt.Errorf("flush workspace lock %s: %w", export.lockPath, err))
+		}
+	}
+
+	return flushErr
 }
 
 // If the current client is coming from a function, return the module that function is from

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine"
 	bksession "github.com/dagger/dagger/internal/buildkit/session"
+	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -420,6 +421,82 @@ func TestWorkspaceBindingMode(t *testing.T) {
 		mode, workspaceRef := workspaceBindingMode(client)
 		require.Equal(t, workspaceBindingInherit, mode)
 		require.Equal(t, "", workspaceRef)
+	})
+}
+
+func TestNestedClientMetadata(t *testing.T) {
+	t.Parallel()
+
+	execMD := &engineutil.ExecutionMetadata{
+		ClientID:          "nested-client",
+		SessionID:         "session",
+		SecretToken:       "secret",
+		Hostname:          "nested-host",
+		ClientStableID:    "stable",
+		SSHAuthSocketPath: "/tmp/ssh.sock",
+		AllowedLLMModules: []string{"parent"},
+	}
+
+	t.Run("inherits forwarded lock mode", func(t *testing.T) {
+		t.Parallel()
+
+		md := nestedClientMetadata(execMD, &engine.ClientMetadata{
+			ClientVersion:        "v-test",
+			AllowedLLMModules:    []string{"child"},
+			ExtraModules:         []engine.ExtraModule{{Ref: "github.com/dagger/mod", Entrypoint: true}},
+			SkipWorkspaceModules: true,
+			LockMode:             string(workspace.LockModeLive),
+			EagerRuntime:         true,
+			Workspace:            stringPtr("github.com/dagger/dagger@main"),
+		}, string(workspace.LockModeFrozen))
+
+		require.Equal(t, "nested-client", md.ClientID)
+		require.Equal(t, "v-test", md.ClientVersion)
+		require.Equal(t, []string{"child"}, md.AllowedLLMModules)
+		require.Equal(t, string(workspace.LockModeLive), md.LockMode)
+		require.True(t, md.SkipWorkspaceModules)
+		require.True(t, md.EagerRuntime)
+		require.Equal(t, "github.com/dagger/dagger@main", *md.Workspace)
+		require.Len(t, md.ExtraModules, 1)
+	})
+
+	t.Run("falls back to caller lock mode when child omits it", func(t *testing.T) {
+		t.Parallel()
+
+		md := nestedClientMetadata(execMD, &engine.ClientMetadata{
+			ClientVersion:     "v-test",
+			AllowedLLMModules: []string{"child"},
+		}, string(workspace.LockModeLive))
+
+		require.Equal(t, string(workspace.LockModeLive), md.LockMode)
+	})
+
+	t.Run("falls back to execution metadata defaults", func(t *testing.T) {
+		t.Parallel()
+
+		md := nestedClientMetadata(execMD, nil, "")
+
+		require.Equal(t, engine.Version, md.ClientVersion)
+		require.Equal(t, []string{"parent"}, md.AllowedLLMModules)
+		require.Empty(t, md.LockMode)
+		require.Nil(t, md.Workspace)
+	})
+}
+
+func TestInheritedNestedClientLockMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers execution metadata lock mode", func(t *testing.T) {
+		t.Parallel()
+
+		srv := &Server{}
+		mode := srv.inheritedNestedClientLockMode(&engineutil.ExecutionMetadata{
+			LockMode:       string(workspace.LockModeLive),
+			SessionID:      "session",
+			CallerClientID: "caller",
+		})
+
+		require.Equal(t, string(workspace.LockModeLive), mode)
 	})
 }
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/dagger/dagger/engine/engineutil"
+	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -30,7 +30,7 @@ func (srv *Server) CurrentWorkspace(ctx context.Context) (*core.Workspace, error
 		return nil, err
 	}
 	if client.workspace == nil {
-		return nil, fmt.Errorf("workspace not loaded")
+		return nil, fmt.Errorf("%w: workspace not loaded", core.ErrNoCurrentWorkspace)
 	}
 	return client.workspace, nil
 }

--- a/hack/designs/lockfile.md
+++ b/hack/designs/lockfile.md
@@ -1,0 +1,604 @@
+# Lockfile: Lookup Resolution
+
+## Status: Partially Implemented
+
+This is the general design reference for Dagger lockfiles.
+
+It describes:
+
+- the lock entry format
+- lock policy and lock mode semantics
+- lock update flows
+- what is implemented now
+- what remains to be built
+
+## Problem
+
+1. Symbolic lookup inputs drift over time.
+2. Dagger needs one lock model across lookup functions, not one-off behavior per subsystem.
+3. Reproducible runs need a clear distinction between recorded results, live resolution, and explicit refresh.
+4. Lock maintenance must work both as a whole-lockfile operation and while running real workloads.
+5. Some consumers are implemented today, but the full target surface is larger.
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| Lookup function | A function that turns symbolic inputs into a concrete resolved result. |
+| Lookup inputs | The symbolic arguments to the lookup function. |
+| Lookup result | The concrete resolved value: digest, commit SHA, immutable ID, and so on. |
+| Lock entry | A recorded mapping from `(namespace, operation, inputs)` to `(value, policy)`. |
+| Lock policy | Entry-level refresh intent: `pin` or `float`. |
+| Lock mode | Run-level read/write behavior: `disabled`, `live`, `pinned`, or `frozen`. |
+| Lockfile snapshot | Parsed `.dagger/lock` state loaded into session-owned live state. |
+| Lockfile delta | Tuple upserts buffered in session-owned live state before final export. |
+
+## Lock Entry Format
+
+Lockfiles are JSON lines. The first line is the version tuple:
+
+```json
+[["version","1"]]
+```
+
+Each entry is a flat ordered tuple:
+
+```json
+[namespace, operation, inputs, value, policy]
+```
+
+Examples:
+
+```json
+["","container.from",["alpine:latest","linux/amd64"],"sha256:3d23f8","pin"]
+["","git.branch",["https://github.com/dagger/dagger.git","main"],"495a8c8ce85670e58560a9561626297a436225c0","float"]
+```
+
+Rules:
+
+- `namespace` is `""` for core lookups.
+- `operation` is a stable lookup key such as `container.from` or `git.branch`.
+- `inputs` is always an ordered positional array.
+- `value` is the resolved immutable result.
+- `policy` is `pin` or `float`.
+- dictionaries, maps, and named-argument encodings are forbidden anywhere in lock entries
+- ordering is deterministic by `(namespace, operation, inputs-json)`
+- legacy object-shaped result envelopes are invalid
+
+## Lock Policy
+
+Lock policy is stored per entry.
+
+| Policy | Meaning |
+| --- | --- |
+| `pin` | Prefer the recorded value when the mode allows it. |
+| `float` | Prefer live resolution when the mode allows it. |
+
+What users should memorize:
+
+- `pin`: stay on this recorded result
+- `float`: refresh this result when live resolution is allowed
+
+## Lock Mode
+
+Lock mode is chosen per run, typically with `--lock`.
+
+| Mode | Meaning |
+| --- | --- |
+| `disabled` | Ignore the lockfile completely. |
+| `live` | Resolve everything live and record the result. |
+| `pinned` | Reuse pinned entries, resolve everything else live, and record the result. |
+| `frozen` | Resolve only from the lockfile and fail on misses. |
+
+What users should memorize:
+
+- `disabled`: feature off
+- `live`: refresh while running
+- `pinned`: prefer stable pins, refresh the rest
+- `frozen`: use the lockfile only
+
+## Behavior Matrix
+
+| Mode | Existing `pin` entry | Existing `float` entry | Missing entry |
+| --- | --- | --- | --- |
+| `disabled` | resolve live, do not read or write lockfile | resolve live, do not read or write lockfile | resolve live, do not write |
+| `live` | resolve live and rewrite | resolve live and rewrite | resolve live and write |
+| `pinned` | use lockfile value | resolve live and rewrite | resolve live and write |
+| `frozen` | use lockfile value | use lockfile value | error |
+
+Important consequence:
+
+- in `frozen`, an existing `float` entry is still treated as a recorded snapshot
+- `float` only matters in modes that allow live resolution
+
+## Design Delta From Current Branch
+
+This section is the proposed diff from the current `lockfile` branch.
+
+It is intentionally narrow:
+
+- it only changes the ambient live lock path
+- it does not introduce a new public DagQL lockfile API
+- it does not redesign `currentWorkspace.update()` / `dagger lock update()` in the same
+  change
+
+| Area | Current branch | Proposed |
+| --- | --- | --- |
+| Ambient reads | each lock-aware consumer rereads `.dagger/lock` from caller host | read `.dagger/lock` at most once per bound workspace in a session, via lazy init into `daggerSession` state |
+| Ambient writes | reread + merge + export on each touched lookup | mutate session-owned workspace state in memory; export once on graceful shutdown |
+| State owner | schema-local `workspaceLookupLock` helper | `daggerSession` |
+| Concurrency | repeated sync caller-host I/O guarded only at export time | one workspace-keyed lock state map on `daggerSession`, guarded by an RW mutex |
+| Synchronization boundary | schema helpers still own part of write coordination | locking and merge/export coordination live in `engine/server` only |
+| Hot path boundary | schema consumers do caller-host lockfile I/O directly | schema consumers call lock methods exposed through `core.Query.Server` |
+| DagQL role | not part of the live path today | still not part of the live path in this change |
+| Explicit update | `currentWorkspace.update(): Changeset!` | unchanged in this change |
+
+Concretely, the design change is:
+
+- store live lock state on `daggerSession`, keyed by workspace binding
+- initialize it lazily on first lock access
+- guard it with an RW mutex on `daggerSession`
+- expose read/write through engine server methods and the `core.Query.Server` interface
+- export it back once when the main client shuts down gracefully
+- keep lockfile synchronization and final export inside `engine/server`, not `core/schema`
+
+## Update Flows
+
+There are three real update paths:
+
+### `dagger lock update`
+
+Refresh entries already present in `.dagger/lock`.
+
+Properties:
+
+- best-effort by entry type
+- uses the current environment's ambient authentication
+- does not discover new entries on its own
+- thin CLI wrapper over `currentWorkspace.update()`
+
+### `--lock=live`
+
+Run the real workload in live lock mode.
+
+Properties:
+
+- refreshes existing entries the run touches
+- discovers missing entries the run touches
+- reads `.dagger/lock` at most once per bound workspace in a session
+- mutates the lockfile server-side throughout the session
+- exports the final lockfile once on graceful session shutdown
+- is the authoritative discovery path for new lock entries
+
+### `currentWorkspace.update(): Changeset!`
+
+Engine API for refreshing entries already present in `.dagger/lock`.
+
+Properties:
+
+- returns a `Changeset` instead of writing directly
+- refreshes supported existing entries only
+- errors if `.dagger/lock` does not exist
+
+This design update leaves explicit maintenance alone. It only changes the ambient live
+path.
+
+## Session-State Lifecycle
+
+### Session State
+
+Store live lockfile state on `daggerSession` in `engine/server/session.go`.
+
+One session may host more than one bound workspace, so this state should be a
+map keyed by workspace binding, not a single session-global lockfile.
+
+Recommended shape:
+
+- `lockFiles map[workspaceLockKey]*workspaceLockState`
+- `lockFileMu sync.RWMutex`
+
+Where:
+
+- `workspaceLockKey` identifies the bound workspace for lockfile purposes
+- `workspaceLockState` holds:
+  - parsed `*workspace.Lock`
+  - `loaded` bit
+  - `dirty` bit
+  - any precomputed lockfile path needed for final export
+
+Properties:
+
+- lazy init on first lock access
+- read `.dagger/lock` from caller host at most once per bound workspace
+- all later reads come from in-memory session state
+- all live writes update that same in-memory session state
+- clients that share a bound workspace share one live lock state
+- clients bound to different workspaces get different live lock states
+
+### Access Pattern
+
+Expose lockfile access through engine server methods:
+
+- add methods on the engine server that find the current client/session
+- expose corresponding methods on `core.Query.Server`
+- have `core/` and `core/schema/` callers use those methods
+
+This follows the existing server/session pattern already used elsewhere in the engine.
+
+### Live Execution Path
+
+Ambient execution (`--lock=live`, plus the write-through cases of `pinned`) should:
+
+- read current session lockfile state
+- resolve the live lookup
+- update current session lockfile state in memory
+
+It should not:
+
+- reread `.dagger/lock` from the caller host on each lookup
+- export `.dagger/lock` after each lookup
+- route lock mutation through nested DagQL calls
+
+### Final Export
+
+When the main client shuts down:
+
+- if a workspace lock state was never loaded, do nothing
+- if it was loaded but never modified, do nothing
+- if it was modified, export it back once
+- serialize cross-session export by lockfile path inside `engine/server`
+
+The natural place for this is the `/shutdown` endpoint.
+
+To preserve current behavior under cross-session contention, the final export can reuse
+the existing "merge against latest on-disk state" logic at shutdown time instead of on
+every lookup.
+
+The important cleanup constraint is:
+
+- `core/schema/lockfile.go` should not own any global mutex map or export-time
+  synchronization
+- it should only adapt schema callers to `core.Query.Server`
+- `engine/server` should own the actual read/write/merge/export implementation
+
+### Anti-goals
+
+- do not add a new public DagQL lockfile API as part of this change
+- do not make hot-path lock reads/writes re-enter DagQL
+- do not keep direct per-consumer caller-host lockfile reads in schema code
+- do not redesign `currentWorkspace.update()` / `dagger lock update()` in the same
+  change
+
+## Lookup Coverage
+
+Target model: one lock system for all lookup functions.
+
+Current core operation keys:
+
+| Operation | Inputs | Result |
+| --- | --- | --- |
+| `container.from` | `[imageRef, platform]` | image digest |
+| `modules.resolve` | `[source]` | commit SHA |
+| `git.head` | `[remoteURL]` | commit SHA |
+| `git.branch` | `[remoteURL, branchName]` | commit SHA |
+| `git.tag` | `[remoteURL, tagName]` | commit SHA |
+| `git.ref` | `[remoteURL, refName]` | commit SHA |
+
+Notes:
+
+- `git.commit` is already pinned by input and does not create lock entries
+- `modules.resolve` defaults to `pin` for tags and explicit commits, `float`
+  otherwise
+- `git.ref` only creates lock entries for mutable refs
+- the recorded Git URL should be the resolved canonical remote URL used for transport
+
+## Current Implementation
+
+### Implemented
+
+- [x] tuple lockfile substrate in `util/lockfile`
+- [x] flat lock entry format `[namespace, operation, inputs, value, policy]`
+- [x] hard cutover to ordered positional tuples only
+- [x] lock policy parsing and validation
+- [x] lock mode parsing and transport through CLI and client metadata
+- [x] nested-client and module-runtime lock mode propagation
+- [x] local workspace lockfile read/write helpers
+- [x] serialized lockfile writes with merge against latest on-disk state
+- [x] `container.from` lookup locking
+- [x] `modules.resolve` lookup locking
+- [x] Git lookup locking for `head`, `branch`, `tag`, and mutable `ref`
+- [x] `currentWorkspace.update(): Changeset!` temporary umbrella API
+- [x] `dagger lock update`
+- [x] execution-driven discovery via `--lock=live`
+- [x] unit and integration coverage for substrate, CLI, container, Git, module, and nested execution
+- [x] session-backed live lock state on `daggerSession`
+- [x] lazy one-time lockfile load on first live lock access
+- [x] graceful-shutdown export of dirty session lock state
+- [x] `core.Query.Server` lock methods for hot-path consumers
+- [x] removal of direct per-consumer caller-host lockfile reads
+- [x] engine-owned lock synchronization for final export
+
+### Not Yet Implemented From This Design
+
+- [ ] integration coverage for session shutdown export behavior
+
+### Implemented Semantics
+
+- [x] `--lock=disabled|live|pinned|frozen`
+- [x] default lock mode is `disabled`
+- [x] `live` writes through
+- [x] `pinned` writes through for `float` and missing entries
+- [x] `frozen` reuses both `pin` and `float` entries and fails on misses
+
+### Current Consumer Defaults
+
+- [x] `container.from` defaults to `pin`
+- [x] `modules.resolve` defaults to `pin` for tags and commits, `float` otherwise
+- [x] `git.branch` defaults to `float`
+- [x] `git.head` defaults to `float`
+- [x] `git.tag` defaults to `pin`
+- [x] `git.ref` defaults to `pin` for tags and `float` for other mutable refs
+
+## Current Implementation Constraints
+
+These are current branch facts, not necessarily the final target for all future workspace behavior.
+
+- lockfile location is derived from the detected workspace directory
+- on `workspace-plumbing`, that means `.dagger/lock` sits under the current detected workspace path, not necessarily repo root
+- lockfile mutation is local-only
+- remote workspaces currently error for lock-aware mutation paths
+- hot lookup paths do not reread `.dagger/lock` from the caller host after the session
+  snapshot is loaded
+- live lock writes are buffered in session-owned workspace state and exported once on
+  graceful shutdown
+- final export still rereads latest on-disk state and merges the session delta before
+  writing
+- `dagger lock update` relies on ambient authentication for private registries and repositories
+
+## Implementation Principle
+
+New lockfile consumers should attach to existing lookup resolution flows rather than
+introducing new engine hooks just for locking.
+
+Why:
+
+- the existing lookup path is already the source of truth for symbolic input parsing
+  and live resolution
+- reusing that path keeps lock semantics aligned with normal runtime behavior
+- it avoids duplicating resolution logic in parallel lock-specific plumbing
+- it makes the same consumer reusable across workspace-specific and generic API
+  entrypoints
+
+Implication:
+
+- when adding a new consumer such as `modules.resolve`, hook lock read/write behavior
+  into the current module resolution path
+- have that path consult the session-owned live lock state, not raw caller-host
+  file reads
+- do not refactor the engine to create a second resolution hook whose only purpose is
+  lockfile integration
+
+## Implementation Plan
+
+This section is intentionally concrete. It is the level of detail that should have
+been reviewed before implementation so type shapes and file boundaries stay aligned.
+
+### `core/query.go`
+
+#### Server lock accessors
+
+```go
+type Server interface {
+	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)
+	SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error
+}
+```
+
+These are the only live-path hooks schema consumers should need.
+
+### `core/schema/lockfile.go`
+
+#### Thin schema adapter for live lookups
+
+```go
+type workspaceLookupLock struct {
+	ctx   context.Context
+	query *core.Query
+	lock  *workspace.Lock
+}
+
+func loadWorkspaceLookupLock(ctx context.Context, query *core.Query) (*workspaceLookupLock, error)
+func (l *workspaceLookupLock) SetLookup(namespace, operation string, inputs []any, result workspace.LookupResult) error
+```
+
+The live-path responsibilities in this file should be narrow:
+
+- ask `core.Query.Server` for the current lock snapshot
+- ask `core.Query.Server` to stage an upsert
+- update the local clone returned to the resolver so repeated lookups in one call stay coherent
+
+This file should not:
+
+- own any global mutex map
+- coordinate final export
+- expose engine-facing lockfile I/O helpers
+
+### `core/schema/container.go`
+
+#### `container.from` lock integration
+
+```go
+lookupLock, err := loadWorkspaceLookupLock(ctx, query)
+resolution, err := resolveLookupFromLock(lockMode, lookupLock.lock, lockContainerFromOperation, inputs, workspace.PolicyPin)
+```
+
+After live resolution:
+
+```go
+if resolution.ShouldWrite {
+	err = lookupLock.SetLookup(lockCoreNamespace, lockContainerFromOperation, inputs, result)
+}
+```
+
+### `core/schema/modulesource.go`
+
+#### `modules.resolve` lock integration
+
+The shape is the same as `container.from`:
+
+- read session-backed lock state through `loadWorkspaceLookupLock`
+- use `resolveLookupFromLock` for policy/mode behavior
+- stage the updated lookup through `SetLookup` after live resolution
+
+### `core/schema/git.go`
+
+#### Git lookup integration
+
+Each mutable Git lookup follows the same pattern:
+
+- `git.head`
+- `git.branch`
+- mutable `git.ref`
+
+Pinned Git lookups such as immutable refs do not create lock entries.
+
+### `core/workspace/lock.go`
+
+#### Shared lock mutation helpers
+
+```go
+func (l *Lock) Clone() (*Lock, error)
+func (l *Lock) Merge(other *Lock) error
+```
+
+These helpers are the shared mutation substrate used by both:
+
+- session-owned live lock state
+- explicit `currentWorkspace.update()` refresh paths
+
+### `engine/server/session.go`
+
+#### Session-owned lock state
+
+```go
+type daggerSession struct {
+	lockFiles  map[workspaceLockKey]*workspaceLockState
+	lockFileMu sync.RWMutex
+}
+
+type workspaceLockKey struct {
+	ownerClientID string
+	lockPath      string
+}
+
+type workspaceLockState struct {
+	ws       *core.Workspace
+	lockPath string
+	lock     *workspace.Lock
+	delta    *workspace.Lock
+	loaded   bool
+	dirty    bool
+}
+```
+
+#### Live-path server methods
+
+```go
+func (srv *Server) CurrentWorkspaceLock(ctx context.Context) (*workspace.Lock, bool, error)
+func (srv *Server) SetCurrentWorkspaceLookup(ctx context.Context, namespace string, operation string, inputs []any, result workspace.LookupResult) error
+```
+
+These methods:
+
+- resolve the current workspace binding
+- lazy-load the lock snapshot once per workspace key
+- clone on read so callers cannot mutate session state directly
+- stage writes into both the working lock and the `delta`
+
+#### Engine-owned lockfile I/O helpers
+
+```go
+func workspaceLockPath(ws *core.Workspace) (string, error)
+func readWorkspaceLockState(ctx context.Context, bk interface{ ReadCallerHostFile(context.Context, string) ([]byte, error) }, ws *core.Workspace) (*workspace.Lock, bool, error)
+func exportWorkspaceLockToHost(ctx context.Context, bk *buildkit.Client, ws *core.Workspace, lock *workspace.Lock) error
+```
+
+These helpers stay in `engine/server` for the live path. `core/schema` should not be
+used as a utility package for engine-owned merge/export logic.
+
+#### Final export on shutdown
+
+```go
+func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient) error
+```
+
+The export flow should be:
+
+```go
+srv.locker.Lock(export.lockPath)
+defer srv.locker.Unlock(export.lockPath)
+
+latest, _, err := readWorkspaceLockState(workspaceCtx, bk, export.ws)
+if err == nil {
+	err = latest.Merge(export.delta)
+}
+if err == nil {
+	err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
+}
+```
+
+Important constraints:
+
+- the per-session `lockFileMu` protects session-owned state
+- cross-session serialization by lock path happens in `engine/server`
+- no schema-level synchronization participates in this flow
+
+## Remaining Work
+
+### High-priority design/implementation gaps
+
+- [ ] add direct coverage for session shutdown export behavior
+- [ ] `http` lookup locking
+- [ ] decide whether additional Git lookup operations such as `refs`, `symrefs`, or `isPublic` belong in the lock model
+- [ ] remote-workspace read semantics, if any
+- [ ] final initialized-workspace semantics for `.dagger/lock` anchoring
+
+### UX and maintenance follow-ups
+
+- [ ] decide whether `disabled` should remain the long-term default
+- [ ] decide whether `dagger lock update` should gain richer output or selection flags
+- [ ] decide whether lock update should prune stale entries
+- [ ] decide whether to add a public lockfile DagQL API later
+
+### Longer-term extensions
+
+- [ ] full offline / airgapped design
+- [ ] extension model for user-defined lookup functions
+- [ ] broader conformance coverage as new lookup consumers are added
+
+## Workspace Relationship
+
+Lockfiles are attached to workspace bindings.
+
+Why:
+
+- the lockfile path is derived from the bound workspace
+- host filesystem access for local workspaces routes through the workspace owner
+- deterministic workspace loading eventually needs recorded lookup results
+- `modules.resolve` is the clearest workspace-driven lookup consumer
+
+So the intended long-term shape is:
+
+- one lock model for core lookups
+- one lock model for workspace-owned lock state
+- one maintenance interface for refreshing recorded results
+
+## Reference Commands
+
+```bash
+dagger --lock=disabled call ...
+dagger --lock=live call ...
+dagger --lock=pinned call ...
+dagger --lock=frozen call ...
+dagger lock update
+```

--- a/hack/designs/lockfile.md
+++ b/hack/designs/lockfile.md
@@ -389,8 +389,8 @@ been reviewed before implementation so type shapes and file boundaries stay alig
 
 ```go
 type Server interface {
-	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)
-	SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error
+ CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)
+ SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error
 }
 ```
 
@@ -402,9 +402,9 @@ These are the only live-path hooks schema consumers should need.
 
 ```go
 type workspaceLookupLock struct {
-	ctx   context.Context
-	query *core.Query
-	lock  *workspace.Lock
+ ctx   context.Context
+ query *core.Query
+ lock  *workspace.Lock
 }
 
 func loadWorkspaceLookupLock(ctx context.Context, query *core.Query) (*workspaceLookupLock, error)
@@ -436,7 +436,7 @@ After live resolution:
 
 ```go
 if resolution.ShouldWrite {
-	err = lookupLock.SetLookup(lockCoreNamespace, lockContainerFromOperation, inputs, result)
+ err = lookupLock.SetLookup(lockCoreNamespace, lockContainerFromOperation, inputs, result)
 }
 ```
 
@@ -482,22 +482,22 @@ These helpers are the shared mutation substrate used by both:
 
 ```go
 type daggerSession struct {
-	lockFiles  map[workspaceLockKey]*workspaceLockState
-	lockFileMu sync.RWMutex
+ lockFiles  map[workspaceLockKey]*workspaceLockState
+ lockFileMu sync.RWMutex
 }
 
 type workspaceLockKey struct {
-	ownerClientID string
-	lockPath      string
+ ownerClientID string
+ lockPath      string
 }
 
 type workspaceLockState struct {
-	ws       *core.Workspace
-	lockPath string
-	lock     *workspace.Lock
-	delta    *workspace.Lock
-	loaded   bool
-	dirty    bool
+ ws       *core.Workspace
+ lockPath string
+ lock     *workspace.Lock
+ delta    *workspace.Lock
+ loaded   bool
+ dirty    bool
 }
 ```
 
@@ -540,10 +540,10 @@ defer srv.locker.Unlock(export.lockPath)
 
 latest, _, err := readWorkspaceLockState(workspaceCtx, bk, export.ws)
 if err == nil {
-	err = latest.Merge(export.delta)
+ err = latest.Merge(export.delta)
 }
 if err == nil {
-	err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
+ err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
 }
 ```
 

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -203,6 +203,26 @@ defmodule Dagger.Workspace do
       client: workspace.client
     }
   end
+
+  @doc """
+  Refresh workspace-managed state and return the resulting changeset.
+
+  Currently this refreshes existing lockfile entries only.
+
+  > #### Experimental {: .warning}
+  >
+  > "Experimental workspace update API currently refreshes existing lockfile entries only."
+  """
+  @spec update(t()) :: Dagger.Changeset.t()
+  def update(%__MODULE__{} = workspace) do
+    query_builder =
+      workspace.query_builder |> QB.select("update")
+
+    %Dagger.Changeset{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
 end
 
 defimpl Jason.Encoder, for: Dagger.Workspace do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -15520,6 +15520,19 @@ func (r *Workspace) Services(opts ...WorkspaceServicesOpts) *UpGroup {
 	}
 }
 
+// Refresh workspace-managed state and return the resulting changeset.
+//
+// Currently this refreshes existing lockfile entries only.
+//
+// Experimental: Experimental workspace update API currently refreshes existing lockfile entries only.
+func (r *Workspace) Update() *Changeset {
+	q := r.query.Select("update")
+
+	return &Changeset{
+		query: q,
+	}
+}
+
 // Sharing mode of the cache volume.
 type CacheSharingMode string
 

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -170,4 +170,15 @@ class Workspace extends Client\AbstractObject implements Client\IdAble
         }
         return new \Dagger\UpGroup($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
+
+    /**
+     * Refresh workspace-managed state and return the resulting changeset.
+     *
+     * Currently this refreshes existing lockfile entries only.
+     */
+    public function update(): Changeset
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('update');
+        return new \Dagger\Changeset($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15365,6 +15365,19 @@ class Workspace(Type):
         _ctx = self._select("services", _args)
         return UpGroup(_ctx)
 
+    def update(self) -> Changeset:
+        """Refresh workspace-managed state and return the resulting changeset.
+
+        Currently this refreshes existing lockfile entries only.
+
+        .. caution::
+            Experimental: Experimental workspace update API currently
+            refreshes existing lockfile entries only.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("update", _args)
+        return Changeset(_ctx)
+
 
 class Client(Query):
     """The Dagger client.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15846,6 +15846,16 @@ impl Workspace {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Refresh workspace-managed state and return the resulting changeset.
+    /// Currently this refreshes existing lockfile entries only.
+    pub fn update(&self) -> Changeset {
+        let query = self.selection.select("update");
+        Changeset {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
 }
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub enum CacheSharingMode {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -14839,6 +14839,17 @@ export class Workspace extends BaseClient {
     const ctx = this._ctx.select("services", { ...opts })
     return new UpGroup(ctx)
   }
+
+  /**
+   * Refresh workspace-managed state and return the resulting changeset.
+   *
+   * Currently this refreshes existing lockfile entries only.
+   * @experimental
+   */
+  update = (): Changeset => {
+    const ctx = this._ctx.select("update")
+    return new Changeset(ctx)
+  }
 }
 
 export const dag = new Client()

--- a/util/gitutil/url.go
+++ b/util/gitutil/url.go
@@ -133,6 +133,39 @@ func ParseURL(remote string) (*GitURL, error) {
 	return nil, ErrUnknownProtocol
 }
 
+// cloneURLFallbackProtocols is the priority order for resolving a clone ref
+// that omits its scheme (e.g. "github.com/foo/bar"). Callers iterate the
+// candidates and try the next one when authentication fails.
+var cloneURLFallbackProtocols = []string{HTTPSProtocol, SSHProtocol}
+
+// ParseCloneURL parses a clone reference into one or more candidate GitURLs,
+// in priority order.
+//
+// Module sources may omit the scheme (e.g. "github.com/foo/bar") since the
+// transport is decided at clone time, not parse time. For those, ParseCloneURL
+// returns multiple candidates with common protocols prepended; callers iterate
+// and try the next one on authentication failure. For fully-qualified URLs,
+// it returns a single-element slice.
+func ParseCloneURL(remote string) ([]*GitURL, error) {
+	u, err := ParseURL(remote)
+	if err == nil {
+		return []*GitURL{u}, nil
+	}
+	if !errors.Is(err, ErrUnknownProtocol) {
+		return nil, err
+	}
+	candidates := make([]*GitURL, 0, len(cloneURLFallbackProtocols))
+	for _, proto := range cloneURLFallbackProtocols {
+		if u, err := ParseURL(proto + "://" + remote); err == nil {
+			candidates = append(candidates, u)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownProtocol, remote)
+	}
+	return candidates, nil
+}
+
 func IsGitTransport(remote string) bool {
 	if proto := protoRegexp.FindString(remote); proto != "" {
 		proto = strings.ToLower(strings.TrimSuffix(proto, "://"))

--- a/util/gitutil/url_test.go
+++ b/util/gitutil/url_test.go
@@ -173,3 +173,58 @@ func TestParseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCloneURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantSchemes []string
+		wantErr     bool
+	}{
+		{
+			name:        "https URL is single candidate",
+			url:         "https://github.com/foo/bar",
+			wantSchemes: []string{HTTPSProtocol},
+		},
+		{
+			name:        "ssh URL is single candidate",
+			url:         "ssh://git@github.com/foo/bar.git",
+			wantSchemes: []string{SSHProtocol},
+		},
+		{
+			name:        "scp-style URL is single candidate",
+			url:         "git@github.com:foo/bar.git",
+			wantSchemes: []string{SSHProtocol},
+		},
+		{
+			name:        "schemeless URL yields https then ssh candidates",
+			url:         "github.com/foo/bar",
+			wantSchemes: []string{HTTPSProtocol, SSHProtocol},
+		},
+		{
+			name:        "schemeless URL with subpath yields https then ssh candidates",
+			url:         "github.com/foo/bar/subdir",
+			wantSchemes: []string{HTTPSProtocol, SSHProtocol},
+		},
+		{
+			name:    "unsupported protocol propagates error",
+			url:     "httpx://github.com/foo/bar",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidates, err := ParseCloneURL(test.url)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, candidates, len(test.wantSchemes))
+			for i, want := range test.wantSchemes {
+				require.Equal(t, want, candidates[i].Scheme, "candidate %d scheme", i)
+			}
+		})
+	}
+}

--- a/util/lockfile/lockfile.go
+++ b/util/lockfile/lockfile.go
@@ -1,0 +1,368 @@
+package lockfile
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	versionKey   = "version"
+	versionValue = "1"
+)
+
+// Lockfile stores lock entries keyed by (namespace, operation, inputs).
+type Lockfile struct {
+	entries map[tupleKey]lockEntry
+}
+
+type tupleKey struct {
+	namespace  string
+	operation  string
+	inputsJSON string
+}
+
+type lockEntry struct {
+	namespace  string
+	operation  string
+	inputs     []any
+	inputsJSON string
+	value      any
+	policy     string
+}
+
+// Entry is a single lockfile tuple entry.
+type Entry struct {
+	Namespace string
+	Operation string
+	Inputs    []any
+	Value     any
+	Policy    string
+}
+
+// New returns an empty lockfile.
+func New() *Lockfile {
+	return &Lockfile{entries: map[tupleKey]lockEntry{}}
+}
+
+// Parse decodes lockfile JSON lines.
+//
+// Non-empty files must start with a version header line: [["version","1"]].
+func Parse(data []byte) (*Lockfile, error) {
+	lock := New()
+	lines := bytes.Split(data, []byte("\n"))
+
+	firstContentLine := true
+	for i, rawLine := range lines {
+		line := strings.TrimSpace(string(rawLine))
+		if line == "" {
+			continue
+		}
+
+		if firstContentLine {
+			if err := parseVersionHeader([]byte(line)); err != nil {
+				return nil, fmt.Errorf("lockfile line %d: %w", i+1, err)
+			}
+			firstContentLine = false
+			continue
+		}
+
+		entry, err := parseEntry([]byte(line))
+		if err != nil {
+			return nil, fmt.Errorf("lockfile line %d: %w", i+1, err)
+		}
+		lock.entries[entryKey(entry.namespace, entry.operation, entry.inputsJSON)] = entry
+	}
+
+	return lock, nil
+}
+
+// Marshal encodes lockfile entries to deterministic JSON lines.
+//
+// Empty lockfiles marshal to empty bytes.
+func (l *Lockfile) Marshal() ([]byte, error) {
+	if len(l.entries) == 0 {
+		return nil, nil
+	}
+
+	lines := make([][]byte, 0, len(l.entries)+1)
+	header, err := json.Marshal([][]string{{versionKey, versionValue}})
+	if err != nil {
+		return nil, fmt.Errorf("marshal lockfile header: %w", err)
+	}
+	lines = append(lines, header)
+
+	for _, entry := range l.sortedEntries() {
+		line, err := json.Marshal([]any{entry.namespace, entry.operation, entry.inputs, entry.value, entry.policy})
+		if err != nil {
+			return nil, fmt.Errorf("marshal lockfile entry %q %q: %w", entry.namespace, entry.operation, err)
+		}
+		lines = append(lines, line)
+	}
+
+	return bytes.Join(lines, []byte("\n")), nil
+}
+
+// Get retrieves the value and policy for (namespace, operation, inputs).
+func (l *Lockfile) Get(namespace, operation string, inputs []any) (any, string, bool) {
+	if l == nil || len(l.entries) == 0 {
+		return nil, "", false
+	}
+	_, inputsJSON, err := canonicalizeInputs(inputs)
+	if err != nil {
+		return nil, "", false
+	}
+	entry, ok := l.entries[entryKey(namespace, operation, inputsJSON)]
+	if !ok {
+		return nil, "", false
+	}
+	value, err := canonicalizeValue(entry.value)
+	if err != nil {
+		return nil, "", false
+	}
+	return value, entry.policy, true
+}
+
+// Set records the value and policy for (namespace, operation, inputs).
+func (l *Lockfile) Set(namespace, operation string, inputs []any, value any, policy string) error {
+	if l == nil {
+		return fmt.Errorf("nil lockfile")
+	}
+	if l.entries == nil {
+		l.entries = map[tupleKey]lockEntry{}
+	}
+
+	canonicalInputs, inputsJSON, err := canonicalizeInputs(inputs)
+	if err != nil {
+		return fmt.Errorf("canonicalizing lock inputs: %w", err)
+	}
+	canonicalValue, err := canonicalizeValue(value)
+	if err != nil {
+		return fmt.Errorf("canonicalizing lock value: %w", err)
+	}
+
+	l.entries[entryKey(namespace, operation, inputsJSON)] = lockEntry{
+		namespace:  namespace,
+		operation:  operation,
+		inputs:     canonicalInputs,
+		inputsJSON: inputsJSON,
+		value:      canonicalValue,
+		policy:     policy,
+	}
+	return nil
+}
+
+// Delete removes the result for (namespace, operation, inputs).
+func (l *Lockfile) Delete(namespace, operation string, inputs []any) bool {
+	if l == nil || len(l.entries) == 0 {
+		return false
+	}
+	_, inputsJSON, err := canonicalizeInputs(inputs)
+	if err != nil {
+		return false
+	}
+	key := entryKey(namespace, operation, inputsJSON)
+	if _, ok := l.entries[key]; !ok {
+		return false
+	}
+	delete(l.entries, key)
+	return true
+}
+
+// Entries returns a deterministic snapshot of all lock entries.
+func (l *Lockfile) Entries() []Entry {
+	if l == nil || len(l.entries) == 0 {
+		return nil
+	}
+
+	entries := make([]Entry, 0, len(l.entries))
+	for _, entry := range l.sortedEntries() {
+		inputs, _, err := canonicalizeInputs(entry.inputs)
+		if err != nil {
+			continue
+		}
+		value, err := canonicalizeValue(entry.value)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, Entry{
+			Namespace: entry.namespace,
+			Operation: entry.operation,
+			Inputs:    inputs,
+			Value:     value,
+			Policy:    entry.policy,
+		})
+	}
+	return entries
+}
+
+func parseVersionHeader(line []byte) error {
+	var header []json.RawMessage
+	if err := decodeJSON(line, &header); err != nil {
+		return fmt.Errorf("invalid version header: %w", err)
+	}
+	if len(header) != 1 {
+		return fmt.Errorf("missing version header")
+	}
+	var versionPair []string
+	if err := decodeJSON(header[0], &versionPair); err != nil {
+		return fmt.Errorf("missing version header")
+	}
+	if len(versionPair) != 2 || versionPair[0] != versionKey {
+		return fmt.Errorf("missing version header")
+	}
+	if versionPair[1] != versionValue {
+		return fmt.Errorf("unsupported lockfile version %q", versionPair[1])
+	}
+	return nil
+}
+
+func parseEntry(line []byte) (lockEntry, error) {
+	var tuple []json.RawMessage
+	if err := decodeJSON(line, &tuple); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid tuple JSON: %w", err)
+	}
+	if len(tuple) != 5 {
+		return lockEntry{}, fmt.Errorf("invalid tuple length %d: expected 5", len(tuple))
+	}
+
+	var namespace string
+	if err := decodeJSON(tuple[0], &namespace); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid namespace: %w", err)
+	}
+
+	var operation string
+	if err := decodeJSON(tuple[1], &operation); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid operation: %w", err)
+	}
+
+	var inputs []any
+	if err := decodeJSON(tuple[2], &inputs); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid inputs: %w", err)
+	}
+	canonicalInputs, inputsJSON, err := canonicalizeInputs(inputs)
+	if err != nil {
+		return lockEntry{}, fmt.Errorf("canonicalizing inputs: %w", err)
+	}
+
+	var value any
+	if err := decodeJSON(tuple[3], &value); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid value: %w", err)
+	}
+	canonicalValue, err := canonicalizeValue(value)
+	if err != nil {
+		return lockEntry{}, fmt.Errorf("canonicalizing value: %w", err)
+	}
+	var policy string
+	if err := decodeJSON(tuple[4], &policy); err != nil {
+		return lockEntry{}, fmt.Errorf("invalid policy: %w", err)
+	}
+
+	return lockEntry{
+		namespace:  namespace,
+		operation:  operation,
+		inputs:     canonicalInputs,
+		inputsJSON: inputsJSON,
+		value:      canonicalValue,
+		policy:     policy,
+	}, nil
+}
+
+func canonicalizeInputs(inputs []any) ([]any, string, error) {
+	if inputs == nil {
+		inputs = []any{}
+	}
+	data, err := json.Marshal(inputs)
+	if err != nil {
+		return nil, "", err
+	}
+	var canonical []any
+	if err := decodeJSON(data, &canonical); err != nil {
+		return nil, "", err
+	}
+	if err := validateOrderedInputs(canonical); err != nil {
+		return nil, "", err
+	}
+	return canonical, string(data), nil
+}
+
+func canonicalizeValue(value any) (any, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var canonical any
+	if err := decodeJSON(data, &canonical); err != nil {
+		return nil, err
+	}
+	if err := validateNoMaps(canonical, "lock value"); err != nil {
+		return nil, err
+	}
+	return canonical, nil
+}
+
+func validateOrderedInputs(inputs []any) error {
+	for i, value := range inputs {
+		if err := validateNoMaps(value, "lock inputs"); err != nil {
+			return fmt.Errorf("input %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateNoMaps(value any, subject string) error {
+	switch typed := value.(type) {
+	case []any:
+		for i, nested := range typed {
+			if err := validateNoMaps(nested, subject); err != nil {
+				return fmt.Errorf("nested input %d: %w", i, err)
+			}
+		}
+	case map[string]any:
+		return fmt.Errorf("unordered object/map/dict in %s", subject)
+	}
+	return nil
+}
+
+func decodeJSON(data []byte, out any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(out); err != nil {
+		return err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing content")
+		}
+		return err
+	}
+	return nil
+}
+
+func entryKey(namespace, operation, inputsJSON string) tupleKey {
+	return tupleKey{
+		namespace:  namespace,
+		operation:  operation,
+		inputsJSON: inputsJSON,
+	}
+}
+
+func (l *Lockfile) sortedEntries() []lockEntry {
+	entries := make([]lockEntry, 0, len(l.entries))
+	for _, entry := range l.entries {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].namespace != entries[j].namespace {
+			return entries[i].namespace < entries[j].namespace
+		}
+		if entries[i].operation != entries[j].operation {
+			return entries[i].operation < entries[j].operation
+		}
+		return entries[i].inputsJSON < entries[j].inputsJSON
+	})
+	return entries
+}

--- a/util/lockfile/lockfile_test.go
+++ b/util/lockfile/lockfile_test.go
@@ -1,0 +1,150 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMarshalRoundTrip(t *testing.T) {
+	input := strings.Join([]string{
+		`[["version","1"]]`,
+		`["","container.from",["alpine:latest","linux/amd64"],"sha256:3d23f8","float"]`,
+		`["github.com/acme/release","lookupVersion",["stable"],"v1.2.3","float"]`,
+	}, "\n")
+
+	parsed, err := Parse([]byte(input))
+	require.NoError(t, err)
+
+	output, err := parsed.Marshal()
+	require.NoError(t, err)
+
+	reparsed, err := Parse(output)
+	require.NoError(t, err)
+
+	output2, err := reparsed.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, string(output), string(output2))
+
+	value, policy, ok := reparsed.Get("", "container.from", []any{"alpine:latest", "linux/amd64"})
+	require.True(t, ok)
+	require.Equal(t, "sha256:3d23f8", value)
+	require.Equal(t, "float", policy)
+}
+
+func TestMarshalDeterministicOrdering(t *testing.T) {
+	lock := New()
+	require.NoError(t, lock.Set("b", "lookup", []any{"x"}, "r3", "float"))
+	require.NoError(t, lock.Set("", "git.resolveRef", []any{"c", "d"}, "r1", "pin"))
+	require.NoError(t, lock.Set("", "git.resolveRef", []any{"a", "b"}, "r2", "pin"))
+
+	output, err := lock.Marshal()
+	require.NoError(t, err)
+
+	require.Equal(t, strings.Join([]string{
+		`[["version","1"]]`,
+		`["","git.resolveRef",["a","b"],"r2","pin"]`,
+		`["","git.resolveRef",["c","d"],"r1","pin"]`,
+		`["b","lookup",["x"],"r3","float"]`,
+	}, "\n"), string(output))
+}
+
+func TestParseDuplicateTupleOverwrites(t *testing.T) {
+	input := strings.Join([]string{
+		`[["version","1"]]`,
+		`["","container.from",["alpine:latest","linux/amd64"],"old","float"]`,
+		`["","container.from",["alpine:latest","linux/amd64"],"new","float"]`,
+	}, "\n")
+
+	lock, err := Parse([]byte(input))
+	require.NoError(t, err)
+
+	value, policy, ok := lock.Get("", "container.from", []any{"alpine:latest", "linux/amd64"})
+	require.True(t, ok)
+	require.Equal(t, "new", value)
+	require.Equal(t, "float", policy)
+
+	output, err := lock.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(strings.Split(string(output), "\n")))
+	require.Contains(t, string(output), `"new"`)
+	require.NotContains(t, string(output), `"old"`)
+}
+
+func TestParseMalformedAndEmpty(t *testing.T) {
+	t.Run("empty file", func(t *testing.T) {
+		lock, err := Parse(nil)
+		require.NoError(t, err)
+
+		output, err := lock.Marshal()
+		require.NoError(t, err)
+		require.Empty(t, output)
+	})
+
+	t.Run("missing header", func(t *testing.T) {
+		_, err := Parse([]byte(`["","container.from",["alpine:latest"],"abc","float"]`))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "missing version header")
+	})
+
+	t.Run("unsupported version", func(t *testing.T) {
+		_, err := Parse([]byte(`[["version","2"]]`))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unsupported lockfile version")
+	})
+
+	t.Run("invalid tuple length", func(t *testing.T) {
+		_, err := Parse([]byte(strings.Join([]string{
+			`[["version","1"]]`,
+			`["","container.from",["alpine:latest"]]`,
+		}, "\n")))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid tuple length")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := Parse([]byte(strings.Join([]string{
+			`[["version","1"]]`,
+			`not-json`,
+		}, "\n")))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid tuple JSON")
+	})
+
+	t.Run("unordered object input", func(t *testing.T) {
+		_, err := Parse([]byte(strings.Join([]string{
+			`[["version","1"]]`,
+			`["","git.resolveRef",[{"ref":"main"}],"abc","pin"]`,
+		}, "\n")))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unordered object/map/dict in lock inputs")
+	})
+
+	t.Run("unordered object value", func(t *testing.T) {
+		_, err := Parse([]byte(strings.Join([]string{
+			`[["version","1"]]`,
+			`["","git.resolveRef",["main"],{"sha":"abc"},"pin"]`,
+		}, "\n")))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unordered object/map/dict in lock value")
+	})
+}
+
+func TestSetRejectsUnorderedInputObjects(t *testing.T) {
+	lock := New()
+	err := lock.Set("", "git.resolveRef", []any{map[string]any{"ref": "main"}}, "abc", "pin")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unordered object/map/dict in lock inputs")
+}
+
+func TestParseRejectsLegacyResultEnvelope(t *testing.T) {
+	input := strings.Join([]string{
+		`[["version","1"]]`,
+		`["","container.from",["alpine:latest","linux/amd64"],{"value":"sha256:3d23f8","policy":"float"}]`,
+	}, "\n")
+
+	_, err := Parse([]byte(input))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid tuple length 4: expected 5")
+}


### PR DESCRIPTION
## What

Adds a lockfile system that records resolved values of mutable lookups (`container.from`, git branches/tags/refs) into `.dagger/lock`, so runs can be reproduced exactly or intentionally refreshed.

Stacks on [#11995](https://github.com/dagger/dagger/pull/11995) (`workspace-plumbing`), which provides the workspace detection and `.dagger/` directory plumbing this builds on.

## Why

Image tags and git branches are mutable. `alpine:latest` today resolves to a different digest than it did last week. This makes Dagger pipelines non-reproducible by default — the same pipeline can silently produce different results depending on when it runs.

Users need a way to pin these lookups and control when they get refreshed.

## Why now

The [workspace-plumbing PR](https://github.com/dagger/dagger/pull/11995) intentionally keeps the workspace config file free of pins — it stores symbolic inputs only. The lockfile provides a separate, namespaced place to record resolved values. Its entry format is extensible by namespace and operation, so runtime lookups like `container.from` and `git.branch` can coexist with dependency lookups like `modules.resolve` under one lock model.

## How it works

See the [user-facing lockfile reference](https://github.com/dagger/dagger/blob/lockfile/docs/current_docs/reference/cli/lockfiles.mdx) for modes, policies, lock-aware operations, and the full behavior matrix.

See the [design doc](https://github.com/dagger/dagger/blob/lockfile/hack/designs/lockfile.md) for the entry format spec, update flows, implementation status, and remaining work.

### Implementation shape

Core lockfile substrate: `util/lockfile/`
Workspace lock helpers and constants: `core/workspace/lock.go`
Resolution logic and host export: `core/schema/lockfile.go`
Consumer hooks: `core/schema/container.go`, `core/schema/git.go`
Mode plumbing: `engine/opts.go` → `ClientMetadata.LockMode` → nested clients and module runtimes
CLI: `--lock` flag in `cmd/dagger/main.go`, `dagger lock update` in `cmd/dagger/lock.go`

### Safety

Default mode is `disabled`. Without `--lock`, this changes zero behavior. The lockfile is never read or written unless the user explicitly opts in.

## UI / API changes

**New global flag:**
```
--lock <disabled|live|pinned|frozen>
```

**New command:**
```
dagger lock update    # refresh entries already in .dagger/lock
```

**New engine-internal GraphQL** (not exposed to module authors):
```graphql
currentWorkspace { update { isEmpty export(path: ".") } }
```

Lock mode propagates through nested clients and module runtimes automatically.

## Not included (intentionally deferred)

- `modules.resolve` lock entries
- `http` lookup locking
- Remote workspace lockfile mutation
- Final workspace config/migration UX

## Downstream CI tasks

Compared against [#11995](https://github.com/dagger/dagger/pull/11995), these failing checks were specific to this branch. The shared nil-pointer panic in served module schema loading is now fixed locally and these targeted repros pass:

- [x] `test-split:test-workspaces`: `dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspace/TestFindUp$'`
- [x] `test-split:test-client-generator`: `dagger call engine-dev test --pkg=./core/integration --run='^TestClientGenerator/TestEngineVersionPinning/dev_version_does_not_get_pinned_in_go\.mod$'`
- [x] `test-split:test-container`: `dagger call engine-dev test --pkg=./core/integration --run='^TestDockerfile/TestCrossSessionDockerbuildSockets$'`

## Validation

- Unit tests: `go test ./util/lockfile ./core/workspace`
- Integration tests: `TestLockfile` suite covering CLI plumbing, mode propagation, `container.from`, and Git consumers
- Cross-compiled: `cmd/dagger`, `core/schema`, `engine/server`
