### PR TITLE
core/schema: don't prefix main workspace module checks

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -69,6 +69,14 @@ func (ChecksSuite) TestChecksDirectSDK(ctx context.Context, t *testctx.T) {
 			require.Contains(t, out, "failing-container")
 			require.Contains(t, out, "test:lint")
 			require.Contains(t, out, "test:unit")
+			// The current module is a main workspace module, so its
+			// checks must appear unprefixed — not "<module-name>:<check>".
+			require.NotContains(t, out, tc.path+":passing-check")
+			require.NotContains(t, out, tc.path+":failing-check")
+			require.NotContains(t, out, tc.path+":passing-container")
+			require.NotContains(t, out, tc.path+":failing-container")
+			require.NotContains(t, out, tc.path+":test:lint")
+			require.NotContains(t, out, tc.path+":test:unit")
 			// run a specific passing check
 			out, err = modGen.
 				With(daggerExec("--progress=report", "check", "passing*")).
@@ -120,6 +128,10 @@ func (ChecksSuite) TestChecksAsBlueprint(ctx context.Context, t *testctx.T) {
 			require.NoError(t, err)
 			require.Contains(t, out, "passing-check")
 			require.Contains(t, out, "failing-check")
+			// A blueprint is a main workspace module, so its checks must
+			// appear unprefixed — not "<blueprint-name>:<check>".
+			require.NotContains(t, out, tc.path+":passing-check")
+			require.NotContains(t, out, tc.path+":failing-check")
 			// run a specific passing check
 			out, err = modGen.
 				With(daggerExec("--progress=report", "check", "passing-check")).

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -135,16 +135,24 @@ func (b *SchemaBuilder) Mods() []Mod {
 	return mods
 }
 
-// PrimaryMods returns only the modules whose constructors should appear
-// on the Query root (i.e. those not installed with SkipConstructor).
-func (b *SchemaBuilder) PrimaryMods() []Mod {
+// PrimaryMods returns the modules whose constructors should appear on
+// the Query root (i.e. those not installed with SkipConstructor), along
+// with the set of names of "main" modules — those whose main-object
+// methods are proxied onto the Query root (i.e. installed with
+// Entrypoint). Toolchain modules are not main modules.
+func (b *SchemaBuilder) PrimaryMods() ([]Mod, map[string]bool) {
 	var mods []Mod
+	proxiedMods := map[string]bool{}
 	for _, e := range b.entries {
-		if !e.opts.SkipConstructor {
-			mods = append(mods, e.mod)
+		if e.opts.SkipConstructor {
+			continue
+		}
+		mods = append(mods, e.mod)
+		if e.opts.Entrypoint {
+			proxiedMods[e.mod.Name()] = true
 		}
 	}
-	return mods
+	return mods, proxiedMods
 }
 
 // Server builds and caches the dagql server for all modules. When any

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -360,7 +360,7 @@ func (s *workspaceSchema) checks(
 	},
 ) (*core.CheckGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, proxiedMods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (s *workspaceSchema) checks(
 		if err != nil {
 			return nil, fmt.Errorf("checks from module %q: %w", mod.Name(), err)
 		}
-		reparentWorkspaceTreeRoot(checkGroup.Node, mod.Name())
+		reparentWorkspaceTreeRoot(checkGroup.Node, mod.Name(), proxiedMods)
 		filtered, err := filterNodesByInclude(
 			ctx,
 			checkGroup.Checks,
@@ -417,7 +417,7 @@ func (s *workspaceSchema) generators(
 	},
 ) (*core.GeneratorGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, proxiedMods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (s *workspaceSchema) generators(
 	var allGenerators []*core.Generator
 	allowSingleModuleCompat := generatorModuleCount == 1
 	for _, entry := range moduleGenerators {
-		reparentWorkspaceTreeRoot(entry.group.Node, entry.mod.Name())
+		reparentWorkspaceTreeRoot(entry.group.Node, entry.mod.Name(), proxiedMods)
 		filtered, err := filterGeneratorsByInclude(
 			ctx,
 			entry.group.Generators,
@@ -472,7 +472,7 @@ func (s *workspaceSchema) services(
 	},
 ) (*core.UpGroup, error) {
 	include := workspaceIncludePatterns(args.Include)
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, proxiedMods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func (s *workspaceSchema) services(
 		if err != nil {
 			return nil, fmt.Errorf("services from module %q: %w", mod.Name(), err)
 		}
-		reparentWorkspaceTreeRoot(upGroup.Node, mod.Name())
+		reparentWorkspaceTreeRoot(upGroup.Node, mod.Name(), proxiedMods)
 		filtered, err := filterNodesByInclude(
 			ctx,
 			upGroup.Ups,
@@ -630,18 +630,25 @@ func matchWorkspaceIncludePath(
 	return false, nil
 }
 
-func currentWorkspacePrimaryModules(ctx context.Context) ([]*core.Module, error) {
+// currentWorkspacePrimaryModules returns the user modules loaded in the
+// current workspace along with the set of "main" module names. Main
+// modules (the workspace root module or a blueprint) expose their
+// checks, generators, and services at the workspace root without a
+// module-name prefix; non-proxied modules (toolchains) are prefixed with
+// their module name.
+func currentWorkspacePrimaryModules(ctx context.Context) ([]*core.Module, map[string]bool, error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	served, err := query.Server.CurrentServedDeps(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("current served deps: %w", err)
+		return nil, nil, fmt.Errorf("current served deps: %w", err)
 	}
 
-	mods := make([]*core.Module, 0, len(served.PrimaryMods()))
-	for _, mod := range served.PrimaryMods() {
+	primary, proxiedMods := served.PrimaryMods()
+	mods := make([]*core.Module, 0, len(primary))
+	for _, mod := range primary {
 		userMod, ok := mod.(*core.Module)
 		if !ok {
 			continue
@@ -651,7 +658,7 @@ func currentWorkspacePrimaryModules(ctx context.Context) ([]*core.Module, error)
 		}
 		mods = append(mods, userMod)
 	}
-	return mods, nil
+	return mods, proxiedMods, nil
 }
 
 // toolchainIgnorePatterns builds a map of toolchain module name → ignore
@@ -713,8 +720,12 @@ func filterNodesByExclude[T any](
 	return filtered, nil
 }
 
-func reparentWorkspaceTreeRoot(root *core.ModTreeNode, modName string) {
-	if root == nil {
+// reparentWorkspaceTreeRoot wraps the module's tree root with a synthetic
+// parent named modName so check/generator/service paths are prefixed with
+// the module name (e.g. "go:lint"). Proxied workspace modules are skipped so
+// their paths remain unprefixed at the workspace root.
+func reparentWorkspaceTreeRoot(root *core.ModTreeNode, modName string, proxiedMods map[string]bool) {
+	if root == nil || proxiedMods[modName] {
 		return
 	}
 	root.Parent = &core.ModTreeNode{}


### PR DESCRIPTION
`reparentWorkspaceTreeRoot` was unconditionally wrapping every primary workspace module's tree root with a synthetic parent named after the module, so every check/generator/service path was rendered as `<module>:<item>` — including the workspace's own root module.

As a result, `dagger check -l` on this repo showed `dagger-dev:generated` instead of just `generated`, contradicting the documented behavior (docs/current_docs/introduction/core-concepts/checks.mdx) where only toolchain items are namespaced. The integration contract is already asserted strictly for toolchains by `TestChecksAsToolchain` but only loosely for main modules by `TestChecksDirectSDK` / `TestChecksAsBlueprint` (via `Contains`, which accepts either form).

Fix: have `SchemaBuilder.PrimaryMods` also return the set of "main" (entrypoint-proxied) module names, and skip the reparent for those modules inside `reparentWorkspaceTreeRoot`. Main modules are the ones installed with `Entrypoint` — the workspace root module or a blueprint — whose main-object methods are proxied onto the Query root. Toolchain modules remain prefixed with their module name.

Also strengthen `TestChecksDirectSDK` and `TestChecksAsBlueprint` with `NotContains` assertions on the prefixed form, so a future regression surfaces immediately.