### PR TITLE
docs: add Nix installation to official docs

### DIFF
--- a/docs/current_docs/getting-started/installation.mdx
+++ b/docs/current_docs/getting-started/installation.mdx
@@ -17,7 +17,7 @@ runtimes](../reference/container-runtimes/) for more information).
 
 To update the Dagger CLI, use the same method that you originally used to install it. This will overwrite your currently-installed version with the latest (or specified) version.
 
-Homebrew users can alternatively use the following commands:
+Homebrew and Nix users can alternatively use the following commands:
 
 ```shell
 brew update
@@ -36,6 +36,12 @@ Homebrew users can alternatively use the following command:
 
 ```shell
 brew uninstall dagger
+```
+
+Nix users can uninstall using:
+
+```shell
+nix profile remove dagger
 ```
 
 Next, remove the Dagger container using the following commands:

--- a/docs/current_docs/getting-started/installation.mdx
+++ b/docs/current_docs/getting-started/installation.mdx
@@ -41,7 +41,7 @@ brew uninstall dagger
 Nix users can uninstall using:
 
 ```shell
-nix profile remove dagger
+nix profile remove github:dagger/nix#dagger
 ```
 
 Next, remove the Dagger container using the following commands:

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -110,41 +110,13 @@ dagger version
 
 <TabItem value="Nix">
 
-Dagger is available via [Nix](https://nixos.org) in two ways:
+Install Dagger using `nix profile`:
 
-#### Flake (recommended)
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    dagger.url = "github:dagger/nix";
-    dagger.inputs.nixpkgs.follows = "nixpkgs";
-  };
-
-  outputs = { self, nixpkgs, flake-utils, dagger, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-      in {
-        devShells.default = pkgs.mkShell {
-          buildInputs = [ dagger.packages.${system}.dagger ];
-        };
-      });
-}
+```shell
+nix profile install github:dagger/nix#dagger
 ```
 
-#### NUR (Nix User Repository)
-
-```nix
-{
-  nixpkgs.config.allowUnfree = true;
-  packages.dagger = import (builtins.fetchTarball "https://github.com/dagger/nix/archive/main.tar.gz") {};
-}
-```
-
-For more information, see the [dagger/nix GitHub repository](https://github.com/dagger/nix).
+For alternative installation methods, see the [dagger/nix GitHub repository](https://github.com/dagger/nix).
 
 </TabItem>
 </Tabs>

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -107,6 +107,46 @@ dagger version
 ```
 
 </TabItem>
+
+<TabItem value="Nix">
+
+Dagger is available via [Nix](https://nixos.org) in two ways:
+
+#### Flake (recommended)
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    dagger.url = "github:dagger/nix";
+    dagger.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, dagger, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ dagger.packages.${system}.dagger ];
+        };
+      });
+}
+```
+
+#### NUR (Nix User Repository)
+
+```nix
+{
+  nixpkgs.config.allowUnfree = true;
+  packages.dagger = import (builtins.fetchTarball "https://github.com/dagger/nix/archive/main.tar.gz") {};
+}
+```
+
+For more information, see the [dagger/nix GitHub repository](https://github.com/dagger/nix).
+
+</TabItem>
 </Tabs>
 
 ### Development release


### PR DESCRIPTION
Hello, just a pull request to modify the documentation. I found myself in the same situation as the user who opened issue [#35](https://github.com/dagger/nix/issues/35) (in dagger/nix repository), there's no reference to Nix in the official documentation.

I propose adding Nix as a supported installation method in the documentation.

- New "Nix" tab in the stable releases section with Flake and NUR options
- Update and uninstall instructions