### PR TITLE
test: bump testctx for better attributes + errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/creack/pty v1.1.24
 	github.com/dagger/otel-go v1.41.1-0.20260303185236-072f65948887
-	github.com/dagger/testctx v0.1.1
-	github.com/dagger/testctx/oteltest v0.1.1
+	github.com/dagger/testctx v0.1.2
+	github.com/dagger/testctx/oteltest v0.1.2
 	github.com/dave/jennifer v1.7.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/distribution/reference v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -252,10 +252,10 @@ github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT
 github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dagger/otel-go v1.41.1-0.20260303185236-072f65948887 h1:M+yTYQkNo0ZC0A6+CS9vEXtYDhsr4xmSu5RfQaMVEfE=
 github.com/dagger/otel-go v1.41.1-0.20260303185236-072f65948887/go.mod h1:RP74B3xmOq2MWL1lBsAWD9uvTryDhZ+m1dDzJj9QJEI=
-github.com/dagger/testctx v0.1.1 h1:nK5ajGSjeL2g+IKy4lpGsOPTvwXGozhqaZhsKgZWCvA=
-github.com/dagger/testctx v0.1.1/go.mod h1:2T9w5oiFscVVzgQo7YW2q1WxVkLFumHWjwlGQqVT/Sk=
-github.com/dagger/testctx/oteltest v0.1.1 h1:b+fnfnhi4HsJM0kszVhzm5bqCr0F0WcQRCKSnAyoLZ4=
-github.com/dagger/testctx/oteltest v0.1.1/go.mod h1:qiLr630+2ezKak27f2Px4nAxgFyuP/TPzpx+StF4ziA=
+github.com/dagger/testctx v0.1.2 h1:p9/92CttP6N3AhTWnAOrGfFGGNSqD5uDgY32+LISFoE=
+github.com/dagger/testctx v0.1.2/go.mod h1:2T9w5oiFscVVzgQo7YW2q1WxVkLFumHWjwlGQqVT/Sk=
+github.com/dagger/testctx/oteltest v0.1.2 h1:uw84VFKcHY9AVjx/ETWT0hw6+fds1001ozkGLQBTi54=
+github.com/dagger/testctx/oteltest v0.1.2/go.mod h1:v7p9Fe87Kw0nirDk8wES2YgOG66em0jeKxrXlckftMs=
 github.com/danielgatis/go-ansicode v1.0.7 h1:ozOFtNlQHgI3lMJFbT0CxqbbToqtT7mu8GXOwq10Xn0=
 github.com/danielgatis/go-ansicode v1.0.7/go.mod h1:xft3lPCsvHAC9KEGRcEzX+Jm8bTyUbya4rk7zD/nWvk=
 github.com/danielgatis/go-iterator v0.0.1 h1:pTptWDVAKzR0EUdtfmFMP3v+hSetqB091V9um1DTO8I=

--- a/internal/testutil/middleware.go
+++ b/internal/testutil/middleware.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -11,20 +10,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const testctxTypeAttr = "dagger.io/testctx.type"
-const testctxNameAttr = "dagger.io/testctx.name"
-const testctxPrewarmAttr = "dagger.io/testctx.prewarm"
+const benchPrewarmAttr = "dagger.io/bench.prewarm"
 
 func isPrewarm() bool {
-	_, ok := os.LookupEnv("TESTCTX_PREWARM")
+	_, ok := os.LookupEnv("DAGGER_BENCH_PREWARM")
 	return ok
 }
 
 func SpanOpts[T testctx.Runner[T]](w *testctx.W[T]) []trace.SpanStartOption {
-	var t T
 	attrs := []attribute.KeyValue{
-		attribute.String(testctxNameAttr, w.Name()),
-		attribute.String(testctxTypeAttr, fmt.Sprintf("%T", t)),
 		// Prevent revealed/rolled-up stuff bubbling up through test spans.
 		attribute.Bool(telemetry.UIBoundaryAttr, true),
 	}
@@ -34,7 +28,7 @@ func SpanOpts[T testctx.Runner[T]](w *testctx.W[T]) []trace.SpanStartOption {
 		attrs = append(attrs, attribute.Bool(telemetry.UIRevealAttr, true))
 	}
 	if isPrewarm() {
-		attrs = append(attrs, attribute.Bool(testctxPrewarmAttr, true))
+		attrs = append(attrs, attribute.Bool(benchPrewarmAttr, true))
 	}
 	return []trace.SpanStartOption{
 		trace.WithAttributes(attrs...),

--- a/toolchains/engine-dev/bench.go
+++ b/toolchains/engine-dev/bench.go
@@ -233,7 +233,7 @@ func (dev *EngineDev) bench(
 	}
 
 	if opts.prewarm {
-		_, err = run(ctr.WithEnvVariable("TESTCTX_PREWARM", "true")).Sync(ctx)
+		_, err = run(ctr.WithEnvVariable("DAGGER_BENCH_PREWARM", "true")).Sync(ctx)
 		if err != nil {
 			return fmt.Errorf("failed during prewarm run: %w", err)
 		}


### PR DESCRIPTION
* use standard semconv attributes for test name etc
* put useful error messages on failed test spans
* remove outdated, unused attributes
* rename weirdly named bench prewarm attribute

Net UI effect _for now_ is that you can 'go to error' to jump all the way into a bubbled-up `require.NoError` assertion failure. Later, Cloud will also detect and display tests discovered within the trace.