### PR TITLE
fix(helm): fix envFrom secretRef indentation in engine statefulset

### DIFF
--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -96,11 +96,11 @@ spec:
           {{- if .Values.magicache.enabled }}
           envFrom:
             - secretRef:
-              {{- if .Values.magicache.secretName }}
-              name: {{ .Values.magicache.secretName }}
-              {{- else }}
-              name: {{ include "dagger.fullname" . }}-magicache-token
-              {{- end }}
+                {{- if .Values.magicache.secretName }}
+                name: {{ .Values.magicache.secretName }}
+                {{- else }}
+                name: {{ include "dagger.fullname" . }}-magicache-token
+                {{- end }}
           {{- end }}
           {{- if or .Values.engine.containerPorts .Values.engine.port }}
           ports:


### PR DESCRIPTION
## Summary

Fix YAML indentation of `name` under `secretRef` in the engine StatefulSet template.

## Problem

When `magicache.enabled: true`, the rendered `envFrom` block was invalid:
```yaml
envFrom:
  - secretRef:      # empty object
    name: foo       # sibling instead of child
```

Kubernetes rejected the pod with:
> spec.containers[0].envFrom: Invalid value: "": must specify one of: `configMapRef` or `secretRef`

## Fix

Indent `name` two additional spaces so it is correctly nested under `secretRef`.

## Testing

Deployed with `magicache.enabled: true` on a local Kubernetes cluster — pod now starts successfully and PVC binds correctly.