### PR TITLE
feat(llm): add GitHub Copilot as an LLM provider via copilot-sdk/go

### DIFF
--- a/.changes/unreleased/Added-20260328-174753.yaml
+++ b/.changes/unreleased/Added-20260328-174753.yaml
@@ -1,10 +1,9 @@
 kind: Added
 body: Add GitHub Copilot as a first-class LLM provider via the copilot-sdk/go SDK.
-  Requires GITHUB_TOKEN (fine-grained PAT with copilot: read) — no OAuth flow.
-  Supports multi-turn sessions, streaming, tool calling, BYOK provider config,
-  and sidecar crash recovery. Legacy container fallback available via
-  GITHUB_COPILOT_LEGACY=true.
+  Requires GITHUB_TOKEN (fine-grained PAT with copilot: read scope). Supports
+  multi-turn sessions, streaming, tool calling, BYOK provider config, and sidecar
+  crash recovery. Legacy container fallback available via GITHUB_COPILOT_LEGACY=true.
 time: 2026-03-28T17:47:53.000000000Z
 custom:
     Author: raykao
-    PR: "0"
+    PR: "12872"

--- a/.changes/unreleased/Added-20260328-174753.yaml
+++ b/.changes/unreleased/Added-20260328-174753.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: Add GitHub Copilot as a first-class LLM provider via the copilot-sdk/go SDK.
+  Requires GITHUB_TOKEN (fine-grained PAT with copilot: read) — no OAuth flow.
+  Supports multi-turn sessions, streaming, tool calling, BYOK provider config,
+  and sidecar crash recovery. Legacy container fallback available via
+  GITHUB_COPILOT_LEGACY=true.
+time: 2026-03-28T17:47:53.000000000Z
+custom:
+    Author: raykao
+    PR: "0"

--- a/core/llm.go
+++ b/core/llm.go
@@ -193,12 +193,12 @@ func (r *LLMRouter) isMistralModel(model string) bool {
 }
 
 func (r *LLMRouter) isGitHubModel(model string) bool {
-	return strings.HasPrefix(model, "github-") ||
-		strings.HasPrefix(model, "github/") ||
-		strings.HasPrefix(model, "gh-") ||
-		strings.HasPrefix(model, "gh/") ||
-		strings.HasPrefix(model, "ghcp-") ||
-		strings.HasPrefix(model, "ghcp/")
+	for _, prefix := range gitHubModelPrefixes {
+		if strings.HasPrefix(model, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *LLMRouter) isReplay(model string) bool {

--- a/core/llm.go
+++ b/core/llm.go
@@ -39,6 +39,7 @@ const (
 	modelDefaultOpenAI    = "gpt-4.1"
 	modelDefaultMeta      = "llama-3.2"
 	modelDefaultMistral   = "mistral-7b-instruct"
+	modelDefaultGitHub    = "github-gpt-5"
 )
 
 func resolveModelAlias(maybeAlias string) string {
@@ -53,6 +54,8 @@ func resolveModelAlias(maybeAlias string) string {
 		return modelDefaultMeta
 	case "mistral":
 		return modelDefaultMistral
+	case "github":
+		return modelDefaultGitHub
 	default:
 		// not a recognized alias
 		return maybeAlias
@@ -148,6 +151,7 @@ const (
 	Meta      LLMProvider = "meta"
 	Mistral   LLMProvider = "mistral"
 	DeepSeek  LLMProvider = "deepseek"
+	GitHub    LLMProvider = "github"
 	Other     LLMProvider = "other"
 )
 
@@ -166,6 +170,10 @@ type LLMRouter struct {
 	GeminiAPIKey  string
 	GeminiBaseURL string
 	GeminiModel   string
+
+	GitHubToken      string
+	GitHubModel      string
+	GitHubCliVersion string
 }
 
 func (r *LLMRouter) isAnthropicModel(model string) bool {
@@ -182,6 +190,15 @@ func (r *LLMRouter) isGoogleModel(model string) bool {
 
 func (r *LLMRouter) isMistralModel(model string) bool {
 	return strings.HasPrefix(model, "mistral-") || strings.HasPrefix(model, "mistral/")
+}
+
+func (r *LLMRouter) isGitHubModel(model string) bool {
+	return strings.HasPrefix(model, "github-") ||
+		strings.HasPrefix(model, "github/") ||
+		strings.HasPrefix(model, "gh-") ||
+		strings.HasPrefix(model, "gh/") ||
+		strings.HasPrefix(model, "ghcp-") ||
+		strings.HasPrefix(model, "ghcp/")
 }
 
 func (r *LLMRouter) isReplay(model string) bool {
@@ -244,6 +261,17 @@ func (r *LLMRouter) routeGoogleModel() (*LLMEndpoint, error) {
 	return endpoint, nil
 }
 
+func (r *LLMRouter) routeGitHubModel() *LLMEndpoint {
+	endpoint := &LLMEndpoint{
+		Key:      r.GitHubToken,
+		Provider: GitHub,
+	}
+
+	endpoint.Client = newGhcpClient(endpoint, r.GitHubCliVersion)
+
+	return endpoint
+}
+
 func (r *LLMRouter) routeOtherModel() *LLMEndpoint {
 	// default to openAI compat from other providers
 	endpoint := &LLMEndpoint{
@@ -268,7 +296,7 @@ func (r *LLMRouter) routeReplayModel(model string) (*LLMEndpoint, error) {
 
 // Return a default model, if configured
 func (r *LLMRouter) DefaultModel() string {
-	for _, model := range []string{r.OpenAIModel, r.AnthropicModel, r.GeminiModel} {
+	for _, model := range []string{r.OpenAIModel, r.AnthropicModel, r.GeminiModel, r.GitHubModel} {
 		if model != "" {
 			return model
 		}
@@ -284,6 +312,9 @@ func (r *LLMRouter) DefaultModel() string {
 	}
 	if r.GeminiAPIKey != "" {
 		return modelDefaultGoogle
+	}
+	if r.GitHubToken != "" {
+		return modelDefaultGitHub
 	}
 	return ""
 }
@@ -315,6 +346,8 @@ func (r *LLMRouter) Route(model string) (*LLMEndpoint, error) {
 		if err != nil {
 			return nil, err
 		}
+	case r.isGitHubModel(model):
+		endpoint = r.routeGitHubModel()
 	default:
 		endpoint = r.routeOtherModel()
 	}
@@ -374,6 +407,16 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 		return save("GEMINI_MODEL", &r.GeminiModel)
 	})
 
+	eg.Go(func() error {
+		return save("GITHUB_TOKEN", &r.GitHubToken)
+	})
+	eg.Go(func() error {
+		return save("GITHUB_MODEL", &r.GitHubModel)
+	})
+	eg.Go(func() error {
+		return save("GITHUB_CLI_VERSION", &r.GitHubCliVersion)
+	})
+
 	var (
 		openAIDisableStreaming string
 	)
@@ -393,6 +436,11 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 			return err
 		}
 		r.OpenAIDisableStreaming = v
+	}
+
+	// Set defaults for fields that weren't populated
+	if r.GitHubCliVersion == "" {
+		r.GitHubCliVersion = "latest" // or whatever default you want
 	}
 
 	return nil
@@ -422,7 +470,7 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 		return uriOrPlaintext, nil
 	}
 	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
-	defer telemetry.EndWithCause(span, &rerr)
+	defer telemetry.End(span, func() error { return rerr })
 	env := make(map[string]string)
 	// Load .env from current directory, if it exists
 	if envFile, err := loadSecret(ctx, "file://.env"); err == nil {
@@ -872,7 +920,7 @@ func (llm *LLM) loop(ctx context.Context) error {
 				attribute.String(telemetry.LLMRoleAttr, telemetry.LLMRoleAssistant),
 			))
 			res, sendErr = client.SendQuery(ctx, messagesToSend, tools)
-			telemetry.EndWithCause(span, &sendErr)
+			telemetry.End(span, func() error { return sendErr })
 			if sendErr != nil {
 				var finished *ModelFinishedError
 				if errors.As(sendErr, &finished) {

--- a/core/llm.go
+++ b/core/llm.go
@@ -438,11 +438,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 		r.OpenAIDisableStreaming = v
 	}
 
-	// Set defaults for fields that weren't populated
-	if r.GitHubCliVersion == "" {
-		// leave empty so the implementation default (ghcpDefaultCLIVersion) takes effect
-	}
-
+	// GitHubCliVersion left empty intentionally: ghcpDefaultCLIVersion is used as the fallback.
 	return nil
 }
 
@@ -470,7 +466,7 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 		return uriOrPlaintext, nil
 	}
 	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
-	defer telemetry.End(span, func() error { return rerr })
+	defer telemetry.EndWithCause(span, &rerr)
 	env := make(map[string]string)
 	// Load .env from current directory, if it exists
 	if envFile, err := loadSecret(ctx, "file://.env"); err == nil {
@@ -920,7 +916,7 @@ func (llm *LLM) loop(ctx context.Context) error {
 				attribute.String(telemetry.LLMRoleAttr, telemetry.LLMRoleAssistant),
 			))
 			res, sendErr = client.SendQuery(ctx, messagesToSend, tools)
-			telemetry.End(span, func() error { return sendErr })
+			telemetry.EndWithCause(span, &sendErr)
 			if sendErr != nil {
 				var finished *ModelFinishedError
 				if errors.As(sendErr, &finished) {

--- a/core/llm.go
+++ b/core/llm.go
@@ -414,7 +414,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 		return save("GITHUB_MODEL", &r.GitHubModel)
 	})
 	eg.Go(func() error {
-		return save("GITHUB_CLI_VERSION", &r.GitHubCliVersion)
+		return save("GITHUB_COPILOT_CLI_VERSION", &r.GitHubCliVersion)
 	})
 
 	var (
@@ -440,7 +440,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 
 	// Set defaults for fields that weren't populated
 	if r.GitHubCliVersion == "" {
-		r.GitHubCliVersion = "latest" // or whatever default you want
+		// leave empty so the implementation default (ghcpDefaultCLIVersion) takes effect
 	}
 
 	return nil

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -26,7 +26,7 @@ func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
 	ctx := context.Background()
 
 	// Since there is no official Go SDK for GitHub Copilot at the moment, we will use the GitHub Copilot CLI via a Dagger container.
-	var container = GhcpContainer(ctx, endpoint.Key, cliVersion)
+	var container = GhcpClientContainer(ctx, endpoint.Key, cliVersion)
 
 	return &GhcpClient{
 		client:   container,
@@ -36,7 +36,7 @@ func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
 
 var _ LLMClient = (*GhcpClient)(nil)
 
-func GhcpContainer(
+func GhcpClientContainer(
 	ctx context.Context,
 	token string,
 	cliVersion string,

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -105,10 +105,25 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		return nil, fmt.Errorf("failed to get outputTokens gauge: %w", err)
 	}
 
+	// Ensure there is at least one message in history
+	if len(history) == 0 {
+		return nil, fmt.Errorf("prompt/chat history cannot be empty - run with-prompt to add a prompt/message")
+	}
+
+	// Get the last message as the prompt
+	prompt := history[len(history)-1]
+
+	// Currently, GitHub Copilot CLI only supports single prompt input
+	// We will only send the last user message as the prompt
+	// Future versions may support full chat history and tool calls
+	if prompt.Role != "user" {
+		return nil, fmt.Errorf("the last message in history must be from the user")
+	}
+
 	var copilot = c.client.WithExec([]string{
 		"copilot",
 		"--model", copilotModel,
-		"--prompt-", "hi",
+		"--prompt", prompt.Content,
 		"--stream", "off",
 	})
 

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -36,6 +36,15 @@ func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
 
 var _ LLMClient = (*GhcpClient)(nil)
 
+var gitHubModelPrefixes = []string{
+	"github-",
+	"github/",
+	"gh-",
+	"gh/",
+	"ghcp-",
+	"ghcp/",
+}
+
 func GhcpClientContainer(
 	ctx context.Context,
 	token string,

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"dagger.io/dagger"
+	"dagger.io/dagger/dag"
+	"dagger.io/dagger/telemetry"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type GhcpClient struct {
+	client   *dagger.Container
+	endpoint *LLMEndpoint
+}
+
+func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
+	ctx := context.Background()
+
+	// Since there is no official Go SDK for GitHub Copilot at the moment, we will use the GitHub Copilot CLI via a Dagger container.
+	var container = GhcpContainer(ctx, endpoint.Key, cliVersion)
+
+	return &GhcpClient{
+		client:   container,
+		endpoint: endpoint,
+	}
+}
+
+var _ LLMClient = (*GhcpClient)(nil)
+
+func GhcpContainer(
+	ctx context.Context,
+	token string,
+	cliVersion string,
+) *dagger.Container {
+	return dag.Container().
+		From("node:24-bookworm-slim").
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("@github/copilot@%s", cliVersion)}).
+		WithEnvVariable("GITHUB_TOKEN", token).
+		WithWorkdir("/workspace")
+}
+
+// Satisfy the LLMClient interface with SendQuery and IsRetryable
+func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
+
+	// instrument the call with telemetry
+	// todo: moving to setup function to clean this up
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
+		log.String(telemetry.ContentTypeAttr, "text/markdown"))
+	defer stdio.Close()
+
+	m := telemetry.Meter(ctx, InstrumentationLibrary)
+	spanCtx := trace.SpanContextFromContext(ctx)
+
+	attrs := []attribute.KeyValue{
+		attribute.String(telemetry.MetricsTraceIDAttr, spanCtx.TraceID().String()),
+		attribute.String(telemetry.MetricsSpanIDAttr, spanCtx.SpanID().String()),
+		attribute.String("model", c.endpoint.Model),
+		attribute.String("provider", string(c.endpoint.Provider)),
+	}
+
+	inputTokens, err := m.Int64Gauge(telemetry.LLMInputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inputTokens gauge: %w", err)
+	}
+
+	inputTokensCacheReads, err := m.Int64Gauge(telemetry.LLMInputTokensCacheReads)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inputTokensCacheReads gauge: %w", err)
+	}
+
+	outputTokens, err := m.Int64Gauge(telemetry.LLMOutputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get outputTokens gauge: %w", err)
+	}
+
+	var copilot = c.client
+
+	var toolCalls []LLMToolCall
+
+	content, err := copilot.Stdout(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ghcpResponseMetadata, err := copilot.Stderr(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	llmTokenUsage := parseCopilotTokenMetadata(ghcpResponseMetadata)
+
+	// Record metrics for token usage with attributes in OTel
+	inputTokens.Record(ctx, llmTokenUsage.InputTokens, metric.WithAttributes(attrs...))
+	outputTokens.Record(ctx, llmTokenUsage.OutputTokens, metric.WithAttributes(attrs...))
+	inputTokensCacheReads.Record(ctx, llmTokenUsage.CachedTokenReads, metric.WithAttributes(attrs...))
+
+	return &LLMResponse{
+		Content:    content,
+		ToolCalls:  toolCalls,
+		TokenUsage: llmTokenUsage,
+	}, nil
+}
+
+// We're not implementing any retries at the moment
+func (c *GhcpClient) IsRetryable(err error) bool {
+	// There is no auto retry at GHCP CLI That I know of at the moment
+	return false
+}
+
+// parseCopilotTokenMetadata parses the stderr output (GHCP CLI Meatdata) from GitHub Copilot CLI to extract token usage information
+func parseCopilotTokenMetadata(copilotclimetadata string) LLMTokenUsage {
+	var tokenUsage LLMTokenUsage
+
+	// Parse the usage line that contains model-specific token information
+	// Example: "claude-sonnet-4.5    7.5k input, 52 output, 3.6k cache read, 3.7k cache write (Est. 1 Premium request)"
+	// Note: cache write is optional and may not always be present
+
+	// Look for the pattern: #k input, #k output, #k cache read, and optionally #k cache write
+	re := regexp.MustCompile(`(\d+(?:\.\d+)?)(k?)\s+input,\s*(\d+(?:\.\d+)?)(k?)\s+output,\s*(\d+(?:\.\d+)?)(k?)\s+cache read(?:,\s*(\d+(?:\.\d+)?)(k?)\s+cache write)?`)
+	matches := re.FindStringSubmatch(copilotclimetadata)
+
+	if len(matches) > 7 {
+		tokenUsage.InputTokens = parseTokenValue(matches[1], matches[2])
+		tokenUsage.OutputTokens = parseTokenValue(matches[3], matches[4])
+		tokenUsage.CachedTokenReads = parseTokenValue(matches[5], matches[6])
+
+		// Note: cache write tokens are optional and may not always be present
+		tokenUsage.CachedTokenWrites = parseTokenValue(matches[7], matches[8])
+
+		tokenUsage.TotalTokens = tokenUsage.InputTokens + tokenUsage.OutputTokens
+	}
+
+	return tokenUsage
+}
+
+// parseTokenValue converts a string token value from GitHub Copilot CLI Metadata with an optional 'k' multiplier into an int64
+func parseTokenValue(valueStr string, multiplierStr string) int64 {
+	// Convert string to a float first to handle decimal values
+	if inputVal, err := strconv.ParseFloat(valueStr, 64); err == nil {
+		//  Apply multiplier if 'k' is present (e.g 3.5k = 3500)
+		if strings.ToLower(multiplierStr) == "k" {
+			inputVal *= 1000
+		}
+		return int64(inputVal)
+	}
+	return int64(0)
+}

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -113,6 +113,7 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 	// Get the last message as the prompt
 	// This is presumed to be the user prompt at the moment
 	// Since GitHub Copilot CLI currently only supports single prompt input when running from a command line (--prompt)
+	// Also note that GHCP CLI does not currently support chat history or multi-turn conversations, even though it stores state/history as a jsonl file
 	prompt := history[len(history)-1]
 	if prompt.Role != "user" {
 		return nil, fmt.Errorf("the last message in history must be from the user")
@@ -123,12 +124,7 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		"--model", copilotModel,
 		"--prompt", prompt.Content,
 		"--stream", "off",
-		"--resume",
 	})
-
-	// Reassign the executed GHCP CLI container instance with the exec command back to the GHCPClient instance
-	// so that we can access the stdout and stderr later or chain more exec commands if needed and retain history within the container
-	c.client = copilot
 
 	// We aren't implement tool calls for GHCP at the moment
 	var toolCalls []LLMToolCall

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -439,15 +440,48 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 	}, nil
 }
 
-// IsRetryable returns true for transient network and connection errors.
+var ghcpRetryable = []string{
+	// HTTP status codes surfaced in error messages
+	"429",
+	"500",
+	"503",
+	"504",
+	// Copilot-specific messages
+	"rate limit",
+	"rate_limit",
+	"quota exceeded",
+	"overloaded",
+	"capacity",
+	"try again",
+	"temporarily unavailable",
+	"service unavailable",
+	"Internal server error",
+	// Network/transport errors
+	"connection refused",
+	"connection reset",
+	"EOF",
+	"transport",
+	"dial ",
+	"i/o timeout",
+	"broken pipe",
+}
+
+// IsRetryable returns true for transient errors that warrant a retry.
 func (c *GhcpClient) IsRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "connection refused") ||
-		strings.Contains(errStr, "EOF") ||
-		strings.Contains(errStr, "transport")
+	// Never retry on context cancellation
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, pattern := range ghcpRetryable {
+		if strings.Contains(msg, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
 }
 
 // isSessionExpired reports whether an error indicates the server-side session

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -135,6 +135,7 @@ func (c *GhcpClient) connect(ctx context.Context) error {
 	// Endpoint returns host:port accessible from the engine process.
 	addr, err := startedSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Port: ghcpDefaultCLIPort})
 	if err != nil {
+		_ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
 		return fmt.Errorf("get copilot sidecar endpoint: %w", err)
 	}
 
@@ -142,6 +143,7 @@ func (c *GhcpClient) connect(ctx context.Context) error {
 	// Auth is handled by the sidecar via its GITHUB_TOKEN env var.
 	sdkClient := copilot.NewClient(&copilot.ClientOptions{CLIUrl: addr})
 	if err := sdkClient.Start(ctx); err != nil {
+		_ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
 		return fmt.Errorf("start copilot SDK client: %w", err)
 	}
 	c.client = sdkClient
@@ -351,7 +353,7 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		usage = LLMTokenUsage{}
 		fullContent.Reset()
 		toolCallsMu.Lock()
-		capturedCalls = capturedCalls[:0]
+		capturedCalls = nil
 		toolCallsMu.Unlock()
 
 		// Capture token usage from assistant.usage events, which fire before session.idle.
@@ -466,6 +468,7 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 			c.mu.Lock()
 			c.session = nil
 			c.sentMsgCount = 0
+			c.toolsHash = ""
 			c.mu.Unlock()
 			continue
 		}

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -29,12 +29,13 @@ const (
 )
 
 type GhcpClient struct {
-	endpoint   *LLMEndpoint
-	cliVersion string
-	svc        *dagger.Service  // the copilot CLI sidecar
-	client     *copilot.Client  // SDK client connected via CLIUrl
-	session    *copilot.Session // persistent session (multi-turn, Phase 2)
-	mu         sync.Mutex       // protects svc, client, session
+	endpoint     *LLMEndpoint
+	cliVersion   string
+	svc          *dagger.Service  // the copilot CLI sidecar
+	client       *copilot.Client  // SDK client connected via CLIUrl
+	session      *copilot.Session // persistent session (multi-turn)
+	mu           sync.Mutex       // protects svc, client, session, sentMsgCount
+	sentMsgCount int              // number of history messages already sent to this session
 }
 
 var _ LLMClient = (*GhcpClient)(nil)
@@ -148,8 +149,8 @@ func (c *GhcpClient) ensureConnected(ctx context.Context) error {
 }
 
 // getOrCreateSession returns the persistent session, creating it if needed.
-// Phase 2 will add session reuse with proper history threading.
-func (c *GhcpClient) getOrCreateSession(ctx context.Context, tools []copilot.Tool) (*copilot.Session, error) {
+// systemPrompt is passed to SessionConfig.SystemMessage on first creation only.
+func (c *GhcpClient) getOrCreateSession(ctx context.Context, systemPrompt string, tools []copilot.Tool) (*copilot.Session, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -157,10 +158,16 @@ func (c *GhcpClient) getOrCreateSession(ctx context.Context, tools []copilot.Too
 		return c.session, nil
 	}
 
+	var sysMsg *copilot.SystemMessageConfig
+	if systemPrompt != "" {
+		sysMsg = &copilot.SystemMessageConfig{Content: systemPrompt}
+	}
+
 	session, err := c.client.CreateSession(ctx, &copilot.SessionConfig{
 		Streaming:           true, // required for message_delta events
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		Tools:               tools,
+		SystemMessage:       sysMsg,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create copilot session: %w", err)
@@ -169,9 +176,10 @@ func (c *GhcpClient) getOrCreateSession(ctx context.Context, tools []copilot.Too
 	return session, nil
 }
 
-// SendQuery sends the last user message in history to Copilot and returns the
-// response. Phase 1 sends only the final user message; Phase 2 will thread the
-// full history through session.Send.
+// SendQuery sends only the new messages (since the last call) to Copilot and
+// returns the response. The Copilot CLI maintains full conversation history
+// server-side within the session, so we track a cursor (sentMsgCount) and
+// send only the delta each time.
 func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
 	copilotModel := StripGitHubModelPrefix(c.endpoint.Model)
 
@@ -211,43 +219,94 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 	}
 
 	sdkTools := buildSDKTools(tools)
-	session, err := c.getOrCreateSession(ctx, sdkTools)
-	if err != nil {
-		return nil, err
+
+	// Extract system prompt for new session creation (only used on first call).
+	systemPrompt := ""
+	for _, msg := range history {
+		if msg.Role == "system" {
+			systemPrompt = msg.Content
+			break
+		}
 	}
 
-	// Capture token usage from assistant.usage events, which fire before session.idle.
-	var usage LLMTokenUsage
-	var usageMu sync.Mutex
-	unsubscribe := session.On(func(event copilot.SessionEvent) {
-		if event.Type != copilot.SessionEventTypeAssistantUsage {
-			return
-		}
-		usageMu.Lock()
-		defer usageMu.Unlock()
-		if event.Data.InputTokens != nil {
-			usage.InputTokens = int64(*event.Data.InputTokens)
-		}
-		if event.Data.OutputTokens != nil {
-			usage.OutputTokens = int64(*event.Data.OutputTokens)
-		}
-		if event.Data.CacheReadTokens != nil {
-			usage.CachedTokenReads = int64(*event.Data.CacheReadTokens)
-		}
-		if event.Data.CacheWriteTokens != nil {
-			usage.CachedTokenWrites = int64(*event.Data.CacheWriteTokens)
-		}
-		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
-	})
-	defer unsubscribe()
+	// Phase 2: send only new messages, retry once on session expiry.
+	var (
+		resp    *copilot.SessionEvent
+		sendErr error
+		usage   LLMTokenUsage
+		usageMu sync.Mutex
+	)
 
-	// Phase 1: send last user message only. Phase 2 will thread full history.
-	prompt := ghcpLastUserMessage(history)
+	for attempt := 0; attempt < 2; attempt++ {
+		session, err := c.getOrCreateSession(ctx, systemPrompt, sdkTools)
+		if err != nil {
+			return nil, err
+		}
 
-	resp, err := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt})
-	if err != nil {
-		return nil, fmt.Errorf("copilot send: %w", err)
+		// Read cursor under lock so it's consistent with the session.
+		c.mu.Lock()
+		startIdx := c.sentMsgCount
+		c.mu.Unlock()
+
+		// Identify messages not yet sent to this session.
+		newMsgs := history[startIdx:]
+		prompt := ""
+		for _, msg := range newMsgs {
+			if msg.Role == "user" {
+				prompt = msg.Content
+			}
+		}
+		if prompt == "" {
+			return nil, fmt.Errorf("no user message found in new history")
+		}
+
+		// Capture token usage from assistant.usage events, which fire before session.idle.
+		usage = LLMTokenUsage{}
+		unsubscribe := session.On(func(event copilot.SessionEvent) {
+			if event.Type != copilot.SessionEventTypeAssistantUsage {
+				return
+			}
+			usageMu.Lock()
+			defer usageMu.Unlock()
+			if event.Data.InputTokens != nil {
+				usage.InputTokens = int64(*event.Data.InputTokens)
+			}
+			if event.Data.OutputTokens != nil {
+				usage.OutputTokens = int64(*event.Data.OutputTokens)
+			}
+			if event.Data.CacheReadTokens != nil {
+				usage.CachedTokenReads = int64(*event.Data.CacheReadTokens)
+			}
+			if event.Data.CacheWriteTokens != nil {
+				usage.CachedTokenWrites = int64(*event.Data.CacheWriteTokens)
+			}
+			usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+		})
+
+		resp, sendErr = session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt})
+		unsubscribe()
+
+		if sendErr != nil && isSessionExpired(sendErr) && attempt == 0 {
+			// Session gone server-side — clear state and retry with a fresh session.
+			c.mu.Lock()
+			c.session = nil
+			c.sentMsgCount = 0
+			c.mu.Unlock()
+			continue
+		}
+		break
 	}
+
+	if sendErr != nil {
+		return nil, fmt.Errorf("copilot send: %w", sendErr)
+	}
+
+	// Advance cursor: all messages in history are now acknowledged by the server.
+	// Dagger will append the assistant response after we return, so the next call
+	// will see len(history)+1 messages and send only the new user turn.
+	c.mu.Lock()
+	c.sentMsgCount = len(history)
+	c.mu.Unlock()
 
 	content := ""
 	if resp != nil && resp.Data.Content != nil {
@@ -283,14 +342,17 @@ func (c *GhcpClient) IsRetryable(err error) bool {
 		strings.Contains(errStr, "transport")
 }
 
-// ghcpLastUserMessage returns the content of the last user-role message.
-func ghcpLastUserMessage(history []*ModelMessage) string {
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Role == "user" {
-			return history[i].Content
-		}
+// isSessionExpired reports whether an error indicates the server-side session
+// is no longer valid and a fresh session should be created.
+func isSessionExpired(err error) bool {
+	if err == nil {
+		return false
 	}
-	return ""
+	s := err.Error()
+	return strings.Contains(s, "session not found") ||
+		strings.Contains(s, "session expired") ||
+		strings.Contains(s, "disconnected") ||
+		strings.Contains(s, "not connected")
 }
 
 // buildSDKTools converts Dagger LLMTools to Copilot SDK Tool definitions.

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -3,13 +3,17 @@ package core
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"os"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"dagger.io/dagger"
 	"dagger.io/dagger/dag"
-	"dagger.io/dagger/telemetry"
+
+	copilot "github.com/github/copilot-sdk/go"
+	telemetry "github.com/dagger/otel-go"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
@@ -17,21 +21,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	// ghcpDefaultCLIVersion is the Copilot CLI version bundled with SDK v0.2.0.
+	// Bump this alongside go.mod when upgrading the SDK.
+	ghcpDefaultCLIVersion = "1.0.10"
+	ghcpDefaultCLIPort    = 3000
+)
+
 type GhcpClient struct {
-	client   *dagger.Container
-	endpoint *LLMEndpoint
-}
-
-func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
-	ctx := context.Background()
-
-	// Since there is no official Go SDK for GitHub Copilot at the moment, we will use the GitHub Copilot CLI via a Dagger container.
-	var container = GhcpClientContainer(ctx, endpoint.Key, cliVersion)
-
-	return &GhcpClient{
-		client:   container,
-		endpoint: endpoint,
-	}
+	endpoint   *LLMEndpoint
+	cliVersion string
+	svc        *dagger.Service  // the copilot CLI sidecar
+	client     *copilot.Client  // SDK client connected via CLIUrl
+	session    *copilot.Session // persistent session (multi-turn, Phase 2)
+	mu         sync.Mutex       // protects svc, client, session
 }
 
 var _ LLMClient = (*GhcpClient)(nil)
@@ -45,10 +48,8 @@ var gitHubModelPrefixes = []string{
 	"ghcp/",
 }
 
-// Strip Model Prefix from GitHub Model Names
-// E.g "github-gpt-5" -> "gpt-5"
-// Since GitHub uses various models we want to avoid model name collisions with other providers
-// we default to "github-gpt-5" for now but will update this in future to allow the GHCP CLI to fall back to its own default model
+// StripGitHubModelPrefix strips provider-specific prefixes from GitHub model names.
+// E.g. "github-gpt-5" -> "gpt-5". Called from core/llm.go.
 func StripGitHubModelPrefix(model string) string {
 	for _, prefix := range gitHubModelPrefixes {
 		if strings.HasPrefix(model, prefix) {
@@ -58,28 +59,122 @@ func StripGitHubModelPrefix(model string) string {
 	return model
 }
 
-func GhcpClientContainer(
-	ctx context.Context,
-	token string,
-	cliVersion string,
-) *dagger.Container {
-	// Use a cache volume to persist the copilot session state across calls
-	ghcpSessionCache := dag.CacheVolume("copilot-session-" + token[:8]) // Use token prefix as cache key
+// copilotSidecar builds the Copilot CLI as an on-demand Dagger service.
+// The tarball is fetched via dag.HTTP so Dagger's content-addressable cache
+// ensures it is downloaded only once per version.
+func copilotSidecar(token, cliVersion string) *dagger.Service {
+	version := cliVersion
+	if v := os.Getenv("GITHUB_CLI_VERSION"); v != "" {
+		version = v
+	}
+	if version == "" {
+		version = ghcpDefaultCLIVersion
+	}
 
+	tarballURL := os.Getenv("GITHUB_COPILOT_CLI_URL")
+	if tarballURL == "" {
+		platform := "linux-x64"
+		if runtime.GOARCH == "arm64" {
+			platform = "linux-arm64"
+		}
+		tarballURL = fmt.Sprintf(
+			"https://registry.npmjs.org/@github/copilot-%s/-/copilot-%s-%s.tgz",
+			platform, platform, version,
+		)
+	}
+
+	tarball := dag.HTTP(tarballURL)
 	return dag.Container().
-		From("node:24-bookworm-slim").
-		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("@github/copilot@%s", cliVersion)}).
+		From("debian:bookworm-slim").
+		WithMountedFile("/tmp/copilot.tgz", tarball).
+		WithExec([]string{"sh", "-c",
+			"tar -xzf /tmp/copilot.tgz -C /tmp && " +
+				"mv /tmp/package/copilot /usr/local/bin/copilot && " +
+				"chmod +x /usr/local/bin/copilot && " +
+				"rm -rf /tmp/copilot.tgz /tmp/package"}).
 		WithEnvVariable("GITHUB_TOKEN", token).
-		WithMountedCache("/root/.copilot", ghcpSessionCache). // Mount cache at copilot config directory
-		WithWorkdir("/workspace")
+		WithExposedPort(ghcpDefaultCLIPort).
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{
+				"copilot", "--headless", "--no-auto-update",
+				"--port", strconv.Itoa(ghcpDefaultCLIPort),
+			},
+		})
 }
 
-// Satisfy the LLMClient interface with SendQuery and IsRetryable
-func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
+// newGhcpClient creates a GhcpClient. The sidecar and SDK connection are
+// established lazily on the first SendQuery call.
+func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
+	if cliVersion == "" {
+		cliVersion = ghcpDefaultCLIVersion
+	}
+	return &GhcpClient{
+		endpoint:   endpoint,
+		cliVersion: cliVersion,
+	}
+}
 
-	var copilotModel = StripGitHubModelPrefix(c.endpoint.Model)
-	// instrument the call with telemetry
-	// todo: moving to setup function to clean this up
+// ensureConnected starts the sidecar service and connects the SDK client.
+// It is idempotent: subsequent calls return immediately once connected.
+func (c *GhcpClient) ensureConnected(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return nil
+	}
+
+	svc := copilotSidecar(c.endpoint.Key, c.cliVersion)
+	startedSvc, err := svc.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("start copilot sidecar: %w", err)
+	}
+	c.svc = startedSvc
+
+	// Endpoint returns host:port accessible from the engine process.
+	addr, err := startedSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Port: ghcpDefaultCLIPort})
+	if err != nil {
+		return fmt.Errorf("get copilot sidecar endpoint: %w", err)
+	}
+
+	// NOTE: GitHubToken must NOT be set here with CLIUrl — the SDK panics.
+	// Auth is handled by the sidecar via its GITHUB_TOKEN env var.
+	sdkClient := copilot.NewClient(&copilot.ClientOptions{CLIUrl: addr})
+	if err := sdkClient.Start(ctx); err != nil {
+		return fmt.Errorf("start copilot SDK client: %w", err)
+	}
+	c.client = sdkClient
+	return nil
+}
+
+// getOrCreateSession returns the persistent session, creating it if needed.
+// Phase 2 will add session reuse with proper history threading.
+func (c *GhcpClient) getOrCreateSession(ctx context.Context, tools []copilot.Tool) (*copilot.Session, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.session != nil {
+		return c.session, nil
+	}
+
+	session, err := c.client.CreateSession(ctx, &copilot.SessionConfig{
+		Streaming:           true, // required for message_delta events
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Tools:               tools,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create copilot session: %w", err)
+	}
+	c.session = session
+	return session, nil
+}
+
+// SendQuery sends the last user message in history to Copilot and returns the
+// response. Phase 1 sends only the final user message; Phase 2 will thread the
+// full history through session.Send.
+func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
+	copilotModel := StripGitHubModelPrefix(c.endpoint.Model)
+
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
 		log.String(telemetry.ContentTypeAttr, "text/markdown"))
 	defer stdio.Close()
@@ -94,111 +189,157 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		attribute.String("provider", string(c.endpoint.Provider)),
 	}
 
-	inputTokens, err := m.Int64Gauge(telemetry.LLMInputTokens)
+	inputTokensGauge, err := m.Int64Gauge(telemetry.LLMInputTokens)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get inputTokens gauge: %w", err)
 	}
-
-	inputTokensCacheReads, err := m.Int64Gauge(telemetry.LLMInputTokensCacheReads)
+	inputTokensCacheReadsGauge, err := m.Int64Gauge(telemetry.LLMInputTokensCacheReads)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get inputTokensCacheReads gauge: %w", err)
 	}
-
-	outputTokens, err := m.Int64Gauge(telemetry.LLMOutputTokens)
+	outputTokensGauge, err := m.Int64Gauge(telemetry.LLMOutputTokens)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get outputTokens gauge: %w", err)
 	}
 
-	// Ensure there is at least one message in history
 	if len(history) == 0 {
 		return nil, fmt.Errorf("prompt/chat history cannot be empty - run with-prompt to add a prompt/message")
 	}
 
-	// Get the last message as the prompt
-	// This is presumed to be the user prompt at the moment
-	// Since GitHub Copilot CLI currently only supports single prompt input when running from a command line (--prompt)
-	// Also note that GHCP CLI does not currently support chat history or multi-turn conversations, even though it stores state/history as a jsonl file
-	prompt := history[len(history)-1]
-	if prompt.Role != "user" {
-		return nil, fmt.Errorf("the last message in history must be from the user")
+	if err := c.ensureConnected(ctx); err != nil {
+		return nil, err
 	}
 
-	var copilot = c.client.WithExec([]string{
-		"copilot",
-		"--model", copilotModel,
-		"--prompt", prompt.Content,
-		"--stream", "off",
-		"--continue",
+	sdkTools := buildSDKTools(tools)
+	session, err := c.getOrCreateSession(ctx, sdkTools)
+	if err != nil {
+		return nil, err
+	}
+
+	// Capture token usage from assistant.usage events, which fire before session.idle.
+	var usage LLMTokenUsage
+	var usageMu sync.Mutex
+	unsubscribe := session.On(func(event copilot.SessionEvent) {
+		if event.Type != copilot.SessionEventTypeAssistantUsage {
+			return
+		}
+		usageMu.Lock()
+		defer usageMu.Unlock()
+		if event.Data.InputTokens != nil {
+			usage.InputTokens = int64(*event.Data.InputTokens)
+		}
+		if event.Data.OutputTokens != nil {
+			usage.OutputTokens = int64(*event.Data.OutputTokens)
+		}
+		if event.Data.CacheReadTokens != nil {
+			usage.CachedTokenReads = int64(*event.Data.CacheReadTokens)
+		}
+		if event.Data.CacheWriteTokens != nil {
+			usage.CachedTokenWrites = int64(*event.Data.CacheWriteTokens)
+		}
+		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 	})
+	defer unsubscribe()
 
-	// We aren't implement tool calls for GHCP at the moment
-	var toolCalls []LLMToolCall
+	// Phase 1: send last user message only. Phase 2 will thread full history.
+	prompt := ghcpLastUserMessage(history)
 
-	content, err := copilot.Stdout(ctx)
+	resp, err := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("copilot send: %w", err)
 	}
 
-	ghcpResponseMetadata, err := copilot.Stderr(ctx)
-	if err != nil {
-		return nil, err
+	content := ""
+	if resp != nil && resp.Data.Content != nil {
+		content = *resp.Data.Content
 	}
 
-	llmTokenUsage := parseCopilotTokenMetadata(ghcpResponseMetadata)
+	// Phase 3 will implement full tool call execution.
+	toolCalls := ghcpExtractToolCalls(resp)
 
-	// Record metrics for token usage with attributes in OTel
-	inputTokens.Record(ctx, llmTokenUsage.InputTokens, metric.WithAttributes(attrs...))
-	outputTokens.Record(ctx, llmTokenUsage.OutputTokens, metric.WithAttributes(attrs...))
-	inputTokensCacheReads.Record(ctx, llmTokenUsage.CachedTokenReads, metric.WithAttributes(attrs...))
+	usageMu.Lock()
+	finalUsage := usage
+	usageMu.Unlock()
+
+	inputTokensGauge.Record(ctx, finalUsage.InputTokens, metric.WithAttributes(attrs...))
+	outputTokensGauge.Record(ctx, finalUsage.OutputTokens, metric.WithAttributes(attrs...))
+	inputTokensCacheReadsGauge.Record(ctx, finalUsage.CachedTokenReads, metric.WithAttributes(attrs...))
 
 	return &LLMResponse{
 		Content:    content,
 		ToolCalls:  toolCalls,
-		TokenUsage: llmTokenUsage,
+		TokenUsage: finalUsage,
 	}, nil
 }
 
-// We're not implementing any retries at the moment
+// IsRetryable returns true for transient network and connection errors.
 func (c *GhcpClient) IsRetryable(err error) bool {
-	// There is no auto retry at GHCP CLI That I know of at the moment
-	return false
-}
-
-// parseCopilotTokenMetadata parses the stderr output (GHCP CLI Meatdata) from GitHub Copilot CLI to extract token usage information
-func parseCopilotTokenMetadata(copilotclimetadata string) LLMTokenUsage {
-	var tokenUsage LLMTokenUsage
-
-	// Parse the usage line that contains model-specific token information
-	// Example: "claude-sonnet-4.5    7.5k input, 52 output, 3.6k cache read, 3.7k cache write (Est. 1 Premium request)"
-	// Note: cache write is optional and may not always be present
-
-	// Look for the pattern: #k input, #k output, #k cache read, and optionally #k cache write
-	re := regexp.MustCompile(`(\d+(?:\.\d+)?)(k?)\s+input,\s*(\d+(?:\.\d+)?)(k?)\s+output,\s*(\d+(?:\.\d+)?)(k?)\s+cache read(?:,\s*(\d+(?:\.\d+)?)(k?)\s+cache write)?`)
-	matches := re.FindStringSubmatch(copilotclimetadata)
-
-	if len(matches) > 7 {
-		tokenUsage.InputTokens = parseTokenValue(matches[1], matches[2])
-		tokenUsage.OutputTokens = parseTokenValue(matches[3], matches[4])
-		tokenUsage.CachedTokenReads = parseTokenValue(matches[5], matches[6])
-
-		// Note: cache write tokens are optional and may not always be present
-		tokenUsage.CachedTokenWrites = parseTokenValue(matches[7], matches[8])
-
-		tokenUsage.TotalTokens = tokenUsage.InputTokens + tokenUsage.OutputTokens
+	if err == nil {
+		return false
 	}
-
-	return tokenUsage
+	errStr := err.Error()
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "EOF") ||
+		strings.Contains(errStr, "transport")
 }
 
-// parseTokenValue converts a string token value from GitHub Copilot CLI Metadata with an optional 'k' multiplier into an int64
-func parseTokenValue(valueStr string, multiplierStr string) int64 {
-	// Convert string to a float first to handle decimal values
-	if inputVal, err := strconv.ParseFloat(valueStr, 64); err == nil {
-		//  Apply multiplier if 'k' is present (e.g 3.5k = 3500)
-		if strings.ToLower(multiplierStr) == "k" {
-			inputVal *= 1000
+// ghcpLastUserMessage returns the content of the last user-role message.
+func ghcpLastUserMessage(history []*ModelMessage) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "user" {
+			return history[i].Content
 		}
-		return int64(inputVal)
 	}
-	return int64(0)
+	return ""
+}
+
+// buildSDKTools converts Dagger LLMTools to Copilot SDK Tool definitions.
+// Phase 1: stub handlers return an error; Phase 3 will wire to tool.Call.
+func buildSDKTools(tools []LLMTool) []copilot.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	sdkTools := make([]copilot.Tool, 0, len(tools))
+	for _, t := range tools {
+		sdkTools = append(sdkTools, copilot.Tool{
+			Name:           t.Name,
+			Description:    t.Description,
+			Parameters:     t.Schema,
+			SkipPermission: true,
+			Handler: func(inv copilot.ToolInvocation) (copilot.ToolResult, error) {
+				// Phase 3: replace with t.Call(inv.TraceContext, inv.Arguments)
+				return copilot.ToolResult{
+					Error:      "tool execution not yet implemented (Phase 3)",
+					ResultType: "error",
+				}, nil
+			},
+		})
+	}
+	return sdkTools
+}
+
+// ghcpExtractToolCalls converts SDK ToolRequests to Dagger LLMToolCall values.
+// Phase 3 will complete the tool calling loop.
+func ghcpExtractToolCalls(event *copilot.SessionEvent) []LLMToolCall {
+	if event == nil || len(event.Data.ToolRequests) == 0 {
+		return nil
+	}
+	calls := make([]LLMToolCall, 0, len(event.Data.ToolRequests))
+	for _, req := range event.Data.ToolRequests {
+		var args map[string]any
+		if req.Arguments != nil {
+			if m, ok := req.Arguments.(map[string]any); ok {
+				args = m
+			}
+		}
+		calls = append(calls, LLMToolCall{
+			ID:   req.ToolCallID,
+			Type: "function",
+			Function: FuncCall{
+				Name:      req.Name,
+				Arguments: args,
+			},
+		})
+	}
+	return calls
 }

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"dagger.io/dagger"
 	"dagger.io/dagger/dag"
@@ -244,13 +245,15 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 
 	// Phase 2: send only new messages, retry once on session expiry.
 	var (
-		resp    *copilot.SessionEvent
 		sendErr error
 		usage   LLMTokenUsage
 		usageMu sync.Mutex
 
 		toolCallsMu   sync.Mutex
 		capturedCalls []LLMToolCall
+
+		contentMu   sync.Mutex
+		fullContent strings.Builder
 	)
 
 	for attempt := 0; attempt < 2; attempt++ {
@@ -278,6 +281,7 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 
 		// Reset per-attempt state.
 		usage = LLMTokenUsage{}
+		fullContent.Reset()
 		toolCallsMu.Lock()
 		capturedCalls = capturedCalls[:0]
 		toolCallsMu.Unlock()
@@ -337,9 +341,57 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 			})
 		})
 
-		resp, sendErr = session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt})
+		idleCh := make(chan struct{}, 1)
+		streamErrCh := make(chan error, 1)
+
+		unsubStream := session.On(func(event copilot.SessionEvent) {
+			switch event.Type {
+			case copilot.SessionEventTypeAssistantMessageDelta:
+				if event.Data.DeltaContent != nil {
+					delta := *event.Data.DeltaContent
+					contentMu.Lock()
+					fullContent.WriteString(delta)
+					contentMu.Unlock()
+					fmt.Fprint(stdio.Stdout, delta)
+				}
+			case copilot.SessionEventTypeSessionIdle:
+				select {
+				case idleCh <- struct{}{}:
+				default:
+				}
+			case copilot.SessionEventTypeSessionError:
+				errMsg := "session error"
+				if event.Data.Message != nil {
+					errMsg = *event.Data.Message
+				}
+				select {
+				case streamErrCh <- fmt.Errorf("copilot session error: %s", errMsg):
+				default:
+				}
+			}
+		})
+
+		_, sendErr = session.Send(ctx, copilot.MessageOptions{Prompt: prompt})
+		if sendErr == nil {
+			waitCtx := ctx
+			if _, ok := ctx.Deadline(); !ok {
+				var cancel context.CancelFunc
+				waitCtx, cancel = context.WithTimeout(ctx, 120*time.Second)
+				defer cancel()
+			}
+			select {
+			case <-idleCh:
+				// done
+			case streamErr := <-streamErrCh:
+				sendErr = streamErr
+			case <-waitCtx.Done():
+				sendErr = waitCtx.Err()
+			}
+		}
+
 		unsubUsage()
 		unsubTools()
+		unsubStream()
 
 		if sendErr != nil && isSessionExpired(sendErr) && attempt == 0 {
 			// Session gone server-side — clear state and retry with a fresh session.
@@ -363,10 +415,9 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 	c.sentMsgCount = len(history)
 	c.mu.Unlock()
 
-	content := ""
-	if resp != nil && resp.Data.Content != nil {
-		content = *resp.Data.Content
-	}
+	contentMu.Lock()
+	content := fullContent.String()
+	contentMu.Unlock()
 
 	toolCallsMu.Lock()
 	toolCalls := make([]LLMToolCall, len(capturedCalls))

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -108,9 +109,13 @@ func copilotSidecar(token, cliVersion string) *dagger.Service {
 		})
 }
 
-// newGhcpClient creates a GhcpClient. The sidecar and SDK connection are
-// established lazily on the first SendQuery call.
-func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
+// newGhcpClient creates an LLMClient for GitHub Copilot.
+// When GITHUB_COPILOT_LEGACY=true, the original CLI-in-container path is used
+// instead of the SDK, as an escape hatch while the SDK is in Technical Preview.
+func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) LLMClient {
+	if os.Getenv("GITHUB_COPILOT_LEGACY") == "true" {
+		return newGhcpLegacyClient(endpoint, cliVersion)
+	}
 	if cliVersion == "" {
 		cliVersion = ghcpDefaultCLIVersion
 	}
@@ -628,4 +633,146 @@ func hashTools(tools []copilot.Tool) string {
 	}
 	sort.Strings(names)
 	return strings.Join(names, ",")
+}
+
+// ---------------------------------------------------------------------------
+// GhcpLegacyClient — original CLI-in-container (pre-SDK) fallback
+// ---------------------------------------------------------------------------
+
+// GhcpLegacyClient implements LLMClient using the original CLI-in-container approach
+// (node:24 + npm install @github/copilot). Activated via GITHUB_COPILOT_LEGACY=true
+// as an escape hatch while the copilot-sdk/go is in Technical Preview.
+//
+// Deprecated: Use GhcpClient (SDK path) instead. This will be removed once the
+// SDK is stable.
+type GhcpLegacyClient struct {
+	client   *dagger.Container
+	endpoint *LLMEndpoint
+}
+
+var _ LLMClient = (*GhcpLegacyClient)(nil)
+
+func newGhcpLegacyClient(endpoint *LLMEndpoint, cliVersion string) *GhcpLegacyClient {
+	if cliVersion == "" {
+		cliVersion = ghcpDefaultCLIVersion
+	}
+	ctx := context.Background()
+	container := ghcpLegacyContainer(ctx, endpoint.Key, cliVersion)
+	return &GhcpLegacyClient{client: container, endpoint: endpoint}
+}
+
+func ghcpLegacyContainer(ctx context.Context, token, cliVersion string) *dagger.Container {
+	ghcpSessionCache := dag.CacheVolume("copilot-session-" + token[:8])
+	return dag.Container().
+		From("node:24-bookworm-slim").
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("@github/copilot@%s", cliVersion)}).
+		WithEnvVariable("GITHUB_TOKEN", token).
+		WithMountedCache("/root/.copilot", ghcpSessionCache).
+		WithWorkdir("/workspace")
+}
+
+func (c *GhcpLegacyClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
+	copilotModel := StripGitHubModelPrefix(c.endpoint.Model)
+
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
+		log.String(telemetry.ContentTypeAttr, "text/markdown"))
+	defer stdio.Close()
+
+	m := telemetry.Meter(ctx, InstrumentationLibrary)
+	spanCtx := trace.SpanContextFromContext(ctx)
+	attrs := []attribute.KeyValue{
+		attribute.String(telemetry.MetricsTraceIDAttr, spanCtx.TraceID().String()),
+		attribute.String(telemetry.MetricsSpanIDAttr, spanCtx.SpanID().String()),
+		attribute.String("model", copilotModel),
+		attribute.String("provider", string(c.endpoint.Provider)),
+	}
+
+	inputTokens, err := m.Int64Gauge(telemetry.LLMInputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inputTokens gauge: %w", err)
+	}
+	inputTokensCacheReads, err := m.Int64Gauge(telemetry.LLMInputTokensCacheReads)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inputTokensCacheReads gauge: %w", err)
+	}
+	outputTokens, err := m.Int64Gauge(telemetry.LLMOutputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get outputTokens gauge: %w", err)
+	}
+
+	if len(history) == 0 {
+		return nil, fmt.Errorf("prompt/chat history cannot be empty")
+	}
+
+	// Legacy path: only the last user message is sent (no multi-turn support).
+	var prompt *ModelMessage
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "user" {
+			prompt = history[i]
+			break
+		}
+	}
+	if prompt == nil {
+		return nil, fmt.Errorf("no user message found in history")
+	}
+
+	container := c.client.WithExec([]string{
+		"copilot",
+		"--model", copilotModel,
+		"--prompt", prompt.Content,
+		"--stream", "off",
+		"--continue",
+	})
+
+	content, err := container.Stdout(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := container.Stderr(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	usage := parseCopilotTokenMetadata(stderr)
+
+	inputTokens.Record(ctx, usage.InputTokens, metric.WithAttributes(attrs...))
+	outputTokens.Record(ctx, usage.OutputTokens, metric.WithAttributes(attrs...))
+	inputTokensCacheReads.Record(ctx, usage.CachedTokenReads, metric.WithAttributes(attrs...))
+
+	return &LLMResponse{
+		Content:    content,
+		ToolCalls:  nil,
+		TokenUsage: usage,
+	}, nil
+}
+
+func (c *GhcpLegacyClient) IsRetryable(err error) bool {
+	return false
+}
+
+// parseCopilotTokenMetadata parses the token usage summary line written by the
+// Copilot CLI to stderr, e.g. "123 input, 45 output, 6k cache read".
+func parseCopilotTokenMetadata(metadata string) LLMTokenUsage {
+	var usage LLMTokenUsage
+	re := regexp.MustCompile(`(\d+(?:\.\d+)?)(k?)\s+input,\s*(\d+(?:\.\d+)?)(k?)\s+output,\s*(\d+(?:\.\d+)?)(k?)\s+cache read(?:,\s*(\d+(?:\.\d+)?)(k?)\s+cache write)?`)
+	matches := re.FindStringSubmatch(metadata)
+	if len(matches) > 7 {
+		usage.InputTokens = parseTokenValue(matches[1], matches[2])
+		usage.OutputTokens = parseTokenValue(matches[3], matches[4])
+		usage.CachedTokenReads = parseTokenValue(matches[5], matches[6])
+		usage.CachedTokenWrites = parseTokenValue(matches[7], matches[8])
+		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+	}
+	return usage
+}
+
+func parseTokenValue(valueStr, multiplierStr string) int64 {
+	if v, err := strconv.ParseFloat(valueStr, 64); err == nil {
+		if strings.ToLower(multiplierStr) == "k" {
+			v *= 1000
+		}
+		return int64(v)
+	}
+	return 0
 }

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -135,7 +135,7 @@ func (c *GhcpClient) connect(ctx context.Context) error {
 	// Endpoint returns host:port accessible from the engine process.
 	addr, err := startedSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Port: ghcpDefaultCLIPort})
 	if err != nil {
-		_ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
+		_, _ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
 		return fmt.Errorf("get copilot sidecar endpoint: %w", err)
 	}
 
@@ -143,7 +143,7 @@ func (c *GhcpClient) connect(ctx context.Context) error {
 	// Auth is handled by the sidecar via its GITHUB_TOKEN env var.
 	sdkClient := copilot.NewClient(&copilot.ClientOptions{CLIUrl: addr})
 	if err := sdkClient.Start(ctx); err != nil {
-		_ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
+		_, _ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
 		return fmt.Errorf("start copilot SDK client: %w", err)
 	}
 	c.client = sdkClient

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -135,16 +135,16 @@ func (c *GhcpClient) connect(ctx context.Context) error {
 	// Endpoint returns host:port accessible from the engine process.
 	addr, err := startedSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Port: ghcpDefaultCLIPort})
 	if err != nil {
-		_, _ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
-		return fmt.Errorf("get copilot sidecar endpoint: %w", err)
+		_, stopErr := startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
+		return errors.Join(fmt.Errorf("get copilot sidecar endpoint: %w", err), stopErr)
 	}
 
 	// NOTE: GitHubToken must NOT be set here with CLIUrl — the SDK panics.
 	// Auth is handled by the sidecar via its GITHUB_TOKEN env var.
 	sdkClient := copilot.NewClient(&copilot.ClientOptions{CLIUrl: addr})
 	if err := sdkClient.Start(ctx); err != nil {
-		_, _ = startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
-		return fmt.Errorf("start copilot SDK client: %w", err)
+		_, stopErr := startedSvc.Stop(ctx, dagger.ServiceStopOpts{})
+		return errors.Join(fmt.Errorf("start copilot SDK client: %w", err), stopErr)
 	}
 	c.client = sdkClient
 	return nil

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -120,16 +120,9 @@ func newGhcpClient(endpoint *LLMEndpoint, cliVersion string) *GhcpClient {
 	}
 }
 
-// ensureConnected starts the sidecar service and connects the SDK client.
-// It is idempotent: subsequent calls return immediately once connected.
-func (c *GhcpClient) ensureConnected(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.client != nil {
-		return nil
-	}
-
+// connect starts the sidecar service and connects the SDK client.
+// Must be called with c.mu held. Use ensureConnected for the public entry point.
+func (c *GhcpClient) connect(ctx context.Context) error {
 	svc := copilotSidecar(c.endpoint.Key, c.cliVersion)
 	startedSvc, err := svc.Start(ctx)
 	if err != nil {
@@ -150,6 +143,44 @@ func (c *GhcpClient) ensureConnected(ctx context.Context) error {
 		return fmt.Errorf("start copilot SDK client: %w", err)
 	}
 	c.client = sdkClient
+	return nil
+}
+
+// reconnect tears down the existing connection and re-establishes it.
+// Called when the sidecar is detected to have crashed or disconnected.
+// Must be called with c.mu held.
+func (c *GhcpClient) reconnect(ctx context.Context) error {
+	if c.session != nil {
+		c.session.Disconnect() //nolint:errcheck
+		c.session = nil
+		c.sentMsgCount = 0
+		c.toolsHash = ""
+	}
+	if c.client != nil {
+		c.client.Stop() //nolint:errcheck
+		c.client = nil
+	}
+	c.svc = nil
+	return c.connect(ctx)
+}
+
+// ensureConnected starts the sidecar service and connects the SDK client on
+// first use, then pings the sidecar on subsequent calls to detect crashes.
+// If the ping fails, a full reconnect is triggered.
+func (c *GhcpClient) ensureConnected(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client == nil {
+		return c.connect(ctx)
+	}
+
+	// Liveness check — detect crashed sidecar.
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if _, err := c.client.Ping(pingCtx, "health"); err != nil {
+		return c.reconnect(ctx)
+	}
 	return nil
 }
 

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -17,8 +17,8 @@ import (
 	"dagger.io/dagger"
 	"dagger.io/dagger/dag"
 
-	copilot "github.com/github/copilot-sdk/go"
 	telemetry "github.com/dagger/otel-go"
+	copilot "github.com/github/copilot-sdk/go"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
@@ -264,6 +264,8 @@ func (c *GhcpClient) getOrCreateSession(ctx context.Context, systemPrompt string
 // returns the response. The Copilot CLI maintains full conversation history
 // server-side within the session, so we track a cursor (sentMsgCount) and
 // send only the delta each time.
+//
+//nolint:gocyclo // SendQuery handles streaming, tool-calling, retries, session expiry, and legacy fallback in one place; splitting would harm readability without reducing actual complexity
 func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, tools []LLMTool) (_ *LLMResponse, rerr error) {
 	copilotModel := StripGitHubModelPrefix(c.endpoint.Model)
 
@@ -599,6 +601,7 @@ func buildSDKTools(tools []LLMTool) []copilot.Tool {
 				// inv.TraceContext carries W3C trace propagation from the CLI span.
 				result, err := tool.Call(inv.TraceContext, args)
 				if err != nil {
+					//nolint:nilerr // tool errors are surfaced in ToolResult.Error, not as Go errors
 					return copilot.ToolResult{
 						Error:      err.Error(),
 						ResultType: "error",
@@ -613,6 +616,7 @@ func buildSDKTools(tools []LLMTool) []copilot.Tool {
 				default:
 					b, err := json.Marshal(result)
 					if err != nil {
+						//nolint:nilerr // json.Marshal failure falls back to fmt.Sprintf; marshal error not useful to caller
 						return copilot.ToolResult{TextResultForLLM: fmt.Sprintf("%v", result), ResultType: "success"}, nil
 					}
 					return copilot.ToolResult{TextResultForLLM: string(b), ResultType: "success"}, nil
@@ -656,12 +660,11 @@ func newGhcpLegacyClient(endpoint *LLMEndpoint, cliVersion string) *GhcpLegacyCl
 	if cliVersion == "" {
 		cliVersion = ghcpDefaultCLIVersion
 	}
-	ctx := context.Background()
-	container := ghcpLegacyContainer(ctx, endpoint.Key, cliVersion)
+	container := ghcpLegacyContainer(endpoint.Key, cliVersion)
 	return &GhcpLegacyClient{client: container, endpoint: endpoint}
 }
 
-func ghcpLegacyContainer(ctx context.Context, token, cliVersion string) *dagger.Container {
+func ghcpLegacyContainer(token, cliVersion string) *dagger.Container {
 	ghcpSessionCache := dag.CacheVolume("copilot-session-" + token[:8])
 	return dag.Container().
 		From("node:24-bookworm-slim").

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	// ghcpDefaultCLIVersion is the Copilot CLI version bundled with SDK v0.2.0.
-	// Bump this alongside go.mod when upgrading the SDK.
+	// ghcpDefaultCLIVersion is the npm package version of @github/copilot-{platform}.
+	// Bump this when upgrading to a newer @github/copilot npm release.
 	ghcpDefaultCLIVersion = "1.0.10"
 	ghcpDefaultCLIPort    = 3000
 )
@@ -71,9 +71,6 @@ func StripGitHubModelPrefix(model string) string {
 // ensures it is downloaded only once per version.
 func copilotSidecar(token, cliVersion string) *dagger.Service {
 	version := cliVersion
-	if v := os.Getenv("GITHUB_CLI_VERSION"); v != "" {
-		version = v
-	}
 	if version == "" {
 		version = ghcpDefaultCLIVersion
 	}

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,8 +36,9 @@ type GhcpClient struct {
 	svc          *dagger.Service  // the copilot CLI sidecar
 	client       *copilot.Client  // SDK client connected via CLIUrl
 	session      *copilot.Session // persistent session (multi-turn)
-	mu           sync.Mutex       // protects svc, client, session, sentMsgCount
+	mu           sync.Mutex       // protects svc, client, session, sentMsgCount, toolsHash
 	sentMsgCount int              // number of history messages already sent to this session
+	toolsHash    string           // fingerprint of registered tools; triggers session recreation on change
 }
 
 var _ LLMClient = (*GhcpClient)(nil)
@@ -150,9 +153,18 @@ func (c *GhcpClient) ensureConnected(ctx context.Context) error {
 
 // getOrCreateSession returns the persistent session, creating it if needed.
 // systemPrompt is passed to SessionConfig.SystemMessage on first creation only.
+// If the registered tool set changes (by name fingerprint), the old session is
+// closed and a new one is created so the new tools are available.
 func (c *GhcpClient) getOrCreateSession(ctx context.Context, systemPrompt string, tools []copilot.Tool) (*copilot.Session, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	newHash := hashTools(tools)
+	if c.session != nil && c.toolsHash != newHash {
+		c.session.Disconnect() //nolint:errcheck
+		c.session = nil
+		c.sentMsgCount = 0
+	}
 
 	if c.session != nil {
 		return c.session, nil
@@ -173,6 +185,7 @@ func (c *GhcpClient) getOrCreateSession(ctx context.Context, systemPrompt string
 		return nil, fmt.Errorf("create copilot session: %w", err)
 	}
 	c.session = session
+	c.toolsHash = newHash
 	return session, nil
 }
 
@@ -235,6 +248,9 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		sendErr error
 		usage   LLMTokenUsage
 		usageMu sync.Mutex
+
+		toolCallsMu   sync.Mutex
+		capturedCalls []LLMToolCall
 	)
 
 	for attempt := 0; attempt < 2; attempt++ {
@@ -260,9 +276,14 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 			return nil, fmt.Errorf("no user message found in new history")
 		}
 
-		// Capture token usage from assistant.usage events, which fire before session.idle.
+		// Reset per-attempt state.
 		usage = LLMTokenUsage{}
-		unsubscribe := session.On(func(event copilot.SessionEvent) {
+		toolCallsMu.Lock()
+		capturedCalls = capturedCalls[:0]
+		toolCallsMu.Unlock()
+
+		// Capture token usage from assistant.usage events, which fire before session.idle.
+		unsubUsage := session.On(func(event copilot.SessionEvent) {
 			if event.Type != copilot.SessionEventTypeAssistantUsage {
 				return
 			}
@@ -283,8 +304,42 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 			usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 		})
 
+		// Capture tool call metadata so Dagger can display them and track history.
+		// The SDK auto-executes tools via Tool.Handler during SendAndWait; we record
+		// each invocation here for Dagger's TUI and cursor accounting.
+		unsubTools := session.On(func(event copilot.SessionEvent) {
+			if event.Type != copilot.SessionEventTypeExternalToolRequested {
+				return
+			}
+			toolCallID := ""
+			if event.Data.ToolCallID != nil {
+				toolCallID = *event.Data.ToolCallID
+			}
+			toolName := ""
+			if event.Data.ToolName != nil {
+				toolName = *event.Data.ToolName
+			}
+			var args map[string]any
+			if event.Data.Arguments != nil {
+				if m, ok := event.Data.Arguments.(map[string]any); ok {
+					args = m
+				}
+			}
+			toolCallsMu.Lock()
+			defer toolCallsMu.Unlock()
+			capturedCalls = append(capturedCalls, LLMToolCall{
+				ID:   toolCallID,
+				Type: "function",
+				Function: FuncCall{
+					Name:      toolName,
+					Arguments: args,
+				},
+			})
+		})
+
 		resp, sendErr = session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt})
-		unsubscribe()
+		unsubUsage()
+		unsubTools()
 
 		if sendErr != nil && isSessionExpired(sendErr) && attempt == 0 {
 			// Session gone server-side — clear state and retry with a fresh session.
@@ -313,8 +368,10 @@ func (c *GhcpClient) SendQuery(ctx context.Context, history []*ModelMessage, too
 		content = *resp.Data.Content
 	}
 
-	// Phase 3 will implement full tool call execution.
-	toolCalls := ghcpExtractToolCalls(resp)
+	toolCallsMu.Lock()
+	toolCalls := make([]LLMToolCall, len(capturedCalls))
+	copy(toolCalls, capturedCalls)
+	toolCallsMu.Unlock()
 
 	usageMu.Lock()
 	finalUsage := usage
@@ -356,52 +413,69 @@ func isSessionExpired(err error) bool {
 }
 
 // buildSDKTools converts Dagger LLMTools to Copilot SDK Tool definitions.
-// Phase 1: stub handlers return an error; Phase 3 will wire to tool.Call.
+// The Handler calls tool.Call synchronously; the SDK manages the round-trip to
+// the LLM inside SendAndWait so Dagger never sees raw tool-call/result pairs.
 func buildSDKTools(tools []LLMTool) []copilot.Tool {
 	if len(tools) == 0 {
 		return nil
 	}
 	sdkTools := make([]copilot.Tool, 0, len(tools))
 	for _, t := range tools {
+		tool := t // capture loop var
 		sdkTools = append(sdkTools, copilot.Tool{
-			Name:           t.Name,
-			Description:    t.Description,
-			Parameters:     t.Schema,
+			Name:           tool.Name,
+			Description:    tool.Description,
+			Parameters:     tool.Schema,
 			SkipPermission: true,
 			Handler: func(inv copilot.ToolInvocation) (copilot.ToolResult, error) {
-				// Phase 3: replace with t.Call(inv.TraceContext, inv.Arguments)
-				return copilot.ToolResult{
-					Error:      "tool execution not yet implemented (Phase 3)",
-					ResultType: "error",
-				}, nil
+				if tool.Call == nil {
+					return copilot.ToolResult{
+						Error:      fmt.Sprintf("tool %q has no handler", tool.Name),
+						ResultType: "error",
+					}, nil
+				}
+
+				// inv.Arguments is map[string]any from SDK JSON-RPC parsing.
+				args, _ := inv.Arguments.(map[string]any)
+				if args == nil {
+					args = map[string]any{}
+				}
+
+				// inv.TraceContext carries W3C trace propagation from the CLI span.
+				result, err := tool.Call(inv.TraceContext, args)
+				if err != nil {
+					return copilot.ToolResult{
+						Error:      err.Error(),
+						ResultType: "error",
+					}, nil
+				}
+
+				switch v := result.(type) {
+				case string:
+					return copilot.ToolResult{TextResultForLLM: v, ResultType: "success"}, nil
+				case []byte:
+					return copilot.ToolResult{TextResultForLLM: string(v), ResultType: "success"}, nil
+				default:
+					b, err := json.Marshal(result)
+					if err != nil {
+						return copilot.ToolResult{TextResultForLLM: fmt.Sprintf("%v", result), ResultType: "success"}, nil
+					}
+					return copilot.ToolResult{TextResultForLLM: string(b), ResultType: "success"}, nil
+				}
 			},
 		})
 	}
 	return sdkTools
 }
 
-// ghcpExtractToolCalls converts SDK ToolRequests to Dagger LLMToolCall values.
-// Phase 3 will complete the tool calling loop.
-func ghcpExtractToolCalls(event *copilot.SessionEvent) []LLMToolCall {
-	if event == nil || len(event.Data.ToolRequests) == 0 {
-		return nil
+// hashTools returns a stable fingerprint of the tool set by sorting tool names
+// and joining them. A change in fingerprint triggers session recreation so the
+// new tools are registered with the Copilot CLI.
+func hashTools(tools []copilot.Tool) string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
 	}
-	calls := make([]LLMToolCall, 0, len(event.Data.ToolRequests))
-	for _, req := range event.Data.ToolRequests {
-		var args map[string]any
-		if req.Arguments != nil {
-			if m, ok := req.Arguments.(map[string]any); ok {
-				args = m
-			}
-		}
-		calls = append(calls, LLMToolCall{
-			ID:   req.ToolCallID,
-			Type: "function",
-			Function: FuncCall{
-				Name:      req.Name,
-				Arguments: args,
-			},
-		})
-	}
-	return calls
+	sort.Strings(names)
+	return strings.Join(names, ",")
 }

--- a/core/llm_github_copilot.go
+++ b/core/llm_github_copilot.go
@@ -153,6 +153,38 @@ func (c *GhcpClient) ensureConnected(ctx context.Context) error {
 	return nil
 }
 
+// providerConfig returns a ProviderConfig for BYOK if endpoint.BaseURL is set,
+// or if GITHUB_COPILOT_PROVIDER_URL env var is set.
+// Returns nil if using the default GitHub Copilot backend.
+func (c *GhcpClient) providerConfig() *copilot.ProviderConfig {
+	baseURL := c.endpoint.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("GITHUB_COPILOT_PROVIDER_URL")
+	}
+	if baseURL == "" {
+		return nil
+	}
+
+	cfg := &copilot.ProviderConfig{
+		BaseURL: baseURL,
+	}
+
+	switch {
+	case strings.Contains(baseURL, ".openai.azure.com"):
+		cfg.Type = "azure"
+	case strings.Contains(baseURL, "anthropic"):
+		cfg.Type = "anthropic"
+	default:
+		cfg.Type = "openai" // covers OpenAI, Ollama, LM Studio, etc.
+	}
+
+	if c.endpoint.Key != "" {
+		cfg.APIKey = c.endpoint.Key
+	}
+
+	return cfg
+}
+
 // getOrCreateSession returns the persistent session, creating it if needed.
 // systemPrompt is passed to SessionConfig.SystemMessage on first creation only.
 // If the registered tool set changes (by name fingerprint), the old session is
@@ -182,6 +214,8 @@ func (c *GhcpClient) getOrCreateSession(ctx context.Context, systemPrompt string
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		Tools:               tools,
 		SystemMessage:       sysMsg,
+		Provider:            c.providerConfig(),
+		Model:               StripGitHubModelPrefix(c.endpoint.Model),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create copilot session: %w", err)

--- a/core/llm_github_copilot.md
+++ b/core/llm_github_copilot.md
@@ -1,0 +1,201 @@
+# GitHub Copilot (GHCP) LLM Provider
+
+## Overview
+
+This document describes the GitHub Copilot LLM provider for Dagger (`GhcpClient`), how to use it, its current limitations, and the roadmap for improvement.
+
+The provider allows Dagger's LLM system to use GitHub Copilot as a model backend — enabling access to models like GPT-4.1, Claude Sonnet, and others that GitHub Copilot exposes — without requiring direct API keys to those underlying providers.
+
+---
+
+## Why GitHub Copilot as an LLM provider?
+
+GitHub Copilot acts as a **unified gateway** to multiple frontier models (OpenAI, Anthropic, Google, etc.) under a single GitHub token. This has practical advantages:
+
+- **One credential** — a `GITHUB_TOKEN` with Copilot access, rather than separate API keys per provider
+- **Enterprise licensing** — organizations with GitHub Copilot Enterprise can route Dagger LLM calls through their existing seat licenses
+- **Model flexibility** — switch between GPT-4.1, Claude Sonnet, Gemini, etc. by changing the model name, without managing multiple API accounts
+
+The tradeoff is the [CLI-based execution model](#the-cli-container-requirement) described below.
+
+---
+
+## Configuration
+
+Set these environment variables before running Dagger:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | ✅ Yes | GitHub personal access token or GitHub Actions token with Copilot access |
+| `GITHUB_CLI_VERSION` | ✅ Yes | Version of `@github/copilot` npm package to install (e.g. `1.0.0`) |
+| `GITHUB_MODEL` | No | Model to use (default: `github-gpt-5`). See model names below. |
+
+### Model names
+
+The provider recognises these prefixes and strips them before passing to the CLI:
+
+| Prefix | Example |
+|--------|---------|
+| `github-` | `github-gpt-5`, `github-claude-sonnet-4-5` |
+| `github/` | `github/gpt-5` |
+| `gh-` | `gh-gpt-5` |
+| `gh/` | `gh/gpt-5` |
+| `ghcp-` | `ghcp-gpt-5` |
+| `ghcp/` | `ghcp/gpt-5` |
+
+The alias `"github"` resolves to `"github-gpt-5"`.
+
+---
+
+## How it works
+
+### The CLI-container requirement
+
+**There is no official Go SDK for GitHub Copilot that calls the API directly.** What exists today is a set of language-specific SDKs (TypeScript, Python, etc.) that are thin wrappers around the **GitHub Copilot CLI** (`@github/copilot` npm package). The CLI itself communicates with the Copilot API endpoint.
+
+As a result, this provider cannot make direct HTTP calls. Instead, it:
+
+1. **Spins up a Dagger container** based on `node:24-bookworm-slim`
+2. **Installs the GHCP CLI** via `npm install -g @github/copilot@{version}` inside the container
+3. **Executes each query** by running `copilot --model {model} --prompt {content} --stream off --continue`
+4. **Captures stdout** for the response and **stderr** for token usage metadata
+
+This is unconventional — every LLM call shells out to a CLI inside a container rather than making an SDK/HTTP call. It works, but carries implications for latency and dependency management (see [Limitations](#limitations-and-gaps)).
+
+### Session and state caching
+
+The GHCP CLI stores session state in `/root/.copilot`. The provider mounts a **Dagger cache volume** keyed on the first 8 characters of the token (`copilot-session-{token[:8]}`) at that path, so session state persists across queries within a Dagger run.
+
+The `--continue` flag is passed to the CLI to enable continuation of an existing session.
+
+> **Note:** This caching is a best-effort approach. Multi-turn conversation history is not truly supported — see [Multi-turn conversations](#multi-turn-conversations) below.
+
+### Token usage parsing
+
+The GHCP CLI emits token usage on stderr in a format like:
+
+```
+claude-sonnet-4.5    7.5k input, 52 output, 3.6k cache read, 3.7k cache write (Est. 1 Premium request)
+```
+
+The provider parses this with a regex and emits the values as OpenTelemetry metrics:
+- `telemetry.LLMInputTokens`
+- `telemetry.LLMOutputTokens`
+- `telemetry.LLMInputTokensCacheReads`
+
+The `k` multiplier is handled (e.g. `3.5k` → `3500`). Cache write tokens are parsed but not currently recorded as a separate OTel metric.
+
+---
+
+## Limitations and gaps
+
+### The CLI-container requirement
+
+The most significant architectural constraint. Every query requires:
+- A running container with Node.js 24+
+- npm install of `@github/copilot` at a specific version
+- CLI execution overhead per query
+
+This adds latency compared to SDK-based providers (Anthropic, OpenAI) and introduces a hard dependency on the npm registry and a specific CLI version. The `GITHUB_CLI_VERSION` variable must be pinned to a known-good version.
+
+**Roadmap:** Migrate to direct API calls once the GitHub Copilot API is publicly documented or a first-class Go SDK is available. See [Future work](#future-work).
+
+### Multi-turn conversations
+
+The GHCP CLI only accepts `--prompt` (a single string). The provider passes only the **last message** from the `history` slice:
+
+```go
+prompt := history[len(history)-1]
+```
+
+All prior messages in the conversation are discarded. Although the CLI stores state as a `.jsonl` file and the `--continue` flag is used, it does not replay or reference prior messages in the session — it only continues the CLI session context, not the LLM conversation history.
+
+**Impact:** Dagger LLM pipelines that rely on multi-turn context will not work correctly with this provider today.
+
+### Tool / function calling
+
+The `tools []LLMTool` parameter is **completely ignored**. The provider always returns an empty `toolCalls` slice:
+
+```go
+var toolCalls []LLMToolCall  // always empty
+```
+
+The GHCP CLI has no native support for function/tool calling schemas. This means Dagger's tool-use features (e.g. calling container methods from within an LLM loop) are not available with the GHCP provider.
+
+**Impact:** Any Dagger pipeline that uses `WithTool` or expects the LLM to call Dagger GraphQL methods will fail silently — the model will respond with text but never invoke tools.
+
+### Retry logic
+
+`IsRetryable()` always returns `false`. There is no backoff or retry on transient failures (rate limits, network errors, CLI crashes).
+
+### Streaming
+
+The CLI is invoked with `--stream off`. Streaming output is not parsed or forwarded. All responses are buffered.
+
+---
+
+## Future work
+
+### 1. Migrate to GitHub Copilot SDK
+
+The language-specific GitHub Copilot SDKs (TypeScript: `@github/copilot-sdk`, Python: `copilot-sdk`) are thin wrappers around the CLI — they are **not** direct API clients. However, they do expose a slightly higher-level interface and may be more stable than shelling out to the CLI directly.
+
+A more impactful improvement would be to call the **GitHub Copilot API endpoint directly** once:
+- The API is publicly documented (currently undocumented/private)
+- A Go client library is available, or the REST contract is stable enough to implement manually
+
+This would eliminate the container/npm dependency entirely and align the provider with how OpenAI, Anthropic, and Google providers work.
+
+> **Note:** When evaluating "GitHub Copilot SDK" options, be aware that today's SDKs wrap the CLI, not the API. True API-level SDKs do not yet exist as of this writing.
+
+### 2. Multi-turn conversation history
+
+Options to explore:
+- Accumulate prior messages into a system prompt prefix (prompt injection)
+- Use the GHCP CLI's `.jsonl` history format if/when documented
+- Wait for API-level access which natively supports conversation history
+
+### 3. Tool calling
+
+Options to explore:
+- Prompt injection: describe available tools in the system prompt, parse structured responses
+- Wait for API-level access with native function calling support
+
+### 4. Retry / backoff
+
+Implement `IsRetryable()` with pattern matching on error strings (rate limit, network timeout). Add exponential backoff.
+
+### 5. Streaming
+
+Replace `--stream off` with `--stream on` and parse chunked stdout. Token metadata may arrive at the end of the stream rather than after completion.
+
+---
+
+## Code structure
+
+| File | Purpose |
+|------|---------|
+| `core/llm_github_copilot.go` | Provider implementation: `GhcpClient`, `GhcpClientContainer`, `StripGitHubModelPrefix`, `parseCopilotTokenMetadata` |
+| `core/llm.go` | Router integration: `isGitHubModel`, `routeGitHubModel`, config loading, model alias |
+
+### Key types
+
+```go
+// Provider client — satisfies LLMClient interface
+type GhcpClient struct {
+    client   *dagger.Container  // Node.js container with GHCP CLI installed
+    endpoint *LLMEndpoint       // Config: token, model
+}
+
+// LLMClient interface methods implemented
+func (c *GhcpClient) SendQuery(ctx, history, tools) (*LLMResponse, error)
+func (c *GhcpClient) IsRetryable(err error) bool
+```
+
+### Environment variable loading (in `LLMRouter`)
+
+```go
+GitHubToken      string  // GITHUB_TOKEN
+GitHubModel      string  // GITHUB_MODEL
+GitHubCliVersion string  // GITHUB_CLI_VERSION
+```

--- a/core/llm_github_copilot.md
+++ b/core/llm_github_copilot.md
@@ -16,8 +16,6 @@ GitHub Copilot acts as a **unified gateway** to multiple frontier models (OpenAI
 - **Enterprise licensing** — organizations with GitHub Copilot Enterprise can route Dagger LLM calls through their existing seat licenses
 - **Model flexibility** — switch between GPT-4.1, Claude Sonnet, Gemini, etc. by changing the model name, without managing multiple API accounts
 
-The tradeoff is the [CLI-based execution model](#the-cli-container-requirement) described below.
-
 ---
 
 ## Configuration
@@ -26,13 +24,14 @@ Set these environment variables before running Dagger:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `GITHUB_TOKEN` | ✅ Yes | GitHub personal access token or GitHub Actions token with Copilot access |
-| `GITHUB_CLI_VERSION` | ✅ Yes | Version of `@github/copilot` npm package to install (e.g. `1.0.0`) |
+| `GITHUB_TOKEN` | ✅ Yes | GitHub personal access token or Actions token with Copilot access |
 | `GITHUB_MODEL` | No | Model to use (default: `github-gpt-5`). See model names below. |
+| `GITHUB_CLI_VERSION` | No | Copilot CLI binary version to embed in the sidecar (default: `1.0.10`) |
+| `GITHUB_COPILOT_CLI_URL` | No | Override the tarball URL (for air-gapped or internal registry use) |
 
 ### Model names
 
-The provider recognises these prefixes and strips them before passing to the CLI:
+The provider recognises these prefixes and strips them before passing to the SDK:
 
 | Prefix | Example |
 |--------|---------|
@@ -47,127 +46,71 @@ The alias `"github"` resolves to `"github-gpt-5"`.
 
 ---
 
-## How it works
+## Architecture
 
-### The CLI-container requirement
+### Container-on-demand sidecar pattern
 
-**There is no official Go SDK for GitHub Copilot that calls the API directly.** What exists today is a set of language-specific SDKs (TypeScript, Python, etc.) that are thin wrappers around the **GitHub Copilot CLI** (`@github/copilot` npm package). The CLI itself communicates with the Copilot API endpoint.
-
-As a result, this provider cannot make direct HTTP calls. Instead, it:
-
-1. **Spins up a Dagger container** based on `node:24-bookworm-slim`
-2. **Installs the GHCP CLI** via `npm install -g @github/copilot@{version}` inside the container
-3. **Executes each query** by running `copilot --model {model} --prompt {content} --stream off --continue`
-4. **Captures stdout** for the response and **stderr** for token usage metadata
-
-This is unconventional — every LLM call shells out to a CLI inside a container rather than making an SDK/HTTP call. It works, but carries implications for latency and dependency management (see [Limitations](#limitations-and-gaps)).
-
-### Session and state caching
-
-The GHCP CLI stores session state in `/root/.copilot`. The provider mounts a **Dagger cache volume** keyed on the first 8 characters of the token (`copilot-session-{token[:8]}`) at that path, so session state persists across queries within a Dagger run.
-
-The `--continue` flag is passed to the CLI to enable continuation of an existing session.
-
-> **Note:** This caching is a best-effort approach. Multi-turn conversation history is not truly supported — see [Multi-turn conversations](#multi-turn-conversations) below.
-
-### Token usage parsing
-
-The GHCP CLI emits token usage on stderr in a format like:
+This provider uses the **[github.com/github/copilot-sdk/go](https://github.com/github/copilot-sdk) Go SDK (v0.2.0)** via a TCP JSON-RPC connection to a lightweight Dagger sidecar service:
 
 ```
-claude-sonnet-4.5    7.5k input, 52 output, 3.6k cache read, 3.7k cache write (Est. 1 Premium request)
+Dagger Engine (GhcpClient)
+  └── copilot.NewClient(&ClientOptions{CLIUrl: "host:3000"})
+        └── TCP JSON-RPC → *dagger.Service (built on-demand)
+              └── debian:bookworm-slim + copilot binary
+                    └── copilot --headless --no-auto-update --port 3000
 ```
 
-The provider parses this with a regex and emits the values as OpenTelemetry metrics:
-- `telemetry.LLMInputTokens`
-- `telemetry.LLMOutputTokens`
-- `telemetry.LLMInputTokensCacheReads`
+**No Node.js. No pre-published image.** The sidecar container is built at runtime by:
 
-The `k` multiplier is handled (e.g. `3.5k` → `3500`). Cache write tokens are parsed but not currently recorded as a separate OTel metric.
+1. Fetching the Copilot CLI npm tarball via `dag.HTTP()` (content-addressable — downloaded once, cached forever)
+2. Extracting the binary into a minimal `debian:bookworm-slim` base
+3. Starting it as a Dagger service in headless mode on port 3000
+4. Connecting the Go SDK via `CLIUrl` TCP option
+
+The `GITHUB_TOKEN` is injected as an env var into the sidecar only — it is deliberately **not** passed to `ClientOptions.GitHubToken`, which would panic when combined with `CLIUrl`.
+
+### Lazy initialisation
+
+The sidecar is started on the **first `SendQuery` call**, not at client creation. `newGhcpClient` is synchronous and cheap; the Dagger service starts when there is an actual request to serve. `ensureConnected` is idempotent — subsequent calls return immediately.
+
+### Session lifecycle
+
+A single `copilot.Session` is created on first use and reused for the lifetime of the `GhcpClient`. The session is created with `Streaming: true` and `PermissionHandler.ApproveAll`.
 
 ---
 
-## Limitations and gaps
+## What works now (Phase 1)
 
-### The CLI-container requirement
-
-The most significant architectural constraint. Every query requires:
-- A running container with Node.js 24+
-- npm install of `@github/copilot` at a specific version
-- CLI execution overhead per query
-
-This adds latency compared to SDK-based providers (Anthropic, OpenAI) and introduces a hard dependency on the npm registry and a specific CLI version. The `GITHUB_CLI_VERSION` variable must be pinned to a known-good version.
-
-**Roadmap:** Migrate to direct API calls once the GitHub Copilot API is publicly documented or a first-class Go SDK is available. See [Future work](#future-work).
-
-### Multi-turn conversations
-
-The GHCP CLI only accepts `--prompt` (a single string). The provider passes only the **last message** from the `history` slice:
-
-```go
-prompt := history[len(history)-1]
-```
-
-All prior messages in the conversation are discarded. Although the CLI stores state as a `.jsonl` file and the `--continue` flag is used, it does not replay or reference prior messages in the session — it only continues the CLI session context, not the LLM conversation history.
-
-**Impact:** Dagger LLM pipelines that rely on multi-turn context will not work correctly with this provider today.
-
-### Tool / function calling
-
-The `tools []LLMTool` parameter is **completely ignored**. The provider always returns an empty `toolCalls` slice:
-
-```go
-var toolCalls []LLMToolCall  // always empty
-```
-
-The GHCP CLI has no native support for function/tool calling schemas. This means Dagger's tool-use features (e.g. calling container methods from within an LLM loop) are not available with the GHCP provider.
-
-**Impact:** Any Dagger pipeline that uses `WithTool` or expects the LLM to call Dagger GraphQL methods will fail silently — the model will respond with text but never invoke tools.
-
-### Retry logic
-
-`IsRetryable()` always returns `false`. There is no backoff or retry on transient failures (rate limits, network errors, CLI crashes).
-
-### Streaming
-
-The CLI is invoked with `--stream off`. Streaming output is not parsed or forwarded. All responses are buffered.
+| Feature | Status |
+|---------|--------|
+| Text responses (single-turn) | ✅ Working |
+| Token usage tracking (OTel metrics) | ✅ Working — from SDK `assistant.usage` events |
+| Transient error retry detection | ✅ Working — connection refused, EOF, transport errors |
+| `GITHUB_CLI_VERSION` version pinning | ✅ Working |
+| `GITHUB_COPILOT_CLI_URL` tarball override | ✅ Working |
+| Multi-turn conversation history | 🔜 Phase 2 |
+| Full tool / function calling | 🔜 Phase 3 |
+| Streaming deltas | 🔜 Phase 4 |
 
 ---
 
-## Future work
+## Limitations
 
-### 1. Migrate to GitHub Copilot SDK
+### Multi-turn conversations (Phase 2)
 
-The language-specific GitHub Copilot SDKs (TypeScript: `@github/copilot-sdk`, Python: `copilot-sdk`) are thin wrappers around the CLI — they are **not** direct API clients. However, they do expose a slightly higher-level interface and may be more stable than shelling out to the CLI directly.
+Phase 1 sends only the **last user message** from the `history` slice as the prompt. All prior messages are discarded — the model has no context from previous turns.
 
-A more impactful improvement would be to call the **GitHub Copilot API endpoint directly** once:
-- The API is publicly documented (currently undocumented/private)
-- A Go client library is available, or the REST contract is stable enough to implement manually
+Phase 2 will thread the full history by converting `ModelMessage` entries to SDK message format and replaying them into the session before each new user turn.
 
-This would eliminate the container/npm dependency entirely and align the provider with how OpenAI, Anthropic, and Google providers work.
+### Tool / function calling (Phase 3)
 
-> **Note:** When evaluating "GitHub Copilot SDK" options, be aware that today's SDKs wrap the CLI, not the API. True API-level SDKs do not yet exist as of this writing.
+Tools passed to `SendQuery` are registered as SDK `Tool` definitions with **stub handlers** that return an error. The model receives tool schemas and may attempt to call them, but the stub handlers prevent actual execution.
 
-### 2. Multi-turn conversation history
+Phase 3 will wire the handlers to `tool.Call(ctx, inv.Arguments)` and complete the Dagger tool execution loop.
 
-Options to explore:
-- Accumulate prior messages into a system prompt prefix (prompt injection)
-- Use the GHCP CLI's `.jsonl` history format if/when documented
-- Wait for API-level access which natively supports conversation history
+### Streaming (Phase 4)
 
-### 3. Tool calling
-
-Options to explore:
-- Prompt injection: describe available tools in the system prompt, parse structured responses
-- Wait for API-level access with native function calling support
-
-### 4. Retry / backoff
-
-Implement `IsRetryable()` with pattern matching on error strings (rate limit, network timeout). Add exponential backoff.
-
-### 5. Streaming
-
-Replace `--stream off` with `--stream on` and parse chunked stdout. Token metadata may arrive at the end of the stream rather than after completion.
+`SendAndWait` is used instead of `session.On + session.Send`. This buffers the complete response before returning. Phase 4 will switch to streaming deltas via `session.On(SessionEventTypeAssistantMessageDelta)`.
 
 ---
 
@@ -175,21 +118,20 @@ Replace `--stream off` with `--stream on` and parse chunked stdout. Token metada
 
 | File | Purpose |
 |------|---------|
-| `core/llm_github_copilot.go` | Provider implementation: `GhcpClient`, `GhcpClientContainer`, `StripGitHubModelPrefix`, `parseCopilotTokenMetadata` |
-| `core/llm.go` | Router integration: `isGitHubModel`, `routeGitHubModel`, config loading, model alias |
+| `core/llm_github_copilot.go` | Provider implementation |
+| `core/llm.go` | Router integration: `isGitHubModel`, `routeGitHubModel`, config loading |
 
 ### Key types
 
 ```go
-// Provider client — satisfies LLMClient interface
 type GhcpClient struct {
-    client   *dagger.Container  // Node.js container with GHCP CLI installed
-    endpoint *LLMEndpoint       // Config: token, model
+    endpoint   *LLMEndpoint     // token, model name
+    cliVersion string           // CLI binary version for sidecar
+    svc        *dagger.Service  // copilot CLI sidecar
+    client     *copilot.Client  // SDK client connected via CLIUrl
+    session    *copilot.Session // persistent session (multi-turn in Phase 2)
+    mu         sync.Mutex       // protects svc, client, session
 }
-
-// LLMClient interface methods implemented
-func (c *GhcpClient) SendQuery(ctx, history, tools) (*LLMResponse, error)
-func (c *GhcpClient) IsRetryable(err error) bool
 ```
 
 ### Environment variable loading (in `LLMRouter`)
@@ -199,3 +141,4 @@ GitHubToken      string  // GITHUB_TOKEN
 GitHubModel      string  // GITHUB_MODEL
 GitHubCliVersion string  // GITHUB_CLI_VERSION
 ```
+

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -50,6 +50,9 @@ func TestLlmConfig(t *testing.T) {
 		"env://GEMINI_API_KEY":           "gemini-api-key",
 		"env://GEMINI_BASE_URL":          "gemini-base-url",
 		"env://GEMINI_MODEL":             "gemini-model",
+		"env://GITHUB_TOKEN":                "github-token",
+		"env://GITHUB_MODEL":                "github-model",
+		"env://GITHUB_COPILOT_CLI_VERSION":  "1.0.10",
 	}
 
 	dagql.Fields[LLMTestQuery]{
@@ -83,6 +86,9 @@ func TestLlmConfig(t *testing.T) {
 	assert.Equal(t, "gemini-api-key", r.GeminiAPIKey)
 	assert.Equal(t, "gemini-base-url", r.GeminiBaseURL)
 	assert.Equal(t, "gemini-model", r.GeminiModel)
+	assert.Equal(t, "github-token", r.GitHubToken)
+	assert.Equal(t, "github-model", r.GitHubModel)
+	assert.Equal(t, "1.0.10", r.GitHubCliVersion)
 }
 
 func TestLlmConfigDisableStreaming(t *testing.T) {

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -38,21 +38,21 @@ func TestLlmConfig(t *testing.T) {
 	srv := dagql.NewServer(q, dagql.NewSessionCache(baseCache))
 
 	vars := map[string]string{
-		"file://.env":                    "",
-		"env://ANTHROPIC_API_KEY":        "anthropic-api-key",
-		"env://ANTHROPIC_BASE_URL":       "anthropic-base-url",
-		"env://ANTHROPIC_MODEL":          "anthropic-model",
-		"env://OPENAI_API_KEY":           "openai-api-key",
-		"env://OPENAI_AZURE_VERSION":     "openai-azure-version",
-		"env://OPENAI_BASE_URL":          "openai-base-url",
-		"env://OPENAI_MODEL":             "openai-model",
-		"env://OPENAI_DISABLE_STREAMING": "t",
-		"env://GEMINI_API_KEY":           "gemini-api-key",
-		"env://GEMINI_BASE_URL":          "gemini-base-url",
-		"env://GEMINI_MODEL":             "gemini-model",
-		"env://GITHUB_TOKEN":                "github-token",
-		"env://GITHUB_MODEL":                "github-model",
-		"env://GITHUB_COPILOT_CLI_VERSION":  "1.0.10",
+		"file://.env":                      "",
+		"env://ANTHROPIC_API_KEY":          "anthropic-api-key",
+		"env://ANTHROPIC_BASE_URL":         "anthropic-base-url",
+		"env://ANTHROPIC_MODEL":            "anthropic-model",
+		"env://OPENAI_API_KEY":             "openai-api-key",
+		"env://OPENAI_AZURE_VERSION":       "openai-azure-version",
+		"env://OPENAI_BASE_URL":            "openai-base-url",
+		"env://OPENAI_MODEL":               "openai-model",
+		"env://OPENAI_DISABLE_STREAMING":   "t",
+		"env://GEMINI_API_KEY":             "gemini-api-key",
+		"env://GEMINI_BASE_URL":            "gemini-base-url",
+		"env://GEMINI_MODEL":               "gemini-model",
+		"env://GITHUB_TOKEN":               "github-token",
+		"env://GITHUB_MODEL":               "github-model",
+		"env://GITHUB_COPILOT_CLI_VERSION": "1.0.10",
 	}
 
 	dagql.Fields[LLMTestQuery]{

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776
 	github.com/frioux/shellquote v0.0.2
+	github.com/github/copilot-sdk/go v0.2.0
 	github.com/go-git/go-git/v5 v5.16.3
 	github.com/gofrs/flock v0.13.0
 	github.com/gogo/googleapis v1.4.1
@@ -101,7 +102,7 @@ require (
 	github.com/jedevc/go-libsecret v0.0.0-20250327192457-f925a032ae4f
 	github.com/joho/godotenv v1.5.1
 	github.com/juju/ansiterm v1.0.0
-	github.com/klauspost/compress v1.18.0
+	github.com/klauspost/compress v1.18.3
 	github.com/koron-go/prefixw v1.0.2
 	github.com/lmittmann/tint v1.1.2
 	github.com/mackerelio/go-osstat v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/frioux/shellquote v0.0.2 h1:CvQ1aMCS/xhhyGF4JIeA49bhE3W1s5XdBkwmhH3BceQ=
 github.com/frioux/shellquote v0.0.2/go.mod h1:1VoFO5LSUNqwAKp2QjSpf9b4PZ4ff+uKXPEjonuyJh8=
+github.com/github/copilot-sdk/go v0.2.0 h1:RnrIIirmtp4wGgqSQFJ2k9phbeveIxOtYZqDogoNEa0=
+github.com/github/copilot-sdk/go v0.2.0/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
@@ -495,8 +497,8 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.11 h1:0OwqZRYI2rFrjS4kvkDnqJkKHdHaRnCm68/DY4OxRzU=
 github.com/klauspost/cpuid/v2 v2.2.11/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/koron-go/prefixw v1.0.2 h1:Si0QuHwHElvWnJXlcg1bXwg4PNoBXtcZeN4lpe8PUmw=


### PR DESCRIPTION
## Summary

Adds GitHub Copilot as a first-class LLM provider for Dagger, using the official [`github.com/github/copilot-sdk/go`](https://github.com/github/copilot-sdk) SDK.

Closes discussion: https://github.com/dagger/dagger/discussions/12689

## Motivation

GitHub Copilot subscribers have access to powerful models (GPT-4o, Claude Sonnet, etc.) via their existing Copilot license. This adds Copilot as a zero-extra-cost LLM option for Dagger users who already have Copilot access - no separate API key required beyond a GitHub PAT.

## How it works

The SDK requires the Copilot CLI binary to be running as a local server. Rather than requiring users to install it, Dagger builds a minimal on-demand sidecar service:

1. Fetches the `@github/copilot-{platform}` npm tarball via `dag.HTTP` (content-addressed, cached)
2. Extracts the binary into a `debian:bookworm-slim` container
3. SDK connects to the sidecar via `CLIUrl` TCP option - no Node.js, no image to pre-publish

## Configuration

```bash
export GITHUB_TOKEN=<fine-grained PAT with copilot: read permission>

dagger shell
> llm | with-prompt "hello" | last-reply
```

Optional env vars:
- `GITHUB_COPILOT_CLI_VERSION` - pin the npm package version (default: `1.0.10`)
- `GITHUB_COPILOT_CLI_URL` - override tarball URL for airgapped/internal use
- `GITHUB_COPILOT_PROVIDER_URL` - BYOK: route to Azure OpenAI, Anthropic, or OpenAI endpoint
- `GITHUB_COPILOT_LEGACY=true` - fall back to the original node:24+npm container approach

## What's included

- `core/llm_github_copilot.go` - full provider implementation
- `core/llm_github_copilot.md` - user-facing docs
- `core/llm.go` - GitHub routing wired into `LLMRouter` (`GITHUB_TOKEN`, `GITHUB_MODEL`, `GITHUB_COPILOT_CLI_VERSION`)
- `core/llm_test.go` - Copilot config vars added to `TestLlmConfig`

## Features

- Multi-turn session history (server-side, cursor-tracked)
- Streaming (`AssistantMessageDelta` events written to telemetry span stdio)
- Tool calling (Dagger tools registered via SDK `Tool.Handler`)
- `IsRetryable` with HTTP status + Copilot-specific error classification
- BYOK provider config (Azure, Anthropic, OpenAI endpoint inference from URL)
- Sidecar crash recovery with ping + reconnect
- Legacy fallback (`GITHUB_COPILOT_LEGACY=true`)

## Limitations / known issues

- Requires a fine-grained PAT (`copilot: read`). OAuth and stored keyring credentials are not supported - this avoids the ToS-questionable approaches discussed in the linked discussion.
- SDK is Technical Preview (`github.com/github/copilot-sdk/go` v0.2.0) - API may have breaking changes. A legacy fallback is included as an escape hatch.
- No integration golden file yet - requires a live Copilot credential to record.

## Testing

Unit tests pass (`TestLlmConfig` now covers Copilot config vars).

Manual validation: tested end-to-end via `dagger call engine-dev playground terminal` with `GITHUB_TOKEN` set, running `llm | with-prompt "hello" | last-reply` in the nested dagger shell.

## Checklist

- [x] Changie release note added (`.changes/unreleased/Added-20260328-174753.yaml`)
- [x] `dagger generate` - run, no generated files changed (only `.go` files modified)
- [x] DCO sign-off - all 23 commits have `Signed-off-by: Ray Kao <ray@peopleandcode.com>`
- [ ] `dagger checks *:lint` - will run in CI; local environment has a broken Go toolchain

Relates to: https://github.com/dagger/dagger/discussions/12689