### PR TITLE
core(changeset): run git diff with GIT_DIR=/dev/null to skip repo discovery

### DIFF
--- a/core/changeset_git.go
+++ b/core/changeset_git.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -29,8 +30,7 @@ type lineChanges struct {
 // -z uses NUL delimiters so filenames with spaces/newlines are handled correctly.
 func compareDirectories(ctx context.Context, oldDir, newDir string) (fileChanges, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--no-index", "--name-status", "-z", oldDir, newDir)
-	// Avoid inheriting a caller cwd with a broken worktree .git file.
-	cmd.Dir = oldDir
+	disableGitRepoDiscovery(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		// git diff exits 1 when differences exist, which is not an error here.
@@ -45,8 +45,7 @@ func compareDirectories(ctx context.Context, oldDir, newDir string) (fileChanges
 // compareDirectoriesNumStat returns per-file line-change counts between two directories.
 func compareDirectoriesNumStat(ctx context.Context, oldDir, newDir string) (map[string]lineChanges, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--no-index", "--numstat", "-z", oldDir, newDir)
-	// Avoid inheriting a caller cwd with a broken worktree .git file.
-	cmd.Dir = oldDir
+	disableGitRepoDiscovery(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -60,8 +59,7 @@ func compareDirectoriesNumStat(ctx context.Context, oldDir, newDir string) (map[
 // directoriesAreIdentical returns true if both directories have identical content.
 func directoriesAreIdentical(ctx context.Context, dir1, dir2 string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--no-index", "--quiet", dir1, dir2)
-	// Avoid inheriting a caller cwd with a broken worktree .git file.
-	cmd.Dir = dir1
+	disableGitRepoDiscovery(cmd)
 	err := cmd.Run()
 	if err == nil {
 		return true, nil
@@ -71,6 +69,26 @@ func directoriesAreIdentical(ctx context.Context, dir1, dir2 string) (bool, erro
 		return false, nil
 	}
 	return false, err
+}
+
+// disableGitRepoDiscovery prevents git's repository-discovery walk from
+// latching onto a dangling `.git` pointer in cwd or in the mounted source
+// directories.
+//
+// Source directories loaded from a git worktree carry a `.git` FILE at
+// their root — a one-line pointer to an absolute "gitdir:" path on the
+// original host. When buildkit mounts such a ref, that gitdir is
+// unreachable from inside the sandbox, so git bails out with
+// "fatal: not a git repository: <host path>". `--no-index` does not help
+// on its own: git runs repository discovery before it parses flags, so the
+// broken pointer kills the command before --no-index is even considered.
+//
+// Setting GIT_DIR short-circuits discovery entirely — git takes the value
+// verbatim and skips the walk. `git diff --no-index` never actually reads
+// from the git dir, so any sentinel works; /dev/null is a self-documenting
+// "intentionally unusable" choice.
+func disableGitRepoDiscovery(cmd *exec.Cmd) {
+	cmd.Env = append(os.Environ(), "GIT_DIR=/dev/null")
 }
 
 func parseGitOutput(out []byte, oldDir, newDir string) fileChanges {

--- a/core/changeset_git_test.go
+++ b/core/changeset_git_test.go
@@ -231,6 +231,45 @@ func TestCompareDirectories_Integration(t *testing.T) {
 	require.True(t, identical)
 }
 
+// Regression test: the buildkit refs mounted for a Changeset's Before and
+// After can come from a git worktree checkout whose root is a `.git` FILE
+// (a one-line "gitdir:" pointer to an absolute host path). When
+// compareDirectories used to set cmd.Dir = oldDir, git's repository
+// discovery would pick up that pointer and bail out with
+//
+//	fatal: not a git repository: <host path>/.git/worktrees/<name>
+//
+// even though `git diff --no-index` doesn't need a repository at all.
+// This test reproduces that layout and asserts that the diff still
+// succeeds.
+func TestCompareDirectories_OldDirIsBrokenWorktree(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	// Plant a worktree-style .git pointer file at the root of both dirs,
+	// matching what a worktree checkout looks like on disk.
+	brokenPointer := []byte("gitdir: /does/not/exist\n")
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, ".git"), brokenPointer, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, ".git"), brokenPointer, 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "file.txt"), []byte("v1"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, "file.txt"), []byte("v2"), 0644))
+
+	ctx := context.Background()
+
+	changes, err := compareDirectories(ctx, oldDir, newDir)
+	require.NoError(t, err)
+	require.Equal(t, []string{"file.txt"}, changes.Modified)
+
+	stats, err := compareDirectoriesNumStat(ctx, oldDir, newDir)
+	require.NoError(t, err)
+	require.Contains(t, stats, "file.txt")
+
+	identical, err := directoriesAreIdentical(ctx, oldDir, newDir)
+	require.NoError(t, err)
+	require.False(t, identical)
+}
+
 func TestCompareDirectoriesNumStat_Integration(t *testing.T) {
 	oldDir := t.TempDir()
 	newDir := t.TempDir()


### PR DESCRIPTION
compareDirectories and friends set cmd.Dir = oldDir to avoid inheriting
the caller's cwd, with the stated intent of dodging a broken worktree
.git file. That only half-works: the mitigation assumes oldDir itself
is free of any broken .git — but when the mounted buildkit refs come
from a git worktree, every mount has a .git FILE at its root carrying
a host-absolute "gitdir:" path that doesn't exist inside the buildkit
session. Git's repository discovery walks cwd, finds that .git file,
follows the pointer, and bails out with

    fatal: not a git repository: /host/path/.git/worktrees/<name>

--no-index alone does not save us here: git runs repository discovery
before it parses flags, so the broken pointer kills the command before
--no-index is even considered.

Set GIT_DIR=/dev/null on the command env instead. When GIT_DIR is set
explicitly, git short-circuits the discovery walk entirely and uses
that value verbatim. git diff --no-index never actually reads from the
git dir, so any sentinel works; /dev/null is a self-documenting
"intentionally unusable" placeholder. No temp dir, no cleanup.