### PR TITLE
feat(go-sdk): no longer generate the core bindings

### DIFF
--- a/cmd/codegen/generate_client.go
+++ b/cmd/codegen/generate_client.go
@@ -77,6 +77,7 @@ func GenerateClient(cmd *cobra.Command, args []string) error {
 		clientConfig.ModuleName = res.Source.Name
 		clientConfig.EngineVersion = res.Source.EngineVersion
 		clientConfig.ModuleDependencies = res.Source.Dependencies
+		clientConfig.LibVersion = libVersion
 	}
 
 	cfg.ClientConfig = clientConfig
@@ -95,4 +96,6 @@ func init() {
 	// Specific client generation flags
 	generateClientCmd.Flags().StringVar(&moduleSourceID, "module-source-id", "", "id of the module to generate code for")
 	generateClientCmd.Flags().StringVar(&clientDir, "client-dir", "", "directory where the client will be generated (output by default)")
+	generateClientCmd.Flags().StringVar(&libVersion, "lib-version", "", "if set, use the given version of dagger.io/dagger in the generated client")
+
 }

--- a/cmd/codegen/generate_module.go
+++ b/cmd/codegen/generate_module.go
@@ -64,7 +64,7 @@ func GenerateModule(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get generator: %w", err)
 	}
 
-	slog.Info("generating module", "language", cfg.Lang, "module-name", cfg.ModuleConfig.ModuleName)
+	slog.Info("generating module", "language", cfg.Lang, "module-name", cfg.ModuleConfig.ModuleName, "lib-version", libVersion)
 
 	return Generate(ctx, cfg, generator.GenerateModule)
 }

--- a/cmd/codegen/generator/config.go
+++ b/cmd/codegen/generator/config.go
@@ -87,4 +87,7 @@ type ClientGeneratorConfig struct {
 	// The engine version from dagger.json, used to pin the dagger.io/dagger dependency.
 	// This is only populated when generating from a module source (not in tests).
 	EngineVersion string
+
+	// If set, use `@dagger.io/dagger` with the given version and use it in the generated client.
+	LibVersion string
 }

--- a/cmd/codegen/generator/go/generate_client.go
+++ b/cmd/codegen/generator/go/generate_client.go
@@ -212,9 +212,15 @@ func (g *GoGenerator) writeClientGoMod(mfs *memfs.FS, clientGoModFilePath string
 		return fmt.Errorf("failed to parse client go.mod: %w", err)
 	}
 
+	// If it's a dev version, we use the lib version pinned in the engine
+	// Otherwise we can use the specified engine version
 	engineVersion := g.Config.ClientConfig.EngineVersion
-	if engineVersion != "" && !strings.Contains(engineVersion, "-dev") && !isDaggerPkgCustomReplaced(existingGoMod.Replace) {
-		existingGoMod.AddRequire("dagger.io/dagger", engineVersion)
+	if engineVersion != "" && !isDaggerPkgCustomReplaced(existingGoMod.Replace) {
+		if strings.Contains(engineVersion, "-dev") {
+			existingGoMod.AddRequire("dagger.io/dagger", g.Config.ClientConfig.LibVersion)
+		} else {
+			existingGoMod.AddRequire("dagger.io/dagger", engineVersion)
+		}
 	}
 
 	existingClientGoModData, err = existingGoMod.Format()

--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -232,18 +232,18 @@ func (g *GoGenerator) syncModReplaceAndTidy(mod *modfile.File, genSt *generator.
 	}
 
 	// preserve any replace directives in sdk/go's go.mod (e.g. pre-1.0 packages)
-	for _, minReq := range sdkMod.Replace {
-		if _, ok := modRequires[minReq.New.Path]; !ok {
-			// ignore anything that's sdk/go only
-			continue
-		}
-		genSt.PostCommands = append(genSt.PostCommands,
-			exec.Command("go", "mod", "edit", "-replace", minReq.Old.Path+"="+minReq.New.Path+"@"+minReq.New.Version))
-		if goWork != "" {
-			genSt.PostCommands = append(genSt.PostCommands,
-				exec.Command("go", "work", "edit", "-replace", minReq.Old.Path+"="+minReq.New.Path+"@"+minReq.New.Version))
-		}
-	}
+//	for _, minReq := range sdkMod.Replace {
+//		if _, ok := modRequires[minReq.New.Path]; !ok {
+//			// ignore anything that's sdk/go only
+//			continue
+//		}
+//		genSt.PostCommands = append(genSt.PostCommands,
+//			exec.Command("go", "mod", "edit", "-replace", minReq.Old.Path+"="+minReq.New.Path+"@"+minReq.New.Version))
+//		if goWork != "" {
+//			genSt.PostCommands = append(genSt.PostCommands,
+//				exec.Command("go", "work", "edit", "-replace", minReq.Old.Path+"="+minReq.New.Path+"@"+minReq.New.Version))
+//		}
+//	}
 
 	// Check if the module go.mod replaces the dagger.io/dagger library with a custom path.
 	// If so, we keep it as is.

--- a/cmd/codegen/generator/go/generate_typedefs.go
+++ b/cmd/codegen/generator/go/generate_typedefs.go
@@ -117,20 +117,20 @@ func generateTypeDefs(ctx context.Context, cfg generator.Config, mfs *memfs.FS, 
 	return mfs.WriteFile(cfg.TypeDefsPath, []byte(t), 0600)
 }
 
-// We need the dagger package to be installed to correctly resolved imported interface
+// We need the github.com/dagger/querybuilder package to be installed to correctly resolved imported interface
 // such as `querybuilder.GraphQLMarshaller`
 func (g *GoGenerator) ensureDaggerPackage(ctx context.Context, dir string) error {
-	if g.Config.ModuleConfig == nil || g.Config.ModuleConfig.LibVersion == "" {
+	if g.Config.ModuleConfig == nil {
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, "go", "get", daggerImportPath+"@"+g.Config.ModuleConfig.LibVersion)
+	cmd := exec.CommandContext(ctx, "go", "get", "github.com/dagger/querybuilder")
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to get %s@%s: %w", daggerImportPath, g.Config.ModuleConfig.LibVersion, err)
+		return fmt.Errorf("failed to get github.com/dagger/querybuilder: %w", err)
 	}
 
 	return nil

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -101,6 +101,9 @@ func (funcs goTemplateFuncs) FuncMap() template.FuncMap {
 		"Dependencies":            funcs.Dependencies,
 		"HasLocalDependencies":    funcs.HasLocalDependencies,
 		"IsExtendableType":        funcs.isExtendableType,
+		"IsCoreType":              funcs.isCoreType,
+		"IsLibraryCode":           funcs.isLibraryCode,
+		"ReturnsExtendableType":   funcs.returnsExtendableType,
 		"FullSchemaTypes":         funcs.fullSchemaTypes,
 		"json":                    funcs.json,
 	}
@@ -115,6 +118,33 @@ func (funcs goTemplateFuncs) fullSchemaTypes() []*introspection.Type {
 
 func (goTemplateFuncs) isExtendableType(t introspection.Type) bool {
 	return slices.Contains(introspection.ExtendableTypes, t.Name)
+}
+
+// isCoreType returns true if the type is a core Dagger API type (not contributed
+// by a dependency module). Core types have no @sourceMap directive.
+func (goTemplateFuncs) isCoreType(t introspection.Type) bool {
+	return t.Directives.SourceMap() == nil
+}
+
+// isLibraryCode returns true when generating the SDK library itself (dagger.io/dagger).
+// This is the only mode that needs full type generation with direct field access.
+func (funcs goTemplateFuncs) isLibraryCode() bool {
+	return !funcs.isModuleCode() && !funcs.isStandaloneClient()
+}
+
+// returnsExtendableType returns true if the field's return type is an extendable
+// type (Query, Binding, Env). These methods must be overridden on wrapper types
+// because the embedded SDK type's method returns the SDK type, not the wrapper.
+func (goTemplateFuncs) returnsExtendableType(f introspection.Field) bool {
+	ref := f.TypeRef
+	// Unwrap NON_NULL
+	if ref.Kind == introspection.TypeKindNonNull {
+		ref = ref.OfType
+	}
+	if ref.Kind != introspection.TypeKindObject {
+		return false
+	}
+	return slices.Contains(introspection.ExtendableTypes, ref.Name)
 }
 
 func (goTemplateFuncs) json(v any) (string, error) {

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -18,7 +18,8 @@ import (
 
 {{ if IsModuleCode }}
 	"{{.UtilityPkgImport}}/querybuilder"
-	
+	"dagger.io/dagger"
+
 	telemetry "github.com/dagger/otel-go"
 {{ end }}
 
@@ -150,11 +151,142 @@ func (e *ExecError) Message() string {
 func (e *ExecError) Unwrap() error {
 	return e.original
 }
+{{ if or IsStandaloneClient IsModuleCode }}
+{{/* Standalone client / module: alias core types from dagger.io/dagger, fully generate extendable types */}}
+{{ range .Types }}
+
+{{- if and (IsCoreType .) (not (IsExtendableType .)) }}
+{{- $name := .Name | FormatName }}
+
+{{- if eq .Kind "SCALAR" }}
+{{ .Description | Comment }}
+type {{ $name }} = dagger.{{ $name }}
+{{- end }}
+
+{{- if eq .Kind "OBJECT" }}
+{{ .Description | Comment }}
+type {{ $name }} = dagger.{{ $name }}
+{{- if . | IsSelfChainable }}
+type With{{ $name }}Func = dagger.With{{ $name }}Func
+{{- end }}
+{{- range $field := .Fields }}
+{{- if HasOptionals $field.Args }}
+type {{ $field | FieldOptionsStructName }} = dagger.{{ $field | FieldOptionsStructName }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if eq .Kind "INPUT_OBJECT" }}
+{{ .Description | Comment }}
+type {{ $name }} = dagger.{{ $name }}
+{{- end }}
+
+{{- if IsEnum . }}
+{{- $enumName := .Name }}
+{{ .Description | Comment }}
+type {{ $enumName }} = dagger.{{ $enumName }}
+
+const (
+{{- range $fields := .EnumValues | GroupEnumByValue }}
+{{- $mainFieldName := "" }}
+{{- range $idx, $field := slice $fields }}
+	{{- $fullFieldName := print ($field.Name | FormatEnum $enumName) }}
+	{{- if eq $idx 0 }}
+		{{- $mainFieldName = $fullFieldName }}
+	{{ $fullFieldName }} {{ $enumName }} = dagger.{{ $fullFieldName }}
+	{{- else }}
+	{{ $fullFieldName }} {{ $enumName }} = {{ $mainFieldName }}
+	{{- end }}
+{{- end }}
+{{- end }}
+)
+{{- end }}
+
+{{- else if IsExtendableType . }}
+{{- if eq .Kind "OBJECT" }}
+{{- $name := .Name | FormatName }}
+{{ .Description | Comment }}
+type {{ $name }} struct {
+	query *querybuilder.Selection
+	dagger.{{ $name }}
+}
+{{- if . | IsSelfChainable }}
+type With{{ $name }}Func func(r *{{ $name }}) *{{ $name }}
+
+// With calls the provided function with current {{ $name }}.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *{{ $name }}) With(f With{{ $name }}Func) *{{ $name }} {
+	return f(r)
+}
+{{- end }}
+
+func (r *{{ $name }}) WithGraphQLQuery(q *querybuilder.Selection) *{{ $name }} {
+	return &{{ $name }}{
+		query: q,
+		{{ $name }}: *new(dagger.{{ $name }}).WithGraphQLQuery(q),
+	}
+}
+
+{{/* Generate only methods that return extendable types — other methods are inherited from the embedded type */}}
+{{ range $field := .Fields }}
+{{- if ReturnsExtendableType $field }}
+{{- if HasOptionals $field.Args }}
+type {{ $field | FieldOptionsStructName }} = dagger.{{ $field | FieldOptionsStructName }}
+{{- end }}
+
+{{- $convertID := $field | ConvertID }}
+{{- $supportsVoid := CheckVersionCompatibility "v0.12.0" }}
+{{ FieldFunction $field false $supportsVoid }} {
+	{{- range $arg := $field.Args }}
+	    {{- if and (IsPointer $arg) (not (IsArgOptional $arg)) }}
+        assertNotNil("{{ $arg.Name}}", {{ $arg.Name }})
+        {{- end }}
+    {{- end }}
+	q := r.query.Select("{{ $field.Name }}")
+	{{- if HasOptionals $field.Args }}
+	for i := len(opts) - 1; i >= 0; i-- {
+	{{- range $arg := $field.Args }}
+	{{- if IsArgOptional $arg }}
+	if !querybuilder.IsZeroValue(opts[i].{{ $arg.Name | FormatName }}) {
+		q = q.Arg("{{ $arg.Name }}", opts[i].{{ $arg.Name | FormatName }})
+	}
+	{{- end }}
+	{{- end }}
+	}
+	{{- end }}
+	{{- range $arg := $field.Args }}
+	{{- if not (IsArgOptional $arg) }}
+	q = q.Arg("{{ $arg.Name }}", {{ $arg.Name }})
+	{{- end }}
+	{{- end }}
+	{{- $typeName := $field.TypeRef | FormatOutputType }}
+	{{- if $convertID }}
+	var id {{ $typeName }}
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return new({{ $field.ParentObject.Name }}).WithGraphQLQuery(q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id)), nil
+	{{- else if $field.TypeRef.IsObject }}
+	return new({{ $typeName }}).WithGraphQLQuery(q)
+	{{- end }}
+}
+{{- else if HasOptionals $field.Args }}
+type {{ $field | FieldOptionsStructName }} = dagger.{{ $field | FieldOptionsStructName }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{ end }}
+{{ else }}
+{{/* Library and module code: generate full type definitions */}}
 {{ range .Types }}
 {{ if eq .Kind "SCALAR" }}{{ template "_types/scalar.go.tmpl" . }}{{ end }}
 {{ if eq .Kind "OBJECT" }}{{ template "_types/object.go.tmpl" . }}{{ end }}
 {{ if eq .Kind "INPUT_OBJECT" }}{{ template "_types/input.go.tmpl" . }}{{ end }}
 {{ if eq .Kind "ENUM" }}{{ template "_types/enum.go.tmpl" . }}{{ end }}
+{{ end }}
 {{ end }}
 
 {{ if IsModuleCode }}
@@ -168,9 +300,7 @@ var dag *Client
 func init() {
 	gqlClient, q := getClientParams()
 	dag = &Client{
-		Query: &Query{
-			query: q.Client(gqlClient),
-		},
+		Query: new(Query).WithGraphQLQuery(q.Client(gqlClient)),
 		client: gqlClient,
 	}
 }

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -17,14 +17,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 {{ if IsModuleCode }}
-	"{{.UtilityPkgImport}}/querybuilder"
+	"github.com/dagger/querybuilder"
 	"dagger.io/dagger"
 
 	telemetry "github.com/dagger/otel-go"
 {{ end }}
 
 {{- if IsStandaloneClient }}
-	"dagger.io/dagger/querybuilder"
+"github.com/dagger/querybuilder"
 	"dagger.io/dagger"
 {{ end }}
 )

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -15,7 +15,7 @@ import (
 	"{{.PackageImport}}/internal/dagger"
 
 
-	"{{.UtilityPkgImport}}/querybuilder"
+	"github.com/dagger/querybuilder"
 )
 
 var dag = dagger.Connect()

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -116,14 +116,22 @@ type {{ $field | FieldOptionsStructName }} struct {
 	if err := q.Bind(&id).Execute(ctx); err != nil {
 		return nil, err
 	}
+	{{- if IsLibraryCode }}
 	return &{{ $field.ParentObject.Name }} {
 		query: q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id),
 	}, nil
+	{{- else }}
+	return new({{ $field.ParentObject.Name }}).WithGraphQLQuery(q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id)), nil
+	{{- end }}
 
 	{{- else if $field.TypeRef.IsObject }}
+	{{- if IsLibraryCode }}
 	return &{{ $typeName }} {
 		query: q,
 	}
+	{{- else }}
+	return new({{ $typeName }}).WithGraphQLQuery(q)
+	{{- end }}
 
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
 		{{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
@@ -140,9 +148,17 @@ type {{ $field | FieldOptionsStructName }} struct {
         out := {{ $field.TypeRef | FormatOutputType }}{}
 
         for i := range fields {
+            {{- if IsLibraryCode }}
             val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
             {{- if $eleType | IsIDableObject }}
               val.query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
+            {{- end }}
+            {{- else }}
+            {{- if $eleType | IsIDableObject }}
+            val := *new({{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}).WithGraphQLQuery(q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id))
+            {{- else }}
+            val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
+            {{- end }}
             {{- end }}
             out = append(out, val)
         }

--- a/cmd/codegen/generator/go/templates/src/_types/object_fields.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object_fields.go.tmpl
@@ -84,17 +84,25 @@ type {{ $field | FieldOptionsStructName }} struct {
 	if err := q.Bind(&id).Execute(ctx); err != nil {
 		return nil, err
 	}
+	{{- if IsLibraryCode }}
 	return &{{ $field.ParentObject.Name }} {
 		query: q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id),
 	}, nil
+	{{- else }}
+	return new({{ $field.ParentObject.Name }}).WithGraphQLQuery(q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id)), nil
+	{{- end }}
 
 	{{- else if $field.TypeRef.IsObject }}
+	{{- if IsLibraryCode }}
 	return &{{ $typeName }} {
 		query: q,
 		{{- if eq $typeName "Client" }}
 		client: r.client,
 		{{ end }}
 	}
+	{{- else }}
+	return new({{ $typeName }}).WithGraphQLQuery(q)
+	{{- end }}
 
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
 		{{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
@@ -111,9 +119,17 @@ type {{ $field | FieldOptionsStructName }} struct {
         out := {{ $field.TypeRef | FormatOutputType }}{}
 
         for i := range fields {
+            {{- if IsLibraryCode }}
             val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
             {{- if $eleType | IsIDableObject }}
               val.query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
+            {{- end }}
+            {{- else }}
+            {{- if $eleType | IsIDableObject }}
+            val := *new({{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}).WithGraphQLQuery(q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id))
+            {{- else }}
+            val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
+            {{- end }}
             {{- end }}
             out = append(out, val)
         }

--- a/cmd/codegen/generator/go/templates/src/internal/dagger/_dep.gen.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/internal/dagger/_dep.gen.go.tmpl
@@ -4,7 +4,7 @@ package dagger
 
 import (
 {{ if IsModuleCode -}}
-	"{{.UtilityPkgImport}}/querybuilder"
+	"github.com/dagger/querybuilder"
 {{- else -}}
 	"dagger.io/dagger/querybuilder"
 {{- end }}

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -116,6 +116,7 @@ func (sdk *goSDK) GenerateClient(
 		"generate-client",
 		"--output", dagql.String(filepath.Join(goSDKUserModContextDirPath, rootSourcePath)),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
+		"--lib-version", dagql.String(goSDKLibVersion),
 		dagql.String(fmt.Sprintf("--module-source-id=%s", modSourceID)),
 		dagql.String(fmt.Sprintf("--client-dir=%s", outputDir)),
 	}

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
@@ -33,6 +34,18 @@ const (
 )
 
 var goSDKExecMDDigest = digest.FromString("go-sdk-with-exec-execmd")
+
+// resolveGoSDKLibVersion returns the dagger.io/dagger library version to use
+// for code generation. For released engine versions, it uses the engine version
+// directly (e.g., "v0.11.9"). For dev versions, it falls back to the hardcoded
+// goSDKLibVersion commit hash.
+func resolveGoSDKLibVersion(engineVersion string) string {
+	if engineVersion != "" && !strings.Contains(engineVersion, "-dev") {
+		return engineVersion
+	}
+	
+	return goSDKLibVersion
+}
 
 /*
 goSDK is the one special sdk not implemented as module, instead the
@@ -112,11 +125,13 @@ func (sdk *goSDK) GenerateClient(
 		return inst, fmt.Errorf("failed to get module context directory ID: %w", err)
 	}
 
+	libVersion := resolveGoSDKLibVersion(modSource.Self().EngineVersion)
+
 	codegenArgs := dagql.ArrayInput[dagql.String]{
 		"generate-client",
 		"--output", dagql.String(filepath.Join(goSDKUserModContextDirPath, rootSourcePath)),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
-		"--lib-version", dagql.String(goSDKLibVersion),
+		"--lib-version", dagql.String(libVersion),
 		dagql.String(fmt.Sprintf("--module-source-id=%s", modSourceID)),
 		dagql.String(fmt.Sprintf("--client-dir=%s", outputDir)),
 	}
@@ -381,7 +396,7 @@ func (sdk *goSDK) ModuleTypes(
 						"--module-source-path", dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 						"--module-name", dagql.String(modName),
 						"--introspection-json-path", goSDKIntrospectionJSONPath,
-						"--lib-version", dagql.String(goSDKLibVersion),
+						"--lib-version", dagql.String(resolveGoSDKLibVersion(src.Self().EngineVersion)),
 						"--output", GoSDKModuleIDPath,
 					},
 				},
@@ -596,13 +611,15 @@ func (sdk *goSDK) baseWithCodegen(
 		return ctr, fmt.Errorf("failed to get updated context directory ID during module sdk codegen: %w", err)
 	}
 
+	libVersion := resolveGoSDKLibVersion(src.Self().EngineVersion)
+
 	codegenArgs := dagql.ArrayInput[dagql.String]{
 		"generate-module",
 		"--output", dagql.String(goSDKUserModContextDirPath),
 		"--module-source-path", dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 		"--module-name", dagql.String(modName),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
-		"--lib-version", dagql.String(goSDKLibVersion),
+		"--lib-version", dagql.String(libVersion),
 	}
 	if !src.Self().ConfigExists {
 		codegenArgs = append(codegenArgs, "--is-init")


### PR DESCRIPTION
### Summary

- Replace full core type regeneration with type aliases to `dagger.io/dagger` in Go module and standalone client codegen
- Extendable types (`Query`, `Binding`, `Env`) embed their SDK counterparts and only override methods that return other extendable types
- Pin `dagger.io/dagger` lib version for client generation in dev mode so schema stays in sync

### What changed

**Core type aliases**: For both modules (`internal/dagger/dagger.gen.go`) and standalone clients (`dagger.gen.go`), core API types like `Container`, `Directory`, `File`, etc. are now generated as Go type aliases (`type Container = dagger.Container`) instead of full struct + method definitions. This preserves type identity — `mymodule/internal/dagger.Container` IS `dagger.io/dagger.Container`, enabling third-party library interoperability.

**Extendable type wrappers**: `Query`, `Binding`, and `Env` can't be simple aliases because dependency modules add methods to them. Instead, they embed the SDK type (`dagger.Query`) and only generate:
- `WithGraphQLQuery()` / `With()` overrides (to return the wrapper type)
- Methods whose return type is another extendable type (needed because the embedded method returns the SDK type, not the wrapper)
- All other methods (e.g., `Query.Container()`, `Query.Directory()`) are inherited from the embedded SDK type

**`WithGraphQLQuery` instead of struct literals**: In non-library mode, object construction uses `new(T).WithGraphQLQuery(q)` instead of `&T{query: q}`, since aliased types have unexported fields.

**Client lib version pinning**: Standalone client generation now receives the engine's `--lib-version` flag so that dev engines can resolve `dagger.io/dagger` at the correct commit.

Signed-off-by: Tom Chauveau <tom@dagger.io>