### PR TITLE
Fix wording in custom CA documentation

### DIFF
--- a/docs/current_docs/reference/configuration/custom-ca.mdx
+++ b/docs/current_docs/reference/configuration/custom-ca.mdx
@@ -33,7 +33,7 @@ Dagger startup if found in that directory.
 {`    registry.dagger.io/engine:v${daggerVersion}`}
 </CodeBlock>
 
-Alternatively, if you are using the default Dagger engine (e.g. via `dagger
+Alternatively, if the engine is provisioned automatically (e.g. via `dagger
 call` or the SDKs), you can place your custom CA certificates in the
 `~/.config/dagger/ca-certificates` directory (or `$XDG_CONFIG_HOME/dagger/ca-certificates`
 if that environment variable is set). Dagger will automatically detect and install


### PR DESCRIPTION
clarify wording regarding automatic cert config por automatically provisioned engines