### PR TITLE
fix(shell): clear error when passing string literal for object argument

### DIFF
--- a/cmd/dagger/shell_exec.go
+++ b/cmd/dagger/shell_exec.go
@@ -796,6 +796,30 @@ func (h *shellCallHandler) parseFlagValue(ctx context.Context, value string, arg
 						return newPath, false, nil
 					}
 				}
+			default:
+				// If the object type doesn't have custom flag support,
+				// a plain string can't be used — it needs an object ID
+				// from a constructor (e.g. via command substitution).
+				if GetCustomFlagValue(argType.AsObject.Name) == nil {
+					return "", false, fmt.Errorf(
+						"argument %q expects a %s object, not a string literal; "+
+							"use a constructor via command substitution, e.g. $(%s ...)",
+						arg.FlagName(),
+						argType.AsObject.Name,
+						cliName(argType.AsObject.Name),
+					)
+				}
+			}
+		}
+		if argType.AsInput != nil {
+			if GetCustomFlagValue(argType.AsInput.Name) == nil {
+				return "", false, fmt.Errorf(
+					"argument %q expects a %s input object, not a string literal; "+
+						"use a constructor via command substitution, e.g. $(%s ...)",
+					arg.FlagName(),
+					argType.AsInput.Name,
+					cliName(argType.AsInput.Name),
+				)
 			}
 		}
 		return value, false, nil


### PR DESCRIPTION
## Summary

- `dagger shell` gives cryptic protobuf/base64 errors when passing a plain string where a custom object type is expected
- Validates in `parseFlagValue` that plain strings aren't passed for object/input types without custom flag support
- Addresses the existing TODO comment at line 721: "This will likely fail if value doesn't come from command expansion"

**Before:** `failed to unmarshal proto: proto: cannot parse invalid wire-format data`

**After:** `argument "config" expects a MyConfig object, not a string literal; use a constructor via command substitution, e.g. $(my-config ...)`

Fixes #12841
Originally reported in https://github.com/dagger/dagger/discussions/12668