### PR TITLE
fix(python-sdk): always stop progress spinner to restore terminal cursor

### DIFF
--- a/sdk/python/src/dagger/provisioning/_engine.py
+++ b/sdk/python/src/dagger/provisioning/_engine.py
@@ -92,7 +92,7 @@ class Engine:
         conn = await self.stack.enter_async_context(conn)
 
         client = dagger.Client.from_connection(conn)
-        self.stack.push_async_callback(self.progress.update, "Disconnecting")
+        self.stack.push_async_callback(self.progress.stop)
 
         return await self.verify(client)
 
@@ -123,10 +123,7 @@ class Engine:
         except dagger.QueryError as e:
             logger.warning("Failed to check Dagger engine version compatibility: %s", e)
 
-        # If log_output is set, we don't need to show any more progress.
-        if self.cfg.log_output:
-            await self.progress.stop()
-        else:
-            await self.progress.update("Running pipelines")
+        await self.progress.update("Running pipelines")
+        await self.progress.stop()
 
         return client


### PR DESCRIPTION
## Summary

- Always call `progress.stop()` on shutdown, ensuring the terminal cursor is restored regardless of `log_output` configuration
- Previously, `stop()` was only called when `log_output` was set, leaving the cursor hidden in the default path

## Root Cause

`Progress.start()` emits ANSI `\x1b[?25l` (hide cursor) via Rich's `Status` spinner. `Progress.stop()` emits `\x1b[?25h` (show cursor). But `stop()` was only called when `cfg.log_output` was configured — in the default path, the shutdown callback only called `update("Disconnecting")`, never `stop()`.

## Fix

1. Shutdown callback: `progress.stop()` instead of `progress.update("Disconnecting")`
2. `verify()`: always stop progress after setup, not just when `log_output` is set

`progress.stop()` is idempotent (no-op if already stopped), so both calls are safe.

Fixes #12834