### PR TITLE
Built-in check for generate functions

### DIFF
--- a/.changes/unreleased/Added-20260416-173459.yaml
+++ b/.changes/unreleased/Added-20260416-173459.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |
+  Automatically expose a `check` for each `generate` function.
+
+  The `check` has the same name than the `generate` function. This allows to know if `generate` must be re-run or not.
+  A `--no-generate` flag can be passed to `dagger check` command to list/run functions marked as check, ignoring the generated ones.
+  The toolchain customisation field `ignoreChecks` let the possibility to not create a `check` for a specific `generate` function.
+time: 2026-04-16T17:34:59.743549238+02:00
+custom:
+    Author: eunomie
+    PR: "12923"

--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	checksListMode bool
-	checksFailFast bool
+	checksListMode   bool
+	checksFailFast   bool
+	checksNoGenerate bool
 )
 
 //go:embed checks.graphql
@@ -30,6 +31,7 @@ var loadChecksQuery string
 func init() {
 	checksCmd.Flags().BoolVarP(&checksListMode, "list", "l", false, "List available checks")
 	checksCmd.Flags().BoolVar(&checksFailFast, "failfast", false, "Cancel remaining checks on first failure")
+	checksCmd.Flags().BoolVar(&checksNoGenerate, "no-generate", false, "Only run annotated check functions, skip generate-as-checks")
 }
 
 var checksCmd = &cobra.Command{
@@ -56,12 +58,10 @@ Examples:
 			func(ctx context.Context, engineClient *client.Client) error {
 				dag := engineClient.Dagger()
 				ws := dag.CurrentWorkspace()
-				var checks *dagger.CheckGroup
-				if len(args) > 0 {
-					checks = ws.Checks(dagger.WorkspaceChecksOpts{Include: args})
-				} else {
-					checks = ws.Checks()
-				}
+				checks := ws.Checks(dagger.WorkspaceChecksOpts{
+					Include:    args,
+					NoGenerate: checksNoGenerate,
+				})
 				if checksListMode {
 					return listChecks(ctx, dag, checks, cmd)
 				}
@@ -121,6 +121,7 @@ func loadGroupListDetails(
 type groupListItem struct {
 	Name        string
 	Description string
+	CheckType   string
 }
 
 func loadCheckGroupInfo(ctx context.Context, dag *dagger.Client, checkgroup *dagger.CheckGroup) (*CheckGroupInfo, error) {
@@ -136,6 +137,7 @@ func loadCheckGroupInfo(ctx context.Context, dag *dagger.Client, checkgroup *dag
 		info.Checks = append(info.Checks, &CheckInfo{
 			Name:        cliName(item.Name),
 			Description: item.Description,
+			Type:        item.CheckType,
 		})
 	}
 	return info, nil
@@ -148,6 +150,7 @@ type CheckGroupInfo struct {
 type CheckInfo struct {
 	Name        string
 	Description string
+	Type        string
 }
 
 // 'dagger checks -l'
@@ -156,17 +159,39 @@ func listChecks(ctx context.Context, dag *dagger.Client, checkgroup *dagger.Chec
 	if err != nil {
 		return err
 	}
+
+	// Partition into checks and generators
+	var checks, generators []*CheckInfo
+	for _, c := range info.Checks {
+		if c.Type == "generate" {
+			generators = append(generators, c)
+		} else {
+			checks = append(checks, c)
+		}
+	}
+
 	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
 	fmt.Fprintf(tw, "%s\t%s\n",
 		termenv.String("Name").Bold(),
 		termenv.String("Description").Bold(),
 	)
-	for _, check := range info.Checks {
+	for _, check := range checks {
 		firstLine := check.Description
 		if idx := strings.Index(check.Description, "\n"); idx != -1 {
 			firstLine = check.Description[:idx]
 		}
 		fmt.Fprintf(tw, "%s\t%s\n", check.Name, firstLine)
+	}
+	if len(generators) > 0 {
+		fmt.Fprintf(tw, "\t\n")
+		fmt.Fprintf(tw, "%s\t\n", termenv.String("Generators").Bold())
+		for _, gen := range generators {
+			firstLine := gen.Description
+			if idx := strings.Index(gen.Description, "\n"); idx != -1 {
+				firstLine = gen.Description[:idx]
+			}
+			fmt.Fprintf(tw, "%s\t%s\n", gen.Name, firstLine)
+		}
 	}
 	return tw.Flush()
 }

--- a/cmd/dagger/checks.graphql
+++ b/cmd/dagger/checks.graphql
@@ -3,6 +3,7 @@ query CheckGroupListDetails($id: CheckGroupID!) {
     list {
       name
       description
+      checkType
     }
   }
 }

--- a/core/checks.go
+++ b/core/checks.go
@@ -17,6 +17,10 @@ type Check struct {
 	Passed    bool         `field:"true" doc:"Whether the check passed"`
 
 	Error dagql.Nullable[dagql.ObjectResult[*Error]] `field:"true" doc:"If the check failed, this is the error"`
+
+	// IsGenerate indicates this check was derived from a +generate function.
+	// When true, the check passes if the generator produces an empty changeset.
+	IsGenerate bool
 }
 
 type CheckGroup struct {
@@ -24,7 +28,7 @@ type CheckGroup struct {
 	Checks []*Check     `json:"checks"`
 }
 
-func NewCheckGroup(ctx context.Context, mod dagql.ObjectResult[*Module], include []string) (*CheckGroup, error) {
+func NewCheckGroup(ctx context.Context, mod dagql.ObjectResult[*Module], include []string, noGenerate bool) (*CheckGroup, error) {
 	rootNode, err := NewModTree(ctx, mod)
 	if err != nil {
 		return nil, err
@@ -39,6 +43,25 @@ func NewCheckGroup(ctx context.Context, mod dagql.ObjectResult[*Module], include
 	for _, checkNode := range checkNodes {
 		checks = append(checks, &Check{Node: checkNode})
 	}
+
+	if !noGenerate {
+		genNodes, err := rootNode.RollupGenerator(ctx, include, nil)
+		if err != nil {
+			return nil, err
+		}
+		// Build a set of existing check paths to avoid duplicates when a
+		// function is annotated with both +check and +generate.
+		checkPaths := make(map[string]struct{}, len(checks))
+		for _, c := range checks {
+			checkPaths[c.Name()] = struct{}{}
+		}
+		for _, genNode := range genNodes {
+			if _, exists := checkPaths[genNode.PathString()]; !exists {
+				checks = append(checks, &Check{Node: genNode, IsGenerate: true})
+			}
+		}
+	}
+
 	return &CheckGroup{
 		Node:   rootNode,
 		Checks: checks,
@@ -66,7 +89,12 @@ func (r *CheckGroup) Run(ctx context.Context, failFast bool) (*CheckGroup, error
 		check.Completed = false
 		check.Passed = false
 		jobs = jobs.WithJob(check.Name(), func(ctx context.Context) error {
-			err := check.Node.RunCheck(ctx, nil, nil)
+			var err error
+			if check.IsGenerate {
+				err = check.Node.RunGeneratorAsCheck(ctx, nil, nil)
+			} else {
+				err = check.Node.RunCheck(ctx, nil, nil)
+			}
 			check.Completed = true
 			if err != nil {
 				check.Passed = false
@@ -89,11 +117,12 @@ func (r *CheckGroup) Run(ctx context.Context, failFast bool) (*CheckGroup, error
 }
 
 func (r *CheckGroup) Report(ctx context.Context) (dagql.ObjectResult[*File], error) {
-	headers := []string{"check", "description", "success"}
+	headers := []string{"check", "type", "description", "success"}
 	rows := [][]string{}
 	for _, check := range r.Checks {
 		rows = append(rows, []string{
 			check.Name(),
+			check.CheckType(),
 			check.Description(),
 			check.ResultEmoji(),
 		})
@@ -179,6 +208,13 @@ func (c *Check) Name() string {
 	return c.Node.PathString()
 }
 
+func (c *Check) CheckType() string {
+	if c.IsGenerate {
+		return "generate"
+	}
+	return "check"
+}
+
 func (c *Check) Clone() *Check {
 	cp := *c
 	cp.Node = c.Node.Clone()
@@ -188,7 +224,12 @@ func (c *Check) Clone() *Check {
 func (c *Check) Run(ctx context.Context) (*Check, error) {
 	c = c.Clone()
 
-	err := c.Node.RunCheck(ctx, nil, nil)
+	var err error
+	if c.IsGenerate {
+		err = c.Node.RunGeneratorAsCheck(ctx, nil, nil)
+	} else {
+		err = c.Node.RunCheck(ctx, nil, nil)
+	}
 	c.Completed = true
 	if err != nil {
 		c.Passed = false

--- a/core/env.go
+++ b/core/env.go
@@ -199,11 +199,11 @@ func (env *Env) WithoutInput(key string) *Env {
 }
 
 // Checks returns a CheckGroup from the main module
-func (env *Env) Checks(ctx context.Context, include []string) (*CheckGroup, error) {
+func (env *Env) Checks(ctx context.Context, include []string, noGenerate bool) (*CheckGroup, error) {
 	if env.MainModule.Self() == nil {
 		return nil, fmt.Errorf("no main module set on environment")
 	}
-	return NewCheckGroup(ctx, env.MainModule, include)
+	return NewCheckGroup(ctx, env.MainModule, include, noGenerate)
 }
 
 // Services returns an UpGroup from the main module
@@ -216,7 +216,7 @@ func (env *Env) Services(ctx context.Context, include []string) (*UpGroup, error
 
 // Check returns a single check by name from the main module
 func (env *Env) Check(ctx context.Context, name string) (*Check, error) {
-	checkGroup, err := env.Checks(ctx, []string{name})
+	checkGroup, err := env.Checks(ctx, []string{name}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -143,6 +143,76 @@ func (ChecksSuite) TestChecksAsBlueprint(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (ChecksSuite) TestChecksGenerateAsCheck(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := checksTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-generate-checks")
+
+	t.Run("list includes generators", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		// Should list both regular checks and generators
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "empty-generate")
+		require.Contains(t, out, "non-empty-generate")
+		// Should show "Generators" section header
+		require.Contains(t, out, "Generators")
+	})
+
+	t.Run("list with no-generate excludes generators", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l", "--no-generate")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		// Should only list regular checks, no Generators section
+		require.Contains(t, out, "passing-check")
+		require.NotContains(t, out, "Generators")
+		require.NotContains(t, out, "empty-generate")
+		require.NotContains(t, out, "non-empty-generate")
+	})
+
+	t.Run("run empty generator passes", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("--progress=report", "check", "empty-generate")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `empty-generate.*OK`, out)
+	})
+
+	t.Run("run non-empty generator fails", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExecFail("--progress=report", "check", "non-empty-generate")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `non-empty-generate.*ERROR`, out)
+	})
+
+	t.Run("run all includes generators", func(ctx context.Context, t *testctx.T) {
+		// Should fail because non-empty-generate produces changes
+		out, err := modGen.
+			With(daggerExecFail("--progress=report", "check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.Regexp(t, `empty-generate.*OK`, out)
+		require.Regexp(t, `non-empty-generate.*ERROR`, out)
+	})
+
+	t.Run("run with no-generate skips generators", func(ctx context.Context, t *testctx.T) {
+		// Should pass because only passing-check runs
+		out, err := modGen.
+			With(daggerExec("--progress=report", "check", "--no-generate")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.NotContains(t, out, "empty-generate")
+		require.NotContains(t, out, "non-empty-generate")
+	})
+}
+
 func (ChecksSuite) TestChecksFailFast(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen, err := checksTestEnv(t, c)

--- a/core/integration/testdata/checks/hello-with-generate-checks/dagger.json
+++ b/core/integration/testdata/checks/hello-with-generate-checks/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "hello-with-generate-checks",
+  "engineVersion": "v0.20.1",
+  "sdk": {
+    "source": "go"
+  }
+}

--- a/core/integration/testdata/checks/hello-with-generate-checks/main.go
+++ b/core/integration/testdata/checks/hello-with-generate-checks/main.go
@@ -1,0 +1,31 @@
+// A module with both +check and +generate functions to test generate-as-check
+package main
+
+import (
+	"context"
+
+	"dagger/hello-with-generate-checks/internal/dagger"
+)
+
+type HelloWithGenerateChecks struct{}
+
+// A regular passing check
+// +check
+func (m *HelloWithGenerateChecks) PassingCheck(ctx context.Context) error {
+	_, err := dag.Container().From("alpine:3").WithExec([]string{"sh", "-c", "exit 0"}).Sync(ctx)
+	return err
+}
+
+// A generator that produces an empty changeset (should pass as check)
+// +generate
+func (m *HelloWithGenerateChecks) EmptyGenerate() *dagger.Changeset {
+	return dag.Directory().Changes(dag.Directory())
+}
+
+// A generator that produces changes (should fail as check)
+// +generate
+func (m *HelloWithGenerateChecks) NonEmptyGenerate() *dagger.Changeset {
+	return dag.Directory().
+		WithNewFile("generated.txt", "this file was generated").
+		Changes(dag.Directory())
+}

--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -557,6 +557,104 @@ func (ToolchainSuite) TestToolchainIgnoreChecks(ctx context.Context, t *testctx.
 	})
 }
 
+func (ToolchainSuite) TestToolchainIgnoreChecksGenerators(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	t.Run("ignore generate-as-checks via ignoreChecks config", func(ctx context.Context, t *testctx.T) {
+		// Set up test environment with hello-with-generate-checks as a toolchain
+		modGen := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory(".", c.Host().Directory("./testdata/checks")).
+			WithDirectory("app", c.Directory()).
+			WithWorkdir("app").
+			With(daggerExec("init"))
+
+		// Install hello-with-generate-checks as a toolchain
+		modGen = modGen.With(daggerExec("toolchain", "install", "../hello-with-generate-checks"))
+
+		// Verify all items are visible by default (regular check + both generators)
+		out, err := modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello-with-generate-checks:passing-check")
+		require.Contains(t, out, "hello-with-generate-checks:empty-generate")
+		require.Contains(t, out, "hello-with-generate-checks:non-empty-generate")
+
+		// Now add ignoreChecks to filter out the failing generator
+		modGen = modGen.WithNewFile("dagger.json", `{
+  "name": "app",
+  "engineVersion": "v0.16.0",
+  "toolchains": [
+    {
+      "name": "hello-with-generate-checks",
+      "source": "../hello-with-generate-checks",
+      "ignoreChecks": [
+        "non-empty-generate"
+      ]
+    }
+  ]
+}`)
+
+		// List checks - the non-empty-generate should be filtered out
+		out, err = modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello-with-generate-checks:passing-check")
+		require.Contains(t, out, "hello-with-generate-checks:empty-generate")
+		require.NotContains(t, out, "non-empty-generate")
+
+		// Run all checks - should succeed since the failing generator is ignored
+		out, err = modGen.
+			With(daggerExec("--progress=report", "check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.Regexp(t, `empty-generate.*OK`, out)
+		require.NotContains(t, out, "non-empty-generate")
+	})
+
+	t.Run("ignore generate-as-checks with glob pattern", func(ctx context.Context, t *testctx.T) {
+		modGen := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory(".", c.Host().Directory("./testdata/checks")).
+			WithDirectory("app", c.Directory()).
+			WithWorkdir("app").
+			With(daggerExec("init"))
+
+		modGen = modGen.With(daggerExec("toolchain", "install", "../hello-with-generate-checks"))
+
+		// Exclude all generators with a glob pattern
+		modGen = modGen.WithNewFile("dagger.json", `{
+  "name": "app",
+  "engineVersion": "v0.16.0",
+  "toolchains": [
+    {
+      "name": "hello-with-generate-checks",
+      "source": "../hello-with-generate-checks",
+      "ignoreChecks": [
+        "*-generate"
+      ]
+    }
+  ]
+}`)
+
+		out, err := modGen.
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello-with-generate-checks:passing-check")
+		require.NotContains(t, out, "empty-generate")
+		require.NotContains(t, out, "non-empty-generate")
+	})
+}
+
 func (ToolchainSuite) TestToolchainMultipleVersions(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -118,30 +118,123 @@ func (node *ModTreeNode) Run(
 }
 
 func (node *ModTreeNode) RunCheck(ctx context.Context, include, exclude []string) error {
-	return node.Run(ctx,
+	return node.runAsCheck(ctx,
 		func(n *ModTreeNode) bool { return n.IsCheck },
+		func(n *ModTreeNode, ctx context.Context) (bool, error) {
+			return node.tryRunCheckScaleOut(ctx)
+		},
+		func(n *ModTreeNode, ctx context.Context) error {
+			return n.runCheckLocally(ctx)
+		},
+		include, exclude)
+}
+
+func (node *ModTreeNode) RunGeneratorAsCheck(ctx context.Context, include, exclude []string) error {
+	return node.runAsCheck(ctx,
+		func(n *ModTreeNode) bool { return n.IsGenerator },
+		func(n *ModTreeNode, ctx context.Context) (bool, error) {
+			return n.tryRunGeneratorAsCheckScaleOut(ctx)
+		},
+		func(n *ModTreeNode, ctx context.Context) error {
+			return n.runGeneratorAsCheckLocally(ctx)
+		},
+		include, exclude)
+}
+
+// runAsCheck runs a leaf node as a check, with telemetry span and optional scale-out.
+func (node *ModTreeNode) runAsCheck(
+	ctx context.Context,
+	isLeaf func(*ModTreeNode) bool,
+	tryScaleOut func(*ModTreeNode, context.Context) (bool, error),
+	runLocally func(*ModTreeNode, context.Context) error,
+	include, exclude []string,
+) error {
+	return node.Run(ctx,
+		isLeaf,
 		func(ctx context.Context, n *ModTreeNode, clientMD *engine.ClientMetadata) (rerr error) {
 			// Try scale-out if enabled (will be false for scaled-out sessions)
 			if clientMD != nil && clientMD.EnableCloudScaleOut {
-				if ok, err := node.tryRunCheckScaleOut(ctx); ok {
+				if ok, err := tryScaleOut(n, ctx); ok {
 					return err
 				}
 			}
-			ctx, span := Tracer(ctx).Start(ctx, node.PathString(),
+			ctx, span := Tracer(ctx).Start(ctx, n.PathString(),
 				telemetry.Reveal(),
 				trace.WithAttributes(
 					attribute.Bool(telemetry.UIRollUpLogsAttr, true),
 					attribute.Bool(telemetry.UIRollUpSpansAttr, true),
-					attribute.String(telemetry.CheckNameAttr, node.PathString()),
+					attribute.String(telemetry.CheckNameAttr, n.PathString()),
 				),
 			)
 			defer func() {
 				span.SetAttributes(attribute.Bool(telemetry.CheckPassedAttr, rerr == nil))
 				telemetry.EndWithCause(span, &rerr)
 			}()
-			return n.runCheckLocally(ctx)
+			return runLocally(n, ctx)
 		},
 		include, exclude)
+}
+
+func (node *ModTreeNode) runGeneratorAsCheckLocally(ctx context.Context) error {
+	cs, err := node.runGeneratorLocally(ctx)
+	if err != nil {
+		return err
+	}
+	if cs == nil {
+		return nil
+	}
+	empty, err := cs.IsEmpty(ctx)
+	if err != nil {
+		return err
+	}
+	if !empty {
+		return fmt.Errorf("generate function %s produced changes; run 'dagger generate %s' to apply",
+			node.PathString(), node.PathString())
+	}
+	return nil
+}
+
+func (node *ModTreeNode) tryRunGeneratorAsCheckScaleOut(ctx context.Context) (_ bool, rerr error) {
+	q, err := CurrentQuery(ctx)
+	if err != nil {
+		return true, err
+	}
+
+	cloudClient, useCloud, err := q.CloudEngineClient(ctx,
+		node.RootAddress(),
+		node.PathString(),
+		nil,
+	)
+	if err != nil {
+		return true, fmt.Errorf("engine-to-engine connect: %w", err)
+	}
+	if !useCloud {
+		return false, nil
+	}
+	defer func() {
+		rerr = errors.Join(rerr, cloudClient.Close())
+	}()
+
+	query, err := node.buildScaleOutModuleQuery(cloudClient.Dagger().QueryBuilder())
+	if err != nil {
+		return true, err
+	}
+
+	query = query.Select("generator").Arg("name", node.PathString())
+	query = query.Select("run")
+	query = query.Select("isEmpty")
+
+	var empty bool
+	if err := query.Bind(&empty).Execute(ctx); err != nil {
+		return true, err
+	}
+
+	if !empty {
+		return true, fmt.Errorf("generate function %s produced changes; run 'dagger generate %s' to apply",
+			node.PathString(), node.PathString())
+	}
+
+	return true, nil
 }
 
 func (node *ModTreeNode) runCheckLocally(ctx context.Context) error {

--- a/core/schema/checks.go
+++ b/core/schema/checks.go
@@ -36,6 +36,8 @@ func (s checksSchema) Install(srv *dagql.Server) {
 			Doc("The path of the check within its module"),
 		dagql.Func("originalModule", s.originalModule).
 			Doc("The original module in which the check has been defined"),
+		dagql.Func("checkType", s.checkType).
+			Doc("The type of check: 'check' for annotated checks, 'generate' for generate-as-checks"),
 
 		dagql.Func("resultEmoji", s.resultEmoji).
 			Doc("An emoji representing the result of the check"),
@@ -58,6 +60,10 @@ func (s checksSchema) path(_ context.Context, parent *core.Check, args struct{})
 
 func (s checksSchema) originalModule(_ context.Context, parent *core.Check, args struct{}) (*core.Module, error) {
 	return parent.OriginalModule(), nil
+}
+
+func (s checksSchema) checkType(_ context.Context, parent *core.Check, args struct{}) (string, error) {
+	return parent.CheckType(), nil
 }
 
 func (s checksSchema) resultEmoji(_ context.Context, parent *core.Check, args struct{}) (string, error) {

--- a/core/schema/env.go
+++ b/core/schema/env.go
@@ -82,6 +82,7 @@ func (s environmentSchema) Install(srv *dagql.Server) {
 			Doc("Return all checks defined by the installed modules").
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("noGenerate").Doc("When true, only return annotated check functions; exclude generate-as-checks"),
 			),
 		dagql.Func("check", s.envCheck).
 			Experimental("Checks API is highly experimental and may be removed or replaced entirely.").
@@ -355,7 +356,8 @@ func (s environmentSchema) bindingIsNull(ctx context.Context, b *core.Binding, a
 }
 
 func (s environmentSchema) envChecks(ctx context.Context, env *core.Env, args struct {
-	Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+	Include    dagql.Optional[dagql.ArrayInput[dagql.String]]
+	NoGenerate dagql.Optional[dagql.Boolean]
 }) (*core.CheckGroup, error) {
 	var include []string
 	if args.Include.Valid {
@@ -363,7 +365,7 @@ func (s environmentSchema) envChecks(ctx context.Context, env *core.Env, args st
 			include = append(include, pattern.String())
 		}
 	}
-	return env.Checks(ctx, include)
+	return env.Checks(ctx, include, args.NoGenerate.GetOr(false).Bool())
 }
 
 func (s environmentSchema) envCheck(ctx context.Context, env *core.Env, args struct {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -252,6 +252,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`Return all checks defined by the module`).
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("noGenerate").Doc("When true, only return annotated check functions; exclude generate-as-checks"),
 			),
 
 		dagql.NodeFunc("check", s.moduleCheck).
@@ -2595,7 +2596,8 @@ func (s *moduleSchema) moduleChecks(
 	ctx context.Context,
 	mod dagql.ObjectResult[*core.Module],
 	args struct {
-		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Include    dagql.Optional[dagql.ArrayInput[dagql.String]]
+		NoGenerate dagql.Optional[dagql.Boolean]
 	},
 ) (*core.CheckGroup, error) {
 	var include []string
@@ -2604,7 +2606,7 @@ func (s *moduleSchema) moduleChecks(
 			include = append(include, pattern.String())
 		}
 	}
-	return core.NewCheckGroup(ctx, mod, include)
+	return core.NewCheckGroup(ctx, mod, include, args.NoGenerate.GetOr(false).Bool())
 }
 
 func (s *moduleSchema) moduleCheck(
@@ -2614,7 +2616,7 @@ func (s *moduleSchema) moduleCheck(
 		Name string
 	},
 ) (*core.Check, error) {
-	checkGroup, err := core.NewCheckGroup(ctx, mod, []string{args.Name})
+	checkGroup, err := core.NewCheckGroup(ctx, mod, []string{args.Name}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -58,6 +58,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("Return all checks from modules loaded in the workspace.").
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("noGenerate").Doc("When true, only return annotated check functions; exclude generate-as-checks"),
 			),
 		dagql.Func("generators", s.generators).
 			Doc("Return all generators from modules loaded in the workspace.").
@@ -341,12 +342,12 @@ func (s *workspaceSchema) findUp(
 	return none, nil
 }
 
-//nolint:dupl // same collect-filter-exclude pattern as services(), different types
 func (s *workspaceSchema) checks(
 	ctx context.Context,
 	parent *core.Workspace,
 	args struct {
-		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Include    dagql.Optional[dagql.ArrayInput[dagql.String]]
+		NoGenerate dagql.Optional[dagql.Boolean]
 	},
 ) (*core.CheckGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
@@ -356,6 +357,7 @@ func (s *workspaceSchema) checks(
 		return nil, err
 	}
 
+	noGenerate := args.NoGenerate.GetOr(false).Bool()
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -369,7 +371,7 @@ func (s *workspaceSchema) checks(
 
 	var allChecks []*core.Check
 	for _, mod := range mods {
-		checkGroup, err := core.NewCheckGroup(ctx, mod, nil)
+		checkGroup, err := core.NewCheckGroup(ctx, mod, nil, noGenerate)
 		if err != nil {
 			return nil, fmt.Errorf("checks from module %q: %w", mod.Self().Name(), err)
 		}
@@ -546,7 +548,6 @@ func (s *workspaceSchema) generators(
 	return &core.GeneratorGroup{Generators: allGenerators}, nil
 }
 
-//nolint:dupl // same collect-filter-exclude pattern as checks(), different types
 func (s *workspaceSchema) services(
 	ctx context.Context,
 	parent *core.Workspace,

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -357,6 +357,11 @@ enum ChangesetsMergeConflict {
 }
 
 type Check {
+  """
+  The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+  """
+  checkType: String!
+
   """Whether the check completed"""
   completed: Boolean!
 
@@ -2426,6 +2431,11 @@ type Env {
   checks(
     """Only include checks matching the specified patterns"""
     include: [String!]
+
+    """
+    When true, only return annotated check functions; exclude generate-as-checks
+    """
+    noGenerate: Boolean
   ): CheckGroup! @experimental(reason: "Checks API is highly experimental and may be removed or replaced entirely.")
 
   """A unique identifier for this Env."""
@@ -4417,6 +4427,11 @@ type Module {
   checks(
     """Only include checks matching the specified patterns"""
     include: [String!]
+
+    """
+    When true, only return annotated check functions; exclude generate-as-checks
+    """
+    noGenerate: Boolean
   ): CheckGroup! @experimental(reason: "This API is highly experimental and may be removed or replaced entirely.")
 
   """The dependencies of the module."""
@@ -6065,6 +6080,11 @@ type Workspace {
   checks(
     """Only include checks matching the specified patterns"""
     include: [String!]
+
+    """
+    When true, only return annotated check functions; exclude generate-as-checks
+    """
+    noGenerate: Boolean
   ): CheckGroup!
 
   """The client ID that owns this workspace's host filesystem."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6148,6 +6148,10 @@
                     </thead>
                     <tbody>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="Check-checkType" href="#Check-checkType"><code>checkType</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The type of check: 'check' for annotated checks, 'generate' for generate-as-checks </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="Check-completed" href="#Check-completed"><code>completed</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
                         <td> Whether the check completed </td>
                       </tr>
@@ -9497,6 +9501,10 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Only include checks matching the specified patterns</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noGenerate</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>When true, only return annotated check functions; exclude generate-as-checks</p>
                               </div>
                             </div>
                           </div>
@@ -14171,6 +14179,10 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Only include checks matching the specified patterns</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noGenerate</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>When true, only return annotated check functions; exclude generate-as-checks</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -16856,6 +16868,10 @@
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
                                 <p>Only include checks matching the specified patterns</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>noGenerate</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>When true, only return annotated check functions; exclude generate-as-checks</p>
                               </div>
                             </div>
                           </div>

--- a/docs/static/reference/php/Dagger/Check.html
+++ b/docs/static/reference/php/Dagger/Check.html
@@ -141,6 +141,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_checkType">checkType</a>()
+        
+                                            <p><p>The type of check: 'check' for annotated checks, 'generate' for generate-as-checks</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     bool
                 </div>
                 <div class="col-md-8">
@@ -335,8 +345,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_completed">
+                    <h3 id="method_checkType">
         <div class="location">at line 16</div>
+        <code>                    string
+    <strong>checkType</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The type of check: 'check' for annotated checks, 'generate' for generate-as-checks</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_completed">
+        <div class="location">at line 25</div>
         <code>                    bool
     <strong>completed</strong>()
         </code>
@@ -368,7 +410,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_description">
-        <div class="location">at line 25</div>
+        <div class="location">at line 34</div>
         <code>                    string
     <strong>description</strong>()
         </code>
@@ -400,7 +442,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_error">
-        <div class="location">at line 34</div>
+        <div class="location">at line 43</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>error</strong>()
         </code>
@@ -432,7 +474,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 43</div>
+        <div class="location">at line 52</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -464,7 +506,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 52</div>
+        <div class="location">at line 61</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -496,7 +538,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_originalModule">
-        <div class="location">at line 61</div>
+        <div class="location">at line 70</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>originalModule</strong>()
         </code>
@@ -528,7 +570,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_passed">
-        <div class="location">at line 70</div>
+        <div class="location">at line 79</div>
         <code>                    bool
     <strong>passed</strong>()
         </code>
@@ -560,7 +602,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_path">
-        <div class="location">at line 79</div>
+        <div class="location">at line 88</div>
         <code>                    array
     <strong>path</strong>()
         </code>
@@ -592,7 +634,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_resultEmoji">
-        <div class="location">at line 88</div>
+        <div class="location">at line 97</div>
         <code>                    string
     <strong>resultEmoji</strong>()
         </code>
@@ -624,7 +666,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_run">
-        <div class="location">at line 97</div>
+        <div class="location">at line 106</div>
         <code>                    <a href="../Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a>
     <strong>run</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Env.html
+++ b/docs/static/reference/php/Dagger/Env.html
@@ -154,7 +154,7 @@
                     <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_checks">checks</a>(array|null $include = null)
+                    <a href="#method_checks">checks</a>(array|null $include = null, bool|null $noGenerate = null)
         
                                             <p><p>Return all checks defined by the installed modules</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1061,7 +1061,7 @@
                     <h3 id="method_checks">
         <div class="location">at line 26</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
-    <strong>checks</strong>(array|null $include = null)
+    <strong>checks</strong>(array|null $include = null, bool|null $noGenerate = null)
         </code>
     </h3>
     <div class="details">    
@@ -1078,6 +1078,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
                 <td></td>
             </tr>
             </table>
@@ -1101,7 +1106,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 38</div>
+        <div class="location">at line 41</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1133,7 +1138,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_input">
-        <div class="location">at line 47</div>
+        <div class="location">at line 50</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>input</strong>(string $name)
         </code>
@@ -1175,7 +1180,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_inputs">
-        <div class="location">at line 57</div>
+        <div class="location">at line 60</div>
         <code>                    array
     <strong>inputs</strong>()
         </code>
@@ -1207,7 +1212,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_output">
-        <div class="location">at line 66</div>
+        <div class="location">at line 69</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>output</strong>(string $name)
         </code>
@@ -1249,7 +1254,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_outputs">
-        <div class="location">at line 76</div>
+        <div class="location">at line 79</div>
         <code>                    array
     <strong>outputs</strong>()
         </code>
@@ -1281,7 +1286,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 85</div>
+        <div class="location">at line 88</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1323,7 +1328,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAddressInput">
-        <div class="location">at line 97</div>
+        <div class="location">at line 100</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withAddressInput</strong>(string $name, <abbr title="Dagger\AddressId|Dagger\Address">Address</abbr> $value, string $description)
         </code>
@@ -1375,7 +1380,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAddressOutput">
-        <div class="location">at line 109</div>
+        <div class="location">at line 112</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withAddressOutput</strong>(string $name, string $description)
         </code>
@@ -1422,7 +1427,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCacheVolumeInput">
-        <div class="location">at line 120</div>
+        <div class="location">at line 123</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCacheVolumeInput</strong>(string $name, <abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $value, string $description)
         </code>
@@ -1474,7 +1479,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCacheVolumeOutput">
-        <div class="location">at line 132</div>
+        <div class="location">at line 135</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCacheVolumeOutput</strong>(string $name, string $description)
         </code>
@@ -1521,7 +1526,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChangesetInput">
-        <div class="location">at line 143</div>
+        <div class="location">at line 146</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withChangesetInput</strong>(string $name, <abbr title="Dagger\ChangesetId|Dagger\Changeset">Changeset</abbr> $value, string $description)
         </code>
@@ -1573,7 +1578,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChangesetOutput">
-        <div class="location">at line 155</div>
+        <div class="location">at line 158</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withChangesetOutput</strong>(string $name, string $description)
         </code>
@@ -1620,7 +1625,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCheckGroupInput">
-        <div class="location">at line 166</div>
+        <div class="location">at line 169</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCheckGroupInput</strong>(string $name, <abbr title="Dagger\CheckGroupId|Dagger\CheckGroup">CheckGroup</abbr> $value, string $description)
         </code>
@@ -1672,7 +1677,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCheckGroupOutput">
-        <div class="location">at line 178</div>
+        <div class="location">at line 181</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCheckGroupOutput</strong>(string $name, string $description)
         </code>
@@ -1719,7 +1724,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCheckInput">
-        <div class="location">at line 189</div>
+        <div class="location">at line 192</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCheckInput</strong>(string $name, <abbr title="Dagger\CheckId|Dagger\Check">Check</abbr> $value, string $description)
         </code>
@@ -1771,7 +1776,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCheckOutput">
-        <div class="location">at line 201</div>
+        <div class="location">at line 204</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCheckOutput</strong>(string $name, string $description)
         </code>
@@ -1818,7 +1823,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCloudInput">
-        <div class="location">at line 212</div>
+        <div class="location">at line 215</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCloudInput</strong>(string $name, <abbr title="Dagger\CloudId|Dagger\Cloud">Cloud</abbr> $value, string $description)
         </code>
@@ -1870,7 +1875,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCloudOutput">
-        <div class="location">at line 224</div>
+        <div class="location">at line 227</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCloudOutput</strong>(string $name, string $description)
         </code>
@@ -1917,7 +1922,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withContainerInput">
-        <div class="location">at line 235</div>
+        <div class="location">at line 238</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withContainerInput</strong>(string $name, <abbr title="Dagger\ContainerId|Dagger\Container">Container</abbr> $value, string $description)
         </code>
@@ -1969,7 +1974,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withContainerOutput">
-        <div class="location">at line 247</div>
+        <div class="location">at line 250</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withContainerOutput</strong>(string $name, string $description)
         </code>
@@ -2016,7 +2021,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCurrentModule">
-        <div class="location">at line 260</div>
+        <div class="location">at line 263</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withCurrentModule</strong>()
         </code>
@@ -2048,7 +2053,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDiffStatInput">
-        <div class="location">at line 269</div>
+        <div class="location">at line 272</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDiffStatInput</strong>(string $name, <abbr title="Dagger\DiffStatId|Dagger\DiffStat">DiffStat</abbr> $value, string $description)
         </code>
@@ -2100,7 +2105,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDiffStatOutput">
-        <div class="location">at line 281</div>
+        <div class="location">at line 284</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDiffStatOutput</strong>(string $name, string $description)
         </code>
@@ -2147,7 +2152,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectoryInput">
-        <div class="location">at line 292</div>
+        <div class="location">at line 295</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDirectoryInput</strong>(string $name, <abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $value, string $description)
         </code>
@@ -2199,7 +2204,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectoryOutput">
-        <div class="location">at line 304</div>
+        <div class="location">at line 307</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withDirectoryOutput</strong>(string $name, string $description)
         </code>
@@ -2246,7 +2251,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileInput">
-        <div class="location">at line 315</div>
+        <div class="location">at line 318</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvFileInput</strong>(string $name, <abbr title="Dagger\EnvFileId|Dagger\EnvFile">EnvFile</abbr> $value, string $description)
         </code>
@@ -2298,7 +2303,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileOutput">
-        <div class="location">at line 327</div>
+        <div class="location">at line 330</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvFileOutput</strong>(string $name, string $description)
         </code>
@@ -2345,7 +2350,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvInput">
-        <div class="location">at line 338</div>
+        <div class="location">at line 341</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvInput</strong>(string $name, <abbr title="Dagger\EnvId|Dagger\Env">Env</abbr> $value, string $description)
         </code>
@@ -2397,7 +2402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvOutput">
-        <div class="location">at line 350</div>
+        <div class="location">at line 353</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withEnvOutput</strong>(string $name, string $description)
         </code>
@@ -2444,7 +2449,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFileInput">
-        <div class="location">at line 361</div>
+        <div class="location">at line 364</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withFileInput</strong>(string $name, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $value, string $description)
         </code>
@@ -2496,7 +2501,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFileOutput">
-        <div class="location">at line 373</div>
+        <div class="location">at line 376</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withFileOutput</strong>(string $name, string $description)
         </code>
@@ -2543,7 +2548,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGeneratorGroupInput">
-        <div class="location">at line 384</div>
+        <div class="location">at line 387</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGeneratorGroupInput</strong>(string $name, <abbr title="Dagger\GeneratorGroupId|Dagger\GeneratorGroup">GeneratorGroup</abbr> $value, string $description)
         </code>
@@ -2595,7 +2600,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGeneratorGroupOutput">
-        <div class="location">at line 399</div>
+        <div class="location">at line 402</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGeneratorGroupOutput</strong>(string $name, string $description)
         </code>
@@ -2642,7 +2647,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGeneratorInput">
-        <div class="location">at line 410</div>
+        <div class="location">at line 413</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGeneratorInput</strong>(string $name, <abbr title="Dagger\GeneratorId|Dagger\Generator">Generator</abbr> $value, string $description)
         </code>
@@ -2694,7 +2699,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGeneratorOutput">
-        <div class="location">at line 422</div>
+        <div class="location">at line 425</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGeneratorOutput</strong>(string $name, string $description)
         </code>
@@ -2741,7 +2746,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRefInput">
-        <div class="location">at line 433</div>
+        <div class="location">at line 436</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRefInput</strong>(string $name, <abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $value, string $description)
         </code>
@@ -2793,7 +2798,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRefOutput">
-        <div class="location">at line 445</div>
+        <div class="location">at line 448</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRefOutput</strong>(string $name, string $description)
         </code>
@@ -2840,7 +2845,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRepositoryInput">
-        <div class="location">at line 456</div>
+        <div class="location">at line 459</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRepositoryInput</strong>(string $name, <abbr title="Dagger\GitRepositoryId|Dagger\GitRepository">GitRepository</abbr> $value, string $description)
         </code>
@@ -2892,7 +2897,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGitRepositoryOutput">
-        <div class="location">at line 471</div>
+        <div class="location">at line 474</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withGitRepositoryOutput</strong>(string $name, string $description)
         </code>
@@ -2939,7 +2944,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withHTTPStateInput">
-        <div class="location">at line 482</div>
+        <div class="location">at line 485</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withHTTPStateInput</strong>(string $name, <abbr title="Dagger\HTTPStateId|Dagger\HTTPState">HTTPState</abbr> $value, string $description)
         </code>
@@ -2991,7 +2996,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withHTTPStateOutput">
-        <div class="location">at line 494</div>
+        <div class="location">at line 497</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withHTTPStateOutput</strong>(string $name, string $description)
         </code>
@@ -3038,7 +3043,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withJSONValueInput">
-        <div class="location">at line 505</div>
+        <div class="location">at line 508</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withJSONValueInput</strong>(string $name, <abbr title="Dagger\JsonValueId|Dagger\JsonValue">JsonValue</abbr> $value, string $description)
         </code>
@@ -3090,7 +3095,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withJSONValueOutput">
-        <div class="location">at line 517</div>
+        <div class="location">at line 520</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withJSONValueOutput</strong>(string $name, string $description)
         </code>
@@ -3137,7 +3142,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMainModule">
-        <div class="location">at line 530</div>
+        <div class="location">at line 533</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withMainModule</strong>(<abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $module)
         </code>
@@ -3179,7 +3184,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 542</div>
+        <div class="location">at line 545</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModule</strong>(<abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $module)
         </code>
@@ -3221,7 +3226,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleConfigClientInput">
-        <div class="location">at line 552</div>
+        <div class="location">at line 555</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleConfigClientInput</strong>(string $name, <abbr title="Dagger\ModuleConfigClientId|Dagger\ModuleConfigClient">ModuleConfigClient</abbr> $value, string $description)
         </code>
@@ -3273,7 +3278,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleConfigClientOutput">
-        <div class="location">at line 567</div>
+        <div class="location">at line 570</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleConfigClientOutput</strong>(string $name, string $description)
         </code>
@@ -3320,7 +3325,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleInput">
-        <div class="location">at line 578</div>
+        <div class="location">at line 581</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleInput</strong>(string $name, <abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $value, string $description)
         </code>
@@ -3372,7 +3377,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleOutput">
-        <div class="location">at line 590</div>
+        <div class="location">at line 593</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleOutput</strong>(string $name, string $description)
         </code>
@@ -3419,7 +3424,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleSourceInput">
-        <div class="location">at line 601</div>
+        <div class="location">at line 604</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleSourceInput</strong>(string $name, <abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $value, string $description)
         </code>
@@ -3471,7 +3476,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModuleSourceOutput">
-        <div class="location">at line 613</div>
+        <div class="location">at line 616</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withModuleSourceOutput</strong>(string $name, string $description)
         </code>
@@ -3518,7 +3523,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPhpSdkInput">
-        <div class="location">at line 624</div>
+        <div class="location">at line 627</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withPhpSdkInput</strong>(string $name, <abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr> $value, string $description)
         </code>
@@ -3570,7 +3575,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPhpSdkOutput">
-        <div class="location">at line 636</div>
+        <div class="location">at line 639</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withPhpSdkOutput</strong>(string $name, string $description)
         </code>
@@ -3617,7 +3622,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchResultInput">
-        <div class="location">at line 647</div>
+        <div class="location">at line 650</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchResultInput</strong>(string $name, <abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $value, string $description)
         </code>
@@ -3669,7 +3674,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchResultOutput">
-        <div class="location">at line 659</div>
+        <div class="location">at line 662</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchResultOutput</strong>(string $name, string $description)
         </code>
@@ -3716,7 +3721,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchSubmatchInput">
-        <div class="location">at line 670</div>
+        <div class="location">at line 673</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchSubmatchInput</strong>(string $name, <abbr title="Dagger\SearchSubmatchId|Dagger\SearchSubmatch">SearchSubmatch</abbr> $value, string $description)
         </code>
@@ -3768,7 +3773,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchSubmatchOutput">
-        <div class="location">at line 685</div>
+        <div class="location">at line 688</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchSubmatchOutput</strong>(string $name, string $description)
         </code>
@@ -3815,7 +3820,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretInput">
-        <div class="location">at line 696</div>
+        <div class="location">at line 699</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSecretInput</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $value, string $description)
         </code>
@@ -3867,7 +3872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretOutput">
-        <div class="location">at line 708</div>
+        <div class="location">at line 711</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSecretOutput</strong>(string $name, string $description)
         </code>
@@ -3914,7 +3919,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceInput">
-        <div class="location">at line 719</div>
+        <div class="location">at line 722</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceInput</strong>(string $name, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $value, string $description)
         </code>
@@ -3966,7 +3971,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceOutput">
-        <div class="location">at line 731</div>
+        <div class="location">at line 734</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceOutput</strong>(string $name, string $description)
         </code>
@@ -4013,7 +4018,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketInput">
-        <div class="location">at line 742</div>
+        <div class="location">at line 745</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketInput</strong>(string $name, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $value, string $description)
         </code>
@@ -4065,7 +4070,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketOutput">
-        <div class="location">at line 754</div>
+        <div class="location">at line 757</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketOutput</strong>(string $name, string $description)
         </code>
@@ -4112,7 +4117,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStatInput">
-        <div class="location">at line 765</div>
+        <div class="location">at line 768</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStatInput</strong>(string $name, <abbr title="Dagger\StatId|Dagger\Stat">Stat</abbr> $value, string $description)
         </code>
@@ -4164,7 +4169,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStatOutput">
-        <div class="location">at line 777</div>
+        <div class="location">at line 780</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStatOutput</strong>(string $name, string $description)
         </code>
@@ -4211,7 +4216,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringInput">
-        <div class="location">at line 788</div>
+        <div class="location">at line 791</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringInput</strong>(string $name, string $value, string $description)
         </code>
@@ -4263,7 +4268,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringOutput">
-        <div class="location">at line 800</div>
+        <div class="location">at line 803</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringOutput</strong>(string $name, string $description)
         </code>
@@ -4310,7 +4315,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpGroupInput">
-        <div class="location">at line 811</div>
+        <div class="location">at line 814</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpGroupInput</strong>(string $name, <abbr title="Dagger\UpGroupId|Dagger\UpGroup">UpGroup</abbr> $value, string $description)
         </code>
@@ -4362,7 +4367,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpGroupOutput">
-        <div class="location">at line 823</div>
+        <div class="location">at line 826</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpGroupOutput</strong>(string $name, string $description)
         </code>
@@ -4409,7 +4414,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpInput">
-        <div class="location">at line 834</div>
+        <div class="location">at line 837</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpInput</strong>(string $name, <abbr title="Dagger\UpId|Dagger\Up">Up</abbr> $value, string $description)
         </code>
@@ -4461,7 +4466,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpOutput">
-        <div class="location">at line 846</div>
+        <div class="location">at line 849</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpOutput</strong>(string $name, string $description)
         </code>
@@ -4508,7 +4513,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspace">
-        <div class="location">at line 857</div>
+        <div class="location">at line 860</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspace</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $workspace)
         </code>
@@ -4550,7 +4555,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspaceInput">
-        <div class="location">at line 867</div>
+        <div class="location">at line 870</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspaceInput</strong>(string $name, <abbr title="Dagger\WorkspaceId|Dagger\Workspace">Workspace</abbr> $value, string $description)
         </code>
@@ -4602,7 +4607,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspaceOutput">
-        <div class="location">at line 879</div>
+        <div class="location">at line 882</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspaceOutput</strong>(string $name, string $description)
         </code>
@@ -4649,7 +4654,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutOutputs">
-        <div class="location">at line 890</div>
+        <div class="location">at line 893</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withoutOutputs</strong>()
         </code>
@@ -4681,7 +4686,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workspace">
-        <div class="location">at line 896</div>
+        <div class="location">at line 899</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>workspace</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Module.html
+++ b/docs/static/reference/php/Dagger/Module.html
@@ -156,7 +156,7 @@
                     <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_checks">checks</a>(array|null $include = null)
+                    <a href="#method_checks">checks</a>(array|null $include = null, bool|null $noGenerate = null)
         
                                             <p><p>Return all checks defined by the module</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -522,7 +522,7 @@
                     <h3 id="method_checks">
         <div class="location">at line 29</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
-    <strong>checks</strong>(array|null $include = null)
+    <strong>checks</strong>(array|null $include = null, bool|null $noGenerate = null)
         </code>
     </h3>
     <div class="details">    
@@ -539,6 +539,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
                 <td></td>
             </tr>
             </table>
@@ -562,7 +567,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_dependencies">
-        <div class="location">at line 41</div>
+        <div class="location">at line 44</div>
         <code>                    array
     <strong>dependencies</strong>()
         </code>
@@ -594,7 +599,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_description">
-        <div class="location">at line 50</div>
+        <div class="location">at line 53</div>
         <code>                    string
     <strong>description</strong>()
         </code>
@@ -626,7 +631,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_enums">
-        <div class="location">at line 59</div>
+        <div class="location">at line 62</div>
         <code>                    array
     <strong>enums</strong>()
         </code>
@@ -658,7 +663,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedContextDirectory">
-        <div class="location">at line 68</div>
+        <div class="location">at line 71</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>generatedContextDirectory</strong>()
         </code>
@@ -690,7 +695,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generator">
-        <div class="location">at line 77</div>
+        <div class="location">at line 80</div>
         <code>                    <a href="../Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a>
     <strong>generator</strong>(string $name)
         </code>
@@ -732,7 +737,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 87</div>
+        <div class="location">at line 90</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -774,7 +779,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 99</div>
+        <div class="location">at line 102</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -806,7 +811,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_interfaces">
-        <div class="location">at line 108</div>
+        <div class="location">at line 111</div>
         <code>                    array
     <strong>interfaces</strong>()
         </code>
@@ -838,7 +843,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_introspectionSchemaJSON">
-        <div class="location">at line 121</div>
+        <div class="location">at line 124</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>introspectionSchemaJSON</strong>()
         </code>
@@ -871,7 +876,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 130</div>
+        <div class="location">at line 133</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -903,7 +908,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_objects">
-        <div class="location">at line 139</div>
+        <div class="location">at line 142</div>
         <code>                    array
     <strong>objects</strong>()
         </code>
@@ -935,7 +940,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_runtime">
-        <div class="location">at line 148</div>
+        <div class="location">at line 151</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>runtime</strong>()
         </code>
@@ -967,7 +972,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 157</div>
+        <div class="location">at line 160</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>sdk</strong>()
         </code>
@@ -999,7 +1004,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_serve">
-        <div class="location">at line 168</div>
+        <div class="location">at line 171</div>
         <code>                    void
     <strong>serve</strong>(bool|null $includeDependencies = null, bool|null $entrypoint = null)
         </code>
@@ -1046,7 +1051,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 183</div>
+        <div class="location">at line 186</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1088,7 +1093,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_source">
-        <div class="location">at line 195</div>
+        <div class="location">at line 198</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>source</strong>()
         </code>
@@ -1120,7 +1125,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 204</div>
+        <div class="location">at line 207</div>
         <code>                    <a href="../Dagger/ModuleId.html"><abbr title="Dagger\ModuleId">ModuleId</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1152,7 +1157,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 213</div>
+        <div class="location">at line 216</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -1184,7 +1189,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDescription">
-        <div class="location">at line 222</div>
+        <div class="location">at line 225</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withDescription</strong>(string $description)
         </code>
@@ -1226,7 +1231,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnum">
-        <div class="location">at line 232</div>
+        <div class="location">at line 235</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withEnum</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $enum)
         </code>
@@ -1268,7 +1273,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInterface">
-        <div class="location">at line 242</div>
+        <div class="location">at line 245</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withInterface</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $iface)
         </code>
@@ -1310,7 +1315,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withObject">
-        <div class="location">at line 252</div>
+        <div class="location">at line 255</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withObject</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $object)
         </code>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -156,7 +156,7 @@
                     <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_checks">checks</a>(array|null $include = null)
+                    <a href="#method_checks">checks</a>(array|null $include = null, bool|null $noGenerate = null)
         
                                             <p><p>Return all checks from modules loaded in the workspace.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -402,7 +402,7 @@
                     <h3 id="method_checks">
         <div class="location">at line 28</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
-    <strong>checks</strong>(array|null $include = null)
+    <strong>checks</strong>(array|null $include = null, bool|null $noGenerate = null)
         </code>
     </h3>
     <div class="details">    
@@ -419,6 +419,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
                 <td></td>
             </tr>
             </table>
@@ -442,7 +447,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_clientId">
-        <div class="location">at line 40</div>
+        <div class="location">at line 43</div>
         <code>                    string
     <strong>clientId</strong>()
         </code>
@@ -474,7 +479,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configPath">
-        <div class="location">at line 49</div>
+        <div class="location">at line 52</div>
         <code>                    string
     <strong>configPath</strong>()
         </code>
@@ -506,7 +511,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 60</div>
+        <div class="location">at line 63</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>(string $path, array|null $exclude = null, array|null $include = null, bool|null $gitignore = false)
         </code>
@@ -563,7 +568,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 85</div>
+        <div class="location">at line 88</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path)
         </code>
@@ -605,7 +610,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 101</div>
+        <div class="location">at line 104</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string|null $from = &#039;.&#039;)
         </code>
@@ -654,7 +659,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 114</div>
+        <div class="location">at line 117</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -696,7 +701,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_hasConfig">
-        <div class="location">at line 126</div>
+        <div class="location">at line 129</div>
         <code>                    bool
     <strong>hasConfig</strong>()
         </code>
@@ -728,7 +733,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 135</div>
+        <div class="location">at line 138</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -760,7 +765,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_initialized">
-        <div class="location">at line 144</div>
+        <div class="location">at line 147</div>
         <code>                    bool
     <strong>initialized</strong>()
         </code>
@@ -792,7 +797,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_path">
-        <div class="location">at line 153</div>
+        <div class="location">at line 156</div>
         <code>                    string
     <strong>path</strong>()
         </code>
@@ -824,7 +829,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 162</div>
+        <div class="location">at line 165</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -266,7 +266,9 @@
                     <dd></dd><dt><a href="Dagger/ChangesetDiffStatEntryId.html"><abbr title="Dagger\ChangesetDiffStatEntryId">ChangesetDiffStatEntryId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>ChangesetDiffStatEntryID</code> scalar type represents an identifier for an object of type ChangesetDiffStatEntry.</p></dd><dt><a href="Dagger/ChangesetId.html"><abbr title="Dagger\ChangesetId">ChangesetId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>The <code>ChangesetID</code> scalar type represents an identifier for an object of type Changeset.</p></dd><dt><a href="Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
-                    <dd></dd><dt><a href="Dagger/Check.html#method_completed">
+                    <dd></dd><dt><a href="Dagger/Check.html#method_checkType">
+<abbr title="Dagger\Check">Check</abbr>::checkType</a>() &mdash; <em>Method in class <a href="Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a></em></dt>
+                    <dd><p>The type of check: 'check' for annotated checks, 'generate' for generate-as-checks</p></dd><dt><a href="Dagger/Check.html#method_completed">
 <abbr title="Dagger\Check">Check</abbr>::completed</a>() &mdash; <em>Method in class <a href="Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a></em></dt>
                     <dd><p>Whether the check completed</p></dd><dt><a href="Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd></dd><dt><a href="Dagger/CheckGroupId.html"><abbr title="Dagger\CheckGroupId">CheckGroupId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2005,6 +2005,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Check::checkType",
+			"p": "Dagger/Check.html#method_checkType",
+			"d": "<p>The type of check: 'check' for annotated checks, 'generate' for generate-as-checks</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Check::completed",
 			"p": "Dagger/Check.html#method_completed",
 			"d": "<p>Whether the check completed</p>"

--- a/sdk/elixir/lib/dagger/gen/check.ex
+++ b/sdk/elixir/lib/dagger/gen/check.ex
@@ -16,6 +16,17 @@ defmodule Dagger.Check do
   @type t() :: %__MODULE__{}
 
   @doc """
+  The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+  """
+  @spec check_type(t()) :: {:ok, String.t()} | {:error, term()}
+  def check_type(%__MODULE__{} = check) do
+    query_builder =
+      check.query_builder |> QB.select("checkType")
+
+    Client.execute(check.client, query_builder)
+  end
+
+  @doc """
   Whether the check completed
   """
   @spec completed(t()) :: {:ok, boolean()} | {:error, term()}

--- a/sdk/elixir/lib/dagger/gen/env.ex
+++ b/sdk/elixir/lib/dagger/gen/env.ex
@@ -40,12 +40,14 @@ defmodule Dagger.Env do
   >
   > "Checks API is highly experimental and may be removed or replaced entirely."
   """
-  @spec checks(t(), [{:include, [String.t()]}]) :: Dagger.CheckGroup.t()
+  @spec checks(t(), [{:include, [String.t()]}, {:no_generate, boolean() | nil}]) ::
+          Dagger.CheckGroup.t()
   def checks(%__MODULE__{} = env, optional_args \\ []) do
     query_builder =
       env.query_builder
       |> QB.select("checks")
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
 
     %Dagger.CheckGroup{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -40,12 +40,14 @@ defmodule Dagger.Module do
   >
   > "This API is highly experimental and may be removed or replaced entirely."
   """
-  @spec checks(t(), [{:include, [String.t()]}]) :: Dagger.CheckGroup.t()
+  @spec checks(t(), [{:include, [String.t()]}, {:no_generate, boolean() | nil}]) ::
+          Dagger.CheckGroup.t()
   def checks(%__MODULE__{} = module, optional_args \\ []) do
     query_builder =
       module.query_builder
       |> QB.select("checks")
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
 
     %Dagger.CheckGroup{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -29,12 +29,14 @@ defmodule Dagger.Workspace do
   @doc """
   Return all checks from modules loaded in the workspace.
   """
-  @spec checks(t(), [{:include, [String.t()]}]) :: Dagger.CheckGroup.t()
+  @spec checks(t(), [{:include, [String.t()]}, {:no_generate, boolean() | nil}]) ::
+          Dagger.CheckGroup.t()
   def checks(%__MODULE__{} = workspace, optional_args \\ []) do
     query_builder =
       workspace.query_builder
       |> QB.select("checks")
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
 
     %Dagger.CheckGroup{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5637,6 +5637,8 @@ func (r *Env) Check(name string) *Check {
 type EnvChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// When true, only return annotated check functions; exclude generate-as-checks
+	NoGenerate bool
 }
 
 // Return all checks defined by the installed modules
@@ -5648,6 +5650,10 @@ func (r *Env) Checks(opts ...EnvChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `noGenerate` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {
+			q = q.Arg("noGenerate", opts[i].NoGenerate)
 		}
 	}
 
@@ -10579,6 +10585,8 @@ func (r *Module) Check(name string) *Check {
 type ModuleChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// When true, only return annotated check functions; exclude generate-as-checks
+	NoGenerate bool
 }
 
 // Return all checks defined by the module
@@ -10590,6 +10598,10 @@ func (r *Module) Checks(opts ...ModuleChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `noGenerate` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {
+			q = q.Arg("noGenerate", opts[i].NoGenerate)
 		}
 	}
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1271,6 +1271,7 @@ func (r *Changeset) WithChangesets(changes []*Changeset, opts ...ChangesetWithCh
 type Check struct {
 	query *querybuilder.Selection
 
+	checkType   *string
 	completed   *bool
 	description *string
 	id          *CheckID
@@ -1291,6 +1292,19 @@ func (r *Check) WithGraphQLQuery(q *querybuilder.Selection) *Check {
 	return &Check{
 		query: q,
 	}
+}
+
+// The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+func (r *Check) CheckType(ctx context.Context) (string, error) {
+	if r.checkType != nil {
+		return *r.checkType, nil
+	}
+	q := r.query.Select("checkType")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // Whether the check completed
@@ -15242,6 +15256,8 @@ func (r *Workspace) Address(ctx context.Context) (string, error) {
 type WorkspaceChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// When true, only return annotated check functions; exclude generate-as-checks
+	NoGenerate bool
 }
 
 // Return all checks from modules loaded in the workspace.
@@ -15251,6 +15267,10 @@ func (r *Workspace) Checks(opts ...WorkspaceChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `noGenerate` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {
+			q = q.Arg("noGenerate", opts[i].NoGenerate)
 		}
 	}
 

--- a/sdk/php/generated/Check.php
+++ b/sdk/php/generated/Check.php
@@ -11,6 +11,15 @@ namespace Dagger;
 class Check extends Client\AbstractObject implements Client\IdAble
 {
     /**
+     * The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+     */
+    public function checkType(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('checkType');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'checkType');
+    }
+
+    /**
      * Whether the check completed
      */
     public function completed(): bool

--- a/sdk/php/generated/Env.php
+++ b/sdk/php/generated/Env.php
@@ -23,11 +23,14 @@ class Env extends Client\AbstractObject implements Client\IdAble
     /**
      * Return all checks defined by the installed modules
      */
-    public function checks(?array $include = null): CheckGroup
+    public function checks(?array $include = null, ?bool $noGenerate = null): CheckGroup
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('checks');
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $noGenerate) {
+        $innerQueryBuilder->setArgument('noGenerate', $noGenerate);
         }
         return new \Dagger\CheckGroup($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -26,11 +26,14 @@ class Module extends Client\AbstractObject implements Client\IdAble
     /**
      * Return all checks defined by the module
      */
-    public function checks(?array $include = null): CheckGroup
+    public function checks(?array $include = null, ?bool $noGenerate = null): CheckGroup
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('checks');
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $noGenerate) {
+        $innerQueryBuilder->setArgument('noGenerate', $noGenerate);
         }
         return new \Dagger\CheckGroup($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -25,11 +25,14 @@ class Workspace extends Client\AbstractObject implements Client\IdAble
     /**
      * Return all checks from modules loaded in the workspace.
      */
-    public function checks(?array $include = null): CheckGroup
+    public function checks(?array $include = null, ?bool $noGenerate = null): CheckGroup
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('checks');
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $noGenerate) {
+        $innerQueryBuilder->setArgument('noGenerate', $noGenerate);
         }
         return new \Dagger\CheckGroup($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1367,6 +1367,28 @@ class Changeset(Type):
 
 @typecheck
 class Check(Type):
+    async def check_type(self) -> str:
+        """The type of check: 'check' for annotated checks, 'generate' for
+        generate-as-checks
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("checkType", _args)
+        return await _ctx.execute(str)
+
     async def completed(self) -> bool:
         """Whether the check completed
 
@@ -5724,6 +5746,7 @@ class Env(Type):
         self,
         *,
         include: list[str] | None = None,
+        no_generate: bool | None = None,
     ) -> CheckGroup:
         """Return all checks defined by the installed modules
 
@@ -5735,9 +5758,13 @@ class Env(Type):
         ----------
         include:
             Only include checks matching the specified patterns
+        no_generate:
+            When true, only return annotated check functions; exclude
+            generate-as-checks
         """
         _args = [
             Arg("include", include, None),
+            Arg("noGenerate", no_generate, None),
         ]
         _ctx = self._select("checks", _args)
         return CheckGroup(_ctx)
@@ -10873,6 +10900,7 @@ class Module(Type):
         self,
         *,
         include: list[str] | None = None,
+        no_generate: bool | None = None,
     ) -> CheckGroup:
         """Return all checks defined by the module
 
@@ -10884,9 +10912,13 @@ class Module(Type):
         ----------
         include:
             Only include checks matching the specified patterns
+        no_generate:
+            When true, only return annotated check functions; exclude
+            generate-as-checks
         """
         _args = [
             Arg("include", include, None),
+            Arg("noGenerate", no_generate, None),
         ]
         _ctx = self._select("checks", _args)
         return CheckGroup(_ctx)
@@ -15050,6 +15082,7 @@ class Workspace(Type):
         self,
         *,
         include: list[str] | None = None,
+        no_generate: bool | None = None,
     ) -> CheckGroup:
         """Return all checks from modules loaded in the workspace.
 
@@ -15057,9 +15090,13 @@ class Workspace(Type):
         ----------
         include:
             Only include checks matching the specified patterns
+        no_generate:
+            When true, only return annotated check functions; exclude
+            generate-as-checks
         """
         _args = [
             Arg("include", include, None),
+            Arg("noGenerate", no_generate, None),
         ]
         _ctx = self._select("checks", _args)
         return CheckGroup(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2994,6 +2994,11 @@ pub struct Check {
     pub graphql_client: DynGraphQLClient,
 }
 impl Check {
+    /// The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+    pub async fn check_type(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("checkType");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Whether the check completed
     pub async fn completed(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("completed");
@@ -7446,6 +7451,9 @@ pub struct EnvChecksOpts<'a> {
     /// Only include checks matching the specified patterns
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
+    /// When true, only return annotated check functions; exclude generate-as-checks
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct EnvServicesOpts<'a> {
@@ -7490,6 +7498,9 @@ impl Env {
         let mut query = self.selection.select("checks");
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
         }
         CheckGroup {
             proc: self.proc.clone(),
@@ -11656,6 +11667,9 @@ pub struct ModuleChecksOpts<'a> {
     /// Only include checks matching the specified patterns
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
+    /// When true, only return annotated check functions; exclude generate-as-checks
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ModuleGeneratorsOpts<'a> {
@@ -11715,6 +11729,9 @@ impl Module {
         let mut query = self.selection.select("checks");
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
         }
         CheckGroup {
             proc: self.proc.clone(),
@@ -15574,6 +15591,9 @@ pub struct WorkspaceChecksOpts<'a> {
     /// Only include checks matching the specified patterns
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
+    /// When true, only return annotated check functions; exclude generate-as-checks
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceDirectoryOpts<'a> {
@@ -15633,6 +15653,9 @@ impl Workspace {
         let mut query = self.selection.select("checks");
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
         }
         CheckGroup {
             proc: self.proc.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1357,6 +1357,11 @@ export type EnvChecksOpts = {
    * Only include checks matching the specified patterns
    */
   include?: string[]
+
+  /**
+   * When true, only return annotated check functions; exclude generate-as-checks
+   */
+  noGenerate?: boolean
 }
 
 export type EnvServicesOpts = {
@@ -2031,6 +2036,11 @@ export type ModuleChecksOpts = {
    * Only include checks matching the specified patterns
    */
   include?: string[]
+
+  /**
+   * When true, only return annotated check functions; exclude generate-as-checks
+   */
+  noGenerate?: boolean
 }
 
 export type ModuleGeneratorsOpts = {
@@ -2882,6 +2892,11 @@ export type WorkspaceChecksOpts = {
    * Only include checks matching the specified patterns
    */
   include?: string[]
+
+  /**
+   * When true, only return annotated check functions; exclude generate-as-checks
+   */
+  noGenerate?: boolean
 }
 
 export type WorkspaceDirectoryOpts = {
@@ -3681,6 +3696,7 @@ export class Changeset extends BaseClient {
 
 export class Check extends BaseClient {
   private readonly _id?: CheckID = undefined
+  private readonly _checkType?: string = undefined
   private readonly _completed?: boolean = undefined
   private readonly _description?: string = undefined
   private readonly _name?: string = undefined
@@ -3693,6 +3709,7 @@ export class Check extends BaseClient {
   constructor(
     ctx?: Context,
     _id?: CheckID,
+    _checkType?: string,
     _completed?: boolean,
     _description?: string,
     _name?: string,
@@ -3702,6 +3719,7 @@ export class Check extends BaseClient {
     super(ctx)
 
     this._id = _id
+    this._checkType = _checkType
     this._completed = _completed
     this._description = _description
     this._name = _name
@@ -3720,6 +3738,21 @@ export class Check extends BaseClient {
     const ctx = this._ctx.select("id")
 
     const response: Awaited<CheckID> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The type of check: 'check' for annotated checks, 'generate' for generate-as-checks
+   */
+  checkType = async (): Promise<string> => {
+    if (this._checkType) {
+      return this._checkType
+    }
+
+    const ctx = this._ctx.select("checkType")
+
+    const response: Awaited<string> = await ctx.execute()
 
     return response
   }
@@ -6807,6 +6840,7 @@ export class Env extends BaseClient {
   /**
    * Return all checks defined by the installed modules
    * @param opts.include Only include checks matching the specified patterns
+   * @param opts.noGenerate When true, only return annotated check functions; exclude generate-as-checks
    * @experimental
    */
   checks = (opts?: EnvChecksOpts): CheckGroup => {
@@ -10970,6 +11004,7 @@ export class Module_ extends BaseClient {
   /**
    * Return all checks defined by the module
    * @param opts.include Only include checks matching the specified patterns
+   * @param opts.noGenerate When true, only return annotated check functions; exclude generate-as-checks
    * @experimental
    */
   checks = (opts?: ModuleChecksOpts): CheckGroup => {
@@ -14654,6 +14689,7 @@ export class Workspace extends BaseClient {
   /**
    * Return all checks from modules loaded in the workspace.
    * @param opts.include Only include checks matching the specified patterns
+   * @param opts.noGenerate When true, only return annotated check functions; exclude generate-as-checks
    */
   checks = (opts?: WorkspaceChecksOpts): CheckGroup => {
     const ctx = this._ctx.select("checks", { ...opts })


### PR DESCRIPTION
Currently we have one single function in `.dagger` main module that runs all the generate functions and ensure the result is empty.
Those changes handle that in the engine: all `generate` functions are now automatically handled as a `check` function. When they are run, it will succeed if the resulting changeset is empty.

This allows to always ensure all generated functions are correctly run on CI, without to introduce a new module or concept.
Just declare your checks and generates and both `dagger generate` and `dagger checks` will work.

You can still use `dagger check --no-generate` if you don't want to include the generate functions.

```console
$ dagger check -l

Name                                         Description
ci:bootstrap                                 Build dagger from source, and check that it can bootstrap its own CI
cli:release-dry-run                          Verify that the CLI builds without actually publishing anything
docs:lint-markdown                           Lint documentation files
elixir-sdk:codegen-test                      Run dagger_codegen tests
elixir-sdk:lint                              Lint the SDK
elixir-sdk:release-dry-run                   Test the publishing process
elixir-sdk:sdk-test                          Run the SDK tests
...
typescript-sdk:test-nodejs-lts               Test the SDK with LTS version of Node
typescript-sdk:test-nodejs-prev-lts          Test the SDK with previous LTS version of Node

Generators
changelog:generate                           Generate the changelog with 'changie merge'. Only run this manually, at release time.
docs:references                              Regenerate the API schema and CLI reference docs
engine-dev:generate                          Generate any engine-related files
go-sdk:generate                              Regenerate the Go SDK API
...
```