### PR TITLE
Fix elixir toolchain

### DIFF
--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -251,8 +251,8 @@ defmodule Dagger.ClientTest do
 
     assert {:ok, _} =
              dag
-             |> Client.host()
-             |> Host.directory(".")
+             |> Client.directory()
+             |> Directory.with_new_file("Dockerfile", dockerfile)
              |> Directory.docker_build(dockerfile: "Dockerfile", secrets: [secret])
              |> Sync.sync()
 
@@ -327,7 +327,7 @@ defmodule Dagger.ClientTest do
              |> Sync.sync()
 
     assert Exception.message(error) =~
-                  ~r/container\.from\.withExec\.sync exit code: 1/
+             ~r/container\.from\.withExec\.sync exit code: 1/
   end
 
   test "iss 8601 - Dagger.Directory.with_directory/4 should not crash", %{dag: dag} do

--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -21,16 +21,6 @@ type ElixirSdkDev {
   }
 
   """
-  Test the SDK
-  """
-  pub test: Void! {
-    # Run SDK and codegen tests in parallel
-    let sdkResult = sdkTest
-    let codegenResult = codegenTest
-    null
-  }
-
-  """
   Lint the SDK
   """
   pub lint: Void! @check {


### PR DESCRIPTION
Enable check on toolchains/elixir-sdk to make it run on CI. The checks run `sdkTest`, `lint` and `publishDryRun`. 