### PR TITLE
fix: ensure image layer blobs are local before ContainerDagOp returns

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -559,6 +559,10 @@ func (container *Container) FromCanonicalRef(
 		return nil, err
 	}
 
+	if err := ref.EnsureLocal(ctx, bkSessionGroup); err != nil {
+		return nil, fmt.Errorf("failed to ensure image is local: %w", err)
+	}
+
 	rootfsDir := &Directory{
 		Result: ref,
 	}
@@ -2334,7 +2338,7 @@ func (container *Container) AsService(ctx context.Context, args ContainerAsServi
 		useEntrypoint = true
 	}
 
-	var cmdargs = container.Config.Cmd
+	cmdargs := container.Config.Cmd
 	if len(args.Args) > 0 {
 		cmdargs = args.Args
 		if !args.UseEntrypoint {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -37,8 +37,10 @@ import (
 	"github.com/dagger/dagger/network"
 )
 
-var ErrNoCommand = errors.New("no command has been set")
-var ErrNoSvcCommand = errors.New("no service command has been set")
+var (
+	ErrNoCommand    = errors.New("no command has been set")
+	ErrNoSvcCommand = errors.New("no service command has been set")
+)
 
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command

--- a/internal/buildkit/cache/refs.go
+++ b/internal/buildkit/cache/refs.go
@@ -65,6 +65,12 @@ type ImmutableRef interface {
 	GetRemotes(ctx context.Context, createIfNeeded bool, cfg config.RefConfig, all bool, s session.Group) ([]*solver.Remote, error)
 	LayerChain() RefList
 	FileList(ctx context.Context, s session.Group) ([]string, error)
+	// EnsureLocal ensures that all layers in the ref's chain are stored in the
+	// local content store. This is needed for lazy blob refs whose descriptor
+	// handlers are session-scoped: if they are not materialized before the
+	// session closes, future cache lookups will fail because the handlers are
+	// gone and the blobs can't be fetched.
+	EnsureLocal(ctx context.Context, s session.Group) error
 }
 
 type MutableRef interface {
@@ -1085,6 +1091,19 @@ func (sr *immutableRef) Extract(ctx context.Context, s session.Group) (rerr erro
 	}
 
 	return sr.unlazy(ctx, sr.descHandlers, sr.progress, s, true, false)
+}
+
+func (sr *immutableRef) EnsureLocal(ctx context.Context, s session.Group) error {
+	for _, ref := range sr.LayerChain() {
+		ir, ok := ref.(*immutableRef)
+		if !ok {
+			continue
+		}
+		if err := ir.unlazy(ctx, ir.descHandlers, ir.progress, s, true, true); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (sr *immutableRef) withRemoteSnapshotLabelsStargzMode(ctx context.Context, s session.Group, f func()) error {


### PR DESCRIPTION
## Problem

Running: 
 ```
NO_COLOR=1 _EXPERIMENTAL_DAGGER_RUNNER_HOST=container://dagger-engine.dev dagger --progress plain -vvvvvv core directory with-new-file --contents 'type Foo {}' --path foo.dang with-new-file --contents '{"name": "foo", "engineVersion": "v0.20.3", "sdk":{"source":"github.com/vito/dang/dagger-sdk@8eba69d6ac5bcf1e4050bb855783e01d8b557ea9"}}' --path dagger.json as-module sync 2>&1 | grep Container.from | grep CACHED
``` 
on a newly created engine never yields to a cache hit from the Container.from operations.

## Solution (AI assisted)

We're calling `EnsureLocal` in the `FromCanonicalRef` path so this un-lazifies the immutable refs so whe the next session tries to reference them, they're guaranteed to get a cache-hit.

Signed-off-by: Marcos Nils <marcosnils@gmail.com>