### PR TITLE
test(dang): migrate sdk tests upstream

### DIFF
--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -1,0 +1,189 @@
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+type DangSuite struct{}
+
+func TestDang(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(DangSuite{})
+}
+
+func (DangSuite) TestDirectives(_ context.Context, t *testctx.T) {
+	t.Run("positional defaultPath", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-positional-default-path")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "got source")
+	})
+
+	t.Run("named defaultPath", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-named-default-path")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "got source")
+	})
+
+	t.Run("positional ignorePatterns", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-positional-ignore")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "got source")
+	})
+
+	t.Run("named ignorePatterns", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-named-ignore")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "got source")
+	})
+
+	t.Run("mixed syntax", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-mixed-syntax")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "got source")
+	})
+}
+
+func (DangSuite) TestEnums(_ context.Context, t *testctx.T) {
+	t.Run("get status", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-enum").
+			With(daggerCall("get-status", "--status", "COMPLETED")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "COMPLETED")
+	})
+
+	t.Run("is completed true", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-enum").
+			With(daggerCall("is-completed", "--status", "COMPLETED")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "true", strings.TrimSpace(out))
+	})
+
+	t.Run("is completed false", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-enum").
+			With(daggerCall("is-completed", "--status", "PENDING")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "false", strings.TrimSpace(out))
+	})
+
+	t.Run("log level priority", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-enum").
+			With(daggerCall("get-level-priority", "--level", "ERROR")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "3", strings.TrimSpace(out))
+	})
+}
+
+func (DangSuite) TestMismatch(_ context.Context, t *testctx.T) {
+	t.Run("child parent name", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-mismatch").
+			With(daggerCall("--n", "hello", "child", "parent-name")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello", strings.TrimSpace(out))
+	})
+}
+
+func (DangSuite) TestPrivateArg(_ context.Context, t *testctx.T) {
+	t.Run("default private value", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-private-arg").
+			With(daggerCall("display")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "84", strings.TrimSpace(out))
+	})
+
+	t.Run("custom private value", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-private-arg").
+			With(daggerCall("--private", "10", "display")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "20", strings.TrimSpace(out))
+	})
+
+	t.Run("ls with default source", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-private-arg").
+			With(daggerCall("ls")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "main.dang")
+		require.Contains(t, out, "dagger.json")
+	})
+}
+
+func (DangSuite) TestScalars(_ context.Context, t *testctx.T) {
+	t.Run("timestamp", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-scalar").
+			With(daggerCall("get-timestamp", "--ts", "2024-01-01T00:00:00Z")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "2024-01-01")
+	})
+
+	t.Run("url", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-scalar").
+			With(daggerCall("get-url", "--url", "https://example.com")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "example.com")
+	})
+}
+
+func dangModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
+	t.Helper()
+	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/dang", moduleName))
+	require.NoError(t, err)
+
+	return goGitBase(t, c).
+		WithDirectory("testdata/modules/dang/"+moduleName, c.Host().Directory(modSrc)).
+		WithWorkdir("/work/testdata/modules/dang/" + moduleName)
+}

--- a/core/integration/testdata/modules/dang/test-directives/dagger.json
+++ b/core/integration/testdata/modules/dang/test-directives/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-directives",
+  "engineVersion": "v0.20.3",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-directives/main.dang
+++ b/core/integration/testdata/modules/dang/test-directives/main.dang
@@ -1,0 +1,51 @@
+"""
+Test module for directive argument handling in Dagger SDK.
+
+Tests both named and positional argument syntax for directives.
+"""
+type TestDirectives {
+  """
+  Test @defaultPath with positional argument syntax.
+  The source directory defaults to "/" using positional arg.
+  """
+  pub withPositionalDefaultPath(source: Directory! @defaultPath("/")): String! {
+    "got source"
+  }
+
+  """
+  Test @defaultPath with named argument syntax.
+  The source directory defaults to "/" using named arg.
+  """
+  pub withNamedDefaultPath(
+    source: Directory! @defaultPath(path: "/"),
+  ): String! {
+    "got source"
+  }
+
+  """
+  Test @ignorePatterns with positional argument syntax.
+  """
+  pub withPositionalIgnore(
+    source: Directory! @defaultPath("/") @ignorePatterns(["*.tmp", "*.log"]),
+  ): String! {
+    "got source"
+  }
+
+  """
+  Test @ignorePatterns with named argument syntax.
+  """
+  pub withNamedIgnore(
+    source: Directory! @defaultPath(path: "/") @ignorePatterns(patterns: ["*.tmp", "*.log"]),
+  ): String! {
+    "got source"
+  }
+
+  """
+  Test mixing positional and named across multiple directives.
+  """
+  pub withMixedSyntax(
+    source: Directory! @defaultPath("/") @ignorePatterns(patterns: ["*.tmp"]),
+  ): String! {
+    "got source"
+  }
+}

--- a/core/integration/testdata/modules/dang/test-enum/dagger.json
+++ b/core/integration/testdata/modules/dang/test-enum/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-enum",
+  "engineVersion": "v0.20.3",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-enum/main.dang
+++ b/core/integration/testdata/modules/dang/test-enum/main.dang
@@ -1,0 +1,47 @@
+enum Status {
+  PENDING
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+enum LogLevel {
+  DEBUG
+  INFO
+  WARN
+  ERROR
+}
+
+"""
+Test module for enum support in Dagger SDK.
+"""
+type TestEnum {
+  """
+  Returns the status value
+  """
+  pub getStatus(status: Status!): String! {
+    toJSON(status)
+  }
+
+  """
+  Checks if the status is completed
+  """
+  pub isCompleted(status: Status!): Boolean! {
+    status == Status.COMPLETED
+  }
+
+  """
+  Gets log level priority
+  """
+  pub getLevelPriority(level: LogLevel!): Int! {
+    if (level == LogLevel.DEBUG) {
+      0
+    } else if (level == LogLevel.INFO) {
+      1
+    } else if (level == LogLevel.WARN) {
+      2
+    } else {
+      3
+    }
+  }
+}

--- a/core/integration/testdata/modules/dang/test-mismatch/dagger.json
+++ b/core/integration/testdata/modules/dang/test-mismatch/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-mismatch",
+  "engineVersion": "v0.20.3",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-mismatch/main.dang
+++ b/core/integration/testdata/modules/dang/test-mismatch/main.dang
@@ -1,0 +1,29 @@
+# Test constructor arg names that don't match field names
+# when passing typed objects
+
+type TestMismatch {
+  pub name: String!
+
+  new(n: String!) {
+    self.name = n
+    self
+  }
+
+  pub child: Child! {
+    Child(self)
+  }
+}
+
+type Child {
+  pub parent: TestMismatch!
+
+  # Constructor arg is "p" but field is "parent"
+  new(p: TestMismatch!) {
+    self.parent = p
+    self
+  }
+
+  pub parentName: String! {
+    self.parent.name
+  }
+}

--- a/core/integration/testdata/modules/dang/test-private-arg/dagger.json
+++ b/core/integration/testdata/modules/dang/test-private-arg/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-private-arg",
+  "engineVersion": "v0.20.3",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-private-arg/main.dang
+++ b/core/integration/testdata/modules/dang/test-private-arg/main.dang
@@ -1,0 +1,21 @@
+type TestPrivateArg {
+  let private: Int!
+  pub source: Directory!
+
+  new(
+    private: Int! = 42,
+    source: Directory! @defaultPath(path: "."),
+  ) {
+    self.private = private * 2
+    self.source = source
+    self
+  }
+
+  pub display: String! {
+    toString(private)
+  }
+
+  pub ls: [String!]! {
+    source.entries
+  }
+}

--- a/core/integration/testdata/modules/dang/test-scalar/dagger.json
+++ b/core/integration/testdata/modules/dang/test-scalar/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-scalar",
+  "engineVersion": "v0.20.3",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-scalar/main.dang
+++ b/core/integration/testdata/modules/dang/test-scalar/main.dang
@@ -1,0 +1,21 @@
+scalar Timestamp
+scalar URL
+
+"""
+Test module for scalar support in Dagger SDK.
+"""
+type TestScalar {
+  """
+  Returns the timestamp value as a string
+  """
+  pub getTimestamp(ts: Timestamp!): String! {
+    toJSON(ts)
+  }
+
+  """
+  Returns the URL value as a string
+  """
+  pub getURL(url: URL!): String! {
+    toJSON(url)
+  }
+}

--- a/toolchains/test-split/main.dang
+++ b/toolchains/test-split/main.dang
@@ -28,7 +28,7 @@ type TestSplit {
   """
   pub testBase: Void @check {
     testSkip(
-      skip: ["TestProvision", "TestTelemetry", "TestModule", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava", "TestContainer", "TestDockerfile", "TestLLM", "TestCLI", "TestEngine", "TestClientGenerator", "TestInterface", "TestCall", "TestShell", "TestDaggerCMD", "TestWorkspace"],
+      skip: ["TestProvision", "TestTelemetry", "TestModule", "TestDang", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava", "TestContainer", "TestDockerfile", "TestLLM", "TestCLI", "TestEngine", "TestClientGenerator", "TestInterface", "TestCall", "TestShell", "TestDaggerCMD", "TestWorkspace"],
       pkg: "./...",
       race: true,
     )
@@ -94,7 +94,7 @@ type TestSplit {
   Test Module Runtimes
   """
   pub testModuleRuntimes: Void @check {
-    testSpecific(["TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"])
+    testSpecific(["TestDang", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava"])
   }
 
   """


### PR DESCRIPTION
Moving these tests from the Dang repo to Dagger, to cover the native SDK.