### PR TITLE
fix(workspace): preserve subpath for remote workspace directories

### DIFF
--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -30,6 +30,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			DagOpDirectoryWrapper(
 				srv, s.directory,
 				WithHashContentDir[*core.Workspace, workspaceDirectoryArgs](),
+				WithPathFn(workspaceDirectoryDagOpPath),
 			), dagql.CachePerClient).
 			Doc(`Returns a Directory from the workspace.`,
 				`Relative paths resolve from the workspace directory. Absolute paths resolve from the workspace boundary.`).
@@ -267,6 +268,26 @@ func workspaceAPIPath(resolvedPath string) string {
 		return "/"
 	}
 	return "/" + strings.TrimPrefix(clean, "/")
+}
+
+// workspaceDirectoryDagOpPath tells DagOpDirectoryWrapper which path to record
+// as the resulting Directory's Dir.
+//
+// For remote workspaces with no filter, resolveRootfs returns the subpath via
+// Directory.Dir while the LLB still points at the full rootfs; we must carry
+// that subpath through the wrapper so downstream consumers (WithDirectory,
+// Entries, content hashing) see the right view. Local workspaces (which
+// resolve through host.directory) and filtered remote workspaces (which copy
+// via withDirectory) both produce LLB rooted at the requested content, so
+// "/" is correct.
+func workspaceDirectoryDagOpPath(_ context.Context, ws *core.Workspace, args workspaceDirectoryArgs) (string, error) {
+	if ws.HostPath() != "" {
+		return "/", nil
+	}
+	if len(args.Include) > 0 || len(args.Exclude) > 0 {
+		return "/", nil
+	}
+	return workspaceAPIPath(resolveWorkspacePath(args.Path, ws.Path)), nil
 }
 
 type workspaceFindUpArgs struct {

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -107,6 +107,64 @@ func TestWorkspaceAPIPath(t *testing.T) {
 	})
 }
 
+func TestWorkspaceDirectoryDagOpPath(t *testing.T) {
+	ctx := context.Background()
+
+	localWS := func(wsPath string) *core.Workspace {
+		ws := &core.Workspace{Path: wsPath}
+		ws.SetHostPath("/host/workspace")
+		return ws
+	}
+	remoteWS := func(wsPath string) *core.Workspace {
+		return &core.Workspace{Path: wsPath}
+	}
+
+	t.Run("local workspace always reports root", func(t *testing.T) {
+		got, err := workspaceDirectoryDagOpPath(ctx, localWS("."), workspaceDirectoryArgs{Path: "/sub"})
+		require.NoError(t, err)
+		require.Equal(t, "/", got)
+	})
+
+	t.Run("remote workspace with filter reports root", func(t *testing.T) {
+		got, err := workspaceDirectoryDagOpPath(ctx, remoteWS("."), workspaceDirectoryArgs{
+			Path:       "/sub",
+			CopyFilter: core.CopyFilter{Include: []string{"*.go"}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "/", got)
+
+		got, err = workspaceDirectoryDagOpPath(ctx, remoteWS("."), workspaceDirectoryArgs{
+			Path:       "/sub",
+			CopyFilter: core.CopyFilter{Exclude: []string{"node_modules/"}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "/", got)
+	})
+
+	t.Run("remote workspace at boundary root reports root", func(t *testing.T) {
+		got, err := workspaceDirectoryDagOpPath(ctx, remoteWS("."), workspaceDirectoryArgs{Path: "/"})
+		require.NoError(t, err)
+		require.Equal(t, "/", got)
+	})
+
+	// Regression: Workspace.directory on a remote workspace must report the
+	// requested subpath. Reporting "/" (the wrapper default) made the DagOp
+	// evaluate the full rootfs while the outer Directory's Dir stayed at "/",
+	// so consumers like WithDirectory and Entries saw the repo root instead of
+	// the subdirectory the caller asked for.
+	t.Run("remote workspace with absolute subpath reports subpath", func(t *testing.T) {
+		got, err := workspaceDirectoryDagOpPath(ctx, remoteWS("."), workspaceDirectoryArgs{Path: "/helm/dagger"})
+		require.NoError(t, err)
+		require.Equal(t, "/helm/dagger", got)
+	})
+
+	t.Run("remote workspace with relative path resolves from workspace dir", func(t *testing.T) {
+		got, err := workspaceDirectoryDagOpPath(ctx, remoteWS("services/payment"), workspaceDirectoryArgs{Path: "src"})
+		require.NoError(t, err)
+		require.Equal(t, "/services/payment/src", got)
+	})
+}
+
 func modTreeNode(parts ...string) *core.ModTreeNode {
 	parent := &core.ModTreeNode{}
 	for _, part := range parts {


### PR DESCRIPTION
The Workspace.directory DagOp wrapper defaulted its filename to "/", which overrode the Dir on the Directory returned by resolveRootfs. For remote workspaces without filters, resolveRootfs selects the subpath via Directory.directory (which updates Dir but not LLB), so the subpath was lost once the DagOp ran and evaluated the full rootfs LLB. Downstream consumers (WithDirectory, Entries, content hashing) then saw the repo root instead of the requested subdirectory.

Pass a WithPathFn to the wrapper that reports the correct Dir: "/" for local workspaces (host.directory already scopes the LLB) and for filtered remote workspaces (withDirectory copies into a fresh dir), and the resolved subpath for unfiltered remote workspaces.

Fixes #12978 

---

The linked issue #12978 contains a repro, that fails.

```go
package main

import (
	"context"
	"fmt"
	"os"

	"dagger.io/dagger"
)

func main() {
	ctx := context.Background()
	dag, err := dagger.Connect(ctx,
		dagger.WithWorkspace("github.com/dagger/dagger@431e8d248dd0d4755a2c5ebe3638d69c29e7118c"),
		dagger.WithLogOutput(os.Stderr))
	if err != nil {
		panic(err)
	}
	c, err := dag.CurrentWorkspace().Checks(dagger.WorkspaceChecksOpts{Include: []string{"helm:lint"}}).Run().List(ctx)
	if err != nil {
		panic(err)
	}
	fmt.Println(len(c))

	if len(c) > 0 {
		fmt.Println(c[0].Passed(ctx))
	}
}
```

From the current branch, run the same command:

```bash
./hack/dev go run repro/main.go
```

And this time you should have something like:

```
828 : ┆ Container.withExec DONE [0.2s]
828 : ┆ [0.3s] | ==> Linting .
828 : ┆ [0.3s] | [INFO] Chart.yaml: icon is recommended
828 : ┆ [0.3s] |
828 : ┆ [0.3s] | 1 chart(s) linted, 0 chart(s) failed
829 : ┆ Container.withExec DONE [0.2s]
829 : ┆ [0.5s] | ==> Linting .
829 : ┆ [0.5s] | [INFO] Chart.yaml: icon is recommended
829 : ┆ [0.5s] |
829 : ┆ [0.5s] | 1 chart(s) linted, 0 chart(s) failed
1
true <nil>
```