### PR TITLE
fix(workspace): restore toolchain ignoreGenerators compat

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -221,3 +221,71 @@ func (GeneratorsSuite) TestGeneratorsAsToolchain(ctx context.Context, t *testctx
 		})
 	}
 }
+
+func (GeneratorsSuite) TestToolchainIgnoreGenerators(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen, err := generatorsTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.
+		WithWorkdir("app").
+		With(daggerExec("init")).
+		With(daggerExec("toolchain", "install", "../hello-with-generators"))
+
+	out, err := modGen.
+		With(daggerExec("generate", "-l")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "hello-with-generators:generate-files")
+	require.Contains(t, out, "hello-with-generators:generate-other-files")
+	require.Contains(t, out, "hello-with-generators:other-generators:gen-things")
+
+	modGen = modGen.WithNewFile("dagger.json", `{
+  "name": "app",
+  "engineVersion": "v0.20.5",
+  "toolchains": [
+    {
+      "name": "hello-with-generators",
+      "source": "../hello-with-generators",
+      "ignoreGenerators": [
+        "generate-other-files",
+        "other-generators:*"
+      ]
+    }
+  ]
+}`)
+
+	out, err = modGen.
+		With(daggerExec("generate", "-l")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "hello-with-generators:generate-files")
+	require.NotContains(t, out, "hello-with-generators:generate-other-files")
+	require.NotContains(t, out, "hello-with-generators:other-generators:gen-things")
+
+	modGen = modGen.
+		With(daggerExec("generate", "hello-with-generators:generate-*", "-y", "--progress=plain"))
+	out, err = modGen.
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "hello-with-generators:generate-files")
+	require.NotContains(t, out, "hello-with-generators:generate-other-files")
+
+	exists, err := modGen.Exists(ctx, "foo")
+	require.NoError(t, err)
+	require.True(t, exists)
+	exists, err = modGen.Exists(ctx, "bar")
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	modGen = modGen.
+		With(daggerExec("generate", "hello-with-generators:other-generators:*", "-y", "--progress=plain"))
+	out, err = modGen.
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, out, "hello-with-generators:other-generators:gen-things")
+
+	exists, err = modGen.Exists(ctx, "meta-gen")
+	require.NoError(t, err)
+	require.False(t, exists)
+}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -422,6 +422,10 @@ func (s *workspaceSchema) generators(
 		return nil, err
 	}
 
+	ignoreGenerators := toolchainIgnorePatterns(mods, func(cfg *modules.ModuleConfigDependency) []string {
+		return cfg.IgnoreGenerators
+	})
+
 	moduleGenerators := make([]struct {
 		mod   *core.Module
 		group *core.GeneratorGroup
@@ -456,6 +460,19 @@ func (s *workspaceSchema) generators(
 		)
 		if err != nil {
 			return nil, err
+		}
+		if exclude := ignoreGenerators[entry.mod.Name()]; len(exclude) > 0 {
+			filtered, err = filterNodesByExclude(
+				ctx,
+				filtered,
+				exclude,
+				func(generator *core.Generator) *core.ModTreeNode { return generator.Node },
+				func(generator *core.Generator) string { return generator.Name() },
+				"generator",
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 		allGenerators = append(allGenerators, filtered...)
 	}


### PR DESCRIPTION
Restore toolchain ignoreGenerators support for dagger generate so generators excluded in dagger.json are omitted from dagger generate -l and skipped during generation again, including nested generator patterns. Fixes #12955.