### PR TITLE
docs: clarify Dagger Shell POSIX syntax rather than full Bash

### DIFF
--- a/docs/current_docs/introduction/features/shell.mdx
+++ b/docs/current_docs/introduction/features/shell.mdx
@@ -50,12 +50,14 @@ Dagger Shell uses the Bash syntax as a frontend, but its behavior is quite diffe
 - Instead of using the local host as an execution environment, you use containerized runtimes
 - Instead of being mixed with regular commands, shell builtins are prefixed with `.` (similar to SQLite)
 
-Besides these differences, all the features of the Bash syntax are available in Dagger Shell, including:
+Besides these differences, Dagger Shell accepts POSIX shell syntax and supports many familiar shell features, including:
 
 - **Shell variables**: `container=$(container | from alpine)`
 - **Shell functions**: `container() { container | from alpine; }`
 - **Job control**: `frontend | test & backend | test & .wait`
 - **Quoting**: single quotes and double quotes have the same meaning as in Bash
+
+Note that Dagger Shell uses a POSIX-compliant parser under the hood; Bash-specific extensions (such as variable slicing `${X:1}` or the `[` builtin) are not supported.
 
 ## Input modes
 


### PR DESCRIPTION
Hi team! 👋\n\nThis PR addresses the documentation inconsistency raised in #12893.\n\n**Problem**\nThe current shell docs claim that "all the features of the Bash syntax are available in Dagger Shell". However, the underlying parser is configured with `syntax.LangPOSIX` (introduced in #8996), which means Bash-specific extensions like variable slicing or the `[` builtin are not actually supported.\n\n**Change**\n- Replaced the "full Bash" wording with a more accurate description: Dagger Shell accepts POSIX shell syntax and supports many familiar shell features.\n- Added a short note explicitly mentioning that Bash-specific extensions are not supported.\n\nHappy to tweak the wording if you prefer a different tone. Thanks for maintaining such an awesome project! 🙏\n\n---\nCloses #12893