### PR TITLE
fix: .env user defaults not applied when arg has module default

### DIFF
--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -602,6 +602,50 @@ func tempDirWithEnvFile(t *testctx.T, environ ...string) string {
 	return tmp
 }
 
+// Test that .env user defaults override module defaults for object types.
+// Regression test: when a constructor arg has a module default (e.g. Python's
+// "= None"), the schema default was incorrectly treated as an explicit user
+// input, preventing .env values from being applied.
+func (UserDefaultsSuite) TestObjectDefaultOverride(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := daggerCliBase(t, c).
+		WithExec([]string{"apk", "add", "git"}).
+		WithExec([]string{"git", "init"}).
+		With(daggerInitPython()).
+		WithNewFile("src/test/main.py", `import dagger
+from dagger import dag, function, object_type
+
+@object_type
+class Test:
+    secret_with_default: dagger.Secret | None = None
+
+    @function
+    async def check(self) -> str:
+        if self.secret_with_default is None:
+            return "secret is None"
+        val = await self.secret_with_default.plaintext()
+        return f"secret is: {val}"
+`).
+		WithEnvVariable("MY_SECRET", "hello-from-env")
+
+	// Without .env, should get None
+	out, err := base.
+		With(daggerCall("check")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "secret is None", out)
+
+	// FIXME: With .env providing a Secret via env://, should get the secret value.
+	// User defaults currently match the constructor arg's GraphQL name
+	// (`secretWithDefault`), not snake_case env-style names.
+	out, err = base.
+		WithNewFile(".env", "secretWithDefault=env://MY_SECRET").
+		With(daggerCall("check")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "secret is: hello-from-env", out)
+}
+
 func (UserDefaultsSuite) TestSimple(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	ctr := nestedDaggerContainer(t, c, "go", "defaults")

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -195,7 +195,7 @@ func (fn *ModuleFunction) setCallInputs(ctx context.Context, opts *CallOpts) ([]
 		var defaultInput *FunctionCallArgValue
 		if hasUserDefault {
 			// 1. User-defined user default
-			userDefaultInput, err := userDefault.CallInput()
+			userDefaultInput, err := userDefault.CallInput(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -357,6 +357,24 @@ func (ud *UserDefault) IsObject() bool {
 
 func (ud *UserDefault) IsList() bool {
 	return ud.Arg.TypeDef.Kind == TypeDefKindList
+}
+
+func (ud *UserDefault) CallInput(ctx context.Context) (*FunctionCallArgValue, error) {
+	if !ud.IsObject() && (!ud.IsList() || ud.Arg.TypeDef.AsList.Value.ElementTypeDef.Kind != TypeDefKindObject) {
+		return ud.UserDefaultPrimitive.CallInput()
+	}
+	value, err := ud.Value(ctx)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, ud.errorf(err, "marshal object default")
+	}
+	return &FunctionCallArgValue{
+		Name:  ud.Arg.Name,
+		Value: encoded,
+	}, nil
 }
 
 func (ud *UserDefault) Value(ctx context.Context) (any, error) {
@@ -574,8 +592,17 @@ func (fn *ModuleFunction) CacheConfigForCall(
 	var workspaceArgs []*FunctionArg
 	var userDefaults []*UserDefault
 
+	// Build a set of args explicitly provided in the call (not schema defaults).
+	// The args map includes schema default values, but the call ID only has
+	// args the user actually set. We need this distinction so that .env user
+	// defaults can override schema defaults (e.g. Python's "= None").
+	explicitArgs := map[string]bool{}
+	for _, idArg := range req.CacheKey.ID.Args() {
+		explicitArgs[idArg.Name()] = true
+	}
+
 	for _, argMetadata := range fn.metadata.Args {
-		if args[argMetadata.Name] != nil {
+		if explicitArgs[argMetadata.Name] {
 			// was explicitly set by the user, skip
 			continue
 		}


### PR DESCRIPTION
## Summary

- Fix .env user defaults being silently ignored when a constructor arg has a schema default value (e.g. Python's `dagger.Secret | None = None`)
- Root cause: `CacheConfigForCall` checked the `args` map (which includes schema defaults from `ExtractIDArgs`) instead of the call ID args (which only contain user-explicit inputs)
- Add `UserDefault.CallInput(ctx)` method that handles object types, as defense-in-depth

## Root cause

In `dagql/objects.go`, `ExtractIDArgs` populates the `inputArgs` map with schema defaults for args not explicitly provided. This map is passed to `CacheConfigForCall` as the `args` parameter. The check `args[argMetadata.Name] != nil` was meant to skip explicitly-set args, but a schema default of `null` (from Python `= None`) is a non-nil Go interface value, causing the .env user default resolution to be skipped entirely.

The fix checks the original call ID args (`req.CacheKey.ID.Args()`) which only contains args the user actually provided.

## Test plan

- [x] New integration test: Python module with `dagger.Secret | None = None` field, verifying `.env` with `env://` overrides the module default
- [ ] Existing `TestConstructorOptional` and `TestConstructorRequired` tests still pass (Go modules with `+optional` have no schema default, so behavior is unchanged)

Fixes #12853