### PR TITLE
fix: allow custom liveness/readiness probes in Helm chart

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -125,25 +125,9 @@ spec:
                 - ALL
           resources: {{- toYaml .Values.engine.resources | nindent 12 }}
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -exc
-                - |-
-                  dagger core version
-            {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
-            {{- end }}
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -exc
-                - |-
-                  dagger core version
-            {{- if .Values.engine.livenessProbeSettings }}
             {{- toYaml .Values.engine.livenessProbeSettings | nindent 12 }}
-            {{- end }}
           {{- if .Values.engine.lifecycle }}
           lifecycle:
             {{- if .Values.engine.lifecycle.preStop }}

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -136,25 +136,9 @@ spec:
             {{- end }}
           {{- end }}
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -exc
-                - |-
-                  dagger core version
-            {{- if .Values.engine.readinessProbeSettings }}
             {{- toYaml .Values.engine.readinessProbeSettings | nindent 12 }}
-            {{- end }}
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -exc
-                - |-
-                  dagger core version
-            {{- if .Values.engine.livenessProbeSettings }}
             {{- toYaml .Values.engine.livenessProbeSettings | nindent 12 }}
-            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/dagger

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -136,6 +136,12 @@ engine:
   shareProcessNamespace: false
 
   readinessProbeSettings:
+    exec:
+      command:
+        - sh
+        - -exc
+        - |-
+          dagger core version
     initialDelaySeconds: 5
     timeoutSeconds: 14
     periodSeconds: 15
@@ -143,6 +149,12 @@ engine:
     failureThreshold: 10
 
   livenessProbeSettings:
+    exec:
+      command:
+        - sh
+        - -exc
+        - |-
+          dagger core version
     initialDelaySeconds: 5
     timeoutSeconds: 29
     periodSeconds: 30

--- a/toolchains/helm-dev/main.go
+++ b/toolchains/helm-dev/main.go
@@ -39,6 +39,49 @@ func (h *HelmDev) Lint(ctx context.Context) error {
 	return err
 }
 
+// Test that custom probe settings can override the defaults without producing duplicate YAML keys
+// +check
+func (h *HelmDev) TestCustomProbes(ctx context.Context) error {
+	customValues := `
+engine:
+  readinessProbeSettings:
+    exec:
+      command:
+        - sh
+        - -c
+        - "echo ready"
+    initialDelaySeconds: 10
+    periodSeconds: 20
+  livenessProbeSettings:
+    exec:
+      command:
+        - sh
+        - -c
+        - "echo alive"
+    initialDelaySeconds: 15
+    periodSeconds: 30
+`
+	out, err := h.chart().
+		WithNewFile("/tmp/custom-probes.yaml", customValues).
+		WithExec([]string{"helm", "template", ".", "-f", "/tmp/custom-probes.yaml"}).
+		Stdout(ctx)
+	if err != nil {
+		return err
+	}
+	// Check that the custom command appears
+	if !strings.Contains(out, "echo ready") {
+		return fmt.Errorf("custom readiness probe command not found in rendered template")
+	}
+	if !strings.Contains(out, "echo alive") {
+		return fmt.Errorf("custom liveness probe command not found in rendered template")
+	}
+	// Check that the default command does NOT appear (it should be fully overridden)
+	if strings.Contains(out, "dagger core version") {
+		return fmt.Errorf("default probe command still present after override")
+	}
+	return nil
+}
+
 // +check
 // Test the helm chart on an ephemeral K3S service
 func (h *HelmDev) Test(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- The Helm chart hardcoded `exec` probe commands in the DaemonSet and StatefulSet templates, then appended `readinessProbeSettings`/`livenessProbeSettings` from values. This produced duplicate YAML keys when users customized probes, causing unmarshal errors.
- Move the default `exec` command into `values.yaml` defaults and render the full probe from values in both templates.
- Add `TestCustomProbes` check to `toolchains/helm-dev` that verifies custom probe overrides work.

Fixes #12860

## Test plan

- [x] `dagger -m toolchains/helm-dev call --chart=./helm/dagger test-custom-probes` passes with fix
- [x] Same test fails without fix (`default probe command still present after override`)
- [x] `helm template` with default values produces identical output to before
- [x] `helm template` with custom `exec` probes no longer produces duplicate keys