### PR TITLE
Volatile variables: env vars that don’t invalidate exec cache

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -85,6 +85,9 @@ type Container struct {
 	// Secrets to expose to the container.
 	Secrets []ContainerSecret
 
+	// Volatile env vars exposed to future execs but not persisted in image config.
+	VolatileEnv []string
+
 	// Sockets to expose to the container.
 	Sockets []ContainerSocket
 
@@ -177,7 +180,20 @@ type ContainerWithSystemEnvVariableLazy struct {
 	Name   string
 }
 
+type ContainerWithVolatileVariableLazy struct {
+	LazyState
+	Parent dagql.ObjectResult[*Container]
+	Name   string
+	Value  string
+}
+
 type ContainerWithoutEnvVariableLazy struct {
+	LazyState
+	Parent dagql.ObjectResult[*Container]
+	Name   string
+}
+
+type ContainerWithoutVolatileVariableLazy struct {
 	LazyState
 	Parent dagql.ObjectResult[*Container]
 	Name   string
@@ -510,6 +526,7 @@ type persistedContainerPayload struct {
 	Services           []persistedServiceBinding           `json:"services,omitempty"`
 	DefaultTerminalCmd DefaultTerminalCmdOpts              `json:"defaultTerminalCmd"`
 	SystemEnvNames     []string                            `json:"systemEnvNames,omitempty"`
+	VolatileEnv        []string                            `json:"volatileEnv,omitempty"`
 	DefaultArgs        bool                                `json:"defaultArgs,omitempty"`
 	LazyJSON           json.RawMessage                     `json:"lazyJSON,omitempty"`
 }
@@ -575,7 +592,18 @@ type persistedContainerWithSystemEnvVariableLazy struct {
 	Name           string `json:"name"`
 }
 
+type persistedContainerWithVolatileVariableLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+	Name           string `json:"name"`
+	Value          string `json:"value"`
+}
+
 type persistedContainerWithoutEnvVariableLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+	Name           string `json:"name"`
+}
+
+type persistedContainerWithoutVolatileVariableLazy struct {
 	ParentResultID uint64 `json:"parentResultID"`
 	Name           string `json:"name"`
 }
@@ -986,6 +1014,7 @@ func materializeContainerStateFromParent(ctx context.Context, dst *Container, pa
 	dst.Platform = parent.Self().Platform
 	dst.Annotations = slices.Clone(parent.Self().Annotations)
 	dst.Secrets = slices.Clone(parent.Self().Secrets)
+	dst.VolatileEnv = slices.Clone(parent.Self().VolatileEnv)
 	dst.Sockets = slices.Clone(parent.Self().Sockets)
 	dst.ImageRef = parent.Self().ImageRef
 	dst.Ports = slices.Clone(parent.Self().Ports)
@@ -1438,6 +1467,7 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 		Services:           services,
 		DefaultTerminalCmd: container.DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(container.SystemEnvNames),
+		VolatileEnv:        slices.Clone(container.VolatileEnv),
 		DefaultArgs:        container.DefaultArgs,
 	}
 	if container.Lazy != nil {
@@ -1676,6 +1706,7 @@ func (*Container) DecodePersistedObject(ctx context.Context, dag *dagql.Server, 
 		Services:           services,
 		DefaultTerminalCmd: persisted.DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(persisted.SystemEnvNames),
+		VolatileEnv:        slices.Clone(persisted.VolatileEnv),
 		DefaultArgs:        persisted.DefaultArgs,
 	}
 	if persisted.Form != persistedContainerFormLazy {
@@ -1889,11 +1920,19 @@ func expandContainerInput(container *Container, input string, expand bool) (stri
 	for _, secret := range container.Secrets {
 		secretEnvs = append(secretEnvs, secret.EnvName)
 	}
+	volatileEnvs := []string{}
+	WalkEnv(container.VolatileEnv, func(name, _, _ string) {
+		volatileEnvs = append(volatileEnvs, name)
+	})
 
 	var secretEnvFoundError error
 	expanded := os.Expand(input, func(k string) string {
 		if slices.Contains(secretEnvs, k) {
 			secretEnvFoundError = fmt.Errorf("expand cannot be used with secret env variable %q", k)
+			return ""
+		}
+		if slices.Contains(volatileEnvs, k) {
+			secretEnvFoundError = fmt.Errorf("expand cannot be used with volatile env variable %q", k)
 			return ""
 		}
 
@@ -2364,6 +2403,38 @@ func (lazy *ContainerWithSystemEnvVariableLazy) EncodePersisted(ctx context.Cont
 	})
 }
 
+func (lazy *ContainerWithVolatileVariableLazy) Evaluate(ctx context.Context, container *Container) error {
+	return lazy.LazyState.Evaluate(ctx, "Container.withVolatileVariable", func(ctx context.Context) error {
+		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+			return err
+		}
+		container.WithVolatileVariable(lazy.Name, lazy.Value)
+		container.Lazy = nil
+		return nil
+	})
+}
+
+func (lazy *ContainerWithVolatileVariableLazy) AttachDependencies(ctx context.Context, attach func(dagql.AnyResult) (dagql.AnyResult, error)) ([]dagql.AnyResult, error) {
+	parent, err := attachContainerResult(attach, lazy.Parent, "attach container withVolatileVariable parent")
+	if err != nil {
+		return nil, err
+	}
+	lazy.Parent = parent
+	return []dagql.AnyResult{parent}, nil
+}
+
+func (lazy *ContainerWithVolatileVariableLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container withVolatileVariable parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerWithVolatileVariableLazy{
+		ParentResultID: parentID,
+		Name:           lazy.Name,
+		Value:          lazy.Value,
+	})
+}
+
 func (lazy *ContainerWithoutEnvVariableLazy) Evaluate(ctx context.Context, container *Container) error {
 	return lazy.LazyState.Evaluate(ctx, "Container.withoutEnvVariable", func(ctx context.Context) error {
 		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
@@ -2384,6 +2455,37 @@ func (lazy *ContainerWithoutEnvVariableLazy) Evaluate(ctx context.Context, conta
 		}
 		container.Lazy = nil
 		return nil
+	})
+}
+
+func (lazy *ContainerWithoutVolatileVariableLazy) Evaluate(ctx context.Context, container *Container) error {
+	return lazy.LazyState.Evaluate(ctx, "Container.withoutVolatileVariable", func(ctx context.Context) error {
+		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+			return err
+		}
+		container.WithoutVolatileVariable(lazy.Name)
+		container.Lazy = nil
+		return nil
+	})
+}
+
+func (lazy *ContainerWithoutVolatileVariableLazy) AttachDependencies(ctx context.Context, attach func(dagql.AnyResult) (dagql.AnyResult, error)) ([]dagql.AnyResult, error) {
+	parent, err := attachContainerResult(attach, lazy.Parent, "attach container withoutVolatileVariable parent")
+	if err != nil {
+		return nil, err
+	}
+	lazy.Parent = parent
+	return []dagql.AnyResult{parent}, nil
+}
+
+func (lazy *ContainerWithoutVolatileVariableLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container withoutVolatileVariable parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerWithoutVolatileVariableLazy{
+		ParentResultID: parentID,
+		Name:           lazy.Name,
 	})
 }
 
@@ -4193,6 +4295,22 @@ func decodePersistedContainerLazy(
 			Name:      persisted.Name,
 		}
 		return nil
+	case "withVolatileVariable":
+		var persisted persistedContainerWithVolatileVariableLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return fmt.Errorf("decode persisted container withVolatileVariable lazy payload: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container withVolatileVariable parent")
+		if err != nil {
+			return err
+		}
+		container.Lazy = &ContainerWithVolatileVariableLazy{
+			LazyState: NewLazyState(),
+			Parent:    parent,
+			Name:      persisted.Name,
+			Value:     persisted.Value,
+		}
+		return nil
 	case "withoutEnvVariable":
 		var persisted persistedContainerWithoutEnvVariableLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
@@ -4203,6 +4321,21 @@ func decodePersistedContainerLazy(
 			return err
 		}
 		container.Lazy = &ContainerWithoutEnvVariableLazy{
+			LazyState: NewLazyState(),
+			Parent:    parent,
+			Name:      persisted.Name,
+		}
+		return nil
+	case "withoutVolatileVariable":
+		var persisted persistedContainerWithoutVolatileVariableLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return fmt.Errorf("decode persisted container withoutVolatileVariable lazy payload: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container withoutVolatileVariable parent")
+		if err != nil {
+			return err
+		}
+		container.Lazy = &ContainerWithoutVolatileVariableLazy{
 			LazyState: NewLazyState(),
 			Parent:    parent,
 			Name:      persisted.Name,
@@ -5868,6 +6001,32 @@ func (container *Container) WithSecretVariable(
 	container.ImageRef = ""
 
 	return container, nil
+}
+
+// mutates container caller must have handled cloning or creating a new child.
+func (container *Container) WithVolatileVariable(name string, value string) *Container {
+	container.VolatileEnv = AddEnv(container.VolatileEnv, name, value)
+
+	// set image ref to empty string
+	container.ImageRef = ""
+
+	return container
+}
+
+// mutates container caller must have handled cloning or creating a new child.
+func (container *Container) WithoutVolatileVariable(name string) *Container {
+	newEnv := []string{}
+	WalkEnv(container.VolatileEnv, func(k, _, env string) {
+		if !shell.EqualEnvKeys(k, name) {
+			newEnv = append(newEnv, env)
+		}
+	})
+	container.VolatileEnv = newEnv
+
+	// set image ref to empty string
+	container.ImageRef = ""
+
+	return container
 }
 
 // mutates container caller must have handled cloning or creating a new child.

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -102,14 +102,14 @@ type ContainerExecLazy struct {
 }
 
 type persistedContainerExecLazy struct {
-	ParentResultID                  uint64                        `json:"parentResultID"`
-	ModuleContextResultID           uint64                        `json:"moduleContextResultID,omitempty"`
-	Opts                            ContainerExecOpts             `json:"opts"`
-	ExecMD                          *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
-	FunctionCall                    *FunctionCall                 `json:"functionCall,omitempty"`
-	ExtractModuleError              bool                          `json:"extractModuleError,omitempty"`
-	VolatileCacheHitParentResultID  uint64                        `json:"volatileCacheHitParentResultID,omitempty"`
-	VolatileCacheHitVolatileEnv     []string                      `json:"volatileCacheHitVolatileEnv,omitempty"`
+	ParentResultID                 uint64                        `json:"parentResultID"`
+	ModuleContextResultID          uint64                        `json:"moduleContextResultID,omitempty"`
+	Opts                           ContainerExecOpts             `json:"opts"`
+	ExecMD                         *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
+	FunctionCall                   *FunctionCall                 `json:"functionCall,omitempty"`
+	ExtractModuleError             bool                          `json:"extractModuleError,omitempty"`
+	VolatileCacheHitParentResultID uint64                        `json:"volatileCacheHitParentResultID,omitempty"`
+	VolatileCacheHitVolatileEnv    []string                      `json:"volatileCacheHitVolatileEnv,omitempty"`
 }
 
 // ContainerVolatileExecCacheHitLazy materializes from a broad volatile exec

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -102,12 +102,24 @@ type ContainerExecLazy struct {
 }
 
 type persistedContainerExecLazy struct {
-	ParentResultID        uint64                        `json:"parentResultID"`
-	ModuleContextResultID uint64                        `json:"moduleContextResultID,omitempty"`
-	Opts                  ContainerExecOpts             `json:"opts"`
-	ExecMD                *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
-	FunctionCall          *FunctionCall                 `json:"functionCall,omitempty"`
-	ExtractModuleError    bool                          `json:"extractModuleError,omitempty"`
+	ParentResultID                  uint64                        `json:"parentResultID"`
+	ModuleContextResultID           uint64                        `json:"moduleContextResultID,omitempty"`
+	Opts                            ContainerExecOpts             `json:"opts"`
+	ExecMD                          *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
+	FunctionCall                    *FunctionCall                 `json:"functionCall,omitempty"`
+	ExtractModuleError              bool                          `json:"extractModuleError,omitempty"`
+	VolatileCacheHitParentResultID  uint64                        `json:"volatileCacheHitParentResultID,omitempty"`
+	VolatileCacheHitVolatileEnv     []string                      `json:"volatileCacheHitVolatileEnv,omitempty"`
+}
+
+// ContainerVolatileExecCacheHitLazy materializes from a broad volatile exec
+// cache hit, then restores the request-local volatile environment for
+// descendants of the returned container.
+type ContainerVolatileExecCacheHitLazy struct {
+	LazyState
+
+	Parent      dagql.ObjectResult[*Container]
+	VolatileEnv []string
 }
 
 func (lazy *ContainerExecLazy) Evaluate(ctx context.Context, ctr *Container) error {
@@ -166,6 +178,46 @@ func (lazy *ContainerExecLazy) EncodePersisted(ctx context.Context, cache dagql.
 		ExecMD:                lazy.State.ExecMD,
 		FunctionCall:          lazy.State.FunctionCall,
 		ExtractModuleError:    lazy.State.ExtractModuleError,
+	})
+}
+
+func (lazy *ContainerVolatileExecCacheHitLazy) Evaluate(ctx context.Context, container *Container) error {
+	if lazy == nil {
+		return nil
+	}
+	return lazy.LazyState.Evaluate(ctx, "Container.withExec.cacheHit", func(ctx context.Context) error {
+		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+			return err
+		}
+		container.VolatileEnv = slices.Clone(lazy.VolatileEnv)
+		container.Lazy = nil
+		return nil
+	})
+}
+
+func (lazy *ContainerVolatileExecCacheHitLazy) AttachDependencies(ctx context.Context, attach func(dagql.AnyResult) (dagql.AnyResult, error)) ([]dagql.AnyResult, error) {
+	if lazy == nil {
+		return nil, nil
+	}
+	parent, err := attachContainerResult(attach, lazy.Parent, "attach container volatile exec cache hit parent")
+	if err != nil {
+		return nil, err
+	}
+	lazy.Parent = parent
+	return []dagql.AnyResult{parent}, nil
+}
+
+func (lazy *ContainerVolatileExecCacheHitLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	if lazy == nil {
+		return nil, fmt.Errorf("encode persisted container volatile exec cache hit lazy: nil lazy")
+	}
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container volatile exec cache hit parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerExecLazy{
+		VolatileCacheHitParentResultID: parentID,
+		VolatileCacheHitVolatileEnv:    slices.Clone(lazy.VolatileEnv),
 	})
 }
 
@@ -262,7 +314,7 @@ func (container *Container) execMeta(
 	return &execMD, nil
 }
 
-func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts) (*executor.Meta, error) {
+func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts, includeVolatileEnv bool) (*executor.Meta, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get current query: %w", err)
@@ -297,6 +349,9 @@ func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts
 	}
 
 	metaSpec.Env = addDefaultEnvvar(metaSpec.Env, "PATH", utilsystem.DefaultPathEnv(platform.OS))
+	if includeVolatileEnv {
+		metaSpec.Env = mergeEnv(metaSpec.Env, container.VolatileEnv)
+	}
 
 	if opts.Expect != ReturnSuccess {
 		metaSpec.ValidExitCodes = opts.Expect.ReturnCodes()
@@ -1224,7 +1279,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 
 		cache := query.SnapshotManager()
 
-		metaSpec, err := container.metaSpec(ctx, opts)
+		metaSpec, err := container.metaSpec(ctx, opts, true)
 		if err != nil {
 			return err
 		}
@@ -2142,6 +2197,18 @@ func decodePersistedContainerExecLazy(
 	var persisted persistedContainerExecLazy
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return fmt.Errorf("decode persisted container withExec lazy payload: %w", err)
+	}
+	if persisted.VolatileCacheHitParentResultID != 0 {
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.VolatileCacheHitParentResultID, "container volatile exec cache hit parent")
+		if err != nil {
+			return err
+		}
+		container.Lazy = &ContainerVolatileExecCacheHitLazy{
+			LazyState:   NewLazyState(),
+			Parent:      parent,
+			VolatileEnv: slices.Clone(persisted.VolatileCacheHitVolatileEnv),
+		}
+		return nil
 	}
 	parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container exec parent")
 	if err != nil {

--- a/core/healthcheck.go
+++ b/core/healthcheck.go
@@ -185,7 +185,7 @@ func (chk *dockerHealthcheck) Check(ctx context.Context) error {
 func (chk *dockerHealthcheck) check(ctx context.Context) error {
 	healthcheckMeta, err := chk.ctr.metaSpec(ctx, ContainerExecOpts{
 		Args: chk.args,
-	})
+	}, false)
 	if err != nil {
 		return err
 	}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1019,6 +1019,179 @@ func (ContainerSuite) TestWithEnvVariableExpand(ctx context.Context, t *testctx.
 	})
 }
 
+func (ContainerSuite) TestVolatileVariables(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("cache ignores value changes", func(ctx context.Context, t *testctx.T) {
+		base := c.Container().From(alpineImage)
+
+		run := func(runID string) string {
+			out, err := base.
+				WithVolatileVariable("RUN_ID", runID).
+				WithExec([]string{"sh", "-c", "head -c 32 /dev/random | sha256sum | cut -d ' ' -f1"}).
+				Stdout(ctx)
+			require.NoError(t, err)
+			return strings.TrimSpace(out)
+		}
+
+		out1 := run(identity.NewID())
+		out2 := run(identity.NewID())
+		require.Equal(t, out1, out2, "execution was re-run when only a volatile variable changed")
+	})
+
+	t.Run("cache ignores value changes through from", func(ctx context.Context, t *testctx.T) {
+		run := func(runID string) string {
+			out, err := c.Container().
+				WithVolatileVariable("RUN_ID", runID).
+				From(alpineImage).
+				WithExec([]string{"sh", "-c", "head -c 32 /dev/random | sha256sum | cut -d ' ' -f1"}).
+				Stdout(ctx)
+			require.NoError(t, err)
+			return strings.TrimSpace(out)
+		}
+
+		out1 := run(identity.NewID())
+		out2 := run(identity.NewID())
+		require.Equal(t, out1, out2, "execution was re-run when only a volatile variable changed below from")
+	})
+
+	t.Run("rerun sees latest value when another input changes", func(ctx context.Context, t *testctx.T) {
+		run := func(marker, runID string) string {
+			out, err := c.Container().
+				From(alpineImage).
+				WithNewFile("/marker", marker).
+				WithVolatileVariable("RUN_ID", runID).
+				WithExec([]string{"sh", "-c", `printf '%s:%s' "$RUN_ID" "$(cat /marker)"`}).
+				Stdout(ctx)
+			require.NoError(t, err)
+			return out
+		}
+
+		out1 := run("a", "one")
+		out2 := run("b", "two")
+		require.Equal(t, "one:a", out1)
+		require.Equal(t, "two:b", out2)
+	})
+
+	t.Run("visibility excludes volatile vars", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From(alpineImage).
+			WithEnvVariable("PERSIST", "persist").
+			WithVolatileVariable("VOL", "volatile")
+
+		vars, err := ctr.EnvVariables(ctx)
+		require.NoError(t, err)
+		for _, envVar := range vars {
+			name, err := envVar.Name(ctx)
+			require.NoError(t, err)
+			require.NotEqual(t, "VOL", name)
+		}
+
+		persistentVal, err := ctr.EnvVariable(ctx, "PERSIST")
+		require.NoError(t, err)
+		require.Equal(t, "persist", persistentVal)
+
+		volatileVal, err := ctr.EnvVariable(ctx, "VOL")
+		require.NoError(t, err)
+		require.Empty(t, volatileVal)
+
+		out, err := ctr.WithExec([]string{"sh", "-c", `printf '%s:%s' "$PERSIST" "$VOL"`}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "persist:volatile", out)
+	})
+
+	t.Run("volatile value overrides persistent env and can be removed", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From(alpineImage).
+			WithEnvVariable("FOO", "persist").
+			WithVolatileVariable("FOO", "first").
+			WithVolatileVariable("FOO", "second")
+
+		envVal, err := ctr.EnvVariable(ctx, "FOO")
+		require.NoError(t, err)
+		require.Equal(t, "persist", envVal)
+
+		out, err := ctr.WithExec([]string{"sh", "-c", `printf '%s' "$FOO"`}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "second", out)
+
+		out, err = ctr.
+			WithoutVolatileVariable("FOO").
+			WithExec([]string{"sh", "-c", `printf '%s' "$FOO"`}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "persist", out)
+	})
+
+	t.Run("removing a volatile variable with no persistent fallback unsets it", func(ctx context.Context, t *testctx.T) {
+		out, err := c.Container().
+			From(alpineImage).
+			WithVolatileVariable("FOO", "volatile").
+			WithoutVolatileVariable("FOO").
+			WithExec([]string{"sh", "-c", `printf '%s' "${FOO-unset}"`}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "unset", out)
+	})
+
+	t.Run("service start does not see volatile vars", func(ctx context.Context, t *testctx.T) {
+		svc := c.Container().
+			From(alpineImage).
+			WithDefaultArgs([]string{"sh", "-c", `test -z "$VOL" && sleep 1`}).
+			WithVolatileVariable("VOL", "volatile").
+			AsService()
+
+		_, err := svc.Start(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("export excludes volatile vars", func(ctx context.Context, t *testctx.T) {
+		imagePath := filepath.Join(t.TempDir(), identity.NewID()+".tar")
+
+		ctr := c.Container().
+			From(alpineImage).
+			WithEnvVariable("PERSIST", "persist").
+			WithVolatileVariable("VOL", "volatile")
+
+		actual, err := ctr.Export(ctx, imagePath)
+		require.NoError(t, err)
+		require.Equal(t, imagePath, actual)
+
+		dockerManifestBytes := readTarFile(t, imagePath, "manifest.json")
+		var dockerManifest []struct {
+			Config string
+		}
+		require.NoError(t, json.Unmarshal(dockerManifestBytes, &dockerManifest))
+		require.Len(t, dockerManifest, 1)
+
+		configBytes := readTarFile(t, imagePath, dockerManifest[0].Config)
+		var img ocispecs.Image
+		require.NoError(t, json.Unmarshal(configBytes, &img))
+		require.Contains(t, img.Config.Env, "PERSIST=persist")
+		require.NotContains(t, img.Config.Env, "VOL=volatile")
+	})
+
+	t.Run("expand rejects volatile vars", func(ctx context.Context, t *testctx.T) {
+		_, err := c.Container().
+			From(alpineImage).
+			WithVolatileVariable("RUN_ID", "123").
+			WithExec([]string{"sh", "-c", `test "${RUN_ID}" = "123"`}, dagger.ContainerWithExecOpts{Expand: true}).
+			Sync(ctx)
+
+		requireErrOut(t, err, `expand cannot be used with volatile env variable "RUN_ID"`)
+	})
+
+	t.Run("with env variable expand rejects volatile vars", func(ctx context.Context, t *testctx.T) {
+		_, err := c.Container().
+			From(alpineImage).
+			WithVolatileVariable("RUN_ID", "123").
+			WithEnvVariable("COPY", "$RUN_ID", dagger.ContainerWithEnvVariableOpts{Expand: true}).
+			Sync(ctx)
+
+		requireErrOut(t, err, `expand cannot be used with volatile env variable "RUN_ID"`)
+	})
+}
+
 func (ContainerSuite) TestLabel(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/container_volatile_test.go
+++ b/core/integration/container_volatile_test.go
@@ -1,0 +1,77 @@
+// These volatile-variable tests live in the container integration suite because
+// the behavior under test crosses GraphQL recipe cache lookup and container exec
+// materialization. Unit tests for env helpers or call digests cannot catch stale
+// volatile values being returned inside cached Container results.
+package core
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+)
+
+// TestVolatileVariableCachedExecOutputSeesLatestValue verifies that a cache hit
+// for an exec whose key intentionally ignores volatile values does not also
+// reuse the cached output container's stale volatile environment. The first exec
+// is a cacheable no-op that should be shared across RUN_ID changes; the second
+// exec changes an ordinary input so it must rerun and read RUN_ID from the
+// cached parent. If the engine returns the first cached output unchanged, the
+// second run observes "one:second" instead of the current value "two:second".
+func (ContainerSuite) TestVolatileVariableCachedExecOutputSeesLatestValue(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := c.Container().From(alpineImage)
+
+	run := func(runID, marker string) string {
+		out, err := base.
+			WithVolatileVariable("RUN_ID", runID).
+			WithExec([]string{"true"}).
+			WithExec([]string{"sh", "-c", `printf '%s:%s' "$RUN_ID" "$1"`, "_", marker}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+
+	require.Equal(t, "one:first", run("one", "first"))
+	require.Equal(t, "two:second", run("two", "second"))
+}
+
+// TestVolatileVariableCacheHitKeepsEachContainerValue verifies that rebasing a
+// volatile exec cache hit is scoped to the requesting Container result. Volatile
+// values are intentionally ignored for the first no-op exec's broad cache key,
+// but the returned Container is still an immutable value used by later execs and
+// by serialized IDs. A cache-hit rebase that mutates the shared cached result
+// would make the earlier RUN_ID=one handle, or its ID, observe RUN_ID=two after
+// the second equivalent no-op exec.
+func (ContainerSuite) TestVolatileVariableCacheHitKeepsEachContainerValue(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := c.Container().From(alpineImage)
+
+	read := func(ctr *dagger.Container, marker string) string {
+		out, err := ctr.
+			WithExec([]string{"sh", "-c", `printf '%s:%s' "$RUN_ID" "$1"`, "_", marker}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+
+	first := base.
+		WithVolatileVariable("RUN_ID", "one").
+		WithExec([]string{"true"})
+	require.Equal(t, "one:first", read(first, "first"))
+	firstID, err := first.ID(ctx)
+	require.NoError(t, err)
+
+	second := base.
+		WithVolatileVariable("RUN_ID", "two").
+		WithExec([]string{"true"})
+	require.Equal(t, "two:second", read(second, "second"))
+	secondID, err := second.ID(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "one:first-again", read(first, "first-again"))
+	require.Equal(t, "one:first-id", read(c.LoadContainerFromID(firstID), "first-id"))
+	require.Equal(t, "two:second-id", read(c.LoadContainerFromID(secondID), "second-id"))
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
 	serverresolver "github.com/dagger/dagger/engine/server/resolver"
@@ -147,10 +148,10 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				`Should default to "/".`),
 
 		dagql.NodeFunc("envVariables", s.envVariables).
-			Doc(`Retrieves the list of environment variables passed to commands.`),
+			Doc(`Retrieves the list of persistent environment variables configured on the container.`),
 
 		dagql.NodeFunc("envVariable", s.envVariable).
-			Doc(`Retrieves the value of the specified environment variable.`).
+			Doc(`Retrieves the value of the specified persistent environment variable.`).
 			Args(
 				dagql.Arg("name").Doc(`The name of the environment variable to retrieve (e.g., "PATH").`),
 			),
@@ -228,6 +229,14 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("secret").Doc(`Identifier of the secret value.`),
 			),
 
+		dagql.NodeFunc("withVolatileVariable", s.withVolatileVariable).
+			Doc(`Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.`,
+				`This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.`).
+			Args(
+				dagql.Arg("name").Doc(`Name of the volatile variable (e.g., "CI_RUN_ID").`),
+				dagql.Arg("value").Doc(`Value of the volatile variable.`),
+			),
+
 		dagql.NodeFunc("withoutEnvVariable", s.withoutEnvVariable).
 			Doc(`Retrieves this container minus the given environment variable.`).
 			Args(
@@ -238,6 +247,12 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			Doc(`Retrieves this container minus the given environment variable containing the secret.`).
 			Args(
 				dagql.Arg("name").Doc(`The name of the environment variable (e.g., "HOST").`),
+			),
+
+		dagql.NodeFunc("withoutVolatileVariable", s.withoutVolatileVariable).
+			Doc(`Retrieves this container minus the given volatile environment variable.`).
+			Args(
+				dagql.Arg("name").Doc(`The name of the volatile environment variable (e.g., "CI_RUN_ID").`),
 			),
 
 		dagql.NodeFunc("withLabel", s.withLabel).
@@ -561,7 +576,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("err").Doc(`Message of the error to raise. If empty, the error will be ignored.`),
 			),
 
-		dagql.NodeFunc("withExec", s.withExec).
+		dagql.NodeFuncWithDynamicInputs("withExec", s.withExec, s.withExecCacheKey).
 			IsPersistable().
 			View(AllVersion).
 			Doc(`Execute a command in the container, and return a new snapshot of the container state after execution.`).
@@ -1000,6 +1015,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 			Services:           slices.Clone(parent.Self().Services),
 			DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 			SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+			VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 			DefaultArgs:        parent.Self().DefaultArgs,
 		}
 
@@ -1242,6 +1258,7 @@ func (s *containerSchema) withRootfs(ctx context.Context, parent dagql.ObjectRes
 		Services:           slices.Clone(parent.Self().Services),
 		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 		Lazy: &core.ContainerWithRootFSLazy{
 			LazyState: core.NewLazyState(),
@@ -1357,6 +1374,7 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 		Services:           slices.Clone(parent.Self().Services),
 		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 	}
 	err = ctr.WithExec(ctx, parent, args.ContainerExecOpts, md, moduleContext, nil, false)
@@ -1364,6 +1382,195 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 		return inst, err
 	}
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ctr)
+}
+
+const volatileExecExtraDigestLabel = "container.withExec.volatileEnv"
+
+func (s *containerSchema) withExecCacheKey(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ containerExecArgs, req *dagql.CallRequest) error {
+	parentID, err := parent.RecipeID(ctx)
+	if err != nil {
+		return fmt.Errorf("volatile exec cache key: parent recipe ID: %w", err)
+	}
+	if !hasVolatileVariableMutations(parentID) {
+		return nil
+	}
+
+	parentDigest, volatileEnv, err := normalizedVolatileParentDigest(parentID)
+	if err != nil {
+		return fmt.Errorf("volatile exec cache key: normalize parent: %w", err)
+	}
+
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return err
+	}
+	reqID, err := cache.RecipeIDForCall(ctx, req.ResultCall)
+	if err != nil {
+		return fmt.Errorf("volatile exec cache key: request recipe ID: %w", err)
+	}
+	execDigest, err := reqID.DigestWithReceiverDigest(parentDigest)
+	if err != nil {
+		return fmt.Errorf("volatile exec cache key: digest exec: %w", err)
+	}
+
+	extraDigest := execDigest
+	if len(volatileEnv) > 0 {
+		inputs := []string{execDigest.String()}
+		core.WalkEnv(volatileEnv, func(name, _, _ string) {
+			inputs = append(inputs, name)
+		})
+		extraDigest = hashutil.HashStrings(inputs...)
+	}
+	req.ExtraDigests = append(req.ExtraDigests, call.ExtraDigest{
+		Digest: extraDigest,
+		Label:  volatileExecExtraDigestLabel,
+	})
+
+	currentVolatileEnv := slices.Clone(parent.Self().VolatileEnv)
+	requestCall, err := req.ToResultCall()
+	if err != nil {
+		return err
+	}
+	req.CacheHitTransform = func(ctx context.Context, hit dagql.AnyResult) (dagql.AnyResult, error) {
+		ctr, ok := hit.(dagql.ObjectResult[*core.Container])
+		if !ok || ctr.Self() == nil {
+			return hit, nil
+		}
+		rebased, err := cloneContainerForVolatileExecCacheHit(ctx, ctr, currentVolatileEnv)
+		if err != nil {
+			return nil, err
+		}
+		srv, err := core.CurrentDagqlServer(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return dagql.NewObjectResultForCall(rebased, srv, requestCall)
+	}
+	return nil
+}
+
+func hasVolatileVariableMutations(id *call.ID) bool {
+	for cur := id; cur != nil; cur = cur.Receiver() {
+		switch cur.Field() {
+		case "withVolatileVariable", "withoutVolatileVariable":
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedVolatileParentDigest(id *call.ID) (digest.Digest, []string, error) {
+	if id == nil {
+		return "", nil, nil
+	}
+
+	receiverDigest, volatileEnv, err := normalizedVolatileParentDigest(id.Receiver())
+	if err != nil {
+		return "", nil, err
+	}
+
+	switch id.Field() {
+	case "withVolatileVariable":
+		name, err := callStringArg(id, "name")
+		if err != nil {
+			return "", nil, err
+		}
+		return receiverDigest, core.AddEnv(volatileEnv, name, ""), nil
+	case "withoutVolatileVariable":
+		name, err := callStringArg(id, "name")
+		if err != nil {
+			return "", nil, err
+		}
+		return receiverDigest, withoutEnvName(volatileEnv, name), nil
+	default:
+		dig, err := id.DigestWithReceiverDigest(receiverDigest)
+		if err != nil {
+			return "", nil, err
+		}
+		return dig, volatileEnv, nil
+	}
+}
+
+func withoutEnvName(env []string, name string) []string {
+	newEnv := []string{}
+	core.WalkEnv(env, func(k, _, entry string) {
+		if !shell.EqualEnvKeys(k, name) {
+			newEnv = append(newEnv, entry)
+		}
+	})
+	return newEnv
+}
+
+func callStringArg(id *call.ID, name string) (string, error) {
+	arg := id.Arg(name)
+	if arg == nil {
+		return "", fmt.Errorf("call %q missing string arg %q", id.Field(), name)
+	}
+	lit, ok := arg.Value().(*call.LiteralString)
+	if !ok {
+		return "", fmt.Errorf("call %q arg %q: expected string, got %T", id.Field(), name, arg.Value())
+	}
+	return lit.Value(), nil
+}
+
+func cloneContainerForVolatileExecCacheHit(
+	ctx context.Context,
+	hit dagql.ObjectResult[*core.Container],
+	volatileEnv []string,
+) (*core.Container, error) {
+	src := hit.Self()
+	if src == nil {
+		return nil, fmt.Errorf("volatile exec cache hit: nil container")
+	}
+	clonedFS, err := core.CloneContainerDirectoryAccessor(ctx, src.FS)
+	if err != nil {
+		return nil, err
+	}
+	clonedMounts, err := core.CloneContainerMounts(ctx, src.Mounts)
+	if err != nil {
+		return nil, err
+	}
+	clonedMeta, err := core.CloneContainerMetaSnapshot(ctx, src.MetaSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	defaultTerminalCmd := src.DefaultTerminalCmd
+	defaultTerminalCmd.Args = slices.Clone(defaultTerminalCmd.Args)
+
+	ctr := &core.Container{
+		FS:                 clonedFS,
+		MetaSnapshot:       clonedMeta,
+		Config:             core.CloneContainerImageConfig(src.Config),
+		EnabledGPUs:        slices.Clone(src.EnabledGPUs),
+		Mounts:             clonedMounts,
+		Platform:           src.Platform,
+		Annotations:        slices.Clone(src.Annotations),
+		Secrets:            slices.Clone(src.Secrets),
+		VolatileEnv:        slices.Clone(volatileEnv),
+		Sockets:            slices.Clone(src.Sockets),
+		ImageRef:           src.ImageRef,
+		Ports:              slices.Clone(src.Ports),
+		Services:           slices.Clone(src.Services),
+		DefaultTerminalCmd: defaultTerminalCmd,
+		SystemEnvNames:     slices.Clone(src.SystemEnvNames),
+		DefaultArgs:        src.DefaultArgs,
+	}
+	if src.Lazy == nil {
+		return ctr, nil
+	}
+	lazy, ok := src.Lazy.(*core.ContainerExecLazy)
+	if !ok {
+		return nil, fmt.Errorf("volatile exec cache hit: expected container exec lazy, got %T", src.Lazy)
+	}
+	if lazy.State == nil {
+		return nil, fmt.Errorf("volatile exec cache hit: nil exec lazy state")
+	}
+	ctr.Lazy = &core.ContainerVolatileExecCacheHitLazy{
+		LazyState:   core.NewLazyState(),
+		Parent:      hit,
+		VolatileEnv: slices.Clone(volatileEnv),
+	}
+	return ctr, nil
 }
 
 func (s *containerSchema) stdout(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (string, error) {
@@ -1519,6 +1726,7 @@ func (s *containerSchema) withSymlink(ctx context.Context, parent dagql.ObjectRe
 		Services:           slices.Clone(parent.Self().Services),
 		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 		Lazy: &core.ContainerWithSymlinkLazy{
 			LazyState: core.NewLazyState(),
@@ -1919,6 +2127,11 @@ type containerWithSystemEnvArgs struct {
 	Name string
 }
 
+type containerWithVolatileVariableArgs struct {
+	Name  string
+	Value string
+}
+
 func (s *containerSchema) withSystemEnvVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithSystemEnvArgs) (*core.Container, error) {
 	ctr, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
@@ -1930,6 +2143,23 @@ func (s *containerSchema) withSystemEnvVariable(ctx context.Context, parent dagq
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
 			Name:      args.Name,
+		}
+	}
+	return ctr, nil
+}
+
+func (s *containerSchema) withVolatileVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithVolatileVariableArgs) (*core.Container, error) {
+	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	ctr.WithVolatileVariable(args.Name, args.Value)
+	if parent.Self().Lazy != nil {
+		ctr.Lazy = &core.ContainerWithVolatileVariableLazy{
+			LazyState: core.NewLazyState(),
+			Parent:    parent,
+			Name:      args.Name,
+			Value:     args.Value,
 		}
 	}
 	return ctr, nil
@@ -2011,6 +2241,22 @@ func (s *containerSchema) withoutEnvVariable(ctx context.Context, parent dagql.O
 	}
 	if parent.Self().Lazy != nil {
 		ctr.Lazy = &core.ContainerWithoutEnvVariableLazy{
+			LazyState: core.NewLazyState(),
+			Parent:    parent,
+			Name:      args.Name,
+		}
+	}
+	return ctr, nil
+}
+
+func (s *containerSchema) withoutVolatileVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutVariableArgs) (*core.Container, error) {
+	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	ctr.WithoutVolatileVariable(args.Name)
+	if parent.Self().Lazy != nil {
+		ctr.Lazy = &core.ContainerWithoutVolatileVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
 			Name:      args.Name,
@@ -2170,6 +2416,7 @@ func (s *containerSchema) withMountedDirectory(ctx context.Context, parent dagql
 		Services:           slices.Clone(parent.Self().Services),
 		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 		Lazy: &core.ContainerWithMountedDirectoryLazy{
 			LazyState: core.NewLazyState(),
@@ -2881,6 +3128,7 @@ func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult
 		Services:           slices.Clone(parent.Self().Services),
 		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
+		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 	}
 	return ctr, nil
@@ -2900,12 +3148,20 @@ func expandEnvVar(ctx context.Context, parent *core.Container, input string, exp
 	for _, secret := range parent.Secrets {
 		secretEnvs = append(secretEnvs, secret.EnvName)
 	}
+	volatileEnvs := []string{}
+	core.WalkEnv(parent.VolatileEnv, func(name, _, _ string) {
+		volatileEnvs = append(volatileEnvs, name)
+	})
 
 	var secretEnvFoundError error
 	expanded := os.Expand(input, func(k string) string {
 		// set error if its a secret env variable
 		if slices.Contains(secretEnvs, k) {
 			secretEnvFoundError = fmt.Errorf("expand cannot be used with secret env variable %q", k)
+			return ""
+		}
+		if slices.Contains(volatileEnvs, k) {
+			secretEnvFoundError = fmt.Errorf("expand cannot be used with volatile env variable %q", k)
 			return ""
 		}
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1347,35 +1347,9 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 		}
 	}
 
-	clonedFS, err := core.CloneContainerDirectoryAccessor(ctx, parent.Self().FS)
+	ctr, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
-	}
-	clonedMounts, err := core.CloneContainerMounts(ctx, parent.Self().Mounts)
-	if err != nil {
-		return inst, err
-	}
-	clonedMeta, err := core.CloneContainerMetaSnapshot(ctx, parent.Self().MetaSnapshot)
-	if err != nil {
-		return inst, err
-	}
-	ctr := &core.Container{
-		FS:                 clonedFS,
-		MetaSnapshot:       clonedMeta,
-		Config:             core.CloneContainerImageConfig(parent.Self().Config),
-		EnabledGPUs:        slices.Clone(parent.Self().EnabledGPUs),
-		Mounts:             clonedMounts,
-		Platform:           parent.Self().Platform,
-		Annotations:        slices.Clone(parent.Self().Annotations),
-		Secrets:            slices.Clone(parent.Self().Secrets),
-		Sockets:            slices.Clone(parent.Self().Sockets),
-		ImageRef:           parent.Self().ImageRef,
-		Ports:              slices.Clone(parent.Self().Ports),
-		Services:           slices.Clone(parent.Self().Services),
-		DefaultTerminalCmd: parent.Self().DefaultTerminalCmd,
-		SystemEnvNames:     slices.Clone(parent.Self().SystemEnvNames),
-		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
-		DefaultArgs:        parent.Self().DefaultArgs,
 	}
 	err = ctr.WithExec(ctx, parent, args.ContainerExecOpts, md, moduleContext, nil, false)
 	if err != nil {

--- a/core/service.go
+++ b/core/service.go
@@ -712,7 +712,7 @@ func (svc *Service) startContainer(
 			ExperimentalPrivilegedNesting: svc.ExperimentalPrivilegedNesting,
 			InsecureRootCapabilities:      svc.InsecureRootCapabilities,
 			NoInit:                        svc.NoInit,
-		})
+		}, false)
 		if err != nil {
 			return err
 		}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3449,7 +3449,7 @@ func (c *Cache) lookupCacheForDigests(
 	nowUnix := now.Unix()
 	match := c.lookupMatchForDigestsLocked(recipeDigest, extraDigests, nowUnix)
 	c.traceLookupAttempt(ctx, recipeDigest.String(), "", nil, false)
-	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
+	hitRes := c.selectLookupCandidateForSessionAndRecipeLocked(sessionID, match.candidates, recipeDigest)
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, recipeDigest.String(), false, -1, "", 0)
 		c.egraphMu.Unlock()

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -864,6 +864,11 @@ func (c *Cache) lookupCacheForRequestLocked(
 		return retRes, true, true, nil
 	}
 
+	// Dynamic-input / CacheHitTransform support exists for volatile container
+	// variables (Container.withVolatileVariable). It may generalize to other
+	// cache-identity-excluded inputs in the future, but today volatile variables
+	// are the only consumer.
+	//
 	// Some dynamic-input callers intentionally use a broad equivalent digest as
 	// a lookup-only key, then rebase request-local state onto a private result.
 	// In that case, do not teach the exact request identity to the broad hit; the

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -655,6 +655,33 @@ func (c *Cache) selectLookupCandidateForSessionLocked(sessionID string, candidat
 	return nil
 }
 
+func (c *Cache) resultMatchesRecipeDigestLocked(res *sharedResult, recipeDigest digest.Digest) bool {
+	if res == nil || recipeDigest == "" {
+		return false
+	}
+	frame := res.loadResultCall()
+	if frame == nil {
+		return false
+	}
+	resDigest, err := frame.deriveRecipeDigest(c)
+	return err == nil && resDigest == recipeDigest
+}
+
+func (c *Cache) selectLookupCandidateForSessionAndRecipeLocked(sessionID string, candidates *set.TreeSet[*sharedResult], recipeDigest digest.Digest) *sharedResult {
+	if candidates == nil {
+		return nil
+	}
+	for res := range candidates.Items() {
+		if !c.sessionSatisfiesResourceRequirementsLocked(sessionID, res) {
+			continue
+		}
+		if c.resultMatchesRecipeDigestLocked(res, recipeDigest) {
+			return res
+		}
+	}
+	return c.selectLookupCandidateForSessionLocked(sessionID, candidates)
+}
+
 func (c *Cache) lookupMatchForDigestsLocked(recipeDigest digest.Digest, extraDigests []call.ExtraDigest, nowUnix int64) lookupMatch {
 	match := lookupMatch{
 		primaryLookupPossible: true,
@@ -810,54 +837,66 @@ func (c *Cache) lookupCacheForRequestLocked(
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
 	requestInputRefs []ResultCallStructuralInputRef,
-) (AnyResult, bool, error) {
+) (AnyResult, bool, bool, error) {
 	if req == nil || req.ResultCall == nil {
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 	now := time.Now()
 	nowUnix := now.Unix()
 	match := c.lookupMatchForCallLocked(req.ResultCall, requestDigest, requestSelf, requestInputs, nowUnix)
 	c.traceLookupAttempt(ctx, requestDigest.String(), match.selfDigest.String(), match.inputDigests, req.IsPersistable)
-	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
+	hitRes := c.selectLookupCandidateForSessionAndRecipeLocked(sessionID, match.candidates, requestDigest)
 
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, requestDigest.String(), match.primaryLookupPossible, match.missingInputIndex, match.termDigest, match.termSetSize)
-		return nil, false, nil
+		return nil, false, false, nil
 	}
+	hitExactRecipe := match.hitRecipeDigest && c.resultMatchesRecipeDigestLocked(hitRes, requestDigest)
 
 	// fast-path: if we got a very simple recipe-digest hit we can skip trying to teach the egraph anything new
-	if requestDigest != "" && len(req.ResultCall.ExtraDigests) == 0 && req.TTL == 0 && !req.IsPersistable && match.hitRecipeDigest {
+	if requestDigest != "" && len(req.ResultCall.ExtraDigests) == 0 && req.TTL == 0 && !req.IsPersistable && hitExactRecipe {
 		touchSharedResultLastUsed(hitRes, now.UnixNano())
 		retRes := Result[Typed]{
 			shared:   hitRes,
 			hitCache: true,
 		}
 		c.traceLookupHit(ctx, requestDigest.String(), hitRes, match.termDigest)
-		return retRes, true, nil
+		return retRes, true, true, nil
 	}
+
+	// Some dynamic-input callers intentionally use a broad equivalent digest as
+	// a lookup-only key, then rebase request-local state onto a private result.
+	// In that case, do not teach the exact request identity to the broad hit; the
+	// transformed result will be indexed for the exact request after it is
+	// materialized.
+	shouldTransformHit := req.CacheHitTransform != nil && !hitExactRecipe
 
 	// We have a cache hit. Teach this request identity onto the existing shared
 	// result so any raw ID we hand back is itself resolvable by the cache later.
 	res := hitRes
 	// A TTL-bearing call can alias an existing result on lookup; apply the same
 	// conservative expiry merge policy here so TTL remains effective on hits.
-	res.expiresAtUnix = mergeSharedResultExpiryUnix(
-		res.expiresAtUnix,
-		candidateSharedResultExpiryUnix(nowUnix, req.TTL),
-	)
+	if !shouldTransformHit {
+		res.expiresAtUnix = mergeSharedResultExpiryUnix(
+			res.expiresAtUnix,
+			candidateSharedResultExpiryUnix(nowUnix, req.TTL),
+		)
+	}
 	touchSharedResultLastUsed(res, now.UnixNano())
-	if req.IsPersistable {
+	if req.IsPersistable && !shouldTransformHit {
 		c.upsertPersistedEdgeLocked(ctx, res, candidateSharedResultExpiryUnix(nowUnix, req.TTL), false)
 	}
-	if err := c.teachResultIdentityLocked(ctx, res, req.ResultCall, requestDigest, requestSelf, requestInputs, requestInputRefs); err != nil {
-		return nil, false, err
+	if !shouldTransformHit {
+		if err := c.teachResultIdentityLocked(ctx, res, req.ResultCall, requestDigest, requestSelf, requestInputs, requestInputRefs); err != nil {
+			return nil, false, false, err
+		}
 	}
 	retRes := Result[Typed]{
 		shared:   res,
 		hitCache: true,
 	}
 	c.traceLookupHit(ctx, requestDigest.String(), res, match.termDigest)
-	return retRes, true, nil
+	return retRes, true, hitExactRecipe, nil
 }
 
 func (c *Cache) lookupCacheForRequest(
@@ -881,7 +920,7 @@ func (c *Cache) lookupCacheForRequest(
 	}
 
 	c.egraphMu.Lock()
-	retRes, hit, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs)
+	retRes, hit, hitRecipeDigest, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs)
 	if err != nil || !hit {
 		c.egraphMu.Unlock()
 		return retRes, hit, err
@@ -912,8 +951,7 @@ func (c *Cache) lookupCacheForRequest(
 	c.sessionMu.Unlock()
 	c.egraphMu.Unlock()
 
-	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
-	if err != nil {
+	rollbackTrackedHit := func(err error) (AnyResult, bool, error) {
 		c.egraphMu.Lock()
 		c.sessionMu.Lock()
 		if resultIDs := c.sessionResultIDsBySession[sessionID]; resultIDs != nil {
@@ -933,10 +971,74 @@ func (c *Cache) lookupCacheForRequest(
 		return nil, false, errors.Join(err, decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases))
 	}
 
+	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
+	if err != nil {
+		return rollbackTrackedHit(err)
+	}
+	if req.CacheHitTransform != nil && !hitRecipeDigest {
+		transformedHit, err := req.CacheHitTransform(ctx, loadedHit)
+		if err != nil {
+			return rollbackTrackedHit(err)
+		}
+		loadedHit, err = c.publishTransformedCacheHit(ctx, sessionID, resolver, req, transformedHit)
+		if err != nil {
+			return rollbackTrackedHit(err)
+		}
+	}
+
 	if c.traceEnabled() {
 		c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
 	}
 	return loadedHit, true, nil
+}
+
+func (c *Cache) publishTransformedCacheHit(
+	ctx context.Context,
+	sessionID string,
+	resolver TypeResolver,
+	req *CallRequest,
+	val AnyResult,
+) (AnyResult, error) {
+	if val == nil {
+		return nil, fmt.Errorf("publish transformed cache hit: nil result")
+	}
+	if shared := val.cacheSharedResult(); shared != nil && shared.id != 0 {
+		return nil, fmt.Errorf("publish transformed cache hit: transform returned cache-backed result")
+	}
+	oc := &ongoingCall{
+		val:           val,
+		isPersistable: req.IsPersistable,
+		ttlSeconds:    req.TTL,
+	}
+	if err := c.initCompletedResult(ctx, resolver, oc, req, sessionID); err != nil {
+		return nil, fmt.Errorf("publish transformed cache hit: %w", err)
+	}
+	if oc.res == nil {
+		return nil, fmt.Errorf("publish transformed cache hit: completed without initialized result")
+	}
+
+	retRes := Result[Typed]{
+		shared:   oc.res,
+		hitCache: true,
+	}
+	c.trackSessionResult(ctx, sessionID, retRes, true)
+	if oc.handoffHoldActive {
+		c.egraphMu.Lock()
+		queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
+		collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
+		c.egraphMu.Unlock()
+		oc.handoffHoldActive = false
+		if relErr := errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases)); relErr != nil {
+			return nil, fmt.Errorf("publish transformed cache hit: release publication hold: %w", relErr)
+		}
+	}
+	touchSharedResultLastUsed(oc.res, time.Now().UnixNano())
+
+	loaded, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
+	if err != nil {
+		return nil, fmt.Errorf("publish transformed cache hit: normalize transformed result: %w", err)
+	}
+	return loaded, nil
 }
 
 func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID string, frame *ResultCall, res AnyResult) error {
@@ -1095,6 +1197,11 @@ func (c *Cache) resultIDForCall(frame *ResultCall) (sharedResultID, error) {
 	match := c.lookupMatchForCallLocked(frame, requestDigest, requestSelf, requestInputs, time.Now().Unix())
 	if match.candidates == nil || match.candidates.Empty() {
 		return 0, fmt.Errorf("resolve result ID for call: no attached result for %s", requestDigest)
+	}
+	for hitRes := range match.candidates.Items() {
+		if hitRes != nil && hitRes.id != 0 && c.resultMatchesRecipeDigestLocked(hitRes, requestDigest) {
+			return hitRes.id, nil
+		}
 	}
 	for hitRes := range match.candidates.Items() {
 		if hitRes != nil && hitRes.id != 0 {

--- a/dagql/cache_persistence_resolver.go
+++ b/dagql/cache_persistence_resolver.go
@@ -70,10 +70,12 @@ func (c *Cache) sharedResultByResultID(ctx context.Context, sessionID string, re
 		return nil, false, 0, fmt.Errorf("resolve result %d: missing shared result", resultID)
 	}
 	if mode == sharedResultLookupCanonicalEquivalent {
-		res = c.canonicalEquivalentSharedResultLocked(sessionID, res, time.Now().Unix())
-		if res == nil {
-			c.egraphMu.Unlock()
-			return nil, false, 0, fmt.Errorf("resolve result %d: canonical shared result missing", resultID)
+		if res.loadResultCall() == nil || !c.sessionSatisfiesResourceRequirementsLocked(sessionID, res) {
+			res = c.canonicalEquivalentSharedResultLocked(sessionID, res, time.Now().Unix())
+			if res == nil {
+				c.egraphMu.Unlock()
+				return nil, false, 0, fmt.Errorf("resolve result %d: canonical shared result missing", resultID)
+			}
 		}
 	}
 

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -832,6 +832,258 @@ func TestCacheVolatileSessionResourceInvariants(t *testing.T) {
 	assert.NilError(t, c.ReleaseSession(unboundCtx, "volatile-unbound-session"))
 }
 
+// TestCacheVolatileConcurrentSessionsDivergentValues verifies that two sessions
+// with different volatile values for the same slot both get correct results.
+// Session A binds handle→"alpha", session B binds handle→"beta". Both look up
+// the same broad cache key. Each session's resolved resource must reflect its
+// own binding, not the other's.
+func TestCacheVolatileConcurrentSessionsDivergentValues(t *testing.T) {
+	t.Parallel()
+
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	ctx := ContextWithCache(baseCtx, c)
+	srv := cacheTestServer(t)
+
+	type volatileArgs struct {
+		Slot  String `name:"slot"`
+		Value String `name:"value"`
+	}
+
+	var calls atomic.Int32
+	Fields[cacheTestQuery]{
+		NodeFuncWithDynamicInputs(
+			"volatileConcurrentParent",
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs) (Result[*cacheTestObject], error) {
+				if got := string(args.Value); got != cacheTestVolatileValueSentinel {
+					return Result[*cacheTestObject]{}, fmt.Errorf("resolver saw unrewritten volatile value %q", got)
+				}
+				leaf, err := cacheTestSessionResourceLeaf(ctx, cacheTestVolatileSessionResourceHandle(string(args.Slot)))
+				if err != nil {
+					return Result[*cacheTestObject]{}, err
+				}
+				return NewResultForCurrentCall(ctx, &cacheTestObject{
+					Value:             int(calls.Add(1)),
+					dependencyResults: []AnyResult{leaf},
+				})
+			},
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs, req *CallRequest) error {
+				cache, err := EngineCache(ctx)
+				if err != nil {
+					return err
+				}
+				clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+				if err != nil {
+					return err
+				}
+				handle := cacheTestVolatileSessionResourceHandle(string(args.Slot))
+				if err := cache.BindSessionResource(ctx, clientMetadata.SessionID, clientMetadata.ClientID, handle, string(args.Value)); err != nil {
+					return err
+				}
+				return req.SetArgInput(ctx, "value", NewString(cacheTestVolatileValueSentinel), false)
+			},
+		),
+	}.Install(srv)
+
+	const slot = "CONCURRENT_SLOT"
+	handle := cacheTestVolatileSessionResourceHandle(slot)
+
+	selectVolatile := func(ctx context.Context, value string) ObjectResult[*cacheTestObject] {
+		t.Helper()
+		var res ObjectResult[*cacheTestObject]
+		err := srv.Select(ctx, srv.Root(), &res, Selector{
+			Field: "volatileConcurrentParent",
+			Args: []NamedInput{
+				{Name: "slot", Value: NewString(slot)},
+				{Name: "value", Value: NewString(value)},
+			},
+		})
+		assert.NilError(t, err)
+		return res
+	}
+
+	// Session A: bind "alpha"
+	sessionACtx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "client-a",
+		SessionID: "session-a",
+	})
+	sessionACtx = ContextWithCache(sessionACtx, c)
+	assert.NilError(t, c.BindSessionResource(sessionACtx, "session-a", "client-a", handle, "alpha"))
+
+	// Prime cache from default session
+	first := selectVolatile(ctx, "alpha")
+	assert.Assert(t, !first.HitCache())
+	assert.Equal(t, int32(1), calls.Load())
+
+	// Session B: bind "beta", same slot
+	sessionBCtx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "client-b",
+		SessionID: "session-b",
+	})
+	sessionBCtx = ContextWithCache(sessionBCtx, c)
+	assert.NilError(t, c.BindSessionResource(sessionBCtx, "session-b", "client-b", handle, "beta"))
+
+	// Both sessions look up the same broad cache key
+	hitA, hitAOk, err := c.lookupCallRequest(sessionACtx, "session-a", srv, &CallRequest{
+		ResultCall: func() *ResultCall {
+			rc, err := first.ResultCall()
+			assert.NilError(t, err)
+			return rc.clone()
+		}(),
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, hitAOk, "session A should hit cache")
+	assert.Assert(t, hitA.HitCache())
+
+	hitB, hitBOk, err := c.lookupCallRequest(sessionBCtx, "session-b", srv, &CallRequest{
+		ResultCall: func() *ResultCall {
+			rc, err := first.ResultCall()
+			assert.NilError(t, err)
+			return rc.clone()
+		}(),
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, hitBOk, "session B should hit cache")
+	assert.Assert(t, hitB.HitCache())
+
+	// Verify each session resolves its own volatile value
+	resolvedA, err := c.ResolveSessionResource(sessionACtx, "session-a", "client-a", handle)
+	assert.NilError(t, err)
+	assert.Equal(t, "alpha", resolvedA)
+
+	resolvedB, err := c.ResolveSessionResource(sessionBCtx, "session-b", "client-b", handle)
+	assert.NilError(t, err)
+	assert.Equal(t, "beta", resolvedB)
+
+	// Resolver should NOT have been called again — both are cache hits
+	assert.Equal(t, int32(1), calls.Load())
+
+	assert.NilError(t, c.ReleaseSession(ctx, "test-session"))
+	assert.NilError(t, c.ReleaseSession(sessionACtx, "session-a"))
+	assert.NilError(t, c.ReleaseSession(sessionBCtx, "session-b"))
+}
+
+// TestCacheVolatileNestedWithNonVolatile verifies that a volatile exec followed
+// by a non-volatile exec produces correct cache behavior: changing only the
+// volatile value should reuse the volatile exec but still run the non-volatile
+// exec if its non-volatile inputs changed.
+func TestCacheVolatileNestedWithNonVolatile(t *testing.T) {
+	t.Parallel()
+
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	ctx := ContextWithCache(baseCtx, c)
+	srv := cacheTestServer(t)
+
+	type volatileArgs struct {
+		Slot  String `name:"slot"`
+		Value String `name:"value"`
+	}
+
+	var volatileCalls atomic.Int32
+	Fields[cacheTestQuery]{
+		NodeFuncWithDynamicInputs(
+			"volatileNestedParent",
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs) (Result[*cacheTestObject], error) {
+				if got := string(args.Value); got != cacheTestVolatileValueSentinel {
+					return Result[*cacheTestObject]{}, fmt.Errorf("resolver saw unrewritten volatile value %q", got)
+				}
+				leaf, err := cacheTestSessionResourceLeaf(ctx, cacheTestVolatileSessionResourceHandle(string(args.Slot)))
+				if err != nil {
+					return Result[*cacheTestObject]{}, err
+				}
+				return NewResultForCurrentCall(ctx, &cacheTestObject{
+					Value:             int(volatileCalls.Add(1)),
+					dependencyResults: []AnyResult{leaf},
+				})
+			},
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs, req *CallRequest) error {
+				cache, err := EngineCache(ctx)
+				if err != nil {
+					return err
+				}
+				clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+				if err != nil {
+					return err
+				}
+				handle := cacheTestVolatileSessionResourceHandle(string(args.Slot))
+				if err := cache.BindSessionResource(ctx, clientMetadata.SessionID, clientMetadata.ClientID, handle, string(args.Value)); err != nil {
+					return err
+				}
+				return req.SetArgInput(ctx, "value", NewString(cacheTestVolatileValueSentinel), false)
+			},
+		),
+	}.Install(srv)
+
+	type regularArgs struct {
+		Marker String `name:"marker"`
+	}
+	var regularCalls atomic.Int32
+	Fields[*cacheTestObject]{
+		NodeFunc("regularChild", func(ctx context.Context, self ObjectResult[*cacheTestObject], args regularArgs) (Result[*cacheTestObject], error) {
+			return NewResultForCurrentCall(ctx, &cacheTestObject{
+				Value: int(regularCalls.Add(1)),
+			})
+		}),
+	}.Install(srv)
+
+	const slot = "NESTED_SLOT"
+
+	selectChain := func(ctx context.Context, volatileValue, marker string) ObjectResult[*cacheTestObject] {
+		t.Helper()
+		var parent ObjectResult[*cacheTestObject]
+		err := srv.Select(ctx, srv.Root(), &parent, Selector{
+			Field: "volatileNestedParent",
+			Args: []NamedInput{
+				{Name: "slot", Value: NewString(slot)},
+				{Name: "value", Value: NewString(volatileValue)},
+			},
+		})
+		assert.NilError(t, err)
+		var child ObjectResult[*cacheTestObject]
+		err = srv.Select(ctx, parent, &child, Selector{
+			Field: "regularChild",
+			Args: []NamedInput{
+				{Name: "marker", Value: NewString(marker)},
+			},
+		})
+		assert.NilError(t, err)
+		return child
+	}
+
+	// First call: volatile=v1, marker=m1
+	first := selectChain(ctx, "v1", "m1")
+	assert.Assert(t, !first.HitCache())
+	assert.Equal(t, int32(1), volatileCalls.Load())
+	assert.Equal(t, int32(1), regularCalls.Load())
+
+	// Same volatile, same marker → full cache hit
+	second := selectChain(ctx, "v1", "m1")
+	assert.Assert(t, second.HitCache())
+	assert.Equal(t, int32(1), volatileCalls.Load())
+	assert.Equal(t, int32(1), regularCalls.Load())
+
+	// Different volatile, same marker → volatile exec hits cache, regular child
+	// also hits cache because its non-volatile inputs (marker) didn't change
+	third := selectChain(ctx, "v2", "m1")
+	assert.Assert(t, third.HitCache())
+	assert.Equal(t, int32(1), volatileCalls.Load())
+	assert.Equal(t, int32(1), regularCalls.Load())
+
+	// Different volatile AND different marker → volatile exec hits cache,
+	// regular child misses because marker changed
+	fourth := selectChain(ctx, "v3", "m2")
+	assert.Assert(t, !fourth.HitCache())
+	assert.Equal(t, int32(1), volatileCalls.Load())
+	assert.Equal(t, int32(2), regularCalls.Load())
+
+	assert.NilError(t, c.ReleaseSession(ctx, "test-session"))
+}
+
 func TestCacheConcurrent(t *testing.T) {
 	t.Parallel()
 	ctx := cacheTestContext(t.Context())

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -632,6 +632,206 @@ func cacheTestObjectResultWithValue(
 	return res
 }
 
+const cacheTestVolatileValueSentinel = "dagql.cache-test.volatile-value"
+
+func cacheTestVolatileSessionResourceHandle(slot string) SessionResourceHandle {
+	return SessionResourceHandle(digest.FromString("cache-test volatile session resource: " + slot).String())
+}
+
+func cacheTestSessionResourceLeaf(ctx context.Context, handle SessionResourceHandle) (Result[String], error) {
+	leaf, err := NewResultForCall(NewString("volatile"), &ResultCall{
+		Kind:        ResultCallKindSynthetic,
+		Type:        NewResultCallType(NewString("").Type()),
+		SyntheticOp: "cache-test.volatile-session-resource",
+		Args: []*ResultCallArg{{
+			Name: "handle",
+			Value: &ResultCallLiteral{
+				Kind:        ResultCallLiteralKindString,
+				StringValue: string(handle),
+			},
+		}},
+	})
+	if err != nil {
+		return Result[String]{}, err
+	}
+	leaf, err = leaf.WithContentDigest(ctx, digest.Digest(handle))
+	if err != nil {
+		return Result[String]{}, err
+	}
+	return leaf.WithSessionResourceHandle(ctx, handle)
+}
+
+func cacheTestStringResultCallArg(t *testing.T, frame *ResultCall, name string) string {
+	t.Helper()
+	for _, arg := range frame.Args {
+		if arg == nil || arg.Name != name {
+			continue
+		}
+		assert.Assert(t, arg.Value != nil, "expected arg %q to have a value", name)
+		assert.Equal(t, ResultCallLiteralKindString, arg.Value.Kind)
+		return arg.Value.StringValue
+	}
+	t.Fatalf("expected result call arg %q", name)
+	return ""
+}
+
+func cacheTestSessionResourceSetContains(handles *set.TreeSet[SessionResourceHandle], handle SessionResourceHandle) bool {
+	if handles == nil {
+		return false
+	}
+	for candidate := range handles.Items() {
+		if candidate == handle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCacheVolatileSessionResourceInvariants(t *testing.T) {
+	t.Parallel()
+
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	ctx := ContextWithCache(baseCtx, c)
+	srv := cacheTestServer(t)
+
+	type volatileArgs struct {
+		Slot  String `name:"slot"`
+		Value String `name:"value"`
+	}
+
+	var calls atomic.Int32
+	Fields[cacheTestQuery]{
+		NodeFuncWithDynamicInputs(
+			"volatileSessionParent",
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs) (Result[*cacheTestObject], error) {
+				if got := string(args.Value); got != cacheTestVolatileValueSentinel {
+					return Result[*cacheTestObject]{}, fmt.Errorf("resolver saw unrewritten volatile value %q", got)
+				}
+				leaf, err := cacheTestSessionResourceLeaf(ctx, cacheTestVolatileSessionResourceHandle(string(args.Slot)))
+				if err != nil {
+					return Result[*cacheTestObject]{}, err
+				}
+				return NewResultForCurrentCall(ctx, &cacheTestObject{
+					Value:             int(calls.Add(1)),
+					dependencyResults: []AnyResult{leaf},
+				})
+			},
+			func(ctx context.Context, _ ObjectResult[cacheTestQuery], args volatileArgs, req *CallRequest) error {
+				cache, err := EngineCache(ctx)
+				if err != nil {
+					return err
+				}
+				clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+				if err != nil {
+					return err
+				}
+				handle := cacheTestVolatileSessionResourceHandle(string(args.Slot))
+				if err := cache.BindSessionResource(ctx, clientMetadata.SessionID, clientMetadata.ClientID, handle, string(args.Value)); err != nil {
+					return err
+				}
+				return req.SetArgInput(ctx, "value", NewString(cacheTestVolatileValueSentinel), false)
+			},
+		),
+	}.Install(srv)
+
+	const slot = "CI_JOB_ID"
+	handle := cacheTestVolatileSessionResourceHandle(slot)
+	selectVolatile := func(ctx context.Context, value string) ObjectResult[*cacheTestObject] {
+		t.Helper()
+		var res ObjectResult[*cacheTestObject]
+		err := srv.Select(ctx, srv.Root(), &res, Selector{
+			Field: "volatileSessionParent",
+			Args: []NamedInput{
+				{Name: "slot", Value: NewString(slot)},
+				{Name: "value", Value: NewString(value)},
+			},
+		})
+		assert.NilError(t, err)
+		return res
+	}
+
+	first := selectVolatile(ctx, "first")
+	assert.Assert(t, !first.HitCache())
+	assert.Equal(t, 1, first.Self().Value)
+	assert.Equal(t, int32(1), calls.Load())
+
+	firstCall, err := first.ResultCall()
+	assert.NilError(t, err)
+	assert.Equal(t, slot, cacheTestStringResultCallArg(t, firstCall, "slot"))
+	assert.Equal(t, cacheTestVolatileValueSentinel, cacheTestStringResultCallArg(t, firstCall, "value"))
+
+	firstShared := first.cacheSharedResult()
+	assert.Assert(t, firstShared != nil)
+	assert.Assert(t, firstShared.id != 0)
+	c.egraphMu.Lock()
+	parentRequiresHandle := cacheTestSessionResourceSetContains(firstShared.requiredSessionResources, handle)
+	var leafShared *sharedResult
+	for depID := range firstShared.deps {
+		dep := c.resultsByID[depID]
+		if dep != nil && dep.sessionResourceHandle == handle {
+			leafShared = dep
+			break
+		}
+	}
+	leafRequiresHandle := leafShared != nil && cacheTestSessionResourceSetContains(leafShared.requiredSessionResources, handle)
+	leafHandle := SessionResourceHandle("")
+	if leafShared != nil {
+		leafHandle = leafShared.sessionResourceHandle
+	}
+	c.egraphMu.Unlock()
+	assert.Assert(t, parentRequiresHandle)
+	assert.Assert(t, leafShared != nil, "expected volatile session resource leaf dependency")
+	assert.Equal(t, handle, leafHandle)
+	assert.Assert(t, leafRequiresHandle)
+
+	second := selectVolatile(ctx, "second")
+	assert.Assert(t, second.HitCache())
+	assert.Equal(t, firstShared.id, second.cacheSharedResult().id)
+	assert.Equal(t, 1, second.Self().Value)
+	assert.Equal(t, int32(1), calls.Load())
+	resolved, err := c.ResolveSessionResource(ctx, "test-session", "dagql-test-client", handle)
+	assert.NilError(t, err)
+	assert.Equal(t, "second", resolved)
+
+	boundCtx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "volatile-bound-client",
+		SessionID: "volatile-bound-session",
+	})
+	boundCtx = ContextWithCache(boundCtx, c)
+	extraHandle := cacheTestVolatileSessionResourceHandle("EXTRA_VOLATILE")
+	assert.NilError(t, c.BindSessionResource(boundCtx, "volatile-bound-session", "volatile-bound-client", handle, "bound"))
+	assert.NilError(t, c.BindSessionResource(boundCtx, "volatile-bound-session", "volatile-bound-client", extraHandle, "extra"))
+	boundHit, hit, err := c.lookupCallRequest(boundCtx, "volatile-bound-session", srv, &CallRequest{ResultCall: firstCall.clone()})
+	assert.NilError(t, err)
+	assert.Assert(t, hit)
+	assert.Assert(t, boundHit.HitCache())
+	assert.Equal(t, firstShared.id, boundHit.cacheSharedResult().id)
+
+	unboundCtx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "volatile-unbound-client",
+		SessionID: "volatile-unbound-session",
+	})
+	unboundCtx = ContextWithCache(unboundCtx, c)
+	var unboundInitCalls int
+	unbound, err := c.GetOrInitCall(unboundCtx, "volatile-unbound-session", srv, &CallRequest{ResultCall: firstCall.clone()}, func(ctx context.Context) (AnyResult, error) {
+		unboundInitCalls++
+		return NewObjectResultForCurrentCall(ctx, srv, &cacheTestObject{Value: 99})
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, unboundInitCalls)
+	assert.Assert(t, !unbound.HitCache())
+	unboundObj, ok := unbound.(ObjectResult[*cacheTestObject])
+	assert.Assert(t, ok, "expected unbound miss to return cacheTestObject, got %T", unbound)
+	assert.Equal(t, 99, unboundObj.Self().Value)
+
+	assert.NilError(t, c.ReleaseSession(ctx, "test-session"))
+	assert.NilError(t, c.ReleaseSession(boundCtx, "volatile-bound-session"))
+	assert.NilError(t, c.ReleaseSession(unboundCtx, "volatile-unbound-session"))
+}
+
 func TestCacheConcurrent(t *testing.T) {
 	t.Parallel()
 	ctx := cacheTestContext(t.Context())

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -210,6 +210,23 @@ func (id *ID) Digest() digest.Digest {
 	return digest.Digest(id.pb.Digest)
 }
 
+// DigestWithReceiverDigest returns the recipe digest this call would have if
+// its immediate receiver had the given recipe digest.
+//
+// Only this call's receiver edge is overridden. Any IDs referenced by args,
+// implicit inputs, or module identity keep their own recipe digests.
+func (id *ID) DigestWithReceiverDigest(receiverDigest digest.Digest) (digest.Digest, error) {
+	if id == nil {
+		return "", nil
+	}
+	id.mustBeRecipe("DigestWithReceiverDigest")
+	dig, err := id.calcDigestWithReceiverDigest(receiverDigest)
+	if err != nil {
+		return "", err
+	}
+	return digest.Digest(dig), nil
+}
+
 func (id *ID) ContentDigest() digest.Digest {
 	id.mustBeRecipe("ContentDigest")
 	if id == nil {
@@ -824,13 +841,26 @@ func (id *ID) calcDigest() (string, error) {
 		return "", nil
 	}
 
+	var receiverDigest digest.Digest
+	if id.receiver != nil {
+		receiverDigest = id.receiver.Digest()
+	}
+	return id.calcDigestWithReceiverDigest(receiverDigest)
+}
+
+func (id *ID) calcDigestWithReceiverDigest(receiverDigest digest.Digest) (string, error) {
+	id.mustBeRecipe("calcDigestWithReceiverDigest")
+	if id == nil {
+		return "", nil
+	}
+
 	var err error
 
 	h := hashutil.NewHasher()
 
 	// ReceiverDigest (recipe identity only)
 	if id.receiver != nil {
-		h = h.WithString(id.receiver.Digest().String())
+		h = h.WithString(receiverDigest.String())
 	}
 	h = h.WithDelim()
 

--- a/dagql/call/id_test.go
+++ b/dagql/call/id_test.go
@@ -107,6 +107,50 @@ func TestImplicitInputsAffectDigest(t *testing.T) {
 	}
 }
 
+func TestDigestWithReceiverDigest(t *testing.T) {
+	typ := &ast.Type{
+		NamedType: "String",
+		NonNull:   true,
+	}
+	receiverA := New().Append(
+		typ,
+		"receiver",
+		WithArgs(NewArgument("value", NewLiteralString("a"), false)),
+	)
+	receiverB := New().Append(
+		typ,
+		"receiver",
+		WithArgs(NewArgument("value", NewLiteralString("b"), false)),
+	)
+
+	childOpts := func() []IDOpt {
+		return []IDOpt{
+			WithArgs(NewArgument("arg", NewLiteralString("same"), false)),
+			WithImplicitInputs(NewArgument("implicit", NewLiteralString("input"), false)),
+			WithNth(2),
+			WithView(View("test")),
+		}
+	}
+	childA := receiverA.Append(typ, "child", childOpts()...)
+	childB := receiverB.Append(typ, "child", childOpts()...)
+
+	normalDigest, err := childA.DigestWithReceiverDigest(receiverA.Digest())
+	if err != nil {
+		t.Fatalf("digest with original receiver: %v", err)
+	}
+	if normalDigest != childA.Digest() {
+		t.Fatalf("digest with original receiver mismatch: got %s, want %s", normalDigest, childA.Digest())
+	}
+
+	overrideDigest, err := childA.DigestWithReceiverDigest(receiverB.Digest())
+	if err != nil {
+		t.Fatalf("digest with override receiver: %v", err)
+	}
+	if overrideDigest != childB.Digest() {
+		t.Fatalf("digest with override receiver mismatch: got %s, want %s", overrideDigest, childB.Digest())
+	}
+}
+
 func TestImplicitInputsRoundTrip(t *testing.T) {
 	orig := New().Append(
 		&ast.Type{

--- a/dagql/call_request.go
+++ b/dagql/call_request.go
@@ -12,6 +12,12 @@ type CallRequest struct {
 	TTL            int64
 	DoNotCache     bool
 	IsPersistable  bool
+
+	// CacheHitTransform can rebase request-local state onto an equivalent cache
+	// hit before it is returned to the caller. It must return a detached result;
+	// the cache will publish that result under this request without mutating the
+	// shared result that satisfied the broad cache lookup.
+	CacheHitTransform func(context.Context, AnyResult) (AnyResult, error)
 }
 
 func (req *CallRequest) Clone() *CallRequest {
@@ -23,11 +29,12 @@ func (req *CallRequest) Clone() *CallRequest {
 		frame = &ResultCall{}
 	}
 	return &CallRequest{
-		ResultCall:     frame,
-		ConcurrencyKey: req.ConcurrencyKey,
-		TTL:            req.TTL,
-		DoNotCache:     req.DoNotCache,
-		IsPersistable:  req.IsPersistable,
+		ResultCall:        frame,
+		ConcurrencyKey:    req.ConcurrencyKey,
+		TTL:               req.TTL,
+		DoNotCache:        req.DoNotCache,
+		IsPersistable:     req.IsPersistable,
+		CacheHitTransform: req.CacheHitTransform,
 	}
 }
 

--- a/docs/current_docs/cookbook/containers.mdx
+++ b/docs/current_docs/cookbook/containers.mdx
@@ -18,3 +18,24 @@ Dagger allows you to build, publish, and export container images, also known as 
 <ExportContainerImageToHost />
 
 <SetEnvVar />
+
+## Use volatile variables for exec-time metadata
+
+`withVolatileVariable` sets a non-secret environment variable for future `withExec` calls without invalidating exec cache when only the variable's value changes.
+
+Typical examples include CI and reporting metadata such as:
+- commit SHA
+- branch or ref
+- CI run ID
+
+:::warning
+`withVolatileVariable` is an expert-only escape hatch. Use it only when you are certain that changing the variable alone must not invalidate cached `withExec` results. If that assumption is wrong, Dagger may reuse stale or incorrect cached results.
+:::
+
+Unlike `withEnvVariable`, volatile variables:
+- are visible only to future `withExec` calls
+- are not persisted into the container image config
+- are not returned by `envVariable` or `envVariables`
+- are not available to `expand: true`
+
+Use `withEnvVariable` for normal container configuration, `withSecretVariable` for sensitive values, and `withVolatileVariable` only for exec-time metadata that should not decide cache reuse.

--- a/docs/current_docs/extending/modules/function-caching.mdx
+++ b/docs/current_docs/extending/modules/function-caching.mdx
@@ -252,6 +252,8 @@ This means:
 If you need a specific step to always re-run, add a cache-busting input to that step (for example, a
 timestamp environment variable used only for that operation).
 
+If you need non-secret metadata to be visible to a `withExec` step without invalidating cache when only that metadata changes, use `withVolatileVariable` on the `Container`. This is an expert-only escape hatch: cached `withExec` results may be reused even when the volatile value changes, and reruns caused by other inputs will see the latest volatile value. See the [container cookbook](../../cookbook/containers.mdx#use-volatile-variables-for-exec-time-metadata).
+
 ### Secrets and caching
 
 [Secrets](../../getting-started/types/secret.mdx) are never cached on disk by Dagger. Function calls that return Secrets or values that reference Secrets (e.g. a Container that has a secret set as an environment variable) *may* be cached provided that the Secret in question was sourced using a secret provider (e.g. `env://MY_SECRET`). In these cases, Dagger is able to cache the source of the secret without having to write the plaintext to disk, [instead using a securely derived hash of the secret plaintext](secrets.mdx#caching).

--- a/docs/current_docs/partials/types/_container.mdx
+++ b/docs/current_docs/partials/types/_container.mdx
@@ -17,6 +17,7 @@ Some of the common operations used on the `Container` type include:
 | `withExec` | Returns the container after executing a command inside it |
 | `withFile` / `withMountedFile` | Returns the container plus a file copied / mounted at the given path |
 | `withMountedCache` | Returns the container plus a cache volume mounted at the given path |
+| `withVolatileVariable` | Sets non-secret env for future `withExec` calls without invalidating exec cache when only the value changes |
 | `withRegistryAuth` | Returns the container with registry authentication configured |
 | `withWorkdir` | Returns the container configured with a specific working directory |
 | `withServiceBinding` | Returns the container with runtime dependency on another `Service` |

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -554,13 +554,15 @@ type Container {
   """Return the container's OCI entrypoint."""
   entrypoint: [String!]!
 
-  """Retrieves the value of the specified environment variable."""
+  """Retrieves the value of the specified persistent environment variable."""
   envVariable(
     """The name of the environment variable to retrieve (e.g., "PATH")."""
     name: String!
   ): String
 
-  """Retrieves the list of environment variables passed to commands."""
+  """
+  Retrieves the list of persistent environment variables configured on the container.
+  """
   envVariables: [EnvVariable!]!
 
   """check if a file or directory exists"""
@@ -1506,6 +1508,20 @@ type Container {
     name: String!
   ): Container!
 
+  """
+  Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
+
+  This is an expert-only escape hatch. If a volatile value affects observable
+  exec results, stale cached results may be reused.
+  """
+  withVolatileVariable(
+    """Name of the volatile variable (e.g., "CI_RUN_ID")."""
+    name: String!
+
+    """Value of the volatile variable."""
+    value: String!
+  ): Container!
+
   """Change the container's working directory. Like WORKDIR in Dockerfile."""
   withWorkdir(
     """The path to set as the working directory (e.g., "/app")."""
@@ -1653,6 +1669,14 @@ type Container {
   Should default to root.
   """
   withoutUser: Container!
+
+  """
+  Retrieves this container minus the given volatile environment variable.
+  """
+  withoutVolatileVariable(
+    """The name of the volatile environment variable (e.g., "CI_RUN_ID")."""
+    name: String!
+  ): Container!
 
   """
   Unset the container's working directory.

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6507,7 +6507,7 @@
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-envVariable" href="#Container-envVariable"><code>envVariable</code></a> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span> </td>
-                        <td> Retrieves the value of the specified environment variable. </td>
+                        <td> Retrieves the value of the specified persistent environment variable. </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -6524,7 +6524,7 @@
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Container-envVariables" href="#Container-envVariables"><code>envVariables</code></a> - <span class="property-type"><a href="#definition-EnvVariable"><code>[EnvVariable!]!</code></a></span> </td>
-                        <td> Retrieves the list of environment variables passed to commands. </td>
+                        <td> Retrieves the list of persistent environment variables configured on the container. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-exists" href="#Container-exists"><code>exists</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
@@ -7714,6 +7714,30 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Container-withVolatileVariable" href="#Container-withVolatileVariable"><code>withVolatileVariable</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td>
+                          <p>Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.</p>
+                          <p>This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.</p>
+                        </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Name of the volatile variable (e.g., &quot;CI_RUN_ID&quot;).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>value</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Value of the volatile variable.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Container-withWorkdir" href="#Container-withWorkdir"><code>withWorkdir</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
                         <td> Change the container's working directory. Like WORKDIR in Dockerfile. </td>
                       </tr>
@@ -7976,6 +8000,23 @@
                         <td>
                           <p>Retrieves this container with an unset command user.</p>
                           <p>Should default to root.</p>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Container-withoutVolatileVariable" href="#Container-withoutVolatileVariable"><code>withoutVolatileVariable</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
+                        <td> Retrieves this container minus the given volatile environment variable. </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the volatile environment variable (e.g., &quot;CI_RUN_ID&quot;).</p>
+                              </div>
+                            </div>
+                          </div>
                         </td>
                       </tr>
                       <tr>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -80,31 +80,31 @@
         </div>
                 <div id="page-content">
     <div class="page-header">
-        <h1>Container    
+        <h1>Container
             </h1>
     </div>
 
-    
+
     <p>        class
     <strong>Container</strong>        extends <a href="../Dagger/Client/AbstractObject.html"><abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a>        implements        <a href="../Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a>
 </p>
 
-        
-    
-        
+
+
+
 
             <div class="description">
             <p><p>An OCI-compatible container, also known as a Docker container.</p></p>                    </div>
-            
-        
-    
+
+
+
             <h2>Properties</h2>
 
             <table class="table table-condensed">
                     <tr>
                 <td class="type" id="property_lastQuery">
-                                                                                
-                                                                                
+
+
                                     </td>
                 <td>$lastQuery</td>
                 <td class="last"></td>
@@ -113,17 +113,17 @@
             </tr>
             </table>
 
-    
+
             <h2>Methods</h2>
 
             <div class="container-fluid underlined">
                     <div class="row">
                 <div class="col-md-2 type">
-                    
+
                 </div>
                 <div class="col-md-8">
                     <a href="#method___construct">__construct</a>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method___construct">
@@ -135,7 +135,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_queryLeaf">queryLeaf</a>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method_queryLeaf">
@@ -147,7 +147,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asService">asService</a>(array|null $args = null, bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
-        
+
                                             <p><p>Turn the container into a Service.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -157,7 +157,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asTarball">asTarball</a>(array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
-        
+
                                             <p><p>Package the container state as an OCI image, and return it as a tar archive</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -167,7 +167,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_combinedOutput">combinedOutput</a>()
-        
+
                                             <p><p>The combined buffered standard output and standard error stream of the last executed command</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -177,7 +177,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_defaultArgs">defaultArgs</a>()
-        
+
                                             <p><p>Return the container's default arguments.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -187,7 +187,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_directory">directory</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Retrieve a directory from the container's root filesystem</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -197,7 +197,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_dockerHealthcheck">dockerHealthcheck</a>()
-        
+
                                             <p><p>Retrieves this container's configured docker healthcheck.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -207,7 +207,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_entrypoint">entrypoint</a>()
-        
+
                                             <p><p>Return the container's OCI entrypoint.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -217,8 +217,8 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_envVariable">envVariable</a>(string $name)
-        
-                                            <p><p>Retrieves the value of the specified environment variable.</p></p>                </div>
+
+                                            <p><p>Retrieves the value of the specified persistent environment variable.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -227,8 +227,8 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_envVariables">envVariables</a>()
-        
-                                            <p><p>Retrieves the list of environment variables passed to commands.</p></p>                </div>
+
+                                            <p><p>Retrieves the list of persistent environment variables configured on the container.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -237,7 +237,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_exists">exists</a>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false)
-        
+
                                             <p><p>check if a file or directory exists</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -247,7 +247,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_exitCode">exitCode</a>()
-        
+
                                             <p><p>The exit code of the last executed command</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -257,7 +257,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_experimentalWithAllGPUs">experimentalWithAllGPUs</a>()
-        
+
                                             <p><p>EXPERIMENTAL API! Subject to change/removal at any time.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -267,7 +267,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_experimentalWithGPU">experimentalWithGPU</a>(array $devices)
-        
+
                                             <p><p>EXPERIMENTAL API! Subject to change/removal at any time.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -277,7 +277,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_export">export</a>(string $path, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, bool|null $expand = false)
-        
+
                                             <p><p>Writes the container as an OCI tarball to the destination file path on the host.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -287,7 +287,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_exportImage">exportImage</a>(string $name, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
-        
+
                                             <p><p>Exports the container as an image to the host's container image store.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -297,7 +297,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_exposedPorts">exposedPorts</a>()
-        
+
                                             <p><p>Retrieves the list of exposed ports.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -307,7 +307,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_file">file</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves a file at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -317,7 +317,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_from">from</a>(string $address)
-        
+
                                             <p><p>Download a container image, and apply it to the container state. All previous state will be lost.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -327,7 +327,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_id">id</a>()
-        
+
                                             <p><p>A unique identifier for this Container.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -337,7 +337,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_imageRef">imageRef</a>()
-        
+
                                             <p><p>The unique image reference which can only be retrieved immediately after the 'Container.From' call.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -347,7 +347,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_import">import</a>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $tag = &#039;&#039;)
-        
+
                                             <p><p>Reads the container from an OCI tarball.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -357,7 +357,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_label">label</a>(string $name)
-        
+
                                             <p><p>Retrieves the value of the specified label.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -367,7 +367,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_labels">labels</a>()
-        
+
                                             <p><p>Retrieves the list of labels passed to container.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -377,7 +377,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_mounts">mounts</a>()
-        
+
                                             <p><p>Retrieves the list of paths where a directory is mounted.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -387,7 +387,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_platform">platform</a>()
-        
+
                                             <p><p>The platform this container executes and publishes as.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -397,7 +397,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_publish">publish</a>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
-        
+
                                             <p><p>Package the container state as an OCI image, and publish it to a registry</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -407,7 +407,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_rootfs">rootfs</a>()
-        
+
                                             <p><p>Return a snapshot of the container's root filesystem. The snapshot can be modified then written back using withRootfs. Use that method for filesystem modifications.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -417,7 +417,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stat">stat</a>(string $path, bool|null $doNotFollowSymlinks = false)
-        
+
                                             <p><p>Return file status</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -427,7 +427,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stderr">stderr</a>()
-        
+
                                             <p><p>The buffered standard error stream of the last executed command</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -437,7 +437,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stdout">stdout</a>()
-        
+
                                             <p><p>The buffered standard output stream of the last executed command</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -447,7 +447,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sync">sync</a>()
-        
+
                                             <p><p>Forces evaluation of the pipeline in the engine.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -457,7 +457,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_terminal">terminal</a>(array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
-        
+
                                             <p><p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -467,7 +467,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_up">up</a>(bool|null $random = false, array|null $ports = null, array|null $args = null, bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
-        
+
                                             <p><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -477,7 +477,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_user">user</a>()
-        
+
                                             <p><p>Retrieves the user to be set for all commands.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -487,7 +487,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withAnnotation">withAnnotation</a>(string $name, string $value)
-        
+
                                             <p><p>Retrieves this container plus the given OCI annotation.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -497,7 +497,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDefaultArgs">withDefaultArgs</a>(array $args)
-        
+
                                             <p><p>Configures default arguments for future commands. Like CMD in Dockerfile.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -507,7 +507,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDefaultTerminalCmd">withDefaultTerminalCmd</a>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
-        
+
                                             <p><p>Set the default command to invoke for the container's terminal API.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -517,7 +517,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDirectory">withDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $expand = false, int|null $permissions = null)
-        
+
                                             <p><p>Return a new container snapshot, with a directory added to its filesystem</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -527,7 +527,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withDockerHealthcheck">withDockerHealthcheck</a>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
-        
+
                                             <p><p>Retrieves this container with the specificed docker healtcheck command set.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -537,7 +537,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withEntrypoint">withEntrypoint</a>(array $args, bool|null $keepDefaultArgs = false)
-        
+
                                             <p><p>Set an OCI-style entrypoint. It will be included in the container's OCI configuration. Note, withExec ignores the entrypoint by default.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -547,7 +547,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withEnvFileVariables">withEnvFileVariables</a>(<abbr title="Dagger\EnvFileId|Dagger\EnvFile">EnvFile</abbr> $source)
-        
+
                                             <p><p>Export environment variables from an env-file to the container.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -557,7 +557,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withEnvVariable">withEnvVariable</a>(string $name, string $value, bool|null $expand = false)
-        
+
                                             <p><p>Set a new environment variable in the container.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -567,7 +567,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withError">withError</a>(string $err)
-        
+
                                             <p><p>Raise an error.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -577,7 +577,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withExec">withExec</a>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
-        
+
                                             <p><p>Execute a command in the container, and return a new snapshot of the container state after execution.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -587,7 +587,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withExposedPort">withExposedPort</a>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
-        
+
                                             <p><p>Expose a network port. Like EXPOSE in Dockerfile (but with healthcheck support)</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -597,7 +597,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withFile">withFile</a>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Return a container snapshot with a file added</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -607,7 +607,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withFiles">withFiles</a>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus the contents of the given files copied to the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -617,7 +617,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withLabel">withLabel</a>(string $name, string $value)
-        
+
                                             <p><p>Retrieves this container plus the given label.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -627,7 +627,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withMountedCache">withMountedCache</a>(string $path, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $cache, <abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a cache volume mounted at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -637,7 +637,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withMountedDirectory">withMountedDirectory</a>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, string|null $owner = &#039;&#039;, bool|null $readOnly = false, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a directory mounted at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -647,7 +647,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withMountedFile">withMountedFile</a>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a file mounted at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -657,7 +657,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withMountedSecret">withMountedSecret</a>(string $path, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $source, string|null $owner = &#039;&#039;, int|null $mode = 256, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a secret mounted into a file at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -667,7 +667,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withMountedTemp">withMountedTemp</a>(string $path, int|null $size = null, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -677,7 +677,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withNewFile">withNewFile</a>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Return a new container snapshot, with a file added to its filesystem with text content</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -687,7 +687,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withRegistryAuth">withRegistryAuth</a>(string $address, string $username, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
-        
+
                                             <p><p>Attach credentials for future publishing to a registry. Use in combination with publish</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -697,7 +697,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withRootfs">withRootfs</a>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory)
-        
+
                                             <p><p>Change the container's root filesystem. The previous root filesystem will be lost.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -707,7 +707,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSecretVariable">withSecretVariable</a>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
-        
+
                                             <p><p>Set a new environment variable, using a secret value</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -717,7 +717,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withServiceBinding">withServiceBinding</a>(string $alias, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service)
-        
+
                                             <p><p>Establish a runtime dependency from a container to a network service.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -727,7 +727,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withSymlink">withSymlink</a>(string $target, string $linkName, bool|null $expand = false)
-        
+
                                             <p><p>Return a snapshot with a symlink</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -737,7 +737,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withUnixSocket">withUnixSocket</a>(string $path, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -747,7 +747,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withUser">withUser</a>(string $name)
-        
+
                                             <p><p>Retrieves this container with a different command user.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -756,8 +756,18 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withVolatileVariable">withVolatileVariable</a>(string $name, string $value)
+
+                                            <p><p>Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withWorkdir">withWorkdir</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Change the container's working directory. Like WORKDIR in Dockerfile.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -767,7 +777,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutAnnotation">withoutAnnotation</a>(string $name)
-        
+
                                             <p><p>Retrieves this container minus the given OCI annotation.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -777,7 +787,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutDefaultArgs">withoutDefaultArgs</a>()
-        
+
                                             <p><p>Remove the container's default arguments.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -787,7 +797,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutDirectory">withoutDirectory</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Return a new container snapshot, with a directory removed from its filesystem</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -797,7 +807,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutDockerHealthcheck">withoutDockerHealthcheck</a>()
-        
+
                                             <p><p>Retrieves this container without a configured docker healtcheck command.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -807,7 +817,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutEntrypoint">withoutEntrypoint</a>(bool|null $keepDefaultArgs = false)
-        
+
                                             <p><p>Reset the container's OCI entrypoint.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -817,7 +827,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutEnvVariable">withoutEnvVariable</a>(string $name)
-        
+
                                             <p><p>Retrieves this container minus the given environment variable.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -827,7 +837,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutExposedPort">withoutExposedPort</a>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
-        
+
                                             <p><p>Unexpose a previously exposed port.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -837,7 +847,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutFile">withoutFile</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container with the file at the given path removed.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -847,7 +857,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutFiles">withoutFiles</a>(array $paths, bool|null $expand = false)
-        
+
                                             <p><p>Return a new container spanshot with specified files removed</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -857,7 +867,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutLabel">withoutLabel</a>(string $name)
-        
+
                                             <p><p>Retrieves this container minus the given environment label.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -867,7 +877,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutMount">withoutMount</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container after unmounting everything at the given path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -877,7 +887,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutRegistryAuth">withoutRegistryAuth</a>(string $address)
-        
+
                                             <p><p>Retrieves this container without the registry authentication of a given address.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -887,7 +897,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutSecretVariable">withoutSecretVariable</a>(string $name)
-        
+
                                             <p><p>Retrieves this container minus the given environment variable containing the secret.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -897,7 +907,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutUnixSocket">withoutUnixSocket</a>(string $path, bool|null $expand = false)
-        
+
                                             <p><p>Retrieves this container with a previously added Unix socket removed.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -907,7 +917,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_withoutUser">withoutUser</a>()
-        
+
                                             <p><p>Retrieves this container with an unset command user.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -916,8 +926,18 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withoutVolatileVariable">withoutVolatileVariable</a>(string $name)
+
+                                            <p><p>Retrieves this container minus the given volatile environment variable.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withoutWorkdir">withoutWorkdir</a>()
-        
+
                                             <p><p>Unset the container's working directory.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -927,7 +947,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_workdir">workdir</a>()
-        
+
                                             <p><p>Retrieves the working directory for all commands.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -941,17 +961,17 @@
                     <h3 id="method___construct">
         <div class="location">in <a href="../Dagger/Client/AbstractObject.html#method___construct">
 <abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a> at line 13</div>
-        <code>                    
+        <code>
     <strong>__construct</strong>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -969,10 +989,10 @@
             </tr>
             </table>
 
-            
-            
-            
-            
+
+
+
+
                     </div>
     </div>
 
@@ -985,13 +1005,13 @@
     <strong>queryLeaf</strong>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1009,7 +1029,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1019,9 +1039,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1033,12 +1053,12 @@
     <strong>asService</strong>(array|null $args = null, bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Turn the container into a Service.</p></p>                <p><p>Be sure to set any exposed ports before this conversion.</p></p>        
+                            <p><p>Turn the container into a Service.</p></p>                <p><p>Be sure to set any exposed ports before this conversion.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1076,7 +1096,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1086,9 +1106,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1100,12 +1120,12 @@
     <strong>asTarball</strong>(array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Package the container state as an OCI image, and return it as a tar archive</p></p>                        
+                            <p><p>Package the container state as an OCI image, and return it as a tar archive</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1128,7 +1148,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1138,9 +1158,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1152,15 +1172,15 @@
     <strong>combinedOutput</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The combined buffered standard output and standard error stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>        
+                            <p><p>The combined buffered standard output and standard error stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1170,9 +1190,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1184,15 +1204,15 @@
     <strong>defaultArgs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return the container's default arguments.</p></p>                        
+                            <p><p>Return the container's default arguments.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1202,9 +1222,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1216,12 +1236,12 @@
     <strong>directory</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieve a directory from the container's root filesystem</p></p>                <p><p>Mounts are included.</p></p>        
+                            <p><p>Retrieve a directory from the container's root filesystem</p></p>                <p><p>Mounts are included.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1239,7 +1259,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1249,9 +1269,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1263,15 +1283,15 @@
     <strong>dockerHealthcheck</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container's configured docker healthcheck.</p></p>                        
+                            <p><p>Retrieves this container's configured docker healthcheck.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1281,9 +1301,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1295,15 +1315,15 @@
     <strong>entrypoint</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return the container's OCI entrypoint.</p></p>                        
+                            <p><p>Return the container's OCI entrypoint.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1313,9 +1333,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1327,12 +1347,12 @@
     <strong>envVariable</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the value of the specified environment variable.</p></p>                        
+                            <p><p>Retrieves the value of the specified persistent environment variable.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1345,7 +1365,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1355,9 +1375,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1369,15 +1389,15 @@
     <strong>envVariables</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the list of environment variables passed to commands.</p></p>                        
+                            <p><p>Retrieves the list of persistent environment variables configured on the container.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1387,9 +1407,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1401,12 +1421,12 @@
     <strong>exists</strong>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>check if a file or directory exists</p></p>                        
+                            <p><p>check if a file or directory exists</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1429,7 +1449,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1439,9 +1459,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1453,15 +1473,15 @@
     <strong>exitCode</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The exit code of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>        
+                            <p><p>The exit code of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1471,9 +1491,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1485,16 +1505,16 @@
     <strong>experimentalWithAllGPUs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p><p>EXPERIMENTAL API! Subject to change/removal at any time.</p></p>                <p><p>Configures all available GPUs on the host to be accessible to this container.</p>
-<p>This currently works for Nvidia devices only.</p></p>        
+<p>This currently works for Nvidia devices only.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1504,9 +1524,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1518,13 +1538,13 @@
     <strong>experimentalWithGPU</strong>(array $devices)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p><p>EXPERIMENTAL API! Subject to change/removal at any time.</p></p>                <p><p>Configures the provided list of devices to be accessible to this container.</p>
-<p>This currently works for Nvidia devices only.</p></p>        
+<p>This currently works for Nvidia devices only.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1537,7 +1557,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1547,9 +1567,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1561,12 +1581,12 @@
     <strong>export</strong>(string $path, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Writes the container as an OCI tarball to the destination file path on the host.</p></p>                <p><p>It can also export platform variants.</p></p>        
+                            <p><p>Writes the container as an OCI tarball to the destination file path on the host.</p></p>                <p><p>It can also export platform variants.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1599,7 +1619,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1609,9 +1629,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1623,12 +1643,12 @@
     <strong>exportImage</strong>(string $name, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Exports the container as an image to the host's container image store.</p></p>                        
+                            <p><p>Exports the container as an image to the host's container image store.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1656,7 +1676,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1666,9 +1686,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1680,15 +1700,15 @@
     <strong>exposedPorts</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the list of exposed ports.</p></p>                <p><p>This includes ports already exposed by the image, even if not explicitly added with dagger.</p></p>        
+                            <p><p>Retrieves the list of exposed ports.</p></p>                <p><p>This includes ports already exposed by the image, even if not explicitly added with dagger.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1698,9 +1718,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1712,12 +1732,12 @@
     <strong>file</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves a file at the given path.</p></p>                <p><p>Mounts are included.</p></p>        
+                            <p><p>Retrieves a file at the given path.</p></p>                <p><p>Mounts are included.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1735,7 +1755,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1745,9 +1765,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1759,12 +1779,12 @@
     <strong>from</strong>(string $address)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Download a container image, and apply it to the container state. All previous state will be lost.</p></p>                        
+                            <p><p>Download a container image, and apply it to the container state. All previous state will be lost.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1777,7 +1797,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1787,9 +1807,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1801,15 +1821,15 @@
     <strong>id</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>A unique identifier for this Container.</p></p>                        
+                            <p><p>A unique identifier for this Container.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1819,9 +1839,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1833,15 +1853,15 @@
     <strong>imageRef</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The unique image reference which can only be retrieved immediately after the 'Container.From' call.</p></p>                        
+                            <p><p>The unique image reference which can only be retrieved immediately after the 'Container.From' call.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1851,9 +1871,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1865,12 +1885,12 @@
     <strong>import</strong>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $tag = &#039;&#039;)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Reads the container from an OCI tarball.</p></p>                        
+                            <p><p>Reads the container from an OCI tarball.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1888,7 +1908,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1898,9 +1918,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1912,12 +1932,12 @@
     <strong>label</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the value of the specified label.</p></p>                        
+                            <p><p>Retrieves the value of the specified label.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1930,7 +1950,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1940,9 +1960,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1954,15 +1974,15 @@
     <strong>labels</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the list of labels passed to container.</p></p>                        
+                            <p><p>Retrieves the list of labels passed to container.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -1972,9 +1992,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -1986,15 +2006,15 @@
     <strong>mounts</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the list of paths where a directory is mounted.</p></p>                        
+                            <p><p>Retrieves the list of paths where a directory is mounted.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2004,9 +2024,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2018,15 +2038,15 @@
     <strong>platform</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The platform this container executes and publishes as.</p></p>                        
+                            <p><p>The platform this container executes and publishes as.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2036,9 +2056,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2050,12 +2070,12 @@
     <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Package the container state as an OCI image, and publish it to a registry</p></p>                <p><p>Returns the fully qualified address of the published image, with digest</p></p>        
+                            <p><p>Package the container state as an OCI image, and publish it to a registry</p></p>                <p><p>Returns the fully qualified address of the published image, with digest</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2083,7 +2103,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2093,9 +2113,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2107,15 +2127,15 @@
     <strong>rootfs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a snapshot of the container's root filesystem. The snapshot can be modified then written back using withRootfs. Use that method for filesystem modifications.</p></p>                        
+                            <p><p>Return a snapshot of the container's root filesystem. The snapshot can be modified then written back using withRootfs. Use that method for filesystem modifications.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2125,9 +2145,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2139,12 +2159,12 @@
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return file status</p></p>                        
+                            <p><p>Return file status</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2162,7 +2182,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2172,9 +2192,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2186,15 +2206,15 @@
     <strong>stderr</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The buffered standard error stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>        
+                            <p><p>The buffered standard error stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2204,9 +2224,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2218,15 +2238,15 @@
     <strong>stdout</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The buffered standard output stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>        
+                            <p><p>The buffered standard output stream of the last executed command</p></p>                <p><p>Returns an error if no command was executed</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2236,9 +2256,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2250,15 +2270,15 @@
     <strong>sync</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Forces evaluation of the pipeline in the engine.</p></p>                <p><p>It doesn't run the default command if no exec has been set.</p></p>        
+                            <p><p>Forces evaluation of the pipeline in the engine.</p></p>                <p><p>It doesn't run the default command if no exec has been set.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2268,9 +2288,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2282,12 +2302,12 @@
     <strong>terminal</strong>(array|null $cmd = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p></p>                        
+                            <p><p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2310,7 +2330,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2320,9 +2340,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2334,12 +2354,12 @@
     <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = null, bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></p>                <p><p>Be sure to set any exposed ports before calling this api.</p></p>        
+                            <p><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></p>                <p><p>Be sure to set any exposed ports before calling this api.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2387,7 +2407,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2397,9 +2417,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2411,15 +2431,15 @@
     <strong>user</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the user to be set for all commands.</p></p>                        
+                            <p><p>Retrieves the user to be set for all commands.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2429,9 +2449,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2443,12 +2463,12 @@
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus the given OCI annotation.</p></p>                        
+                            <p><p>Retrieves this container plus the given OCI annotation.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2466,7 +2486,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2476,9 +2496,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2490,12 +2510,12 @@
     <strong>withDefaultArgs</strong>(array $args)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Configures default arguments for future commands. Like CMD in Dockerfile.</p></p>                        
+                            <p><p>Configures default arguments for future commands. Like CMD in Dockerfile.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2508,7 +2528,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2518,9 +2538,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2532,12 +2552,12 @@
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Set the default command to invoke for the container's terminal API.</p></p>                        
+                            <p><p>Set the default command to invoke for the container's terminal API.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2560,7 +2580,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2570,9 +2590,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2584,12 +2604,12 @@
     <strong>withDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $expand = false, int|null $permissions = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a new container snapshot, with a directory added to its filesystem</p></p>                        
+                            <p><p>Return a new container snapshot, with a directory added to its filesystem</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2637,7 +2657,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2647,9 +2667,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2661,12 +2681,12 @@
     <strong>withDockerHealthcheck</strong>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container with the specificed docker healtcheck command set.</p></p>                        
+                            <p><p>Retrieves this container with the specificed docker healtcheck command set.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2709,7 +2729,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2719,9 +2739,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2733,12 +2753,12 @@
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Set an OCI-style entrypoint. It will be included in the container's OCI configuration. Note, withExec ignores the entrypoint by default.</p></p>                        
+                            <p><p>Set an OCI-style entrypoint. It will be included in the container's OCI configuration. Note, withExec ignores the entrypoint by default.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2756,7 +2776,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2766,9 +2786,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2780,12 +2800,12 @@
     <strong>withEnvFileVariables</strong>(<abbr title="Dagger\EnvFileId|Dagger\EnvFile">EnvFile</abbr> $source)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Export environment variables from an env-file to the container.</p></p>                        
+                            <p><p>Export environment variables from an env-file to the container.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2798,7 +2818,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2808,9 +2828,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2822,12 +2842,12 @@
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Set a new environment variable in the container.</p></p>                        
+                            <p><p>Set a new environment variable in the container.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2850,7 +2870,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2860,9 +2880,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2874,12 +2894,12 @@
     <strong>withError</strong>(string $err)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Raise an error.</p></p>                        
+                            <p><p>Raise an error.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2892,7 +2912,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2902,9 +2922,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -2916,12 +2936,12 @@
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Execute a command in the container, and return a new snapshot of the container state after execution.</p></p>                        
+                            <p><p>Execute a command in the container, and return a new snapshot of the container state after execution.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2984,7 +3004,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -2994,9 +3014,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3008,9 +3028,9 @@
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p><p>Expose a network port. Like EXPOSE in Dockerfile (but with healthcheck support)</p></p>                <p><p>Exposed ports serve two purposes:</p>
@@ -3021,7 +3041,7 @@
 <li>
 <p>For setting the EXPOSE OCI field when publishing the container</p>
 </li>
-</ul></p>        
+</ul></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3049,7 +3069,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3059,9 +3079,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3073,12 +3093,12 @@
     <strong>withFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a container snapshot with a file added</p></p>                        
+                            <p><p>Return a container snapshot with a file added</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3111,7 +3131,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3121,9 +3141,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3135,12 +3155,12 @@
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus the contents of the given files copied to the given path.</p></p>                        
+                            <p><p>Retrieves this container plus the contents of the given files copied to the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3173,7 +3193,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3183,9 +3203,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3197,12 +3217,12 @@
     <strong>withLabel</strong>(string $name, string $value)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus the given label.</p></p>                        
+                            <p><p>Retrieves this container plus the given label.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3220,7 +3240,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3230,9 +3250,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3244,12 +3264,12 @@
     <strong>withMountedCache</strong>(string $path, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $cache, <abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a cache volume mounted at the given path.</p></p>                        
+                            <p><p>Retrieves this container plus a cache volume mounted at the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3287,7 +3307,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3297,9 +3317,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3311,12 +3331,12 @@
     <strong>withMountedDirectory</strong>(string $path, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $source, string|null $owner = &#039;&#039;, bool|null $readOnly = false, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a directory mounted at the given path.</p></p>                        
+                            <p><p>Retrieves this container plus a directory mounted at the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3349,7 +3369,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3359,9 +3379,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3373,12 +3393,12 @@
     <strong>withMountedFile</strong>(string $path, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a file mounted at the given path.</p></p>                        
+                            <p><p>Retrieves this container plus a file mounted at the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3406,7 +3426,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3416,9 +3436,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3430,12 +3450,12 @@
     <strong>withMountedSecret</strong>(string $path, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $source, string|null $owner = &#039;&#039;, int|null $mode = 256, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a secret mounted into a file at the given path.</p></p>                        
+                            <p><p>Retrieves this container plus a secret mounted into a file at the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3468,7 +3488,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3478,9 +3498,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3492,12 +3512,12 @@
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.</p></p>                        
+                            <p><p>Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3520,7 +3540,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3530,9 +3550,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3544,12 +3564,12 @@
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a new container snapshot, with a file added to its filesystem with text content</p></p>                        
+                            <p><p>Return a new container snapshot, with a file added to its filesystem with text content</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3582,7 +3602,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3592,9 +3612,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3606,12 +3626,12 @@
     <strong>withRegistryAuth</strong>(string $address, string $username, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Attach credentials for future publishing to a registry. Use in combination with publish</p></p>                        
+                            <p><p>Attach credentials for future publishing to a registry. Use in combination with publish</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3634,7 +3654,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3644,9 +3664,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3658,12 +3678,12 @@
     <strong>withRootfs</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $directory)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Change the container's root filesystem. The previous root filesystem will be lost.</p></p>                        
+                            <p><p>Change the container's root filesystem. The previous root filesystem will be lost.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3676,7 +3696,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3686,9 +3706,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3700,12 +3720,12 @@
     <strong>withSecretVariable</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $secret)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Set a new environment variable, using a secret value</p></p>                        
+                            <p><p>Set a new environment variable, using a secret value</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3723,7 +3743,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3733,9 +3753,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3747,14 +3767,14 @@
     <strong>withServiceBinding</strong>(string $alias, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $service)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p><p>Establish a runtime dependency from a container to a network service.</p></p>                <p><p>The service will be started automatically when needed and detached when it is no longer needed, executing the default command if none is set.</p>
 <p>The service will be reachable from the container via the provided hostname alias.</p>
-<p>The service dependency will also convey to any files or directories produced by the container.</p></p>        
+<p>The service dependency will also convey to any files or directories produced by the container.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3772,7 +3792,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3782,9 +3802,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3796,12 +3816,12 @@
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a snapshot with a symlink</p></p>                        
+                            <p><p>Return a snapshot with a symlink</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3824,7 +3844,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3834,9 +3854,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3848,12 +3868,12 @@
     <strong>withUnixSocket</strong>(string $path, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p></p>                        
+                            <p><p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3881,7 +3901,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3891,9 +3911,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -3905,12 +3925,12 @@
     <strong>withUser</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container with a different command user.</p></p>                        
+                            <p><p>Retrieves this container with a different command user.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3923,7 +3943,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3933,26 +3953,73 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withVolatileVariable">
+        <div class="location">at line 1040</div>
+        <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+    <strong>withVolatileVariable</strong>(string $name, string $value)
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.</p></p>                <p><p>This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.</p></p>
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string</td>
+                <td>$value</td>
+                <td></td>
+            </tr>
+            </table>
+
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 1046</div>
+        <div class="location">at line 1051</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Change the container's working directory. Like WORKDIR in Dockerfile.</p></p>                        
+                            <p><p>Change the container's working directory. Like WORKDIR in Dockerfile.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -3970,7 +4037,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -3980,26 +4047,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 1059</div>
+        <div class="location">at line 1064</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container minus the given OCI annotation.</p></p>                        
+                            <p><p>Retrieves this container minus the given OCI annotation.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4012,7 +4079,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4022,29 +4089,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1069</div>
+        <div class="location">at line 1074</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Remove the container's default arguments.</p></p>                        
+                            <p><p>Remove the container's default arguments.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4054,26 +4121,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1078</div>
+        <div class="location">at line 1083</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a new container snapshot, with a directory removed from its filesystem</p></p>                        
+                            <p><p>Return a new container snapshot, with a directory removed from its filesystem</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4091,7 +4158,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4101,29 +4168,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDockerHealthcheck">
-        <div class="location">at line 1091</div>
+        <div class="location">at line 1096</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDockerHealthcheck</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container without a configured docker healtcheck command.</p></p>                        
+                            <p><p>Retrieves this container without a configured docker healtcheck command.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4133,26 +4200,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1100</div>
+        <div class="location">at line 1105</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Reset the container's OCI entrypoint.</p></p>                        
+                            <p><p>Reset the container's OCI entrypoint.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4165,7 +4232,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4175,26 +4242,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1112</div>
+        <div class="location">at line 1117</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container minus the given environment variable.</p></p>                        
+                            <p><p>Retrieves this container minus the given environment variable.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4207,7 +4274,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4217,26 +4284,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1122</div>
+        <div class="location">at line 1127</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Unexpose a previously exposed port.</p></p>                        
+                            <p><p>Unexpose a previously exposed port.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4254,7 +4321,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4264,26 +4331,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1135</div>
+        <div class="location">at line 1140</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container with the file at the given path removed.</p></p>                        
+                            <p><p>Retrieves this container with the file at the given path removed.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4301,7 +4368,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4311,26 +4378,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1148</div>
+        <div class="location">at line 1153</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Return a new container spanshot with specified files removed</p></p>                        
+                            <p><p>Return a new container spanshot with specified files removed</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4348,7 +4415,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4358,26 +4425,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1161</div>
+        <div class="location">at line 1166</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container minus the given environment label.</p></p>                        
+                            <p><p>Retrieves this container minus the given environment label.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4390,7 +4457,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4400,26 +4467,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1171</div>
+        <div class="location">at line 1176</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container after unmounting everything at the given path.</p></p>                        
+                            <p><p>Retrieves this container after unmounting everything at the given path.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4437,7 +4504,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4447,26 +4514,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1184</div>
+        <div class="location">at line 1189</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container without the registry authentication of a given address.</p></p>                        
+                            <p><p>Retrieves this container without the registry authentication of a given address.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4479,7 +4546,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4489,26 +4556,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1194</div>
+        <div class="location">at line 1199</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container minus the given environment variable containing the secret.</p></p>                        
+                            <p><p>Retrieves this container minus the given environment variable containing the secret.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4521,7 +4588,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4531,26 +4598,26 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1204</div>
+        <div class="location">at line 1209</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container with a previously added Unix socket removed.</p></p>                        
+                            <p><p>Retrieves this container with a previously added Unix socket removed.</p></p>
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -4568,7 +4635,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4578,29 +4645,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1219</div>
+        <div class="location">at line 1224</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves this container with an unset command user.</p></p>                <p><p>Should default to root.</p></p>        
+                            <p><p>Retrieves this container with an unset command user.</p></p>                <p><p>Should default to root.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4610,29 +4677,71 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withoutVolatileVariable">
+        <div class="location">at line 1233</div>
+        <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+    <strong>withoutVolatileVariable</strong>(string $name)
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>Retrieves this container minus the given volatile environment variable.</p></p>
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$name</td>
+                <td></td>
+            </tr>
+            </table>
+
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1230</div>
+        <div class="location">at line 1245</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Unset the container's working directory.</p></p>                <p><p>Should default to &quot;/&quot;.</p></p>        
+                            <p><p>Unset the container's working directory.</p></p>                <p><p>Should default to &quot;/&quot;.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4642,29 +4751,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1239</div>
+        <div class="location">at line 1254</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Retrieves the working directory for all commands.</p></p>                        
+                            <p><p>Retrieves the working directory for all commands.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -4674,16 +4783,16 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
             </div>
 
-    
+
 </div><div id="footer">
         Generated by <a href="https://github.com/code-lts/doctum">Doctum, a API Documentation generator and fork of Sami</a>.</div></div>
     </div>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -504,9 +504,9 @@
 <abbr title="Dagger\Container">Container</abbr>::entrypoint</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Return the container's OCI entrypoint.</p></dd><dt><a href="Dagger/Container.html#method_envVariable">
 <abbr title="Dagger\Container">Container</abbr>::envVariable</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves the value of the specified environment variable.</p></dd><dt><a href="Dagger/Container.html#method_envVariables">
+                    <dd><p>Retrieves the value of the specified persistent environment variable.</p></dd><dt><a href="Dagger/Container.html#method_envVariables">
 <abbr title="Dagger\Container">Container</abbr>::envVariables</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves the list of environment variables passed to commands.</p></dd><dt><a href="Dagger/Container.html#method_exists">
+                    <dd><p>Retrieves the list of persistent environment variables configured on the container.</p></dd><dt><a href="Dagger/Container.html#method_exists">
 <abbr title="Dagger\Container">Container</abbr>::exists</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>check if a file or directory exists</p></dd><dt><a href="Dagger/Container.html#method_exitCode">
 <abbr title="Dagger\Container">Container</abbr>::exitCode</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
@@ -1594,7 +1594,9 @@
 <abbr title="Dagger\Container">Container</abbr>::withUnixSocket</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Retrieves this container plus a socket forwarded to the given Unix socket path.</p></dd><dt><a href="Dagger/Container.html#method_withUser">
 <abbr title="Dagger\Container">Container</abbr>::withUser</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves this container with a different command user.</p></dd><dt><a href="Dagger/Container.html#method_withWorkdir">
+                    <dd><p>Retrieves this container with a different command user.</p></dd><dt><a href="Dagger/Container.html#method_withVolatileVariable">
+<abbr title="Dagger\Container">Container</abbr>::withVolatileVariable</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
+                    <dd><p>Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.</p></dd><dt><a href="Dagger/Container.html#method_withWorkdir">
 <abbr title="Dagger\Container">Container</abbr>::withWorkdir</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Change the container's working directory. Like WORKDIR in Dockerfile.</p></dd><dt><a href="Dagger/Container.html#method_withoutAnnotation">
 <abbr title="Dagger\Container">Container</abbr>::withoutAnnotation</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
@@ -1626,7 +1628,9 @@
 <abbr title="Dagger\Container">Container</abbr>::withoutUnixSocket</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Retrieves this container with a previously added Unix socket removed.</p></dd><dt><a href="Dagger/Container.html#method_withoutUser">
 <abbr title="Dagger\Container">Container</abbr>::withoutUser</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
-                    <dd><p>Retrieves this container with an unset command user.</p></dd><dt><a href="Dagger/Container.html#method_withoutWorkdir">
+                    <dd><p>Retrieves this container with an unset command user.</p></dd><dt><a href="Dagger/Container.html#method_withoutVolatileVariable">
+<abbr title="Dagger\Container">Container</abbr>::withoutVolatileVariable</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
+                    <dd><p>Retrieves this container minus the given volatile environment variable.</p></dd><dt><a href="Dagger/Container.html#method_withoutWorkdir">
 <abbr title="Dagger\Container">Container</abbr>::withoutWorkdir</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Unset the container's working directory.</p></dd><dt><a href="Dagger/Container.html#method_workdir">
 <abbr title="Dagger\Container">Container</abbr>::workdir</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2883,13 +2883,13 @@
 			"t": "M",
 			"n": "Dagger\\Container::envVariable",
 			"p": "Dagger/Container.html#method_envVariable",
-			"d": "<p>Retrieves the value of the specified environment variable.</p>"
+			"d": "<p>Retrieves the value of the specified persistent environment variable.</p>"
 		},
 		{
 			"t": "M",
 			"n": "Dagger\\Container::envVariables",
 			"p": "Dagger/Container.html#method_envVariables",
-			"d": "<p>Retrieves the list of environment variables passed to commands.</p>"
+			"d": "<p>Retrieves the list of persistent environment variables configured on the container.</p>"
 		},
 		{
 			"t": "M",
@@ -3205,6 +3205,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Container::withVolatileVariable",
+			"p": "Dagger/Container.html#method_withVolatileVariable",
+			"d": "<p>Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Container::withWorkdir",
 			"p": "Dagger/Container.html#method_withWorkdir",
 			"d": "<p>Change the container's working directory. Like WORKDIR in Dockerfile.</p>"
@@ -3298,6 +3304,12 @@
 			"n": "Dagger\\Container::withoutUser",
 			"p": "Dagger/Container.html#method_withoutUser",
 			"d": "<p>Retrieves this container with an unset command user.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Container::withoutVolatileVariable",
+			"p": "Dagger/Container.html#method_withoutVolatileVariable",
+			"d": "<p>Retrieves this container minus the given volatile environment variable.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1895,7 +1895,7 @@ func (r *Container) Entrypoint(ctx context.Context) ([]string, error) {
 	return response, q.Execute(ctx)
 }
 
-// Retrieves the value of the specified environment variable.
+// Retrieves the value of the specified persistent environment variable.
 func (r *Container) EnvVariable(ctx context.Context, name string) (string, error) {
 	if r.envVariable != nil {
 		return *r.envVariable, nil
@@ -1909,7 +1909,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 	return response, q.Execute(ctx)
 }
 
-// Retrieves the list of environment variables passed to commands.
+// Retrieves the list of persistent environment variables configured on the container.
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 	q := r.query.Select("envVariables")
 
@@ -3367,6 +3367,19 @@ func (r *Container) WithUser(name string) *Container {
 	}
 }
 
+// Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
+//
+// This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.
+func (r *Container) WithVolatileVariable(name string, value string) *Container {
+	q := r.query.Select("withVolatileVariable")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &Container{
+		query: q,
+	}
+}
+
 // ContainerWithWorkdirOpts contains options for Container.WithWorkdir
 type ContainerWithWorkdirOpts struct {
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -3617,6 +3630,16 @@ func (r *Container) WithoutUnixSocket(path string, opts ...ContainerWithoutUnixS
 // Should default to root.
 func (r *Container) WithoutUser() *Container {
 	q := r.query.Select("withoutUser")
+
+	return &Container{
+		query: q,
+	}
+}
+
+// Retrieves this container minus the given volatile environment variable.
+func (r *Container) WithoutVolatileVariable(name string) *Container {
+	q := r.query.Select("withoutVolatileVariable")
+	q = q.Arg("name", name)
 
 	return &Container{
 		query: q,

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -123,7 +123,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Retrieves the value of the specified environment variable.
+     * Retrieves the value of the specified persistent environment variable.
      */
     public function envVariable(string $name): string
     {
@@ -133,7 +133,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Retrieves the list of environment variables passed to commands.
+     * Retrieves the list of persistent environment variables configured on the container.
      */
     public function envVariables(): array
     {
@@ -1041,6 +1041,19 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
+     *
+     * This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.
+     */
+    public function withVolatileVariable(string $name, string $value): Container
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withVolatileVariable');
+        $innerQueryBuilder->setArgument('name', $name);
+        $innerQueryBuilder->setArgument('value', $value);
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Change the container's working directory. Like WORKDIR in Dockerfile.
      */
     public function withWorkdir(string $path, ?bool $expand = false): Container
@@ -1219,6 +1232,16 @@ class Container extends Client\AbstractObject implements Client\IdAble
     public function withoutUser(): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutUser');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Retrieves this container minus the given volatile environment variable.
+     */
+    public function withoutVolatileVariable(string $name): Container
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutVolatileVariable');
+        $innerQueryBuilder->setArgument('name', $name);
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1897,7 +1897,7 @@ class Container(Type):
         return await _ctx.execute(list[str])
 
     async def env_variable(self, name: str) -> str | None:
-        """Retrieves the value of the specified environment variable.
+        """Retrieves the value of the specified persistent environment variable.
 
         Parameters
         ----------
@@ -1925,7 +1925,9 @@ class Container(Type):
         return await _ctx.execute(str | None)
 
     async def env_variables(self) -> list["EnvVariable"]:
-        """Retrieves the list of environment variables passed to commands."""
+        """Retrieves the list of persistent environment variables configured on
+        the container.
+        """
         _args: list[Arg] = []
         _ctx = self._select("envVariables", _args)
         return await _ctx.execute_object_list(EnvVariable)
@@ -3500,6 +3502,27 @@ class Container(Type):
         _ctx = self._select("withUser", _args)
         return Container(_ctx)
 
+    def with_volatile_variable(self, name: str, value: str) -> Self:
+        """Set a new non-secret environment variable for future execs without
+        invalidating exec cache when only its value changes.
+
+        This is an expert-only escape hatch. If a volatile value affects
+        observable exec results, stale cached results may be reused.
+
+        Parameters
+        ----------
+        name:
+            Name of the volatile variable (e.g., "CI_RUN_ID").
+        value:
+            Value of the volatile variable.
+        """
+        _args = [
+            Arg("name", name),
+            Arg("value", value),
+        ]
+        _ctx = self._select("withVolatileVariable", _args)
+        return Container(_ctx)
+
     def with_workdir(
         self,
         path: str,
@@ -3783,6 +3806,21 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("withoutUser", _args)
+        return Container(_ctx)
+
+    def without_volatile_variable(self, name: str) -> Self:
+        """Retrieves this container minus the given volatile environment
+        variable.
+
+        Parameters
+        ----------
+        name:
+            The name of the volatile environment variable (e.g., "CI_RUN_ID").
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withoutVolatileVariable", _args)
         return Container(_ctx)
 
     def without_workdir(self) -> Self:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3772,7 +3772,7 @@ impl Container {
         let query = self.selection.select("entrypoint");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Retrieves the value of the specified environment variable.
+    /// Retrieves the value of the specified persistent environment variable.
     ///
     /// # Arguments
     ///
@@ -3782,7 +3782,7 @@ impl Container {
         query = query.arg("name", name.into());
         query.execute(self.graphql_client.clone()).await
     }
-    /// Retrieves the list of environment variables passed to commands.
+    /// Retrieves the list of persistent environment variables configured on the container.
     pub async fn env_variables(&self) -> Result<Vec<EnvVariable>, DaggerError> {
         let query = self.selection.select("envVariables");
         let query = query.select("id");
@@ -5456,6 +5456,27 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
+    /// This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the volatile variable (e.g., "CI_RUN_ID").
+    /// * `value` - Value of the volatile variable.
+    pub fn with_volatile_variable(
+        &self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Container {
+        let mut query = self.selection.select("withVolatileVariable");
+        query = query.arg("name", name.into());
+        query = query.arg("value", value.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Change the container's working directory. Like WORKDIR in Dockerfile.
     ///
     /// # Arguments
@@ -5844,6 +5865,20 @@ impl Container {
     /// Should default to root.
     pub fn without_user(&self) -> Container {
         let query = self.selection.select("withoutUser");
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Retrieves this container minus the given volatile environment variable.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the volatile environment variable (e.g., "CI_RUN_ID").
+    pub fn without_volatile_variable(&self, name: impl Into<String>) -> Container {
+        let mut query = self.selection.select("withoutVolatileVariable");
+        query = query.arg("name", name.into());
         Container {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -4211,7 +4211,7 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Retrieves the value of the specified environment variable.
+   * Retrieves the value of the specified persistent environment variable.
    * @param name The name of the environment variable to retrieve (e.g., "PATH").
    */
   envVariable = async (name: string): Promise<string> => {
@@ -4227,7 +4227,7 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Retrieves the list of environment variables passed to commands.
+   * Retrieves the list of persistent environment variables configured on the container.
    */
   envVariables = async (): Promise<EnvVariable[]> => {
     type envVariables = {
@@ -5152,6 +5152,18 @@ export class Container extends BaseClient {
   }
 
   /**
+   * Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
+   *
+   * This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.
+   * @param name Name of the volatile variable (e.g., "CI_RUN_ID").
+   * @param value Value of the volatile variable.
+   */
+  withVolatileVariable = (name: string, value: string): Container => {
+    const ctx = this._ctx.select("withVolatileVariable", { name, value })
+    return new Container(ctx)
+  }
+
+  /**
    * Change the container's working directory. Like WORKDIR in Dockerfile.
    * @param path The path to set as the working directory (e.g., "/app").
    * @param opts.expand Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -5323,6 +5335,15 @@ export class Container extends BaseClient {
    */
   withoutUser = (): Container => {
     const ctx = this._ctx.select("withoutUser")
+    return new Container(ctx)
+  }
+
+  /**
+   * Retrieves this container minus the given volatile environment variable.
+   * @param name The name of the volatile environment variable (e.g., "CI_RUN_ID").
+   */
+  withoutVolatileVariable = (name: string): Container => {
+    const ctx = this._ctx.select("withoutVolatileVariable", { name })
     return new Container(ctx)
   }
 

--- a/version/main.go
+++ b/version/main.go
@@ -225,7 +225,8 @@ func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, err
 		From("alpine/git:latest").
 		WithWorkdir("/src").
 		WithMountedDirectory(".git", v.GitDir).
-		WithExec([]string{"git", "config", "url.https://github.com/.insteadOf", "git@github.com:"}).
+		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "git@github.com:"}).
+		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "ssh://git@github.com/"}).
 		WithExec([]string{"git", "fetch", "--tags"}).
 		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
 		Stdout(ctx)


### PR DESCRIPTION
**tl;dr** — New `Container.withVolatileVariable` lets you pass non-secret env vars (commit SHA, branch ref, CI run ID) into execs without invalidating cache and without the log redaction you get from the `withSecretVariable` workaround.

Fixes #12902

Today the only way to pass changing metadata into execs without busting cache is `withSecretVariable` with a fixed `cacheKey` — but these values aren't secrets, so you get unwanted redaction. `withVolatileVariable` fixes this: it sets a non-secret env var visible to `withExec` but excluded from cache identity. If an exec reruns for another reason, it sees the latest volatile values.

Volatile variables are not persisted into OCI image config, not returned by `envVariable`/`envVariables`, and not available to `expand: true`. This is an expert-only escape hatch — if the value actually affects the exec result, Dagger will silently serve stale cache.

### Example

```ts
dag.container()
  .from("mcr.microsoft.com/playwright:v1.52.0-noble")
  .withVolatileVariable("CURRENTS_COMMIT_SHA", process.env.GITHUB_SHA!)
  .withVolatileVariable("CURRENTS_GITHUB_RUN_ID", process.env.GITHUB_RUN_ID!)
  .withExec(["pnpm", "playwright", "test"])
```

### Schema

[Full diff](https://github.com/dagger/dagger/pull/12903/files#diff-c81ef0da97f498e05ddd33b6e5e809018e498e2c3c1e03d0d2db6e7e9e25e060)

```graphql
extend type Container {
  """
  Set a non-secret env var for future execs without invalidating exec cache
  when only its value changes. Expert-only: if the value affects exec results,
  stale cache may be reused.
  """
  withVolatileVariable(
    """Name of the volatile variable (e.g., "CI_RUN_ID")."""
    name: String!
    """Value of the volatile variable."""
    value: String!
  ): Container!

  """Remove a volatile environment variable from future execs."""
  withoutVolatileVariable(
    """The name of the volatile variable (e.g., "CI_RUN_ID")."""
    name: String!
  ): Container!
}
```

### Internals

The dagql cache layer gains support for "dynamic inputs" — call arguments whose raw values are rewritten out of cache identity but whose session-bound handles are still propagated and validated on cache hits.