### PR TITLE
core: add asService/asServices to Up/UpGroup schema

### DIFF
--- a/core/integration/testdata/services/hello-with-services/main.go
+++ b/core/integration/testdata/services/hello-with-services/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"dagger/hello-with-services/internal/dagger"
@@ -37,6 +38,71 @@ func (m *HelloWithServices) CurrentEnvServices(ctx context.Context) ([]string, e
 	names := make([]string, 0, len(services))
 	for _, svc := range services {
 		name, err := svc.Name(ctx)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Exercises Up.asService: for each +up service visible from the current
+// environment, converts the Up to a Service via AsService and verifies the
+// resulting Service yields a non-empty hostname. Returns the fully-qualified
+// service names (one per successful conversion) so tests can assert on them.
+func (m *HelloWithServices) CurrentEnvUpAsServiceNames(ctx context.Context) ([]string, error) {
+	ups, err := dag.CurrentEnv().Services().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(ups))
+	for _, up := range ups {
+		hostname, err := up.AsService().Hostname(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("up.asService.hostname: %w", err)
+		}
+		if hostname == "" {
+			return nil, fmt.Errorf("up.asService yielded empty hostname")
+		}
+		name, err := up.Name(ctx)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Exercises UpGroup.asServices: materializes every Up in the current-env
+// UpGroup to a Service in one call and verifies each produces a non-empty
+// hostname. Returns the fully-qualified Up names (fetched in parallel via
+// List) so tests can assert on them. List() and AsServices() must return
+// parallel slices.
+func (m *HelloWithServices) CurrentEnvGroupAsServiceNames(ctx context.Context) ([]string, error) {
+	group := dag.CurrentEnv().Services()
+	ups, err := group.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	services, err := group.AsServices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(ups) != len(services) {
+		return nil, fmt.Errorf("list/asServices length mismatch: %d vs %d", len(ups), len(services))
+	}
+	names := make([]string, 0, len(ups))
+	for i, svc := range services {
+		hostname, err := svc.Hostname(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("upGroup.asServices[%d].hostname: %w", i, err)
+		}
+		if hostname == "" {
+			return nil, fmt.Errorf("upGroup.asServices[%d] yielded empty hostname", i)
+		}
+		name, err := ups[i].Name(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -107,6 +107,44 @@ func (UpSuite) TestUpEnvServices(ctx context.Context, t *testctx.T) {
 	require.Contains(t, out, "infra:database")
 }
 
+func (UpSuite) TestUpAsService(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := upTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-services")
+
+	// Calls a helper that iterates over dag.CurrentEnv().Services().List()
+	// and converts each Up via .AsService().Hostname() — exercising the new
+	// Up.asService schema field. The helper errors out if any hostname is
+	// empty and otherwise returns the service names, which are deterministic.
+	out, err := modGen.
+		With(daggerExec("call", "current-env-up-as-service-names")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "web")
+	require.Contains(t, out, "redis")
+	require.Contains(t, out, "infra:database")
+}
+
+func (UpSuite) TestUpGroupAsServices(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := upTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-services")
+
+	// Calls a helper that invokes dag.CurrentEnv().Services().AsServices()
+	// to materialize the full UpGroup to a []*Service in one call, then
+	// verifies each produces a non-empty hostname — exercising the new
+	// UpGroup.asServices schema field.
+	out, err := modGen.
+		With(daggerExec("call", "current-env-group-as-service-names")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "web")
+	require.Contains(t, out, "redis")
+	require.Contains(t, out, "infra:database")
+}
+
 func (UpSuite) TestUpPortCollision(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen, err := upTestEnv(t, c)

--- a/core/schema/up.go
+++ b/core/schema/up.go
@@ -17,6 +17,8 @@ func (s upSchema) Install(srv *dagql.Server) {
 			Doc("Return a list of individual services and their details"),
 		dagql.Func("run", s.run).
 			Doc("Execute all selected service functions"),
+		dagql.Func("asServices", s.asServices).
+			Doc("Return the Services produced by each selected service function, in the same order as list"),
 	}.Install(srv)
 
 	dagql.Fields[*core.Up]{
@@ -30,6 +32,8 @@ func (s upSchema) Install(srv *dagql.Server) {
 			Doc("The original module in which the service has been defined"),
 		dagql.Func("run", s.runSingleUp).
 			Doc("Execute the service function"),
+		dagql.Func("asService", s.asService).
+			Doc("Return the Service produced by this service function"),
 	}.Install(srv)
 }
 
@@ -59,4 +63,12 @@ func (s upSchema) run(ctx context.Context, parent *core.UpGroup, args struct{}) 
 
 func (s upSchema) runSingleUp(ctx context.Context, parent *core.Up, args struct{}) (*core.Up, error) {
 	return parent.Run(ctx)
+}
+
+func (s upSchema) asService(ctx context.Context, parent *core.Up, args struct{}) (dagql.ObjectResult[*core.Service], error) {
+	return parent.AsService(ctx)
+}
+
+func (s upSchema) asServices(ctx context.Context, parent *core.UpGroup, args struct{}) ([]dagql.ObjectResult[*core.Service], error) {
+	return parent.AsServices(ctx)
 }

--- a/core/up.go
+++ b/core/up.go
@@ -240,3 +240,30 @@ func (u *Up) Run(ctx context.Context) (*Up, error) {
 	<-ctx.Done()
 	return u, nil
 }
+
+// AsService evaluates the underlying +up-tagged module function and returns
+// the Service it produces. The returned ObjectResult carries the dagql ID of
+// the original user function, so downstream calls (hostname, start, up, ...)
+// share cache identity with direct invocations of that function.
+func (u *Up) AsService(ctx context.Context) (dagql.ObjectResult[*Service], error) {
+	var svcResult dagql.ObjectResult[*Service]
+	if err := u.Node.DagqlValue(ctx, &svcResult); err != nil {
+		return svcResult, fmt.Errorf("%q: evaluate service: %w", u.Name(), err)
+	}
+	return svcResult, nil
+}
+
+// AsServices evaluates each Up in the group and returns the Services they
+// produce, in the same order as List(). Fails fast on the first evaluation
+// error.
+func (ug *UpGroup) AsServices(ctx context.Context) ([]dagql.ObjectResult[*Service], error) {
+	services := make([]dagql.ObjectResult[*Service], 0, len(ug.Ups))
+	for _, up := range ug.Ups {
+		svc, err := up.AsService(ctx)
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, svc)
+	}
+	return services, nil
+}


### PR DESCRIPTION
Expose the Service produced by a +up-tagged module function as a new schema field on Up (asService) and a list on UpGroup (asServices). Both reuse ModTreeNode.DagqlValue for evaluation, so the returned Services carry the original user-function dagql ID and share cache identity with direct function invocations.

This lets callers of workspace.services() (and similar APIs that return UpGroup) access the underlying Services directly, without having to run them via Up.run / UpGroup.run.

Integration tests added in UpSuite cover both fields end-to-end via the hello-with-services test module.