### PR TITLE
docs: fix registry mirror example

### DIFF
--- a/docs/current_docs/reference/configuration/engine.mdx
+++ b/docs/current_docs/reference/configuration/engine.mdx
@@ -360,17 +360,10 @@ For example, to mirror the default Docker Hub `docker.io` registry to `mirror.gc
 To test the configuration:
 
 ```shell
-dagger query --progress=plain <<'EOF'
-{
-  container {
-    from(address:"hello-world") {
-      withExec(args:["/hello"]) {
-        stdout
-      }
-    }
-  }
-}
-EOF
+dagger -M call --progress=plain container \
+  from --address=hello-world \
+  with-exec --args=/hello \
+  stdout
 ```
 
 The specified `hello-world` container will now be pulled from the mirror
@@ -410,17 +403,10 @@ The configuration can be repeated for multiple registries and mirrors if needed:
 To test the configuration:
 
 ```shell
-dagger query --progress=plain <<'EOF'
-{
-  container {
-    from(address:"hello-world") {
-      withExec(args:["/hello"]) {
-        stdout
-      }
-    }
-  }
-}
-EOF
+dagger -M call --progress=plain container \
+  from --address=hello-world \
+  with-exec --args=/hello \
+  stdout
 ```
 
 The specified `hello-world` container will now be pulled from the mirror


### PR DESCRIPTION
Fixes #12833

## Summary
- fix the custom registry mirror docs example so it executes `/hello` before reading `stdout`
- align the docs example with the built-in `dagger query --help` example
- note that debug output can still show the canonical `docker.io/...` ref and that mirror verification should use registry access logs

## Verification
- reproduced the broken query locally and got `container.from.stdout no command has been set`
- verified the corrected query succeeds with a fresh engine started from an `engine.json` containing `"mirrors": ["mirror.gcr.io"]`

Context: https://github.com/dagger/dagger/discussions/12769