### PR TITLE
wip: prototype moduleTypes persistence

### DIFF
--- a/core/integration/module_go_test.go
+++ b/core/integration/module_go_test.go
@@ -18,6 +18,87 @@ func TestGo(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(GoSuite{})
 }
 
+func (GoSuite) TestModuleTypesUsesCodegenOverlay(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
+
+	t.Run("fresh edits are visible immediately", func(ctx context.Context, t *testctx.T) {
+		first := base.WithNewFile("main.go", `package main
+
+type Test struct{}
+
+// doc for alpha
+func (m *Test) Alpha() string {
+	return "alpha"
+}
+`)
+
+		out, err := first.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "alpha")
+		require.Contains(t, out, "doc for alpha")
+
+		second := first.WithNewFile("main.go", `package main
+
+type Test struct{}
+
+// doc for beta
+func (m *Test) Beta() string {
+	return "beta"
+}
+`)
+
+		out, err = second.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "beta")
+		require.Contains(t, out, "doc for beta")
+		require.NotContains(t, out, "alpha")
+	})
+
+	t.Run("body-only compile errors do not break typedef loading", func(ctx context.Context, t *testctx.T) {
+		mod := base.WithNewFile("main.go", `package main
+
+type Test struct{}
+
+// doc for hello
+func (m *Test) Hello() string {
+	return doesNotExist
+}
+`)
+
+		out, err := mod.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello")
+		require.Contains(t, out, "doc for hello")
+	})
+
+	t.Run("user init does not run during typedef loading", func(ctx context.Context, t *testctx.T) {
+		mod := base.WithNewFile("main.go", `package main
+
+func init() {
+	panic("init should not run during dagger functions")
+}
+
+// doc for hello
+type Test struct{}
+
+// doc for hello
+func (m *Test) Hello() string {
+	return "hello"
+}
+`)
+
+		out, err := mod.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello")
+		require.Contains(t, out, "doc for hello")
+	})
+}
+
 func (GoSuite) TestInit(ctx context.Context, t *testctx.T) {
 	t.Run("from scratch", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -236,18 +236,12 @@ func (sdk *goSDK) ModuleTypes(
 		return inst, fmt.Errorf("failed to get dag for go module sdk codegen: %w", err)
 	}
 
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFileForModule(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get schema introspection json during module client generation: %w", err)
-	}
-
 	var ctr dagql.ObjectResult[*core.Container]
 
 	modName := src.Self().ModuleOriginalName
-	contextDir := src.Self().ContextDirectory
 	srcSubpath := src.Self().SourceSubpath
 
-	ctr, err = sdk.base(ctx)
+	ctr, err = sdk.baseWithCodegen(ctx, deps, src)
 	if err != nil {
 		return inst, err
 	}
@@ -265,50 +259,6 @@ func (sdk *goSDK) ModuleTypes(
 
 	var modDefsID string
 	err = dag.Select(ctx, ctr, &modDefsID,
-		dagql.Selector{
-			Field: "withMountedFile",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "path",
-					Value: dagql.NewString(goSDKIntrospectionJSONPath),
-				},
-				{
-					Name:  "source",
-					Value: dagql.NewID[*core.File](schemaJSONFile.ID()),
-				},
-			},
-		},
-		dagql.Selector{
-			Field: "withMountedDirectory",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "path",
-					Value: dagql.NewString(goSDKUserModContextDirPath),
-				},
-				{
-					Name:  "source",
-					Value: dagql.NewID[*core.Directory](contextDir.ID()),
-				},
-			},
-		},
-		dagql.Selector{
-			Field: "withoutFile",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "path",
-					Value: dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath, "dagger.gen.go")),
-				},
-			},
-		},
-		dagql.Selector{
-			Field: "withoutDirectory",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "path",
-					Value: dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath, "internal")),
-				},
-			},
-		},
 		dagql.Selector{
 			Field: "withWorkdir",
 			Args: []dagql.NamedInput{

--- a/hack/designs/codegen-moduletypes.md
+++ b/hack/designs/codegen-moduletypes.md
@@ -1,0 +1,402 @@
+# Persist `moduleTypes` as Saved `Module` State
+
+*Builds on [Stable Save/Load State for Dagger Objects](./save-load-object-state.md)*
+
+## Status: Draft (`codegen-moduletypes`)
+
+## Summary
+
+This design stops treating `moduleTypes` as a live SDK codegen problem.
+
+Instead:
+
+1. the engine saves the initialized `Module` typedef state to a checked-in JSON
+   artifact during `generatedContextDirectory`
+2. module loading reuses that artifact on the next load
+3. the SDK `moduleTypes` hook remains as a fallback for bootstrap and stale or
+   missing artifacts
+
+New artifact:
+
+```text
+<module-source-subpath>/dagger.moduletypes.json
+```
+
+That file contains:
+
+- a version number
+- the content-scoped module source digest it was generated from
+- the stable saved `Module` state payload from
+  [`__saveModuleState`](./save-load-object-state.md)
+
+With that file present and current, `dagger functions` no longer needs to run
+SDK typedef codegen at runtime.
+
+## Problem
+
+Today the engine has no portable representation of `moduleTypes`.
+
+The current path is:
+
+```text
+module load
+  -> SDK moduleTypes()
+  -> SDK-specific live introspection / codegen
+  -> JSON ModuleID
+  -> loadModuleFromID
+```
+
+For Go, that live typedef generation still happens in
+[`(*goSDK).ModuleTypes`](../../core/sdk/go_sdk.go), which runs
+`codegen generate-typedefs` inside the SDK container.
+
+That means:
+
+- `dagger generate` does not persist the typedef result
+- `dagger functions` still depends on live SDK work
+- the engine cannot trust a checked-in artifact
+
+The missing piece is not “another generated Go entrypoint”.
+It is “a portable, engine-readable saved `Module` state”.
+
+## Proposal
+
+Persist the initialized `Module` state to a tracked JSON file and short-circuit
+future `moduleTypes` loads through that file.
+
+New shape:
+
+```text
+dagger generate / generatedContextDirectory
+  -> load module normally once
+  -> __saveModuleState(module.id)
+  -> write dagger.moduletypes.json
+
+later module load
+  -> if dagger.moduletypes.json exists and digest matches:
+       __loadModuleFromState(state)
+     else:
+       SDK moduleTypes()
+```
+
+This keeps the current SDK contract as fallback, but removes live SDK work from
+the steady-state path.
+
+## Artifact Format
+
+New file:
+
+```text
+<module-source-subpath>/dagger.moduletypes.json
+```
+
+The file format is:
+
+```go
+type moduleTypesArtifactV1 struct {
+	ArtifactVersion    int             `json:"artifactVersion"`
+	ModuleSourceDigest string          `json:"moduleSourceDigest"`
+	State              json.RawMessage `json:"state"`
+}
+```
+
+Rules:
+
+1. `ArtifactVersion` starts at `1`.
+2. `ModuleSourceDigest` is the content-scoped digest already used during module
+   load in [`initializeSDKModule`](../../core/schema/modulesource.go#L3068).
+3. `State` is the exact JSON string returned by `__saveModuleState`.
+
+Example:
+
+```json
+{
+  "artifactVersion": 1,
+  "moduleSourceDigest": "sha256:6f5b...",
+  "state": {
+    "type": "Module",
+    "version": 1,
+    "state": {
+      "description": "Test module",
+      "objects": [
+        {
+          "kind": "OBJECT_KIND",
+          "optional": false,
+          "asObject": {
+            "name": "Test",
+            "originalName": "Test"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generate-Time Write Path
+
+Write the artifact in [`runGeneratedContext`](../../core/schema/modulesource.go#L2748).
+
+That function already:
+
+1. runs SDK codegen
+2. generates clients
+3. writes `dagger.json`
+4. returns the generated context overlay
+
+Extend it with one more step when the module has both a name and SDK:
+
+1. load the module through normal `asModule`
+2. call `__saveModuleState`
+3. wrap it in `moduleTypesArtifactV1`
+4. write `dagger.moduletypes.json` into the generated context directory
+
+Exact insertion point:
+
+after `runCodegen` / client generation and before the final return from
+[`runGeneratedContext`](../../core/schema/modulesource.go#L2748).
+
+Exact operations:
+
+```go
+scopedSourceDigest := srcInst.Self().ContentScopedDigest()
+
+var mod dagql.ObjectResult[*core.Module]
+err = dag.Select(ctx, srcInst, &mod, dagql.Selector{Field: "asModule"})
+
+var stateJSON string
+err = dag.Select(ctx, dag.Root(), &stateJSON,
+	dagql.Selector{
+		Field: "__saveModuleState",
+		Args: []dagql.NamedInput{{
+			Name:  "id",
+			Value: dagql.NewID[*core.Module](mod.ID()),
+		}},
+	},
+)
+
+artifactBytes, err := json.MarshalIndent(moduleTypesArtifactV1{
+	ArtifactVersion:    1,
+	ModuleSourceDigest: scopedSourceDigest,
+	State:              json.RawMessage(stateJSON),
+}, "", "  ")
+artifactBytes = append(artifactBytes, '\n')
+
+artifactPath := filepath.Join(sourceSubpathOrRoot(srcInst.Self()), "dagger.moduletypes.json")
+```
+
+Then write the file with `withNewFile`.
+
+`sourceSubpathOrRoot` means:
+
+- `SourceSubpath` if non-empty
+- otherwise `SourceRootSubpath`
+
+The artifact belongs next to the module implementation, not next to the
+workspace root.
+
+## Load-Time Fast Path
+
+Add the fast path at the start of
+[`runModuleDefInSDK`](../../core/schema/modulesource.go#L2875), before calling
+the SDK `moduleTypes` hook.
+
+Current code:
+
+```go
+typeDefsImpl, typeDefsEnabled := src.Self().SDKImpl.AsModuleTypes()
+if typeDefsEnabled {
+	resultInst, err = typeDefsImpl.ModuleTypes(ctx, mod.Deps, srcInstContentHashed, mod.ResultID)
+	...
+}
+```
+
+Replace that with:
+
+1. try to read `dagger.moduletypes.json` from the raw source context
+2. if missing, keep the current path
+3. if present, decode and validate it
+4. if the digest matches `srcInstContentHashed.ID().Digest().String()`, load the
+   saved state through `__loadModuleFromState`
+5. only call SDK `moduleTypes` when the artifact is missing, malformed, or stale
+
+Pseudo-code:
+
+```go
+if typeDefsEnabled {
+	initialized, ok, err = s.tryLoadModuleStateArtifact(ctx, src, srcInstContentHashed)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		resultInst, err := typeDefsImpl.ModuleTypes(ctx, mod.Deps, srcInstContentHashed, mod.ResultID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize module: %w", err)
+		}
+		initialized = resultInst.Self()
+	}
+}
+```
+
+New helper in [`core/schema/modulesource.go`](../../core/schema/modulesource.go):
+
+```go
+func (s *moduleSourceSchema) tryLoadModuleStateArtifact(
+	ctx context.Context,
+	src dagql.ObjectResult[*core.ModuleSource],
+	srcInstContentHashed dagql.ObjectResult[*core.ModuleSource],
+) (_ *core.Module, ok bool, _ error)
+```
+
+Behavior:
+
+- `ok=false, err=nil` when the file does not exist
+- `ok=false, err=nil` when the digest does not match
+- `ok=false, err=nil` when `artifactVersion` is unsupported
+- `ok=false, err=nil` when `state.type != "Module"` or `state.version` is unsupported
+- `ok=false, err=nil` when the file is invalid JSON
+- `ok=true` only when a valid current artifact was loaded
+
+This keeps the fast path opportunistic and non-breaking.
+
+## Why The Digest Check Is Required
+
+Without a digest check, this would silently load stale typedefs after source
+edits.
+
+That would be worse than the current behavior.
+
+The engine already computes the right digest in
+[`initializeSDKModule`](../../core/schema/modulesource.go#L3068):
+
+```go
+scopedSourceDigest := src.Self().ContentScopedDigest()
+srcInstContentHashed := src.WithObjectDigest(digest.Digest(scopedSourceDigest))
+```
+
+That is the digest the artifact must store and validate against.
+
+## SDK Impact
+
+None for the steady-state design.
+
+The SDK contract stays exactly the same:
+
+```graphql
+moduleTypes(
+  modSource: ModuleSource!
+  introspectionJSON: File!
+  outputFilePath: String!
+): Container!
+```
+
+Current implementation:
+
+- [`core/sdk/module_typedefs.go`](../../core/sdk/module_typedefs.go)
+
+The engine simply stops calling it when a current saved artifact exists.
+
+That means:
+
+- no new SDK codegen target
+- no new SDK entrypoint
+- no new SDK helper binary
+
+The existing hook is still required:
+
+- for bootstrap, before the artifact exists
+- when the artifact is stale
+- for SDKs that do not use `generatedContextDirectory`
+
+## Why This Is Better Than the `baseWithCodegen` Prototype
+
+The smaller `baseWithCodegen` change is still a valid stopgap.
+
+But this design is better because it changes the steady-state cost model:
+
+```text
+old steady state:
+  dagger functions -> SDK live typedef codegen
+
+new steady state:
+  dagger functions -> read dagger.moduletypes.json
+```
+
+So this actually moves typedef generation out of runtime.
+
+## Exact Files To Edit
+
+### New
+
+- [`hack/designs/save-load-object-state.md`](./save-load-object-state.md)
+
+### Engine
+
+- [`dagql/stable_state.go`](../../dagql/stable_state.go)
+- [`dagql/server.go`](../../dagql/server.go)
+- [`core/module_state.go`](../../core/module_state.go)
+- [`core/schema/module.go`](../../core/schema/module.go)
+- [`core/schema/modulesource.go`](../../core/schema/modulesource.go)
+
+### No SDK Changes Required
+
+- [`core/sdk/go_sdk.go`](../../core/sdk/go_sdk.go) stays unchanged in the final
+  design
+- [`core/sdk/module_typedefs.go`](../../core/sdk/module_typedefs.go) stays
+  unchanged because the fast path happens before it is called
+
+## Tests
+
+Add tests in three groups.
+
+### 1. Artifact write path
+
+New integration test in [`core/integration/module_go_test.go`](../../core/integration/module_go_test.go):
+
+- `generatedContextDirectory` writes `dagger.moduletypes.json`
+- the file contains `artifactVersion == 1`
+- the file contains the current content-scoped source digest
+- the file contains a `Module` state payload
+
+### 2. Fast-path load
+
+New integration tests in [`core/integration/module_go_test.go`](../../core/integration/module_go_test.go):
+
+- when `dagger.moduletypes.json` is current, `dagger functions` does not call
+  the Go SDK live typedef path
+- when the file is missing, fallback works
+- when the digest is stale, fallback works
+- when the file is malformed JSON, fallback works
+
+The fallback assertion should be implemented by mutating the artifact or by
+removing it from the context and observing that the module still loads.
+
+### 3. Behavioral parity
+
+Round-trip parity test:
+
+1. load a module through current SDK `moduleTypes`
+2. save its state to JSON
+3. load it back through `__loadModuleFromState`
+4. compare:
+   - `Description`
+   - object names
+   - function names
+   - argument defaults
+   - enum values
+   - `+check`
+   - `+generate`
+   - source maps
+
+Compare semantic fields, not raw `ModuleID` values.
+
+## Rollout
+
+1. land the generic internal state primitive with `Module` support
+2. land artifact write support in `runGeneratedContext`
+3. land fast-path artifact load in `runModuleDefInSDK`
+4. keep SDK `moduleTypes` fallback indefinitely
+
+After that lands, the previous `baseWithCodegen` patch is no longer the target
+design. It remains a useful experiment and fallback idea, but it is not the
+preferred steady-state architecture.

--- a/hack/designs/save-load-object-state.md
+++ b/hack/designs/save-load-object-state.md
@@ -1,0 +1,564 @@
+# Stable Save/Load State for Dagger Objects
+
+## Status: Draft (`codegen-moduletypes`)
+
+## Summary
+
+Dagger already has one generic object reload primitive:
+
+```graphql
+type Query {
+  loadModuleFromID(id: ModuleID!): Module!
+}
+```
+
+That primitive reloads a live engine object from an engine ID.
+
+It does **not** produce a portable artifact. IDs are runtime objects. They are
+not suitable for source control.
+
+This proposal adds a second engine-owned primitive:
+
+```graphql
+type Query {
+  __saveModuleState(id: ModuleID!): String!
+  __loadModuleFromState(state: String!): Module!
+}
+```
+
+The returned string is a versioned JSON payload containing the stable public
+state of the object. In v1, the only supported type is `Module`.
+
+This is enough to solve the `moduleTypes` persistence problem without adding a
+new SDK-specific codegen target.
+
+## Problem
+
+Today the engine has two relevant capabilities:
+
+1. It can load objects from IDs.
+2. It can rebuild modules from semantic typedef state.
+
+The first capability is already exposed by DAGQL automatically. Every object
+type with IDs gets:
+
+```graphql
+loadFooFromID(id: FooID!): Foo!
+```
+
+This is installed in [`dagql/server.go`](../../dagql/server.go):
+
+```go
+spec := FieldSpec{
+	Name: fmt.Sprintf("load%sFromID", class.TypeName()),
+	...
+}
+```
+
+The second capability exists, but only in narrow engine code paths. For
+example, module loading already rebuilds a module from semantic typedef data in
+[`core/schema/modulesource.go`](../../core/schema/modulesource.go):
+
+```go
+mod.Description = initialized.Description
+for _, obj := range initialized.ObjectDefs {
+	mod, err = mod.WithObject(ctx, obj)
+}
+for _, iface := range initialized.InterfaceDefs {
+	mod, err = mod.WithInterface(ctx, iface)
+}
+for _, enum := range initialized.EnumDefs {
+	mod, err = mod.WithEnum(ctx, enum)
+}
+err = mod.Patch()
+```
+
+What is missing is a portable, versioned, engine-owned serialization boundary
+for that semantic state.
+
+Without that boundary:
+
+- `moduleTypes` can only return a live `ModuleID`
+- the result cannot be checked into git
+- each SDK must keep its own live introspection/codegen path
+- `dagger functions` cannot reuse a checked-in artifact
+
+## Non-Goals
+
+This proposal does **not** do the following in v1:
+
+- expose a public user-facing save/load API for every Dagger object
+- infer stable state from raw Go struct fields
+- make all current object behavior available on state-loaded objects
+- add automatic save/load support for every module-defined object
+
+The v1 goal is smaller:
+
+```text
+add one internal engine primitive for stable object state
+register it for Module
+use it to persist module typedef state
+```
+
+## Why V1 Is `Module`-Only
+
+The `Module` use case is the one we need immediately, and it has a clean,
+engine-defined semantic state boundary:
+
+- `Description`
+- `ObjectDefs`
+- `InterfaceDefs`
+- `EnumDefs`
+
+It also already has a consumer that uses exactly those fields:
+[`runModuleDefInSDK`](../../core/schema/modulesource.go#L2875).
+
+By contrast, most Dagger objects today are runtime handles. Existing SDK JSON
+marshaling for objects like `Container`, `Directory`, `File`, `Secret`, and
+`Service` serializes their IDs, not their public state:
+
+- [`Container.MarshalJSON`](../../sdk/go/dagger.gen.go#L2051)
+- [`Directory.MarshalJSON`](../../sdk/go/dagger.gen.go#L4047)
+- [`File.MarshalJSON`](../../sdk/go/dagger.gen.go#L6955)
+- [`Secret.MarshalJSON`](../../sdk/go/dagger.gen.go#L13241)
+- [`Service.MarshalJSON`](../../sdk/go/dagger.gen.go#L13395)
+
+Even `Module` itself is not safe to dump directly with `encoding/json`.
+[`core.Module`](../../core/module.go) mixes:
+
+- semantic state we want
+- runtime/source/dependency fields we do not want
+
+So the state boundary must be explicit and engine-owned.
+
+## API
+
+### Internal GraphQL Fields
+
+V1 adds two hidden top-level fields:
+
+```graphql
+type Query {
+  __saveModuleState(id: ModuleID!): String!
+  __loadModuleFromState(state: String!): Module!
+}
+```
+
+Why hidden:
+
+- the loaded `Module` is a typedef carrier, not a fully live module runtime
+- this primitive is needed immediately by engine internals
+- we should not freeze a public surface for all object types before we prove the
+  state model on `Module`
+
+The names mirror the existing `loadFooFromID` pattern and can be made public
+later if we broaden support.
+
+### Internal Go API
+
+Add a generic state codec registry in `dagql`.
+
+New file:
+
+- [`dagql/stable_state.go`](../../dagql/stable_state.go) (new)
+
+New types:
+
+```go
+type StableStateCodec interface {
+	Version() int
+	Save(ctx context.Context, value AnyObjectResult) (json.RawMessage, error)
+	Load(ctx context.Context, srv *Server, state json.RawMessage) (AnyObjectResult, error)
+}
+
+func (s *Server) InstallStableState(class ObjectType, codec StableStateCodec)
+```
+
+`InstallStableState` does four things:
+
+1. verifies that `class` is already installed
+2. verifies that `class` has an ID type
+3. stores the codec in a server map keyed by `class.TypeName()`
+4. installs two hidden root fields:
+   - `__save<TypeName>State`
+   - `__load<TypeName>FromState`
+
+The new `Server` field:
+
+```go
+type Server struct {
+	...
+	stableStateCodecs map[string]StableStateCodec
+}
+```
+
+Initialize it in [`dagql.NewServer`](../../dagql/server.go).
+
+## Generic Wire Format
+
+The root fields exchange UTF-8 JSON text in a `String!`.
+
+The generic envelope is:
+
+```go
+type stableStateEnvelope struct {
+	Type    string          `json:"type"`
+	Version int             `json:"version"`
+	State   json.RawMessage `json:"state"`
+}
+```
+
+Example:
+
+```json
+{
+  "type": "Module",
+  "version": 1,
+  "state": {
+    "description": "Test module",
+    "objects": [
+      {
+        "kind": "OBJECT_KIND",
+        "optional": false,
+        "asObject": {
+          "name": "Test",
+          "originalName": "Test",
+          "functions": [
+            {
+              "name": "hello",
+              "originalName": "Hello",
+              "description": "doc for hello",
+              "returnType": {
+                "kind": "STRING_KIND",
+                "optional": false
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+1. `Type` must match the target type exactly.
+2. `Version` is owned by the codec for that type.
+3. Unknown top-level keys are ignored on load.
+4. Unknown nested keys inside `State` are also ignored on load.
+5. Save always writes the latest supported version.
+
+## `InstallStableState` Behavior
+
+### `__save<Type>State`
+
+`__save<Type>State` is implemented generically.
+
+Resolver flow:
+
+1. decode the input ID
+2. call existing [`Server.Load`](../../dagql/server.go#L696)
+3. pass the resulting object to `codec.Save`
+4. wrap the payload in `stableStateEnvelope`
+5. return the JSON bytes as `string`
+
+### `__load<Type>FromState`
+
+`__load<Type>FromState` is also implemented generically.
+
+Resolver flow:
+
+1. parse the incoming JSON string into `stableStateEnvelope`
+2. verify `Type == class.TypeName()`
+3. verify `Version == codec.Version()`
+4. call `codec.Load`
+5. return the loaded object
+
+The resolver must return an error on:
+
+- invalid JSON
+- wrong `type`
+- unsupported `version`
+- codec decode failure
+
+## `Module` Codec
+
+New file:
+
+- [`core/module_state.go`](../../core/module_state.go) (new)
+
+New entry points:
+
+```go
+type moduleStableStateCodec struct{}
+
+func ModuleStableStateCodec() dagql.StableStateCodec
+func (moduleStableStateCodec) Version() int
+func (moduleStableStateCodec) Save(ctx context.Context, value dagql.AnyObjectResult) (json.RawMessage, error)
+func (moduleStableStateCodec) Load(ctx context.Context, srv *dagql.Server, state json.RawMessage) (dagql.AnyObjectResult, error)
+```
+
+Register it in [`core/schema/module.go`](../../core/schema/module.go) after the
+`Module` object type is installed:
+
+```go
+class, ok := dag.ObjectType("Module")
+if !ok {
+	panic("Module object type not installed")
+}
+dag.InstallStableState(class, core.ModuleStableStateCodec())
+```
+
+### What `Module` State Includes
+
+`Module` state v1 saves only the fields consumed by
+[`runModuleDefInSDK`](../../core/schema/modulesource.go#L2875):
+
+- `Description`
+- `ObjectDefs`
+- `InterfaceDefs`
+- `EnumDefs`
+
+It does **not** save:
+
+- `Source`
+- `NameField`
+- `OriginalName`
+- `SDKConfig`
+- `Deps`
+- `Runtime`
+- `ResultID`
+- workspace config fields
+
+Those remain owned by the surrounding module load path.
+
+### State DTOs
+
+The saved JSON must be produced from explicit DTOs, not from raw `core.Module`
+or raw `core.TypeDef` values.
+
+New DTOs in [`core/module_state.go`](../../core/module_state.go):
+
+```go
+type moduleStateV1 struct {
+	Description string           `json:"description,omitempty"`
+	Objects     []typeDefStateV1 `json:"objects,omitempty"`
+	Interfaces  []typeDefStateV1 `json:"interfaces,omitempty"`
+	Enums       []typeDefStateV1 `json:"enums,omitempty"`
+}
+```
+
+`typeDefStateV1` mirrors the semantic subset of [`core.TypeDef`](../../core/typedef.go#L525).
+It must include:
+
+- `Kind`
+- `Optional`
+- `AsList`
+- `AsObject`
+- `AsInterface`
+- `AsInput`
+- `AsScalar`
+- `AsEnum`
+
+The nested DTOs must preserve the following fields exactly.
+
+From [`core.ObjectTypeDef`](../../core/typedef.go#L845):
+
+- `Name`
+- `Description`
+- `SourceMap`
+- `Fields`
+- `Functions`
+- `Constructor`
+- `Deprecated`
+- `SourceModuleName`
+- `OriginalName`
+- `IsMainObject`
+
+From [`core.FieldTypeDef`](../../core/typedef.go#L995):
+
+- `Name`
+- `Description`
+- `TypeDef`
+- `SourceMap`
+- `Deprecated`
+- `OriginalName`
+
+From [`core.InterfaceTypeDef`](../../core/typedef.go#L1044):
+
+- `Name`
+- `Description`
+- `SourceMap`
+- `Functions`
+- `SourceModuleName`
+- `OriginalName`
+
+From [`core.Function`](../../core/typedef.go#L20):
+
+- `Name`
+- `Description`
+- `Args`
+- `ReturnType`
+- `Deprecated`
+- `SourceMap`
+- `SourceModuleName`
+- `CachePolicy`
+- `CacheTTLSeconds`
+- `IsCheck`
+- `IsGenerator`
+- `ParentOriginalName`
+- `OriginalName`
+
+From [`core.FunctionArg`](../../core/typedef.go#L332):
+
+- `Name`
+- `Description`
+- `SourceMap`
+- `TypeDef`
+- `DefaultValue`
+- `DefaultPath`
+- `DefaultAddress`
+- `Ignore`
+- `Deprecated`
+- `OriginalName`
+
+From [`core.EnumTypeDef`](../../core/typedef.go#L1226):
+
+- `Name`
+- `Description`
+- `Members`
+- `SourceMap`
+- `SourceModuleName`
+- `OriginalName`
+
+From [`core.EnumMemberTypeDef`](../../core/typedef.go#L1274):
+
+- `Name`
+- `Value`
+- `Description`
+- `SourceMap`
+- `Deprecated`
+- `OriginalName`
+
+From [`core.SourceMap`](../../core/typedef.go#L1540) when present:
+
+- `Module`
+- `Filename`
+- `Line`
+- `Column`
+- `URL`
+
+The DTOs must not use `dagql.Nullable`.
+Represent optional values in plain JSON form.
+
+### Save Algorithm
+
+`moduleStableStateCodec.Save`:
+
+1. assert that the input is a `*core.Module`
+2. copy semantic fields into DTOs
+3. marshal the DTO with `encoding/json`
+4. return the raw JSON bytes
+
+### Load Algorithm
+
+`moduleStableStateCodec.Load`:
+
+1. decode `moduleStateV1`
+2. convert DTOs back into fresh `*core.TypeDef`, `*core.Function`, and nested
+   values
+3. construct a fresh `*core.Module` with:
+
+```go
+mod := &core.Module{
+	Description:   state.Description,
+	ObjectDefs:    decodedObjects,
+	InterfaceDefs: decodedInterfaces,
+	EnumDefs:      decodedEnums,
+}
+```
+
+4. return it as a DAGQL object result
+
+The loaded object is intentionally **state-only**.
+It is only guaranteed to support consumers that read:
+
+- `Description`
+- `ObjectDefs`
+- `InterfaceDefs`
+- `EnumDefs`
+
+That is enough for the `moduleTypes` use case.
+
+## Why This Is Better Than Saving `ModuleID`
+
+Current `moduleTypes` writes a JSON-encoded `ModuleID` and the engine loads it
+through [`loadModuleFromID`](../../core/sdk/module_typedefs.go#L114).
+
+That `ModuleID` is:
+
+- runtime-specific
+- session-specific in practice
+- not suitable for source control
+
+By contrast, saved `Module` state is:
+
+- engine-owned
+- versioned
+- structurally portable
+- readable in git
+
+## Tests
+
+Add tests in three layers.
+
+### 1. DAGQL state registry
+
+New tests in [`dagql/dagql_test.go`](../../dagql/dagql_test.go):
+
+- registering a state codec installs `__saveFooState`
+- registering a state codec installs `__loadFooFromState`
+- `__saveFooState` round-trips a test object through `__loadFooFromState`
+- wrong `type` is rejected
+- wrong `version` is rejected
+- invalid JSON is rejected
+
+Use the existing `Point` test object as a small codec smoke test.
+
+### 2. Module codec
+
+New tests in [`core/integration/module_test.go`](../../core/integration/module_test.go)
+or a focused unit test file:
+
+- save/load round-trip preserves:
+  - object names and original names
+  - function names and original names
+  - arg defaults
+  - `+check`
+  - `+generate`
+  - cache policy
+  - source maps
+  - enum values
+- saved JSON does not contain runtime-only fields like `ResultID`
+
+### 3. `moduleTypes` consumer
+
+This is covered in the follow-on design, but the codec must be exercised by a
+module-loading test that uses saved state instead of SDK `moduleTypes`.
+
+## Rollout
+
+V1 rollout:
+
+1. add the generic `dagql` state codec registry
+2. register `Module`
+3. add module-state roundtrip tests
+4. consume the new primitive from the `moduleTypes` persistence path
+
+Future work, not part of this change:
+
+- add codecs for other engine-owned semantic objects
+- add structural save/load support for module-defined objects whose field graph
+  contains only saveable types
+- decide whether any of the hidden fields should become public API


### PR DESCRIPTION
## Problem

Every time you run `dagger functions`, the engine calls the SDK's `moduleTypes` hook, which runs live codegen inside a container just to figure out what functions and types your module exposes. This is slow and unnecessary — the answer only changes when your source code changes.

## Solution

Move typedef discovery out of runtime. During `dagger generate`, persist the module's type definitions as a checked-in artifact (`dagger.moduletypes.json`). At load time, read that file instead of running SDK codegen. Keep the live codegen path as a fallback for bootstrap and stale artifacts.

## Design

**This PR** is a first step + handoff draft:

1. **Simplify `ModuleTypes()`** — reuse `baseWithCodegen()` instead of duplicating ~45 lines of container setup. Same behavior, less code.
2. **Add regression tests** for three behaviors we must preserve:
   - Fresh source edits are visible immediately in `dagger functions`
   - Compile errors in function bodies don't break function listing
   - User `init()` doesn't run during typedef loading
3. **Two design docs** describe the full plan:
   - [save-load-object-state.md](https://github.com/dagger/dagger/blob/codegen-moduletypes/hack/designs/save-load-object-state.md) — a generic engine primitive for saving/loading stable object state as portable JSON
   - [codegen-moduletypes.md](https://github.com/dagger/dagger/blob/codegen-moduletypes/hack/designs/codegen-moduletypes.md) — using that primitive to persist module typedefs, so `dagger functions` becomes a file read instead of a codegen run