### PR TITLE
test(core/integration): add regression test for interactive TUI final render

### DIFF
--- a/core/integration/module_tui_test.go
+++ b/core/integration/module_tui_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// The TUI draws on the terminal's alternate screen; this escape sequence is
+// emitted when it leaves that screen, marking the boundary between frames
+// the user only sees while the command runs and output that stays in their
+// terminal after it exits.
+const exitAltScreen = "\x1b[?1049l"
+
+// TestInteractiveFinalRenderEmitsProgress guards #12936: a failed `dagger
+// call` under an interactive TTY must still leave the progress tree and the
+// failing exec's stderr visible in the user's terminal after the CLI exits.
+// The regression was subtle because the TUI shows both while it's running:
+// only the post-teardown render was empty.
+func (ModuleSuite) TestInteractiveFinalRenderEmitsProgress(ctx context.Context, t *testctx.T) {
+	t.Run("failure renders final progress", func(ctx context.Context, t *testctx.T) {
+		modDir := t.TempDir()
+
+		_, err := hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=progress", "--sdk=go")
+		require.NoError(t, err)
+
+		moduleSrc := fmt.Sprintf(`package main
+
+import (
+	"context"
+	"errors"
+)
+
+type Progress struct{}
+
+func (m *Progress) Fail(ctx context.Context) (string, error) {
+	_, err := dag.Container().
+		From("%[1]s").
+		WithExec([]string{"sh", "-c", "printf tui-final-render && exit 1"}).
+		Sync(ctx)
+	if err == nil {
+		return "", errors.New("expected failure")
+	}
+	return "", err
+}
+`, alpineImage)
+		err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(moduleSrc), 0o644)
+		require.NoError(t, err)
+
+		// Warm the module so the run under test is bounded by the failing
+		// exec, not by codegen/load.
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
+		require.NoError(t, err)
+
+		console, err := newTUIConsole(t, 60*time.Second)
+		require.NoError(t, err)
+		defer console.Close()
+
+		tty := console.Tty()
+		require.NoError(t, pty.Setsize(tty, &pty.Winsize{Rows: 12, Cols: 60}))
+
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "fail")
+		cmd.Stdin = tty
+		cmd.Stdout = tty
+		cmd.Stderr = tty
+
+		require.NoError(t, cmd.Start())
+
+		// The key idea of this test: go-expect reads the pty stream in order
+		// and never rewinds. Once we've matched a piece of output, any later
+		// ExpectString can only match bytes that came *after* it.
+		//
+		// So we first wait for the TUI to leave the alternate screen. After
+		// that point, everything we match is part of what the user still
+		// sees in their terminal after the command has exited: which is
+		// exactly the final render we're trying to protect.
+		//
+		// Doing it this way matters: while the TUI is running it also shows
+		// the failure icon and the "tui-final-render" marker, so if we just
+		// called ExpectString without the alt-screen gate first, the test
+		// would happily pass even when the final render is completely empty
+		// (which is the bug we're guarding against).
+		_, err = console.ExpectString(exitAltScreen)
+		require.NoError(t, err, "TUI never left the alternate screen")
+
+		_, err = console.ExpectString(idtui.IconFailure)
+		require.NoError(t, err, "final render is missing the failure icon")
+
+		_, err = console.ExpectString("tui-final-render")
+		require.NoError(t, err, "final render is missing the failing exec's stderr")
+
+		go console.ExpectEOF()
+
+		err = cmd.Wait()
+		require.Error(t, err, "dagger call fail should exit non-zero")
+	})
+}


### PR DESCRIPTION
Follow-up to #12936: adds an integration test so the final render can't silently disappear again.

### Problem

#12936 fixed a regression introduced by the tuist bump (#12874): on a failed `dagger call` under an interactive TTY, `frontendPretty.FinalRender` was silently dropping everything because `Render()` early-returned on `fe.quitting`. The user was left with an empty terminal after a run.

_The fix landed with no test, which is how the regression slipped in to begin with_: the existing `module_terminal_test.go` coverage only exercises the interactive shell path, not the final render after a call.

### Solution

Add `TestInteractiveFinalRenderEmitsProgress` in `core/integration/module_tui_test.go`.

It runs a real `dagger call` against a failing module through a pty using go-expect (same infra as the existing `TestDaggerTerminal` suite) and asserts that the progress tree and the failing exec's stderr are still visible after the TUI tears down.

The one non-obvious bit: while the TUI is running it *also* shows the failure icon and the stderr marker, so a naive `ExpectString` passes even on the broken code. The test first waits for the alternate-screen exit sequence (`\x1b[?1049l`); because go-expect reads the stream in order and never rewinds, everything matched after that is guaranteed to be post-teardown output — i.e. the actual final render. There's an inline comment explaining this so nobody "simplifies" it later.

### How I verified it

Ran locally against both states of the fix:

```
dagger call engine-dev test \
  --pkg=./core/integration \
  --run '^TestModule/TestInteractiveFinalRenderEmitsProgress$' \
  --test-verbose
```

- With the fix applied (current `main`): PASS in ~1m43s
- With `frontend_pretty.go:1266` reverted to the buggy `fe.backgrounded || fe.quitting`: FAIL with `final render is missing the failure icon` — exactly the regression symptom.