### PR TITLE
Collections

### DIFF
--- a/cmd/codegen/generator/go/templates/collection_authoring_test.go
+++ b/cmd/codegen/generator/go/templates/collection_authoring_test.go
@@ -1,0 +1,111 @@
+package templates
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/dagger/dagger/cmd/codegen/generator"
+)
+
+var collectionAuthoringSources = map[string]string{
+	"main.go": `package main
+
+type GoTest struct{}
+
+// +collection
+type GoTests struct {
+	// +keys
+	Paths []string ` + "`json:\"paths\"`" + `
+}
+
+func (tests *GoTests) Get(name string) *GoTest {
+	return &GoTest{}
+}
+
+// +get
+func (tests *GoTests) Lookup(name string) *GoTest {
+	return &GoTest{}
+}
+`,
+}
+
+func loadCollectionAuthoringTestPackage(t *testing.T) *packages.Package {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	syntax := make([]*ast.File, 0, len(collectionAuthoringSources))
+	for fileName, src := range collectionAuthoringSources {
+		file, err := parser.ParseFile(fset, fileName, src, parser.ParseComments)
+		require.NoErrorf(t, err, "parse %q", fileName)
+		syntax = append(syntax, file)
+	}
+
+	typesPkg, err := (&types.Config{}).Check("example.com/collections", fset, syntax, nil)
+	require.NoError(t, err)
+
+	return &packages.Package{
+		Types:  typesPkg,
+		Syntax: syntax,
+		Fset:   fset,
+		Module: &packages.Module{Dir: "."},
+	}
+}
+
+func TestParseCollectionAuthoringPragmas(t *testing.T) {
+	t.Parallel()
+
+	testPkg := loadCollectionAuthoringTestPackage(t)
+	funcs := goTemplateFuncs{
+		cfg: generator.Config{
+			ModuleConfig: &generator.ModuleGeneratorConfig{
+				ModuleName: "go-tests",
+			},
+		},
+		modulePkg:  testPkg,
+		moduleFset: testPkg.Fset,
+	}
+
+	var got *parsedObjectType
+	err := funcs.visitTypes(false, &visitorFuncs{
+		RootVisitor: func(string) error { return nil },
+		StructVisitor: func(_ *parseState, _ *types.Named, obj *types.TypeName, objTypeSpec *parsedObjectType, _ *types.Struct) error {
+			if obj.Name() == "GoTests" {
+				got = objTypeSpec
+			}
+			return nil
+		},
+		IfaceVisitor: func(_ *parseState, _ *types.Named, _ *types.TypeName, _ *parsedIfaceType, _ *types.Interface) error {
+			return nil
+		},
+		EnumVisitor: func(_ *parseState, _ *types.Named, _ *types.TypeName, _ *parsedEnumType, _ *types.Basic) error {
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.isCollection)
+	require.Len(t, got.fields, 1)
+	require.Equal(t, "paths", got.fields[0].name)
+	require.True(t, got.fields[0].isCollectionKeys)
+
+	var lookup *funcTypeSpec
+	var get *funcTypeSpec
+	for _, method := range got.methods {
+		switch method.name {
+		case "Lookup":
+			lookup = method
+		case "Get":
+			get = method
+		}
+	}
+	require.NotNil(t, get)
+	require.NotNil(t, lookup)
+	require.False(t, get.isCollectionGet)
+	require.True(t, lookup.isCollectionGet)
+}

--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -66,6 +66,17 @@ func (ps *parseState) parseGoFunc(parentType *types.Named, fn *types.Func) (*fun
 		}
 	}
 
+	if v, ok := docPragmas["get"]; ok {
+		if v == nil {
+			spec.isCollectionGet = true
+		} else {
+			spec.isCollectionGet, ok = v.(bool)
+			if !ok {
+				return nil, fmt.Errorf("get pragma %q, must be a valid boolean", v)
+			}
+		}
+	}
+
 	spec.sourceMap = ps.sourceMap(funcDecl)
 
 	sig, ok := fn.Type().(*types.Signature)
@@ -132,12 +143,13 @@ func (ps *parseState) parseGoFunc(parentType *types.Named, fn *types.Func) (*fun
 }
 
 type funcTypeSpec struct {
-	name        string
-	doc         string
-	sourceMap   *sourceMap
-	cachePolicy string
-	isCheck     bool
-	isGenerator bool
+	name            string
+	doc             string
+	sourceMap       *sourceMap
+	cachePolicy     string
+	isCheck         bool
+	isGenerator     bool
+	isCollectionGet bool
 
 	argSpecs []paramSpec
 

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -75,6 +75,17 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 	if doc := docForAstSpec(astSpec); doc != nil {
 		docPragmas, docComment := parsePragmaComment(doc.Text())
 		comment := strings.TrimSpace(docComment)
+		if v, ok := docPragmas["collection"]; ok {
+			if v == nil {
+				spec.isCollection = true
+			} else {
+				var ok bool
+				spec.isCollection, ok = v.(bool)
+				if !ok {
+					return nil, fmt.Errorf("collection pragma %q, must be a valid boolean", v)
+				}
+			}
+		}
 		if raw, ok := docPragmas["deprecated"]; ok {
 			reason := ""
 			if str, _ := raw.(string); str != "" {
@@ -142,6 +153,17 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 				fieldSpec.isPrivate, _ = v.(bool)
 			}
 		}
+		if v, ok := pragmas["keys"]; ok {
+			if v == nil {
+				fieldSpec.isCollectionKeys = true
+			} else {
+				var ok bool
+				fieldSpec.isCollectionKeys, ok = v.(bool)
+				if !ok {
+					return nil, fmt.Errorf("keys pragma %q, must be a valid boolean", v)
+				}
+			}
+		}
 		if raw, ok := pragmas["deprecated"]; ok {
 			reason := ""
 			if str, _ := raw.(string); str != "" {
@@ -168,11 +190,12 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 }
 
 type parsedObjectType struct {
-	name       string
-	moduleName string
-	doc        string
-	sourceMap  *sourceMap
-	deprecated *string
+	name         string
+	moduleName   string
+	doc          string
+	sourceMap    *sourceMap
+	deprecated   *string
+	isCollection bool
 
 	fields      []*fieldSpec
 	methods     []*funcTypeSpec
@@ -198,6 +221,9 @@ func (spec *parsedObjectType) TypeDef(dag *dagger.Client) (*dagger.TypeDef, erro
 		return nil, fmt.Errorf("object name is empty")
 	}
 	typeDefObject := dag.TypeDef().WithObject(spec.name, withObjectOpts)
+	if spec.isCollection {
+		typeDefObject = typeDefObject.WithCollection()
+	}
 
 	for _, m := range spec.methods {
 		fnTypeDef, err := m.TypeDefFunc(dag)
@@ -235,6 +261,20 @@ func (spec *parsedObjectType) TypeDef(dag *dagger.Client) (*dagger.TypeDef, erro
 			return nil, fmt.Errorf("failed to convert constructor to function def: %w", err)
 		}
 		typeDefObject = typeDefObject.WithConstructor(fnTypeDef)
+	}
+
+	for _, field := range spec.fields {
+		if field.isCollectionKeys {
+			typeDefObject = typeDefObject.WithCollectionKeys(field.name)
+			break
+		}
+	}
+
+	for _, method := range spec.methods {
+		if method.isCollectionGet {
+			typeDefObject = typeDefObject.WithCollectionGet(method.name)
+			break
+		}
 	}
 
 	return typeDefObject, nil
@@ -535,6 +575,8 @@ type fieldSpec struct {
 
 	// isPrivate is true if the field is marked with the +private pragma
 	isPrivate bool
+	// isCollectionKeys is true if the field is marked with the +keys pragma
+	isCollectionKeys bool
 	// goName is the name of the field in the Go struct. It may be different than name if the user changed the name of the field via a json tag
 	goName string
 

--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
@@ -20,7 +22,10 @@ import (
 	telemetry "github.com/dagger/otel-go"
 )
 
-var checksListMode bool
+var (
+	checksListMode  bool
+	checksNeedsHelp bool
+)
 
 //go:embed checks.graphql
 var loadChecksQuery string
@@ -30,10 +35,12 @@ func init() {
 }
 
 var checksCmd = &cobra.Command{
-	Hidden:  true,
-	Aliases: []string{"checks"},
-	Use:     "check [options] [pattern...]",
-	Short:   "Check the state of your project by running tests, linters, etc.",
+	Hidden:                true,
+	Aliases:               []string{"checks"},
+	Use:                   "check [options] [pattern...]",
+	Short:                 "Check the state of your project by running tests, linters, etc.",
+	DisableFlagParsing:    true,
+	DisableFlagsInUseLine: true,
 	Long: `Check the state of your project by running tests, linters, etc.
 
 Examples:
@@ -42,6 +49,9 @@ Examples:
   dagger check go:lint            # Run the go:lint check and any subchecks
 `,
 	Args: cobra.ArbitraryArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return preparseDynamicFlags(cmd, args, &checksNeedsHelp)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params := client.Params{
 			EnableCloudScaleOut: enableScaleOut,
@@ -51,12 +61,51 @@ Examples:
 			params,
 			func(ctx context.Context, engineClient *client.Client) error {
 				dag := engineClient.Dagger()
+				def, err := initializeWorkspace(ctx, dag)
+				if err != nil {
+					return err
+				}
+				collectionFlags := discoverCollectionFilterFlags(def)
+				addCollectionFilterFlags(cmd, collectionFlags)
+				if err := cmd.ParseFlags(args); err != nil {
+					if checksNeedsHelp && errors.Is(err, pflag.ErrHelp) {
+						return cmd.Help()
+					}
+					return cmd.FlagErrorFunc()(cmd, err)
+				}
+
+				activeFilters, listFlags, err := activeCollectionFilters(cmd, collectionFlags)
+				if err != nil {
+					return err
+				}
+				if checksListMode && len(activeFilters) > 0 {
+					if flagName, ok := firstActiveCollectionFilterFlag(cmd, collectionFlags); ok {
+						return fmt.Errorf("can't use -l with --%s; use --list-%s instead", flagName, flagName)
+					}
+				}
+				if checksListMode && len(listFlags) > 0 {
+					return fmt.Errorf("can't use -l with --%s; choose one listing mode", listFlags[0].ListName)
+				}
+
+				patterns := cmd.Flags().Args()
 				ws := dag.CurrentWorkspace()
 				var checks *dagger.CheckGroup
-				if len(args) > 0 {
-					checks = ws.Checks(dagger.WorkspaceChecksOpts{Include: args})
+				if len(patterns) > 0 || len(activeFilters) > 0 {
+					checks = ws.Checks(dagger.WorkspaceChecksOpts{
+						Include: patterns,
+						Filters: activeFilters,
+					})
 				} else {
 					checks = ws.Checks()
+				}
+
+				if len(listFlags) > 0 {
+					values, err := loadCheckCollectionFilterValues(ctx, dag, checks, collectionFilterTypeNames(listFlags))
+					if err != nil {
+						return err
+					}
+					printCollectionFilterValues(cmd, values)
+					return nil
 				}
 				if checksListMode {
 					return listChecks(ctx, dag, checks, cmd)

--- a/cmd/dagger/checks.graphql
+++ b/cmd/dagger/checks.graphql
@@ -16,3 +16,12 @@ query CheckGroupRunStatuses($checkGroup: CheckGroupID!) {
     }
   }
 }
+
+query CheckGroupCollectionFilterValues($id: CheckGroupID!, $typeNames: [String!]!) {
+  group: loadCheckGroupFromID(id: $id) {
+    collectionFilterValues(typeNames: $typeNames) {
+      typeName
+      values
+    }
+  }
+}

--- a/cmd/dagger/collection_filters.go
+++ b/cmd/dagger/collection_filters.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"dagger.io/dagger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type collectionFilterFlag struct {
+	TypeName string
+	FlagName string
+	ListName string
+}
+
+type collectionFilterValuesItem struct {
+	TypeName string
+	Values   []string
+}
+
+func discoverCollectionFilterFlags(def *moduleDef) []collectionFilterFlag {
+	flags := make([]collectionFilterFlag, 0, len(def.Objects))
+	for _, typeDef := range def.Objects {
+		if typeDef.AsCollection == nil || typeDef.AsObject == nil {
+			continue
+		}
+		flagName := cliName(typeDef.AsObject.Name)
+		flags = append(flags, collectionFilterFlag{
+			TypeName: typeDef.AsObject.Name,
+			FlagName: flagName,
+			ListName: "list-" + flagName,
+		})
+	}
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].FlagName < flags[j].FlagName
+	})
+	return flags
+}
+
+func addCollectionFilterFlags(cmd *cobra.Command, filters []collectionFilterFlag) {
+	for _, filter := range filters {
+		if cmd.Flags().Lookup(filter.FlagName) == nil {
+			cmd.Flags().StringSlice(filter.FlagName, nil, fmt.Sprintf("Restrict %s collections to the specified keys", filter.TypeName))
+		}
+		if cmd.Flags().Lookup(filter.ListName) == nil {
+			cmd.Flags().Bool(filter.ListName, false, fmt.Sprintf("List available %s filter values within the current scope", filter.TypeName))
+		}
+	}
+}
+
+func activeCollectionFilters(cmd *cobra.Command, filters []collectionFilterFlag) ([]dagger.CollectionFilterInput, []collectionFilterFlag, error) {
+	active := make([]dagger.CollectionFilterInput, 0, len(filters))
+	lists := make([]collectionFilterFlag, 0, len(filters))
+
+	for _, filter := range filters {
+		if cmd.Flags().Changed(filter.FlagName) {
+			values, err := cmd.Flags().GetStringSlice(filter.FlagName)
+			if err != nil {
+				return nil, nil, err
+			}
+			active = append(active, dagger.CollectionFilterInput{
+				TypeName: filter.TypeName,
+				Values:   values,
+			})
+		}
+		listEnabled, err := cmd.Flags().GetBool(filter.ListName)
+		if err != nil {
+			return nil, nil, err
+		}
+		if listEnabled {
+			lists = append(lists, filter)
+		}
+	}
+
+	return active, lists, nil
+}
+
+func firstActiveCollectionFilterFlag(cmd *cobra.Command, filters []collectionFilterFlag) (string, bool) {
+	for _, filter := range filters {
+		if cmd.Flags().Changed(filter.FlagName) {
+			return filter.FlagName, true
+		}
+	}
+	return "", false
+}
+
+func collectionFilterTypeNames(filters []collectionFilterFlag) []string {
+	typeNames := make([]string, 0, len(filters))
+	for _, filter := range filters {
+		typeNames = append(typeNames, filter.TypeName)
+	}
+	return typeNames
+}
+
+func printCollectionFilterValues(cmd *cobra.Command, values []collectionFilterValuesItem) {
+	for i, valueSet := range values {
+		if i > 0 {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		if len(values) > 1 {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", cliName(valueSet.TypeName))
+		}
+		for _, value := range valueSet.Values {
+			fmt.Fprintln(cmd.OutOrStdout(), value)
+		}
+	}
+}
+
+func loadCheckCollectionFilterValues(ctx context.Context, dag *dagger.Client, checkGroup *dagger.CheckGroup, typeNames []string) ([]collectionFilterValuesItem, error) {
+	id, err := checkGroup.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Group struct {
+			CollectionFilterValues []collectionFilterValuesItem
+		}
+	}
+
+	err = dag.Do(ctx, &dagger.Request{
+		Query:  loadChecksQuery,
+		OpName: "CheckGroupCollectionFilterValues",
+		Variables: map[string]any{
+			"id":        id,
+			"typeNames": typeNames,
+		},
+	}, &dagger.Response{
+		Data: &res,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Group.CollectionFilterValues, nil
+}
+
+func loadGeneratorCollectionFilterValues(ctx context.Context, dag *dagger.Client, generatorGroup *dagger.GeneratorGroup, typeNames []string) ([]collectionFilterValuesItem, error) {
+	id, err := generatorGroup.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Group struct {
+			CollectionFilterValues []collectionFilterValuesItem
+		}
+	}
+
+	err = dag.Do(ctx, &dagger.Request{
+		Query:  loadGeneratorsQuery,
+		OpName: "GeneratorGroupCollectionFilterValues",
+		Variables: map[string]any{
+			"id":        id,
+			"typeNames": typeNames,
+		},
+	}, &dagger.Response{
+		Data: &res,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Group.CollectionFilterValues, nil
+}
+
+func preparseDynamicFlags(cmd *cobra.Command, args []string, needsHelp *bool) error {
+	cmd.DisableFlagParsing = false
+
+	help := pflag.NewFlagSet("help", pflag.ContinueOnError)
+	if helpFlag := cmd.Flags().Lookup("help"); helpFlag != nil {
+		help.AddFlag(helpFlag)
+	}
+	help.ParseErrorsAllowlist.UnknownFlags = true
+	help.ParseAll(args, func(flag *pflag.Flag, value string) error {
+		*needsHelp = value == flag.NoOptDefVal
+		return nil
+	})
+
+	cmd.FParseErrWhitelist.UnknownFlags = true
+	if err := cmd.ParseFlags(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
+		return cmd.FlagErrorFunc()(cmd, err)
+	}
+	cmd.FParseErrWhitelist.UnknownFlags = false
+	return nil
+}

--- a/cmd/dagger/collection_filters_test.go
+++ b/cmd/dagger/collection_filters_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverCollectionFilterFlags(t *testing.T) {
+	def := &moduleDef{
+		Objects: []*modTypeDef{
+			{
+				Kind:         dagger.TypeDefKindObjectKind,
+				AsCollection: &modCollection{},
+				AsObject:     &modObject{Name: "GoTests"},
+			},
+			{
+				Kind:         dagger.TypeDefKindObjectKind,
+				AsCollection: &modCollection{},
+				AsObject:     &modObject{Name: "GoModules"},
+			},
+			{
+				Kind:     dagger.TypeDefKindObjectKind,
+				AsObject: &modObject{Name: "GoTest"},
+			},
+		},
+	}
+
+	flags := discoverCollectionFilterFlags(def)
+	require.Equal(t, []collectionFilterFlag{
+		{TypeName: "GoModules", FlagName: "go-modules", ListName: "list-go-modules"},
+		{TypeName: "GoTests", FlagName: "go-tests", ListName: "list-go-tests"},
+	}, flags)
+}
+
+func TestActiveCollectionFilters(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	filters := []collectionFilterFlag{
+		{TypeName: "GoModules", FlagName: "go-modules", ListName: "list-go-modules"},
+		{TypeName: "GoTests", FlagName: "go-tests", ListName: "list-go-tests"},
+	}
+	addCollectionFilterFlags(cmd, filters)
+
+	err := cmd.ParseFlags([]string{
+		"--go-tests=TestFoo,TestBar",
+		"--go-tests=TestBaz",
+		"--go-modules=./app",
+		"--list-go-tests",
+	})
+	require.NoError(t, err)
+
+	active, lists, err := activeCollectionFilters(cmd, filters)
+	require.NoError(t, err)
+	require.Equal(t, []dagger.CollectionFilterInput{
+		{TypeName: "GoModules", Values: []string{"./app"}},
+		{TypeName: "GoTests", Values: []string{"TestFoo", "TestBar", "TestBaz"}},
+	}, active)
+	require.Equal(t, []collectionFilterFlag{
+		{TypeName: "GoTests", FlagName: "go-tests", ListName: "list-go-tests"},
+	}, lists)
+}
+
+func TestPrintCollectionFilterValues(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	printCollectionFilterValues(cmd, []collectionFilterValuesItem{
+		{TypeName: "GoModules", Values: []string{"./app", "./lib"}},
+		{TypeName: "GoTests", Values: []string{"TestFoo"}},
+	})
+
+	require.Equal(t, "go-modules:\n./app\n./lib\n\ngo-tests:\nTestFoo\n", buf.String())
+}

--- a/cmd/dagger/collection_test.go
+++ b/cmd/dagger/collection_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"dagger.io/dagger"
+	"dagger.io/dagger/querybuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleObjectLeafCollection(t *testing.T) {
+	q := querybuilder.Query().Select("tests")
+	typeDef := &modTypeDef{
+		Kind: dagger.TypeDefKindObjectKind,
+		AsObject: &modObject{
+			Name: "GoTests",
+		},
+		AsCollection: &modCollection{},
+	}
+
+	require.Nil(t, handleObjectLeaf(q, typeDef))
+}
+
+func TestModTypeDefKindDisplayCollection(t *testing.T) {
+	typeDef := &modTypeDef{
+		Kind: dagger.TypeDefKindObjectKind,
+		AsObject: &modObject{
+			Name: "GoTests",
+		},
+		AsCollection: &modCollection{},
+	}
+
+	require.Equal(t, "Collection", typeDef.KindDisplay())
+}

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -677,6 +677,9 @@ func (fc *FuncCommand) RunE(ctx context.Context, fn *modFunction) func(*cobra.Co
 		// else to sub-select. In that case `q` will be nil to signal that we
 		// just want to return the object's name, without making an API request.
 		if q == nil {
+			if fn.ReturnType.AsCollection != nil {
+				return fc.Help(cmd)
+			}
 			return handleResponse(ctx, fc.c.Dagger(), fn.ReturnType, nil, o, e, autoApply)
 		}
 
@@ -694,6 +697,9 @@ func handleObjectLeaf(q *querybuilder.Selection, typeDef *modTypeDef) *querybuil
 	obj := typeDef.AsFunctionProvider()
 	if obj == nil {
 		return q
+	}
+	if typeDef.AsCollection != nil {
+		return nil
 	}
 
 	// Use duck typing to detect supported functions.

--- a/cmd/dagger/generators.go
+++ b/cmd/dagger/generators.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/dagql/dagui"
@@ -18,7 +20,8 @@ import (
 )
 
 var (
-	generateListMode bool
+	generateListMode  bool
+	generateNeedsHelp bool
 )
 
 //go:embed generators.graphql
@@ -29,9 +32,11 @@ func init() {
 }
 
 var generateCmd = &cobra.Command{
-	Hidden: true,
-	Use:    "generate [options] [pattern...]",
-	Short:  "Generate assets of your project",
+	Hidden:                true,
+	Use:                   "generate [options] [pattern...]",
+	Short:                 "Generate assets of your project",
+	DisableFlagParsing:    true,
+	DisableFlagsInUseLine: true,
 	Long: `Generate assets of your project
 
 Examples:
@@ -40,6 +45,9 @@ Examples:
   dagger generate go:bin                     # Generate by selecting the generator function
 `,
 	Args: cobra.ArbitraryArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return preparseDynamicFlags(cmd, args, &generateNeedsHelp)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params := client.Params{
 			EnableCloudScaleOut: enableScaleOut,
@@ -49,12 +57,51 @@ Examples:
 			params,
 			func(ctx context.Context, engineClient *client.Client) error {
 				dag := engineClient.Dagger()
+				def, err := initializeWorkspace(ctx, dag)
+				if err != nil {
+					return err
+				}
+				collectionFlags := discoverCollectionFilterFlags(def)
+				addCollectionFilterFlags(cmd, collectionFlags)
+				if err := cmd.ParseFlags(args); err != nil {
+					if generateNeedsHelp && errors.Is(err, pflag.ErrHelp) {
+						return cmd.Help()
+					}
+					return cmd.FlagErrorFunc()(cmd, err)
+				}
+
+				activeFilters, listFlags, err := activeCollectionFilters(cmd, collectionFlags)
+				if err != nil {
+					return err
+				}
+				if generateListMode && len(activeFilters) > 0 {
+					if flagName, ok := firstActiveCollectionFilterFlag(cmd, collectionFlags); ok {
+						return fmt.Errorf("can't use -l with --%s; use --list-%s instead", flagName, flagName)
+					}
+				}
+				if generateListMode && len(listFlags) > 0 {
+					return fmt.Errorf("can't use -l with --%s; choose one listing mode", listFlags[0].ListName)
+				}
+
+				patterns := cmd.Flags().Args()
 				ws := dag.CurrentWorkspace()
 				var generators *dagger.GeneratorGroup
-				if len(args) > 0 {
-					generators = ws.Generators(dagger.WorkspaceGeneratorsOpts{Include: args})
+				if len(patterns) > 0 || len(activeFilters) > 0 {
+					generators = ws.Generators(dagger.WorkspaceGeneratorsOpts{
+						Include: patterns,
+						Filters: activeFilters,
+					})
 				} else {
 					generators = ws.Generators()
+				}
+
+				if len(listFlags) > 0 {
+					values, err := loadGeneratorCollectionFilterValues(ctx, dag, generators, collectionFilterTypeNames(listFlags))
+					if err != nil {
+						return err
+					}
+					printCollectionFilterValues(cmd, values)
+					return nil
 				}
 				if generateListMode {
 					return listGenerators(ctx, dag, generators, cmd)

--- a/cmd/dagger/generators.graphql
+++ b/cmd/dagger/generators.graphql
@@ -6,3 +6,12 @@ query GeneratorGroupListDetails($id: GeneratorGroupID!) {
     }
   }
 }
+
+query GeneratorGroupCollectionFilterValues($id: GeneratorGroupID!, $typeNames: [String!]!) {
+  group: loadGeneratorGroupFromID(id: $id) {
+    collectionFilterValues(typeNames: $typeNames) {
+      typeName
+      values
+    }
+  }
+}

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -605,6 +605,17 @@ func (m *moduleDef) LoadTypeDef(typeDef *modTypeDef) {
 		if typeDef.AsList != nil {
 			m.LoadTypeDef(typeDef.AsList.ElementTypeDef)
 		}
+		if typeDef.AsCollection != nil {
+			if typeDef.AsCollection.KeyType != nil {
+				m.LoadTypeDef(typeDef.AsCollection.KeyType)
+			}
+			if typeDef.AsCollection.ValueType != nil {
+				m.LoadTypeDef(typeDef.AsCollection.ValueType)
+			}
+			if typeDef.AsCollection.BatchType != nil {
+				m.LoadTypeDef(typeDef.AsCollection.BatchType)
+			}
+		}
 	})
 }
 
@@ -619,14 +630,15 @@ func (m *moduleDef) LoadFunctionTypeDefs(fn *modFunction) {
 
 // modTypeDef is a representation of dagger.TypeDef.
 type modTypeDef struct {
-	Kind        dagger.TypeDefKind
-	Optional    bool
-	AsObject    *modObject
-	AsInterface *modInterface
-	AsInput     *modInput
-	AsList      *modList
-	AsScalar    *modScalar
-	AsEnum      *modEnum
+	Kind         dagger.TypeDefKind
+	Optional     bool
+	AsCollection *modCollection
+	AsObject     *modObject
+	AsInterface  *modInterface
+	AsInput      *modInput
+	AsList       *modList
+	AsScalar     *modScalar
+	AsEnum       *modEnum
 
 	// once protects concurrent update from LoadTypeDef
 	once sync.Once
@@ -678,6 +690,9 @@ func (t *modTypeDef) KindDisplay() string {
 	case dagger.TypeDefKindInputKind:
 		return "Input"
 	case dagger.TypeDefKindObjectKind:
+		if t.AsCollection != nil {
+			return "Collection"
+		}
 		return "Object"
 	case dagger.TypeDefKindInterfaceKind:
 		return "Interface"
@@ -907,6 +922,12 @@ type modInput struct {
 // modList is a representation of dagger.ListTypeDef.
 type modList struct {
 	ElementTypeDef *modTypeDef
+}
+
+type modCollection struct {
+	KeyType   *modTypeDef
+	ValueType *modTypeDef
+	BatchType *modTypeDef
 }
 
 // modField is a representation of dagger.FieldTypeDef.

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -1,6 +1,62 @@
 fragment TypeDefRefParts on TypeDef {
   kind
   optional
+  asCollection {
+    keyType {
+      kind
+      asObject {
+        name
+      }
+      asInterface {
+        name
+      }
+      asInput {
+        name
+      }
+      asScalar {
+        name
+      }
+      asEnum {
+        name
+      }
+    }
+    valueType {
+      kind
+      asObject {
+        name
+      }
+      asInterface {
+        name
+      }
+      asInput {
+        name
+      }
+      asScalar {
+        name
+      }
+      asEnum {
+        name
+      }
+    }
+    batchType {
+      kind
+      asObject {
+        name
+      }
+      asInterface {
+        name
+      }
+      asInput {
+        name
+      }
+      asScalar {
+        name
+      }
+      asEnum {
+        name
+      }
+    }
+  }
   asObject {
     name
   }
@@ -69,6 +125,17 @@ query TypeDefs($hideCore: Boolean) {
   typeDefs: currentTypeDefs(hideCore: $hideCore) {
     kind
     optional
+    asCollection {
+      keyType {
+        ...TypeDefRefParts
+      }
+      valueType {
+        ...TypeDefRefParts
+      }
+      batchType {
+        ...TypeDefRefParts
+      }
+    }
     asObject {
       name
       description

--- a/core/checks.go
+++ b/core/checks.go
@@ -20,12 +20,14 @@ type Check struct {
 }
 
 type CheckGroup struct {
-	Node   *ModTreeNode `json:"node"`
-	Checks []*Check     `json:"checks"`
+	Node    *ModTreeNode `json:"node"`
+	Checks  []*Check     `json:"checks"`
+	include []string
+	exclude []string
 }
 
-func NewCheckGroup(ctx context.Context, mod *Module, include []string) (*CheckGroup, error) {
-	rootNode, err := NewModTree(ctx, mod)
+func NewCheckGroup(ctx context.Context, mod *Module, include []string, filters []CollectionFilterInput) (*CheckGroup, error) {
+	rootNode, err := NewModTree(ctx, mod, NewCollectionFilterSet(filters))
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +42,9 @@ func NewCheckGroup(ctx context.Context, mod *Module, include []string) (*CheckGr
 		checks = append(checks, &Check{Node: checkNode})
 	}
 	return &CheckGroup{
-		Node:   rootNode,
-		Checks: checks,
+		Node:    rootNode,
+		Checks:  checks,
+		include: append([]string(nil), include...),
 	}, nil
 }
 
@@ -140,10 +143,19 @@ func (r *CheckGroup) Clone() *CheckGroup {
 		cp.Node = cp.Node.Clone()
 	}
 	cp.Checks = make([]*Check, len(r.Checks))
+	cp.include = append([]string(nil), r.include...)
+	cp.exclude = append([]string(nil), r.exclude...)
 	for i := range cp.Checks {
 		cp.Checks[i] = r.Checks[i].Clone()
 	}
 	return &cp
+}
+
+func (r *CheckGroup) CollectionFilterValues(ctx context.Context, typeNames []string) ([]*CollectionFilterValues, error) {
+	if r.Node == nil {
+		return collectionFilterValuesFromWorkspaceRoots(ctx, typeNames, r.include, r.exclude, workspaceCheckRoots(r.Checks))
+	}
+	return r.Node.CollectionFilterValues(ctx, typeNames, r.include, r.exclude)
 }
 
 func (c *Check) Path() []string {

--- a/core/collection_filters.go
+++ b/core/collection_filters.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"encoding/json"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+type CollectionFilterInput struct {
+	CollectionType string   `name:"typeName"`
+	Values         []string `name:"values"`
+}
+
+func (CollectionFilterInput) TypeName() string {
+	return "CollectionFilterInput"
+}
+
+type CollectionFilterValues struct {
+	TypeName string   `field:"true" doc:"The collection type name."`
+	Values   []string `field:"true" doc:"The raw filter values available for this collection type."`
+}
+
+func (*CollectionFilterValues) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "CollectionFilterValues",
+		NonNull:   true,
+	}
+}
+
+func (*CollectionFilterValues) TypeDescription() string {
+	return "Values available for a collection-aware CLI filter."
+}
+
+type CollectionFilterSet struct {
+	byType map[string][]string
+}
+
+func NewCollectionFilterSet(filters []CollectionFilterInput) CollectionFilterSet {
+	set := CollectionFilterSet{}
+	if len(filters) == 0 {
+		return set
+	}
+
+	set.byType = make(map[string][]string, len(filters))
+	for _, filter := range filters {
+		key := gqlObjectName(filter.CollectionType)
+		set.byType[key] = append(set.byType[key], filter.Values...)
+	}
+	return set
+}
+
+func (set CollectionFilterSet) Clone() CollectionFilterSet {
+	if len(set.byType) == 0 {
+		return CollectionFilterSet{}
+	}
+
+	cp := CollectionFilterSet{
+		byType: make(map[string][]string, len(set.byType)),
+	}
+	for typeName, values := range set.byType {
+		cp.byType[typeName] = append([]string(nil), values...)
+	}
+	return cp
+}
+
+func (set CollectionFilterSet) HasAny() bool {
+	return len(set.byType) > 0
+}
+
+func (set CollectionFilterSet) ValuesFor(typeName string) ([]string, bool) {
+	if len(set.byType) == 0 {
+		return nil, false
+	}
+	values, ok := set.byType[gqlObjectName(typeName)]
+	if !ok {
+		return nil, false
+	}
+	return append([]string(nil), values...), true
+}
+
+func normalizeCollectionFilterValue(keyType *TypeDef, value any) (string, error) {
+	input, err := keyType.ToInput().Decoder().DecodeInput(value)
+	if err != nil {
+		return "", err
+	}
+	return collectionFilterValueString(input.ToLiteral().ToInput())
+}
+
+func collectionFilterValueString(value any) (string, error) {
+	if str, ok := value.(string); ok {
+		return str, nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}

--- a/core/collection_projection.go
+++ b/core/collection_projection.go
@@ -1,0 +1,762 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+)
+
+const (
+	collectionKeysFieldName   = "keys"
+	collectionListFieldName   = "list"
+	collectionGetFunctionName = "get"
+	collectionSubsetName      = "subset"
+	collectionBatchFieldName  = "batch"
+)
+
+type collectionProjector struct {
+	mod               *Module
+	objectDefsByName  map[string]*TypeDef
+	objectDefCache    map[string]*TypeDef
+	batchTypeDefCache map[string]*TypeDef
+}
+
+func newCollectionProjector(mod *Module) *collectionProjector {
+	projector := &collectionProjector{
+		mod:               mod,
+		objectDefsByName:  make(map[string]*TypeDef, len(mod.ObjectDefs)),
+		objectDefCache:    map[string]*TypeDef{},
+		batchTypeDefCache: map[string]*TypeDef{},
+	}
+	for _, def := range mod.ObjectDefs {
+		projector.objectDefsByName[def.AsObject.Value.Name] = def
+	}
+	return projector
+}
+
+func (p *collectionProjector) projectTypeDef(typeDef *TypeDef) *TypeDef {
+	if typeDef == nil {
+		return nil
+	}
+
+	switch typeDef.Kind {
+	case TypeDefKindList:
+		cp := typeDef.Clone()
+		cp.AsList.Value.ElementTypeDef = p.projectTypeDef(cp.AsList.Value.ElementTypeDef)
+		return cp
+	case TypeDefKindObject:
+		if typeDef.AsObject.Valid {
+			if rawDef, ok := p.objectDefsByName[typeDef.AsObject.Value.Name]; ok {
+				if rawDef.AsCollection.Valid {
+					if rawDef == typeDef {
+						return p.projectObjectDef(rawDef)
+					}
+					return p.projectCollectionRef(typeDef, rawDef)
+				}
+			}
+			if len(typeDef.AsObject.Value.Fields) > 0 || len(typeDef.AsObject.Value.Functions) > 0 || typeDef.AsObject.Value.Constructor.Valid {
+				cp := typeDef.Clone()
+				p.projectObjectMembers(cp.AsObject.Value)
+				return cp
+			}
+		}
+		return typeDef.Clone()
+	case TypeDefKindInterface:
+		cp := typeDef.Clone()
+		if cp.AsInterface.Valid {
+			for i, fn := range cp.AsInterface.Value.Functions {
+				cp.AsInterface.Value.Functions[i] = p.projectFunction(fn)
+			}
+		}
+		return cp
+	default:
+		return typeDef.Clone()
+	}
+}
+
+func (p *collectionProjector) projectObjectDef(typeDef *TypeDef) *TypeDef {
+	if cached, ok := p.objectDefCache[typeDef.AsObject.Value.Name]; ok {
+		return cached.Clone()
+	}
+
+	var projected *TypeDef
+	if typeDef.AsCollection.Valid {
+		projected = p.projectCollectionObjectDef(typeDef)
+	} else {
+		projected = typeDef.Clone()
+		p.projectObjectMembers(projected.AsObject.Value)
+	}
+
+	p.objectDefCache[typeDef.AsObject.Value.Name] = projected.Clone()
+	return projected
+}
+
+func (p *collectionProjector) projectObjectMembers(obj *ObjectTypeDef) {
+	for i, field := range obj.Fields {
+		obj.Fields[i] = p.projectField(field)
+	}
+	for i, fn := range obj.Functions {
+		obj.Functions[i] = p.projectFunction(fn)
+	}
+	if obj.Constructor.Valid {
+		obj.Constructor.Value = p.projectFunction(obj.Constructor.Value)
+	}
+}
+
+func (p *collectionProjector) projectField(field *FieldTypeDef) *FieldTypeDef {
+	cp := field.Clone()
+	cp.TypeDef = p.projectTypeDef(cp.TypeDef)
+	return cp
+}
+
+func (p *collectionProjector) projectFunction(fn *Function) *Function {
+	cp := fn.Clone()
+	cp.ReturnType = p.projectTypeDef(cp.ReturnType)
+	for i, arg := range cp.Args {
+		cp.Args[i] = arg.Clone()
+		cp.Args[i].TypeDef = p.projectTypeDef(cp.Args[i].TypeDef)
+	}
+	return cp
+}
+
+func (p *collectionProjector) projectCollectionRef(typeDef *TypeDef, rawDef *TypeDef) *TypeDef {
+	cp := typeDef.Clone()
+	cp.AsCollection = dagql.NonNull(p.projectCollectionMetadata(rawDef))
+	if len(typeDef.AsObject.Value.Fields) > 0 || len(typeDef.AsObject.Value.Functions) > 0 || typeDef.AsObject.Value.Constructor.Valid {
+		cp.AsObject.Value = p.projectObjectDef(rawDef).AsObject.Value.Clone()
+	}
+	return cp
+}
+
+func (p *collectionProjector) projectCollectionMetadata(typeDef *TypeDef) *CollectionTypeDef {
+	cp := typeDef.AsCollection.Value.Clone()
+	cp.KeyType = p.projectTypeDef(cp.KeyType)
+	cp.ValueType = p.projectTypeDef(cp.ValueType)
+	cp.BatchType = nil
+	if batchTypeDef := p.projectCollectionBatchTypeDef(typeDef); batchTypeDef != nil {
+		cp.BatchType = p.collectionBatchTypeRef(typeDef)
+	}
+	return cp
+}
+
+func (p *collectionProjector) collectionBatchTypeName(typeDef *TypeDef) string {
+	return typeDef.AsObject.Value.Name + "_Batch"
+}
+
+func (p *collectionProjector) collectionBatchTypeRef(typeDef *TypeDef) *TypeDef {
+	batchTypeDef := p.projectCollectionBatchTypeDef(typeDef)
+	if batchTypeDef == nil {
+		return nil
+	}
+	return (&TypeDef{}).WithObject(
+		batchTypeDef.AsObject.Value.Name,
+		batchTypeDef.AsObject.Value.Description,
+		batchTypeDef.AsObject.Value.Deprecated,
+		nullableSourceMapPtr(batchTypeDef.AsObject.Value.SourceMap),
+	)
+}
+
+func (p *collectionProjector) projectCollectionBatchTypeDef(typeDef *TypeDef) *TypeDef {
+	if !typeDef.AsCollection.Valid {
+		return nil
+	}
+	typeName := p.collectionBatchTypeName(typeDef)
+	if cached, ok := p.batchTypeDefCache[typeName]; ok {
+		return cached.Clone()
+	}
+
+	batchFns := p.collectionBatchFunctions(typeDef)
+	if len(batchFns) == 0 {
+		return nil
+	}
+
+	rawObj := typeDef.AsObject.Value
+	batchObj := NewObjectTypeDef(typeName, "Type-specific efficient operations over the current subset.", nil).WithSourceMap(nullableSourceMapPtr(rawObj.SourceMap))
+	batchObj.OriginalName = typeName
+	for _, fn := range batchFns {
+		batchObj.Functions = append(batchObj.Functions, p.projectFunction(fn))
+	}
+
+	batchTypeDef := &TypeDef{
+		Kind:     TypeDefKindObject,
+		AsObject: dagql.NonNull(batchObj),
+	}
+	p.batchTypeDefCache[typeName] = batchTypeDef.Clone()
+	return batchTypeDef
+}
+
+func (p *collectionProjector) projectCollectionObjectDef(typeDef *TypeDef) *TypeDef {
+	rawObj := typeDef.AsObject.Value
+	collection := typeDef.AsCollection.Value
+
+	projectedObj := rawObj.Clone()
+	projectedObj.Fields = nil
+	projectedObj.Functions = nil
+	projectedObj.Constructor = dagql.Null[*Function]()
+
+	keysField, ok := rawObj.FieldByName(collection.KeysFieldName)
+	if !ok {
+		panic(fmt.Sprintf("collection keys field %q missing from %q", collection.KeysFieldName, rawObj.Name))
+	}
+	projectedKeys := p.projectField(keysField)
+	projectedKeys.Name = collectionKeysFieldName
+	projectedKeys.OriginalName = collectionKeysFieldName
+	projectedObj.Fields = append(projectedObj.Fields, projectedKeys)
+
+	projectedObj.Fields = append(projectedObj.Fields, &FieldTypeDef{
+		Name:         collectionListFieldName,
+		OriginalName: collectionListFieldName,
+		Description:  "Items in the current subset, in the same order as `keys`.",
+		TypeDef:      (&TypeDef{}).WithListOf(p.projectTypeDef(collection.ValueType)),
+	})
+
+	getFn, ok := rawObj.FunctionByName(collection.GetFunctionName)
+	if !ok {
+		panic(fmt.Sprintf("collection get function %q missing from %q", collection.GetFunctionName, rawObj.Name))
+	}
+	projectedGet := p.projectFunction(getFn)
+	projectedGet.Name = collectionGetFunctionName
+	projectedGet.OriginalName = collectionGetFunctionName
+	projectedObj.Functions = append(projectedObj.Functions, projectedGet)
+
+	projectedObj.Functions = append(projectedObj.Functions, &Function{
+		Name:         collectionSubsetName,
+		OriginalName: collectionSubsetName,
+		Description:  "Restrict the collection to an exact subset of keys.",
+		Args: []*FunctionArg{
+			{
+				Name:         collectionKeysFieldName,
+				OriginalName: collectionKeysFieldName,
+				Description:  "Keys to retain from the current subset.",
+				TypeDef:      (&TypeDef{}).WithListOf(p.projectTypeDef(collection.KeyType)),
+			},
+		},
+		ReturnType: &TypeDef{
+			Kind: TypeDefKindObject,
+			AsObject: dagql.NonNull(&ObjectTypeDef{
+				Name:         rawObj.Name,
+				OriginalName: rawObj.OriginalName,
+			}),
+			AsCollection: dagql.NonNull(p.projectCollectionMetadata(typeDef)),
+		},
+	})
+
+	if batchTypeRef := p.collectionBatchTypeRef(typeDef); batchTypeRef != nil {
+		projectedObj.Fields = append(projectedObj.Fields, &FieldTypeDef{
+			Name:         collectionBatchFieldName,
+			OriginalName: collectionBatchFieldName,
+			Description:  "Type-specific efficient operations over the current subset.",
+			TypeDef:      batchTypeRef,
+		})
+	}
+
+	return &TypeDef{
+		Kind:         TypeDefKindObject,
+		AsObject:     dagql.NonNull(projectedObj),
+		AsCollection: dagql.NonNull(p.projectCollectionMetadata(typeDef)),
+	}
+}
+
+func (p *collectionProjector) collectionBatchFunctions(typeDef *TypeDef) []*Function {
+	if !typeDef.AsCollection.Valid {
+		return nil
+	}
+	collection := typeDef.AsCollection.Value
+	fns := make([]*Function, 0, len(typeDef.AsObject.Value.Functions))
+	for _, fn := range typeDef.AsObject.Value.Functions {
+		if fn.Name == collection.GetFunctionName {
+			continue
+		}
+		fns = append(fns, fn)
+	}
+	return fns
+}
+
+type CollectionBatchObject struct {
+	Module         *Module
+	TypeDef        *ObjectTypeDef
+	BackingTypeDef *ObjectTypeDef
+	Collection     *CollectionTypeDef
+	Fields         map[string]any
+}
+
+func (obj *CollectionBatchObject) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: obj.TypeDef.Name,
+		NonNull:   true,
+	}
+}
+
+func (obj *CollectionBatchObject) TypeDescription() string {
+	return formatGqlDescription(obj.TypeDef.Description)
+}
+
+func (obj *CollectionBatchObject) TypeDefinition(view call.View) *ast.Definition {
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: obj.Type().Name(),
+	}
+	if obj.TypeDef.SourceMap.Valid {
+		def.Directives = append(def.Directives, obj.TypeDef.SourceMap.Value.TypeDirective())
+	}
+	return def
+}
+
+func (obj *CollectionBatchObject) Install(ctx context.Context, dag *dagql.Server) error {
+	classOpts := dagql.ClassOpts[*CollectionBatchObject]{
+		Typed: obj,
+	}
+
+	installDirectives := []*ast.Directive{}
+	if obj.TypeDef.SourceMap.Valid {
+		classOpts.SourceMap = obj.TypeDef.SourceMap.Value.TypeDirective()
+		installDirectives = append(installDirectives, obj.TypeDef.SourceMap.Value.TypeDirective())
+	}
+
+	class := dagql.NewClass(dag, classOpts)
+	fields, err := obj.functions(ctx, dag)
+	if err != nil {
+		return err
+	}
+	class.Install(fields...)
+	dag.InstallObject(class, installDirectives...)
+	return nil
+}
+
+func (obj *CollectionBatchObject) functions(ctx context.Context, dag *dagql.Server) ([]dagql.Field[*CollectionBatchObject], error) {
+	projector := newCollectionProjector(obj.Module)
+	backingTypeDef := &TypeDef{
+		Kind:         TypeDefKindObject,
+		AsObject:     dagql.NonNull(obj.BackingTypeDef),
+		AsCollection: dagql.NonNull(obj.Collection),
+	}
+	batchFns := projector.collectionBatchFunctions(backingTypeDef)
+	fields := make([]dagql.Field[*CollectionBatchObject], 0, len(batchFns))
+	for _, fn := range batchFns {
+		modFun, err := NewModFunction(ctx, obj.Module, obj.BackingTypeDef, fn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create batch function %q: %w", fn.Name, err)
+		}
+		if err := modFun.mergeUserDefaultsTypeDefs(ctx); err != nil {
+			return nil, fmt.Errorf("failed to merge user defaults for %q: %w", fn.Name, err)
+		}
+		spec, err := fn.FieldSpec(ctx, obj.Module)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get field spec for batch function %q: %w", fn.Name, err)
+		}
+		spec.Module = obj.Module.IDModule()
+		spec.GetCacheConfig = modFun.CacheConfigForCall
+
+		fields = append(fields, dagql.Field[*CollectionBatchObject]{
+			Spec: &spec,
+			Func: func(ctx context.Context, batch dagql.ObjectResult[*CollectionBatchObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+				parent, err := dagql.NewResultForCurrentID(ctx, &ModuleObject{
+					Module:     batch.Self().Module,
+					TypeDef:    batch.Self().BackingTypeDef,
+					Collection: batch.Self().Collection,
+					Fields:     batch.Self().Fields,
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				opts := &CallOpts{
+					ParentTyped:  parent,
+					ParentFields: batch.Self().Fields,
+					Server:       dag,
+				}
+				for name, val := range args {
+					opts.Inputs = append(opts.Inputs, CallInput{
+						Name:  name,
+						Value: val,
+					})
+				}
+				slices.SortFunc(opts.Inputs, func(a, b CallInput) int {
+					switch {
+					case a.Name < b.Name:
+						return -1
+					case a.Name > b.Name:
+						return 1
+					default:
+						return 0
+					}
+				})
+				return modFun.Call(ctx, opts)
+			},
+		})
+	}
+	return fields, nil
+}
+
+func (obj *ModuleObject) collectionMembers(ctx context.Context, dag *dagql.Server) ([]dagql.Field[*ModuleObject], error) {
+	backingTypeDef := &TypeDef{
+		Kind:         TypeDefKindObject,
+		AsObject:     dagql.NonNull(obj.TypeDef),
+		AsCollection: dagql.NonNull(obj.Collection),
+	}
+	projector := newCollectionProjector(obj.Module)
+	if batchTypeDef := projector.projectCollectionBatchTypeDef(backingTypeDef); batchTypeDef != nil {
+		batchObj := &CollectionBatchObject{
+			Module:         obj.Module,
+			TypeDef:        batchTypeDef.AsObject.Value,
+			BackingTypeDef: obj.TypeDef,
+			Collection:     obj.Collection,
+		}
+		if err := batchObj.Install(ctx, dag); err != nil {
+			return nil, err
+		}
+	}
+
+	keysField, ok := obj.TypeDef.FieldByName(obj.Collection.KeysFieldName)
+	if !ok {
+		return nil, fmt.Errorf("collection keys field %q not found on %q", obj.Collection.KeysFieldName, obj.TypeDef.Name)
+	}
+	getFn, ok := obj.TypeDef.FunctionByName(obj.Collection.GetFunctionName)
+	if !ok {
+		return nil, fmt.Errorf("collection get function %q not found on %q", obj.Collection.GetFunctionName, obj.TypeDef.Name)
+	}
+
+	keyModType, ok, err := obj.Module.ModTypeFor(ctx, obj.Collection.KeyType, true)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("could not resolve key type %s", obj.Collection.KeyType.ToType())
+	}
+
+	getModFun, err := NewModFunction(ctx, obj.Module, obj.TypeDef, getFn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get function: %w", err)
+	}
+	if err := getModFun.mergeUserDefaultsTypeDefs(ctx); err != nil {
+		return nil, fmt.Errorf("failed to merge user defaults for get: %w", err)
+	}
+
+	projectedGetFn := projector.projectFunction(getFn)
+	projectedGetFn.Name = collectionGetFunctionName
+	projectedGetFn.OriginalName = collectionGetFunctionName
+	getSpec, err := projectedGetFn.FieldSpec(ctx, obj.Module)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build get field spec: %w", err)
+	}
+	getSpec.Module = obj.Module.IDModule()
+	getSpec.GetCacheConfig = getModFun.CacheConfigForCall
+
+	fields := []dagql.Field[*ModuleObject]{
+		obj.collectionKeysField(keysField),
+		obj.collectionListField(getModFun, dag),
+		{
+			Spec: &getSpec,
+			Func: func(ctx context.Context, self dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+				keyInput, ok := args[getFn.Args[0].Name]
+				if !ok {
+					return nil, fmt.Errorf("missing collection key argument %q", getFn.Args[0].Name)
+				}
+				typedKey, ok := keyInput.(dagql.Typed)
+				if !ok {
+					return nil, fmt.Errorf("unexpected key input type %T", keyInput)
+				}
+				rawKey, err := keyModType.ConvertToSDKInput(ctx, typedKey)
+				if err != nil {
+					return nil, err
+				}
+				if err := self.Self().validateCollectionKey(rawKey); err != nil {
+					return nil, err
+				}
+				return self.Self().callCollectionGet(ctx, self, getModFun, dag, keyInput)
+			},
+		},
+		obj.collectionSubsetField(keyModType),
+	}
+
+	if batchTypeDef := projector.projectCollectionBatchTypeDef(backingTypeDef); batchTypeDef != nil {
+		fields = append(fields, obj.collectionBatchField(batchTypeDef.AsObject.Value))
+	}
+
+	return fields, nil
+}
+
+func (obj *ModuleObject) collectionKeysField(keysField *FieldTypeDef) dagql.Field[*ModuleObject] {
+	spec := &dagql.FieldSpec{
+		Name:             collectionKeysFieldName,
+		Description:      formatGqlDescription(keysField.Description),
+		Type:             keysField.TypeDef.ToTyped(),
+		Module:           obj.Module.IDModule(),
+		GetCacheConfig:   obj.Module.CacheConfigForCall,
+		DeprecatedReason: keysField.Deprecated,
+	}
+	spec.Directives = append(spec.Directives, &ast.Directive{Name: trivialFieldDirectiveName})
+	if keysField.SourceMap.Valid {
+		spec.Directives = append(spec.Directives, keysField.SourceMap.Value.TypeDirective())
+	}
+
+	return dagql.Field[*ModuleObject]{
+		Spec: spec,
+		Func: func(ctx context.Context, self dagql.ObjectResult[*ModuleObject], _ map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+			modType, ok, err := obj.Module.ModTypeFor(ctx, keysField.TypeDef, true)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("could not resolve keys field type %s", keysField.TypeDef.ToType())
+			}
+			return modType.ConvertFromSDKResult(ctx, self.Self().Fields[keysField.OriginalName])
+		},
+	}
+}
+
+func (obj *ModuleObject) collectionListField(getModFun *ModuleFunction, dag *dagql.Server) dagql.Field[*ModuleObject] {
+	listType := (&TypeDef{}).WithListOf(obj.Collection.ValueType.Clone())
+	spec := &dagql.FieldSpec{
+		Name:           collectionListFieldName,
+		Description:    "Items in the current subset, in the same order as `keys`.",
+		Type:           listType.ToTyped(),
+		Module:         obj.Module.IDModule(),
+		GetCacheConfig: obj.Module.CacheConfigForCall,
+	}
+	spec.Directives = append(spec.Directives, &ast.Directive{Name: trivialFieldDirectiveName})
+
+	return dagql.Field[*ModuleObject]{
+		Spec: spec,
+		Func: func(ctx context.Context, self dagql.ObjectResult[*ModuleObject], _ map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+			keys, err := self.Self().collectionKeys()
+			if err != nil {
+				return nil, err
+			}
+			result := dagql.DynamicResultArrayOutput{
+				Elem: obj.Collection.ValueType.ToTyped(),
+			}
+			result.Values = make([]dagql.AnyResult, 0, len(keys))
+			for i, key := range keys {
+				keyInput, err := self.Self().collectionKeyInput(key)
+				if err != nil {
+					return nil, err
+				}
+				itemCtx := dagql.ContextWithID(ctx, dagql.CurrentID(ctx).SelectNth(i+1))
+				item, err := self.Self().callCollectionGet(itemCtx, self, getModFun, dag, keyInput)
+				if err != nil {
+					return nil, err
+				}
+				result.Values = append(result.Values, item)
+			}
+			return dagql.NewResultForCurrentID(ctx, result)
+		},
+	}
+}
+
+func (obj *ModuleObject) collectionSubsetField(keyModType ModType) dagql.Field[*ModuleObject] {
+	keysArgType := (&TypeDef{}).WithListOf(obj.Collection.KeyType.Clone())
+	spec := &dagql.FieldSpec{
+		Name:        collectionSubsetName,
+		Description: "Restrict the collection to an exact subset of keys.",
+		Type:        obj,
+		Module:      obj.Module.IDModule(),
+		Args: dagql.NewInputSpecs(
+			dagql.InputSpec{
+				Name:        collectionKeysFieldName,
+				Description: "Keys to retain from the current subset.",
+				Type:        keysArgType.ToInput(),
+			},
+		),
+		GetCacheConfig: obj.Module.CacheConfigForCall,
+	}
+
+	listKeyModType := &ListType{
+		Elem:       obj.Collection.KeyType.Clone(),
+		Underlying: keyModType,
+	}
+
+	return dagql.Field[*ModuleObject]{
+		Spec: spec,
+		Func: func(ctx context.Context, self dagql.ObjectResult[*ModuleObject], args map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+			keysInput, ok := args[collectionKeysFieldName]
+			if !ok {
+				return nil, fmt.Errorf("missing subset keys")
+			}
+			typedKeys, ok := keysInput.(dagql.Typed)
+			if !ok {
+				return nil, fmt.Errorf("unexpected subset keys input type %T", keysInput)
+			}
+			rawSubset, err := listKeyModType.ConvertToSDKInput(ctx, typedKeys)
+			if err != nil {
+				return nil, err
+			}
+			subsetKeys, err := collectionSliceValues(rawSubset)
+			if err != nil {
+				return nil, err
+			}
+			orderedKeys, err := self.Self().collectionSubsetKeys(subsetKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			fields := maps.Clone(self.Self().Fields)
+			keysField, ok := self.Self().TypeDef.FieldByName(self.Self().Collection.KeysFieldName)
+			if !ok {
+				return nil, fmt.Errorf("collection keys field %q not found on %q", self.Self().Collection.KeysFieldName, self.Self().TypeDef.Name)
+			}
+			fields[keysField.OriginalName] = orderedKeys
+			return dagql.NewResultForCurrentID(ctx, &ModuleObject{
+				Module:     self.Self().Module,
+				TypeDef:    self.Self().TypeDef,
+				Collection: self.Self().Collection,
+				Fields:     fields,
+			})
+		},
+	}
+}
+
+func (obj *ModuleObject) collectionBatchField(batchTypeDef *ObjectTypeDef) dagql.Field[*ModuleObject] {
+	spec := &dagql.FieldSpec{
+		Name:           collectionBatchFieldName,
+		Description:    "Type-specific efficient operations over the current subset.",
+		Type:           &CollectionBatchObject{TypeDef: batchTypeDef},
+		Module:         obj.Module.IDModule(),
+		GetCacheConfig: obj.Module.CacheConfigForCall,
+	}
+	spec.Directives = append(spec.Directives, &ast.Directive{Name: trivialFieldDirectiveName})
+
+	return dagql.Field[*ModuleObject]{
+		Spec: spec,
+		Func: func(ctx context.Context, self dagql.ObjectResult[*ModuleObject], _ map[string]dagql.Input, view call.View) (dagql.AnyResult, error) {
+			return dagql.NewResultForCurrentID(ctx, &CollectionBatchObject{
+				Module:         self.Self().Module,
+				TypeDef:        batchTypeDef,
+				BackingTypeDef: self.Self().TypeDef,
+				Collection:     self.Self().Collection,
+				Fields:         maps.Clone(self.Self().Fields),
+			})
+		},
+	}
+}
+
+func (obj *ModuleObject) collectionKeys() ([]any, error) {
+	keysField, ok := obj.TypeDef.FieldByName(obj.Collection.KeysFieldName)
+	if !ok {
+		return nil, fmt.Errorf("collection keys field %q not found on %q", obj.Collection.KeysFieldName, obj.TypeDef.Name)
+	}
+	return collectionSliceValues(obj.Fields[keysField.OriginalName])
+}
+
+func (obj *ModuleObject) collectionKeyInput(rawKey any) (dagql.Input, error) {
+	return obj.Collection.KeyType.ToInput().Decoder().DecodeInput(rawKey)
+}
+
+func (obj *ModuleObject) validateCollectionKey(rawKey any) error {
+	currentKeys, err := obj.collectionKeys()
+	if err != nil {
+		return err
+	}
+	keyID, err := collectionKeyID(rawKey)
+	if err != nil {
+		return err
+	}
+	for _, currentKey := range currentKeys {
+		currentKeyID, err := collectionKeyID(currentKey)
+		if err != nil {
+			return err
+		}
+		if currentKeyID == keyID {
+			return nil
+		}
+	}
+	return fmt.Errorf("collection %q does not contain key %s in the current subset", obj.TypeDef.Name, keyID)
+}
+
+func (obj *ModuleObject) collectionSubsetKeys(subsetKeys []any) ([]any, error) {
+	currentKeys, err := obj.collectionKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	selected := make(map[string]struct{}, len(subsetKeys))
+	for _, key := range subsetKeys {
+		keyID, err := collectionKeyID(key)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := selected[keyID]; exists {
+			return nil, fmt.Errorf("collection %q subset contains duplicate key %s", obj.TypeDef.Name, keyID)
+		}
+		selected[keyID] = struct{}{}
+	}
+
+	ordered := make([]any, 0, len(subsetKeys))
+	found := make(map[string]struct{}, len(subsetKeys))
+	for _, key := range currentKeys {
+		keyID, err := collectionKeyID(key)
+		if err != nil {
+			return nil, err
+		}
+		if _, keep := selected[keyID]; keep {
+			ordered = append(ordered, key)
+			found[keyID] = struct{}{}
+		}
+	}
+
+	for keyID := range selected {
+		if _, ok := found[keyID]; !ok {
+			return nil, fmt.Errorf("collection %q does not contain key %s in the current subset", obj.TypeDef.Name, keyID)
+		}
+	}
+
+	return ordered, nil
+}
+
+func (obj *ModuleObject) callCollectionGet(
+	ctx context.Context,
+	parent dagql.ObjectResult[*ModuleObject],
+	getModFun *ModuleFunction,
+	dag *dagql.Server,
+	keyInput dagql.Input,
+) (dagql.AnyResult, error) {
+	return getModFun.Call(ctx, &CallOpts{
+		Inputs: []CallInput{{
+			Name:  obj.Collection.GetArgName,
+			Value: keyInput,
+		}},
+		ParentTyped:  parent,
+		ParentFields: parent.Self().Fields,
+		Server:       dag,
+	})
+}
+
+func collectionSliceValues(value any) ([]any, error) {
+	if value == nil {
+		return []any{}, nil
+	}
+	if values, ok := value.([]any); ok {
+		return slices.Clone(values), nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var values []any
+	if err := json.Unmarshal(payload, &values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func collectionKeyID(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func nullableSourceMapPtr(sourceMap dagql.Nullable[*SourceMap]) *SourceMap {
+	if !sourceMap.Valid {
+		return nil
+	}
+	return sourceMap.Value.Clone()
+}

--- a/core/collection_projection.go
+++ b/core/collection_projection.go
@@ -712,7 +712,7 @@ func (obj *ModuleObject) collectionSubsetKeys(subsetKeys []any) ([]any, error) {
 
 func (obj *ModuleObject) callCollectionGet(
 	ctx context.Context,
-	parent dagql.ObjectResult[*ModuleObject],
+	parent dagql.AnyResult,
 	getModFun *ModuleFunction,
 	dag *dagql.Server,
 	keyInput dagql.Input,
@@ -723,7 +723,7 @@ func (obj *ModuleObject) callCollectionGet(
 			Value: keyInput,
 		}},
 		ParentTyped:  parent,
-		ParentFields: parent.Self().Fields,
+		ParentFields: obj.Fields,
 		Server:       dag,
 	})
 }

--- a/core/collection_projection.go
+++ b/core/collection_projection.go
@@ -534,12 +534,16 @@ func (obj *ModuleObject) collectionListField(getModFun *ModuleFunction, dag *dag
 				Elem: obj.Collection.ValueType.ToTyped(),
 			}
 			result.Values = make([]dagql.AnyResult, 0, len(keys))
-			for i, key := range keys {
+			for _, key := range keys {
 				keyInput, err := self.Self().collectionKeyInput(key)
 				if err != nil {
 					return nil, err
 				}
-				itemCtx := dagql.ContextWithID(ctx, dagql.CurrentID(ctx).SelectNth(i+1))
+				itemID, err := self.Self().collectionGetID(self, keyInput)
+				if err != nil {
+					return nil, err
+				}
+				itemCtx := dagql.ContextWithID(ctx, itemID)
 				item, err := self.Self().callCollectionGet(itemCtx, self, getModFun, dag, keyInput)
 				if err != nil {
 					return nil, err
@@ -726,6 +730,27 @@ func (obj *ModuleObject) callCollectionGet(
 		ParentFields: obj.Fields,
 		Server:       dag,
 	})
+}
+
+func (obj *ModuleObject) collectionGetID(parent dagql.AnyResult, keyInput dagql.Input) (*call.ID, error) {
+	parentID := parent.ID()
+	if parentID == nil {
+		return nil, fmt.Errorf("collection %q get call has no parent ID", obj.TypeDef.Name)
+	}
+	// Collection items have a canonical identity: the raw projected get(key) call.
+	// Using that ID keeps list elements equivalent to get(key) results instead of
+	// anonymous nth selections from the enclosing list.
+	getID := parentID.Append(
+		obj.Collection.ValueType.ToType(),
+		collectionGetFunctionName,
+		call.WithView(parentID.View()),
+		call.WithModule(parentID.Module()),
+	)
+	return getID.WithArgument(call.NewArgument(
+		obj.Collection.GetArgName,
+		keyInput.ToLiteral(),
+		false,
+	)), nil
 }
 
 func collectionSliceValues(value any) ([]any, error) {

--- a/core/collection_projection_test.go
+++ b/core/collection_projection_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleTypeDefsProjectCollections(t *testing.T) {
+	ctx := context.Background()
+	mod := &Module{
+		NameField:    "go",
+		OriginalName: "Go",
+		Deps:         NewSchemaBuilder(nil, nil),
+	}
+
+	itemType := (&TypeDef{}).WithObject("GoTest", "", nil, nil)
+	collectionType := (&TypeDef{}).
+		WithObject("GoTests", "Collection of tests.", nil, nil).
+		WithCollection().
+		WithCollectionKeys("names").
+		WithCollectionGet("test")
+
+	var err error
+	collectionType, err = collectionType.WithObjectField(
+		"names",
+		(&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString)),
+		"Raw names field.",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	getFn := NewFunction("Test", itemType).
+		WithArg("name", (&TypeDef{}).WithKind(TypeDefKindString), "Test name.", nil, "", "", nil, nil, nil)
+	collectionType, err = collectionType.WithFunction(getFn)
+	require.NoError(t, err)
+
+	batchFn := NewFunction("RunTests", (&TypeDef{}).WithKind(TypeDefKindString))
+	collectionType, err = collectionType.WithFunction(batchFn)
+	require.NoError(t, err)
+
+	rootType := (&TypeDef{}).WithObject("Go", "", nil, nil)
+	rootType, err = rootType.WithObjectField("tests", collectionType.Clone(), "", nil, nil)
+	require.NoError(t, err)
+
+	mod.ObjectDefs = []*TypeDef{rootType, itemType, collectionType}
+	require.NoError(t, mod.validateTypeDef(ctx, collectionType))
+	require.NoError(t, mod.validateTypeDef(ctx, rootType))
+
+	typeDefs, err := mod.TypeDefs(ctx, nil)
+	require.NoError(t, err)
+
+	typeByName := map[string]*TypeDef{}
+	for _, typeDef := range typeDefs {
+		if typeDef.AsObject.Valid {
+			typeByName[typeDef.AsObject.Value.Name] = typeDef
+		}
+	}
+
+	projectedCollection, ok := typeByName["GoTests"]
+	require.True(t, ok)
+	require.True(t, projectedCollection.AsCollection.Valid)
+
+	projectedObj := projectedCollection.AsObject.Value
+	require.Len(t, projectedObj.Fields, 3)
+	require.Equal(t, "keys", projectedObj.Fields[0].Name)
+	require.Equal(t, "list", projectedObj.Fields[1].Name)
+	require.Equal(t, "batch", projectedObj.Fields[2].Name)
+	require.Len(t, projectedObj.Functions, 2)
+	require.Equal(t, "get", projectedObj.Functions[0].Name)
+	require.Equal(t, "subset", projectedObj.Functions[1].Name)
+
+	require.NotNil(t, projectedCollection.AsCollection.Value.BatchType)
+	require.Equal(t, "GoTests_Batch", projectedCollection.AsCollection.Value.BatchType.AsObject.Value.Name)
+
+	projectedBatch, ok := typeByName["GoTests_Batch"]
+	require.True(t, ok)
+	require.Len(t, projectedBatch.AsObject.Value.Functions, 1)
+	require.Equal(t, "runTests", projectedBatch.AsObject.Value.Functions[0].Name)
+
+	rootProjected, ok := typeByName["Go"]
+	require.True(t, ok)
+	testsField, ok := rootProjected.AsObject.Value.FieldByName("tests")
+	require.True(t, ok)
+	require.True(t, testsField.TypeDef.AsCollection.Valid)
+	require.Equal(t, "GoTests", testsField.TypeDef.AsObject.Value.Name)
+}

--- a/core/collection_test.go
+++ b/core/collection_test.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCollectionTypeDefDefaultMembers(t *testing.T) {
+	ctx := context.Background()
+	mod := &Module{Deps: NewModDeps(nil, nil)}
+
+	itemType := (&TypeDef{}).WithObject("GoTest", "", nil, nil)
+	getFn := NewFunction("Get", itemType).
+		WithArg("name", (&TypeDef{}).WithKind(TypeDefKindString), "", nil, "", "", nil, nil, nil)
+
+	collectionType := (&TypeDef{}).WithObject("GoTests", "", nil, nil).WithCollection()
+
+	var err error
+	collectionType, err = collectionType.WithObjectField(
+		"keys",
+		(&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString)),
+		"",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	collectionType, err = collectionType.WithFunction(getFn)
+	require.NoError(t, err)
+
+	require.NoError(t, mod.validateTypeDef(ctx, collectionType))
+	require.True(t, collectionType.AsCollection.Valid)
+
+	collection := collectionType.AsCollection.Value
+	require.Equal(t, "keys", collection.KeysFieldName)
+	require.Empty(t, collection.KeysFunctionName)
+	require.Equal(t, "get", collection.GetFunctionName)
+	require.Equal(t, "name", collection.GetArgName)
+	require.NotNil(t, collection.KeyType)
+	require.Equal(t, TypeDefKindString, collection.KeyType.Kind)
+	require.NotNil(t, collection.ValueType)
+	require.Equal(t, TypeDefKindObject, collection.ValueType.Kind)
+	require.Equal(t, "GoTest", collection.ValueType.AsObject.Value.Name)
+}
+
+func TestValidateCollectionTypeDefExplicitOverrides(t *testing.T) {
+	ctx := context.Background()
+	mod := &Module{Deps: NewModDeps(nil, nil)}
+
+	itemType := (&TypeDef{}).WithObject("GoModule", "", nil, nil)
+	getFn := NewFunction("Module", itemType).
+		WithArg("path", (&TypeDef{}).WithKind(TypeDefKindString), "", nil, "", "", nil, nil, nil)
+
+	collectionType := (&TypeDef{}).
+		WithObject("GoModules", "", nil, nil).
+		WithCollection().
+		WithCollectionKeys("paths").
+		WithCollectionGet("module")
+
+	var err error
+	collectionType, err = collectionType.WithObjectField(
+		"paths",
+		(&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString)),
+		"",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	collectionType, err = collectionType.WithFunction(getFn)
+	require.NoError(t, err)
+
+	require.NoError(t, mod.validateTypeDef(ctx, collectionType))
+
+	collection := collectionType.AsCollection.Value
+	require.Equal(t, "paths", collection.KeysFieldName)
+	require.Equal(t, "module", collection.GetFunctionName)
+	require.Equal(t, "path", collection.GetArgName)
+}
+
+func TestValidateCollectionTypeDefErrors(t *testing.T) {
+	ctx := context.Background()
+	mod := &Module{Deps: NewModDeps(nil, nil)}
+
+	tests := []struct {
+		name     string
+		typeDef  *TypeDef
+		contains string
+	}{
+		{
+			name:     "missing keys member",
+			typeDef:  collectionTypeWithMembers(t, false, true, nil),
+			contains: `must define exactly one effective keys member`,
+		},
+		{
+			name: "keys function with args",
+			typeDef: collectionTypeWithMembers(t, false, true, func(def *TypeDef) *TypeDef {
+				keysFn := NewFunction("Keys", (&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString))).
+					WithArg("prefix", (&TypeDef{}).WithKind(TypeDefKindString), "", nil, "", "", nil, nil, nil)
+				def, err := def.WithFunction(keysFn)
+				require.NoError(t, err)
+				return def
+			}),
+			contains: `must not accept arguments`,
+		},
+		{
+			name: "get key type mismatch",
+			typeDef: collectionTypeWithMembers(t, true, true, func(def *TypeDef) *TypeDef {
+				def.AsObject.Value.Functions = nil
+				getFn := NewFunction("Get", (&TypeDef{}).WithObject("GoTest", "", nil, nil)).
+					WithArg("name", (&TypeDef{}).WithKind(TypeDefKindInteger), "", nil, "", "", nil, nil, nil)
+				def, err := def.WithFunction(getFn)
+				require.NoError(t, err)
+				return def
+			}),
+			contains: `must match keys member type`,
+		},
+		{
+			name:     "get returns non object",
+			typeDef:  collectionTypeWithMembers(t, true, false, nil),
+			contains: `must return an object`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mod.validateTypeDef(ctx, tt.typeDef)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.contains)
+		})
+	}
+}
+
+func collectionTypeWithMembers(t *testing.T, includeKeys bool, objectReturn bool, mutate func(*TypeDef) *TypeDef) *TypeDef {
+	t.Helper()
+
+	itemReturnType := (&TypeDef{}).WithObject("GoTest", "", nil, nil)
+	if !objectReturn {
+		itemReturnType = (&TypeDef{}).WithKind(TypeDefKindString)
+	}
+
+	def := (&TypeDef{}).WithObject("GoTests", "", nil, nil).WithCollection()
+
+	var err error
+	if includeKeys {
+		def, err = def.WithObjectField(
+			"keys",
+			(&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString)),
+			"",
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+	}
+
+	getFn := NewFunction("Get", itemReturnType).
+		WithArg("name", (&TypeDef{}).WithKind(TypeDefKindString), "", nil, "", "", nil, nil, nil)
+	def, err = def.WithFunction(getFn)
+	require.NoError(t, err)
+
+	if mutate != nil {
+		def = mutate(def)
+	}
+
+	return def
+}

--- a/core/collection_test.go
+++ b/core/collection_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestValidateCollectionTypeDefDefaultMembers(t *testing.T) {
 	ctx := context.Background()
-	mod := &Module{Deps: NewModDeps(nil, nil)}
+	mod := &Module{Deps: NewSchemaBuilder(nil, nil)}
 
 	itemType := (&TypeDef{}).WithObject("GoTest", "", nil, nil)
 	getFn := NewFunction("Get", itemType).
@@ -35,7 +35,6 @@ func TestValidateCollectionTypeDefDefaultMembers(t *testing.T) {
 
 	collection := collectionType.AsCollection.Value
 	require.Equal(t, "keys", collection.KeysFieldName)
-	require.Empty(t, collection.KeysFunctionName)
 	require.Equal(t, "get", collection.GetFunctionName)
 	require.Equal(t, "name", collection.GetArgName)
 	require.NotNil(t, collection.KeyType)
@@ -47,7 +46,7 @@ func TestValidateCollectionTypeDefDefaultMembers(t *testing.T) {
 
 func TestValidateCollectionTypeDefExplicitOverrides(t *testing.T) {
 	ctx := context.Background()
-	mod := &Module{Deps: NewModDeps(nil, nil)}
+	mod := &Module{Deps: NewSchemaBuilder(nil, nil)}
 
 	itemType := (&TypeDef{}).WithObject("GoModule", "", nil, nil)
 	getFn := NewFunction("Module", itemType).
@@ -82,7 +81,7 @@ func TestValidateCollectionTypeDefExplicitOverrides(t *testing.T) {
 
 func TestValidateCollectionTypeDefErrors(t *testing.T) {
 	ctx := context.Background()
-	mod := &Module{Deps: NewModDeps(nil, nil)}
+	mod := &Module{Deps: NewSchemaBuilder(nil, nil)}
 
 	tests := []struct {
 		name     string
@@ -90,12 +89,12 @@ func TestValidateCollectionTypeDefErrors(t *testing.T) {
 		contains string
 	}{
 		{
-			name:     "missing keys member",
+			name:     "missing keys field",
 			typeDef:  collectionTypeWithMembers(t, false, true, nil),
-			contains: `must define exactly one effective keys member`,
+			contains: `must define exactly one effective keys field`,
 		},
 		{
-			name: "keys function with args",
+			name: "keys function unsupported",
 			typeDef: collectionTypeWithMembers(t, false, true, func(def *TypeDef) *TypeDef {
 				keysFn := NewFunction("Keys", (&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString))).
 					WithArg("prefix", (&TypeDef{}).WithKind(TypeDefKindString), "", nil, "", "", nil, nil, nil)
@@ -103,7 +102,7 @@ func TestValidateCollectionTypeDefErrors(t *testing.T) {
 				require.NoError(t, err)
 				return def
 			}),
-			contains: `must not accept arguments`,
+			contains: `must define exactly one effective keys field`,
 		},
 		{
 			name: "get key type mismatch",
@@ -115,7 +114,7 @@ func TestValidateCollectionTypeDefErrors(t *testing.T) {
 				require.NoError(t, err)
 				return def
 			}),
-			contains: `must match keys member type`,
+			contains: `must match keys field type`,
 		},
 		{
 			name:     "get returns non object",

--- a/core/env.go
+++ b/core/env.go
@@ -199,7 +199,7 @@ func (env *Env) Checks(ctx context.Context, include []string) (*CheckGroup, erro
 	if env.MainModule == nil {
 		return nil, fmt.Errorf("no main module set on environment")
 	}
-	return env.MainModule.Checks(ctx, include)
+	return env.MainModule.Checks(ctx, include, nil)
 }
 
 // Check returns a single check by name from the main module

--- a/core/generators.go
+++ b/core/generators.go
@@ -55,10 +55,12 @@ func (g *Generator) Run(ctx context.Context) (*Generator, error) {
 type GeneratorGroup struct {
 	Node       *ModTreeNode `json:"node"`
 	Generators []*Generator `json:"generators"`
+	include    []string
+	exclude    []string
 }
 
-func NewGeneratorGroup(ctx context.Context, mod *Module, include []string) (*GeneratorGroup, error) {
-	rootNode, err := NewModTree(ctx, mod)
+func NewGeneratorGroup(ctx context.Context, mod *Module, include []string, filters []CollectionFilterInput) (*GeneratorGroup, error) {
+	rootNode, err := NewModTree(ctx, mod, NewCollectionFilterSet(filters))
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +78,7 @@ func NewGeneratorGroup(ctx context.Context, mod *Module, include []string) (*Gen
 	return &GeneratorGroup{
 		Node:       rootNode,
 		Generators: generators,
+		include:    append([]string(nil), include...),
 	}, nil
 }
 
@@ -143,8 +146,17 @@ func (gg *GeneratorGroup) Clone() *GeneratorGroup {
 		c.Node = gg.Node.Clone()
 	}
 	c.Generators = make([]*Generator, len(gg.Generators))
+	c.include = append([]string(nil), gg.include...)
+	c.exclude = append([]string(nil), gg.exclude...)
 	for i := range c.Generators {
 		c.Generators[i] = gg.Generators[i].Clone()
 	}
 	return &c
+}
+
+func (gg *GeneratorGroup) CollectionFilterValues(ctx context.Context, typeNames []string) ([]*CollectionFilterValues, error) {
+	if gg.Node == nil {
+		return collectionFilterValuesFromWorkspaceRoots(ctx, typeNames, gg.include, gg.exclude, workspaceGeneratorRoots(gg.Generators))
+	}
+	return gg.Node.CollectionFilterValues(ctx, typeNames, gg.include, gg.exclude)
 }

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -22,6 +22,165 @@ func TestClientGenerator(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(ClientGeneratorTest{})
 }
 
+func (ClientGeneratorTest) TestCollections(ctx context.Context, t *testctx.T) {
+	type testCase struct {
+		baseImage string
+		generator string
+		callCmd   []string
+		setup     dagger.WithContainerFunc
+		postSetup dagger.WithContainerFunc
+	}
+
+	testCases := []testCase{
+		{
+			baseImage: golangImage,
+			generator: "go",
+			callCmd:   []string{"go", "run", "main.go"},
+			setup: func(ctr *dagger.Container) *dagger.Container {
+				return ctr.
+					With(daggerExec("init", "--name=test", "--sdk=go", "--source=.dagger")).
+					WithNewFile(".dagger/main.go", goCollectionModuleSource).
+					With(withGoSetup(`package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"test.com/test/dagger"
+)
+
+type result struct {
+	Keys   []string ` + "`json:\"keys\"`" + `
+	List   []string ` + "`json:\"list\"`" + `
+	Subset []string ` + "`json:\"subset\"`" + `
+	Batch  string   ` + "`json:\"batch\"`" + `
+	Get    string   ` + "`json:\"get\"`" + `
+}
+
+func main() {
+	ctx := context.Background()
+
+	dag, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	tests := dag.Test().Tests()
+
+	keys, err := tests.Keys(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	list, err := tests.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	names := make([]string, 0, len(list))
+	for i := range list {
+		name, err := list[i].Name(ctx)
+		if err != nil {
+			panic(err)
+		}
+		names = append(names, name)
+	}
+
+	subset := tests.Subset([]string{"integration", "unit"})
+	subsetKeys, err := subset.Keys(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	batch, err := subset.Batch().Names(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	get, err := tests.Get("lint").Name(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(result{
+		Keys:   keys,
+		List:   names,
+		Subset: subsetKeys,
+		Batch:  batch,
+		Get:    get,
+	}); err != nil {
+		panic(err)
+	}
+}`))
+			},
+			postSetup: addSDKReplaceToClient(defaultGenDir),
+		},
+		{
+			baseImage: nodeImage,
+			generator: "typescript",
+			callCmd:   []string{"tsx", "index.ts"},
+			setup: func(ctr *dagger.Container) *dagger.Container {
+				return ctr.
+					With(daggerExec("init", "--name=test", "--sdk=go", "--source=.dagger")).
+					WithNewFile(".dagger/main.go", goCollectionModuleSource).
+					With(withTypeScriptSetup(`import { connection, dag } from "@my-app/dagger"
+
+async function main() {
+  await connection(async () => {
+    const tests = dag.test().tests()
+    const keys = await tests.keys()
+    const list = await Promise.all((await tests.list()).map((test) => test.name()))
+    const subset = tests.subset(["integration", "unit"])
+    const subsetKeys = await subset.keys()
+    const batch = await subset.batch().names()
+    const get = await tests.get("lint").name()
+
+    console.log(JSON.stringify({ keys, list, subset: subsetKeys, batch, get }))
+  })
+}
+
+main()
+`, defaultGenDir))
+			},
+			postSetup: func(ctr *dagger.Container) *dagger.Container {
+				return ctr.WithExec([]string{"npm", "install"})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.generator, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+
+			moduleSrc := c.Container().From(tc.baseImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+				With(nonNestedDevEngine(c)).
+				With(tc.setup).
+				With(daggerClientInstall(tc.generator))
+
+			if tc.generator == "go" {
+				moduleSrc = moduleSrc.WithDirectory(filepath.Join(defaultGenDir, "sdk"), c.Host().Directory("../../sdk/go"))
+			}
+
+			moduleSrc = moduleSrc.With(tc.postSetup)
+
+			t.Run(fmt.Sprintf("dagger run %s", strings.Join(tc.callCmd, " ")), func(ctx context.Context, t *testctx.T) {
+				out, err := moduleSrc.With(daggerNonNestedRun(tc.callCmd...)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, collectionClientOutput, out)
+			})
+
+			t.Run(strings.Join(tc.callCmd, " "), func(ctx context.Context, t *testctx.T) {
+				out, err := moduleSrc.WithExec(tc.callCmd).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, collectionClientOutput, out)
+			})
+		})
+	}
+}
+
 func (ClientGeneratorTest) TestGenerateAndCallDependencies(ctx context.Context, t *testctx.T) {
 	t.Run("no dependency", func(ctx context.Context, t *testctx.T) {
 		type testCase struct {

--- a/core/integration/collections_test.go
+++ b/core/integration/collections_test.go
@@ -1,0 +1,37 @@
+package core
+
+const goCollectionModuleSource = `package main
+
+import "strings"
+
+type Test struct{}
+
+func (m *Test) Tests() *GoTests {
+	return &GoTests{
+		Keys: []string{"unit", "lint", "integration"},
+	}
+}
+
+type GoTest struct {
+	Name string ` + "`json:\"name\"`" + `
+}
+
+// +collection
+type GoTests struct {
+	// +keys
+	Keys []string ` + "`json:\"keys\"`" + `
+}
+
+func (tests *GoTests) Get(name string) *GoTest {
+	return &GoTest{Name: name}
+}
+
+func (tests *GoTests) Names() string {
+	return strings.Join(tests.Keys, ",")
+}
+`
+
+const collectionKeysOutput = "unit\nlint\nintegration\n"
+const collectionSubsetKeysOutput = "unit\nintegration\n"
+const collectionBatchOutput = "unit,integration"
+const collectionClientOutput = "{\"keys\":[\"unit\",\"lint\",\"integration\"],\"list\":[\"unit\",\"lint\",\"integration\"],\"subset\":[\"unit\",\"integration\"],\"batch\":\"unit,integration\",\"get\":\"lint\"}\n"

--- a/core/integration/collections_test.go
+++ b/core/integration/collections_test.go
@@ -13,7 +13,11 @@ func (m *Test) Tests() *GoTests {
 }
 
 type GoTest struct {
-	Name string ` + "`json:\"name\"`" + `
+	Label string ` + "`json:\"label\"`" + `
+}
+
+func (test *GoTest) Name() string {
+	return test.Label
 }
 
 // +collection
@@ -23,7 +27,7 @@ type GoTests struct {
 }
 
 func (tests *GoTests) Get(name string) *GoTest {
-	return &GoTest{Name: name}
+	return &GoTest{Label: name}
 }
 
 func (tests *GoTests) Names() string {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -126,6 +126,63 @@ func (CallSuite) TestCollections(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (CallSuite) TestGoToolchainCollections(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	thisRepoPath, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	repo := c.Host().Directory(thisRepoPath, dagger.HostDirectoryOpts{
+		Include: []string{
+			"toolchains/go",
+			"modules/alpine",
+			"modules/wolfi",
+			"util/parallel",
+			"go.mod",
+			"go.sum",
+		},
+	})
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		WithDirectory(".", repo)
+
+	t.Run("keys", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "keys"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "./toolchains/go\n", out)
+	})
+
+	t.Run("get", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "get", "--path=./toolchains/go", "path"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "./toolchains/go\n", out)
+	})
+
+	t.Run("subset", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "subset", "--keys=./toolchains/go", "keys"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "./toolchains/go\n", out)
+	})
+
+	t.Run("batch help", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "batch", "--help"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "check-tidy")
+		require.Contains(t, out, "lint")
+		require.Contains(t, out, "tidy")
+	})
+}
+
 func (CallSuite) TestArgTypes(ctx context.Context, t *testctx.T) {
 	t.Run("service args", func(ctx context.Context, t *testctx.T) {
 		t.Run("used as service binding", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -150,7 +150,7 @@ func (CallSuite) TestGoToolchainCollections(ctx context.Context, t *testctx.T) {
 
 	t.Run("keys", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(
-			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "keys"),
+			daggerCallAt("./toolchains/go", "modules", "--include=./toolchains/go", "keys"),
 		).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "./toolchains/go\n", out)
@@ -158,7 +158,7 @@ func (CallSuite) TestGoToolchainCollections(ctx context.Context, t *testctx.T) {
 
 	t.Run("get", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(
-			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "get", "--path=./toolchains/go", "path"),
+			daggerCallAt("./toolchains/go", "modules", "--include=./toolchains/go", "get", "--path=./toolchains/go", "path"),
 		).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "./toolchains/go\n", out)
@@ -166,7 +166,7 @@ func (CallSuite) TestGoToolchainCollections(ctx context.Context, t *testctx.T) {
 
 	t.Run("subset", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(
-			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "subset", "--keys=./toolchains/go", "keys"),
+			daggerCallAt("./toolchains/go", "modules", "--include=./toolchains/go", "subset", "--keys=./toolchains/go", "keys"),
 		).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "./toolchains/go\n", out)
@@ -174,12 +174,20 @@ func (CallSuite) TestGoToolchainCollections(ctx context.Context, t *testctx.T) {
 
 	t.Run("batch help", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(
-			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "batch", "--help"),
+			daggerCallAt("./toolchains/go", "modules", "--include=./toolchains/go", "batch", "--help"),
 		).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "check-tidy")
 		require.Contains(t, out, "lint")
 		require.Contains(t, out, "tidy")
+	})
+
+	t.Run("explicit source override", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCallAt("./toolchains/go", "--source=.", "modules", "--include=./toolchains/go", "keys"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "./toolchains/go\n", out)
 	})
 }
 

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -85,6 +85,47 @@ func (m *Test) Conflict(ctx context.Context, mod *dagger.Module) (string, error)
 	})
 }
 
+func (CallSuite) TestCollections(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen := modInit(t, c, "go", goCollectionModuleSource)
+
+	t.Run("keys", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("tests", "keys")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, collectionKeysOutput, out)
+	})
+
+	t.Run("list", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("tests", "list", "name")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, collectionKeysOutput, out)
+	})
+
+	t.Run("subset preserves parent order", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCall("tests", "subset", "--keys", "integration", "--keys", "unit", "keys"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, collectionSubsetKeysOutput, out)
+	})
+
+	t.Run("batch reads the current subset", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(
+			daggerCall("tests", "subset", "--keys", "integration", "--keys", "unit", "batch", "names"),
+		).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, collectionBatchOutput, out)
+	})
+
+	t.Run("get rejects keys outside the current subset", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.With(
+			daggerCall("tests", "subset", "--keys", "integration", "--keys", "unit", "get", "--name", "lint", "name"),
+		).Sync(ctx)
+		requireErrOut(t, err, `does not contain key "lint" in the current subset`)
+	})
+}
+
 func (CallSuite) TestArgTypes(ctx context.Context, t *testctx.T) {
 	t.Run("service args", func(ctx context.Context, t *testctx.T) {
 		t.Run("used as service binding", func(ctx context.Context, t *testctx.T) {

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -913,7 +913,6 @@ func (node *ModTreeNode) collectionItemResolver(ctx context.Context, name string
 		}
 
 		results := make([]dagql.AnyResult, 0)
-		nextID := 1
 		for _, collectionValue := range collectionValues {
 			collectionObj, ok := dagql.UnwrapAs[*ModuleObject](collectionValue)
 			if !ok {
@@ -936,11 +935,11 @@ func (node *ModTreeNode) collectionItemResolver(ctx context.Context, name string
 				if err != nil {
 					return nil, err
 				}
-				itemCtx := ctx
-				if curID := dagql.CurrentID(ctx); curID != nil {
-					itemCtx = dagql.ContextWithID(ctx, curID.SelectNth(nextID))
+				itemID, err := collectionObj.collectionGetID(parentResult, keyInput)
+				if err != nil {
+					return nil, err
 				}
-				nextID++
+				itemCtx := dagql.ContextWithID(ctx, itemID)
 				itemValue, err := collectionObj.callCollectionGet(itemCtx, parentResult, getModFun, node.DagqlServer, keyInput)
 				if err != nil {
 					return nil, err

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -33,6 +33,8 @@ type ModTreeNode struct {
 	Type           *TypeDef
 	IsCheck        bool
 	IsGenerator    bool
+	resolveValues  func(context.Context) ([]dagql.AnyResult, error)
+	filterSet      CollectionFilterSet
 }
 
 func (node *ModTreeNode) Path() ModTreePath {
@@ -45,7 +47,7 @@ func (node *ModTreeNode) Path() ModTreePath {
 	return path
 }
 
-func NewModTree(ctx context.Context, mod *Module) (*ModTreeNode, error) {
+func NewModTree(ctx context.Context, mod *Module, filterSet CollectionFilterSet) (*ModTreeNode, error) {
 	mainObj, ok := mod.MainObject()
 	if !ok {
 		return nil, fmt.Errorf("%q: no main object", mod.Name())
@@ -58,6 +60,7 @@ func NewModTree(ctx context.Context, mod *Module) (*ModTreeNode, error) {
 		DagqlServer:    srv,
 		Module:         mod,
 		OriginalModule: mod,
+		filterSet:      filterSet.Clone(),
 		Type: &TypeDef{
 			Kind:     TypeDefKindObject,
 			AsObject: dagql.NonNull(mainObj),
@@ -139,30 +142,43 @@ func (node *ModTreeNode) RunCheck(ctx context.Context, include, exclude []string
 }
 
 func (node *ModTreeNode) runCheckLocally(ctx context.Context) error {
-	var status dagql.AnyResult
-	if err := node.DagqlValue(ctx, &status); err != nil {
+	values, err := node.ResolveValues(ctx)
+	if err != nil {
 		return err
 	}
-	if obj, ok := dagql.UnwrapAs[dagql.AnyObjectResult](status); ok {
-		// If the check returns a syncable type, sync it
-		srv := node.DagqlServer
-		if syncField, has := obj.ObjectType().FieldSpec("sync", srv.View); has {
-			if !syncField.Args.HasRequired(srv.View) {
-				if err := srv.Select(
-					dagql.WithNonInternalTelemetry(ctx),
-					obj,
-					&status,
-					dagql.Selector{Field: "sync"},
-				); err != nil {
-					return err
-				}
-			}
+	for _, status := range values {
+		if status == nil {
+			continue
+		}
+		if err := node.syncCheckResult(ctx, status); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
+func (node *ModTreeNode) syncCheckResult(ctx context.Context, status dagql.AnyResult) error {
+	obj, ok := dagql.UnwrapAs[dagql.AnyObjectResult](status)
+	if !ok {
+		return nil
+	}
+	srv := node.DagqlServer
+	syncField, has := obj.ObjectType().FieldSpec("sync", srv.View)
+	if !has || syncField.Args.HasRequired(srv.View) {
+		return nil
+	}
+	return srv.Select(
+		dagql.WithNonInternalTelemetry(ctx),
+		obj,
+		&status,
+		dagql.Selector{Field: "sync"},
+	)
+}
+
 func (node *ModTreeNode) tryRunCheckScaleOut(ctx context.Context) (_ bool, rerr error) {
+	if node.filterSet.HasAny() {
+		return false, nil
+	}
 	q, err := CurrentQuery(ctx)
 	if err != nil {
 		return true, err
@@ -247,14 +263,39 @@ func (node *ModTreeNode) RunGenerator(ctx context.Context, include, exclude []st
 }
 
 func (node *ModTreeNode) runGeneratorLocally(ctx context.Context) (*Changeset, error) {
-	var changes dagql.ObjectResult[*Changeset]
-	if err := node.DagqlValue(ctx, &changes); err != nil {
+	values, err := node.ResolveValues(ctx)
+	if err != nil {
 		return nil, err
 	}
-	return changes.Self(), nil
+
+	if len(values) == 0 {
+		return NewEmptyChangeset(ctx)
+	}
+
+	changesets := make([]*Changeset, 0, len(values))
+	for _, value := range values {
+		changes, ok := dagql.UnwrapAs[dagql.ObjectResult[*Changeset]](value)
+		if !ok {
+			return nil, fmt.Errorf("expected generator result to be Changeset, got %T", value)
+		}
+		changesets = append(changesets, changes.Self())
+	}
+
+	if len(changesets) == 1 {
+		return changesets[0], nil
+	}
+
+	res, err := NewEmptyChangeset(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return res.WithChangesets(ctx, changesets, FailEarlyOnConflicts)
 }
 
 func (node *ModTreeNode) tryRunGeneratorScaleOut(ctx context.Context) (_ bool, _ *Changeset, rerr error) {
+	if node.filterSet.HasAny() {
+		return false, nil, nil
+	}
 	q, err := CurrentQuery(ctx)
 	if err != nil {
 		return true, nil, err
@@ -375,6 +416,17 @@ func (node *ModTreeNode) Clone() *ModTreeNode {
 	return &cp
 }
 
+func (node *ModTreeNode) ResolveValues(ctx context.Context) ([]dagql.AnyResult, error) {
+	if node.resolveValues != nil {
+		return node.resolveValues(ctx)
+	}
+	var value dagql.AnyResult
+	if err := node.DagqlValue(ctx, &value); err != nil {
+		return nil, err
+	}
+	return []dagql.AnyResult{value}, nil
+}
+
 func (node *ModTreeNode) DagqlValue(ctx context.Context, dest any) error {
 	// We can't direct-select the dagql path, because Select() doesn't support traversing
 	// lists
@@ -451,6 +503,102 @@ func (node *ModTreeNode) RollupGenerator(ctx context.Context, include []string, 
 	return node.RollupNodes(ctx, func(n *ModTreeNode) bool {
 		return n.IsGenerator
 	}, include, exclude)
+}
+
+func (node *ModTreeNode) CollectionFilterValues(ctx context.Context, typeNames []string, include []string, exclude []string) ([]*CollectionFilterValues, error) {
+	orderedTypeNames := make([]string, 0, len(typeNames))
+	seenTypes := make(map[string]string, len(typeNames))
+	for _, typeName := range typeNames {
+		key := gqlObjectName(typeName)
+		if _, ok := seenTypes[key]; ok {
+			continue
+		}
+		seenTypes[key] = typeName
+		orderedTypeNames = append(orderedTypeNames, key)
+	}
+
+	valuesByType := make(map[string][]string, len(orderedTypeNames))
+	seenValuesByType := make(map[string]map[string]struct{}, len(orderedTypeNames))
+	for _, typeName := range orderedTypeNames {
+		seenValuesByType[typeName] = map[string]struct{}{}
+	}
+
+	err := node.Walk(ctx, func(ctx context.Context, n *ModTreeNode) (bool, error) {
+		if !n.Type.AsCollection.Valid {
+			return true, nil
+		}
+		if len(orderedTypeNames) > 0 {
+			if _, ok := seenTypes[gqlObjectName(n.Type.AsObject.Value.Name)]; !ok {
+				return true, nil
+			}
+		}
+		if len(include) > 0 {
+			match, err := n.Match(ctx, include)
+			if err != nil {
+				return false, err
+			}
+			if !match {
+				return true, nil
+			}
+		}
+		if len(exclude) > 0 {
+			match, err := n.Match(ctx, exclude)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				return true, nil
+			}
+		}
+
+		values, err := n.ResolveValues(ctx)
+		if err != nil {
+			return false, err
+		}
+
+		typeKey := gqlObjectName(n.Type.AsObject.Value.Name)
+		if _, ok := seenValuesByType[typeKey]; !ok {
+			seenValuesByType[typeKey] = map[string]struct{}{}
+			if _, ok := seenTypes[typeKey]; !ok {
+				seenTypes[typeKey] = n.Type.AsObject.Value.Name
+				orderedTypeNames = append(orderedTypeNames, typeKey)
+			}
+		}
+		for _, value := range values {
+			collectionObj, ok := dagql.UnwrapAs[*ModuleObject](value)
+			if !ok {
+				return false, fmt.Errorf("expected collection node %q to resolve to ModuleObject, got %T", n.PathString(), value)
+			}
+			keys, err := n.filteredCollectionKeys(collectionObj, true)
+			if err != nil {
+				return false, err
+			}
+			for _, key := range keys {
+				keyValue, err := normalizeCollectionFilterValue(collectionObj.Collection.KeyType, key)
+				if err != nil {
+					return false, err
+				}
+				if _, ok := seenValuesByType[typeKey][keyValue]; ok {
+					continue
+				}
+				seenValuesByType[typeKey][keyValue] = struct{}{}
+				valuesByType[typeKey] = append(valuesByType[typeKey], keyValue)
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*CollectionFilterValues, 0, len(orderedTypeNames))
+	for _, typeKey := range orderedTypeNames {
+		result = append(result, &CollectionFilterValues{
+			TypeName: seenTypes[typeKey],
+			Values:   valuesByType[typeKey],
+		})
+	}
+	return result, nil
 }
 
 type ModTreePath []string
@@ -566,64 +714,305 @@ func (node *ModTreeNode) Walk(ctx context.Context, fn WalkFunc) error {
 }
 
 func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
-	var children []*ModTreeNode
-	if objType := node.ObjectType(); objType != nil {
-		nodeType := objType.Name
-		for _, fn := range objType.Functions {
+	objType := node.ObjectType()
+	if objType == nil {
+		return nil, nil
+	}
+	if node.Type.AsCollection.Valid {
+		return node.collectionChildren(ctx)
+	}
+	return node.objectChildren(ctx, objType)
+}
+
+func (node *ModTreeNode) objectChildren(ctx context.Context, objType *ObjectTypeDef) ([]*ModTreeNode, error) {
+	children := make([]*ModTreeNode, 0, len(objType.Functions)+len(objType.Fields))
+	nodeType := objType.Name
+
+	for _, fn := range objType.Functions {
+		if functionRequiresArgs(fn) {
+			continue
+		}
+		childType, description, isLeaf := node.memberObjectType(node.OriginalModule, nodeType, fn.ReturnType, fn.Description)
+		children = append(children, node.newChildNode(
+			fn.Name,
+			description,
+			childType,
+			fn.IsCheck && isLeaf,
+			fn.IsGenerator && isLeaf,
+			node.OriginalModule,
+			node.memberResolver(fn.Name),
+		))
+	}
+
+	for _, field := range objType.Fields {
+		childType, description, _ := node.memberObjectType(node.OriginalModule, nodeType, field.TypeDef, field.Description)
+		children = append(children, node.newChildNode(
+			field.Name,
+			description,
+			childType,
+			false,
+			false,
+			node.OriginalModule,
+			node.memberResolver(field.Name),
+		))
+	}
+
+	return children, nil
+}
+
+func (node *ModTreeNode) collectionChildren(ctx context.Context) ([]*ModTreeNode, error) {
+	rawCollectionType := &TypeDef{
+		Kind:         TypeDefKindObject,
+		AsObject:     dagql.NonNull(node.ObjectType()),
+		AsCollection: dagql.NonNull(node.Type.AsCollection.Value),
+	}
+	collection := node.Type.AsCollection.Value
+	childrenByName := map[string]*ModTreeNode{}
+
+	valueObj := collection.ValueType.AsObject.Value
+	if fullValueObj, ok := node.OriginalModule.ObjectByName(valueObj.Name); ok {
+		valueObj = fullValueObj
+	}
+	for _, fn := range valueObj.Functions {
+		if functionRequiresArgs(fn) {
+			continue
+		}
+		childType, description, isLeaf := node.memberObjectType(node.OriginalModule, valueObj.Name, fn.ReturnType, fn.Description)
+		childrenByName[fn.Name] = node.newChildNode(
+			fn.Name,
+			description,
+			childType,
+			fn.IsCheck && isLeaf,
+			fn.IsGenerator && isLeaf,
+			node.OriginalModule,
+			node.collectionItemResolver(ctx, fn.Name),
+		)
+	}
+	for _, field := range valueObj.Fields {
+		childType, description, _ := node.memberObjectType(node.OriginalModule, valueObj.Name, field.TypeDef, field.Description)
+		childrenByName[field.Name] = node.newChildNode(
+			field.Name,
+			description,
+			childType,
+			false,
+			false,
+			node.OriginalModule,
+			node.collectionItemResolver(ctx, field.Name),
+		)
+	}
+
+	projector := newCollectionProjector(node.Module)
+	if batchTypeDef := projector.projectCollectionBatchTypeDef(rawCollectionType); batchTypeDef != nil {
+		for _, fn := range batchTypeDef.AsObject.Value.Functions {
 			if functionRequiresArgs(fn) {
 				continue
 			}
-			returnType := fn.ReturnType.ToType().Name()
-			objectAdded := false
-			// if the type returned by the function is an object, check the children of the return type
-			if returnsObject := fn.ReturnType.AsObject.Valid; returnsObject &&
-				// avoid cycles (X.withFoo: X)
-				returnType != nodeType {
-				// search for the object defined by the return type, in the "originalModule" that can be the toolchain one
-				if subObj, ok := node.OriginalModule.ObjectByName(fn.ReturnType.ToType().Name()); ok {
-					objectAdded = true
-					children = append(children, &ModTreeNode{
-						Parent:         node,
-						Name:           fn.Name, // use the name of the function and not the name of the type as we want the chain
-						DagqlServer:    node.DagqlServer,
-						Module:         node.Module,
-						OriginalModule: node.OriginalModule,
-						Type:           &TypeDef{AsObject: dagql.NonNull(subObj)},
-						IsCheck:        false,
-						IsGenerator:    false,
-						Description:    subObj.Description,
-					})
-				}
-			}
-			if !objectAdded {
-				children = append(children, &ModTreeNode{
-					Parent:         node,
-					Name:           fn.Name,
-					DagqlServer:    node.DagqlServer,
-					Module:         node.Module,
-					OriginalModule: node.OriginalModule,
-					Type:           fn.ReturnType,
-					IsCheck:        fn.IsCheck,
-					IsGenerator:    fn.IsGenerator,
-					Description:    fn.Description,
-				})
-			}
-		}
-		for _, field := range objType.Fields {
-			children = append(children, &ModTreeNode{
-				Parent:         node,
-				Name:           field.Name,
-				DagqlServer:    node.DagqlServer,
-				Module:         node.Module,
-				OriginalModule: node.OriginalModule,
-				Type:           field.TypeDef,
-				IsCheck:        false,
-				IsGenerator:    false,
-				Description:    field.Description,
-			})
+			childType, description, isLeaf := node.memberObjectType(node.OriginalModule, batchTypeDef.AsObject.Value.Name, fn.ReturnType, fn.Description)
+			childrenByName[fn.Name] = node.newChildNode(
+				fn.Name,
+				description,
+				childType,
+				fn.IsCheck && isLeaf,
+				fn.IsGenerator && isLeaf,
+				node.OriginalModule,
+				node.collectionBatchResolver(fn.Name),
+			)
 		}
 	}
+
+	children := make([]*ModTreeNode, 0, len(childrenByName))
+	for _, child := range childrenByName {
+		children = append(children, child)
+	}
+	slices.SortFunc(children, func(a, b *ModTreeNode) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return children, nil
+}
+
+func (node *ModTreeNode) newChildNode(
+	name string,
+	description string,
+	typeDef *TypeDef,
+	isCheck bool,
+	isGenerator bool,
+	originalModule *Module,
+	resolve func(context.Context) ([]dagql.AnyResult, error),
+) *ModTreeNode {
+	return &ModTreeNode{
+		Parent:         node,
+		Name:           name,
+		Description:    description,
+		DagqlServer:    node.DagqlServer,
+		Module:         node.Module,
+		OriginalModule: originalModule,
+		Type:           typeDef,
+		IsCheck:        isCheck,
+		IsGenerator:    isGenerator,
+		resolveValues:  resolve,
+		filterSet:      node.filterSet,
+	}
+}
+
+func (node *ModTreeNode) memberObjectType(originalModule *Module, nodeType string, returnType *TypeDef, description string) (*TypeDef, string, bool) {
+	if returnType.AsObject.Valid && returnType.ToType().Name() != nodeType {
+		if subObj, ok := originalModule.ObjectByName(returnType.ToType().Name()); ok {
+			return &TypeDef{Kind: TypeDefKindObject, AsObject: dagql.NonNull(subObj)}, subObj.Description, false
+		}
+	}
+	return returnType, description, true
+}
+
+func (node *ModTreeNode) memberResolver(name string) func(context.Context) ([]dagql.AnyResult, error) {
+	return func(ctx context.Context) ([]dagql.AnyResult, error) {
+		parentValues, err := node.ResolveValues(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return node.selectMemberValues(ctx, parentValues, name)
+	}
+}
+
+func (node *ModTreeNode) collectionBatchResolver(name string) func(context.Context) ([]dagql.AnyResult, error) {
+	return func(ctx context.Context) ([]dagql.AnyResult, error) {
+		collectionValues, err := node.ResolveValues(ctx)
+		if err != nil {
+			return nil, err
+		}
+		batchValues, err := node.selectMemberValues(ctx, collectionValues, collectionBatchFieldName)
+		if err != nil {
+			return nil, err
+		}
+		return node.selectMemberValues(ctx, batchValues, name)
+	}
+}
+
+func (node *ModTreeNode) collectionItemResolver(ctx context.Context, name string) func(context.Context) ([]dagql.AnyResult, error) {
+	getFn, ok := node.ObjectType().FunctionByName(node.Type.AsCollection.Value.GetFunctionName)
+	if !ok {
+		return func(context.Context) ([]dagql.AnyResult, error) {
+			return nil, fmt.Errorf("collection get function %q not found on %q", node.Type.AsCollection.Value.GetFunctionName, node.ObjectType().Name)
+		}
+	}
+	getModFun, err := NewModFunction(ctx, node.Module, node.ObjectType(), getFn)
+	if err != nil {
+		return func(context.Context) ([]dagql.AnyResult, error) {
+			return nil, fmt.Errorf("failed to create collection get function %q: %w", getFn.Name, err)
+		}
+	}
+	if err := getModFun.mergeUserDefaultsTypeDefs(ctx); err != nil {
+		return func(context.Context) ([]dagql.AnyResult, error) {
+			return nil, fmt.Errorf("failed to merge user defaults for %q: %w", getFn.Name, err)
+		}
+	}
+
+	return func(ctx context.Context) ([]dagql.AnyResult, error) {
+		collectionValues, err := node.ResolveValues(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]dagql.AnyResult, 0)
+		nextID := 1
+		for _, collectionValue := range collectionValues {
+			collectionObj, ok := dagql.UnwrapAs[*ModuleObject](collectionValue)
+			if !ok {
+				return nil, fmt.Errorf("expected collection node %q to resolve to ModuleObject, got %T", node.PathString(), collectionValue)
+			}
+			keys, err := node.filteredCollectionKeys(collectionObj, false)
+			if err != nil {
+				return nil, err
+			}
+			parentResult, ok := dagql.UnwrapAs[dagql.AnyResult](collectionValue)
+			if !ok {
+				parentCtx := dagql.ContextWithID(ctx, collectionValue.ID())
+				parentResult, err = dagql.NewResultForCurrentID(parentCtx, collectionObj)
+				if err != nil {
+					return nil, err
+				}
+			}
+			for _, key := range keys {
+				keyInput, err := collectionObj.collectionKeyInput(key)
+				if err != nil {
+					return nil, err
+				}
+				itemCtx := ctx
+				if curID := dagql.CurrentID(ctx); curID != nil {
+					itemCtx = dagql.ContextWithID(ctx, curID.SelectNth(nextID))
+				}
+				nextID++
+				itemValue, err := collectionObj.callCollectionGet(itemCtx, parentResult, getModFun, node.DagqlServer, keyInput)
+				if err != nil {
+					return nil, err
+				}
+				childValue, err := node.selectMemberValue(ctx, itemValue, name)
+				if err != nil {
+					return nil, err
+				}
+				results = append(results, childValue)
+			}
+		}
+		return results, nil
+	}
+}
+
+func (node *ModTreeNode) selectMemberValues(ctx context.Context, parents []dagql.AnyResult, name string) ([]dagql.AnyResult, error) {
+	values := make([]dagql.AnyResult, 0, len(parents))
+	for _, parent := range parents {
+		child, err := node.selectMemberValue(ctx, parent, name)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, child)
+	}
+	return values, nil
+}
+
+func (node *ModTreeNode) selectMemberValue(ctx context.Context, parent dagql.AnyResult, name string) (dagql.AnyResult, error) {
+	parentObj, ok := dagql.UnwrapAs[dagql.AnyObjectResult](parent)
+	if !ok {
+		return nil, fmt.Errorf("node %q parent is not an object: %T", node.PathString(), parent)
+	}
+	var child dagql.AnyResult
+	if err := node.DagqlServer.Select(dagql.WithNonInternalTelemetry(ctx), parentObj, &child, dagql.Selector{Field: name}); err != nil {
+		return nil, err
+	}
+	return child, nil
+}
+
+func (node *ModTreeNode) filteredCollectionKeys(collectionObj *ModuleObject, ignoreSelf bool) ([]any, error) {
+	currentKeys, err := collectionObj.collectionKeys()
+	if err != nil {
+		return nil, err
+	}
+	filterValues, ok := node.filterSet.ValuesFor(collectionObj.TypeDef.Name)
+	if !ok || ignoreSelf {
+		return currentKeys, nil
+	}
+
+	selected := make(map[string]struct{}, len(filterValues))
+	for _, filterValue := range filterValues {
+		keyID, err := normalizeCollectionFilterValue(collectionObj.Collection.KeyType, filterValue)
+		if err != nil {
+			return nil, err
+		}
+		selected[keyID] = struct{}{}
+	}
+	if len(selected) == 0 {
+		return []any{}, nil
+	}
+
+	filtered := make([]any, 0, len(currentKeys))
+	for _, key := range currentKeys {
+		keyID, err := normalizeCollectionFilterValue(collectionObj.Collection.KeyType, key)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := selected[keyID]; ok {
+			filtered = append(filtered, key)
+		}
+	}
+	return filtered, nil
 }
 
 func (node *ModTreeNode) ChildrenNames(ctx context.Context) ([]string, error) {

--- a/core/modtree_collection_test.go
+++ b/core/modtree_collection_test.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModTreeCollectionCheckShadowing(t *testing.T) {
+	ctx := context.Background()
+
+	mod, rootType, collectionType := testCollectionModule(t)
+	root := &ModTreeNode{
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           rootType,
+		filterSet:      NewCollectionFilterSet(nil),
+	}
+
+	collectionNode := &ModTreeNode{
+		Parent:         root,
+		Name:           "tests",
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           collectionType,
+		filterSet:      NewCollectionFilterSet(nil),
+	}
+
+	children, err := collectionNode.Children(ctx)
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+	require.Equal(t, []string{"lint", "runTest"}, []string{children[0].Name, children[1].Name})
+	require.True(t, children[0].IsCheck)
+	require.True(t, children[1].IsCheck)
+
+	checks, err := root.RollupChecks(ctx, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, checks, 2)
+	require.Equal(t, "tests:lint", checks[0].PathString())
+	require.Equal(t, "tests:run-test", checks[1].PathString())
+}
+
+func TestCollectionFilterValuesIgnoreSelfFilter(t *testing.T) {
+	ctx := context.Background()
+
+	mod, _, collectionType := testCollectionModule(t)
+	collectionObj := &ModuleObject{
+		Module:     mod,
+		TypeDef:    collectionType.AsObject.Value,
+		Collection: collectionType.AsCollection.Value,
+		Fields: map[string]any{
+			"names": []string{"TestFoo", "TestBar"},
+		},
+	}
+
+	root := &ModTreeNode{
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           collectionType,
+		filterSet: NewCollectionFilterSet([]CollectionFilterInput{{
+			CollectionType: "GoTests",
+			Values:         []string{"TestFoo"},
+		}}),
+		resolveValues: func(context.Context) ([]dagql.AnyResult, error) {
+			result, err := dagql.NewResultForCurrentID(context.Background(), collectionObj)
+			if err != nil {
+				return nil, err
+			}
+			return []dagql.AnyResult{result}, nil
+		},
+	}
+
+	values, err := root.CollectionFilterValues(ctx, []string{"GoTests"}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	require.Equal(t, "GoTests", values[0].TypeName)
+	require.Equal(t, []string{"TestFoo", "TestBar"}, values[0].Values)
+}
+
+func TestFilteredCollectionKeysIntersectRequestedValues(t *testing.T) {
+	mod, _, collectionType := testCollectionModule(t)
+	collectionObj := &ModuleObject{
+		Module:     mod,
+		TypeDef:    collectionType.AsObject.Value,
+		Collection: collectionType.AsCollection.Value,
+		Fields: map[string]any{
+			"names": []string{"TestFoo", "TestBar"},
+		},
+	}
+
+	node := &ModTreeNode{
+		Type: collectionType,
+		filterSet: NewCollectionFilterSet([]CollectionFilterInput{{
+			CollectionType: "GoTests",
+			Values:         []string{"TestBar", "Missing"},
+		}}),
+	}
+
+	keys, err := node.filteredCollectionKeys(collectionObj, false)
+	require.NoError(t, err)
+	require.Equal(t, []any{"TestBar"}, keys)
+}
+
+func testCollectionModule(t *testing.T) (*Module, *TypeDef, *TypeDef) {
+	t.Helper()
+
+	mod := &Module{
+		NameField:    "go",
+		OriginalName: "Go",
+		Deps:         NewSchemaBuilder(nil, nil),
+	}
+
+	itemType := (&TypeDef{}).WithObject("GoTest", "", nil, nil)
+	var err error
+	itemType, err = itemType.WithFunction(NewFunction("RunTest", (&TypeDef{}).WithKind(TypeDefKindString)).WithCheck())
+	require.NoError(t, err)
+	itemType, err = itemType.WithFunction(NewFunction("Lint", (&TypeDef{}).WithKind(TypeDefKindString)).WithCheck())
+	require.NoError(t, err)
+
+	collectionType := (&TypeDef{}).
+		WithObject("GoTests", "Collection of tests.", nil, nil).
+		WithCollection().
+		WithCollectionKeys("names").
+		WithCollectionGet("test")
+	collectionType, err = collectionType.WithObjectField(
+		"names",
+		(&TypeDef{}).WithListOf((&TypeDef{}).WithKind(TypeDefKindString)),
+		"Raw names field.",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	collectionType, err = collectionType.WithFunction(
+		NewFunction("Test", itemType.Clone()).
+			WithArg("name", (&TypeDef{}).WithKind(TypeDefKindString), "Test name.", nil, "", "", nil, nil, nil),
+	)
+	require.NoError(t, err)
+	collectionType, err = collectionType.WithFunction(NewFunction("RunTest", (&TypeDef{}).WithKind(TypeDefKindString)).WithCheck())
+	require.NoError(t, err)
+
+	rootType := (&TypeDef{}).WithObject("Go", "", nil, nil)
+	rootType, err = rootType.WithObjectField("tests", collectionType.Clone(), "", nil, nil)
+	require.NoError(t, err)
+
+	mod.ObjectDefs = []*TypeDef{rootType, itemType, collectionType}
+	require.NoError(t, mod.validateTypeDef(context.Background(), itemType))
+	require.NoError(t, mod.validateTypeDef(context.Background(), collectionType))
+	require.NoError(t, mod.validateTypeDef(context.Background(), rootType))
+
+	return mod, rootType, collectionType
+}

--- a/core/module.go
+++ b/core/module.go
@@ -907,7 +907,128 @@ func (mod *Module) validateObjectTypeDef(ctx context.Context, typeDef *TypeDef) 
 			}
 		}
 	}
+
+	if err := mod.validateCollectionTypeDef(typeDef); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (mod *Module) validateCollectionTypeDef(typeDef *TypeDef) error {
+	if !typeDef.AsCollection.Valid {
+		return nil
+	}
+	if typeDef.Kind != TypeDefKindObject || !typeDef.AsObject.Valid {
+		return fmt.Errorf("only object types can be marked as collections")
+	}
+
+	obj := typeDef.AsObject.Value
+	collection := typeDef.AsCollection.Value
+
+	keysMemberName := collection.KeysMemberNameOverride
+	if keysMemberName == "" {
+		keysMemberName = "keys"
+	}
+
+	keysField, hasKeysField := obj.FieldByName(keysMemberName)
+	keysFn, hasKeysFn := obj.FunctionByName(keysMemberName)
+	switch {
+	case hasKeysField && hasKeysFn:
+		return fmt.Errorf("collection object %q has multiple effective keys members named %q", obj.OriginalName, keysMemberName)
+	case !hasKeysField && !hasKeysFn:
+		return fmt.Errorf("collection object %q must define exactly one effective keys member", obj.OriginalName)
+	}
+
+	var keysTypeDef *TypeDef
+	collection.KeysFieldName = ""
+	collection.KeysFunctionName = ""
+	switch {
+	case hasKeysField:
+		keysTypeDef = keysField.TypeDef
+		collection.KeysFieldName = keysField.Name
+	case hasKeysFn:
+		if len(keysFn.Args) != 0 {
+			return fmt.Errorf("collection object %q keys member %q must not accept arguments", obj.OriginalName, keysFn.OriginalName)
+		}
+		keysTypeDef = keysFn.ReturnType
+		collection.KeysFunctionName = keysFn.Name
+	}
+
+	keyType, err := validateCollectionKeysType(obj, keysMemberName, keysTypeDef)
+	if err != nil {
+		return err
+	}
+
+	getFunctionName := collection.GetFunctionNameOverride
+	if getFunctionName == "" {
+		getFunctionName = "get"
+	}
+
+	getFn, hasGetFn := obj.FunctionByName(getFunctionName)
+	if !hasGetFn {
+		return fmt.Errorf("collection object %q must define exactly one effective get function", obj.OriginalName)
+	}
+	if len(getFn.Args) != 1 {
+		return fmt.Errorf("collection object %q get function %q must accept exactly one argument", obj.OriginalName, getFn.OriginalName)
+	}
+
+	getArg := getFn.Args[0]
+	if getArg.TypeDef.Optional {
+		return fmt.Errorf("collection object %q get function %q argument %q must be non-null", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
+	}
+	if !isValidCollectionKeyType(getArg.TypeDef) {
+		return fmt.Errorf("collection object %q get function %q argument %q must use a scalar, custom scalar, or enum key type", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
+	}
+	if !typeDefsEqual(keyType, getArg.TypeDef) {
+		return fmt.Errorf("collection object %q get function %q argument %q must match keys member type", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
+	}
+
+	if getFn.ReturnType.Optional {
+		return fmt.Errorf("collection object %q get function %q must return a non-null object", obj.OriginalName, getFn.OriginalName)
+	}
+	if getFn.ReturnType.Kind != TypeDefKindObject || !getFn.ReturnType.AsObject.Valid {
+		return fmt.Errorf("collection object %q get function %q must return an object", obj.OriginalName, getFn.OriginalName)
+	}
+
+	collection.KeyType = keyType.Clone()
+	collection.ValueType = getFn.ReturnType.Clone()
+	collection.GetFunctionName = getFn.Name
+	collection.GetArgName = getArg.Name
+
+	return nil
+}
+
+func validateCollectionKeysType(obj *ObjectTypeDef, keysMemberName string, keysTypeDef *TypeDef) (*TypeDef, error) {
+	if keysTypeDef.Optional {
+		return nil, fmt.Errorf("collection object %q keys member %q must return a non-null list", obj.OriginalName, keysMemberName)
+	}
+	if keysTypeDef.Kind != TypeDefKindList || !keysTypeDef.AsList.Valid {
+		return nil, fmt.Errorf("collection object %q keys member %q must return a list", obj.OriginalName, keysMemberName)
+	}
+
+	keyType := keysTypeDef.AsList.Value.ElementTypeDef
+	if keyType.Optional {
+		return nil, fmt.Errorf("collection object %q keys member %q must return a list of non-null keys", obj.OriginalName, keysMemberName)
+	}
+	if !isValidCollectionKeyType(keyType) {
+		return nil, fmt.Errorf("collection object %q keys member %q must use a scalar, custom scalar, or enum key type", obj.OriginalName, keysMemberName)
+	}
+
+	return keyType, nil
+}
+
+func isValidCollectionKeyType(typeDef *TypeDef) bool {
+	switch typeDef.Kind {
+	case TypeDefKindString, TypeDefKindInteger, TypeDefKindFloat, TypeDefKindBoolean, TypeDefKindScalar, TypeDefKindEnum:
+		return true
+	default:
+		return false
+	}
+}
+
+func typeDefsEqual(a, b *TypeDef) bool {
+	return a != nil && b != nil && a.IsSubtypeOf(b) && b.IsSubtypeOf(a)
 }
 
 func (mod *Module) validateInterfaceTypeDef(ctx context.Context, typeDef *TypeDef) error {
@@ -980,6 +1101,25 @@ func (mod *Module) namespaceTypeDef(ctx context.Context, modPath string, typeDef
 					return err
 				}
 				arg.SourceMap = mod.namespaceSourceMap(modPath, arg.SourceMap)
+			}
+		}
+
+		if typeDef.AsCollection.Valid {
+			collection := typeDef.AsCollection.Value
+			if collection.KeyType != nil {
+				if err := mod.namespaceTypeDef(ctx, modPath, collection.KeyType); err != nil {
+					return err
+				}
+			}
+			if collection.ValueType != nil {
+				if err := mod.namespaceTypeDef(ctx, modPath, collection.ValueType); err != nil {
+					return err
+				}
+			}
+			if collection.BatchType != nil {
+				if err := mod.namespaceTypeDef(ctx, modPath, collection.BatchType); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/core/module.go
+++ b/core/module.go
@@ -95,12 +95,12 @@ func (mod *Module) Name() string {
 	return mod.NameField
 }
 
-func (mod *Module) Checks(ctx context.Context, include []string) (*CheckGroup, error) {
-	return NewCheckGroup(ctx, mod, include)
+func (mod *Module) Checks(ctx context.Context, include []string, filters []CollectionFilterInput) (*CheckGroup, error) {
+	return NewCheckGroup(ctx, mod, include, filters)
 }
 
-func (mod *Module) Generators(ctx context.Context, include []string) (*GeneratorGroup, error) {
-	return NewGeneratorGroup(ctx, mod, include)
+func (mod *Module) Generators(ctx context.Context, include []string, filters []CollectionFilterInput) (*GeneratorGroup, error) {
+	return NewGeneratorGroup(ctx, mod, include, filters)
 }
 
 func (mod *Module) MainObject() (*ObjectTypeDef, bool) {

--- a/core/module.go
+++ b/core/module.go
@@ -926,39 +926,21 @@ func (mod *Module) validateCollectionTypeDef(typeDef *TypeDef) error {
 	obj := typeDef.AsObject.Value
 	collection := typeDef.AsCollection.Value
 
-	keysMemberName := collection.KeysMemberNameOverride
-	if keysMemberName == "" {
-		keysMemberName = "keys"
+	keysFieldName := collection.KeysFieldNameOverride
+	if keysFieldName == "" {
+		keysFieldName = "keys"
 	}
 
-	keysField, hasKeysField := obj.FieldByName(keysMemberName)
-	keysFn, hasKeysFn := obj.FunctionByName(keysMemberName)
-	switch {
-	case hasKeysField && hasKeysFn:
-		return fmt.Errorf("collection object %q has multiple effective keys members named %q", obj.OriginalName, keysMemberName)
-	case !hasKeysField && !hasKeysFn:
-		return fmt.Errorf("collection object %q must define exactly one effective keys member", obj.OriginalName)
+	keysField, hasKeysField := obj.FieldByName(keysFieldName)
+	if !hasKeysField {
+		return fmt.Errorf("collection object %q must define exactly one effective keys field", obj.OriginalName)
 	}
 
-	var keysTypeDef *TypeDef
-	collection.KeysFieldName = ""
-	collection.KeysFunctionName = ""
-	switch {
-	case hasKeysField:
-		keysTypeDef = keysField.TypeDef
-		collection.KeysFieldName = keysField.Name
-	case hasKeysFn:
-		if len(keysFn.Args) != 0 {
-			return fmt.Errorf("collection object %q keys member %q must not accept arguments", obj.OriginalName, keysFn.OriginalName)
-		}
-		keysTypeDef = keysFn.ReturnType
-		collection.KeysFunctionName = keysFn.Name
-	}
-
-	keyType, err := validateCollectionKeysType(obj, keysMemberName, keysTypeDef)
+	keyType, err := validateCollectionKeysType(obj, keysFieldName, keysField.TypeDef)
 	if err != nil {
 		return err
 	}
+	collection.KeysFieldName = keysField.Name
 
 	getFunctionName := collection.GetFunctionNameOverride
 	if getFunctionName == "" {
@@ -981,7 +963,7 @@ func (mod *Module) validateCollectionTypeDef(typeDef *TypeDef) error {
 		return fmt.Errorf("collection object %q get function %q argument %q must use a scalar, custom scalar, or enum key type", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
 	}
 	if !typeDefsEqual(keyType, getArg.TypeDef) {
-		return fmt.Errorf("collection object %q get function %q argument %q must match keys member type", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
+		return fmt.Errorf("collection object %q get function %q argument %q must match keys field type", obj.OriginalName, getFn.OriginalName, getArg.OriginalName)
 	}
 
 	if getFn.ReturnType.Optional {
@@ -999,20 +981,20 @@ func (mod *Module) validateCollectionTypeDef(typeDef *TypeDef) error {
 	return nil
 }
 
-func validateCollectionKeysType(obj *ObjectTypeDef, keysMemberName string, keysTypeDef *TypeDef) (*TypeDef, error) {
+func validateCollectionKeysType(obj *ObjectTypeDef, keysFieldName string, keysTypeDef *TypeDef) (*TypeDef, error) {
 	if keysTypeDef.Optional {
-		return nil, fmt.Errorf("collection object %q keys member %q must return a non-null list", obj.OriginalName, keysMemberName)
+		return nil, fmt.Errorf("collection object %q keys field %q must be a non-null list", obj.OriginalName, keysFieldName)
 	}
 	if keysTypeDef.Kind != TypeDefKindList || !keysTypeDef.AsList.Valid {
-		return nil, fmt.Errorf("collection object %q keys member %q must return a list", obj.OriginalName, keysMemberName)
+		return nil, fmt.Errorf("collection object %q keys field %q must be a list", obj.OriginalName, keysFieldName)
 	}
 
 	keyType := keysTypeDef.AsList.Value.ElementTypeDef
 	if keyType.Optional {
-		return nil, fmt.Errorf("collection object %q keys member %q must return a list of non-null keys", obj.OriginalName, keysMemberName)
+		return nil, fmt.Errorf("collection object %q keys field %q must be a list of non-null keys", obj.OriginalName, keysFieldName)
 	}
 	if !isValidCollectionKeyType(keyType) {
-		return nil, fmt.Errorf("collection object %q keys member %q must use a scalar, custom scalar, or enum key type", obj.OriginalName, keysMemberName)
+		return nil, fmt.Errorf("collection object %q keys field %q must use a scalar, custom scalar, or enum key type", obj.OriginalName, keysFieldName)
 	}
 
 	return keyType, nil

--- a/core/module.go
+++ b/core/module.go
@@ -571,9 +571,14 @@ func (mod *Module) Install(ctx context.Context, dag *dagql.Server, opts ...Insta
 			}
 		}
 
+		var collection *CollectionTypeDef
+		if def.AsCollection.Valid {
+			collection = def.AsCollection.Value
+		}
 		obj := &ModuleObject{
-			Module:  mod,
-			TypeDef: objDef,
+			Module:     mod,
+			TypeDef:    objDef,
+			Collection: collection,
 		}
 
 		if err := obj.Install(ctx, dag, opts...); err != nil {
@@ -614,11 +619,12 @@ func (mod *Module) TypeDefs(ctx context.Context, dag *dagql.Server) ([]*TypeDef,
 	// TODO: use dag arg to reflect dynamic updates (if/when we support that)
 
 	mainObj, _ := mod.MainObject()
+	projector := newCollectionProjector(mod)
 
 	typeDefs := make([]*TypeDef, 0, len(mod.ObjectDefs)+len(mod.InterfaceDefs)+len(mod.EnumDefs))
 
 	for _, def := range mod.ObjectDefs {
-		typeDef := def.Clone()
+		typeDef := projector.projectObjectDef(def)
 		if typeDef.AsObject.Valid {
 			typeDef.AsObject.Value.SourceModuleName = mod.Name()
 			if mainObj != nil && typeDef.AsObject.Value.OriginalName == mainObj.OriginalName {
@@ -626,10 +632,16 @@ func (mod *Module) TypeDefs(ctx context.Context, dag *dagql.Server) ([]*TypeDef,
 			}
 		}
 		typeDefs = append(typeDefs, typeDef)
+		if def.AsCollection.Valid {
+			if batchTypeDef := projector.projectCollectionBatchTypeDef(def); batchTypeDef != nil {
+				batchTypeDef.AsObject.Value.SourceModuleName = mod.Name()
+				typeDefs = append(typeDefs, batchTypeDef)
+			}
+		}
 	}
 
 	for _, def := range mod.InterfaceDefs {
-		typeDef := def.Clone()
+		typeDef := projector.projectTypeDef(def)
 		if typeDef.AsInterface.Valid {
 			typeDef.AsInterface.Value.SourceModuleName = mod.Name()
 		}
@@ -767,9 +779,14 @@ func (mod *Module) modTypeForList(ctx context.Context, typedef *TypeDef, checkDi
 func (mod *Module) modTypeForObject(typeDef *TypeDef) (ModType, bool) {
 	for _, obj := range mod.ObjectDefs {
 		if obj.AsObject.Value.Name == typeDef.AsObject.Value.Name {
+			var collection *CollectionTypeDef
+			if obj.AsCollection.Valid {
+				collection = obj.AsCollection.Value
+			}
 			return &ModuleObjectType{
-				typeDef: obj.AsObject.Value,
-				mod:     mod,
+				typeDef:    obj.AsObject.Value,
+				collection: collection,
+				mod:        mod,
 			}, true
 		}
 	}

--- a/core/object.go
+++ b/core/object.go
@@ -22,8 +22,9 @@ const trivialFieldDirectiveName = "trivialResolveField"
 const deprecatedDirectiveName = "deprecated"
 
 type ModuleObjectType struct {
-	typeDef *ObjectTypeDef
-	mod     *Module
+	typeDef     *ObjectTypeDef
+	collection  *CollectionTypeDef
+	mod         *Module
 }
 
 var _ ModType = &ModuleObjectType{}
@@ -45,9 +46,10 @@ func (t *ModuleObjectType) ConvertFromSDKResult(ctx context.Context, value any) 
 	switch value := value.(type) {
 	case map[string]any:
 		return dagql.NewResultForCurrentID(ctx, &ModuleObject{
-			Module:  t.mod,
-			TypeDef: t.typeDef,
-			Fields:  value,
+			Module:     t.mod,
+			TypeDef:    t.typeDef,
+			Collection: t.collection,
+			Fields:     value,
 		})
 	default:
 		return nil, fmt.Errorf("unexpected result value type %T for object %q", value, t.typeDef.Name)
@@ -155,10 +157,14 @@ func (t *ModuleObjectType) CollectContent(ctx context.Context, value dagql.AnyRe
 }
 
 func (t *ModuleObjectType) TypeDef() *TypeDef {
-	return &TypeDef{
+	typeDef := &TypeDef{
 		Kind:     TypeDefKindObject,
 		AsObject: dagql.NonNull(t.typeDef),
 	}
+	if t.collection != nil {
+		typeDef.AsCollection = dagql.NonNull(t.collection)
+	}
+	return typeDef
 }
 
 type Callable interface {
@@ -200,8 +206,9 @@ func (t *ModuleObjectType) GetCallable(ctx context.Context, name string) (Callab
 type ModuleObject struct {
 	Module *Module
 
-	TypeDef *ObjectTypeDef
-	Fields  map[string]any
+	TypeDef     *ObjectTypeDef
+	Collection  *CollectionTypeDef
+	Fields      map[string]any
 }
 
 func (obj *ModuleObject) Type() *ast.Type {
@@ -252,13 +259,22 @@ func (obj *ModuleObject) Install(ctx context.Context, dag *dagql.Server, opts ..
 			return fmt.Errorf("failed to install constructor: %w", err)
 		}
 	}
-	fields := obj.fields()
+	var fields []dagql.Field[*ModuleObject]
+	var err error
+	if obj.Collection != nil {
+		fields, err = obj.collectionMembers(ctx, dag)
+		if err != nil {
+			return err
+		}
+	} else {
+		fields = obj.fields()
 
-	funs, err := obj.functions(ctx, dag)
-	if err != nil {
-		return err
+		funs, err := obj.functions(ctx, dag)
+		if err != nil {
+			return err
+		}
+		fields = append(fields, funs...)
 	}
-	fields = append(fields, funs...)
 
 	class.Install(fields...)
 	dag.InstallObject(class, installDirectives...)

--- a/core/schema/checks.go
+++ b/core/schema/checks.go
@@ -12,6 +12,8 @@ type checksSchema struct{}
 var _ SchemaResolvers = &checksSchema{}
 
 func (s checksSchema) Install(srv *dagql.Server) {
+	dagql.Fields[*core.CollectionFilterValues]{}.Install(srv)
+
 	dagql.Fields[*core.CheckGroup]{
 		dagql.Func("list", s.list).
 			Doc("Return a list of individual checks and their details"),
@@ -21,6 +23,12 @@ func (s checksSchema) Install(srv *dagql.Server) {
 
 		dagql.Func("report", s.report).
 			Doc("Generate a markdown report"),
+
+		dagql.Func("collectionFilterValues", s.collectionFilterValues).
+			Doc("List the available values for the requested collection-aware filters within the current check scope").
+			Args(
+				dagql.Arg("typeNames").Doc("Collection type names to list values for"),
+			),
 	}.Install(srv)
 
 	// Check methods
@@ -71,6 +79,12 @@ func (s checksSchema) run(ctx context.Context, parent *core.CheckGroup, args str
 
 func (s checksSchema) report(ctx context.Context, parent *core.CheckGroup, args struct{}) (*core.File, error) {
 	return parent.Report(ctx)
+}
+
+func (s checksSchema) collectionFilterValues(ctx context.Context, parent *core.CheckGroup, args struct {
+	TypeNames []string
+}) ([]*core.CollectionFilterValues, error) {
+	return parent.CollectionFilterValues(ctx, args.TypeNames)
 }
 
 func (s checksSchema) runSingleCheck(ctx context.Context, parent *core.Check, args struct{}) (*core.Check, error) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1059,6 +1059,9 @@ func (args containerExecArgs) Digest() (digest.Digest, error) {
 	inputs = append(inputs, digest.FromBytes(res).String())
 
 	if args.ExecMD.Self != nil {
+		if args.ExecMD.Self.CallID != nil {
+			inputs = append(inputs, args.ExecMD.Self.CallID.Digest().String())
+		}
 		inputs = append(inputs, string(args.ExecMD.Self.CacheMixin))
 	}
 

--- a/core/schema/container_test.go
+++ b/core/schema/container_test.go
@@ -1,0 +1,50 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerExecArgsDigestIncludesCallID(t *testing.T) {
+	newCallID := func(field string) *call.ID {
+		return call.New().Append(&ast.Type{NamedType: "Query", NonNull: true}, field)
+	}
+
+	baseArgs := containerExecArgs{
+	}
+	baseArgs.ExecMD.Self = &buildkit.ExecutionMetadata{
+		CacheMixin: digest.FromString("shared-cache-mixin"),
+		CallID:     newCallID("firstCall"),
+	}
+
+	firstDigest, err := baseArgs.Digest()
+	require.NoError(t, err)
+
+	sameCallArgs := baseArgs
+	sameCallArgs.ExecMD.Self = &buildkit.ExecutionMetadata{
+		CacheMixin: digest.FromString("shared-cache-mixin"),
+		CallID:     newCallID("firstCall"),
+		ExecID:     "different-exec-id",
+		ClientID:   "different-client-id",
+	}
+
+	sameCallDigest, err := sameCallArgs.Digest()
+	require.NoError(t, err)
+	require.Equal(t, firstDigest, sameCallDigest)
+
+	secondCallArgs := baseArgs
+	secondCallArgs.ExecMD.Self = &buildkit.ExecutionMetadata{
+		CacheMixin: digest.FromString("shared-cache-mixin"),
+		CallID:     newCallID("secondCall"),
+	}
+
+	secondDigest, err := secondCallArgs.Digest()
+	require.NoError(t, err)
+	require.NotEqual(t, firstDigest, secondDigest)
+}

--- a/core/schema/generators.go
+++ b/core/schema/generators.go
@@ -12,6 +12,8 @@ type generatorsSchema struct{}
 var _ SchemaResolvers = &generatorsSchema{}
 
 func (s generatorsSchema) Install(srv *dagql.Server) {
+	dagql.Fields[*core.CollectionFilterValues]{}.Install(srv)
+
 	dagql.Fields[*core.GeneratorGroup]{
 		dagql.Func("list", s.list).
 			Doc("Return a list of individual generators and their details"),
@@ -29,6 +31,12 @@ func (s generatorsSchema) Install(srv *dagql.Server) {
 				`Set 'continueOnConflicts' flag to force to merge the changes in a 'last write wins' strategy.`).
 			Args(
 				dagql.Arg("onConflict").Doc(`Strategy to apply on conflicts between generators`),
+			),
+
+		dagql.Func("collectionFilterValues", s.collectionFilterValues).
+			Doc("List the available values for the requested collection-aware filters within the current generator scope").
+			Args(
+				dagql.Arg("typeNames").Doc("Collection type names to list values for"),
 			),
 	}.Install(srv)
 
@@ -59,6 +67,12 @@ func (s generatorsSchema) list(ctx context.Context, parent *core.GeneratorGroup,
 
 func (s generatorsSchema) run(ctx context.Context, parent *core.GeneratorGroup, args struct{}) (*core.GeneratorGroup, error) {
 	return parent.Run(ctx)
+}
+
+func (s generatorsSchema) collectionFilterValues(ctx context.Context, parent *core.GeneratorGroup, args struct {
+	TypeNames []string
+}) ([]*core.CollectionFilterValues, error) {
+	return parent.CollectionFilterValues(ctx, args.TypeNames)
 }
 
 type generatorsGroupIsEmptyArgs struct {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -260,9 +260,9 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`Marks an Object TypeDef as a collection.`),
 
 		dagql.Func("withCollectionKeys", s.typeDefWithCollectionKeys).
-			Doc(`Overrides the effective keys member used by a collection TypeDef.`).
+			Doc(`Overrides the effective keys field used by a collection TypeDef.`).
 			Args(
-				dagql.Arg("name").Doc(`The name of the field or no-arg function that enumerates collection keys.`),
+				dagql.Arg("name").Doc(`The name of the field that enumerates collection keys.`),
 			),
 
 		dagql.Func("withCollectionGet", s.typeDefWithCollectionGet).
@@ -402,7 +402,7 @@ func (s *moduleSchema) typeDefWithCollectionKeys(ctx context.Context, def *core.
 	Name string
 }) (*core.TypeDef, error) {
 	if args.Name == "" {
-		return nil, fmt.Errorf("collection keys member name must not be empty")
+		return nil, fmt.Errorf("collection keys field name must not be empty")
 	}
 	return def.WithCollectionKeys(args.Name), nil
 }

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -256,6 +256,21 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 				intent is only to refer to an object. This is how functions are able to
 				return their own object, or any other circular reference.`),
 
+		dagql.Func("withCollection", s.typeDefWithCollection).
+			Doc(`Marks an Object TypeDef as a collection.`),
+
+		dagql.Func("withCollectionKeys", s.typeDefWithCollectionKeys).
+			Doc(`Overrides the effective keys member used by a collection TypeDef.`).
+			Args(
+				dagql.Arg("name").Doc(`The name of the field or no-arg function that enumerates collection keys.`),
+			),
+
+		dagql.Func("withCollectionGet", s.typeDefWithCollectionGet).
+			Doc(`Overrides the effective get function used by a collection TypeDef.`).
+			Args(
+				dagql.Arg("name").Doc(`The name of the function that resolves one collection item by key.`),
+			),
+
 		dagql.Func("withInterface", s.typeDefWithInterface).
 			Doc(`Returns a TypeDef of kind Interface with the provided name.`),
 
@@ -307,6 +322,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			),
 	}.Install(dag)
 
+	dagql.Fields[*core.CollectionTypeDef]{}.Install(dag)
 	dagql.Fields[*core.ObjectTypeDef]{}.Install(dag)
 	dagql.Fields[*core.InterfaceTypeDef]{}.Install(dag)
 	dagql.Fields[*core.InputTypeDef]{}.Install(dag)
@@ -376,6 +392,28 @@ func (s *moduleSchema) typeDefWithObject(ctx context.Context, def *core.TypeDef,
 		return nil, err
 	}
 	return def.WithObject(args.Name, args.Description, args.Deprecated, sourceMap), nil
+}
+
+func (s *moduleSchema) typeDefWithCollection(ctx context.Context, def *core.TypeDef, args struct{}) (*core.TypeDef, error) {
+	return def.WithCollection(), nil
+}
+
+func (s *moduleSchema) typeDefWithCollectionKeys(ctx context.Context, def *core.TypeDef, args struct {
+	Name string
+}) (*core.TypeDef, error) {
+	if args.Name == "" {
+		return nil, fmt.Errorf("collection keys member name must not be empty")
+	}
+	return def.WithCollectionKeys(args.Name), nil
+}
+
+func (s *moduleSchema) typeDefWithCollectionGet(ctx context.Context, def *core.TypeDef, args struct {
+	Name string
+}) (*core.TypeDef, error) {
+	if args.Name == "" {
+		return nil, fmt.Errorf("collection get function name must not be empty")
+	}
+	return def.WithCollectionGet(args.Name), nil
 }
 
 func (s *moduleSchema) typeDefWithInterface(ctx context.Context, def *core.TypeDef, args struct {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -84,6 +84,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`Return all checks defined by the module`).
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("filters").Doc("Collection-aware filters to apply while traversing checks"),
 			),
 
 		dagql.Func("check", s.moduleCheck).
@@ -98,6 +99,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`Return all generators defined by the module`).
 			Args(
 				dagql.Arg("include").Doc("Only include generators matching the specified patterns"),
+				dagql.Arg("filters").Doc("Collection-aware filters to apply while traversing generators"),
 			),
 
 		dagql.Func("generator", s.moduleGenerator).
@@ -182,6 +184,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`Return all generators defined by the module`).
 			Args(
 				dagql.Arg("include").Doc("Only include generators matching the specified patterns"),
+				dagql.Arg("filters").Doc("Collection-aware filters to apply while traversing generators"),
 			),
 	}.Install(dag)
 
@@ -901,6 +904,7 @@ func (s *moduleSchema) moduleChecks(
 	mod *core.Module,
 	args struct {
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Filters dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]
 	},
 ) (*core.CheckGroup, error) {
 	var include []string
@@ -909,7 +913,13 @@ func (s *moduleSchema) moduleChecks(
 			include = append(include, pattern.String())
 		}
 	}
-	return mod.Checks(ctx, include)
+	var filters []core.CollectionFilterInput
+	if args.Filters.Valid {
+		for _, filter := range args.Filters.Value {
+			filters = append(filters, filter.Value)
+		}
+	}
+	return mod.Checks(ctx, include, filters)
 }
 
 func (s *moduleSchema) moduleCheck(
@@ -919,7 +929,7 @@ func (s *moduleSchema) moduleCheck(
 		Name string
 	},
 ) (*core.Check, error) {
-	checkGroup, err := mod.Checks(ctx, []string{args.Name})
+	checkGroup, err := mod.Checks(ctx, []string{args.Name}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -939,6 +949,7 @@ func (s *moduleSchema) moduleGenerators(
 	mod *core.Module,
 	args struct {
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Filters dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]
 	},
 ) (*core.GeneratorGroup, error) {
 	var include []string
@@ -947,7 +958,13 @@ func (s *moduleSchema) moduleGenerators(
 			include = append(include, pattern.String())
 		}
 	}
-	return mod.Generators(ctx, include)
+	var filters []core.CollectionFilterInput
+	if args.Filters.Valid {
+		for _, filter := range args.Filters.Value {
+			filters = append(filters, filter.Value)
+		}
+	}
+	return mod.Generators(ctx, include, filters)
 }
 
 func (s *moduleSchema) currentModuleGenerators(
@@ -955,6 +972,7 @@ func (s *moduleSchema) currentModuleGenerators(
 	mod *core.CurrentModule,
 	args struct {
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Filters dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]
 	},
 ) (*core.GeneratorGroup, error) {
 	var include []string
@@ -963,7 +981,13 @@ func (s *moduleSchema) currentModuleGenerators(
 			include = append(include, pattern.String())
 		}
 	}
-	return mod.Module.Generators(ctx, include)
+	var filters []core.CollectionFilterInput
+	if args.Filters.Valid {
+		for _, filter := range args.Filters.Value {
+			filters = append(filters, filter.Value)
+		}
+	}
+	return mod.Module.Generators(ctx, include, filters)
 }
 
 func (s *moduleSchema) moduleGenerator(
@@ -973,7 +997,7 @@ func (s *moduleSchema) moduleGenerator(
 		Name string
 	},
 ) (*core.Generator, error) {
-	generatorGroup, err := mod.Generators(ctx, []string{args.Name})
+	generatorGroup, err := mod.Generators(ctx, []string{args.Name}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -51,6 +51,7 @@ func (s *querySchema) Install(srv *dagql.Server) {
 	dagql.MustInputSpec(PipelineLabel{}).Install(srv)
 	dagql.MustInputSpec(core.PortForward{}).Install(srv)
 	dagql.MustInputSpec(core.BuildArg{}).Install(srv)
+	dagql.MustInputSpec(core.CollectionFilterInput{}).Install(srv)
 
 	dagql.Fields[core.EnvVariable]{}.Install(srv)
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -58,11 +58,13 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("Return all checks from modules loaded in the workspace.").
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("filters").Doc("Only include checks whose backing collections match the specified filter values"),
 			),
 		dagql.Func("generators", s.generators).
 			Doc("Return all generators from modules loaded in the workspace.").
 			Args(
 				dagql.Arg("include").Doc("Only include generators matching the specified patterns"),
+				dagql.Arg("filters").Doc("Only include generators whose backing collections match the specified filter values"),
 			),
 	}.Install(srv)
 }
@@ -351,9 +353,11 @@ func (s *workspaceSchema) checks(
 	parent *core.Workspace,
 	args struct {
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Filters dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]
 	},
 ) (*core.CheckGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
+	filters := workspaceCollectionFilters(args.Filters)
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -366,8 +370,9 @@ func (s *workspaceSchema) checks(
 	})
 
 	var allChecks []*core.Check
+	workspaceExclude := make([]string, 0)
 	for _, mod := range mods {
-		checkGroup, err := mod.Checks(ctx, nil)
+		checkGroup, err := mod.Checks(ctx, nil, filters)
 		if err != nil {
 			return nil, fmt.Errorf("checks from module %q: %w", mod.Name(), err)
 		}
@@ -385,6 +390,7 @@ func (s *workspaceSchema) checks(
 		}
 		// Apply ignoreChecks exclusion for this toolchain's checks.
 		if exclude := ignoreChecks[mod.Name()]; len(exclude) > 0 {
+			workspaceExclude = append(workspaceExclude, workspaceExcludePatterns(mod.Name(), exclude)...)
 			filtered, err = filterNodesByExclude(
 				ctx,
 				filtered,
@@ -400,7 +406,11 @@ func (s *workspaceSchema) checks(
 		allChecks = append(allChecks, filtered...)
 	}
 
-	return &core.CheckGroup{Checks: allChecks}, nil
+	return &core.CheckGroup{
+		Checks:  allChecks,
+		include: append([]string(nil), include...),
+		exclude: workspaceExclude,
+	}, nil
 }
 
 func (s *workspaceSchema) generators(
@@ -408,9 +418,11 @@ func (s *workspaceSchema) generators(
 	parent *core.Workspace,
 	args struct {
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Filters dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]
 	},
 ) (*core.GeneratorGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
+	filters := workspaceCollectionFilters(args.Filters)
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -422,7 +434,7 @@ func (s *workspaceSchema) generators(
 	}, 0, len(mods))
 	generatorModuleCount := 0
 	for _, mod := range mods {
-		generatorGroup, err := mod.Generators(ctx, nil)
+		generatorGroup, err := mod.Generators(ctx, nil, filters)
 		if err != nil {
 			return nil, fmt.Errorf("generators from module %q: %w", mod.Name(), err)
 		}
@@ -454,7 +466,10 @@ func (s *workspaceSchema) generators(
 		allGenerators = append(allGenerators, filtered...)
 	}
 
-	return &core.GeneratorGroup{Generators: allGenerators}, nil
+	return &core.GeneratorGroup{
+		Generators: allGenerators,
+		include:    append([]string(nil), include...),
+	}, nil
 }
 
 func workspaceIncludePatterns(includeArg dagql.Optional[dagql.ArrayInput[dagql.String]]) []string {
@@ -466,6 +481,32 @@ func workspaceIncludePatterns(includeArg dagql.Optional[dagql.ArrayInput[dagql.S
 		patterns = append(patterns, pattern.String())
 	}
 	return patterns
+}
+
+func workspaceCollectionFilters(filtersArg dagql.Optional[dagql.ArrayInput[dagql.InputObject[core.CollectionFilterInput]]]) []core.CollectionFilterInput {
+	if !filtersArg.Valid {
+		return nil
+	}
+	filters := make([]core.CollectionFilterInput, 0, len(filtersArg.Value))
+	for _, filter := range filtersArg.Value {
+		filters = append(filters, filter.Value)
+	}
+	return filters
+}
+
+func workspaceExcludePatterns(modName string, exclude []string) []string {
+	if len(exclude) == 0 {
+		return nil
+	}
+	prefixed := make([]string, 0, len(exclude))
+	for _, pattern := range exclude {
+		if strings.Contains(pattern, ":") {
+			prefixed = append(prefixed, pattern)
+			continue
+		}
+		prefixed = append(prefixed, modName+":"+pattern)
+	}
+	return prefixed
 }
 
 func filterGeneratorsByInclude(

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -688,7 +688,7 @@ func (typeDef *TypeDef) WithCollection() *TypeDef {
 
 func (typeDef *TypeDef) WithCollectionKeys(name string) *TypeDef {
 	typeDef = typeDef.WithCollection()
-	typeDef.AsCollection.Value.KeysMemberNameOverride = gqlFieldName(name)
+	typeDef.AsCollection.Value.KeysFieldNameOverride = gqlFieldName(name)
 	return typeDef
 }
 
@@ -898,13 +898,12 @@ type CollectionTypeDef struct {
 	BatchType *TypeDef `field:"true" doc:"The synthetic batch type exposed for collection-level operations, if any."`
 
 	// Below are not in public API.
-	KeysMemberNameOverride  string
+	KeysFieldNameOverride   string
 	GetFunctionNameOverride string
 
-	KeysFieldName    string
-	KeysFunctionName string
-	GetFunctionName  string
-	GetArgName       string
+	KeysFieldName   string
+	GetFunctionName string
+	GetArgName      string
 }
 
 func (*CollectionTypeDef) Type() *ast.Type {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -523,14 +523,15 @@ func (d DynamicID) MarshalJSON() ([]byte, error) {
 }
 
 type TypeDef struct {
-	Kind        TypeDefKind                       `field:"true" doc:"The kind of type this is (e.g. primitive, list, object)."`
-	Optional    bool                              `field:"true" doc:"Whether this type can be set to null. Defaults to false."`
-	AsList      dagql.Nullable[*ListTypeDef]      `field:"true" doc:"If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null."`
-	AsObject    dagql.Nullable[*ObjectTypeDef]    `field:"true" doc:"If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null."`
-	AsInterface dagql.Nullable[*InterfaceTypeDef] `field:"true" doc:"If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null."`
-	AsInput     dagql.Nullable[*InputTypeDef]     `field:"true" doc:"If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null."`
-	AsScalar    dagql.Nullable[*ScalarTypeDef]    `field:"true" doc:"If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null."`
-	AsEnum      dagql.Nullable[*EnumTypeDef]      `field:"true" doc:"If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null."`
+	Kind         TypeDefKind                        `field:"true" doc:"The kind of type this is (e.g. primitive, list, object)."`
+	Optional     bool                               `field:"true" doc:"Whether this type can be set to null. Defaults to false."`
+	AsList       dagql.Nullable[*ListTypeDef]       `field:"true" doc:"If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null."`
+	AsObject     dagql.Nullable[*ObjectTypeDef]     `field:"true" doc:"If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null."`
+	AsCollection dagql.Nullable[*CollectionTypeDef] `field:"true" doc:"If kind is OBJECT and the object is a collection, the collection-specific type definition. If the type is not a collection, this will be null."`
+	AsInterface  dagql.Nullable[*InterfaceTypeDef]  `field:"true" doc:"If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null."`
+	AsInput      dagql.Nullable[*InputTypeDef]      `field:"true" doc:"If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null."`
+	AsScalar     dagql.Nullable[*ScalarTypeDef]     `field:"true" doc:"If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null."`
+	AsEnum       dagql.Nullable[*EnumTypeDef]       `field:"true" doc:"If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null."`
 }
 
 func (typeDef TypeDef) Clone() *TypeDef {
@@ -540,6 +541,9 @@ func (typeDef TypeDef) Clone() *TypeDef {
 	}
 	if typeDef.AsObject.Valid {
 		cp.AsObject.Value = typeDef.AsObject.Value.Clone()
+	}
+	if typeDef.AsCollection.Valid {
+		cp.AsCollection.Value = typeDef.AsCollection.Value.Clone()
 	}
 	if typeDef.AsInterface.Valid {
 		cp.AsInterface.Value = typeDef.AsInterface.Value.Clone()
@@ -671,6 +675,26 @@ func (typeDef *TypeDef) WithListOf(elem *TypeDef) *TypeDef {
 func (typeDef *TypeDef) WithObject(name, desc string, deprecated *string, sourceMap *SourceMap) *TypeDef {
 	typeDef = typeDef.WithKind(TypeDefKindObject)
 	typeDef.AsObject = dagql.NonNull(NewObjectTypeDef(name, desc, deprecated).WithSourceMap(sourceMap))
+	return typeDef
+}
+
+func (typeDef *TypeDef) WithCollection() *TypeDef {
+	typeDef = typeDef.Clone()
+	if !typeDef.AsCollection.Valid {
+		typeDef.AsCollection = dagql.NonNull(&CollectionTypeDef{})
+	}
+	return typeDef
+}
+
+func (typeDef *TypeDef) WithCollectionKeys(name string) *TypeDef {
+	typeDef = typeDef.WithCollection()
+	typeDef.AsCollection.Value.KeysMemberNameOverride = gqlFieldName(name)
+	return typeDef
+}
+
+func (typeDef *TypeDef) WithCollectionGet(name string) *TypeDef {
+	typeDef = typeDef.WithCollection()
+	typeDef.AsCollection.Value.GetFunctionNameOverride = gqlFieldName(name)
 	return typeDef
 }
 
@@ -866,6 +890,46 @@ type ObjectTypeDef struct {
 	// Set by Module.TypeDefs() so downstream consumers don't need
 	// name-matching heuristics.
 	IsMainObject bool
+}
+
+type CollectionTypeDef struct {
+	KeyType   *TypeDef `field:"true" doc:"The type accepted by get(key) and subset(keys: ...)."`
+	ValueType *TypeDef `field:"true" doc:"The type returned by get() and enumerated by list."`
+	BatchType *TypeDef `field:"true" doc:"The synthetic batch type exposed for collection-level operations, if any."`
+
+	// Below are not in public API.
+	KeysMemberNameOverride  string
+	GetFunctionNameOverride string
+
+	KeysFieldName    string
+	KeysFunctionName string
+	GetFunctionName  string
+	GetArgName       string
+}
+
+func (*CollectionTypeDef) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "CollectionTypeDef",
+		NonNull:   true,
+	}
+}
+
+func (*CollectionTypeDef) TypeDescription() string {
+	return "A definition of collection semantics layered on top of an object type."
+}
+
+func (typeDef CollectionTypeDef) Clone() *CollectionTypeDef {
+	cp := typeDef
+	if typeDef.KeyType != nil {
+		cp.KeyType = typeDef.KeyType.Clone()
+	}
+	if typeDef.ValueType != nil {
+		cp.ValueType = typeDef.ValueType.Clone()
+	}
+	if typeDef.BatchType != nil {
+		cp.BatchType = typeDef.BatchType.Clone()
+	}
+	return &cp
 }
 
 func (obj ObjectTypeDef) functions() iter.Seq[*Function] {

--- a/core/workspace_group_collection_filters.go
+++ b/core/workspace_group_collection_filters.go
@@ -1,0 +1,134 @@
+package core
+
+import (
+	"context"
+	"strings"
+)
+
+func collectionFilterValuesFromWorkspaceRoots(
+	ctx context.Context,
+	typeNames []string,
+	include []string,
+	exclude []string,
+	roots []*ModTreeNode,
+) ([]*CollectionFilterValues, error) {
+	if len(roots) == 0 {
+		return nil, nil
+	}
+
+	orderedTypeNames := append([]string(nil), typeNames...)
+	seenTypes := make(map[string]string, len(orderedTypeNames))
+	for _, typeName := range orderedTypeNames {
+		seenTypes[gqlObjectName(typeName)] = typeName
+	}
+
+	valuesByType := make(map[string][]string, len(orderedTypeNames))
+	seenValuesByType := make(map[string]map[string]struct{}, len(orderedTypeNames))
+	for _, typeName := range orderedTypeNames {
+		seenValuesByType[gqlObjectName(typeName)] = map[string]struct{}{}
+	}
+
+	for _, root := range roots {
+		rootValues, err := root.CollectionFilterValues(
+			ctx,
+			typeNames,
+			workspaceCompatibleCollectionPatterns(root.Name, include),
+			workspaceCompatibleCollectionPatterns(root.Name, exclude),
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, values := range rootValues {
+			typeKey := gqlObjectName(values.TypeName)
+			if _, ok := seenValuesByType[typeKey]; !ok {
+				seenValuesByType[typeKey] = map[string]struct{}{}
+				if _, ok := seenTypes[typeKey]; !ok {
+					seenTypes[typeKey] = values.TypeName
+					orderedTypeNames = append(orderedTypeNames, values.TypeName)
+				}
+			}
+			for _, value := range values.Values {
+				if _, ok := seenValuesByType[typeKey][value]; ok {
+					continue
+				}
+				seenValuesByType[typeKey][value] = struct{}{}
+				valuesByType[typeKey] = append(valuesByType[typeKey], value)
+			}
+		}
+	}
+
+	result := make([]*CollectionFilterValues, 0, len(orderedTypeNames))
+	for _, typeName := range orderedTypeNames {
+		typeKey := gqlObjectName(typeName)
+		result = append(result, &CollectionFilterValues{
+			TypeName: seenTypes[typeKey],
+			Values:   valuesByType[typeKey],
+		})
+	}
+	return result, nil
+}
+
+func workspaceCompatibleCollectionPatterns(rootName string, patterns []string) []string {
+	if len(patterns) == 0 || rootName == "" {
+		return patterns
+	}
+
+	expanded := make([]string, 0, len(patterns)*2)
+	seen := make(map[string]struct{}, len(patterns)*2)
+	for _, pattern := range patterns {
+		if _, ok := seen[pattern]; !ok {
+			seen[pattern] = struct{}{}
+			expanded = append(expanded, pattern)
+		}
+		if strings.Contains(pattern, ":") {
+			continue
+		}
+		prefixed := rootName + ":" + pattern
+		if _, ok := seen[prefixed]; ok {
+			continue
+		}
+		seen[prefixed] = struct{}{}
+		expanded = append(expanded, prefixed)
+	}
+	return expanded
+}
+
+func workspaceCheckRoots(checks []*Check) []*ModTreeNode {
+	return workspaceRoots(checks, func(check *Check) *ModTreeNode {
+		return check.Node
+	})
+}
+
+func workspaceGeneratorRoots(generators []*Generator) []*ModTreeNode {
+	return workspaceRoots(generators, func(generator *Generator) *ModTreeNode {
+		return generator.Node
+	})
+}
+
+func workspaceRoots[T any](items []T, nodeFor func(T) *ModTreeNode) []*ModTreeNode {
+	roots := make([]*ModTreeNode, 0, len(items))
+	seen := make(map[*ModTreeNode]struct{}, len(items))
+	for _, item := range items {
+		root := workspaceRoot(nodeFor(item))
+		if root == nil {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func workspaceRoot(node *ModTreeNode) *ModTreeNode {
+	if node == nil {
+		return nil
+	}
+	root := node
+	for root.Parent != nil && root.Parent.Module != nil {
+		root = root.Parent
+	}
+	return root
+}

--- a/core/workspace_group_collection_filters_test.go
+++ b/core/workspace_group_collection_filters_test.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceCheckGroupCollectionFilterValues(t *testing.T) {
+	ctx := context.Background()
+
+	mod, _, collectionType := testCollectionModule(t)
+	group := &CheckGroup{
+		Checks: []*Check{
+			{Node: workspaceCheckLeaf(t, mod, collectionType, "alpha", []string{"TestFoo"})},
+			{Node: workspaceCheckLeaf(t, mod, collectionType, "beta", []string{"TestBar"})},
+		},
+	}
+
+	values, err := group.CollectionFilterValues(ctx, []string{"GoTests"})
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	require.Equal(t, "GoTests", values[0].TypeName)
+	require.Equal(t, []string{"TestFoo", "TestBar"}, values[0].Values)
+}
+
+func TestWorkspaceGeneratorGroupCollectionFilterValues(t *testing.T) {
+	ctx := context.Background()
+
+	mod, _, collectionType := testCollectionModule(t)
+	group := &GeneratorGroup{
+		Generators: []*Generator{
+			{Node: workspaceGeneratorLeaf(t, mod, collectionType, "alpha", []string{"TestFoo"})},
+			{Node: workspaceGeneratorLeaf(t, mod, collectionType, "beta", []string{"TestBar"})},
+		},
+	}
+
+	values, err := group.CollectionFilterValues(ctx, []string{"GoTests"})
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	require.Equal(t, "GoTests", values[0].TypeName)
+	require.Equal(t, []string{"TestFoo", "TestBar"}, values[0].Values)
+}
+
+func workspaceCheckLeaf(t *testing.T, mod *Module, collectionType *TypeDef, modName string, names []string) *ModTreeNode {
+	t.Helper()
+	root := workspaceCollectionRoot(t, mod, collectionType, modName, names)
+	return &ModTreeNode{
+		Parent:         root,
+		Name:           "runTest",
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           (&TypeDef{}).WithKind(TypeDefKindString),
+		IsCheck:        true,
+	}
+}
+
+func workspaceGeneratorLeaf(t *testing.T, mod *Module, collectionType *TypeDef, modName string, names []string) *ModTreeNode {
+	t.Helper()
+	root := workspaceCollectionRoot(t, mod, collectionType, modName, names)
+	return &ModTreeNode{
+		Parent:         root,
+		Name:           "generate",
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           (&TypeDef{}).WithKind(TypeDefKindString),
+		IsGenerator:    true,
+	}
+}
+
+func workspaceCollectionRoot(t *testing.T, mod *Module, collectionType *TypeDef, modName string, names []string) *ModTreeNode {
+	t.Helper()
+
+	collectionObj := &ModuleObject{
+		Module:     mod,
+		TypeDef:    collectionType.AsObject.Value,
+		Collection: collectionType.AsCollection.Value,
+		Fields: map[string]any{
+			"names": names,
+		},
+	}
+
+	return &ModTreeNode{
+		Parent:         &ModTreeNode{},
+		Name:           modName,
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           collectionType,
+		filterSet:      NewCollectionFilterSet(nil),
+		resolveValues: func(context.Context) ([]dagql.AnyResult, error) {
+			result, err := dagql.NewResultForCurrentID(context.Background(), collectionObj)
+			if err != nil {
+				return nil, err
+			}
+			return []dagql.AnyResult{result}, nil
+		},
+	}
+}

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -1,6 +1,6 @@
 # Collections
 
-## Status: Draft
+## Status: Implemented
 
 ## Table of Contents
 

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -4,73 +4,118 @@
 
 ## Table of Contents
 
-- [Summary](#summary)
 - [Problem](#problem)
 - [Proposal](#proposal)
-- [Module Definition](#module-definition)
-- [Client Representation](#client-representation)
-- [Schema Representation](#schema-representation)
-- [Tooling and Traversal](#tooling-and-traversal)
-- [Scope](#scope)
-
-## Summary
-
-Collections are a standalone primitive for representing keyed dynamic sets in a
-module's published object graph.
-
-This document intentionally stays narrow:
-- collections define keyed collections of objects
-- this proposal defines the collection primitive only
-- it does not change object semantics beyond collection traversal, selection,
-  and batching
-
-This document includes `subset` as part of the collection primitive so that
-collections can represent exact key-selected subsets of themselves.
+- [Use Cases](#use-cases)
+- [Interfaces](#interfaces)
+- [Checks and Generators](#checks-and-generators)
+- [Implementation](#implementation)
+- [General Maps](#general-maps)
 
 ## Problem
 
-Modules can already discover dynamic sets of related objects, but today they
-have no standard way to publish them as keyed collections.
-
-That leaves a gap:
-
-1. Dagger has lists and objects, but no map-like abstraction in the published
-   schema.
-2. Dynamic sets are usually keyed in practice, but the key structure is not
-   first-class.
-3. Existing traversal and selection mechanisms need keyed targeting without
-   forcing users to spell explicit collection accessors like `get(...)`.
-
-Collections fill that gap.
+Modules can discover dynamic sets of related objects (tests by name, packages
+by path, services by label). But they can't present them to clients without
+losing features like `dagger check`, `dagger call` keyed selection, filtering,
+or batching. Keys aren't first-class in the schema, so every module invents
+ad hoc accessors, and tooling can't offer these features generically.
 
 ## Proposal
 
-A collection is a keyed dynamic set.
+A collection is a keyed set of objects, defined on ordinary module types
+using `@collection` / `+collection` and projected by the engine into a
+synthetic public type with a small standard algebra: `keys`, `list`, `get`,
+`subset`, and `batch`.
 
-It is defined on ordinary module objects using collection semantics, not a new
-type kind.
+This proposal is intentionally narrow:
 
-The current direction is:
-- module-side collection contract: `+keys` and `+get`
-- public DAGQL projection: collection-valued fields/functions project as
-  synthetic collection objects
-- higher-level targeting syntax provides keyed traversal over that projection
+- Collections are keyed sets of objects. A broader map abstraction may follow,
+  but is out of scope.
+- They layer semantics onto existing objects, not a new type kind.
+- They are declared on object types with `@collection` / `+collection`, with
+  `keys` and `get` by convention or `@keys` / `@get` by override.
+- They add keyed traversal, selection, and batching — nothing else.
 
-## Module Definition
+## Use Cases
 
-Collections are defined by semantic annotations on ordinary module fields and
-functions.
+### Test Selection
 
-Leading shape:
+A test suite can publish its tests as a collection keyed by test name. Users
+and tools select tests by key instead of relying on ad hoc command flags or
+list position.
+
+This is the motivation for collection-aware filtering in `dagger check` and
+`dagger generate`: a user should be able to say "run these tests" by naming
+them directly.
+
+### Test Splitting
+
+Collections make test splitting precise because a subset of tests can be
+represented explicitly as another collection.
+
+`subset(keys)` is the key operation here. It turns one collection into an exact
+key-selected subset while preserving collection shape. That lets tooling
+divide tests into buckets without losing the collection abstraction.
+
+`batch` complements this by giving a collection a place to implement efficient
+execution over a selected subset.
+
+### One Module, Many Projects
+
+Collections let one installed module publish a dynamic set of related projects.
+
+In practice, a single repository often contains many apps, packages, modules,
+sites, or services. Those sets are usually discovered at runtime and are keyed
+by names or paths that matter to users.
+
+Collections give modules a standard way to publish those dynamic sets and let
+clients select one project by key or operate on subsets.
+
+## Interfaces
+
+### Module Definition
+
+Collections are defined on ordinary object types by annotating the type itself
+as a collection.
+
+Each collection type has:
+- one effective `keys` member
+- one effective `get` function
+
+The type annotation is required. Member annotations are optional.
+
+- If a collection type exposes a member named `keys`, that member is the
+  effective `keys` member by default.
+- If a collection type exposes a function named `get`, that function is the
+  effective `get` function by default.
+- `@keys` and `@get` are only needed to override those default names.
+
+Canonical schema shape:
 
 ```graphql
 """Collection of Go modules keyed by workspace path."""
-type GoModules {
+type GoModules @collection {
   """All keys currently present in the collection."""
-  keys: [WorkspacePath!]! @keys
+  keys: [WorkspacePath!]!
 
   """Resolve one module by workspace path."""
   get(
+    """Workspace path to resolve."""
+    path: WorkspacePath!
+  ): GoModule!
+}
+```
+
+Non-standard names:
+
+```graphql
+"""Collection of Go modules keyed by workspace path."""
+type GoModules @collection {
+  """All keys currently present in the collection."""
+  paths: [WorkspacePath!]! @keys
+
+  """Resolve one module by workspace path."""
+  module(
     """Workspace path to resolve."""
     path: WorkspacePath!
   ): GoModule! @get
@@ -78,23 +123,110 @@ type GoModules {
 ```
 
 Rules:
-- `+keys` enumerates the collection keyspace
-- `+get` resolves one item by key
-- `get` is required for every collection in v1
-- every key returned by `+keys` must be accepted by `get`; otherwise the
-  collection is invalid
+- `@collection` / `+collection` is required on the type itself
+- the effective `keys` member enumerates the collection keyspace
+- the effective `get` function resolves one item by key
+- `keys` may be an exposed field or an exposed no-arg function
+- `get` must be an exposed function
+- if `@keys` is absent, the exposed member named `keys` is used
+- if `@get` is absent, the exposed function named `get` is used
+- if `@keys` or `@get` is present, it overrides the default name-based
+  convention
+- only scalar and enum input types are valid as collection keys; this includes
+  builtin scalars, custom scalars, and enums; object, input-object, interface,
+  and list types are not valid collection key types
+- the effective `keys` member returns `[KeyType!]!`
+- the effective `get` function accepts exactly one non-null `KeyType` argument
+  and returns a non-null object
+- a collection must have exactly one effective `keys` member and exactly one
+  effective `get` function
 - keys should be unique within a collection
+
+Collection validity is enforced in two stages. At module load time, the engine
+validates structure: whether the type is marked as a collection, whether there
+is exactly one effective `keys` member and one effective `get` function, and
+whether their signatures are valid. At runtime, the engine validates behavior
+when the collection is used: if `keys` advertises a key that `get` cannot
+resolve, collection operations fail at the point of use.
 
 Collections describe how a dynamic set is addressed and traversed. They do not
 by themselves add mutation, execution, or other higher-level behavior.
 
-If a module wants extra behavior on the underlying collection object, that is
-module-specific behavior, not part of the core collection algebra. If surfaced
-publicly, type-specific efficient collection-level behavior belongs under
-namespaces such as `batch`, not alongside the core `keys`, `list`, `get`, and
-`subset` operations.
+Any exposed function on the collection type beyond the effective `keys` and
+`get` is automatically re-homed under the synthetic `batch` namespace (see
+[Batch Namespace](#batch-namespace)). Module authors define batch operations
+as ordinary functions on the collection type; the engine handles projection.
 
-## Client Representation
+Illustrative authoring examples:
+
+```dang
+type GoTests @collection {
+  pub testNames: [String!]
+
+  pub keys: [String!] {
+    testNames
+  }
+
+  pub get(name: String!): GoTest! {
+    GoTest(name: name)
+  }
+}
+```
+
+```go
+// +collection
+type GoTests struct {
+	TestNames []string
+}
+
+func (tests *GoTests) Keys() []string {
+	return tests.TestNames
+}
+
+func (tests *GoTests) Get(name string) *GoTest {
+	return &GoTest{Name: name}
+}
+```
+
+```typescript
+import { collection, func, object } from "@dagger.io/dagger";
+
+@object()
+@collection()
+class GoTests {
+  constructor(private readonly testNames: string[]) {}
+
+  @func()
+  keys(): string[] {
+    return this.testNames;
+  }
+
+  @func()
+  get(name: string): GoTest {
+    return new GoTest(name);
+  }
+}
+```
+
+```python
+from dagger import collection, function, object_type
+
+
+@object_type
+@collection
+class GoTests:
+    test_names: list[str]
+
+    @function
+    def keys(self) -> list[str]:
+        return self.test_names
+
+    @function
+    def get(self, name: str) -> "GoTest":
+        return GoTest(name=name)
+```
+
+### DagQL Schema
 
 The raw module-defined collection object stays hidden from clients.
 
@@ -152,31 +284,19 @@ type _GoModuleCollectionBatch {
 }
 ```
 
-Current rules:
+Rules:
 - projection keeps the original field/function name
-- public collection types are synthetic, engine-defined objects rather than
-  raw module-defined collection objects
-- projected collections expose typed `keys`, `list`, and `get`
-- projected collections also expose `subset`, returning the same synthetic
-  collection type so subsets can be represented across engine boundaries
-- projected collections reserve `batch` as a type-specific namespace for
-  efficient execution over the current subset
-- `get` errors on an unknown key
-- projected item types are otherwise unchanged; collection-relative identity
-  stays on the collection object rather than being injected onto the item type
 - projection applies to both fields and functions returning collections
-- projected list order preserves the order of `+keys`
-- `subset` is exact key-based subset selection, not a general predicate
-  language
-- `subset` preserves the parent key order
-- `subset` errors on unknown keys
-- `subset` errors on duplicate keys
+- public collection types are synthetic and engine-defined
+- item types are unchanged; collection-relative identity stays on the
+  collection, not the item
+- list order preserves the order of the effective `keys` member
+- `get` errors on an unknown key
+- `subset` is exact key selection, not a predicate language; it preserves
+  parent key order and errors on unknown or duplicate keys
 
-The engine materializes `list` by iterating keys and calling backing
-collection `get(...)`.
-`get` is the canonical exact-key access path.
-`subset(keys: [...])` is the operation for representing an exact
-key-selected subset of a collection while preserving collection shape.
+The engine materializes `list` by iterating keys and calling the backing
+`get`. `subset` narrows the keyspace while preserving collection shape.
 
 ### Collection Algebra
 
@@ -197,27 +317,31 @@ both single-engine and cross-engine execution.
 
 ### Batch Namespace
 
-`batch` is not part of the core collection algebra. It is a reserved
-extension point for type-specific collection-level operations that can execute
-more efficiently over the current subset than naively invoking the equivalent
-item-level operation one item at a time.
+`batch` is not part of the core collection algebra. It is a type-specific
+namespace for collection-level operations that can execute more efficiently
+over the current subset than invoking the equivalent item-level operation one
+item at a time.
 
-For example, a collection of test definitions may implement batch `checks`
-that runs one `go test` process over many selected tests rather than one
-process per test.
+The synthetic `batch` type is derived from the backing collection type. The
+engine identifies the effective `keys` member and effective `get` function;
+every other exposed function on the collection type is re-homed under `batch`.
+Non-function fields are not projected publicly, except for the effective `keys`
+member.
+
+For example, a collection of test definitions may expose a `runTests` function
+alongside `keys` and `get`. The engine projects `runTests` under `batch`,
+so clients call `c.batch.runTests` to run one `go test` process over many
+selected tests rather than one process per test.
 
 Important boundaries:
 - `batch` operates on the current subset, so `c.subset(keys: ks).batch`
   sees only `ks`
-- `batch` is about efficient execution over a collection subset
 - `batch` is type-specific; different collection types may expose different
-  methods under it
-- the meaning of methods under `batch` is specific to each collection type and
-  outside the core collection algebra
+  methods under it, and their meaning is outside the core collection algebra
 
-## Schema Representation
+### Typedefs
 
-This section answers how Collections are represented in the schema and
+This section answers how collections are represented in the schema and
 introspection model, as distinct from the public client-facing API they
 project to.
 
@@ -233,8 +357,6 @@ This keeps collection-unaware clients simple: they can continue treating a
 collection projection as an ordinary object. Collection-aware traversal
 surfaces can look for `AsCollection` when they need keyed-hop behavior.
 
-Leading shape:
-
 ```go
 // CollectionTypeDef describes collection semantics layered on top of an object type.
 type CollectionTypeDef struct {
@@ -248,11 +370,6 @@ type CollectionTypeDef struct {
   BatchType *TypeDef
 }
 ```
-
-Intended meaning:
-- `KeyType` is the type accepted by `get(key)` and `subset(keys: [...])`
-- `ValueType` is the type returned by `get()` and enumerated by `list`
-- `BatchType` is the type returned by `batch`
 
 This document does not introduce `TypeDefKindCollection`.
 
@@ -268,59 +385,11 @@ The reservation still matters as a general rule for future Dagger-injected
 members and other projection escape hatches. Module authors should not define
 public fields or arguments with leading `_`.
 
-### Map Semantics
+## Checks and Generators
 
-Collections should be understood as map-shaped at the semantic layer:
-- `+keys` defines a typed keyspace
-- `+get` resolves a value from a key
-
-In part 1, that value is constrained to be an object, and the public DAGQL
-surface projects the collection as a synthetic collection object rather than a
-first-class map kind.
-
-Collections are map-shaped semantically, even though this proposal does not
-introduce a general map kind.
-
-That broader map design is intentionally out of scope here. This document does
-not define:
-- a public DAGQL map kind
-- traversal semantics for arbitrary map values
-- codegen or introspection rules for general maps
-
-## Tooling and Traversal
-
-This document focuses on how Collections affect selection and traversal
-mechanisms that already exist.
-
-Collections affect the following current surfaces.
-
-This document specifies collection-aware traversal semantics, but does not
-require a particular shared implementation strategy for those surfaces.
-Whether keyed traversal is centralized in one lowering layer or implemented in
-surface-specific code is a tactical part 1 detail.
-
-### `dagger call`
-
-`dagger call` already walks a function pipeline over the current object.
-
-Collections add a keyed refinement step to that traversal:
-- selecting a collection-valued member should not force users to spell raw
-  `get(...)`
-- keyed refinement should lower to `get(...)` on the synthetic collection
-  object and then continue traversal on the item type
-- raw DAGQL still degrades gracefully because clients can call `list` and
-  `get` directly
-
-### `dagger shell`
-
-`dagger shell` already pipes state through commands such as `foo | bar`.
-
-Collections add keyed refinement to that existing pipeline model:
-- a collection-valued hop should remain traversable inside shell pipelines
-- keyed refinement should lower to `get(...)` before continuing on item
-  methods/fields
-- shell completion and help should understand collection-valued steps in the
-  current pipeline
+This section describes how collections interact with the existing check and
+generator feature. These rules are specific to that feature and are not part of
+the core collection interfaces defined above.
 
 ### Checks
 
@@ -341,11 +410,18 @@ Two classes of filters are generated automatically from the traversed schema:
 Filter names are derived mechanically from type names using Dagger's existing
 CLI casing rules.
 
+Collection filters follow the same CLI conventions as list-valued function
+arguments. Repeating the flag is the preferred form, for example
+`--go-tests TestFoo --go-tests TestBar`. A comma-separated list in a single
+flag occurrence is also accepted for consistency with existing CLI list
+handling, for example `--go-tests TestFoo,TestBar`. Both forms are equivalent
+and lower to exact-key subset selection.
+
 Examples:
 
 ```bash
 $ dagger check --go=true --nodejs=true --sdk=true --nodejs-sdk=false
-$ dagger check --go-tests=TestFoo,TestBar --go-modules=./myapp/app2
+$ dagger check --go-tests TestFoo --go-tests TestBar --go-modules ./myapp/app2
 ```
 
 These filters are scope-relative constraints, not unique selectors.
@@ -355,7 +431,6 @@ These filters are scope-relative constraints, not unique selectors.
 - A collection filter narrows every matching collection occurrence to the given
   key subset.
 - A filter may match zero, one, or many occurrences.
-- Matching many occurrences is valid.
 - To narrow further, combine filters.
 
 Function-path selectors remain valid, but filters do not depend on them. A
@@ -440,23 +515,36 @@ $ dagger check --go-tests=TestFoo,TestBar go:tests:lint
 # runs once per filtered item using the item type's lint check
 ```
 
-### `+generate` / generators
+### Generators
 
-The current generators path should be treated the same way as current
-`dagger check`.
+Generators follow the same traversal rules as checks. The collection-aware
+filtering and targeting described above applies to both.
 
-Collections do not materially retrofit generator discovery or execution in part
-1.
+## Implementation
 
-This should also be understood as a near no-op:
-- no major collection-aware redesign of current generator walking is specified
-  here
-- no major effort should be spent teaching current modtree walking to become
-  collection-native for generators
-- collection-native generator targeting, if needed, belongs with later
-  higher-layer work rather than this core Collections design
+Collections affect several existing implementation areas.
 
-### Client Libraries
+### Engine
+
+The engine is responsible for validating collection definitions and projecting
+them into the public schema:
+- validate module-side `+collection`, `+keys`, and `+get`
+- synthesize public collection objects
+- expose `AsCollection` alongside `AsObject`
+- implement `keys`, `list`, `get`, `subset`, and `batch` on the synthetic
+  collection object
+
+### Module Runtimes
+
+Module runtimes must support authoring collections on ordinary objects:
+- runtime-side schema registration must accept `+collection`, `+keys`, and
+  `+get`
+- existing pragma/decorator/directive plumbing should extend to collection
+  semantics
+- the raw module-defined collection object remains a backing shape rather than
+  the public client shape
+
+### Generated Clients
 
 Generated client libraries should reflect the projected public DAGQL surface:
 - collection-valued members appear as synthetic collection objects
@@ -465,24 +553,23 @@ Generated client libraries should reflect the projected public DAGQL surface:
 - generated clients should not collapse the core collection algebra into a
   type-specific `batch` surface
 
-### Codegen Tooling
+### `dagger call`
 
-Collections affect both codegen directions:
-- module authoring codegen must understand module-side `+keys` and `+get`
-- client codegen must expose the projected synthetic collection object surface,
-  including the separation between core collection operations and `batch`
-  methods
-- leading `_` reservation must be preserved so generated APIs do not collide
-  with module-defined members
+`dagger call` does not add keyed-refinement sugar for collections. Collection
+traversal follows the projected API directly: users call `keys`, `list`,
+`get`, `subset`, and `batch` explicitly.
 
-### JSON Export Of Object State
+Collection-aware filtering — where generated CLI flags lower to `subset` on
+matching collections — belongs only to `dagger check` and `dagger generate`.
 
-Collections affect the JSON shape of projected values:
-- public collection projection exports as a synthetic collection object, not
-  the raw module-defined collection object
-- enumerated values appear through `list`
+### `dagger shell`
 
-### Other Current Surfaces
+`dagger shell` follows the same rule as `dagger call`: collection traversal
+uses the projected API explicitly. Shell completion and help should understand
+collection-valued steps in the current pipeline, but no collection-aware
+filtering is added.
+
+### `dagger functions`
 
 Other existing discoverability surfaces should follow the same projection model:
 - `dagger functions`
@@ -490,32 +577,38 @@ Other existing discoverability surfaces should follow the same projection model:
 - module/type inspection
 - schema introspection consumed by tooling
 
-## Scope
+## General Maps
 
-### Rooting Scope
+Collections are map-shaped at the semantic layer — `keys` defines a typed
+keyspace, `get` resolves a value from a key — but this proposal restricts
+values to objects. It does not introduce:
+- a public DagQL map kind
+- traversal or codegen rules for arbitrary map values
+- typedef or introspection rules for a general map abstraction
 
-Part 1 fits the current module shape on `main`.
+A broader map design may follow; collections are intended not to close that
+door.
 
-That means:
-- collections live under the existing single rooted module object
-- rooted collections and broader root-model cleanup are out of scope here
+## Implementation Status
 
-### Non-Goals
+### Planned
 
-This document does not define:
-- artifacts
-- provenance
-- verb planning
-- dedicated split/sharding APIs beyond key-based `subset`
-- the contents of any particular collection type's `batch` namespace
-- schema cleanup for multiple rooted constructors
+- [ ] Add collection metadata and validation to module typedefs
+- [ ] Implement schema projection for public collection and batch types
+- [ ] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
+- [ ] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
+- [ ] Add module authoring support across supported SDKs and runtimes
+- [ ] Add integration, CLI, and codegen coverage
 
-### Deferred Work
+### Accomplished
 
-The engine may use private collection splitting internally in part 1.
-
-This document sketches public `subset` because distributed splitting may need
-to represent collection subsets across engine boundaries.
-
-Richer public split/shard APIs stay out of scope until the planned schema
-cleanup for constructors/rooting lands.
+- [x] Locked the design decision that `dagger call` and `dagger shell` use explicit collection traversal only
+- [x] Locked the design decision that collection-aware filtering sugar belongs only to `dagger check` and `dagger generate`
+- [x] Locked the design decision that any exposed collection function beyond effective `keys` and `get` is re-homed under `batch`
+- [x] Locked the design decision that the public projected collection type keeps the author-defined collection type name
+- [x] Locked the design decision that the synthetic batch type is named `<CollectionType>_Batch`
+- [x] Locked the design decision that collection keys may be builtin scalars, custom scalars, or enums, but not object-like or list types
+- [x] Locked the design decision that effective `get` takes exactly one non-null key argument and returns a non-null object
+- [x] Locked the design decision that load time checks structure and runtime checks behavior
+- [x] Locked the design decision that collection filters accept repeated flags and comma-separated input, with repeated flags preferred
+- [x] No engine, CLI, or SDK implementation has started yet

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -593,7 +593,7 @@ door.
 
 ### Planned
 
-- [ ] Add collection metadata and validation to module typedefs
+- [x] Add collection metadata and validation to module typedefs
 - [ ] Implement schema projection for public collection and batch types
 - [ ] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
 - [ ] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
@@ -611,4 +611,4 @@ door.
 - [x] Locked the design decision that effective `get` takes exactly one non-null key argument and returns a non-null object
 - [x] Locked the design decision that load time checks structure and runtime checks behavior
 - [x] Locked the design decision that collection filters accept repeated flags and comma-separated input, with repeated flags preferred
-- [x] No engine, CLI, or SDK implementation has started yet
+- [x] Engine implementation has started with collection typedef metadata and validation

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -233,11 +233,11 @@ Example public projection:
 """Root object exposing the projected public collection."""
 type Go {
   """Projected collection of Go modules."""
-  modules: _GoModuleCollection!
+  modules: GoModules!
 }
 
 """Synthetic public projection of a Go module collection."""
-type _GoModuleCollection {
+type GoModules {
   """Keys in the current subset, in stable collection order."""
   keys: [WorkspacePath!]!
 
@@ -254,14 +254,14 @@ type _GoModuleCollection {
   subset(
     """Keys to retain from the current subset."""
     keys: [WorkspacePath!]!
-  ): _GoModuleCollection!
+  ): GoModules!
 
   """Type-specific efficient operations over the current subset."""
-  batch: _GoModuleCollectionBatch!
+  batch: GoModules_Batch!
 }
 
 """Type-specific batch operations over the current subset."""
-type _GoModuleCollectionBatch {
+type GoModules_Batch {
   """Illustrative only: efficiently evaluate checks over the current subset."""
   checks: CheckGroup!
 }
@@ -577,7 +577,7 @@ door.
 ### Planned
 
 - [x] Add collection metadata and validation to module typedefs
-- [ ] Implement schema projection for public collection and batch types
+- [x] Implement schema projection for public collection and batch types
 - [ ] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
 - [ ] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
 - [ ] Add module authoring support across supported SDKs and runtimes
@@ -596,3 +596,4 @@ door.
 - [x] Locked the design decision that load time checks structure and runtime checks behavior
 - [x] Locked the design decision that collection filters accept repeated flags and comma-separated input, with repeated flags preferred
 - [x] Engine implementation has started with collection typedef metadata and validation
+- [x] Engine implementation now projects synthetic public collection and batch schema types

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -79,13 +79,13 @@ Collections are defined on ordinary object types by annotating the type itself
 as a collection.
 
 Each collection type has:
-- one effective `keys` member
+- one effective `keys` field
 - one effective `get` function
 
 The type annotation is required. Member annotations are optional.
 
-- If a collection type exposes a member named `keys`, that member is the
-  effective `keys` member by default.
+- If a collection type exposes a field named `keys`, that field is the
+  effective `keys` field by default.
 - If a collection type exposes a function named `get`, that function is the
   effective `get` function by default.
 - `@keys` and `@get` are only needed to override those default names.
@@ -124,27 +124,27 @@ type GoModules @collection {
 
 Rules:
 - `@collection` / `+collection` is required on the type itself
-- the effective `keys` member enumerates the collection keyspace
+- the effective `keys` field enumerates the collection keyspace
 - the effective `get` function resolves one item by key
-- `keys` may be an exposed field or an exposed no-arg function
+- `keys` must be an exposed field
 - `get` must be an exposed function
-- if `@keys` is absent, the exposed member named `keys` is used
+- if `@keys` is absent, the exposed field named `keys` is used
 - if `@get` is absent, the exposed function named `get` is used
 - if `@keys` or `@get` is present, it overrides the default name-based
   convention
 - only scalar and enum input types are valid as collection keys; this includes
   builtin scalars, custom scalars, and enums; object, input-object, interface,
   and list types are not valid collection key types
-- the effective `keys` member returns `[KeyType!]!`
+- the effective `keys` field returns `[KeyType!]!`
 - the effective `get` function accepts exactly one non-null `KeyType` argument
   and returns a non-null object
-- a collection must have exactly one effective `keys` member and exactly one
+- a collection must have exactly one effective `keys` field and exactly one
   effective `get` function
 - keys should be unique within a collection
 
 Collection validity is enforced in two stages. At module load time, the engine
 validates structure: whether the type is marked as a collection, whether there
-is exactly one effective `keys` member and one effective `get` function, and
+is exactly one effective `keys` field and one effective `get` function, and
 whether their signatures are valid. At runtime, the engine validates behavior
 when the collection is used: if `keys` advertises a key that `get` cannot
 resolve, collection operations fail at the point of use.
@@ -152,7 +152,7 @@ resolve, collection operations fail at the point of use.
 Collections describe how a dynamic set is addressed and traversed. They do not
 by themselves add mutation, execution, or other higher-level behavior.
 
-Any exposed function on the collection type beyond the effective `keys` and
+Any exposed function on the collection type beyond the effective `keys` field and
 `get` is automatically re-homed under the synthetic `batch` namespace (see
 [Batch Namespace](#batch-namespace)). Module authors define batch operations
 as ordinary functions on the collection type; the engine handles projection.
@@ -161,11 +161,7 @@ Illustrative authoring examples:
 
 ```dang
 type GoTests @collection {
-  pub testNames: [String!]
-
-  pub keys: [String!] {
-    testNames
-  }
+  pub keys: [String!]
 
   pub get(name: String!): GoTest! {
     GoTest(name: name)
@@ -176,11 +172,7 @@ type GoTests @collection {
 ```go
 // +collection
 type GoTests struct {
-	TestNames []string
-}
-
-func (tests *GoTests) Keys() []string {
-	return tests.TestNames
+	Keys []string
 }
 
 func (tests *GoTests) Get(name string) *GoTest {
@@ -194,12 +186,7 @@ import { collection, func, object } from "@dagger.io/dagger";
 @object()
 @collection()
 class GoTests {
-  constructor(private readonly testNames: string[]) {}
-
-  @func()
-  keys(): string[] {
-    return this.testNames;
-  }
+  keys: string[] = [];
 
   @func()
   get(name: string): GoTest {
@@ -215,11 +202,7 @@ from dagger import collection, function, object_type
 @object_type
 @collection
 class GoTests:
-    test_names: list[str]
-
-    @function
-    def keys(self) -> list[str]:
-        return self.test_names
+    keys: list[str]
 
     @function
     def get(self, name: str) -> "GoTest":
@@ -290,7 +273,7 @@ Rules:
 - public collection types are synthetic and engine-defined
 - item types are unchanged; collection-relative identity stays on the
   collection, not the item
-- list order preserves the order of the effective `keys` member
+- list order preserves the order of the effective `keys` field
 - `get` errors on an unknown key
 - `subset` is exact key selection, not a predicate language; it preserves
   parent key order and errors on unknown or duplicate keys
@@ -323,10 +306,10 @@ over the current subset than invoking the equivalent item-level operation one
 item at a time.
 
 The synthetic `batch` type is derived from the backing collection type. The
-engine identifies the effective `keys` member and effective `get` function;
+engine identifies the effective `keys` field and effective `get` function;
 every other exposed function on the collection type is re-homed under `batch`.
 Non-function fields are not projected publicly, except for the effective `keys`
-member.
+field.
 
 For example, a collection of test definitions may expose a `runTests` function
 alongside `keys` and `get`. The engine projects `runTests` under `batch`,
@@ -604,7 +587,8 @@ door.
 
 - [x] Locked the design decision that `dagger call` and `dagger shell` use explicit collection traversal only
 - [x] Locked the design decision that collection-aware filtering sugar belongs only to `dagger check` and `dagger generate`
-- [x] Locked the design decision that any exposed collection function beyond effective `keys` and `get` is re-homed under `batch`
+- [x] Locked the design decision that any exposed collection function beyond the effective `keys` field and `get` is re-homed under `batch`
+- [x] Locked the design decision that collection `keys` are always authored as a field
 - [x] Locked the design decision that the public projected collection type keeps the author-defined collection type name
 - [x] Locked the design decision that the synthetic batch type is named `<CollectionType>_Batch`
 - [x] Locked the design decision that collection keys may be builtin scalars, custom scalars, or enums, but not object-like or list types

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -579,7 +579,7 @@ door.
 - [x] Add collection metadata and validation to module typedefs
 - [x] Implement schema projection for public collection and batch types
 - [x] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
-- [ ] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
+- [x] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
 - [ ] Add module authoring support across supported SDKs and runtimes
 - [ ] Add integration, CLI, and codegen coverage
 
@@ -598,3 +598,4 @@ door.
 - [x] Engine implementation has started with collection typedef metadata and validation
 - [x] Engine implementation now projects synthetic public collection and batch schema types
 - [x] CLI type inspection now recognizes projected collections and `dagger call` treats collection leaves as explicit traversal points
+- [x] Check and generator traversal now apply collection-aware filters, batch shadowing, and raw filter-value listing

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -580,7 +580,7 @@ door.
 - [x] Implement schema projection for public collection and batch types
 - [x] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
 - [x] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
-- [ ] Add module authoring support across supported SDKs and runtimes
+- [x] Add module authoring support across supported SDKs and runtimes
 - [ ] Add integration, CLI, and codegen coverage
 
 ### Accomplished
@@ -599,3 +599,4 @@ door.
 - [x] Engine implementation now projects synthetic public collection and batch schema types
 - [x] CLI type inspection now recognizes projected collections and `dagger call` treats collection leaves as explicit traversal points
 - [x] Check and generator traversal now apply collection-aware filters, batch shadowing, and raw filter-value listing
+- [x] Go, TypeScript, Python, and Java module authoring paths now register collection backing objects and explicit keys/get overrides

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -578,7 +578,7 @@ door.
 
 - [x] Add collection metadata and validation to module typedefs
 - [x] Implement schema projection for public collection and batch types
-- [ ] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
+- [x] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
 - [ ] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
 - [ ] Add module authoring support across supported SDKs and runtimes
 - [ ] Add integration, CLI, and codegen coverage
@@ -597,3 +597,4 @@ door.
 - [x] Locked the design decision that collection filters accept repeated flags and comma-separated input, with repeated flags preferred
 - [x] Engine implementation has started with collection typedef metadata and validation
 - [x] Engine implementation now projects synthetic public collection and batch schema types
+- [x] CLI type inspection now recognizes projected collections and `dagger call` treats collection leaves as explicit traversal points

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -581,7 +581,7 @@ door.
 - [x] Support explicit collection traversal in `dagger call`, `dagger shell`, and discoverability surfaces
 - [x] Add collection-aware filtering and batch shadowing to `dagger check` and `dagger generate`
 - [x] Add module authoring support across supported SDKs and runtimes
-- [ ] Add integration, CLI, and codegen coverage
+- [x] Add integration, CLI, and codegen coverage
 
 ### Accomplished
 
@@ -600,3 +600,4 @@ door.
 - [x] CLI type inspection now recognizes projected collections and `dagger call` treats collection leaves as explicit traversal points
 - [x] Check and generator traversal now apply collection-aware filters, batch shadowing, and raw filter-value listing
 - [x] Go, TypeScript, Python, and Java module authoring paths now register collection backing objects and explicit keys/get overrides
+- [x] Integration coverage now exercises explicit collection traversal in `dagger call` and generated Go and TypeScript clients over the projected `keys` / `list` / `get` / `subset` / `batch` surface

--- a/hack/designs/collections.md
+++ b/hack/designs/collections.md
@@ -1,0 +1,521 @@
+# Collections
+
+## Status: Draft
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Problem](#problem)
+- [Proposal](#proposal)
+- [Module Definition](#module-definition)
+- [Client Representation](#client-representation)
+- [Schema Representation](#schema-representation)
+- [Tooling and Traversal](#tooling-and-traversal)
+- [Scope](#scope)
+
+## Summary
+
+Collections are a standalone primitive for representing keyed dynamic sets in a
+module's published object graph.
+
+This document intentionally stays narrow:
+- collections define keyed collections of objects
+- this proposal defines the collection primitive only
+- it does not change object semantics beyond collection traversal, selection,
+  and batching
+
+This document includes `subset` as part of the collection primitive so that
+collections can represent exact key-selected subsets of themselves.
+
+## Problem
+
+Modules can already discover dynamic sets of related objects, but today they
+have no standard way to publish them as keyed collections.
+
+That leaves a gap:
+
+1. Dagger has lists and objects, but no map-like abstraction in the published
+   schema.
+2. Dynamic sets are usually keyed in practice, but the key structure is not
+   first-class.
+3. Existing traversal and selection mechanisms need keyed targeting without
+   forcing users to spell explicit collection accessors like `get(...)`.
+
+Collections fill that gap.
+
+## Proposal
+
+A collection is a keyed dynamic set.
+
+It is defined on ordinary module objects using collection semantics, not a new
+type kind.
+
+The current direction is:
+- module-side collection contract: `+keys` and `+get`
+- public DAGQL projection: collection-valued fields/functions project as
+  synthetic collection objects
+- higher-level targeting syntax provides keyed traversal over that projection
+
+## Module Definition
+
+Collections are defined by semantic annotations on ordinary module fields and
+functions.
+
+Leading shape:
+
+```graphql
+"""Collection of Go modules keyed by workspace path."""
+type GoModules {
+  """All keys currently present in the collection."""
+  keys: [WorkspacePath!]! @keys
+
+  """Resolve one module by workspace path."""
+  get(
+    """Workspace path to resolve."""
+    path: WorkspacePath!
+  ): GoModule! @get
+}
+```
+
+Rules:
+- `+keys` enumerates the collection keyspace
+- `+get` resolves one item by key
+- `get` is required for every collection in v1
+- every key returned by `+keys` must be accepted by `get`; otherwise the
+  collection is invalid
+- keys should be unique within a collection
+
+Collections describe how a dynamic set is addressed and traversed. They do not
+by themselves add mutation, execution, or other higher-level behavior.
+
+If a module wants extra behavior on the underlying collection object, that is
+module-specific behavior, not part of the core collection algebra. If surfaced
+publicly, type-specific efficient collection-level behavior belongs under
+namespaces such as `batch`, not alongside the core `keys`, `list`, `get`, and
+`subset` operations.
+
+## Client Representation
+
+The raw module-defined collection object stays hidden from clients.
+
+Instead, a field or function returning a collection projects to a synthetic
+collection object with engine-defined standardized members. The projected field
+keeps the original module name.
+
+Example internal shape:
+
+```graphql
+"""Root object exposing a collection of Go modules."""
+type Go {
+  """Collection of Go modules."""
+  modules: GoModules!
+}
+```
+
+Example public projection:
+
+```graphql
+"""Root object exposing the projected public collection."""
+type Go {
+  """Projected collection of Go modules."""
+  modules: _GoModuleCollection!
+}
+
+"""Synthetic public projection of a Go module collection."""
+type _GoModuleCollection {
+  """Keys in the current subset, in stable collection order."""
+  keys: [WorkspacePath!]!
+
+  """Items in the current subset, in the same order as `keys`."""
+  list: [GoModule!]!
+
+  """Resolve one item in the current subset by key."""
+  get(
+    """Key to resolve."""
+    key: WorkspacePath!
+  ): GoModule!
+
+  """Restrict the collection to an exact subset of keys."""
+  subset(
+    """Keys to retain from the current subset."""
+    keys: [WorkspacePath!]!
+  ): _GoModuleCollection!
+
+  """Type-specific efficient operations over the current subset."""
+  batch: _GoModuleCollectionBatch!
+}
+
+"""Type-specific batch operations over the current subset."""
+type _GoModuleCollectionBatch {
+  """Illustrative only: efficiently evaluate checks over the current subset."""
+  checks: CheckGroup!
+}
+```
+
+Current rules:
+- projection keeps the original field/function name
+- public collection types are synthetic, engine-defined objects rather than
+  raw module-defined collection objects
+- projected collections expose typed `keys`, `list`, and `get`
+- projected collections also expose `subset`, returning the same synthetic
+  collection type so subsets can be represented across engine boundaries
+- projected collections reserve `batch` as a type-specific namespace for
+  efficient execution over the current subset
+- `get` errors on an unknown key
+- projected item types are otherwise unchanged; collection-relative identity
+  stays on the collection object rather than being injected onto the item type
+- projection applies to both fields and functions returning collections
+- projected list order preserves the order of `+keys`
+- `subset` is exact key-based subset selection, not a general predicate
+  language
+- `subset` preserves the parent key order
+- `subset` errors on unknown keys
+- `subset` errors on duplicate keys
+
+The engine materializes `list` by iterating keys and calling backing
+collection `get(...)`.
+`get` is the canonical exact-key access path.
+`subset(keys: [...])` is the operation for representing an exact
+key-selected subset of a collection while preserving collection shape.
+
+### Collection Algebra
+
+The synthetic collection object defines a small algebra:
+- `keys` describes the current subset's keyspace
+- `list` materializes the current subset's items
+- `get(key)` materializes one item from the current subset
+- `subset(keys)` narrows the current subset while preserving collection shape
+
+Expected laws:
+- `c.subset(keys: c.keys)` is equivalent to `c`
+- `c.subset(keys: ks).keys` returns `ks` in parent order
+- `c.subset(keys: ks).list` returns the items for `ks` in parent order
+- `c.subset(keys: ks).get(k)` errors unless `k` is in `ks`
+
+This keeps subset transport, exact-key access, and enumeration coherent across
+both single-engine and cross-engine execution.
+
+### Batch Namespace
+
+`batch` is not part of the core collection algebra. It is a reserved
+extension point for type-specific collection-level operations that can execute
+more efficiently over the current subset than naively invoking the equivalent
+item-level operation one item at a time.
+
+For example, a collection of test definitions may implement batch `checks`
+that runs one `go test` process over many selected tests rather than one
+process per test.
+
+Important boundaries:
+- `batch` operates on the current subset, so `c.subset(keys: ks).batch`
+  sees only `ks`
+- `batch` is about efficient execution over a collection subset
+- `batch` is type-specific; different collection types may expose different
+  methods under it
+- the meaning of methods under `batch` is specific to each collection type and
+  outside the core collection algebra
+
+## Schema Representation
+
+This section answers how Collections are represented in the schema and
+introspection model, as distinct from the public client-facing API they
+project to.
+
+Collections should be represented in the type system as metadata layered on an
+object, not as a peer kind.
+
+That means:
+- projected collections still have `TypeDef.Kind = OBJECT`
+- projected collections still populate `TypeDef.AsObject`
+- projected collections additionally populate `TypeDef.AsCollection`
+
+This keeps collection-unaware clients simple: they can continue treating a
+collection projection as an ordinary object. Collection-aware traversal
+surfaces can look for `AsCollection` when they need keyed-hop behavior.
+
+Leading shape:
+
+```go
+// CollectionTypeDef describes collection semantics layered on top of an object type.
+type CollectionTypeDef struct {
+  // KeyType is the type accepted by get(key) and subset(keys: ...).
+  KeyType *TypeDef
+
+  // ValueType is the type returned by get() and enumerated by list.
+  ValueType *TypeDef
+
+  // BatchType is the type returned by batch.
+  BatchType *TypeDef
+}
+```
+
+Intended meaning:
+- `KeyType` is the type accepted by `get(key)` and `subset(keys: [...])`
+- `ValueType` is the type returned by `get()` and enumerated by `list`
+- `BatchType` is the type returned by `batch`
+
+This document does not introduce `TypeDefKindCollection`.
+
+### Reserved Names
+
+Leading `_` is reserved for Dagger-injected fields and arguments.
+
+The core synthetic collection object in this document uses normal names
+(`keys`, `list`, `get`, `subset`, `batch`) because that object is fully
+engine-owned and does not expose raw module-defined collection methods.
+
+The reservation still matters as a general rule for future Dagger-injected
+members and other projection escape hatches. Module authors should not define
+public fields or arguments with leading `_`.
+
+### Map Semantics
+
+Collections should be understood as map-shaped at the semantic layer:
+- `+keys` defines a typed keyspace
+- `+get` resolves a value from a key
+
+In part 1, that value is constrained to be an object, and the public DAGQL
+surface projects the collection as a synthetic collection object rather than a
+first-class map kind.
+
+Collections are map-shaped semantically, even though this proposal does not
+introduce a general map kind.
+
+That broader map design is intentionally out of scope here. This document does
+not define:
+- a public DAGQL map kind
+- traversal semantics for arbitrary map values
+- codegen or introspection rules for general maps
+
+## Tooling and Traversal
+
+This document focuses on how Collections affect selection and traversal
+mechanisms that already exist.
+
+Collections affect the following current surfaces.
+
+This document specifies collection-aware traversal semantics, but does not
+require a particular shared implementation strategy for those surfaces.
+Whether keyed traversal is centralized in one lowering layer or implemented in
+surface-specific code is a tactical part 1 detail.
+
+### `dagger call`
+
+`dagger call` already walks a function pipeline over the current object.
+
+Collections add a keyed refinement step to that traversal:
+- selecting a collection-valued member should not force users to spell raw
+  `get(...)`
+- keyed refinement should lower to `get(...)` on the synthetic collection
+  object and then continue traversal on the item type
+- raw DAGQL still degrades gracefully because clients can call `list` and
+  `get` directly
+
+### `dagger shell`
+
+`dagger shell` already pipes state through commands such as `foo | bar`.
+
+Collections add keyed refinement to that existing pipeline model:
+- a collection-valued hop should remain traversable inside shell pipelines
+- keyed refinement should lower to `get(...)` before continuing on item
+  methods/fields
+- shell completion and help should understand collection-valued steps in the
+  current pipeline
+
+### Checks
+
+Collections affect checks through generated filters and through the collection's
+effective check set.
+
+#### Filter Model
+
+Check filters shape the effective check tree before listing or execution.
+
+Two classes of filters are generated automatically from the traversed schema:
+
+- Every object type touched by check traversal gets a boolean filter of the form
+  `--<type>=true|false`.
+- Every collection type touched by check traversal gets a valued filter of the
+  form `--<collection-type>=<key>[,<key>...]`.
+
+Filter names are derived mechanically from type names using Dagger's existing
+CLI casing rules.
+
+Examples:
+
+```bash
+$ dagger check --go=true --nodejs=true --sdk=true --nodejs-sdk=false
+$ dagger check --go-tests=TestFoo,TestBar --go-modules=./myapp/app2
+```
+
+These filters are scope-relative constraints, not unique selectors.
+
+- An object filter applies to every occurrence of that type within the selected
+  scope.
+- A collection filter narrows every matching collection occurrence to the given
+  key subset.
+- A filter may match zero, one, or many occurrences.
+- Matching many occurrences is valid.
+- To narrow further, combine filters.
+
+Function-path selectors remain valid, but filters do not depend on them. A
+selector narrows the scope first. Filters then shape the tree within that
+scope.
+
+Type renames are CLI-breaking for these generated filters.
+
+#### Listing Filter Values
+
+Every collection filter has a corresponding list flag:
+
+- `--list-<collection-type>`
+
+This lists the flat set of values available for that collection filter within
+the current scope.
+
+Examples:
+
+```bash
+$ dagger check --list-go-tests
+$ dagger check --go-modules=./myapp/app2 --list-go-tests
+$ dagger check --go-tests=TestFoo --list-go-tests --list-go-modules
+```
+
+Listing rules:
+
+- `--list-<collection-type>` lists raw filter values, not schema paths.
+- It applies all other active filters first.
+- It ignores its own active value filter while listing.
+- Multiple `--list-*` flags are allowed.
+- Each listed dimension is printed independently.
+- Parent/child relationships between different filter dimensions are
+  intentionally flattened.
+- Output is unique values in stable order.
+
+`dagger check -l` remains a structural check listing. It is allowed with
+selectors and boolean object filters. It is not allowed with valued collection
+filters.
+
+For example:
+
+```bash
+$ dagger check -l --go=true --sdk=false
+
+$ dagger check -l --go-tests=TestFoo
+Error: can't use -l with --go-tests; use --list-go-tests instead
+```
+
+#### Batch Shadowing
+
+Collections affect checks in two places:
+
+- item checks, defined on the collection's item type
+- batch checks, defined on the collection's `batch` type
+
+A collection contributes one effective check set.
+
+- If an item check and a batch check have the same name, the batch check
+  shadows the item check.
+- If no batch check exists for a name, the item check remains in the effective
+  check set.
+
+Execution follows the same rule.
+
+- A shadowing batch check runs once for the current collection subset.
+- An unshadowed item check runs once per item in the current collection
+  subset.
+
+For example, suppose `go.tests` has item checks `runTest` and `lint`, and
+`go.tests.batch` defines `runTest` but not `lint`.
+
+```bash
+$ dagger check -l
+go:tests:lint
+go:tests:run-test
+
+$ dagger check --go-tests=TestFoo,TestBar go:tests:run-test
+# runs once using go.tests.batch.runTest over the filtered subset
+
+$ dagger check --go-tests=TestFoo,TestBar go:tests:lint
+# runs once per filtered item using the item type's lint check
+```
+
+### `+generate` / generators
+
+The current generators path should be treated the same way as current
+`dagger check`.
+
+Collections do not materially retrofit generator discovery or execution in part
+1.
+
+This should also be understood as a near no-op:
+- no major collection-aware redesign of current generator walking is specified
+  here
+- no major effort should be spent teaching current modtree walking to become
+  collection-native for generators
+- collection-native generator targeting, if needed, belongs with later
+  higher-layer work rather than this core Collections design
+
+### Client Libraries
+
+Generated client libraries should reflect the projected public DAGQL surface:
+- collection-valued members appear as synthetic collection objects
+- projected collections preserve the distinction between the core collection
+  algebra and the type-specific `batch` namespace
+- generated clients should not collapse the core collection algebra into a
+  type-specific `batch` surface
+
+### Codegen Tooling
+
+Collections affect both codegen directions:
+- module authoring codegen must understand module-side `+keys` and `+get`
+- client codegen must expose the projected synthetic collection object surface,
+  including the separation between core collection operations and `batch`
+  methods
+- leading `_` reservation must be preserved so generated APIs do not collide
+  with module-defined members
+
+### JSON Export Of Object State
+
+Collections affect the JSON shape of projected values:
+- public collection projection exports as a synthetic collection object, not
+  the raw module-defined collection object
+- enumerated values appear through `list`
+
+### Other Current Surfaces
+
+Other existing discoverability surfaces should follow the same projection model:
+- `dagger functions`
+- shell completion/help
+- module/type inspection
+- schema introspection consumed by tooling
+
+## Scope
+
+### Rooting Scope
+
+Part 1 fits the current module shape on `main`.
+
+That means:
+- collections live under the existing single rooted module object
+- rooted collections and broader root-model cleanup are out of scope here
+
+### Non-Goals
+
+This document does not define:
+- artifacts
+- provenance
+- verb planning
+- dedicated split/sharding APIs beyond key-based `subset`
+- the contents of any particular collection type's `batch` namespace
+- schema cleanup for multiple rooted constructors
+
+### Deferred Work
+
+The engine may use private collection splitting internally in part 1.
+
+This document sketches public `subset` because distributed splitting may need
+to represent collection subsets across engine boundaries.
+
+Richer public split/shard APIs stay out of scope until the planned schema
+cleanup for constructors/rooting lands.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -14222,6 +14222,35 @@ func (r *TypeDef) WithField(name string, typeDef *TypeDef, opts ...TypeDefWithFi
 	}
 }
 
+// Marks an Object TypeDef as a collection.
+func (r *TypeDef) WithCollection() *TypeDef {
+	q := r.query.Select("withCollection")
+
+	return &TypeDef{
+		query: q,
+	}
+}
+
+// Overrides the effective keys field for a collection Object TypeDef.
+func (r *TypeDef) WithCollectionKeys(name string) *TypeDef {
+	q := r.query.Select("withCollectionKeys")
+	q = q.Arg("name", name)
+
+	return &TypeDef{
+		query: q,
+	}
+}
+
+// Overrides the effective get function for a collection Object TypeDef.
+func (r *TypeDef) WithCollectionGet(name string) *TypeDef {
+	q := r.query.Select("withCollectionGet")
+	q = q.Arg("name", name)
+
+	return &TypeDef{
+		query: q,
+	}
+}
+
 // Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
 func (r *TypeDef) WithFunction(function *Function) *TypeDef {
 	assertNotNil("function", function)

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -14384,6 +14384,8 @@ func (r *Workspace) Address(ctx context.Context) (string, error) {
 type WorkspaceChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// Collection-aware filters to apply while traversing checks
+	Filters []CollectionFilterInput
 }
 
 // Return all checks from modules loaded in the workspace.
@@ -14393,6 +14395,10 @@ func (r *Workspace) Checks(opts ...WorkspaceChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `filters` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Filters) {
+			q = q.Arg("filters", opts[i].Filters)
 		}
 	}
 
@@ -14513,6 +14519,8 @@ func (r *Workspace) FindUp(ctx context.Context, name string, opts ...WorkspaceFi
 type WorkspaceGeneratorsOpts struct {
 	// Only include generators matching the specified patterns
 	Include []string
+	// Collection-aware filters to apply while traversing generators
+	Filters []CollectionFilterInput
 }
 
 // Return all generators from modules loaded in the workspace.
@@ -14522,6 +14530,10 @@ func (r *Workspace) Generators(opts ...WorkspaceGeneratorsOpts) *GeneratorGroup 
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `filters` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Filters) {
+			q = q.Arg("filters", opts[i].Filters)
 		}
 	}
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -350,6 +350,15 @@ type PortForward struct {
 	Protocol NetworkProtocol `json:"protocol,omitempty"`
 }
 
+// Collection-aware filter input for check and generator traversal.
+type CollectionFilterInput struct {
+	// Collection type name.
+	TypeName string `json:"typeName"`
+
+	// Exact filter values to retain within matching collections.
+	Values []string `json:"values"`
+}
+
 // A standardized address to load containers, directories, secrets, and other object types. Address format depends on the type, and is validated at type selection.
 type Address struct {
 	query *querybuilder.Selection
@@ -3529,6 +3538,8 @@ func (r *CurrentModule) GeneratedContextDirectory() *Directory {
 type CurrentModuleGeneratorsOpts struct {
 	// Only include generators matching the specified patterns
 	Include []string
+	// Collection-aware filters to apply while traversing generators
+	Filters []CollectionFilterInput
 }
 
 // Return all generators defined by the module
@@ -3540,6 +3551,10 @@ func (r *CurrentModule) Generators(opts ...CurrentModuleGeneratorsOpts) *Generat
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `filters` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Filters) {
+			q = q.Arg("filters", opts[i].Filters)
 		}
 	}
 
@@ -10090,6 +10105,8 @@ func (r *Module) Check(name string) *Check {
 type ModuleChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// Collection-aware filters to apply while traversing checks
+	Filters []CollectionFilterInput
 }
 
 // Return all checks defined by the module
@@ -10101,6 +10118,10 @@ func (r *Module) Checks(opts ...ModuleChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `filters` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Filters) {
+			q = q.Arg("filters", opts[i].Filters)
 		}
 	}
 
@@ -10213,6 +10234,8 @@ func (r *Module) Generator(name string) *Generator {
 type ModuleGeneratorsOpts struct {
 	// Only include generators matching the specified patterns
 	Include []string
+	// Collection-aware filters to apply while traversing generators
+	Filters []CollectionFilterInput
 }
 
 // Return all generators defined by the module
@@ -10224,6 +10247,10 @@ func (r *Module) Generators(opts ...ModuleGeneratorsOpts) *GeneratorGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `filters` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Filters) {
+			q = q.Arg("filters", opts[i].Filters)
 		}
 	}
 

--- a/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
+++ b/sdk/java/dagger-java-annotation-processor/src/main/java/io/dagger/annotation/processor/DaggerModuleAnnotationProcessor.java
@@ -26,10 +26,13 @@ import io.dagger.module.annotation.Default;
 import io.dagger.module.annotation.DefaultPath;
 import io.dagger.module.annotation.Enum;
 import io.dagger.module.annotation.Function;
+import io.dagger.module.annotation.Get;
 import io.dagger.module.annotation.Generate;
 import io.dagger.module.annotation.Ignore;
+import io.dagger.module.annotation.Keys;
 import io.dagger.module.annotation.Module;
 import io.dagger.module.annotation.Object;
+import io.dagger.module.annotation.Collection;
 import io.dagger.module.info.EnumInfo;
 import io.dagger.module.info.EnumValueInfo;
 import io.dagger.module.info.FieldInfo;
@@ -71,10 +74,13 @@ import javax.lang.model.util.Elements;
 @SupportedAnnotationTypes({
   "io.dagger.module.annotation.Module",
   "io.dagger.module.annotation.Object",
+  "io.dagger.module.annotation.Collection",
   "io.dagger.module.annotation.Enum",
   "io.dagger.module.annotation.Function",
+  "io.dagger.module.annotation.Get",
   "io.dagger.module.annotation.Check",
   "io.dagger.module.annotation.Generate",
+  "io.dagger.module.annotation.Keys",
   "io.dagger.module.annotation.Optional",
   "io.dagger.module.annotation.Default",
   "io.dagger.module.annotation.DefaultPath"
@@ -97,6 +103,7 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
     String moduleDescription = null;
     Set<ObjectInfo> annotatedObjects = new HashSet<>();
     boolean hasModuleAnnotation = false;
+    Set<String> processedObjects = new HashSet<>();
 
     Map<String, EnumInfo> enumInfos = new HashMap<>();
 
@@ -133,6 +140,16 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
           case CLASS, RECORD -> {
             TypeElement typeElement = (TypeElement) element;
             String qName = typeElement.getQualifiedName().toString();
+            boolean isObject = element.getAnnotation(Object.class) != null;
+            boolean isCollection = element.getAnnotation(Collection.class) != null;
+            if (isCollection && !isObject) {
+              throw new RuntimeException(
+                  "The class %s must also be annotated with @Object when using @Collection"
+                      .formatted(qName));
+            }
+            if (!isObject || !processedObjects.add(qName)) {
+              continue;
+            }
             String name = typeElement.getAnnotation(Object.class).value();
             if (name.isEmpty()) {
               name = typeElement.getSimpleName().toString();
@@ -180,7 +197,8 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                                 ((ExecutableElement) elt).getReturnType().getKind().name()),
                             parseParameters((ExecutableElement) elt).toArray(new ParameterInfo[0]),
                             false, // constructors are never checks
-                            false)); // constructors are never generators
+                            false, // constructors are never generators
+                            false)); // constructors are never collection gets
               } else if (constructorDefs.size() > 1) {
                 // There's more than one non-empty constructor, but Dagger only supports to expose a
                 // single one
@@ -198,7 +216,8 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                     .filter(
                         elt ->
                             elt.getModifiers().contains(Modifier.PUBLIC)
-                                || elt.getAnnotation(Function.class) != null)
+                                || elt.getAnnotation(Function.class) != null
+                                || elt.getAnnotation(Keys.class) != null)
                     .map(
                         elt -> {
                           String fieldName = elt.getSimpleName().toString();
@@ -208,18 +227,22 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                               new FieldInfo(
                                   fieldName,
                                   parseSimpleDescription(elt),
-                                  new TypeInfo(tm.toString(), tk.name()));
+                                  new TypeInfo(tm.toString(), tk.name()),
+                                  elt.getAnnotation(Keys.class) != null);
                           return f;
                         })
                     .toList();
             List<FunctionInfo> functionInfos =
                 typeElement.getEnclosedElements().stream()
                     .filter(elt -> elt.getKind() == ElementKind.METHOD)
-                    .filter(elt -> elt.getAnnotation(Function.class) != null)
+                    .filter(
+                        elt ->
+                            elt.getAnnotation(Function.class) != null
+                                || elt.getAnnotation(Get.class) != null)
                     .map(
                         elt -> {
                           Function moduleFunction = elt.getAnnotation(Function.class);
-                          String fName = moduleFunction.value();
+                          String fName = moduleFunction != null ? moduleFunction.value() : "";
                           String fqName = elt.getSimpleName().toString();
                           if (fName.isEmpty()) {
                             fName = fqName;
@@ -237,6 +260,7 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                           TypeKind tk = tm.getKind();
                           boolean isCheck = elt.getAnnotation(Check.class) != null;
                           boolean isGenerate = elt.getAnnotation(Generate.class) != null;
+                          boolean isCollectionGet = elt.getAnnotation(Get.class) != null;
                           FunctionInfo functionInfo =
                               new FunctionInfo(
                                   fName,
@@ -245,7 +269,8 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                                   new TypeInfo(tm.toString(), tk.name()),
                                   parameterInfos.toArray(new ParameterInfo[parameterInfos.size()]),
                                   isCheck,
-                                  isGenerate);
+                                  isGenerate,
+                                  isCollectionGet);
                           return functionInfo;
                         })
                     .toList();
@@ -254,6 +279,7 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                     name,
                     qName,
                     parseObjectDescription(typeElement),
+                    isCollection,
                     fieldInfoInfos.toArray(new FieldInfo[fieldInfoInfos.size()]),
                     functionInfos.toArray(new FunctionInfo[functionInfos.size()]),
                     constructorInfo));
@@ -393,6 +419,9 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
               objectInfo.description());
         }
         rm.addCode(")"); // end of dag().TypeDef().withObject(
+        if (objectInfo.collection()) {
+          rm.addCode("\n            .withCollection()");
+        }
         for (var fnInfo : objectInfo.functions()) {
           rm.addCode("\n            .withFunction(")
               .addCode(withFunction(moduleInfo.enumInfos().keySet(), objectInfo, fnInfo))
@@ -407,6 +436,18 @@ public class DaggerModuleAnnotationProcessor extends AbstractProcessor {
                 .addCode(".withDescription($S)", fieldInfo.description());
           }
           rm.addCode(")");
+        }
+        for (var fieldInfo : objectInfo.fields()) {
+          if (fieldInfo.isCollectionKeys()) {
+            rm.addCode("\n            .withCollectionKeys($S)", fieldInfo.name());
+            break;
+          }
+        }
+        for (var fnInfo : objectInfo.functions()) {
+          if (fnInfo.isCollectionGet()) {
+            rm.addCode("\n            .withCollectionGet($S)", fnInfo.name());
+            break;
+          }
         }
         if (objectInfo.constructor().isPresent()) {
           rm.addCode("\n            .withConstructor(")

--- a/sdk/java/dagger-java-annotation-processor/src/test/java/io/dagger/annotation/processor/CollectionGenerateTest.java
+++ b/sdk/java/dagger-java-annotation-processor/src/test/java/io/dagger/annotation/processor/CollectionGenerateTest.java
@@ -1,0 +1,36 @@
+package io.dagger.annotation.processor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.Test;
+import org.assertj.core.api.Assertions;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+
+public class CollectionGenerateTest {
+  @Test
+  public void testCollectionAnnotationGeneration() throws Exception {
+    new EnvironmentVariables("_DAGGER_JAVA_SDK_MODULE_NAME", "collections")
+        .execute(
+            () -> {
+              Compilation compilation =
+                  javac()
+                      .withProcessors(new DaggerModuleAnnotationProcessor())
+                      .compile(
+                          JavaFileObjects.forResource("io/dagger/java/collection/Collections.java"),
+                          JavaFileObjects.forResource("io/dagger/java/collection/GoTest.java"));
+              assertThat(compilation).succeeded();
+              JavaFileObject generated =
+                  compilation
+                      .generatedSourceFile("io.dagger.gen.entrypoint.Entrypoint")
+                      .orElseThrow();
+              String source = generated.getCharContent(false).toString();
+              Assertions.assertThat(source).contains(".withCollection()");
+              Assertions.assertThat(source).contains(".withCollectionKeys(\"paths\")");
+              Assertions.assertThat(source).contains(".withCollectionGet(\"module\")");
+            });
+  }
+}

--- a/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/collection/Collections.java
+++ b/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/collection/Collections.java
@@ -1,0 +1,18 @@
+package io.dagger.java.collection;
+
+import io.dagger.module.annotation.Collection;
+import io.dagger.module.annotation.Get;
+import io.dagger.module.annotation.Keys;
+import io.dagger.module.annotation.Object;
+import java.util.List;
+
+@Object
+@Collection
+public class Collections {
+  @Keys public List<String> paths;
+
+  @Get
+  public GoTest module(String name) {
+    return new GoTest();
+  }
+}

--- a/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/collection/GoTest.java
+++ b/sdk/java/dagger-java-annotation-processor/src/test/resources/io/dagger/java/collection/GoTest.java
@@ -1,0 +1,8 @@
+package io.dagger.java.collection;
+
+import io.dagger.module.annotation.Object;
+
+@Object
+public class GoTest {
+  public String name;
+}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Collection.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Collection.java
@@ -1,0 +1,10 @@
+package io.dagger.module.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Collection {}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Get.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Get.java
@@ -1,0 +1,10 @@
+package io.dagger.module.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Get {}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Keys.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/annotation/Keys.java
@@ -1,0 +1,10 @@
+package io.dagger.module.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Keys {}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/FieldInfo.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/FieldInfo.java
@@ -1,3 +1,3 @@
 package io.dagger.module.info;
 
-public record FieldInfo(String name, String description, TypeInfo type) {}
+public record FieldInfo(String name, String description, TypeInfo type, boolean isCollectionKeys) {}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/FunctionInfo.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/FunctionInfo.java
@@ -7,4 +7,5 @@ public record FunctionInfo(
     TypeInfo returnType,
     ParameterInfo[] parameters,
     boolean isCheck,
-    boolean isGenerate) {}
+    boolean isGenerate,
+    boolean isCollectionGet) {}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/ObjectInfo.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/module/info/ObjectInfo.java
@@ -6,6 +6,7 @@ public record ObjectInfo(
     String name,
     String qualifiedName,
     String description,
+    boolean collection,
     FieldInfo[] fields,
     FunctionInfo[] functions,
     Optional<FunctionInfo> constructor) {}

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -14129,6 +14129,40 @@ class TypeDef(Type):
         _ctx = self._select("withField", _args)
         return TypeDef(_ctx)
 
+    def with_collection(self) -> Self:
+        """Marks an Object TypeDef as a collection."""
+        _args: list[Arg] = []
+        _ctx = self._select("withCollection", _args)
+        return TypeDef(_ctx)
+
+    def with_collection_keys(self, name: str) -> Self:
+        """Overrides the effective keys field for a collection Object TypeDef.
+
+        Parameters
+        ----------
+        name:
+            The field name to use as the effective keys field
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withCollectionKeys", _args)
+        return TypeDef(_ctx)
+
+    def with_collection_get(self, name: str) -> Self:
+        """Overrides the effective get function for a collection Object TypeDef.
+
+        Parameters
+        ----------
+        name:
+            The function name to use as the effective get function
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withCollectionGet", _args)
+        return TypeDef(_ctx)
+
     def with_function(self, function: Function) -> Self:
         """Adds a function for an Object or Interface TypeDef, failing if the
         type is not one of those kinds.

--- a/sdk/python/src/dagger/mod/__init__.py
+++ b/sdk/python/src/dagger/mod/__init__.py
@@ -12,11 +12,14 @@ from dagger.mod._types import Enum
 _default_mod = Module()
 
 check = _default_mod.check
+collection = _default_mod.collection
 enum_type = _default_mod.enum_type
 function = _default_mod.function
 field = _default_mod.field
 generate = _default_mod.generate
+get = _default_mod.get
 interface = _default_mod.interface
+keys = _default_mod.keys
 object_type = _default_mod.object_type
 
 
@@ -34,10 +37,13 @@ __all__ = [
     "Ignore",
     "Name",
     "check",
+    "collection",
     "enum_type",
     "field",
     "function",
     "generate",
+    "get",
     "interface",
+    "keys",
     "object_type",
 ]

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -55,6 +55,8 @@ FIELD_DEF_KEY: typing.Final[str] = "__dagger_field__"
 FUNCTION_DEF_KEY: typing.Final[str] = "__dagger_function__"
 CHECK_DEF_KEY: typing.Final[str] = "__dagger_check__"
 GENERATOR_DEF_KEY: typing.Final[str] = "__dagger_generate__"
+COLLECTION_DEF_KEY: typing.Final[str] = "__dagger_collection__"
+GET_DEF_KEY: typing.Final[str] = "__dagger_get__"
 MODULE_NAME: typing.Final[str] = os.getenv("DAGGER_MODULE", "")
 MAIN_OBJECT: typing.Final[str] = os.getenv("DAGGER_MAIN_OBJECT", "")
 TYPE_DEF_FILE: typing.Final[str] = os.getenv("DAGGER_MODULE_FILE", "/module.json")
@@ -162,6 +164,8 @@ class Module:
                     description=get_doc(obj_type.cls),
                     deprecated=obj_type.deprecated,
                 )
+                if obj_type.collection:
+                    type_def = type_def.with_collection()
 
             # Object fields
             if obj_type.fields:
@@ -175,6 +179,13 @@ class Module:
                         description=get_doc(field.return_type),
                         deprecated=field.meta.deprecated,
                     )
+
+                collection_keys = next(
+                    (field for field in obj_type.fields.values() if field.meta.collection_key),
+                    None,
+                )
+                if collection_keys is not None:
+                    type_def = type_def.with_collection_keys(collection_keys.name)
 
             # Object/interface functions
             for func_name, func in obj_type.functions.items():
@@ -237,6 +248,17 @@ class Module:
                     if func_name == ""
                     else type_def.with_function(func_def)
                 )
+
+            collection_get = next(
+                (
+                    func
+                    for name, func in obj_type.functions.items()
+                    if name != "" and func.collection_get
+                ),
+                None,
+            )
+            if collection_get is not None:
+                type_def = type_def.with_collection_get(collection_get.name)
 
             # Add object/interface to module
             mod = (
@@ -573,6 +595,7 @@ class Module:
         name: APIName | None = None,
         init: bool = True,
         deprecated: str | None = None,
+        collection_key: bool = False,
     ) -> Any:
         """Exposes an attribute as a :py:class:`dagger.FieldTypeDef`.
 
@@ -608,11 +631,35 @@ class Module:
             kwargs["default_factory" if callable(default) else "default"] = default
 
         return dataclasses.field(
-            metadata={FIELD_DEF_KEY: FieldDefinition(name, optional, deprecated)},
+            metadata={
+                FIELD_DEF_KEY: FieldDefinition(
+                    name,
+                    optional,
+                    deprecated,
+                    collection_key,
+                )
+            },
             kw_only=True,
             init=init,
             repr=init,  # default repr shows field as an __init__ argument
             **kwargs,
+        )
+
+    def keys(
+        self,
+        *,
+        default: Callable[[], Any] | object = ...,
+        name: APIName | None = None,
+        init: bool = True,
+        deprecated: str | None = None,
+    ) -> Any:
+        """Exposes a field as the effective collection keys field."""
+        return self.field(
+            default=default,
+            name=name,
+            init=init,
+            deprecated=deprecated,
+            collection_key=True,
         )
 
     def check(
@@ -680,6 +727,18 @@ class Module:
 
         return wrapper(func) if func else wrapper
 
+    def get(
+        self,
+        func: Func[P, R] | None = None,
+    ) -> Func[P, R] | Callable[[Func[P, R]], Func[P, R]]:
+        """Mark a function as the effective collection get function."""
+
+        def wrapper(fn: Func[P, R]) -> Func[P, R]:
+            setattr(fn, GET_DEF_KEY, True)
+            return fn
+
+        return wrapper(func) if func else wrapper
+
     @overload
     def function(
         self,
@@ -743,6 +802,7 @@ class Module:
             # Check if function is marked as a check or generator
             check = getattr(func, CHECK_DEF_KEY, False)
             generator = getattr(func, GENERATOR_DEF_KEY, False)
+            collection_get = getattr(func, GET_DEF_KEY, False)
 
             meta = FunctionDefinition(
                 name=name,
@@ -751,6 +811,7 @@ class Module:
                 deprecated=deprecated,
                 check=check,
                 generator=generator,
+                collection_get=collection_get,
             )
 
             if inspect.isclass(func):
@@ -835,7 +896,12 @@ class Module:
         interface: bool = False,
         deprecated: str | None = None,
     ) -> T:
-        obj_def = ObjectType(cls, interface=interface, deprecated=deprecated)
+        obj_def = ObjectType(
+            cls,
+            interface=interface,
+            deprecated=deprecated,
+            collection=getattr(cls, COLLECTION_DEF_KEY, False),
+        )
 
         cls.__dagger_module__ = self
         cls.__dagger_object_type__ = obj_def
@@ -871,8 +937,10 @@ class Module:
 
         # Find all fields exposed with `mod.field()`.
         for field in dataclasses.fields(cls):
-            field_def: FieldDefinition | None
-            if field_def := field.metadata.get(FIELD_DEF_KEY, None):
+            field_def: FieldDefinition | None = field.metadata.get(FIELD_DEF_KEY, None)
+            if field_def is None and obj_def.collection and field.name == "keys":
+                field_def = FieldDefinition(name=None)
+            if field_def is not None:
                 r = Field(
                     meta=field_def,
                     original_name=field.name,
@@ -905,6 +973,32 @@ class Module:
         )
 
         return cls
+
+    @overload
+    def collection(self, cls: T) -> T: ...
+
+    @overload
+    def collection(self) -> Callable[[T], T]: ...
+
+    def collection(self, cls: T | None = None) -> T | Callable[[T], T]:
+        """Marks an object type as a collection."""
+
+        def wrapper(cls: T) -> T:
+            setattr(cls, COLLECTION_DEF_KEY, True)
+            obj_def = getattr(cls, "__dagger_object_type__", None)
+            if obj_def is not None:
+                obj_def.collection = True
+                if "keys" not in obj_def.fields:
+                    annotations = inspect.get_annotations(cls)
+                    if "keys" in annotations:
+                        obj_def.fields["keys"] = Field(
+                            meta=FieldDefinition(name=None),
+                            original_name="keys",
+                            return_type=annotations["keys"],
+                        )
+            return cls
+
+        return wrapper(cls) if cls else wrapper
 
     @overload
     def interface(self, cls: T) -> T: ...

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -40,6 +40,7 @@ from dagger.mod._utils import (
 
 CHECK_DEF_KEY: str = "__dagger_check__"
 GENERATOR_DEF_KEY: str = "__dagger_generate__"
+GET_DEF_KEY: str = "__dagger_get__"
 
 logger = logging.getLogger(__package__)
 
@@ -109,6 +110,11 @@ class Function(Generic[P, R]):
         """Indicates whether the function is configured as a generator."""
         # Check both the metadata and the attribute to support either decorator order
         return self.meta.generator or getattr(self.wrapped, GENERATOR_DEF_KEY, False)
+
+    @property
+    def collection_get(self) -> bool:
+        """Indicates whether the function is configured as the collection get function."""
+        return self.meta.collection_get or getattr(self.wrapped, GET_DEF_KEY, False)
 
     @cached_property
     def cache_policy(self):
@@ -277,6 +283,7 @@ class ObjectType(Generic[T]):
     cls: type[T]
     interface: bool = False
     deprecated: str | None = None
+    collection: bool = False
     fields: dict[APIName, Field] = dataclasses.field(default_factory=dict)
     functions: dict[APIName, Function] = dataclasses.field(default_factory=dict)
 

--- a/sdk/python/src/dagger/mod/_types.py
+++ b/sdk/python/src/dagger/mod/_types.py
@@ -14,6 +14,7 @@ class FieldDefinition:
     name: APIName | None
     optional: bool = False
     deprecated: str | None = None
+    collection_key: bool = False
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -24,6 +25,7 @@ class FunctionDefinition:
     deprecated: str | None = None
     check: bool = False
     generator: bool = False
+    collection_get: bool = False
 
 
 class Enum(str, base.Enum):

--- a/sdk/python/tests/mod/test_registration.py
+++ b/sdk/python/tests/mod/test_registration.py
@@ -162,6 +162,51 @@ def test_object_type_deprecated_metadata():
     assert obj.deprecated == "Use NewFoo instead"
 
 
+def test_collection_marks_object_and_exposes_default_keys_field():
+    mod = Module()
+
+    @mod.object_type
+    class GoTest:
+        name: str = mod.field(default="")
+
+    @mod.object_type
+    @mod.collection
+    class GoTests:
+        keys: list[str]
+
+        @mod.function
+        def get(self, name: str) -> GoTest:
+            return GoTest(name=name)
+
+    obj = mod.get_object("GoTests")
+    assert obj.collection is True
+    assert "keys" in obj.fields
+    assert obj.fields["keys"].meta.collection_key is False
+
+
+def test_collection_override_markers():
+    mod = Module()
+
+    @mod.object_type
+    class GoTest:
+        name: str = mod.field(default="")
+
+    @mod.object_type
+    @mod.collection
+    class GoTests:
+        paths: list[str] = mod.keys()
+
+        @mod.function
+        @mod.get
+        def lookup(self, name: str) -> GoTest:
+            return GoTest(name=name)
+
+    obj = mod.get_object("GoTests")
+    assert obj.collection is True
+    assert obj.fields["paths"].meta.collection_key is True
+    assert obj.functions["lookup"].collection_get is True
+
+
 def test_external_constructor_doc():
     mod = Module()
 

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -13696,6 +13696,32 @@ export class TypeDef extends BaseClient {
   }
 
   /**
+   * Marks an Object TypeDef as a collection.
+   */
+  withCollection = (): TypeDef => {
+    const ctx = this._ctx.select("withCollection")
+    return new TypeDef(ctx)
+  }
+
+  /**
+   * Overrides the effective keys field for a collection Object TypeDef.
+   * @param name The field name to use as the effective keys field
+   */
+  withCollectionKeys = (name: string): TypeDef => {
+    const ctx = this._ctx.select("withCollectionKeys", { name })
+    return new TypeDef(ctx)
+  }
+
+  /**
+   * Overrides the effective get function for a collection Object TypeDef.
+   * @param name The function name to use as the effective get function
+   */
+  withCollectionGet = (name: string): TypeDef => {
+    const ctx = this._ctx.select("withCollectionGet", { name })
+    return new TypeDef(ctx)
+  }
+
+  /**
    * Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
    */
   withFunction = (function_: Function_): TypeDef => {

--- a/sdk/typescript/src/module/decorators.ts
+++ b/sdk/typescript/src/module/decorators.ts
@@ -11,6 +11,11 @@ import { registry } from "./registry.js"
 export const object = registry.object
 
 /**
+ * The definition of the `@collection` decorator that marks an object as a collection.
+ */
+export const collection = registry.collection
+
+/**
  * The definition of @func decorator that should be on top of any
  * class' method that must be exposed to the Dagger API.
  *
@@ -18,6 +23,11 @@ export const object = registry.object
  * @param cache The cache setting to use for that function.
  */
 export const func = registry.func
+
+/**
+ * The definition of @get decorator that marks a method as the effective get function.
+ */
+export const get = registry.get
 
 /**
  * The definition of @check decorator that marks a function as a check.
@@ -39,6 +49,11 @@ export const generate = registry.generate
  * @param alias The alias to use for the field when exposed on the API.
  */
 export const field = registry.field
+
+/**
+ * The definition of @keys decorator that marks a field as the effective keys field.
+ */
+export const keys = registry.keys
 
 /**
  * The definition of the `@enumType` decorator that should be on top of any

--- a/sdk/typescript/src/module/entrypoint/register.ts
+++ b/sdk/typescript/src/module/entrypoint/register.ts
@@ -55,6 +55,9 @@ export class Register {
 
       // Register the class Typedef object in Dagger
       let typeDef = dag.typeDef().withObject(object.name, objectOpts)
+      if (object.isCollection) {
+        typeDef = typeDef.withCollection()
+      }
 
       // Register all functions (methods) to this object
       Object.values(object.methods).forEach((method) => {
@@ -77,6 +80,24 @@ export class Register {
           )
         }
       })
+
+      const collectionKeys = Object.values(object.properties).find(
+        (property) => property.isCollectionKeys,
+      )
+      if (collectionKeys) {
+        typeDef = typeDef.withCollectionKeys(
+          collectionKeys.alias ?? collectionKeys.name,
+        )
+      }
+
+      const collectionGet = Object.values(object.methods).find(
+        (method) => method.isCollectionGet,
+      )
+      if (collectionGet) {
+        typeDef = typeDef.withCollectionGet(
+          collectionGet.alias ?? collectionGet.name,
+        )
+      }
 
       if (object._constructor) {
         typeDef = typeDef.withConstructor(

--- a/sdk/typescript/src/module/introspector/dagger_module/decorator.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/decorator.ts
@@ -1,26 +1,35 @@
 import {
   argument,
+  collection,
   func,
   object,
   enumType,
   field,
   check,
   generate,
+  get,
+  keys,
 } from "../../decorators.js"
 
 export type DaggerDecorators =
+  | "collection"
   | "object"
   | "func"
+  | "get"
   | "check"
   | "generate"
   | "argument"
   | "enumType"
   | "field"
+  | "keys"
 
+export const COLLECTION_DECORATOR = collection.name as DaggerDecorators
 export const OBJECT_DECORATOR = object.name as DaggerDecorators
 export const FUNCTION_DECORATOR = func.name as DaggerDecorators
+export const GET_DECORATOR = get.name as DaggerDecorators
 export const CHECK_DECORATOR = check.name as DaggerDecorators
 export const GENERATOR_DECORATOR = generate.name as DaggerDecorators
 export const FIELD_DECORATOR = field.name as DaggerDecorators
+export const KEYS_DECORATOR = keys.name as DaggerDecorators
 export const ARGUMENT_DECORATOR = argument.name as DaggerDecorators
 export const ENUM_DECORATOR = enumType.name as DaggerDecorators

--- a/sdk/typescript/src/module/introspector/dagger_module/function.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/function.ts
@@ -14,6 +14,7 @@ import {
   CHECK_DECORATOR,
   FUNCTION_DECORATOR,
   GENERATOR_DECORATOR,
+  GET_DECORATOR,
 } from "./decorator.js"
 import { Locatable } from "./locatable.js"
 import { References } from "./reference.js"
@@ -31,6 +32,7 @@ export class DaggerFunction extends Locatable {
   public cache: string | undefined
   public isCheck: boolean = false
   public isGenerator: boolean = false
+  public isCollectionGet: boolean = false
 
   private signature: ts.Signature
   private symbol: ts.Symbol
@@ -70,6 +72,10 @@ export class DaggerFunction extends Locatable {
     // Parse @generate decorator
     if (this.ast.isNodeDecoratedWith(this.node, GENERATOR_DECORATOR)) {
       this.isGenerator = true
+    }
+
+    if (this.ast.isNodeDecoratedWith(this.node, GET_DECORATOR)) {
+      this.isCollectionGet = true
     }
 
     for (const parameter of this.node.parameters) {
@@ -145,6 +151,7 @@ export class DaggerFunction extends Locatable {
       description: this.description,
       deprecated: this.deprecated,
       alias: this.alias,
+      isCollectionGet: this.isCollectionGet || undefined,
       arguments: this.arguments,
       returnType: this.returnType,
     }

--- a/sdk/typescript/src/module/introspector/dagger_module/object.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/object.ts
@@ -3,7 +3,12 @@ import ts from "typescript"
 import { IntrospectionError } from "../../../common/errors/index.js"
 import { AST, Location } from "../typescript_module/index.js"
 import { DaggerConstructor } from "./constructor.js"
-import { FUNCTION_DECORATOR, OBJECT_DECORATOR } from "./decorator.js"
+import {
+  COLLECTION_DECORATOR,
+  FUNCTION_DECORATOR,
+  GET_DECORATOR,
+  OBJECT_DECORATOR,
+} from "./decorator.js"
 import { DaggerFunction, DaggerFunctions } from "./function.js"
 import { Locatable } from "./locatable.js"
 import { DaggerObjectBase } from "./objectBase.js"
@@ -30,6 +35,7 @@ export class DaggerObject extends Locatable implements DaggerObjectBase {
   public _constructor: DaggerConstructor | undefined = undefined
   public methods: DaggerFunctions = {}
   public properties: DaggerProperties = {}
+  public isCollection: boolean
 
   private symbol: ts.Symbol
 
@@ -65,6 +71,10 @@ export class DaggerObject extends Locatable implements DaggerObjectBase {
     }
 
     this.symbol = this.ast.getSymbolOrThrow(this.node.name)
+    this.isCollection = this.ast.isNodeDecoratedWith(
+      this.node,
+      COLLECTION_DECORATOR,
+    )
     const { description, deprecated } = this.ast.getSymbolDoc(this.symbol)
     this.description = description
     this.deprecated = deprecated
@@ -72,6 +82,9 @@ export class DaggerObject extends Locatable implements DaggerObjectBase {
     for (const member of this.node.members) {
       if (ts.isPropertyDeclaration(member)) {
         const property = new DaggerProperty(member, this.ast)
+        if (this.isCollection && property.name === "keys") {
+          property.isExposed = true
+        }
         this.properties[property.alias ?? property.name] = property
 
         continue
@@ -85,7 +98,8 @@ export class DaggerObject extends Locatable implements DaggerObjectBase {
 
       if (
         ts.isMethodDeclaration(member) &&
-        this.ast.isNodeDecoratedWith(member, FUNCTION_DECORATOR)
+        (this.ast.isNodeDecoratedWith(member, FUNCTION_DECORATOR) ||
+          this.ast.isNodeDecoratedWith(member, GET_DECORATOR))
       ) {
         const daggerFunction = new DaggerFunction(member, this.ast)
         this.methods[daggerFunction.alias ?? daggerFunction.name] =
@@ -136,10 +150,20 @@ export class DaggerObject extends Locatable implements DaggerObjectBase {
   }
 
   public toJSON() {
+    const collectionKeys = Object.values(this.properties).find(
+      (property) => property.isCollectionKeys,
+    )
+    const collectionGet = Object.values(this.methods).find(
+      (method) => method.isCollectionGet,
+    )
+
     return {
       name: this.name,
       description: this.description,
       deprecated: this.deprecated,
+      isCollection: this.isCollection || undefined,
+      collectionKeys: collectionKeys?.alias ?? collectionKeys?.name,
+      collectionGet: collectionGet?.alias ?? collectionGet?.name,
       constructor: this._constructor,
       methods: this.methods,
       properties: this.properties,

--- a/sdk/typescript/src/module/introspector/dagger_module/objectBase.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/objectBase.ts
@@ -11,6 +11,7 @@ export interface DaggerObjectPropertyBase extends Locatable {
   deprecated?: string
   alias?: string
   isExposed: boolean
+  isCollectionKeys?: boolean
   type?: TypeDef<TypeDefKind>
 
   propagateReferences(references: References): void
@@ -24,6 +25,9 @@ export interface DaggerObjectBase extends Locatable {
   name: string
   description: string
   deprecated?: string
+  isCollection?: boolean
+  collectionKeys?: string
+  collectionGet?: string
   _constructor: DaggerConstructor | undefined
   methods: DaggerFunctions
   properties: DaggerObjectPropertiesBase

--- a/sdk/typescript/src/module/introspector/dagger_module/property.ts
+++ b/sdk/typescript/src/module/introspector/dagger_module/property.ts
@@ -8,7 +8,11 @@ import {
   isTypeDefResolved,
   resolveTypeDef,
 } from "../typescript_module/index.js"
-import { FIELD_DECORATOR, FUNCTION_DECORATOR } from "./decorator.js"
+import {
+  FIELD_DECORATOR,
+  FUNCTION_DECORATOR,
+  KEYS_DECORATOR,
+} from "./decorator.js"
 import { Locatable } from "./locatable.js"
 import { DaggerObjectPropertyBase } from "./objectBase.js"
 import { References } from "./reference.js"
@@ -24,6 +28,7 @@ export class DaggerProperty
   public deprecated?: string
   public alias: string | undefined
   public isExposed: boolean
+  public isCollectionKeys: boolean
 
   private symbol: ts.Symbol
   private _typeRef?: string
@@ -45,7 +50,12 @@ export class DaggerProperty
 
     this.isExposed =
       this.ast.isNodeDecoratedWith(this.node, FUNCTION_DECORATOR) ||
-      this.ast.isNodeDecoratedWith(this.node, FIELD_DECORATOR)
+      this.ast.isNodeDecoratedWith(this.node, FIELD_DECORATOR) ||
+      this.ast.isNodeDecoratedWith(this.node, KEYS_DECORATOR)
+    this.isCollectionKeys = this.ast.isNodeDecoratedWith(
+      this.node,
+      KEYS_DECORATOR,
+    )
 
     const { description, deprecated } = this.ast.getSymbolDoc(this.symbol)
     this.description = description
@@ -123,6 +133,7 @@ export class DaggerProperty
       description: this.description,
       deprecated: this.deprecated,
       alias: this.alias,
+      isCollectionKeys: this.isCollectionKeys || undefined,
       type: this.type,
       isExposed: this.isExposed,
     }

--- a/sdk/typescript/src/module/introspector/test/scan.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/scan.spec.ts
@@ -100,6 +100,10 @@ describe("scan by reference TypeScript", function () {
       directory: "alias",
     },
     {
+      name: "Should correctly scan collections",
+      directory: "collection",
+    },
+    {
       name: "Should correctly scan minimal",
       directory: "minimal",
     },

--- a/sdk/typescript/src/module/introspector/test/testdata/collection/expected.json
+++ b/sdk/typescript/src/module/introspector/test/testdata/collection/expected.json
@@ -1,0 +1,80 @@
+{
+  "name": "Collection",
+  "objects": {
+    "Collection": {
+      "name": "Collection",
+      "description": "",
+      "methods": {
+        "tests": {
+          "name": "tests",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "GoTests"
+          }
+        }
+      },
+      "properties": {}
+    },
+    "GoTest": {
+      "name": "GoTest",
+      "description": "",
+      "methods": {},
+      "properties": {
+        "name": {
+          "name": "name",
+          "description": "",
+          "type": {
+            "kind": "STRING_KIND"
+          },
+          "isExposed": true
+        }
+      }
+    },
+    "GoTests": {
+      "name": "GoTests",
+      "description": "",
+      "isCollection": true,
+      "collectionGet": "lookup",
+      "methods": {
+        "lookup": {
+          "name": "lookup",
+          "description": "",
+          "isCollectionGet": true,
+          "arguments": {
+            "name": {
+              "name": "name",
+              "description": "",
+              "type": {
+                "kind": "STRING_KIND"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "GoTest"
+          }
+        }
+      },
+      "properties": {
+        "keys": {
+          "name": "keys",
+          "description": "",
+          "type": {
+            "kind": "LIST_KIND",
+            "typeDef": {
+              "kind": "STRING_KIND"
+            }
+          },
+          "isExposed": true
+        }
+      }
+    }
+  },
+  "enums": {},
+  "interfaces": {}
+}

--- a/sdk/typescript/src/module/introspector/test/testdata/collection/index.ts
+++ b/sdk/typescript/src/module/introspector/test/testdata/collection/index.ts
@@ -1,0 +1,28 @@
+import { collection, func, get, object } from "../../../../decorators.js"
+
+@object()
+export class GoTest {
+  @func()
+  name: string = ""
+}
+
+@object()
+@collection()
+export class GoTests {
+  keys: string[] = []
+
+  @get()
+  lookup(name: string): GoTest {
+    const test = new GoTest()
+    test.name = name
+    return test
+  }
+}
+
+@object()
+export class Collection {
+  @func()
+  tests(): GoTests {
+    return new GoTests()
+  }
+}

--- a/sdk/typescript/src/module/registry.ts
+++ b/sdk/typescript/src/module/registry.ts
@@ -64,6 +64,8 @@ export type FunctionOptions = {
   alias?: string
 }
 
+export type ObjectOptions = Record<string, never>
+
 /**
  * Registry stores class and method that have the @object decorator.
  *
@@ -104,6 +106,15 @@ export class Registry {
   }
 
   /**
+   * The definition of the @collection decorator that marks an object as a collection.
+   */
+  collection = (): (<T extends Class>(constructor: T) => T) => {
+    return <T extends Class>(constructor: T): T => {
+      return constructor
+    }
+  }
+
+  /**
    * The definition of @field decorator that should be on top of any
    * class' property that must be exposed to the Dagger API.
    *
@@ -117,12 +128,34 @@ export class Registry {
   }
 
   /**
+   * The definition of @keys decorator that marks a field as the effective keys field.
+   */
+  keys = (): ((target: object, propertyKey: string) => void) => {
+    return (target: object, propertyKey: string) => {}
+  }
+
+  /**
    * The definition of @func decorator that should be on top of any
    * class' method that must be exposed to the Dagger API.
    */
   func = (
     opts?: FunctionOptions | string,
   ): ((
+    target: object,
+    propertyKey: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ) => void) => {
+    return (
+      target: object,
+      propertyKey: string | symbol,
+      descriptor?: PropertyDescriptor,
+    ) => {}
+  }
+
+  /**
+   * The definition of @get decorator that marks a function as the effective get function.
+   */
+  get = (): ((
     target: object,
     propertyKey: string | symbol,
     descriptor?: PropertyDescriptor,

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -22,8 +22,16 @@ const (
 )
 
 func New(
-	// Project source directory
-	// +defaultPath="/"
+	// The current workspace containing the project source.
+	// +optional
+	workspace *dagger.Workspace,
+	// Project source path relative to the workspace root.
+	// Ignored when source is provided explicitly.
+	// +optional
+	// +default="."
+	sourcePath string,
+	// Project source directory override.
+	// +optional
 	source *dagger.Directory,
 	// Go version
 	// +optional
@@ -68,9 +76,7 @@ func New(
 	// +optional
 	extraPackages []string,
 ) *Go {
-	if source == nil {
-		source = dag.Directory()
-	}
+	source = resolveSource(workspace, sourcePath, source)
 	if moduleCache == nil {
 		// Cache volumes should be namespaced by module, but they aren't (yet).
 		// For now, we namespace them explicitly here.
@@ -122,6 +128,16 @@ func New(
 		Race:        race,
 		Experiment:  experiment,
 	}
+}
+
+func resolveSource(workspace *dagger.Workspace, sourcePath string, source *dagger.Directory) *dagger.Directory {
+	if source != nil {
+		return source
+	}
+	if workspace != nil {
+		return workspace.Directory(sourcePath)
+	}
+	return dag.Directory()
 }
 
 // A Go project

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -161,6 +161,33 @@ type Go struct {
 	Exclude []string
 }
 
+// A collection of discovered Go modules.
+//
+// +collection
+type GoModules struct {
+	Project *Go // +private
+
+	// Module paths in the current collection.
+	// +keys
+	Keys []string `json:"keys"`
+}
+
+// Resolve one discovered Go module by path.
+func (mods *GoModules) Get(path string) *GoModule {
+	return &GoModule{
+		Project: mods.Project,
+		Path:    path,
+	}
+}
+
+// A discovered Go module.
+type GoModule struct {
+	Project *Go // +private
+
+	// Path to this module within the source tree.
+	Path string `json:"path"`
+}
+
 type AssociativeArray[T any] []struct {
 	Key   string
 	Value T
@@ -465,11 +492,26 @@ func (p *Go) findParentDirs(ctx context.Context, dir *dagger.Directory, filename
 	return dirs, skipped, nil
 }
 
-// Scan the source for go modules, and return their paths
+// Discover Go modules in the source tree.
 func (p *Go) Modules(
 	ctx context.Context,
 	include []string, // +optional
 	exclude []string, // +optional
+) (*GoModules, error) {
+	mods, err := p.modulePaths(ctx, include, exclude)
+	if err != nil {
+		return nil, err
+	}
+	return &GoModules{
+		Project: p,
+		Keys:    mods,
+	}, nil
+}
+
+func (p *Go) modulePaths(
+	ctx context.Context,
+	include []string,
+	exclude []string,
 ) ([]string, error) {
 	mods, _, err := p.findParentDirs(ctx, p.Source, "go.mod", include, exclude)
 	if err != nil {
@@ -478,18 +520,38 @@ func (p *Go) Modules(
 	return mods, nil
 }
 
-func (p *Go) TidyModule(ctx context.Context, mod string) (*dagger.Changeset, error) {
-	p, err := p.GenerateDaggerRuntime(ctx, mod)
+// Run go mod tidy across the selected modules.
+func (mods *GoModules) Tidy(ctx context.Context) (*dagger.Changeset, error) {
+	tidyModules := make([]*dagger.Changeset, len(mods.Keys))
+	jobs := parallel.New()
+	for i, modPath := range mods.Keys {
+		i := i
+		modPath := modPath
+		jobs = jobs.WithJob(modPath, func(ctx context.Context) error {
+			var err error
+			tidyModules[i], err = mods.Get(modPath).Tidy(ctx)
+			return err
+		})
+	}
+	if err := jobs.Run(ctx); err != nil {
+		return nil, err
+	}
+	return changesetMerge(tidyModules...), nil
+}
+
+// Run go mod tidy for one module.
+func (mod *GoModule) Tidy(ctx context.Context) (*dagger.Changeset, error) {
+	p, err := mod.Project.GenerateDaggerRuntime(ctx, mod.Path)
 	if err != nil {
 		return nil, err
 	}
 	tidyModDir := p.Env(defaultPlatform).
-		WithWorkdir(mod).
+		WithWorkdir(mod.Path).
 		WithExec([]string{"go", "mod", "tidy"}).
 		Directory(".")
 	return p.Source.
-		WithFile(path.Join(mod, "/go.mod"), tidyModDir.File("go.mod")).
-		WithFile(path.Join(mod, "/go.sum"), tidyModDir.File("go.sum")).
+		WithFile(path.Join(mod.Path, "/go.mod"), tidyModDir.File("go.mod")).
+		WithFile(path.Join(mod.Path, "/go.sum"), tidyModDir.File("go.sum")).
 		Changes(p.Source), nil
 }
 
@@ -502,19 +564,7 @@ func (p *Go) Tidy(
 	if err != nil {
 		return nil, err
 	}
-	tidyModules := make([]*dagger.Changeset, len(modules))
-	jobs := parallel.New()
-	for i, mod := range modules {
-		jobs = jobs.WithJob(mod, func(ctx context.Context) error {
-			var err error
-			tidyModules[i], err = p.TidyModule(ctx, mod)
-			return err
-		})
-	}
-	if err := jobs.Run(ctx); err != nil {
-		return nil, err
-	}
-	return changesetMerge(tidyModules...), nil
+	return modules.Tidy(ctx)
 }
 
 // Merge Changesets together
@@ -544,6 +594,11 @@ func (p *Go) CheckTidy(
 	if err != nil {
 		return err
 	}
+	return modules.CheckTidy(ctx)
+}
+
+// Check whether go mod tidy is up-to-date for the selected modules.
+func (mods *GoModules) CheckTidy(ctx context.Context) error {
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel golangci-lint jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
@@ -555,25 +610,31 @@ func (p *Go) CheckTidy(
 		// For better display in 'dagger checks': we get a cool activity bar in our sub-checks
 		// TODO: remove this when dagger has a sub-checks API
 		WithRollupSpans(true)
-	for _, mod := range modules {
-		jobs = jobs.WithJob(mod, func(ctx context.Context) error {
-			diffTidy, err := p.TidyModule(ctx, mod)
-			if err != nil {
-				return err
-			}
-			changes, err := diffTidy.AsPatch().Contents(ctx)
-			if err != nil {
-				return err
-			}
-			if len(changes) > 0 {
-				stdio := telemetry.SpanStdio(ctx, "")
-				fmt.Fprint(stdio.Stderr, changes)
-				return fmt.Errorf("%s: 'go mod tidy' must be run", mod)
-			}
-			return nil
+	for _, modPath := range mods.Keys {
+		modPath := modPath
+		jobs = jobs.WithJob(modPath, func(ctx context.Context) error {
+			return mods.Get(modPath).CheckTidy(ctx)
 		})
 	}
 	return jobs.Run(ctx)
+}
+
+// Check whether go mod tidy is up-to-date for one module.
+func (mod *GoModule) CheckTidy(ctx context.Context) error {
+	diffTidy, err := mod.Tidy(ctx)
+	if err != nil {
+		return err
+	}
+	changes, err := diffTidy.AsPatch().Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if len(changes) > 0 {
+		stdio := telemetry.SpanStdio(ctx, "")
+		fmt.Fprint(stdio.Stderr, changes)
+		return fmt.Errorf("%s: 'go mod tidy' must be run", mod.Path)
+	}
+	return nil
 }
 
 func filterPath(path string, include, exclude []string) (bool, error) {
@@ -614,6 +675,11 @@ func (p *Go) Lint(
 	if err != nil {
 		return err
 	}
+	return mods.Lint(ctx)
+}
+
+// Lint the selected modules.
+func (mods *GoModules) Lint(ctx context.Context) error {
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel golangci-lint jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
@@ -625,20 +691,22 @@ func (p *Go) Lint(
 		// For better display in 'dagger checks': we get a cool activity bar in our sub-checks
 		// TODO: remove this when dagger has a sub-checks API
 		WithRollupSpans(true)
-	for _, mod := range mods {
-		jobs = jobs.WithJob(mod, func(ctx context.Context) error {
-			return p.LintModule(ctx, mod)
+	for _, modPath := range mods.Keys {
+		modPath := modPath
+		jobs = jobs.WithJob(modPath, func(ctx context.Context) error {
+			return mods.Get(modPath).Lint(ctx)
 		})
 	}
 	return jobs.Run(ctx)
 }
 
-func (p *Go) LintModule(ctx context.Context, mod string) error {
+// Lint one module.
+func (mod *GoModule) Lint(ctx context.Context) error {
 	lintImageRepo := "docker.io/golangci/golangci-lint"
 	lintImageTag := "v2.5.0-alpine"
 	lintImageDigest := "sha256:ac072ef3a8a6aa52c04630c68a7514e06be6f634d09d5975be60f2d53b484106"
 	lintImage := lintImageRepo + ":" + lintImageTag + "@" + lintImageDigest
-	p, err := p.GenerateDaggerRuntime(ctx, mod)
+	p, err := mod.Project.GenerateDaggerRuntime(ctx, mod.Path)
 	if err != nil {
 		return err
 	}
@@ -650,10 +718,10 @@ func (p *Go) LintModule(ctx context.Context, mod string) error {
 			WithMountedCache("/root/.cache/golangci-lint", dag.CacheVolume("golangci-lint")).
 			WithWorkdir("/src").
 			WithMountedDirectory(".", p.Source).
-			WithWorkdir(mod).
+			WithWorkdir(mod.Path).
 			WithExec([]string{
 				"golangci-lint", "run",
-				"--path-prefix", mod + "/",
+				"--path-prefix", mod.Path + "/",
 				"--output.tab.path=stderr",
 				"--output.tab.print-linter-name=true",
 				"--output.tab.colors=false",


### PR DESCRIPTION
## Summary

Thanks to the [Workspace API](https://github.com/dagger/dagger/pull/11874), modules can discover dynamic sets of related objects (tests by name, packages by path, services by label). But they can't present them to clients without losing features like `check`, `generate`, keyed selection, and batching.

Collections fix this. Annotate a module type with `@collection` / `+collection`, and the engine projects it into a public type with standard operations: `keys`, `list`, `get`, `subset`, and `batch`.

**[Design doc](hack/designs/collections.md)** covers the problem, proposal, interfaces, and edge cases in detail.

## What it looks like

```go
// +collection
type GoTests struct {
	Keys []string
}

func (t *GoTests) Get(name string) *GoTest {
	return &GoTest{Name: name}
}
```

The engine projects this into:

```graphql
type GoTests {
  keys: [String!]!
  list: [GoTest!]!
  get(name: String!): GoTest!
  subset(keys: [String!]!): GoTests!
  batch: GoTestsBatch!
}
```

CLI tools understand collections natively:

```sh
dagger check --go-tests=TestLogin,TestSignup
```

## What's included

- **Engine**: collection typedef metadata, validation, schema projection, collection-aware traversal for `check` and `generate`, canonical get IDs
- **All four SDKs** gain collection authoring annotations (Go struct tags, TS/Python decorators, Java annotations)
- **CLI**: `dagger check` and `dagger generate` accept collection key filters
- **Go toolchain** models discovered Go modules as a collection (first real consumer)

## Bundled fix

**`withExec` cache keys now include the call ID** ([dc87b2cf](https://github.com/dagger/dagger/commit/dc87b2cf4)). Without this, collection items sharing the same exec could incorrectly share cache entries.