### PR TITLE
fix: resolve CA cert symlinks for Kubernetes Secret mounts

### DIFF
--- a/engine/buildkit/containerfs/fs.go
+++ b/engine/buildkit/containerfs/fs.go
@@ -576,13 +576,29 @@ func ReadHostCustomCADir(path string) (
 		dirEntPath := filepath.Join(path, dirEnt.Name())
 		switch dirEnt.Type() {
 		case os.ModeSymlink:
-			linkPath, err := os.Readlink(dirEntPath)
+			// Resolve symlinks and read the target file contents rather than
+			// preserving the symlink. This handles Kubernetes Secret mounts
+			// where files are symlinked through a ..data/ subdirectory that
+			// won't exist inside containers.
+			resolved, err := filepath.EvalSymlinks(dirEntPath)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to resolve symlink %s: %w", dirEntPath, err)
+			}
+			info, err := os.Stat(resolved)
 			if err != nil {
 				return nil, nil, err
 			}
-			symlinks[dirEnt.Name()] = linkPath
+			if info.IsDir() {
+				// skip directories (e.g. ..data itself)
+				continue
+			}
+			bs, err := os.ReadFile(resolved)
+			if err != nil {
+				return nil, nil, err
+			}
+			certsToFileName[strings.TrimSpace(string(bs))] = dirEnt.Name()
 		case os.ModeDir:
-			// TODO: handle subdirs
+			// skip hidden/internal directories (e.g. K8s ..data, ..2025_xx_xx)
 		default:
 			// TODO: only read .pem/.crt files?
 			bs, err := os.ReadFile(dirEntPath)

--- a/engine/buildkit/containerfs/fs_test.go
+++ b/engine/buildkit/containerfs/fs_test.go
@@ -1,0 +1,97 @@
+package containerfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadHostCustomCADirK8sSymlinks(t *testing.T) {
+	// Simulate the Kubernetes Secret mount structure:
+	//   ca.pem -> ..data/ca.pem
+	//   ..data -> ..2025_01_01_00_00_00.123456789
+	//   ..2025_01_01_00_00_00.123456789/ca.pem  (actual file)
+	dir := t.TempDir()
+
+	// Create the timestamped directory with actual cert files
+	tsDir := filepath.Join(dir, "..2025_01_01_00_00_00.123456789")
+	if err := os.Mkdir(tsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	certContents := "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAL...\n-----END CERTIFICATE-----"
+	if err := os.WriteFile(filepath.Join(tsDir, "ca.pem"), []byte(certContents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	otherCert := "-----BEGIN CERTIFICATE-----\nABCDEF...\n-----END CERTIFICATE-----"
+	if err := os.WriteFile(filepath.Join(tsDir, "extra.pem"), []byte(otherCert), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create ..data symlink pointing to timestamped dir
+	if err := os.Symlink("..2025_01_01_00_00_00.123456789", filepath.Join(dir, "..data")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create cert symlinks pointing through ..data
+	if err := os.Symlink("..data/ca.pem", filepath.Join(dir, "ca.pem")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("..data/extra.pem", filepath.Join(dir, "extra.pem")); err != nil {
+		t.Fatal(err)
+	}
+
+	certs, symlinks, err := ReadHostCustomCADir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlinks should be empty -- certs are resolved to file contents
+	if len(symlinks) != 0 {
+		t.Errorf("expected no symlinks, got %d: %v", len(symlinks), symlinks)
+	}
+
+	// Both certs should be in the certs map
+	if len(certs) != 2 {
+		t.Errorf("expected 2 certs, got %d: %v", len(certs), certs)
+	}
+	if name, ok := certs[certContents]; !ok || name != "ca.pem" {
+		t.Errorf("expected ca.pem cert, got name=%q ok=%v", name, ok)
+	}
+	if name, ok := certs[otherCert]; !ok || name != "extra.pem" {
+		t.Errorf("expected extra.pem cert, got name=%q ok=%v", name, ok)
+	}
+}
+
+func TestReadHostCustomCADirRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	cert := "-----BEGIN CERTIFICATE-----\nREGULAR...\n-----END CERTIFICATE-----"
+	if err := os.WriteFile(filepath.Join(dir, "my-cert.pem"), []byte(cert), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	certs, symlinks, err := ReadHostCustomCADir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(symlinks) != 0 {
+		t.Errorf("expected no symlinks, got %d", len(symlinks))
+	}
+	if len(certs) != 1 {
+		t.Errorf("expected 1 cert, got %d", len(certs))
+	}
+	if name, ok := certs[cert]; !ok || name != "my-cert.pem" {
+		t.Errorf("expected my-cert.pem, got name=%q ok=%v", name, ok)
+	}
+}
+
+func TestReadHostCustomCADirNonexistent(t *testing.T) {
+	certs, symlinks, err := ReadHostCustomCADir("/nonexistent/path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) != 0 || len(symlinks) != 0 {
+		t.Errorf("expected empty results for nonexistent dir")
+	}
+}


### PR DESCRIPTION
## Summary

- When CA certs are mounted from a K8s Secret (without `subPath`), files are symlinked through a `..data/` subdirectory. These symlinks break inside containers where `..data/` doesn't exist.
- `ReadHostCustomCADir` now resolves symlinks to their target file contents instead of preserving them, so certs work regardless of mount structure.

Fixes https://github.com/dagger/dagger/discussions/12739

## Repro

Confirm the test fails against unfixed main:

```bash
dagger shell <<'REPRO'
container |
  from golang:1.25 |
  with-directory /src $(git https://github.com/dagger/dagger | commit ae2491bff148ad49a0eb40918c9d44389120da01 | tree) |
  with-file /src/engine/buildkit/containerfs/fs_test.go $(git https://github.com/dagger/dagger | branch fix/cacerts-k8s-symlinks | tree | file engine/buildkit/containerfs/fs_test.go) |
  with-workdir /src |
  with-exec -- go test ./engine/buildkit/containerfs/ -run TestReadHostCustomCADirK8sSymlinks -v |
  stdout
REPRO
```

## Test plan

- [x] Unit tests for `ReadHostCustomCADir` with K8s-style symlink structure
- [x] Test fails against unfixed main, passes with fix
- [ ] Manual verification with K8s Secret-mounted CA certs