### PR TITLE
fix: apply Expand to redirect paths in WithExec

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4491,6 +4491,42 @@ func (ContainerSuite) TestEnvExpand(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "/some-arg/bar\n", output)
 	})
 
+	t.Run("env variable is expanded in WithExec RedirectStdout", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From("alpine:latest").
+			WithEnvVariable("OUT", "/tmp/out").
+			WithEnvVariable("ERR", "/tmp/err").
+			WithExec([]string{"sh", "-c", "echo hello; echo goodbye >/dev/stderr"}, dagger.ContainerWithExecOpts{
+				Expand:         true,
+				RedirectStdout: "${OUT}",
+				RedirectStderr: "${ERR}",
+			})
+
+		stdout, err := ctr.File("/tmp/out").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", stdout)
+
+		stderr, err := ctr.File("/tmp/err").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "goodbye\n", stderr)
+	})
+
+	t.Run("env variable is expanded in WithExec RedirectStdin", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From("alpine:latest").
+			WithEnvVariable("IN", "/tmp/input.txt").
+			WithNewFile("/tmp/input.txt", "hello from stdin\n").
+			WithExec([]string{"cat"}, dagger.ContainerWithExecOpts{
+				Expand:         true,
+				RedirectStdin:  "${IN}",
+				RedirectStdout: "/tmp/out",
+			})
+
+		stdout, err := ctr.File("/tmp/out").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from stdin\n", stdout)
+	})
+
 	t.Run("env variable is expanded in WithoutMount", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().
 			From("alpine:latest").

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1119,6 +1119,25 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 	}
 	args.Args = expandedArgs
 
+	if args.RedirectStdout != "" {
+		args.RedirectStdout, err = expandEnvVar(ctx, parent.Self(), args.RedirectStdout, args.Expand)
+		if err != nil {
+			return inst, err
+		}
+	}
+	if args.RedirectStderr != "" {
+		args.RedirectStderr, err = expandEnvVar(ctx, parent.Self(), args.RedirectStderr, args.Expand)
+		if err != nil {
+			return inst, err
+		}
+	}
+	if args.RedirectStdin != "" {
+		args.RedirectStdin, err = expandEnvVar(ctx, parent.Self(), args.RedirectStdin, args.Expand)
+		if err != nil {
+			return inst, err
+		}
+	}
+
 	var md *buildkit.ExecutionMetadata
 	if args.ExecMD.Self != nil {
 		md = args.ExecMD.Self


### PR DESCRIPTION
## Summary

- `WithExec` with `Expand: true` now expands environment variables in `RedirectStdout`, `RedirectStderr`, and `RedirectStdin` paths, not just command args.
- Adds integration tests for redirect path expansion.

Fixes https://github.com/dagger/dagger/discussions/12818

## Test plan

- [x] New integration tests: `TestExecRedirectStdout` and `TestExecRedirectStdin` with env var expansion
- [x] Existing expand tests continue to pass