### PR TITLE
fix: require run before reading generator results

### DIFF
--- a/core/generators.go
+++ b/core/generators.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dagger/dagger/util/parallel"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -11,7 +12,7 @@ import (
 type Generator struct {
 	Node      *ModTreeNode `json:"node"`
 	Completed bool         `field:"true" doc:"Whether the generator complete"`
-	Changes   *Changeset   `field:"true" doc:"The generated changeset"`
+	Changes   *Changeset   `json:"changes"`
 }
 
 func (*Generator) Type() *ast.Type {
@@ -50,6 +51,16 @@ func (g *Generator) Run(ctx context.Context) (*Generator, error) {
 	g.Completed = true
 	g.Changes = cs
 	return g, nil
+}
+
+func (g *Generator) RequireChanges(field string) (*Changeset, error) {
+	if !g.Completed {
+		return nil, fmt.Errorf("generator %q must be run before querying %s", g.Name(), field)
+	}
+	if g.Changes == nil {
+		return nil, fmt.Errorf("generator %q did not produce a changeset result", g.Name())
+	}
+	return g.Changes, nil
 }
 
 type GeneratorGroup struct {
@@ -114,12 +125,14 @@ func (gg *GeneratorGroup) Run(ctx context.Context) (*GeneratorGroup, error) {
 
 func (gg *GeneratorGroup) IsEmpty(ctx context.Context) (bool, error) {
 	for _, g := range gg.Generators {
-		if g.Changes != nil {
-			if empty, err := g.Changes.IsEmpty(ctx); err != nil {
-				return false, err
-			} else if !empty {
-				return false, nil
-			}
+		changes, err := g.RequireChanges("isEmpty")
+		if err != nil {
+			return false, err
+		}
+		if empty, err := changes.IsEmpty(ctx); err != nil {
+			return false, err
+		} else if !empty {
+			return false, nil
 		}
 	}
 	return true, nil
@@ -132,7 +145,11 @@ func (gg *GeneratorGroup) Changes(ctx context.Context, conflictStrategy WithChan
 	}
 	cs := make([]*Changeset, 0, len(gg.Generators))
 	for _, g := range gg.Generators {
-		cs = append(cs, g.Changes)
+		changes, err := g.RequireChanges("changes")
+		if err != nil {
+			return nil, err
+		}
+		cs = append(cs, changes)
 	}
 	return res.WithChangesets(ctx, cs, conflictStrategy)
 }

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -289,3 +289,55 @@ func (GeneratorsSuite) TestToolchainIgnoreGenerators(ctx context.Context, t *tes
 	require.NoError(t, err)
 	require.False(t, exists)
 }
+
+func (GeneratorsSuite) TestGeneratorResultFieldsRequireRun(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen, err := generatorsTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-generators")
+
+	t.Run("group isEmpty requires run", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){isEmpty}}}`)).
+			Stdout(ctx)
+		requireErrOut(t, err, "must be run before querying isEmpty")
+	})
+
+	t.Run("group changes requires run", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){changes{isEmpty}}}}`)).
+			Stdout(ctx)
+		requireErrOut(t, err, "must be run before querying changes")
+	})
+
+	t.Run("single generator isEmpty requires run", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){list{isEmpty}}}}`)).
+			Stdout(ctx)
+		requireErrOut(t, err, "must be run before querying isEmpty")
+	})
+
+	t.Run("single generator changes requires run", func(ctx context.Context, t *testctx.T) {
+		_, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){list{changes{isEmpty}}}}}`)).
+			Stdout(ctx)
+		requireErrOut(t, err, "must be run before querying changes")
+	})
+
+	t.Run("group result fields work after run", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){run{isEmpty changes{isEmpty}}}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"generators":{"run":{"isEmpty":false,"changes":{"isEmpty":false}}}}}`, out)
+	})
+
+	t.Run("single generator result fields work after run", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQuery(`{currentWorkspace{generators(include:["generate-files"]){list{run{isEmpty changes{isEmpty}}}}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"generators":{"list":[{"run":{"isEmpty":false,"changes":{"isEmpty":false}}}]}}}`, out)
+	})
+}

--- a/core/schema/generators.go
+++ b/core/schema/generators.go
@@ -20,10 +20,10 @@ func (s generatorsSchema) Install(srv *dagql.Server) {
 			Doc("Execute all selected generators"),
 
 		dagql.NodeFunc("isEmpty", DagOpWrapper(srv, s.groupIsEmpty)).
-			Doc("Whether the generated changeset is empty or not"),
+			Doc("Whether the generated changeset from the last run is empty or not"),
 
 		dagql.NodeFunc("changes", DagOpChangesetWrapper(srv, s.groupChanges)).
-			Doc(`The combined changes from the generators execution`,
+			Doc(`The combined changes from the last run of the generators`,
 				`If any conflict occurs, for instance if the same file is modified by multiple generators,
 				or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.`,
 				`Set 'continueOnConflicts' flag to force to merge the changes in a 'last write wins' strategy.`).
@@ -45,11 +45,14 @@ func (s generatorsSchema) Install(srv *dagql.Server) {
 		dagql.Func("originalModule", s.originalModule).
 			Doc("The original module in which the generator has been defined"),
 
+		dagql.NodeFunc("changes", DagOpChangesetWrapper(srv, s.changes)).
+			Doc("The generated changeset from the last run"),
+
 		dagql.Func("run", s.runSingleGenerator).
 			Doc("Execute the generator"),
 
 		dagql.NodeFunc("isEmpty", s.isEmpty).
-			Doc("Wether changeset from the generator execution is empty or not"),
+			Doc("Whether changeset from the last generator run is empty or not"),
 	}.Install(srv)
 }
 
@@ -96,11 +99,23 @@ func (s generatorsSchema) originalModule(_ context.Context, parent *core.Generat
 	return parent.OriginalModule(), nil
 }
 
+type generatorChangesArgs struct {
+	DagOpInternalArgs
+}
+
+func (s generatorsSchema) changes(ctx context.Context, parent dagql.ObjectResult[*core.Generator], args generatorChangesArgs) (*core.Changeset, error) {
+	return parent.Self().RequireChanges("changes")
+}
+
 func (s generatorsSchema) runSingleGenerator(ctx context.Context, parent *core.Generator, args struct{}) (*core.Generator, error) {
 	return parent.Run(ctx)
 }
 
 func (s generatorsSchema) isEmpty(ctx context.Context, parent dagql.ObjectResult[*core.Generator], args struct{}) (dagql.Boolean, error) {
+	if _, err := parent.Self().RequireChanges("isEmpty"); err != nil {
+		return false, err
+	}
+
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return false, err

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3717,7 +3717,7 @@ The `GeneratedCodeID` scalar type represents an identifier for an object of type
 scalar GeneratedCodeID
 
 type Generator {
-  """The generated changeset"""
+  """The generated changeset from the last run"""
   changes: Changeset!
 
   """Whether the generator complete"""
@@ -3729,7 +3729,7 @@ type Generator {
   """A unique identifier for this Generator."""
   id: GeneratorID!
 
-  """Wether changeset from the generator execution is empty or not"""
+  """Whether changeset from the last generator run is empty or not"""
   isEmpty: Boolean!
 
   """Return the fully qualified name of the generator"""
@@ -3747,7 +3747,7 @@ type Generator {
 
 type GeneratorGroup {
   """
-  The combined changes from the generators execution
+  The combined changes from the last run of the generators
 
   If any conflict occurs, for instance if the same file is modified by multiple
   generators, or if a file is both modified and deleted, an error is raised and
@@ -3763,7 +3763,7 @@ type GeneratorGroup {
   """A unique identifier for this GeneratorGroup."""
   id: GeneratorGroupID!
 
-  """Whether the generated changeset is empty or not"""
+  """Whether the generated changeset from the last run is empty or not"""
   isEmpty: Boolean!
 
   """Return a list of individual generators and their details"""
@@ -6064,5 +6064,3 @@ type Workspace {
 The `WorkspaceID` scalar type represents an identifier for an object of type Workspace.
 """
 scalar WorkspaceID
-
-

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6064,3 +6064,5 @@ type Workspace {
 The `WorkspaceID` scalar type represents an identifier for an object of type Workspace.
 """
 scalar WorkspaceID
+
+

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -12186,7 +12186,7 @@
                     <tbody>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Generator-changes" href="#Generator-changes"><code>changes</code></a> - <span class="property-type"><a href="#definition-Changeset"><code>Changeset!</code></a></span> </td>
-                        <td> The generated changeset </td>
+                        <td> The generated changeset from the last run </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Generator-completed" href="#Generator-completed"><code>completed</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
@@ -12202,7 +12202,7 @@
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Generator-isEmpty" href="#Generator-isEmpty"><code>isEmpty</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
-                        <td> Wether changeset from the generator execution is empty or not </td>
+                        <td> Whether changeset from the last generator run is empty or not </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Generator-name" href="#Generator-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
@@ -12246,7 +12246,7 @@
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="GeneratorGroup-changes" href="#GeneratorGroup-changes"><code>changes</code></a> - <span class="property-type"><a href="#definition-Changeset"><code>Changeset!</code></a></span> </td>
                         <td>
-                          <p>The combined changes from the generators execution</p>
+                          <p>The combined changes from the last run of the generators</p>
                           <p>If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.</p>
                           <p>Set &#39;continueOnConflicts&#39; flag to force to merge the changes in a &#39;last write wins&#39; strategy.</p>
                         </td>
@@ -12270,7 +12270,7 @@
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="GeneratorGroup-isEmpty" href="#GeneratorGroup-isEmpty"><code>isEmpty</code></a> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean!</code></a></span> </td>
-                        <td> Whether the generated changeset is empty or not </td>
+                        <td> Whether the generated changeset from the last run is empty or not </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="GeneratorGroup-list" href="#GeneratorGroup-list"><code>list</code></a> - <span class="property-type"><a href="#definition-Generator"><code>[Generator!]!</code></a></span> </td>

--- a/docs/static/reference/php/Dagger/Generator.html
+++ b/docs/static/reference/php/Dagger/Generator.html
@@ -146,7 +146,7 @@
                 <div class="col-md-8">
                     <a href="#method_changes">changes</a>()
         
-                                            <p><p>The generated changeset</p></p>                </div>
+                                            <p><p>The generated changeset from the last run</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -186,7 +186,7 @@
                 <div class="col-md-8">
                     <a href="#method_isEmpty">isEmpty</a>()
         
-                                            <p><p>Wether changeset from the generator execution is empty or not</p></p>                </div>
+                                            <p><p>Whether changeset from the last generator run is empty or not</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -336,7 +336,7 @@
             
 
         <div class="method-description">
-                            <p><p>The generated changeset</p></p>                        
+                            <p><p>The generated changeset from the last run</p></p>                        
         </div>
         <div class="tags">
             
@@ -464,7 +464,7 @@
             
 
         <div class="method-description">
-                            <p><p>Wether changeset from the generator execution is empty or not</p></p>                        
+                            <p><p>Whether changeset from the last generator run is empty or not</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/GeneratorGroup.html
+++ b/docs/static/reference/php/Dagger/GeneratorGroup.html
@@ -146,7 +146,7 @@
                 <div class="col-md-8">
                     <a href="#method_changes">changes</a>(<abbr title="Dagger\Dagger\ChangesetsMergeConflict">ChangesetsMergeConflict</abbr>|null $onConflict = null)
         
-                                            <p><p>The combined changes from the generators execution</p></p>                </div>
+                                            <p><p>The combined changes from the last run of the generators</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -166,7 +166,7 @@
                 <div class="col-md-8">
                     <a href="#method_isEmpty">isEmpty</a>()
         
-                                            <p><p>Whether the generated changeset is empty or not</p></p>                </div>
+                                            <p><p>Whether the generated changeset from the last run is empty or not</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -296,7 +296,7 @@
             
 
         <div class="method-description">
-                            <p><p>The combined changes from the generators execution</p></p>                <p><p>If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.</p>
+                            <p><p>The combined changes from the last run of the generators</p></p>                <p><p>If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.</p>
 <p>Set 'continueOnConflicts' flag to force to merge the changes in a 'last write wins' strategy.</p></p>        
         </div>
         <div class="tags">
@@ -371,7 +371,7 @@
             
 
         <div class="method-description">
-                            <p><p>Whether the generated changeset is empty or not</p></p>                        
+                            <p><p>Whether the generated changeset from the last run is empty or not</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -333,11 +333,11 @@
 <abbr title="Dagger\GeneratedCode">GeneratedCode</abbr>::code</a>() &mdash; <em>Method in class <a href="Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a></em></dt>
                     <dd><p>The directory containing the generated code.</p></dd><dt><a href="Dagger/Generator.html#method_changes">
 <abbr title="Dagger\Generator">Generator</abbr>::changes</a>() &mdash; <em>Method in class <a href="Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a></em></dt>
-                    <dd><p>The generated changeset</p></dd><dt><a href="Dagger/Generator.html#method_completed">
+                    <dd><p>The generated changeset from the last run</p></dd><dt><a href="Dagger/Generator.html#method_completed">
 <abbr title="Dagger\Generator">Generator</abbr>::completed</a>() &mdash; <em>Method in class <a href="Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a></em></dt>
                     <dd><p>Whether the generator complete</p></dd><dt><a href="Dagger/GeneratorGroup.html#method_changes">
 <abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr>::changes</a>() &mdash; <em>Method in class <a href="Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a></em></dt>
-                    <dd><p>The combined changes from the generators execution</p></dd><dt><a href="Dagger/GitRef.html#method_commit">
+                    <dd><p>The combined changes from the last run of the generators</p></dd><dt><a href="Dagger/GitRef.html#method_commit">
 <abbr title="Dagger\GitRef">GitRef</abbr>::commit</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
                     <dd><p>The resolved commit id at this ref.</p></dd><dt><a href="Dagger/GitRef.html#method_commonAncestor">
 <abbr title="Dagger\GitRef">GitRef</abbr>::commonAncestor</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
@@ -786,11 +786,11 @@
 <abbr title="Dagger\Generator">Generator</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a></em></dt>
                     <dd><p>A unique identifier for this Generator.</p></dd><dt><a href="Dagger/Generator.html#method_isEmpty">
 <abbr title="Dagger\Generator">Generator</abbr>::isEmpty</a>() &mdash; <em>Method in class <a href="Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a></em></dt>
-                    <dd><p>Wether changeset from the generator execution is empty or not</p></dd><dt><a href="Dagger/GeneratorGroup.html#method_id">
+                    <dd><p>Whether changeset from the last generator run is empty or not</p></dd><dt><a href="Dagger/GeneratorGroup.html#method_id">
 <abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a></em></dt>
                     <dd><p>A unique identifier for this GeneratorGroup.</p></dd><dt><a href="Dagger/GeneratorGroup.html#method_isEmpty">
 <abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr>::isEmpty</a>() &mdash; <em>Method in class <a href="Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a></em></dt>
-                    <dd><p>Whether the generated changeset is empty or not</p></dd><dt><a href="Dagger/GitRef.html#method_id">
+                    <dd><p>Whether the generated changeset from the last run is empty or not</p></dd><dt><a href="Dagger/GitRef.html#method_id">
 <abbr title="Dagger\GitRef">GitRef</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
                     <dd><p>A unique identifier for this GitRef.</p></dd><dt><a href="Dagger/GitRepository.html#method_id">
 <abbr title="Dagger\GitRepository">GitRepository</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -4683,7 +4683,7 @@
 			"t": "M",
 			"n": "Dagger\\Generator::changes",
 			"p": "Dagger/Generator.html#method_changes",
-			"d": "<p>The generated changeset</p>"
+			"d": "<p>The generated changeset from the last run</p>"
 		},
 		{
 			"t": "M",
@@ -4707,7 +4707,7 @@
 			"t": "M",
 			"n": "Dagger\\Generator::isEmpty",
 			"p": "Dagger/Generator.html#method_isEmpty",
-			"d": "<p>Wether changeset from the generator execution is empty or not</p>"
+			"d": "<p>Whether changeset from the last generator run is empty or not</p>"
 		},
 		{
 			"t": "M",
@@ -4737,7 +4737,7 @@
 			"t": "M",
 			"n": "Dagger\\GeneratorGroup::changes",
 			"p": "Dagger/GeneratorGroup.html#method_changes",
-			"d": "<p>The combined changes from the generators execution</p>"
+			"d": "<p>The combined changes from the last run of the generators</p>"
 		},
 		{
 			"t": "M",
@@ -4749,7 +4749,7 @@
 			"t": "M",
 			"n": "Dagger\\GeneratorGroup::isEmpty",
 			"p": "Dagger/GeneratorGroup.html#method_isEmpty",
-			"d": "<p>Whether the generated changeset is empty or not</p>"
+			"d": "<p>Whether the generated changeset from the last run is empty or not</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8321,7 +8321,7 @@ func (r *Generator) WithGraphQLQuery(q *querybuilder.Selection) *Generator {
 	}
 }
 
-// The generated changeset
+// The generated changeset from the last run
 func (r *Generator) Changes() *Changeset {
 	q := r.query.Select("changes")
 
@@ -8396,7 +8396,7 @@ func (r *Generator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Wether changeset from the generator execution is empty or not
+// Whether changeset from the last generator run is empty or not
 func (r *Generator) IsEmpty(ctx context.Context) (bool, error) {
 	if r.isEmpty != nil {
 		return *r.isEmpty, nil
@@ -8479,7 +8479,7 @@ type GeneratorGroupChangesOpts struct {
 	OnConflict ChangesetsMergeConflict
 }
 
-// The combined changes from the generators execution
+// The combined changes from the last run of the generators
 //
 // If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.
 //
@@ -8538,7 +8538,7 @@ func (r *GeneratorGroup) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Whether the generated changeset is empty or not
+// Whether the generated changeset from the last run is empty or not
 func (r *GeneratorGroup) IsEmpty(ctx context.Context) (bool, error) {
 	if r.isEmpty != nil {
 		return *r.isEmpty, nil

--- a/sdk/php/generated/Generator.php
+++ b/sdk/php/generated/Generator.php
@@ -11,7 +11,7 @@ namespace Dagger;
 class Generator extends Client\AbstractObject implements Client\IdAble
 {
     /**
-     * The generated changeset
+     * The generated changeset from the last run
      */
     public function changes(): Changeset
     {
@@ -47,7 +47,7 @@ class Generator extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Wether changeset from the generator execution is empty or not
+     * Whether changeset from the last generator run is empty or not
      */
     public function isEmpty(): bool
     {

--- a/sdk/php/generated/GeneratorGroup.php
+++ b/sdk/php/generated/GeneratorGroup.php
@@ -11,7 +11,7 @@ namespace Dagger;
 class GeneratorGroup extends Client\AbstractObject implements Client\IdAble
 {
     /**
-     * The combined changes from the generators execution
+     * The combined changes from the last run of the generators
      *
      * If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.
      *
@@ -36,7 +36,7 @@ class GeneratorGroup extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Whether the generated changeset is empty or not
+     * Whether the generated changeset from the last run is empty or not
      */
     public function isEmpty(): bool
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -8764,7 +8764,7 @@ class GeneratedCode(Type):
 @typecheck
 class Generator(Type):
     def changes(self) -> Changeset:
-        """The generated changeset"""
+        """The generated changeset from the last run"""
         _args: list[Arg] = []
         _ctx = self._select("changes", _args)
         return Changeset(_ctx)
@@ -8834,7 +8834,7 @@ class Generator(Type):
         return await _ctx.execute(GeneratorID)
 
     async def is_empty(self) -> bool:
-        """Wether changeset from the generator execution is empty or not
+        """Whether changeset from the last generator run is empty or not
 
         Returns
         -------
@@ -8922,7 +8922,7 @@ class GeneratorGroup(Type):
         on_conflict: ChangesetsMergeConflict
         | None = ChangesetsMergeConflict.FAIL_EARLY,
     ) -> Changeset:
-        """The combined changes from the generators execution
+        """The combined changes from the last run of the generators
 
         If any conflict occurs, for instance if the same file is modified by
         multiple generators, or if a file is both modified and deleted, an
@@ -8967,7 +8967,7 @@ class GeneratorGroup(Type):
         return await _ctx.execute(GeneratorGroupID)
 
     async def is_empty(self) -> bool:
-        """Whether the generated changeset is empty or not
+        """Whether the generated changeset from the last run is empty or not
 
         Returns
         -------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -10129,7 +10129,7 @@ pub struct Generator {
     pub graphql_client: DynGraphQLClient,
 }
 impl Generator {
-    /// The generated changeset
+    /// The generated changeset from the last run
     pub fn changes(&self) -> Changeset {
         let query = self.selection.select("changes");
         Changeset {
@@ -10153,7 +10153,7 @@ impl Generator {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Wether changeset from the generator execution is empty or not
+    /// Whether changeset from the last generator run is empty or not
     pub async fn is_empty(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("isEmpty");
         query.execute(self.graphql_client.clone()).await
@@ -10200,7 +10200,7 @@ pub struct GeneratorGroupChangesOpts {
     pub on_conflict: Option<ChangesetsMergeConflict>,
 }
 impl GeneratorGroup {
-    /// The combined changes from the generators execution
+    /// The combined changes from the last run of the generators
     /// If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.
     /// Set 'continueOnConflicts' flag to force to merge the changes in a 'last write wins' strategy.
     ///
@@ -10215,7 +10215,7 @@ impl GeneratorGroup {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// The combined changes from the generators execution
+    /// The combined changes from the last run of the generators
     /// If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.
     /// Set 'continueOnConflicts' flag to force to merge the changes in a 'last write wins' strategy.
     ///
@@ -10238,7 +10238,7 @@ impl GeneratorGroup {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Whether the generated changeset is empty or not
+    /// Whether the generated changeset from the last run is empty or not
     pub async fn is_empty(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("isEmpty");
         query.execute(self.graphql_client.clone()).await

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -9139,7 +9139,7 @@ export class Generator extends BaseClient {
   }
 
   /**
-   * The generated changeset
+   * The generated changeset from the last run
    */
   changes = (): Changeset => {
     const ctx = this._ctx.select("changes")
@@ -9177,7 +9177,7 @@ export class Generator extends BaseClient {
   }
 
   /**
-   * Wether changeset from the generator execution is empty or not
+   * Whether changeset from the last generator run is empty or not
    */
   isEmpty = async (): Promise<boolean> => {
     if (this._isEmpty) {
@@ -9273,7 +9273,7 @@ export class GeneratorGroup extends BaseClient {
   }
 
   /**
-   * The combined changes from the generators execution
+   * The combined changes from the last run of the generators
    *
    * If any conflict occurs, for instance if the same file is modified by multiple generators, or if a file is both modified and deleted, an error is raised and the merge of the changesets will failed.
    *
@@ -9293,7 +9293,7 @@ export class GeneratorGroup extends BaseClient {
   }
 
   /**
-   * Whether the generated changeset is empty or not
+   * Whether the generated changeset from the last run is empty or not
    */
   isEmpty = async (): Promise<boolean> => {
     if (this._isEmpty) {


### PR DESCRIPTION
## Summary
- require `run()` before reading generator `changes` or `isEmpty`
- add explicit GraphQL resolvers so pre-run reads fail clearly for single generators and groups
- cover the contract with integration tests and update the schema docs

## Testing
- `dagger --progress=plain call -m ./toolchains/engine-dev test --pkg=./core/integration --run='TestGenerators/TestGeneratorResultFieldsRequireRun' --test-verbose`
- `dagger --progress=plain call -m ./toolchains/engine-dev test --pkg=./core/integration --run='TestGenerators/TestGeneratorsDirectSDK/go/generate_multiple' --test-verbose`

Closes #12956
