### PR TITLE
feat(sdk/elixir): implements self call

### DIFF
--- a/core/integration/module_elixir_test.go
+++ b/core/integration/module_elixir_test.go
@@ -373,6 +373,28 @@ func (ElixirSuite) TestCheck(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ElixirSuite) TestSelfCalls(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("can call with arguments", func(ctx context.Context, t *testctx.T) {
+		out, err := elixirModule(t, c, "self-calls").
+			With(daggerCall("print", "--string-arg", "hello")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", out)
+	})
+
+	t.Run("can call with default arguments", func(ctx context.Context, t *testctx.T) {
+		out, err := elixirModule(t, c, "self-calls").
+			With(daggerCall("print-default")).
+			Stdout(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, "Hello Self Calls\n", out)
+	})
+}
+
 func elixirModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/elixir", moduleName))

--- a/core/integration/testdata/modules/elixir/self-calls/dagger.json
+++ b/core/integration/testdata/modules/elixir/self-calls/dagger.json
@@ -1,0 +1,10 @@
+{
+  "name": "self-calls",
+  "engineVersion": "v0.18.3",
+  "sdk": {
+    "source": "../../sdk/elixir",
+    "experimental": {
+      "SELF_CALLS": true
+    }
+  }
+}

--- a/core/integration/testdata/modules/elixir/self-calls/lib/self_calls.ex
+++ b/core/integration/testdata/modules/elixir/self-calls/lib/self_calls.ex
@@ -1,0 +1,32 @@
+defmodule SelfCalls do
+  @moduledoc false
+
+  use Dagger.Mod.Object, name: "SelfCalls"
+
+  defn container_echo(string_arg: {String.t(), default: "Hello Self Calls"}) :: Dagger.Container.t() do
+    dag()
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("alpine:latest")
+    |> Dagger.Container.with_exec(["echo", string_arg])
+  end
+
+  defn print(string_arg: String.t()) :: String.t() do
+    {:ok, result} =
+      dag()
+      |> Dagger.Client.self_calls()
+      |> Dagger.SelfCalls.container_echo(string_arg: string_arg)
+      |> Dagger.Container.stdout()
+
+    result
+  end
+
+  defn print_default() :: String.t() do
+    {:ok, result} =
+      dag()
+      |> Dagger.Client.self_calls()
+      |> Dagger.SelfCalls.container_echo()
+      |> Dagger.Container.stdout()
+
+    result
+  end
+end

--- a/core/integration/testdata/modules/elixir/self-calls/mix.exs
+++ b/core/integration/testdata/modules/elixir/self-calls/mix.exs
@@ -1,0 +1,25 @@
+defmodule Template.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :self_calls,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:dagger, path: "./dagger_sdk"}
+    ]
+  end
+end

--- a/core/integration/testdata/modules/elixir/self-calls/mix.lock
+++ b/core/integration/testdata/modules/elixir/self-calls/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nestru": {:hex, :nestru, "1.0.1", "f02321db91b898da3d598c274f2ccba2c41ec5c50c942eabe900474dbfe4bce3", [:mix], [], "hexpm", "e4fbbd6d64b1c8cb37ef590a891f0b6b17b0b880c1c5ce2ac98de02c0ad7417e"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}

--- a/sdk/elixir/.changes/unreleased/Added-20260411-162310.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20260411-162310.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Self-calls support
+time: 2026-04-11T16:23:10.908890976+07:00
+custom:
+    Author: wingyplus
+    PR: "12881"

--- a/sdk/elixir/lib/dagger/mod.ex
+++ b/sdk/elixir/lib/dagger/mod.ex
@@ -15,6 +15,18 @@ defmodule Dagger.Mod do
     end
   end
 
+  @doc """
+  Register a module by writing its type definition ID to DAGGER_MODULE_FILE.
+  """
+  def register(module) when is_atom(module) do
+    case Dagger.Global.start_link() do
+      {:ok, _} -> do_register(Dagger.Global.dag(), module)
+      otherwise -> otherwise
+    end
+  after
+    Dagger.Global.close()
+  end
+
   def invoke(dag, module) do
     fn_call = Dagger.Client.current_function_call(dag)
 
@@ -64,6 +76,23 @@ defmodule Dagger.Mod do
     return_type = fun_def.return
 
     execute_function(module, fun_name, args, return_type)
+  end
+
+  defp do_register(dag, module) do
+    output_file =
+      System.get_env("DAGGER_MODULE_FILE") ||
+        raise "DAGGER_MODULE_FILE environment variable is not set"
+
+    dag_module = Dagger.Mod.Module.define(dag, module)
+
+    case Dagger.Module.id(dag_module) do
+      {:ok, module_id} ->
+        File.write!(output_file, Jason.encode!(module_id))
+
+      {:error, reason} ->
+        IO.puts(:stderr, format_error(reason))
+        exit({:shutdown, 2})
+    end
   end
 
   defp execute_function(module, fun_name, args, return_type) do

--- a/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
+++ b/sdk/elixir/lib/mix/tasks/dagger.entrypoint.invoke.ex
@@ -13,12 +13,27 @@ defmodule Mix.Tasks.Dagger.Entrypoint.Invoke do
 
   use Mix.Task
 
+  def run(["register", module]) do
+    Application.ensure_all_started(:dagger)
+
+    Mix.Task.run("compile")
+    Mix.Task.reenable("dagger.entrypoint.invoke")
+
+    module = load_module(module)
+    Dagger.Mod.register(module)
+  end
+
   def run([module]) do
     Application.ensure_all_started(:dagger)
 
     Mix.Task.run("compile")
     Mix.Task.reenable("dagger.entrypoint.invoke")
 
+    module = load_module(module)
+    Dagger.Mod.invoke(module)
+  end
+
+  defp load_module(module) do
     module =
       module
       |> String.split(".")
@@ -27,6 +42,6 @@ defmodule Mix.Tasks.Dagger.Entrypoint.Invoke do
     Code.ensure_loaded?(module) ||
       Mix.raise("Cannot find module #{module}")
 
-    Dagger.Mod.invoke(module)
+    module
   end
 end

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -86,6 +86,38 @@ func (m *ElixirSdk) ModuleRuntime(
 		}), nil
 }
 
+func (m *ElixirSdk) ModuleTypes(
+	ctx context.Context,
+	modSource *dagger.ModuleSource,
+	introspectionJSON *dagger.File,
+	outputFilePath string,
+) (*dagger.Container, error) {
+	modName, err := modSource.ModuleName(ctx)
+	if err != nil {
+		return nil, err
+	}
+	subPath, err := modSource.SourceSubpath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := m.Common(ctx, modSource, introspectionJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctr.
+		WithEnvVariable("DAGGER_MODULE_FILE", outputFilePath).
+		WithExec([]string{"mix", "deps.get", "--only", "prod"}).
+		WithExec([]string{"mix", "deps.compile"}).
+		WithExec([]string{"mix", "compile"}).
+		WithEntrypoint([]string{
+			"mix", "cmd",
+			"--cd", path.Join(ModSourceDirPath, subPath),
+			fmt.Sprintf("mix dagger.entrypoint.invoke register %s", toElixirModuleName(modName)),
+		}), nil
+}
+
 func (m *ElixirSdk) Codegen(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,


### PR DESCRIPTION
Implements the ModuleTypes interface in the Elixir SDK runtime to enable
modules to invoke their own functions (self calls).

- Add ModuleTypes to the Go runtime that sets DAGGER_MODULE_FILE and runs
  `mix dagger.entrypoint.invoke register <ModuleName>` to register the module
- Add Dagger.Mod.register/1 that connects to the engine, defines the module,
  and writes its type definition ID to DAGGER_MODULE_FILE
- Add "register" subcommand to Mix.Tasks.Dagger.Entrypoint.Invoke, extracting
  load_module/1 to avoid duplication between register and invoke paths
- Add self-calls test fixture module demonstrating self calls with and without
  default arguments
- Add TestSelfCalls integration test covering both cases