### PR TITLE
elixir-sdk-dev: add @check to test and lint functions

### DIFF
--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -33,7 +33,7 @@ type ElixirSdkDev {
   """
   Lint the SDK
   """
-  pub lint: Void! {
+  pub lint: Void! @check {
     devContainer
       .withExec(["mix", "credo"])
       .sync
@@ -66,7 +66,7 @@ type ElixirSdkDev {
   """
   Run the SDK tests
   """
-  pub sdkTest: Void! {
+  pub sdkTest: Void! @check {
     devContainer
       .withExec(["mix", "test"])
       .sync
@@ -77,7 +77,7 @@ type ElixirSdkDev {
   """
   Run dagger_codegen tests
   """
-  pub codegenTest: Void! {
+  pub codegenTest: Void! @check {
     withCodegen(devContainer)
       .withExec(["mix", "test"])
       .sync
@@ -88,7 +88,7 @@ type ElixirSdkDev {
   """
   Test the publishing process
   """
-  pub releaseDryRun: Void! {
+  pub releaseDryRun: Void! @check {
     publish(
       tag: "HEAD",
       dryRun: true,


### PR DESCRIPTION
Flag sdkTest, codegenTest, lint, and releaseDryRun with @check so they are automatically run in CI. The aggregator function (test) is intentionally left without @check.