### PR TITLE
fix(elixir-sdk-dev): ensure workspace/root dir is found

### DIFF
--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -176,7 +176,10 @@ type ElixirSdkDev {
   let withBase(src: Directory!): Container! {
     container
       .from(baseImage)
-      .withWorkdir("/sdk/elixir")
+      .withExec(["apk", "add", "git"])
+      .withWorkdir("/src")
+      .withExec(["git", "init"])
+      .withWorkdir("/src/sdk/elixir")
       .withDirectory(".", src)
       .withExec(["mix", "local.hex", "--force"])
       .withExec(["mix", "local.rebar", "--force"])


### PR DESCRIPTION
The elixir-sdk-dev toolchain module is creating a container in which tests will be run.
It ended up with a weird issue where the source directory of the elixir SDK is not found. Instead of looking for `/sdk/elixir` it tries to find `/sdk/elixir/sdk/elixir`.

The path of the directory is relative to the root of the workspace (the root of our git repository). But the way this directory is mounted, the root is not correctly computed (the `contextDirPath`).

The `contextDirPath` is computed that way:
- if we are finding a .git file/dir, then the contextDirPath is the path of the .git parent
- if not, then we use the path to the `dagger.json` the closest

The container was created that way:

    container.from()
      .withWorkdir("/sdk/elixir").withDirectory(".", sourceDir)

As `sdk/elixir` (sourceDir) contains a `dagger.json`, at the time we compute the path we are joining the path to the dagger.json parent and the path we provide, meaning `/sdk/elixir/sdk/elixir`.

The fix is to create a `.git` at the root. Just to avoid to create it at the root `/` of the container, I added a `/src` sub directory.

    container.from()
      .withWorkdir("/src").withExec(["git", "init"])
      .withWorkdir("/src/sdk/elixir").withDirectory(".", sourceDir)

That way, when it's time to compute the path, it will be the parent of the .git + the path. So `/src/sdk/elixir`. What we expect.