### PR TITLE
fix: scope asModule cache per-session to prevent cross-worktree collision

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -223,7 +223,7 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 		dagql.Func("localContextDirectoryPath", s.moduleSourceLocalContextDirectoryPath).
 			Doc(`The full absolute path to the context directory on the caller's host filesystem that this module source is loaded from. Only valid for local module sources.`),
 
-		dagql.NodeFunc("asModule", s.moduleSourceAsModule).
+		dagql.NodeFuncWithCacheKey("asModule", s.moduleSourceAsModule, dagql.CachePerSession).
 			Doc(`Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation`),
 
 		dagql.NodeFunc("introspectionSchemaJSON", s.moduleSourceIntrospectionSchemaJSON).


### PR DESCRIPTION
When running `dagger call` from two different git worktrees simultaneously against the same engine daemon, the content-digest cache in dagql could return a Module from a different session. That Module carries a path-dependent ContextDirectoryPath from the wrong worktree, causing "module not found" errors.

Scope the asModule resolver with CachePerSession so each session gets its own result, preventing the content-digest cache from leaking path-dependent state across sessions.