### PR TITLE
fix: gracefully handle stale SSH_AUTH_SOCK during module codegen

### DIFF
--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -859,11 +859,14 @@ func (sdk *goSDK) getUnixSocketSelector(ctx context.Context) ([]dagql.Selector, 
 			Field: "_sshAuthSocket",
 		},
 	); err != nil {
-		return nil, nil, fmt.Errorf("failed to select internal socket: %w", err)
+		// SSH_AUTH_SOCK is set but the socket is unavailable (stale, broken, etc.).
+		// Continue without SSH agent forwarding; if something downstream actually
+		// needs SSH (e.g. private git deps), it will fail with a clear auth error.
+		return nil, nil, nil
 	}
 
 	if sockInst.Self() == nil {
-		return nil, nil, fmt.Errorf("sockInst.Self is NIL")
+		return nil, nil, nil
 	}
 
 	sshSockPath := "/tmp/dagger-ssh-sock"


### PR DESCRIPTION
## Summary

- When `SSH_AUTH_SOCK` is set but points to a stale/broken socket, module codegen no longer crashes with a cryptic EOF error.
- Instead, SSH agent forwarding is skipped. If something downstream needs SSH (e.g. private git deps), it fails with a clear auth error.

Fixes https://github.com/dagger/dagger/discussions/12660

## Repro

```bash
rm -rf /tmp/test-ssh-sock && \
  SSH_AUTH_SOCK=/tmp/doesnotexist dagger init --sdk=go /tmp/test-ssh-sock && \
  SSH_AUTH_SOCK=/tmp/doesnotexist dagger call -m /tmp/test-ssh-sock container-echo --string-arg hello stdout
```

## Test plan

- [ ] Repro above no longer crashes
- [ ] Module with private git deps + valid SSH_AUTH_SOCK still works
- [ ] Module with private git deps + broken SSH_AUTH_SOCK gets clear auth error