### PR TITLE
fix: skip .env when it is a directory

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -339,6 +339,7 @@ func (src *ModuleSource) innerEnvFile(ctx context.Context) (*EnvFile, string, er
 			Field: "exists",
 			Args: []dagql.NamedInput{
 				{Name: "path", Value: dagql.String(".env")},
+				{Name: "expectedType", Value: dagql.Opt(ExistsTypeRegular)},
 			},
 		},
 	); status.Code(err) == codes.NotFound {
@@ -393,6 +394,31 @@ func (src *ModuleSource) outerEnvFile(ctx context.Context) (*EnvFile, string, er
 		return nil, "", fmt.Errorf("failed to find-up outer .env: %s", err.Error())
 	}
 	if envFilePath == "" {
+		return &EnvFile{}, "", nil
+	}
+	// Check if the found .env path is a regular file (not a directory)
+	envFileDir := path.Dir(envFilePath.String())
+	envFileName := path.Base(envFilePath.String())
+	var isRegularFile bool
+	if err := dag.Select(ctx, dag.Root(), &isRegularFile,
+		dagql.Selector{Field: "host"},
+		dagql.Selector{
+			Field: "directory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(envFileDir)},
+			},
+		},
+		dagql.Selector{
+			Field: "exists",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(envFileName)},
+				{Name: "expectedType", Value: dagql.Opt(ExistsTypeRegular)},
+			},
+		},
+	); err != nil {
+		return nil, "", fmt.Errorf("failed to check outer env file type at %q: %w", envFilePath.String(), err)
+	}
+	if !isRegularFile {
 		return &EnvFile{}, "", nil
 	}
 	var envFile *EnvFile


### PR DESCRIPTION
## Summary
- Add regular-file checks in `innerEnvFile()` and `outerEnvFile()` to skip directories named `.env`

## Root Cause
`dagger init` crashes when `.env` exists as a directory because:
- `innerEnvFile()` uses `directory.exists(".env")` which returns true for directories
- `outerEnvFile()` uses `host.findUp(".env")` which matches directories via `Stat`
Both then call `host.file()` which fails on directories.

## Fix
- `innerEnvFile()`: Add `expectedType: REGULAR_TYPE` to the `exists` check
- `outerEnvFile()`: After `findUp` returns a path, verify it's a regular file before reading

## Test plan
- [x] `GOOS=linux go build ./core/...` — build passes
- [x] `GOOS=linux go vet ./core/...` — no new warnings (existing warnings are pre-existing)
- Integration tests require `dagger call engine-dev test` (Linux-only)

Fixes #12826

🤖 Generated with [Claude Code](https://claude.com/claude-code)