### PR TITLE
replace git configs so no ssh keys or agents are needed

### DIFF
--- a/version/main.go
+++ b/version/main.go
@@ -222,6 +222,7 @@ func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, err
 		From("alpine/git:latest").
 		WithWorkdir("/src").
 		WithMountedDirectory(".git", v.GitDir).
+		WithExec([]string{"git", "config", "url.https://github.com/.insteadOf", "git@github.com:"}).
 		WithExec([]string{"git", "fetch", "--tags"}).
 		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
 		Stdout(ctx)


### PR DESCRIPTION
this fixes the issue of some devs getting "Permission denied (publickey)" when trying to call this function