### PR TITLE
fix(sdk/python): handle in-memory streams for log_output

### DIFF
--- a/sdk/python/src/dagger/provisioning/_session.py
+++ b/sdk/python/src/dagger/provisioning/_session.py
@@ -3,10 +3,11 @@ import dataclasses
 import json
 import logging
 import subprocess
+import threading
 import time
 from importlib import metadata
 from pathlib import Path
-from typing import cast
+from typing import TextIO, cast
 
 from dagger._managers import SyncResource
 from dagger.client._session import ConnectParams
@@ -81,6 +82,21 @@ def start_cli_session_sync(cfg: Config, path: str):
         raise SessionError(e) from e
 
 
+def _has_fileno(stream: TextIO) -> bool:
+    """Check if a stream has a valid file descriptor."""
+    try:
+        stream.fileno()
+    except (AttributeError, OSError):
+        return False
+    return True
+
+
+def _forward_stderr(source: TextIO, dest: TextIO) -> None:
+    """Forward lines from source to dest until EOF."""
+    with contextlib.suppress(ValueError):
+        dest.writelines(source)
+
+
 def run(cfg: Config, path: str) -> subprocess.Popen[str]:
     args = [
         path,
@@ -94,6 +110,15 @@ def run(cfg: Config, path: str) -> subprocess.Popen[str]:
         args.extend(["--workdir", str(Path(cfg.workdir).absolute())])
     if cfg.config_path:
         args.extend(["--project", str(Path(cfg.config_path).absolute())])
+
+    # Determine stderr target. If the stream doesn't have a file descriptor
+    # (e.g. StringIO), use a PIPE and forward via a background thread so that
+    # any TextIO works as documented in Config.log_output.
+    log_output = cfg.log_output
+    needs_forwarding = log_output is not None and not _has_fileno(log_output)
+    stderr_target = (
+        subprocess.PIPE if (not log_output or needs_forwarding) else log_output
+    )
 
     # Retry starting if "text file busy" error is hit. That error can happen
     # due to a flaw in how Linux works: if any fork of this process happens
@@ -110,7 +135,7 @@ def run(cfg: Config, path: str) -> subprocess.Popen[str]:
                 bufsize=0,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=cfg.log_output or subprocess.PIPE,
+                stderr=stderr_target,
                 encoding="utf-8",
             )
         except OSError as e:  # noqa: PERF203
@@ -119,6 +144,16 @@ def run(cfg: Config, path: str) -> subprocess.Popen[str]:
             logger.warning("file busy, retrying in 0.1 seconds...")
             time.sleep(0.1)
         else:
+            if needs_forwarding and proc.stderr:
+                t = threading.Thread(
+                    target=_forward_stderr,
+                    args=(proc.stderr, log_output),
+                    daemon=True,
+                )
+                t.start()
+                # Clear proc.stderr so callers don't try to read from it
+                # (it's being consumed by the forwarding thread).
+                proc.stderr = None
             return proc
 
     msg = "CLI busy"

--- a/sdk/python/tests/provisioning/test_cli.py
+++ b/sdk/python/tests/provisioning/test_cli.py
@@ -1,3 +1,4 @@
+import io
 import sys
 
 import httpx
@@ -54,6 +55,42 @@ def test_cli_exec_errors(config_args: dict, call_kwargs: dict, fp: FakeProcess):
         ),
     ):
         ...
+
+
+def test_log_output_stringio(fp: FakeProcess):
+    """Test that in-memory streams like StringIO work as log_output."""
+    buffer = io.StringIO()
+    fp.register(
+        ["dagger", "session", fp.any()],
+        stdout=['{"port":50004,"session_token":"abc"}', ""],
+        stderr=["some log output\n", ""],
+    )
+    with session.start_cli_session_sync(
+        dagger.Config(log_output=buffer),
+        "dagger",
+    ) as conn:
+        assert conn.port == 50004
+        assert conn.session_token == "abc"
+
+
+def test_log_output_with_real_file_descriptor(fp: FakeProcess):
+    """Test that streams with fileno() (like sys.stderr) still work."""
+    fp.register(
+        ["dagger", "session", fp.any()],
+        stdout=['{"port":50004,"session_token":"abc"}', ""],
+    )
+    with session.start_cli_session_sync(
+        dagger.Config(log_output=sys.stderr),
+        "dagger",
+    ) as conn:
+        assert conn.port == 50004
+        assert conn.session_token == "abc"
+
+
+def test_has_fileno():
+    """Test _has_fileno helper function."""
+    assert not session._has_fileno(io.StringIO())
+    assert session._has_fileno(sys.stderr)
 
 
 def test_stderr(fp: FakeProcess):


### PR DESCRIPTION
## Summary
- Handle `TextIO` streams without `fileno()` (e.g. `io.StringIO`) in `Config.log_output`
- Use a background daemon thread to forward subprocess stderr to the in-memory stream

## Root Cause
`subprocess.Popen` requires stderr to have a real file descriptor via `fileno()`. In-memory streams like `StringIO` raise `UnsupportedOperation: fileno` causing `SessionError`.

## Fix
- Add `_has_fileno()` helper that safely checks if a stream has a file descriptor
- When `log_output` lacks `fileno()`, use `subprocess.PIPE` for stderr and forward lines via a daemon thread
- Add `_forward_stderr()` helper using `contextlib.suppress(ValueError)` for clean shutdown

## Test plan
- [x] `pytest` — 274 passed, 0 failed
- [x] `ruff check` — all checks passed
- [x] 3 new tests: `test_log_output_stringio`, `test_log_output_with_real_file_descriptor`, `test_has_fileno`

Fixes #12836

🤖 Generated with [Claude Code](https://claude.com/claude-code)