### PR TITLE
fix: fallback for empty LLM tool descriptions

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -590,10 +590,16 @@ func (m *MCP) typeTools(allTools *LLMToolSet, srv *dagql.Server, schema *ast.Sch
 
 		contextual := autoConstruct != nil
 
+		desc := strings.TrimSpace(field.Description)
+		if desc == "" {
+			// LLM providers (e.g. AWS Bedrock) require non-empty tool descriptions.
+			desc = typeDef.Name + " " + field.Name
+		}
+
 		allTools.Add(LLMTool{
 			Name:        toolName,
 			Field:       field,
-			Description: strings.TrimSpace(field.Description),
+			Description: desc,
 			Schema:      toolSchema,
 
 			// TODO: would be nice, but have to 'or-null' all args and list everything


### PR DESCRIPTION
## Summary

- When a module function has no description, fall back to "TypeName fieldName" (e.g. "MyModule build") instead of passing an empty string to LLM providers
- Some providers like AWS Bedrock require non-empty tool descriptions and reject requests with `description: ""`

## Test plan

- [x] Verify `dagger shell` works with modules that have undocumented functions when using AWS Bedrock

Fixes #12856