### PR TITLE
fix: make workspace module loading opt-in

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/client.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/client.go.tmpl
@@ -24,6 +24,10 @@ var WithWorkspace = dagger.WithWorkspace
 // WithLogOutput sets the progress writer
 var WithLogOutput = dagger.WithLogOutput
 
+// WithLoadWorkspaceModules opts this client into loading workspace modules
+// based on the working directory when the session is created via the CLI.
+var WithLoadWorkspaceModules = dagger.WithLoadWorkspaceModules
+
 // WithConn sets the engine connection explicitly
 var WithConn = dagger.WithConn
 

--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -48,7 +48,8 @@ Examples:
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params := client.Params{
-			EnableCloudScaleOut: enableScaleOut,
+			EnableCloudScaleOut:  enableScaleOut,
+			LoadWorkspaceModules: true,
 		}
 		return withEngine(
 			cmd.Context(),

--- a/cmd/dagger/function_name.go
+++ b/cmd/dagger/function_name.go
@@ -11,12 +11,12 @@ func initModuleParams(a []string) client.Params {
 		ExecCmd:              a,
 		Function:             functionName(a),
 		EagerRuntime:         eagerRuntime,
-		SkipWorkspaceModules: shouldSkipWorkspaceModules(false),
+		LoadWorkspaceModules: shouldLoadWorkspaceModules(false),
 	}
 }
 
-func shouldSkipWorkspaceModules(disableModuleLoad bool) bool {
-	return disableModuleLoad || moduleNoURL
+func shouldLoadWorkspaceModules(disableModuleLoad bool) bool {
+	return !disableModuleLoad && !moduleNoURL
 }
 
 func functionName(args []string) string {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -186,9 +186,8 @@ func (fc *FuncCommand) Command() *cobra.Command {
 					execArgs = stripHelpArgs(execArgs)
 				}
 
-				coreOnly := shouldSkipWorkspaceModules(fc.DisableModuleLoad)
 				params := initModuleParams(execArgs)
-				params.SkipWorkspaceModules = coreOnly
+				params.LoadWorkspaceModules = shouldLoadWorkspaceModules(fc.DisableModuleLoad)
 
 				return withEngine(c.Context(), params, func(ctx context.Context, engineClient *client.Client) (rerr error) {
 					fc.c = engineClient

--- a/cmd/dagger/generators.go
+++ b/cmd/dagger/generators.go
@@ -42,7 +42,8 @@ Examples:
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params := client.Params{
-			EnableCloudScaleOut: enableScaleOut,
+			EnableCloudScaleOut:  enableScaleOut,
+			LoadWorkspaceModules: true,
 		}
 		return withEngine(
 			cmd.Context(),

--- a/cmd/dagger/mcp.go
+++ b/cmd/dagger/mcp.go
@@ -45,8 +45,9 @@ var mcpCmd = &cobra.Command{
 		ctx := cmd.Context()
 		cmd.SetContext(idtui.WithPrintTraceLink(ctx, true))
 		return withEngine(ctx, client.Params{
-			Stdin:  stdin,
-			Stdout: stdout,
+			Stdin:                stdin,
+			Stdout:               stdout,
+			LoadWorkspaceModules: true,
 		}, mcpStart)
 	},
 	Hidden: true,

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1263,12 +1263,12 @@ func optionalModCmdWrapper(
 	presetSecretToken string,
 ) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, cmdArgs []string) error {
+		_, explicitModRefSet := getExplicitModuleSourceRef()
+
 		return withEngine(cmd.Context(), client.Params{
 			SecretToken:          presetSecretToken,
-			SkipWorkspaceModules: moduleNoURL,
+			LoadWorkspaceModules: !moduleNoURL && !explicitModRefSet,
 		}, func(ctx context.Context, engineClient *client.Client) (err error) {
-			_, explicitModRefSet := getExplicitModuleSourceRef()
-
 			if moduleNoURL {
 				return fn(ctx, engineClient, nil, cmd, cmdArgs)
 			}

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -67,6 +67,7 @@ dagger run python main.py
 
 var waitDelay time.Duration
 var runFocus bool
+var runLoadWorkspaceModules bool
 
 func init() {
 	// don't require -- to disambiguate subcommand flags
@@ -80,6 +81,11 @@ func init() {
 	)
 
 	runCmd.Flags().BoolVar(&runFocus, "focus", false, "Only show output for focused commands.")
+	runCmd.Flags().BoolVar(&runLoadWorkspaceModules, "load-workspace-modules", false, "load workspace modules")
+	if err := runCmd.Flags().MarkHidden("load-workspace-modules"); err != nil {
+		fmt.Fprintln(stderr, "Error hiding flag: load-workspace-modules", err)
+		os.Exit(1)
+	}
 }
 
 func Run(cmd *cobra.Command, args []string) error {
@@ -121,7 +127,8 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	return withEngine(ctx, client.Params{
-		SecretToken: sessionToken,
+		SecretToken:          sessionToken,
+		LoadWorkspaceModules: runLoadWorkspaceModules,
 	}, func(ctx context.Context, engineClient *client.Client) error {
 		sessionL, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -23,6 +23,7 @@ import (
 var (
 	sessionLabels               = enginetel.NewLabelFlag()
 	sessionVersion              string
+	sessionLoadWorkspaceModules bool
 	sessionSkipWorkspaceModules bool
 	sessionWorkspace            string
 )
@@ -40,6 +41,7 @@ func sessionCmd() *cobra.Command {
 	// We don't want SDKs failing because this flag is not defined.
 	cmd.Flags().Var(&sessionLabels, "label", "label that identifies the source of this session (e.g, --label 'dagger.io/sdk.name:python' --label 'dagger.io/sdk.version:0.5.2' --label 'dagger.io/sdk.async:true')")
 	cmd.Flags().StringVarP(&sessionWorkspace, "workspace", "W", "", "select the workspace to load")
+	cmd.Flags().BoolVar(&sessionLoadWorkspaceModules, "load-workspace-modules", false, "load workspace modules")
 	cmd.Flags().BoolVar(&sessionSkipWorkspaceModules, "skip-workspace-modules", false, "skip loading workspace modules")
 	return cmd
 }
@@ -85,7 +87,12 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 
 	port := l.Addr().(*net.TCPAddr).Port
 
-	return withEngine(ctx, sessionClientParams(sessionToken.String()), func(ctx context.Context, sess *client.Client) error {
+	params, err := sessionClientParams(sessionToken.String())
+	if err != nil {
+		return err
+	}
+
+	return withEngine(ctx, params, func(ctx context.Context, sess *client.Client) error {
 		// Requests maintain their original trace context from the client, rather
 		// than appearing beneath the dagger session span, so in order to see any
 		// logs we need to reveal everything.
@@ -123,14 +130,18 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func sessionClientParams(secretToken string) client.Params {
+func sessionClientParams(secretToken string) (client.Params, error) {
+	if sessionLoadWorkspaceModules && sessionSkipWorkspaceModules {
+		return client.Params{}, fmt.Errorf("--load-workspace-modules and --skip-workspace-modules are mutually exclusive")
+	}
+
 	params := client.Params{
 		SecretToken:          secretToken,
 		Version:              sessionVersion,
-		SkipWorkspaceModules: sessionSkipWorkspaceModules,
+		LoadWorkspaceModules: sessionLoadWorkspaceModules,
 	}
 	if sessionWorkspace != "" {
 		params.Workspace = &sessionWorkspace
 	}
-	return params
+	return params, nil
 }

--- a/cmd/dagger/session_test.go
+++ b/cmd/dagger/session_test.go
@@ -21,22 +21,40 @@ func TestSessionCmdWorkspaceFlag(t *testing.T) {
 func TestSessionClientParamsWorkspace(t *testing.T) {
 	oldWorkspace := sessionWorkspace
 	oldVersion := sessionVersion
+	oldLoad := sessionLoadWorkspaceModules
 	oldSkip := sessionSkipWorkspaceModules
 	t.Cleanup(func() {
 		sessionWorkspace = oldWorkspace
 		sessionVersion = oldVersion
+		sessionLoadWorkspaceModules = oldLoad
 		sessionSkipWorkspaceModules = oldSkip
 	})
 
 	sessionWorkspace = "github.com/acme/ws"
 	sessionVersion = "v1.2.3"
-	sessionSkipWorkspaceModules = true
+	sessionLoadWorkspaceModules = true
 
-	params := sessionClientParams("secret")
+	params, err := sessionClientParams("secret")
+	require.NoError(t, err)
 
 	require.Equal(t, "secret", params.SecretToken)
 	require.Equal(t, "v1.2.3", params.Version)
-	require.True(t, params.SkipWorkspaceModules)
+	require.True(t, params.LoadWorkspaceModules)
 	require.NotNil(t, params.Workspace)
 	require.Equal(t, "github.com/acme/ws", *params.Workspace)
+}
+
+func TestSessionClientParamsRejectConflictingWorkspaceModuleFlags(t *testing.T) {
+	oldLoad := sessionLoadWorkspaceModules
+	oldSkip := sessionSkipWorkspaceModules
+	t.Cleanup(func() {
+		sessionLoadWorkspaceModules = oldLoad
+		sessionSkipWorkspaceModules = oldSkip
+	})
+
+	sessionLoadWorkspaceModules = true
+	sessionSkipWorkspaceModules = true
+
+	_, err := sessionClientParams("secret")
+	require.ErrorContains(t, err, "mutually exclusive")
 }

--- a/cmd/dagger/up.go
+++ b/cmd/dagger/up.go
@@ -41,7 +41,9 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return withEngine(
 			cmd.Context(),
-			client.Params{},
+			client.Params{
+				LoadWorkspaceModules: true,
+			},
 			func(ctx context.Context, engineClient *client.Client) error {
 				dag := engineClient.Dagger()
 				ws := dag.CurrentWorkspace()

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -394,6 +394,7 @@ main()
 			generator string
 			callCmd   []string
 			setup     dagger.WithContainerFunc
+			runSetup  dagger.WithContainerFunc
 			postSetup dagger.WithContainerFunc
 		}
 
@@ -427,9 +428,36 @@ import (
 func main() {
   ctx := context.Background()
 
-  dag, err := dagger.Connect(ctx)
+  dag, err := dagger.Connect(ctx, dagger.WithLoadWorkspaceModules())
+  if err != nil {
+    panic(fmt.Errorf("connect: %w", err))
+  }
+
+  res, err := dag.Hello(ctx)
   if err != nil {
     panic(err)
+  }
+
+  fmt.Println("result:", res)
+}
+		`))
+				},
+				runSetup: func(ctr *dagger.Container) *dagger.Container {
+					return ctr.With(withGoSetup(`package main
+
+import (
+  "context"
+  "fmt"
+
+  "test.com/test/dagger"
+)
+
+func main() {
+  ctx := context.Background()
+
+  dag, err := dagger.Connect(ctx)
+  if err != nil {
+    panic(fmt.Errorf("connect: %w", err))
   }
 
   res, err := dag.Hello(ctx)
@@ -460,6 +488,20 @@ export class Test {
 }
 				`).
 						With(withTypeScriptSetup(`import { connection, dag } from "@my-app/dagger"
+
+async function main() {
+  await connection(async () => {
+    const res = await dag.hello()
+
+    console.log("result:", res)
+  }, { LoadWorkspaceModules: true })
+}
+
+main()
+`, defaultGenDir))
+				},
+				runSetup: func(ctr *dagger.Container) *dagger.Container {
+					return ctr.With(withTypeScriptSetup(`import { connection, dag } from "@my-app/dagger"
 
 async function main() {
   await connection(async () => {
@@ -500,7 +542,7 @@ main()
 				moduleSrc = moduleSrc.With(tc.postSetup)
 
 				t.Run(fmt.Sprintf("dagger run %s", strings.Join(tc.callCmd, " ")), func(ctx context.Context, t *testctx.T) {
-					out, err := moduleSrc.With(daggerNonNestedRun(tc.callCmd...)).
+					out, err := moduleSrc.With(tc.runSetup).With(daggerNonNestedRunWithWorkspaceModules(tc.callCmd...)).
 						Stdout(ctx)
 
 					require.NoError(t, err)
@@ -783,7 +825,7 @@ main()
 				}
 
 				out, err := regeneratedSrc.
-					With(daggerNonNestedRun(tc.callCmd...)).
+					With(daggerNonNestedRunWithWorkspaceModules(tc.callCmd...)).
 					Stdout(ctx)
 
 				require.NoError(t, err)
@@ -1817,7 +1859,7 @@ func main() {
 
 	dag, err := dagger.Connect(ctx)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("connect: %w", err))
 	}
 
 	res, err := dag.With(dagger.WithOpts{Greeting: "hi"}).Message(ctx)
@@ -1833,7 +1875,7 @@ func main() {
 		With(addSDKReplaceToClient(defaultGenDir)).
 		WithExec([]string{"go", "mod", "tidy"})
 
-	out, err := moduleSrc.With(daggerNonNestedRun("go", "run", "./cmd/main.go")).Stdout(ctx)
+	out, err := moduleSrc.With(daggerNonNestedRunWithWorkspaceModules("go", "run", "./cmd/main.go")).Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "result: hi, world!")
 }

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -501,7 +501,7 @@ main()
 `, defaultGenDir))
 				},
 				runSetup: func(ctr *dagger.Container) *dagger.Container {
-					return ctr.With(withTypeScriptSetup(`import { connection, dag } from "@my-app/dagger"
+					return ctr.WithNewFile("index.ts", `import { connection, dag } from "@my-app/dagger"
 
 async function main() {
   await connection(async () => {
@@ -512,7 +512,7 @@ async function main() {
 }
 
 main()
-`, defaultGenDir))
+`)
 				},
 				postSetup: func(ctr *dagger.Container) *dagger.Container {
 					return ctr.

--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -443,7 +443,7 @@ func main() {
 		`))
 				},
 				runSetup: func(ctr *dagger.Container) *dagger.Container {
-					return ctr.With(withGoSetup(`package main
+					return ctr.WithNewFile("main.go", `package main
 
 import (
   "context"
@@ -467,7 +467,7 @@ func main() {
 
   fmt.Println("result:", res)
 }
-		`))
+		`)
 				},
 				postSetup: addSDKReplaceToClient(defaultGenDir),
 			},

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -8117,6 +8117,12 @@ func daggerNonNestedRun(args ...string) dagger.WithContainerFunc {
 	return daggerNonNestedExec(args...)
 }
 
+func daggerNonNestedRunWithWorkspaceModules(args ...string) dagger.WithContainerFunc {
+	args = append([]string{"run", "--load-workspace-modules"}, args...)
+
+	return daggerNonNestedExec(args...)
+}
+
 func daggerClientInstall(generator string) dagger.WithContainerFunc {
 	return daggerExec("client", "install", generator)
 }

--- a/docs/static/reference/php/Dagger/Binding.html
+++ b/docs/static/reference/php/Dagger/Binding.html
@@ -341,16 +341,6 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_asPhpSdk">asPhpSdk</a>()
-        
-                                            <p><p>Retrieve the binding value, as type PhpSdk</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
                     <a href="../Dagger/SearchResult.html"><abbr title="Dagger\SearchResult">SearchResult</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -1235,40 +1225,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_asPhpSdk">
-        <div class="location">at line 196</div>
-        <code>                    <a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a>
-    <strong>asPhpSdk</strong>()
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Retrieve the binding value, as type PhpSdk</p></p>                        
-        </div>
-        <div class="tags">
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_asSearchResult">
-        <div class="location">at line 205</div>
+        <div class="location">at line 196</div>
         <code>                    <a href="../Dagger/SearchResult.html"><abbr title="Dagger\SearchResult">SearchResult</abbr></a>
     <strong>asSearchResult</strong>()
         </code>
@@ -1300,7 +1258,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asSearchSubmatch">
-        <div class="location">at line 214</div>
+        <div class="location">at line 205</div>
         <code>                    <a href="../Dagger/SearchSubmatch.html"><abbr title="Dagger\SearchSubmatch">SearchSubmatch</abbr></a>
     <strong>asSearchSubmatch</strong>()
         </code>
@@ -1332,7 +1290,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asSecret">
-        <div class="location">at line 223</div>
+        <div class="location">at line 214</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>asSecret</strong>()
         </code>
@@ -1364,7 +1322,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asService">
-        <div class="location">at line 232</div>
+        <div class="location">at line 223</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>asService</strong>()
         </code>
@@ -1396,7 +1354,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asSocket">
-        <div class="location">at line 241</div>
+        <div class="location">at line 232</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>asSocket</strong>()
         </code>
@@ -1428,7 +1386,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asStat">
-        <div class="location">at line 250</div>
+        <div class="location">at line 241</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>asStat</strong>()
         </code>
@@ -1460,7 +1418,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asString">
-        <div class="location">at line 259</div>
+        <div class="location">at line 250</div>
         <code>                    string
     <strong>asString</strong>()
         </code>
@@ -1492,7 +1450,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asUp">
-        <div class="location">at line 268</div>
+        <div class="location">at line 259</div>
         <code>                    <a href="../Dagger/Up.html"><abbr title="Dagger\Up">Up</abbr></a>
     <strong>asUp</strong>()
         </code>
@@ -1524,7 +1482,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asUpGroup">
-        <div class="location">at line 277</div>
+        <div class="location">at line 268</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>asUpGroup</strong>()
         </code>
@@ -1556,7 +1514,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asWorkspace">
-        <div class="location">at line 286</div>
+        <div class="location">at line 277</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>asWorkspace</strong>()
         </code>
@@ -1588,7 +1546,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_digest">
-        <div class="location">at line 295</div>
+        <div class="location">at line 286</div>
         <code>                    string
     <strong>digest</strong>()
         </code>
@@ -1620,7 +1578,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 304</div>
+        <div class="location">at line 295</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1652,7 +1610,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_isNull">
-        <div class="location">at line 313</div>
+        <div class="location">at line 304</div>
         <code>                    bool
     <strong>isNull</strong>()
         </code>
@@ -1684,7 +1642,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 322</div>
+        <div class="location">at line 313</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -1716,7 +1674,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeName">
-        <div class="location">at line 331</div>
+        <div class="location">at line 322</div>
         <code>                    string
     <strong>typeName</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Client.html
+++ b/docs/static/reference/php/Dagger/Client.html
@@ -205,28 +205,6 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_codegen">codegen</a>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        
-                                            <p class="no-description">No description</p>
-                                    </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_codegenBase">codegenBase</a>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        
-                                            <p class="no-description">No description</p>
-                                    </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -897,16 +875,6 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_loadPhpSdkFromID">loadPhpSdkFromID</a>(<abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr> $id)
-        
-                                            <p><p>Load a PhpSdk from its ID.</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
                     <a href="../Dagger/Port.html"><abbr title="Dagger\Port">Port</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -1077,17 +1045,6 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_moduleRuntime">moduleRuntime</a>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        
-                                            <p class="no-description">No description</p>
-                                    </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
                     <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -1118,17 +1075,6 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_sourceDir">sourceDir</a>()
-        
-                                            <p class="no-description">No description</p>
-                                    </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
                     <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -1155,16 +1101,6 @@
                     <a href="#method_version">version</a>()
         
                                             <p><p>Get the current Dagger Engine version.</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_with">with</a>(<abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $sdkSourceDir = null)
-        
-                                            <p><p>Configure the php-sdk constructor arguments.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
             </div>
@@ -1455,104 +1391,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_codegen">
-        <div class="location">at line 54</div>
-        <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
-    <strong>codegen</strong>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p class="no-description">No description</p>
-                    
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td><abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr></td>
-                <td>$modSource</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><abbr title="Dagger\FileId|Dagger\File">File</abbr></td>
-                <td>$introspectionJson</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
-                    <h3 id="method_codegenBase">
-        <div class="location">at line 62</div>
-        <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>codegenBase</strong>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p class="no-description">No description</p>
-                    
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td><abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr></td>
-                <td>$modSource</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><abbr title="Dagger\FileId|Dagger\File">File</abbr></td>
-                <td>$introspectionJson</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_container">
-        <div class="location">at line 75</div>
+        <div class="location">at line 59</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>container</strong>(<abbr title="Dagger\Dagger\Platform">Platform</abbr>|null $platform = null)
         </code>
@@ -1594,7 +1434,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentEnv">
-        <div class="location">at line 91</div>
+        <div class="location">at line 75</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>currentEnv</strong>()
         </code>
@@ -1627,7 +1467,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentFunctionCall">
-        <div class="location">at line 102</div>
+        <div class="location">at line 86</div>
         <code>                    <a href="../Dagger/FunctionCall.html"><abbr title="Dagger\FunctionCall">FunctionCall</abbr></a>
     <strong>currentFunctionCall</strong>()
         </code>
@@ -1659,7 +1499,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentModule">
-        <div class="location">at line 111</div>
+        <div class="location">at line 95</div>
         <code>                    <a href="../Dagger/CurrentModule.html"><abbr title="Dagger\CurrentModule">CurrentModule</abbr></a>
     <strong>currentModule</strong>()
         </code>
@@ -1691,7 +1531,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentTypeDefs">
-        <div class="location">at line 120</div>
+        <div class="location">at line 104</div>
         <code>                    array
     <strong>currentTypeDefs</strong>(bool|null $hideCore = null)
         </code>
@@ -1733,7 +1573,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentWorkspace">
-        <div class="location">at line 132</div>
+        <div class="location">at line 116</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>currentWorkspace</strong>()
         </code>
@@ -1765,7 +1605,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_defaultPlatform">
-        <div class="location">at line 141</div>
+        <div class="location">at line 125</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>defaultPlatform</strong>()
         </code>
@@ -1797,7 +1637,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 150</div>
+        <div class="location">at line 134</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>()
         </code>
@@ -1829,7 +1669,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_engine">
-        <div class="location">at line 159</div>
+        <div class="location">at line 143</div>
         <code>                    <a href="../Dagger/Engine.html"><abbr title="Dagger\Engine">Engine</abbr></a>
     <strong>engine</strong>()
         </code>
@@ -1861,7 +1701,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_env">
-        <div class="location">at line 168</div>
+        <div class="location">at line 152</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>env</strong>(bool|null $privileged = false, bool|null $writable = false)
         </code>
@@ -1908,7 +1748,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envFile">
-        <div class="location">at line 183</div>
+        <div class="location">at line 167</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>envFile</strong>(bool|null $expand = null)
         </code>
@@ -1950,7 +1790,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_error">
-        <div class="location">at line 195</div>
+        <div class="location">at line 179</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>error</strong>(string $message)
         </code>
@@ -1992,7 +1832,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 205</div>
+        <div class="location">at line 189</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $name, string $contents, int|null $permissions = 420)
         </code>
@@ -2044,7 +1884,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_function">
-        <div class="location">at line 219</div>
+        <div class="location">at line 203</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>function</strong>(string $name, <abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $returnType)
         </code>
@@ -2091,7 +1931,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedCode">
-        <div class="location">at line 230</div>
+        <div class="location">at line 214</div>
         <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
     <strong>generatedCode</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $code)
         </code>
@@ -2133,7 +1973,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 240</div>
+        <div class="location">at line 224</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>git</strong>(string $url, bool|null $keepGitDir = true, string|null $sshKnownHosts = &#039;&#039;, <abbr title="Dagger\Dagger\SocketId|Dagger\Socket|null">Socket|null</abbr> $sshAuthSocket = null, string|null $httpAuthUsername = &#039;&#039;, <abbr title="Dagger\Dagger\SecretId|Dagger\Secret|null">Secret|null</abbr> $httpAuthToken = null, <abbr title="Dagger\Dagger\SecretId|Dagger\Secret|null">Secret|null</abbr> $httpAuthHeader = null, <abbr title="Dagger\Dagger\ServiceId|Dagger\Service|null">Service|null</abbr> $experimentalServiceHost = null)
         </code>
@@ -2210,7 +2050,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_host">
-        <div class="location">at line 279</div>
+        <div class="location">at line 263</div>
         <code>                    <a href="../Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a>
     <strong>host</strong>()
         </code>
@@ -2242,7 +2082,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_http">
-        <div class="location">at line 288</div>
+        <div class="location">at line 272</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>http</strong>(string $url, string|null $name = null, int|null $permissions = null, <abbr title="Dagger\Dagger\SecretId|Dagger\Secret|null">Secret|null</abbr> $authHeader = null, <abbr title="Dagger\Dagger\ServiceId|Dagger\Service|null">Service|null</abbr> $experimentalServiceHost = null)
         </code>
@@ -2304,7 +2144,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 315</div>
+        <div class="location">at line 299</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
@@ -2336,7 +2176,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_json">
-        <div class="location">at line 324</div>
+        <div class="location">at line 308</div>
         <code>                    <a href="../Dagger/JsonValue.html"><abbr title="Dagger\JsonValue">JsonValue</abbr></a>
     <strong>json</strong>()
         </code>
@@ -2368,7 +2208,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_llm">
-        <div class="location">at line 333</div>
+        <div class="location">at line 317</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>llm</strong>(string|null $model = null, int|null $maxAPICalls = null)
         </code>
@@ -2415,7 +2255,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadAddressFromID">
-        <div class="location">at line 348</div>
+        <div class="location">at line 332</div>
         <code>                    <a href="../Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a>
     <strong>loadAddressFromID</strong>(<abbr title="Dagger\AddressId|Dagger\Address">Address</abbr> $id)
         </code>
@@ -2457,7 +2297,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadBindingFromID">
-        <div class="location">at line 358</div>
+        <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>loadBindingFromID</strong>(<abbr title="Dagger\BindingId|Dagger\Binding">Binding</abbr> $id)
         </code>
@@ -2499,7 +2339,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCacheVolumeFromID">
-        <div class="location">at line 368</div>
+        <div class="location">at line 352</div>
         <code>                    <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a>
     <strong>loadCacheVolumeFromID</strong>(<abbr title="Dagger\CacheVolumeId|Dagger\CacheVolume">CacheVolume</abbr> $id)
         </code>
@@ -2541,7 +2381,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadChangesetFromID">
-        <div class="location">at line 378</div>
+        <div class="location">at line 362</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>loadChangesetFromID</strong>(<abbr title="Dagger\ChangesetId|Dagger\Changeset">Changeset</abbr> $id)
         </code>
@@ -2583,7 +2423,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCheckFromID">
-        <div class="location">at line 388</div>
+        <div class="location">at line 372</div>
         <code>                    <a href="../Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a>
     <strong>loadCheckFromID</strong>(<abbr title="Dagger\CheckId|Dagger\Check">Check</abbr> $id)
         </code>
@@ -2625,7 +2465,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCheckGroupFromID">
-        <div class="location">at line 398</div>
+        <div class="location">at line 382</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
     <strong>loadCheckGroupFromID</strong>(<abbr title="Dagger\CheckGroupId|Dagger\CheckGroup">CheckGroup</abbr> $id)
         </code>
@@ -2667,7 +2507,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCloudFromID">
-        <div class="location">at line 408</div>
+        <div class="location">at line 392</div>
         <code>                    <a href="../Dagger/Cloud.html"><abbr title="Dagger\Cloud">Cloud</abbr></a>
     <strong>loadCloudFromID</strong>(<abbr title="Dagger\CloudId|Dagger\Cloud">Cloud</abbr> $id)
         </code>
@@ -2709,7 +2549,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadContainerFromID">
-        <div class="location">at line 418</div>
+        <div class="location">at line 402</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>loadContainerFromID</strong>(<abbr title="Dagger\ContainerId|Dagger\Container">Container</abbr> $id)
         </code>
@@ -2751,7 +2591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCurrentModuleFromID">
-        <div class="location">at line 428</div>
+        <div class="location">at line 412</div>
         <code>                    <a href="../Dagger/CurrentModule.html"><abbr title="Dagger\CurrentModule">CurrentModule</abbr></a>
     <strong>loadCurrentModuleFromID</strong>(<abbr title="Dagger\CurrentModuleId|Dagger\CurrentModule">CurrentModule</abbr> $id)
         </code>
@@ -2793,7 +2633,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadDiffStatFromID">
-        <div class="location">at line 438</div>
+        <div class="location">at line 422</div>
         <code>                    <a href="../Dagger/DiffStat.html"><abbr title="Dagger\DiffStat">DiffStat</abbr></a>
     <strong>loadDiffStatFromID</strong>(<abbr title="Dagger\DiffStatId|Dagger\DiffStat">DiffStat</abbr> $id)
         </code>
@@ -2835,7 +2675,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadDirectoryFromID">
-        <div class="location">at line 448</div>
+        <div class="location">at line 432</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>loadDirectoryFromID</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $id)
         </code>
@@ -2877,7 +2717,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheEntryFromID">
-        <div class="location">at line 458</div>
+        <div class="location">at line 442</div>
         <code>                    <a href="../Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a>
     <strong>loadEngineCacheEntryFromID</strong>(<abbr title="Dagger\EngineCacheEntryId|Dagger\EngineCacheEntry">EngineCacheEntry</abbr> $id)
         </code>
@@ -2919,7 +2759,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheEntrySetFromID">
-        <div class="location">at line 468</div>
+        <div class="location">at line 452</div>
         <code>                    <a href="../Dagger/EngineCacheEntrySet.html"><abbr title="Dagger\EngineCacheEntrySet">EngineCacheEntrySet</abbr></a>
     <strong>loadEngineCacheEntrySetFromID</strong>(<abbr title="Dagger\EngineCacheEntrySetId|Dagger\EngineCacheEntrySet">EngineCacheEntrySet</abbr> $id)
         </code>
@@ -2961,7 +2801,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheFromID">
-        <div class="location">at line 478</div>
+        <div class="location">at line 462</div>
         <code>                    <a href="../Dagger/EngineCache.html"><abbr title="Dagger\EngineCache">EngineCache</abbr></a>
     <strong>loadEngineCacheFromID</strong>(<abbr title="Dagger\EngineCacheId|Dagger\EngineCache">EngineCache</abbr> $id)
         </code>
@@ -3003,7 +2843,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineFromID">
-        <div class="location">at line 488</div>
+        <div class="location">at line 472</div>
         <code>                    <a href="../Dagger/Engine.html"><abbr title="Dagger\Engine">Engine</abbr></a>
     <strong>loadEngineFromID</strong>(<abbr title="Dagger\EngineId|Dagger\Engine">Engine</abbr> $id)
         </code>
@@ -3045,7 +2885,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnumTypeDefFromID">
-        <div class="location">at line 498</div>
+        <div class="location">at line 482</div>
         <code>                    <a href="../Dagger/EnumTypeDef.html"><abbr title="Dagger\EnumTypeDef">EnumTypeDef</abbr></a>
     <strong>loadEnumTypeDefFromID</strong>(<abbr title="Dagger\EnumTypeDefId|Dagger\EnumTypeDef">EnumTypeDef</abbr> $id)
         </code>
@@ -3087,7 +2927,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnumValueTypeDefFromID">
-        <div class="location">at line 508</div>
+        <div class="location">at line 492</div>
         <code>                    <a href="../Dagger/EnumValueTypeDef.html"><abbr title="Dagger\EnumValueTypeDef">EnumValueTypeDef</abbr></a>
     <strong>loadEnumValueTypeDefFromID</strong>(<abbr title="Dagger\EnumValueTypeDefId|Dagger\EnumValueTypeDef">EnumValueTypeDef</abbr> $id)
         </code>
@@ -3129,7 +2969,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvFileFromID">
-        <div class="location">at line 518</div>
+        <div class="location">at line 502</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>loadEnvFileFromID</strong>(<abbr title="Dagger\EnvFileId|Dagger\EnvFile">EnvFile</abbr> $id)
         </code>
@@ -3171,7 +3011,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvFromID">
-        <div class="location">at line 528</div>
+        <div class="location">at line 512</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>loadEnvFromID</strong>(<abbr title="Dagger\EnvId|Dagger\Env">Env</abbr> $id)
         </code>
@@ -3213,7 +3053,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvVariableFromID">
-        <div class="location">at line 538</div>
+        <div class="location">at line 522</div>
         <code>                    <a href="../Dagger/EnvVariable.html"><abbr title="Dagger\EnvVariable">EnvVariable</abbr></a>
     <strong>loadEnvVariableFromID</strong>(<abbr title="Dagger\EnvVariableId|Dagger\EnvVariable">EnvVariable</abbr> $id)
         </code>
@@ -3255,7 +3095,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadErrorFromID">
-        <div class="location">at line 548</div>
+        <div class="location">at line 532</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>loadErrorFromID</strong>(<abbr title="Dagger\ErrorId|Dagger\Error">Error</abbr> $id)
         </code>
@@ -3297,7 +3137,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadErrorValueFromID">
-        <div class="location">at line 558</div>
+        <div class="location">at line 542</div>
         <code>                    <a href="../Dagger/ErrorValue.html"><abbr title="Dagger\ErrorValue">ErrorValue</abbr></a>
     <strong>loadErrorValueFromID</strong>(<abbr title="Dagger\ErrorValueId|Dagger\ErrorValue">ErrorValue</abbr> $id)
         </code>
@@ -3339,7 +3179,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFieldTypeDefFromID">
-        <div class="location">at line 568</div>
+        <div class="location">at line 552</div>
         <code>                    <a href="../Dagger/FieldTypeDef.html"><abbr title="Dagger\FieldTypeDef">FieldTypeDef</abbr></a>
     <strong>loadFieldTypeDefFromID</strong>(<abbr title="Dagger\FieldTypeDefId|Dagger\FieldTypeDef">FieldTypeDef</abbr> $id)
         </code>
@@ -3381,7 +3221,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFileFromID">
-        <div class="location">at line 578</div>
+        <div class="location">at line 562</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>loadFileFromID</strong>(<abbr title="Dagger\FileId|Dagger\File">File</abbr> $id)
         </code>
@@ -3423,7 +3263,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionArgFromID">
-        <div class="location">at line 588</div>
+        <div class="location">at line 572</div>
         <code>                    <a href="../Dagger/FunctionArg.html"><abbr title="Dagger\FunctionArg">FunctionArg</abbr></a>
     <strong>loadFunctionArgFromID</strong>(<abbr title="Dagger\FunctionArgId|Dagger\FunctionArg">FunctionArg</abbr> $id)
         </code>
@@ -3465,7 +3305,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionCallArgValueFromID">
-        <div class="location">at line 598</div>
+        <div class="location">at line 582</div>
         <code>                    <a href="../Dagger/FunctionCallArgValue.html"><abbr title="Dagger\FunctionCallArgValue">FunctionCallArgValue</abbr></a>
     <strong>loadFunctionCallArgValueFromID</strong>(<abbr title="Dagger\FunctionCallArgValueId|Dagger\FunctionCallArgValue">FunctionCallArgValue</abbr> $id)
         </code>
@@ -3507,7 +3347,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionCallFromID">
-        <div class="location">at line 609</div>
+        <div class="location">at line 593</div>
         <code>                    <a href="../Dagger/FunctionCall.html"><abbr title="Dagger\FunctionCall">FunctionCall</abbr></a>
     <strong>loadFunctionCallFromID</strong>(<abbr title="Dagger\FunctionCallId|Dagger\FunctionCall">FunctionCall</abbr> $id)
         </code>
@@ -3549,7 +3389,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionFromID">
-        <div class="location">at line 619</div>
+        <div class="location">at line 603</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>loadFunctionFromID</strong>(<abbr title="Dagger\FunctionId|Dagger\Function_">Function_</abbr> $id)
         </code>
@@ -3591,7 +3431,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratedCodeFromID">
-        <div class="location">at line 629</div>
+        <div class="location">at line 613</div>
         <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
     <strong>loadGeneratedCodeFromID</strong>(<abbr title="Dagger\GeneratedCodeId|Dagger\GeneratedCode">GeneratedCode</abbr> $id)
         </code>
@@ -3633,7 +3473,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratorFromID">
-        <div class="location">at line 639</div>
+        <div class="location">at line 623</div>
         <code>                    <a href="../Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a>
     <strong>loadGeneratorFromID</strong>(<abbr title="Dagger\GeneratorId|Dagger\Generator">Generator</abbr> $id)
         </code>
@@ -3675,7 +3515,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratorGroupFromID">
-        <div class="location">at line 649</div>
+        <div class="location">at line 633</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>loadGeneratorGroupFromID</strong>(<abbr title="Dagger\GeneratorGroupId|Dagger\GeneratorGroup">GeneratorGroup</abbr> $id)
         </code>
@@ -3717,7 +3557,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGitRefFromID">
-        <div class="location">at line 659</div>
+        <div class="location">at line 643</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
     <strong>loadGitRefFromID</strong>(<abbr title="Dagger\GitRefId|Dagger\GitRef">GitRef</abbr> $id)
         </code>
@@ -3759,7 +3599,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGitRepositoryFromID">
-        <div class="location">at line 669</div>
+        <div class="location">at line 653</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>loadGitRepositoryFromID</strong>(<abbr title="Dagger\GitRepositoryId|Dagger\GitRepository">GitRepository</abbr> $id)
         </code>
@@ -3801,7 +3641,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadHealthcheckConfigFromID">
-        <div class="location">at line 679</div>
+        <div class="location">at line 663</div>
         <code>                    <a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a>
     <strong>loadHealthcheckConfigFromID</strong>(<abbr title="Dagger\HealthcheckConfigId|Dagger\HealthcheckConfig">HealthcheckConfig</abbr> $id)
         </code>
@@ -3843,7 +3683,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadHostFromID">
-        <div class="location">at line 689</div>
+        <div class="location">at line 673</div>
         <code>                    <a href="../Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a>
     <strong>loadHostFromID</strong>(<abbr title="Dagger\HostId|Dagger\Host">Host</abbr> $id)
         </code>
@@ -3885,7 +3725,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadInputTypeDefFromID">
-        <div class="location">at line 699</div>
+        <div class="location">at line 683</div>
         <code>                    <a href="../Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a>
     <strong>loadInputTypeDefFromID</strong>(<abbr title="Dagger\InputTypeDefId|Dagger\InputTypeDef">InputTypeDef</abbr> $id)
         </code>
@@ -3927,7 +3767,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadInterfaceTypeDefFromID">
-        <div class="location">at line 709</div>
+        <div class="location">at line 693</div>
         <code>                    <a href="../Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a>
     <strong>loadInterfaceTypeDefFromID</strong>(<abbr title="Dagger\InterfaceTypeDefId|Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr> $id)
         </code>
@@ -3969,7 +3809,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadJSONValueFromID">
-        <div class="location">at line 719</div>
+        <div class="location">at line 703</div>
         <code>                    <a href="../Dagger/JsonValue.html"><abbr title="Dagger\JsonValue">JsonValue</abbr></a>
     <strong>loadJSONValueFromID</strong>(<abbr title="Dagger\JsonValueId|Dagger\JsonValue">JsonValue</abbr> $id)
         </code>
@@ -4011,7 +3851,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLLMFromID">
-        <div class="location">at line 729</div>
+        <div class="location">at line 713</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>loadLLMFromID</strong>(<abbr title="Dagger\LLMId|Dagger\LLM">LLM</abbr> $id)
         </code>
@@ -4053,7 +3893,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLLMTokenUsageFromID">
-        <div class="location">at line 739</div>
+        <div class="location">at line 723</div>
         <code>                    <a href="../Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a>
     <strong>loadLLMTokenUsageFromID</strong>(<abbr title="Dagger\LLMTokenUsageId|Dagger\LLMTokenUsage">LLMTokenUsage</abbr> $id)
         </code>
@@ -4095,7 +3935,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLabelFromID">
-        <div class="location">at line 749</div>
+        <div class="location">at line 733</div>
         <code>                    <a href="../Dagger/Label.html"><abbr title="Dagger\Label">Label</abbr></a>
     <strong>loadLabelFromID</strong>(<abbr title="Dagger\LabelId|Dagger\Label">Label</abbr> $id)
         </code>
@@ -4137,7 +3977,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadListTypeDefFromID">
-        <div class="location">at line 759</div>
+        <div class="location">at line 743</div>
         <code>                    <a href="../Dagger/ListTypeDef.html"><abbr title="Dagger\ListTypeDef">ListTypeDef</abbr></a>
     <strong>loadListTypeDefFromID</strong>(<abbr title="Dagger\ListTypeDefId|Dagger\ListTypeDef">ListTypeDef</abbr> $id)
         </code>
@@ -4179,7 +4019,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleConfigClientFromID">
-        <div class="location">at line 769</div>
+        <div class="location">at line 753</div>
         <code>                    <a href="../Dagger/ModuleConfigClient.html"><abbr title="Dagger\ModuleConfigClient">ModuleConfigClient</abbr></a>
     <strong>loadModuleConfigClientFromID</strong>(<abbr title="Dagger\ModuleConfigClientId|Dagger\ModuleConfigClient">ModuleConfigClient</abbr> $id)
         </code>
@@ -4221,7 +4061,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleFromID">
-        <div class="location">at line 779</div>
+        <div class="location">at line 763</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>loadModuleFromID</strong>(<abbr title="Dagger\ModuleId|Dagger\Module">Module</abbr> $id)
         </code>
@@ -4263,7 +4103,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleSourceFromID">
-        <div class="location">at line 789</div>
+        <div class="location">at line 773</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>loadModuleSourceFromID</strong>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $id)
         </code>
@@ -4305,7 +4145,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadObjectTypeDefFromID">
-        <div class="location">at line 799</div>
+        <div class="location">at line 783</div>
         <code>                    <a href="../Dagger/ObjectTypeDef.html"><abbr title="Dagger\ObjectTypeDef">ObjectTypeDef</abbr></a>
     <strong>loadObjectTypeDefFromID</strong>(<abbr title="Dagger\ObjectTypeDefId|Dagger\ObjectTypeDef">ObjectTypeDef</abbr> $id)
         </code>
@@ -4346,50 +4186,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_loadPhpSdkFromID">
-        <div class="location">at line 809</div>
-        <code>                    <a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a>
-    <strong>loadPhpSdkFromID</strong>(<abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr> $id)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Load a PhpSdk from its ID.</p></p>                        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td><abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr></td>
-                <td>$id</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_loadPortFromID">
-        <div class="location">at line 819</div>
+        <div class="location">at line 793</div>
         <code>                    <a href="../Dagger/Port.html"><abbr title="Dagger\Port">Port</abbr></a>
     <strong>loadPortFromID</strong>(<abbr title="Dagger\PortId|Dagger\Port">Port</abbr> $id)
         </code>
@@ -4431,7 +4229,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadQueryFromID">
-        <div class="location">at line 829</div>
+        <div class="location">at line 803</div>
         <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
     <strong>loadQueryFromID</strong>(<abbr title="Dagger\QueryId|Dagger\Query">Query</abbr> $id)
         </code>
@@ -4473,7 +4271,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSDKConfigFromID">
-        <div class="location">at line 839</div>
+        <div class="location">at line 813</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>loadSDKConfigFromID</strong>(<abbr title="Dagger\SDKConfigId|Dagger\SDKConfig">SDKConfig</abbr> $id)
         </code>
@@ -4515,7 +4313,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadScalarTypeDefFromID">
-        <div class="location">at line 849</div>
+        <div class="location">at line 823</div>
         <code>                    <a href="../Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a>
     <strong>loadScalarTypeDefFromID</strong>(<abbr title="Dagger\ScalarTypeDefId|Dagger\ScalarTypeDef">ScalarTypeDef</abbr> $id)
         </code>
@@ -4557,7 +4355,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSearchResultFromID">
-        <div class="location">at line 859</div>
+        <div class="location">at line 833</div>
         <code>                    <a href="../Dagger/SearchResult.html"><abbr title="Dagger\SearchResult">SearchResult</abbr></a>
     <strong>loadSearchResultFromID</strong>(<abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $id)
         </code>
@@ -4599,7 +4397,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSearchSubmatchFromID">
-        <div class="location">at line 869</div>
+        <div class="location">at line 843</div>
         <code>                    <a href="../Dagger/SearchSubmatch.html"><abbr title="Dagger\SearchSubmatch">SearchSubmatch</abbr></a>
     <strong>loadSearchSubmatchFromID</strong>(<abbr title="Dagger\SearchSubmatchId|Dagger\SearchSubmatch">SearchSubmatch</abbr> $id)
         </code>
@@ -4641,7 +4439,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSecretFromID">
-        <div class="location">at line 879</div>
+        <div class="location">at line 853</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>loadSecretFromID</strong>(<abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $id)
         </code>
@@ -4683,7 +4481,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadServiceFromID">
-        <div class="location">at line 889</div>
+        <div class="location">at line 863</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>loadServiceFromID</strong>(<abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $id)
         </code>
@@ -4725,7 +4523,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSocketFromID">
-        <div class="location">at line 899</div>
+        <div class="location">at line 873</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>loadSocketFromID</strong>(<abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $id)
         </code>
@@ -4767,7 +4565,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSourceMapFromID">
-        <div class="location">at line 909</div>
+        <div class="location">at line 883</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>loadSourceMapFromID</strong>(<abbr title="Dagger\SourceMapId|Dagger\SourceMap">SourceMap</abbr> $id)
         </code>
@@ -4809,7 +4607,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadStatFromID">
-        <div class="location">at line 919</div>
+        <div class="location">at line 893</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>loadStatFromID</strong>(<abbr title="Dagger\StatId|Dagger\Stat">Stat</abbr> $id)
         </code>
@@ -4851,7 +4649,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadTerminalFromID">
-        <div class="location">at line 929</div>
+        <div class="location">at line 903</div>
         <code>                    <a href="../Dagger/Terminal.html"><abbr title="Dagger\Terminal">Terminal</abbr></a>
     <strong>loadTerminalFromID</strong>(<abbr title="Dagger\TerminalId|Dagger\Terminal">Terminal</abbr> $id)
         </code>
@@ -4893,7 +4691,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadTypeDefFromID">
-        <div class="location">at line 939</div>
+        <div class="location">at line 913</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>loadTypeDefFromID</strong>(<abbr title="Dagger\TypeDefId|Dagger\TypeDef">TypeDef</abbr> $id)
         </code>
@@ -4935,7 +4733,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadUpFromID">
-        <div class="location">at line 949</div>
+        <div class="location">at line 923</div>
         <code>                    <a href="../Dagger/Up.html"><abbr title="Dagger\Up">Up</abbr></a>
     <strong>loadUpFromID</strong>(<abbr title="Dagger\UpId|Dagger\Up">Up</abbr> $id)
         </code>
@@ -4977,7 +4775,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadUpGroupFromID">
-        <div class="location">at line 959</div>
+        <div class="location">at line 933</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>loadUpGroupFromID</strong>(<abbr title="Dagger\UpGroupId|Dagger\UpGroup">UpGroup</abbr> $id)
         </code>
@@ -5019,7 +4817,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceFromID">
-        <div class="location">at line 969</div>
+        <div class="location">at line 943</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>loadWorkspaceFromID</strong>(<abbr title="Dagger\WorkspaceId|Dagger\Workspace">Workspace</abbr> $id)
         </code>
@@ -5061,7 +4859,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 979</div>
+        <div class="location">at line 953</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>module</strong>()
         </code>
@@ -5092,56 +4890,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_moduleRuntime">
-        <div class="location">at line 985</div>
-        <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>moduleRuntime</strong>(<abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr> $modSource, <abbr title="Dagger\FileId|Dagger\File">File</abbr> $introspectionJson)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p class="no-description">No description</p>
-                    
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td><abbr title="Dagger\ModuleSourceId|Dagger\ModuleSource">ModuleSource</abbr></td>
-                <td>$modSource</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><abbr title="Dagger\FileId|Dagger\File">File</abbr></td>
-                <td>$introspectionJson</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 996</div>
+        <div class="location">at line 962</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $refString, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
         </code>
@@ -5203,7 +4953,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 1023</div>
+        <div class="location">at line 989</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>(string $uri, string|null $cacheKey = null)
         </code>
@@ -5250,7 +5000,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecret">
-        <div class="location">at line 1038</div>
+        <div class="location">at line 1004</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecret</strong>(string $name, string $plaintext)
         </code>
@@ -5296,41 +5046,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_sourceDir">
-        <div class="location">at line 1046</div>
-        <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>sourceDir</strong>()
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p class="no-description">No description</p>
-                    
-        </div>
-        <div class="tags">
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 1055</div>
+        <div class="location">at line 1015</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>sourceMap</strong>(string $filename, int $line, int $column)
         </code>
@@ -5382,7 +5099,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 1067</div>
+        <div class="location">at line 1027</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>
@@ -5414,7 +5131,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 1076</div>
+        <div class="location">at line 1036</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -5433,48 +5150,6 @@
                     <table class="table table-condensed">
         <tr>
             <td>string</td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
-                    <h3 id="method_with">
-        <div class="location">at line 1085</div>
-        <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
-    <strong>with</strong>(<abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr> $sdkSourceDir = null)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Configure the php-sdk constructor arguments.</p></p>                        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td><abbr title="Dagger\Dagger\DirectoryId|Dagger\Directory|null">Directory|null</abbr></td>
-                <td>$sdkSourceDir</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/Dagger/Connection.html
+++ b/docs/static/reference/php/Dagger/Connection.html
@@ -119,7 +119,7 @@
                     static&nbsp;<a href="../Dagger/Connection.html"><abbr title="Dagger\Connection">Connection</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_get">get</a>(string $workingDir = &#039;&#039;)
+                    <a href="#method_get">get</a>(string $workingDir = &#039;&#039;, bool $loadWorkspaceModules = false)
         
                                             <p class="no-description">No description</p>
                                     </div>
@@ -141,7 +141,7 @@
                     static&nbsp;<abbr title="Dagger\Connection\ProcessSessionConnection">ProcessSessionConnection</abbr>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_newProcessSession">newProcessSession</a>(string $workDir, <abbr title="Dagger\Connection\CliDownloader">CliDownloader</abbr> $cliDownloader)
+                    <a href="#method_newProcessSession">newProcessSession</a>(string $workDir, bool $loadWorkspaceModules, <abbr title="Dagger\Connection\CliDownloader">CliDownloader</abbr> $cliDownloader)
         <small><span class="label label-danger">deprecated</span></small>
                                             <p class="no-description">No description</p>
                                     </div>
@@ -190,7 +190,7 @@
                     <h3 id="method_get">
         <div class="location">at line 15</div>
         <code>        static            <a href="../Dagger/Connection.html"><abbr title="Dagger\Connection">Connection</abbr></a>
-    <strong>get</strong>(string $workingDir = &#039;&#039;)
+    <strong>get</strong>(string $workingDir = &#039;&#039;, bool $loadWorkspaceModules = false)
         </code>
     </h3>
     <div class="details">    
@@ -208,6 +208,11 @@
                     <tr>
                 <td>string</td>
                 <td>$workingDir</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool</td>
+                <td>$loadWorkspaceModules</td>
                 <td></td>
             </tr>
             </table>
@@ -266,7 +271,7 @@
                     <h3 id="method_newProcessSession">
         <div class="location">at line 50</div>
         <code>        static            <abbr title="Dagger\Connection\ProcessSessionConnection">ProcessSessionConnection</abbr>
-    <strong>newProcessSession</strong>(string $workDir, <abbr title="Dagger\Connection\CliDownloader">CliDownloader</abbr> $cliDownloader)
+    <strong>newProcessSession</strong>(string $workDir, bool $loadWorkspaceModules, <abbr title="Dagger\Connection\CliDownloader">CliDownloader</abbr> $cliDownloader)
         <small><span class="label label-danger">deprecated</span></small></code>
     </h3>
     <div class="details">    
@@ -295,6 +300,11 @@ so we don't need to download a CLI Client</td>
                 <td></td>
             </tr>
                     <tr>
+                <td>bool</td>
+                <td>$loadWorkspaceModules</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td><abbr title="Dagger\Connection\CliDownloader">CliDownloader</abbr></td>
                 <td>$cliDownloader</td>
                 <td></td>
@@ -320,7 +330,7 @@ so we don't need to download a CLI Client</td>
             </div>
                     <div class="method-item">
                     <h3 id="method_createGraphQlClient">
-        <div class="location">at line 55</div>
+        <div class="location">at line 58</div>
         <code>        static    protected        <abbr title="GraphQL\Client">Client</abbr>
     <strong>createGraphQlClient</strong>(int $port, string $token)
         </code>
@@ -368,7 +378,7 @@ so we don't need to download a CLI Client</td>
             </div>
                     <div class="method-item">
                     <h3 id="method_connect">
-        <div class="location">at line 70</div>
+        <div class="location">at line 73</div>
         <code>    abstract                <abbr title="GraphQL\Client">Client</abbr>
     <strong>connect</strong>()
         </code>
@@ -401,7 +411,7 @@ so we don't need to download a CLI Client</td>
             </div>
                     <div class="method-item">
                     <h3 id="method_close">
-        <div class="location">at line 72</div>
+        <div class="location">at line 75</div>
         <code>    abstract                void
     <strong>close</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Dagger.html
+++ b/docs/static/reference/php/Dagger/Dagger.html
@@ -116,7 +116,7 @@
                     static&nbsp;<a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_connect">connect</a>(string $workingDir = &#039;&#039;)
+                    <a href="#method_connect">connect</a>(string $workingDir = &#039;&#039;, bool $loadWorkspaceModules = false)
         
                                             <p class="no-description">No description</p>
                                     </div>
@@ -165,7 +165,7 @@
                     <h3 id="method_connect">
         <div class="location">at line 22</div>
         <code>        static            <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
-    <strong>connect</strong>(string $workingDir = &#039;&#039;)
+    <strong>connect</strong>(string $workingDir = &#039;&#039;, bool $loadWorkspaceModules = false)
         </code>
     </h3>
     <div class="details">    
@@ -183,6 +183,11 @@
                     <tr>
                 <td>string</td>
                 <td>$workingDir</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool</td>
+                <td>$loadWorkspaceModules</td>
                 <td></td>
             </tr>
             </table>

--- a/docs/static/reference/php/Dagger/Env.html
+++ b/docs/static/reference/php/Dagger/Env.html
@@ -654,26 +654,6 @@
                     <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withPhpSdkInput">withPhpSdkInput</a>(string $name, <abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr> $value, string $description)
-        
-                                            <p><p>Create or update a binding of type PhpSdk in the environment</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_withPhpSdkOutput">withPhpSdkOutput</a>(string $name, string $description)
-        
-                                            <p><p>Declare a desired PhpSdk output to be assigned in the environment</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
-                </div>
-                <div class="col-md-8">
                     <a href="#method_withSearchResultInput">withSearchResultInput</a>(string $name, <abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $value, string $description)
         
                                             <p><p>Create or update a binding of type SearchResult in the environment</p></p>                </div>
@@ -3398,107 +3378,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withPhpSdkInput">
-        <div class="location">at line 601</div>
-        <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
-    <strong>withPhpSdkInput</strong>(string $name, <abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr> $value, string $description)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Create or update a binding of type PhpSdk in the environment</p></p>                        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td>string</td>
-                <td>$name</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><abbr title="Dagger\PhpSdkId|Dagger\PhpSdk">PhpSdk</abbr></td>
-                <td>$value</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td>string</td>
-                <td>$description</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
-                    <h3 id="method_withPhpSdkOutput">
-        <div class="location">at line 613</div>
-        <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
-    <strong>withPhpSdkOutput</strong>(string $name, string $description)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Declare a desired PhpSdk output to be assigned in the environment</p></p>                        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td>string</td>
-                <td>$name</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td>string</td>
-                <td>$description</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_withSearchResultInput">
-        <div class="location">at line 624</div>
+        <div class="location">at line 601</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchResultInput</strong>(string $name, <abbr title="Dagger\SearchResultId|Dagger\SearchResult">SearchResult</abbr> $value, string $description)
         </code>
@@ -3550,7 +3431,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchResultOutput">
-        <div class="location">at line 636</div>
+        <div class="location">at line 613</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchResultOutput</strong>(string $name, string $description)
         </code>
@@ -3597,7 +3478,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchSubmatchInput">
-        <div class="location">at line 647</div>
+        <div class="location">at line 624</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchSubmatchInput</strong>(string $name, <abbr title="Dagger\SearchSubmatchId|Dagger\SearchSubmatch">SearchSubmatch</abbr> $value, string $description)
         </code>
@@ -3649,7 +3530,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSearchSubmatchOutput">
-        <div class="location">at line 662</div>
+        <div class="location">at line 639</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSearchSubmatchOutput</strong>(string $name, string $description)
         </code>
@@ -3696,7 +3577,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretInput">
-        <div class="location">at line 673</div>
+        <div class="location">at line 650</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSecretInput</strong>(string $name, <abbr title="Dagger\SecretId|Dagger\Secret">Secret</abbr> $value, string $description)
         </code>
@@ -3748,7 +3629,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretOutput">
-        <div class="location">at line 685</div>
+        <div class="location">at line 662</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSecretOutput</strong>(string $name, string $description)
         </code>
@@ -3795,7 +3676,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceInput">
-        <div class="location">at line 696</div>
+        <div class="location">at line 673</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceInput</strong>(string $name, <abbr title="Dagger\ServiceId|Dagger\Service">Service</abbr> $value, string $description)
         </code>
@@ -3847,7 +3728,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceOutput">
-        <div class="location">at line 708</div>
+        <div class="location">at line 685</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withServiceOutput</strong>(string $name, string $description)
         </code>
@@ -3894,7 +3775,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketInput">
-        <div class="location">at line 719</div>
+        <div class="location">at line 696</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketInput</strong>(string $name, <abbr title="Dagger\SocketId|Dagger\Socket">Socket</abbr> $value, string $description)
         </code>
@@ -3946,7 +3827,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSocketOutput">
-        <div class="location">at line 731</div>
+        <div class="location">at line 708</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withSocketOutput</strong>(string $name, string $description)
         </code>
@@ -3993,7 +3874,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStatInput">
-        <div class="location">at line 742</div>
+        <div class="location">at line 719</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStatInput</strong>(string $name, <abbr title="Dagger\StatId|Dagger\Stat">Stat</abbr> $value, string $description)
         </code>
@@ -4045,7 +3926,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStatOutput">
-        <div class="location">at line 754</div>
+        <div class="location">at line 731</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStatOutput</strong>(string $name, string $description)
         </code>
@@ -4092,7 +3973,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringInput">
-        <div class="location">at line 765</div>
+        <div class="location">at line 742</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringInput</strong>(string $name, string $value, string $description)
         </code>
@@ -4144,7 +4025,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withStringOutput">
-        <div class="location">at line 777</div>
+        <div class="location">at line 754</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withStringOutput</strong>(string $name, string $description)
         </code>
@@ -4191,7 +4072,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpGroupInput">
-        <div class="location">at line 788</div>
+        <div class="location">at line 765</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpGroupInput</strong>(string $name, <abbr title="Dagger\UpGroupId|Dagger\UpGroup">UpGroup</abbr> $value, string $description)
         </code>
@@ -4243,7 +4124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpGroupOutput">
-        <div class="location">at line 800</div>
+        <div class="location">at line 777</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpGroupOutput</strong>(string $name, string $description)
         </code>
@@ -4290,7 +4171,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpInput">
-        <div class="location">at line 811</div>
+        <div class="location">at line 788</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpInput</strong>(string $name, <abbr title="Dagger\UpId|Dagger\Up">Up</abbr> $value, string $description)
         </code>
@@ -4342,7 +4223,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpOutput">
-        <div class="location">at line 823</div>
+        <div class="location">at line 800</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withUpOutput</strong>(string $name, string $description)
         </code>
@@ -4389,7 +4270,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspace">
-        <div class="location">at line 834</div>
+        <div class="location">at line 811</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspace</strong>(<abbr title="Dagger\DirectoryId|Dagger\Directory">Directory</abbr> $workspace)
         </code>
@@ -4431,7 +4312,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspaceInput">
-        <div class="location">at line 844</div>
+        <div class="location">at line 821</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspaceInput</strong>(string $name, <abbr title="Dagger\WorkspaceId|Dagger\Workspace">Workspace</abbr> $value, string $description)
         </code>
@@ -4483,7 +4364,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspaceOutput">
-        <div class="location">at line 856</div>
+        <div class="location">at line 833</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withWorkspaceOutput</strong>(string $name, string $description)
         </code>
@@ -4530,7 +4411,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutOutputs">
-        <div class="location">at line 867</div>
+        <div class="location">at line 844</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>withoutOutputs</strong>()
         </code>
@@ -4562,7 +4443,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workspace">
-        <div class="location">at line 873</div>
+        <div class="location">at line 850</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>workspace</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -149,9 +149,7 @@
 <abbr title="Dagger\Binding">Binding</abbr>::asModuleConfigClient</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
                     <dd><p>Retrieve the binding value, as type ModuleConfigClient</p></dd><dt><a href="Dagger/Binding.html#method_asModuleSource">
 <abbr title="Dagger\Binding">Binding</abbr>::asModuleSource</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
-                    <dd><p>Retrieve the binding value, as type ModuleSource</p></dd><dt><a href="Dagger/Binding.html#method_asPhpSdk">
-<abbr title="Dagger\Binding">Binding</abbr>::asPhpSdk</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
-                    <dd><p>Retrieve the binding value, as type PhpSdk</p></dd><dt><a href="Dagger/Binding.html#method_asSearchResult">
+                    <dd><p>Retrieve the binding value, as type ModuleSource</p></dd><dt><a href="Dagger/Binding.html#method_asSearchResult">
 <abbr title="Dagger\Binding">Binding</abbr>::asSearchResult</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
                     <dd><p>Retrieve the binding value, as type SearchResult</p></dd><dt><a href="Dagger/Binding.html#method_asSearchSubmatch">
 <abbr title="Dagger\Binding">Binding</abbr>::asSearchSubmatch</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
@@ -276,11 +274,7 @@
 <abbr title="Dagger\Client">Client</abbr>::changeset</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Creates an empty changeset</p></dd><dt><a href="Dagger/Client.html#method_cloud">
 <abbr title="Dagger\Client">Client</abbr>::cloud</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Dagger Cloud configuration and state</p></dd><dt><a href="Dagger/Client.html#method_codegen">
-<abbr title="Dagger\Client">Client</abbr>::codegen</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd></dd><dt><a href="Dagger/Client.html#method_codegenBase">
-<abbr title="Dagger\Client">Client</abbr>::codegenBase</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd></dd><dt><a href="Dagger/Client.html#method_container">
+                    <dd><p>Dagger Cloud configuration and state</p></dd><dt><a href="Dagger/Client.html#method_container">
 <abbr title="Dagger\Client">Client</abbr>::container</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Creates a scratch container, with no image or metadata.</p></dd><dt><a href="Dagger/Client.html#method_currentEnv">
 <abbr title="Dagger\Client">Client</abbr>::currentEnv</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
@@ -983,9 +977,7 @@
 <abbr title="Dagger\Client">Client</abbr>::loadModuleSourceFromID</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Load a ModuleSource from its ID.</p></dd><dt><a href="Dagger/Client.html#method_loadObjectTypeDefFromID">
 <abbr title="Dagger\Client">Client</abbr>::loadObjectTypeDefFromID</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Load a ObjectTypeDef from its ID.</p></dd><dt><a href="Dagger/Client.html#method_loadPhpSdkFromID">
-<abbr title="Dagger\Client">Client</abbr>::loadPhpSdkFromID</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Load a PhpSdk from its ID.</p></dd><dt><a href="Dagger/Client.html#method_loadPortFromID">
+                    <dd><p>Load a ObjectTypeDef from its ID.</p></dd><dt><a href="Dagger/Client.html#method_loadPortFromID">
 <abbr title="Dagger\Client">Client</abbr>::loadPortFromID</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Load a Port from its ID.</p></dd><dt><a href="Dagger/Client.html#method_loadQueryFromID">
 <abbr title="Dagger\Client">Client</abbr>::loadQueryFromID</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
@@ -1054,9 +1046,7 @@
 <abbr title="Dagger\Changeset">Changeset</abbr>::modifiedPaths</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
                     <dd><p>Files and directories that existed before and were updated in the newer directory.</p></dd><dt><a href="Dagger/Client.html#method_module">
 <abbr title="Dagger\Client">Client</abbr>::module</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Create a new module.</p></dd><dt><a href="Dagger/Client.html#method_moduleRuntime">
-<abbr title="Dagger\Client">Client</abbr>::moduleRuntime</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd></dd><dt><a href="Dagger/Client.html#method_moduleSource">
+                    <dd><p>Create a new module.</p></dd><dt><a href="Dagger/Client.html#method_moduleSource">
 <abbr title="Dagger\Client">Client</abbr>::moduleSource</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Create a new module source instance from a source ref string</p></dd><dt><a href="Dagger/Container.html#method_mounts">
 <abbr title="Dagger\Container">Container</abbr>::mounts</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
@@ -1288,9 +1278,7 @@
 <abbr title="Dagger\Client">Client</abbr>::secret</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Creates a new secret.</p></dd><dt><a href="Dagger/Client.html#method_setSecret">
 <abbr title="Dagger\Client">Client</abbr>::setSecret</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Sets a secret given a user defined name to its plaintext and returns the secret.</p></dd><dt><a href="Dagger/Client.html#method_sourceDir">
-<abbr title="Dagger\Client">Client</abbr>::sourceDir</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd></dd><dt><a href="Dagger/Client.html#method_sourceMap">
+                    <dd><p>Sets a secret given a user defined name to its plaintext and returns the secret.</p></dd><dt><a href="Dagger/Client.html#method_sourceMap">
 <abbr title="Dagger\Client">Client</abbr>::sourceMap</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Creates source map metadata.</p></dd><dt><a href="Dagger/Client/QueryBuilder.html#method_setArgument">
 <abbr title="Dagger\Client\QueryBuilder">QueryBuilder</abbr>::setArgument</a>() &mdash; <em>Method in class <a href="Dagger/Client/QueryBuilder.html"><abbr title="Dagger\Client\QueryBuilder">QueryBuilder</abbr></a></em></dt>
@@ -1512,9 +1500,7 @@
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangeset</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
                     <dd><p>Add changes to an existing changeset</p></dd><dt><a href="Dagger/Changeset.html#method_withChangesets">
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangesets</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
-                    <dd><p>Add changes from multiple changesets using git octopus merge strategy</p></dd><dt><a href="Dagger/Client.html#method_with">
-<abbr title="Dagger\Client">Client</abbr>::with</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
-                    <dd><p>Configure the php-sdk constructor arguments.</p></dd><dt><a href="Dagger/Container.html#method_withAnnotation">
+                    <dd><p>Add changes from multiple changesets using git octopus merge strategy</p></dd><dt><a href="Dagger/Container.html#method_withAnnotation">
 <abbr title="Dagger\Container">Container</abbr>::withAnnotation</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Retrieves this container plus the given OCI annotation.</p></dd><dt><a href="Dagger/Container.html#method_withDefaultArgs">
 <abbr title="Dagger\Container">Container</abbr>::withDefaultArgs</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
@@ -1722,11 +1708,7 @@
 <abbr title="Dagger\Env">Env</abbr>::withModuleSourceInput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
                     <dd><p>Create or update a binding of type ModuleSource in the environment</p></dd><dt><a href="Dagger/Env.html#method_withModuleSourceOutput">
 <abbr title="Dagger\Env">Env</abbr>::withModuleSourceOutput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
-                    <dd><p>Declare a desired ModuleSource output to be assigned in the environment</p></dd><dt><a href="Dagger/Env.html#method_withPhpSdkInput">
-<abbr title="Dagger\Env">Env</abbr>::withPhpSdkInput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
-                    <dd><p>Create or update a binding of type PhpSdk in the environment</p></dd><dt><a href="Dagger/Env.html#method_withPhpSdkOutput">
-<abbr title="Dagger\Env">Env</abbr>::withPhpSdkOutput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
-                    <dd><p>Declare a desired PhpSdk output to be assigned in the environment</p></dd><dt><a href="Dagger/Env.html#method_withSearchResultInput">
+                    <dd><p>Declare a desired ModuleSource output to be assigned in the environment</p></dd><dt><a href="Dagger/Env.html#method_withSearchResultInput">
 <abbr title="Dagger\Env">Env</abbr>::withSearchResultInput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>
                     <dd><p>Create or update a binding of type SearchResult in the environment</p></dd><dt><a href="Dagger/Env.html#method_withSearchResultOutput">
 <abbr title="Dagger\Env">Env</abbr>::withSearchResultOutput</a>() &mdash; <em>Method in class <a href="Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -1717,12 +1717,6 @@
 		},
 		{
 			"t": "M",
-			"n": "Dagger\\Binding::asPhpSdk",
-			"p": "Dagger/Binding.html#method_asPhpSdk",
-			"d": "<p>Retrieve the binding value, as type PhpSdk</p>"
-		},
-		{
-			"t": "M",
 			"n": "Dagger\\Binding::asSearchResult",
 			"p": "Dagger/Binding.html#method_asSearchResult",
 			"d": "<p>Retrieve the binding value, as type SearchResult</p>"
@@ -2044,18 +2038,6 @@
 			"n": "Dagger\\Client::cloud",
 			"p": "Dagger/Client.html#method_cloud",
 			"d": "<p>Dagger Cloud configuration and state</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Client::codegen",
-			"p": "Dagger/Client.html#method_codegen",
-			"d": null
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Client::codegenBase",
-			"p": "Dagger/Client.html#method_codegenBase",
-			"d": null
 		},
 		{
 			"t": "M",
@@ -2461,12 +2443,6 @@
 		},
 		{
 			"t": "M",
-			"n": "Dagger\\Client::loadPhpSdkFromID",
-			"p": "Dagger/Client.html#method_loadPhpSdkFromID",
-			"d": "<p>Load a PhpSdk from its ID.</p>"
-		},
-		{
-			"t": "M",
 			"n": "Dagger\\Client::loadPortFromID",
 			"p": "Dagger/Client.html#method_loadPortFromID",
 			"d": "<p>Load a Port from its ID.</p>"
@@ -2569,12 +2545,6 @@
 		},
 		{
 			"t": "M",
-			"n": "Dagger\\Client::moduleRuntime",
-			"p": "Dagger/Client.html#method_moduleRuntime",
-			"d": null
-		},
-		{
-			"t": "M",
 			"n": "Dagger\\Client::moduleSource",
 			"p": "Dagger/Client.html#method_moduleSource",
 			"d": "<p>Create a new module source instance from a source ref string</p>"
@@ -2593,12 +2563,6 @@
 		},
 		{
 			"t": "M",
-			"n": "Dagger\\Client::sourceDir",
-			"p": "Dagger/Client.html#method_sourceDir",
-			"d": null
-		},
-		{
-			"t": "M",
 			"n": "Dagger\\Client::sourceMap",
 			"p": "Dagger/Client.html#method_sourceMap",
 			"d": "<p>Creates source map metadata.</p>"
@@ -2614,12 +2578,6 @@
 			"n": "Dagger\\Client::version",
 			"p": "Dagger/Client.html#method_version",
 			"d": "<p>Get the current Dagger Engine version.</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Client::with",
-			"p": "Dagger/Client.html#method_with",
-			"d": "<p>Configure the php-sdk constructor arguments.</p>"
 		},
 		{
 			"t": "M",
@@ -4042,18 +4000,6 @@
 			"n": "Dagger\\Env::withModuleSourceOutput",
 			"p": "Dagger/Env.html#method_withModuleSourceOutput",
 			"d": "<p>Declare a desired ModuleSource output to be assigned in the environment</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Env::withPhpSdkInput",
-			"p": "Dagger/Env.html#method_withPhpSdkInput",
-			"d": "<p>Create or update a binding of type PhpSdk in the environment</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Env::withPhpSdkOutput",
-			"p": "Dagger/Env.html#method_withPhpSdkOutput",
-			"d": "<p>Declare a desired PhpSdk output to be assigned in the environment</p>"
 		},
 		{
 			"t": "M",

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -125,6 +125,8 @@ type Params struct {
 
 	EagerRuntime bool
 
+	LoadWorkspaceModules bool
+
 	SkipWorkspaceModules bool
 
 	// Workspace explicitly declares workspace binding for this client.
@@ -176,6 +178,16 @@ type Client struct {
 }
 
 func Connect(ctx context.Context, params Params) (_ *Client, rerr error) {
+	loadWorkspaceModules, err := normalizeWorkspaceModuleLoading(
+		params.LoadWorkspaceModules,
+		params.SkipWorkspaceModules,
+	)
+	if err != nil {
+		return nil, err
+	}
+	params.LoadWorkspaceModules = loadWorkspaceModules
+	params.SkipWorkspaceModules = false
+
 	c := &Client{Params: params}
 
 	if c.ID == "" {
@@ -303,6 +315,16 @@ func Connect(ctx context.Context, params Params) (_ *Client, rerr error) {
 	return c, nil
 }
 
+func normalizeWorkspaceModuleLoading(loadWorkspaceModules, skipWorkspaceModules bool) (bool, error) {
+	if loadWorkspaceModules && skipWorkspaceModules {
+		return false, fmt.Errorf("load workspace modules and skip workspace modules are mutually exclusive")
+	}
+	if skipWorkspaceModules {
+		return false, nil
+	}
+	return loadWorkspaceModules, nil
+}
+
 type EngineToEngineParams struct {
 	Params
 
@@ -319,6 +341,16 @@ type EngineToEngineParams struct {
 // ConnectEngineToEngine connects a Dagger client to another Dagger engine using an existing session connection.
 // Session attachables are proxied back to the original client.
 func ConnectEngineToEngine(ctx context.Context, params EngineToEngineParams) (_ *Client, rerr error) {
+	loadWorkspaceModules, err := normalizeWorkspaceModuleLoading(
+		params.LoadWorkspaceModules,
+		params.SkipWorkspaceModules,
+	)
+	if err != nil {
+		return nil, err
+	}
+	params.LoadWorkspaceModules = loadWorkspaceModules
+	params.SkipWorkspaceModules = false
+
 	c := &Client{
 		Params:                params.Params,
 		isCloudScaleOutClient: true,
@@ -1404,10 +1436,9 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 
 	if c.Module != "" {
 		md.ExtraModules = []engine.ExtraModule{{Ref: c.Module, Entrypoint: true}}
-		md.SkipWorkspaceModules = true
 	}
-	if c.SkipWorkspaceModules {
-		md.SkipWorkspaceModules = true
+	if c.Module == "" && c.LoadWorkspaceModules {
+		md.LoadWorkspaceModules = true
 	}
 	if c.Workspace != nil {
 		md.Workspace = c.Workspace

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -117,7 +117,12 @@ type ClientMetadata struct {
 	// the Query root in addition to its namespaced constructor.
 	ExtraModules []ExtraModule `json:"extra_modules,omitempty"`
 
-	// SkipWorkspaceModules skips loading workspace modules when true.
+	// LoadWorkspaceModules opts this client into loading workspace modules.
+	// When false, only the core API is exposed by default.
+	LoadWorkspaceModules bool `json:"load_workspace_modules,omitempty"`
+
+	// SkipWorkspaceModules is a legacy compatibility input. New clients should
+	// use LoadWorkspaceModules instead.
 	SkipWorkspaceModules bool `json:"skip_workspace_modules,omitempty"`
 
 	// Workspace explicitly declares the workspace binding for this client.
@@ -155,12 +160,19 @@ func ClientMetadataFromHTTPHeaders(h http.Header) (*ClientMetadata, error) {
 		// fallback for old clients that don't send a client version!
 		m.ClientVersion = m.Labels["dagger.io/client.version"]
 	}
+	if err := m.normalizeWorkspaceModuleLoading(); err != nil {
+		return nil, err
+	}
 
 	return m, nil
 }
 
 func (m ClientMetadata) AppendToHTTPHeaders(h http.Header) http.Header {
 	h = h.Clone()
+
+	if err := (&m).normalizeWorkspaceModuleLoading(); err != nil {
+		panic(err)
+	}
 
 	bs, err := json.Marshal(m)
 	if err != nil {
@@ -169,6 +181,31 @@ func (m ClientMetadata) AppendToHTTPHeaders(h http.Header) http.Header {
 	h.Set(ClientMetadataMetaKey, base64.StdEncoding.EncodeToString(bs))
 
 	return h
+}
+
+func (m *ClientMetadata) normalizeWorkspaceModuleLoading() error {
+	loadWorkspaceModules, err := normalizeWorkspaceModuleLoading(
+		m.LoadWorkspaceModules,
+		m.SkipWorkspaceModules,
+	)
+	if err != nil {
+		return err
+	}
+
+	m.LoadWorkspaceModules = loadWorkspaceModules
+	m.SkipWorkspaceModules = false
+
+	return nil
+}
+
+func normalizeWorkspaceModuleLoading(loadWorkspaceModules, skipWorkspaceModules bool) (bool, error) {
+	if loadWorkspaceModules && skipWorkspaceModules {
+		return false, fmt.Errorf("load_workspace_modules and skip_workspace_modules are mutually exclusive")
+	}
+	if skipWorkspaceModules {
+		return false, nil
+	}
+	return loadWorkspaceModules, nil
 }
 
 type LocalImportOpts struct {

--- a/engine/opts_test.go
+++ b/engine/opts_test.go
@@ -1,0 +1,45 @@
+package engine
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMetadataAppendToHTTPHeadersNormalizesLegacyWorkspaceModuleLoading(t *testing.T) {
+	t.Parallel()
+
+	headers := (&ClientMetadata{
+		ClientID:             "client",
+		ClientVersion:        "v1.2.3",
+		ClientSecretToken:    "secret",
+		LoadWorkspaceModules: false,
+		SkipWorkspaceModules: true,
+	}).AppendToHTTPHeaders(http.Header{})
+
+	md, err := ClientMetadataFromHTTPHeaders(headers)
+	require.NoError(t, err)
+	require.False(t, md.LoadWorkspaceModules)
+	require.False(t, md.SkipWorkspaceModules)
+}
+
+func TestClientMetadataFromHTTPHeadersRejectsConflictingWorkspaceModuleLoading(t *testing.T) {
+	t.Parallel()
+
+	headers := http.Header{}
+	encoded, err := json.Marshal(ClientMetadata{
+		ClientID:             "client",
+		ClientVersion:        "v1.2.3",
+		ClientSecretToken:    "secret",
+		LoadWorkspaceModules: true,
+		SkipWorkspaceModules: true,
+	})
+	require.NoError(t, err)
+	headers.Set(ClientMetadataMetaKey, base64.StdEncoding.EncodeToString(encoded))
+
+	_, err = ClientMetadataFromHTTPHeaders(headers)
+	require.ErrorContains(t, err, "mutually exclusive")
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -177,10 +177,9 @@ type daggerClient struct {
 	// isn't available during initialization (the session attachables request
 	// is blocked on the same locks that initializeDaggerClient holds).
 
-	// Whether this client should detect its own workspace and auto-load
-	// workspace modules from that workspace.
-	// True for non-module clients (main client and nested non-module clients);
-	// false for module clients (they inherit workspace binding and skip auto-load).
+	// Whether this client should detect its own workspace binding.
+	// Non-module clients detect their own workspace; module clients inherit a
+	// parent workspace binding instead.
 	pendingWorkspaceLoad bool
 	workspaceMu          sync.Mutex
 	workspaceLoaded      bool
@@ -931,8 +930,8 @@ func (srv *Server) getOrInitClient(
 		if client.clientMetadata.AllowedLLMModules == nil {
 			client.clientMetadata.AllowedLLMModules = opts.AllowedLLMModules
 		}
-		if opts.SkipWorkspaceModules {
-			client.clientMetadata.SkipWorkspaceModules = true
+		if opts.LoadWorkspaceModules {
+			client.clientMetadata.LoadWorkspaceModules = true
 		}
 		if client.clientMetadata.Workspace == nil && !client.workspaceLoaded {
 			if workspaceRef, ok := workspaceRefFromClientMetadata(opts.ClientMetadata); ok {
@@ -1016,14 +1015,14 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 
 	allowedLLMModules := execMD.AllowedLLMModules
 	var extraModules []engine.ExtraModule
-	var skipWorkspaceModules bool
+	var loadWorkspaceModules bool
 	var eagerRuntime bool
 	var workspaceRef *string
 	if md, _ := engine.ClientMetadataFromHTTPHeaders(r.Header); md != nil {
 		clientVersion = md.ClientVersion
 		allowedLLMModules = md.AllowedLLMModules
 		extraModules = md.ExtraModules
-		skipWorkspaceModules = md.SkipWorkspaceModules
+		loadWorkspaceModules = md.LoadWorkspaceModules
 		eagerRuntime = md.EagerRuntime
 		if declaredWorkspace, ok := workspaceRefFromClientMetadata(md); ok {
 			ref := declaredWorkspace
@@ -1043,7 +1042,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			SSHAuthSocketPath:    execMD.SSHAuthSocketPath,
 			AllowedLLMModules:    allowedLLMModules,
 			ExtraModules:         extraModules,
-			SkipWorkspaceModules: skipWorkspaceModules,
+			LoadWorkspaceModules: loadWorkspaceModules,
 			EagerRuntime:         eagerRuntime,
 			Workspace:            workspaceRef,
 		},

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -126,6 +126,9 @@ func TestModuleResolutionFromSubdirectory(t *testing.T) {
 
 	client := &daggerClient{
 		pendingWorkspaceLoad: true,
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
 	}
 
 	srv := &Server{}
@@ -144,6 +147,56 @@ func TestModuleResolutionFromSubdirectory(t *testing.T) {
 	require.Len(t, client.pendingModules, 2) // declared module + implicit module
 	require.Equal(t, "/repo/modules/changelog", client.pendingModules[0].Ref)
 	require.Equal(t, "changelog", client.pendingModules[0].Name)
+}
+
+func TestDetectAndLoadWorkspaceDoesNotLoadModulesByDefault(t *testing.T) {
+	t.Parallel()
+
+	existingFiles := map[string]bool{
+		"/repo/.git":        true,
+		"/repo/dagger.json": true,
+	}
+
+	statFS := core.StatFSFunc(func(_ context.Context, path string) (string, *core.Stat, error) {
+		path = filepath.Clean(path)
+		if existingFiles[path] {
+			return filepath.Dir(path), &core.Stat{
+				Name: filepath.Base(path),
+			}, nil
+		}
+		return "", nil, os.ErrNotExist
+	})
+
+	readFile := func(_ context.Context, path string) ([]byte, error) {
+		if filepath.Clean(path) == "/repo/dagger.json" {
+			return []byte(`{"name":"myproject","toolchains":[{"name":"changelog","source":"modules/changelog"}]}`), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID: "test-client",
+	})
+
+	client := &daggerClient{
+		pendingWorkspaceLoad: true,
+		clientMetadata:       &engine.ClientMetadata{},
+	}
+
+	srv := &Server{}
+	err := srv.detectAndLoadWorkspace(ctx, client,
+		statFS,
+		readFile,
+		"/repo/sdk/go",
+		func(ws *workspace.Workspace, relPath string) string {
+			return filepath.Join(ws.Root, ws.Path, relPath)
+		},
+		nil,
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client.workspace)
+	require.Empty(t, client.pendingModules)
 }
 
 func TestIsSameModuleReference(t *testing.T) {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -446,7 +446,7 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	prebuiltRootfs dagql.ObjectResult[*core.Directory],
 ) error {
 	clientMD := client.clientMetadata
-	skipModules := !client.pendingWorkspaceLoad || (clientMD != nil && clientMD.SkipWorkspaceModules)
+	loadModules := client.pendingWorkspaceLoad && clientMD != nil && clientMD.LoadWorkspaceModules
 
 	// --- Detect workspace (pure — no dagger.json knowledge) ---
 	ws, err := workspace.Detect(ctx, func(ctx context.Context, path string) (string, bool, error) {
@@ -489,7 +489,7 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	}
 	client.workspace = coreWS
 
-	if skipModules {
+	if !loadModules {
 		return nil
 	}
 

--- a/sdk/elixir/lib/dagger/core/client.ex
+++ b/sdk/elixir/lib/dagger/core/client.ex
@@ -33,6 +33,11 @@ defmodule Dagger.Core.Client do
         type: :string,
         doc: "Sets the engine workdir."
       ],
+      load_workspace_modules: [
+        type: :boolean,
+        doc: "Opt into loading workspace modules for this connection.",
+        default: false
+      ],
       log_output: [
         type: {:or, [:atom, :pid]},
         doc: "The log device to write the progress.",

--- a/sdk/elixir/lib/dagger/core/session.ex
+++ b/sdk/elixir/lib/dagger/core/session.ex
@@ -16,6 +16,13 @@ defmodule Dagger.Session do
       "dagger.io/sdk.version:#{@sdk_version}"
     ]
 
+    args =
+      if opts[:load_workspace_modules] do
+        args ++ ["--load-workspace-modules"]
+      else
+        args
+      end
+
     port =
       Port.open({:spawn_executable, bin}, [
         :binary,

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -55,6 +55,14 @@ func WithLogOutput(writer io.Writer) ClientOpt {
 	})
 }
 
+// WithLoadWorkspaceModules opts this client into loading workspace modules
+// based on the working directory when the session is created via the CLI.
+func WithLoadWorkspaceModules() ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.LoadWorkspaceModules = true
+	})
+}
+
 // WithConn sets the engine connection explicitly
 func WithConn(conn engineconn.EngineConn) ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {
@@ -99,9 +107,8 @@ func WithEnvironmentVariable(key, value string) ClientOpt {
 	})
 }
 
-// WithSkipWorkspaceModules prevents the engine from automatically loading
-// workspace modules based on the working directory. This is useful for
-// clients that only need the core API schema.
+// Deprecated: workspace modules are core-only by default. Use
+// WithLoadWorkspaceModules to opt into loading them when needed.
 func WithSkipWorkspaceModules() ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {
 		cfg.SkipWorkspaceModules = true

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -21,6 +21,15 @@ func TestWithWorkspace(t *testing.T) {
 	require.Equal(t, "github.com/acme/ws", cfg.Workspace)
 }
 
+func TestWithLoadWorkspaceModules(t *testing.T) {
+	t.Parallel()
+
+	cfg := &engineconn.Config{}
+	WithLoadWorkspaceModules().setClientOpt(cfg)
+
+	require.True(t, cfg.LoadWorkspaceModules)
+}
+
 func TestDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/engineconn/engineconn.go
+++ b/sdk/go/engineconn/engineconn.go
@@ -27,6 +27,7 @@ type Config struct {
 	VersionOverride      string
 	Verbosity            int
 	ExtraEnv             []string
+	LoadWorkspaceModules bool
 	SkipWorkspaceModules bool
 }
 
@@ -41,6 +42,24 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		return cfg.Conn, nil
 	}
 
+	loadWorkspaceModules, err := normalizeWorkspaceModuleLoading(
+		cfg.LoadWorkspaceModules,
+		cfg.SkipWorkspaceModules,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cfg = &Config{
+		Workdir:              cfg.Workdir,
+		Workspace:            cfg.Workspace,
+		LogOutput:            cfg.LogOutput,
+		RunnerHost:           cfg.RunnerHost,
+		VersionOverride:      cfg.VersionOverride,
+		Verbosity:            cfg.Verbosity,
+		ExtraEnv:             cfg.ExtraEnv,
+		LoadWorkspaceModules: loadWorkspaceModules,
+	}
+
 	// Try DAGGER_SESSION_PORT next
 	conn, ok, err := FromSessionEnv()
 	if err != nil {
@@ -52,6 +71,9 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		}
 		if cfg.Workspace != "" {
 			return nil, fmt.Errorf("cannot configure workspace for existing session")
+		}
+		if cfg.LoadWorkspaceModules {
+			return nil, fmt.Errorf("cannot configure workspace module loading for existing session")
 		}
 		return conn, nil
 	}
@@ -71,6 +93,16 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+func normalizeWorkspaceModuleLoading(loadWorkspaceModules, skipWorkspaceModules bool) (bool, error) {
+	if loadWorkspaceModules && skipWorkspaceModules {
+		return false, fmt.Errorf("load workspace modules and skip workspace modules are mutually exclusive")
+	}
+	if skipWorkspaceModules {
+		return false, nil
+	}
+	return loadWorkspaceModules, nil
 }
 
 func fallbackSpanContext(ctx context.Context) context.Context {

--- a/sdk/go/engineconn/session.go
+++ b/sdk/go/engineconn/session.go
@@ -89,8 +89,8 @@ func cliSessionArgs(cfg *Config) []string {
 		}
 	}
 
-	if cfg.SkipWorkspaceModules {
-		args = append(args, "--skip-workspace-modules")
+	if cfg.LoadWorkspaceModules {
+		args = append(args, "--load-workspace-modules")
 	}
 
 	if cfg.Verbosity > 0 {

--- a/sdk/go/engineconn/session_test.go
+++ b/sdk/go/engineconn/session_test.go
@@ -20,6 +20,17 @@ func TestCLISessionArgsIncludeWorkspace(t *testing.T) {
 	require.Contains(t, args, "github.com/acme/ws")
 }
 
+func TestCLISessionArgsIncludeLoadWorkspaceModules(t *testing.T) {
+	t.Parallel()
+
+	args := cliSessionArgs(&Config{
+		LoadWorkspaceModules: true,
+	})
+
+	require.Contains(t, args, "--load-workspace-modules")
+	require.NotContains(t, args, "--skip-workspace-modules")
+}
+
 // TestGetRejectsWorkspaceForExistingSession verifies that an existing session's
 // workspace binding cannot be overridden by client config.
 func TestGetRejectsWorkspaceForExistingSession(t *testing.T) {
@@ -30,4 +41,14 @@ func TestGetRejectsWorkspaceForExistingSession(t *testing.T) {
 		Workspace: "github.com/acme/ws",
 	})
 	require.ErrorContains(t, err, "cannot configure workspace for existing session")
+}
+
+func TestGetRejectsWorkspaceModuleLoadingForExistingSession(t *testing.T) {
+	t.Setenv("DAGGER_SESSION_PORT", "1234")
+	t.Setenv("DAGGER_SESSION_TOKEN", "secret")
+
+	_, err := Get(context.Background(), &Config{
+		LoadWorkspaceModules: true,
+	})
+	require.ErrorContains(t, err, "cannot configure workspace module loading for existing session")
 }

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/Dagger.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/Dagger.java
@@ -32,7 +32,18 @@ public class Dagger {
    * @throws IOException
    */
   public static AutoCloseableClient connect() throws IOException {
-    return connect(System.getProperty("user.dir"));
+    return connect(System.getProperty("user.dir"), false);
+  }
+
+  /**
+   * Opens connection with a Dagger engine.
+   *
+   * @param loadWorkspaceModules whether to opt into loading workspace modules
+   * @return The Dagger API entrypoint
+   * @throws IOException
+   */
+  public static AutoCloseableClient connect(boolean loadWorkspaceModules) throws IOException {
+    return connect(System.getProperty("user.dir"), loadWorkspaceModules);
   }
 
   /**
@@ -43,6 +54,19 @@ public class Dagger {
    * @throws IOException
    */
   public static AutoCloseableClient connect(String workingDir) throws IOException {
-    return new AutoCloseableClient(Connection.get(workingDir));
+    return connect(workingDir, false);
+  }
+
+  /**
+   * Opens connection with a Dagger engine.
+   *
+   * @param workingDir the host working directory
+   * @param loadWorkspaceModules whether to opt into loading workspace modules
+   * @return The Dagger API entrypoint
+   * @throws IOException
+   */
+  public static AutoCloseableClient connect(String workingDir, boolean loadWorkspaceModules)
+      throws IOException {
+    return new AutoCloseableClient(Connection.get(workingDir, loadWorkspaceModules));
   }
 }

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
@@ -77,7 +77,10 @@ class CLIRunner implements Runnable {
     if (loadWorkspaceModules) {
       command.add("--load-workspace-modules");
     }
-    this.process = FluentProcess.start(command.toArray(new String[0])).withAllowedExitCodes(137);
+    this.process =
+        FluentProcess.start(
+                command.get(0), command.subList(1, command.size()).toArray(new String[0]))
+            .withAllowedExitCodes(137);
     LOG.debug("Opening session: {}", process.toString());
     executorService = Executors.newSingleThreadExecutor(r -> new Thread(r, "dagger-runner"));
     executorService.execute(this);

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
@@ -16,14 +16,17 @@ class CLIRunner implements Runnable {
   static final Logger LOG = LoggerFactory.getLogger(CLIRunner.class);
 
   private final String workingDir;
+  private final boolean loadWorkspaceModules;
   private FluentProcess process;
   private ConnectParams params;
   private boolean failed = false;
   private ExecutorService executorService;
   private final CLIDownloader cliDownloader;
 
-  public CLIRunner(String workingDir, CLIDownloader cliDownloader) throws IOException {
+  public CLIRunner(String workingDir, boolean loadWorkspaceModules, CLIDownloader cliDownloader)
+      throws IOException {
     this.workingDir = workingDir;
+    this.loadWorkspaceModules = loadWorkspaceModules;
     this.cliDownloader = cliDownloader;
   }
 
@@ -60,8 +63,9 @@ class CLIRunner implements Runnable {
   }
 
   public void start() throws IOException {
-    this.process =
-        FluentProcess.start(
+    var command =
+        new java.util.ArrayList<String>(
+            java.util.List.of(
                 getCLIPath(),
                 "session",
                 "--workdir",
@@ -69,8 +73,11 @@ class CLIRunner implements Runnable {
                 "--label",
                 "dagger.io/sdk.name:java",
                 "--label",
-                "dagger.io/sdk.version:" + Provisioning.getSDKVersion())
-            .withAllowedExitCodes(137);
+                "dagger.io/sdk.version:" + Provisioning.getSDKVersion()));
+    if (loadWorkspaceModules) {
+      command.add("--load-workspace-modules");
+    }
+    this.process = FluentProcess.start(command.toArray(new String[0])).withAllowedExitCodes(137);
     LOG.debug("Opening session: {}", process.toString());
     executorService = Executors.newSingleThreadExecutor(r -> new Thread(r, "dagger-runner"));
     executorService.execute(this);

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
@@ -73,8 +73,7 @@ public final class Connection {
     return get(workingDir, false);
   }
 
-  public static Connection get(String workingDir, boolean loadWorkspaceModules)
-      throws IOException {
+  public static Connection get(String workingDir, boolean loadWorkspaceModules) throws IOException {
     Optional<Connection> connection = fromEnv();
     return connection.isPresent()
         ? connection.get()

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
@@ -70,10 +70,15 @@ public final class Connection {
   }
 
   public static Connection get(String workingDir) throws IOException {
+    return get(workingDir, false);
+  }
+
+  public static Connection get(String workingDir, boolean loadWorkspaceModules)
+      throws IOException {
     Optional<Connection> connection = fromEnv();
     return connection.isPresent()
         ? connection.get()
-        : fromCLI(new CLIRunner(workingDir, new CLIDownloader()));
+        : fromCLI(new CLIRunner(workingDir, loadWorkspaceModules, new CLIDownloader()));
   }
 
   private static Connection getConnection(int port, String token, Optional<CLIRunner> runner) {

--- a/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
+++ b/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
@@ -80,7 +80,7 @@ public class ConnectionTest {
     environmentVariables.set("_EXPERIMENTAL_DAGGER_CLI_BIN", null);
     CLIDownloader downloader = mock(CLIDownloader.class);
     when(downloader.downloadCLI()).thenThrow(new IOException("DOWNLOAD FAILED"));
-    CLIRunner runner = new CLIRunner(".", downloader);
+    CLIRunner runner = new CLIRunner(".", false, downloader);
     assertThatThrownBy(() -> Connection.fromCLI(runner))
         .isInstanceOf(IOException.class)
         .hasMessage("DOWNLOAD FAILED");

--- a/sdk/php/generated/Binding.php
+++ b/sdk/php/generated/Binding.php
@@ -191,15 +191,6 @@ class Binding extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Retrieve the binding value, as type PhpSdk
-     */
-    public function asPhpSdk(): PhpSdk
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asPhpSdk');
-        return new \Dagger\PhpSdk($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * Retrieve the binding value, as type SearchResult
      */
     public function asSearchResult(): SearchResult

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -51,22 +51,6 @@ class Client extends Client\AbstractClient implements Client\IdAble
         return new \Dagger\Cloud($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
-    public function codegen(ModuleSourceId|ModuleSource $modSource, FileId|File $introspectionJson): GeneratedCode
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('codegen');
-        $innerQueryBuilder->setArgument('modSource', $modSource);
-        $innerQueryBuilder->setArgument('introspectionJson', $introspectionJson);
-        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    public function codegenBase(ModuleSourceId|ModuleSource $modSource, FileId|File $introspectionJson): Container
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('codegenBase');
-        $innerQueryBuilder->setArgument('modSource', $modSource);
-        $innerQueryBuilder->setArgument('introspectionJson', $introspectionJson);
-        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
     /**
      * Creates a scratch container, with no image or metadata.
      *
@@ -804,16 +788,6 @@ class Client extends Client\AbstractClient implements Client\IdAble
     }
 
     /**
-     * Load a PhpSdk from its ID.
-     */
-    public function loadPhpSdkFromID(PhpSdkId|PhpSdk $id): PhpSdk
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadPhpSdkFromID');
-        $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\PhpSdk($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * Load a Port from its ID.
      */
     public function loadPortFromID(PortId|Port $id): Port
@@ -982,14 +956,6 @@ class Client extends Client\AbstractClient implements Client\IdAble
         return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
-    public function moduleRuntime(ModuleSourceId|ModuleSource $modSource, FileId|File $introspectionJson): Container
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleRuntime');
-        $innerQueryBuilder->setArgument('modSource', $modSource);
-        $innerQueryBuilder->setArgument('introspectionJson', $introspectionJson);
-        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
     /**
      * Create a new module source instance from a source ref string
      */
@@ -1043,12 +1009,6 @@ class Client extends Client\AbstractClient implements Client\IdAble
         return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
-    public function sourceDir(): Directory
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceDir');
-        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
     /**
      * Creates source map metadata.
      */
@@ -1077,17 +1037,5 @@ class Client extends Client\AbstractClient implements Client\IdAble
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('version');
         return (string)$this->queryLeaf($leafQueryBuilder, 'version');
-    }
-
-    /**
-     * Configure the php-sdk constructor arguments.
-     */
-    public function with(DirectoryId|Directory|null $sdkSourceDir = null): Client
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('with');
-        if (null !== $sdkSourceDir) {
-        $innerQueryBuilder->setArgument('sdkSourceDir', $sdkSourceDir);
-        }
-        return new \Dagger\Client($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/Env.php
+++ b/sdk/php/generated/Env.php
@@ -596,29 +596,6 @@ class Env extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Create or update a binding of type PhpSdk in the environment
-     */
-    public function withPhpSdkInput(string $name, PhpSdkId|PhpSdk $value, string $description): Env
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withPhpSdkInput');
-        $innerQueryBuilder->setArgument('name', $name);
-        $innerQueryBuilder->setArgument('value', $value);
-        $innerQueryBuilder->setArgument('description', $description);
-        return new \Dagger\Env($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
-     * Declare a desired PhpSdk output to be assigned in the environment
-     */
-    public function withPhpSdkOutput(string $name, string $description): Env
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withPhpSdkOutput');
-        $innerQueryBuilder->setArgument('name', $name);
-        $innerQueryBuilder->setArgument('description', $description);
-        return new \Dagger\Env($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * Create or update a binding of type SearchResult in the environment
      */
     public function withSearchResultInput(string $name, SearchResultId|SearchResult $value, string $description): Env

--- a/sdk/php/src/Connection.php
+++ b/sdk/php/src/Connection.php
@@ -12,7 +12,7 @@ abstract class Connection
 {
     protected ?Client $client;
 
-    public static function get(string $workingDir = ''): Connection
+    public static function get(string $workingDir = '', bool $loadWorkspaceModules = false): Connection
     {
         $connection = static::newEnvSession();
 
@@ -24,7 +24,7 @@ abstract class Connection
         }
 
         if (null === $connection) {
-            $connection = static::newProcessSession($workingDir, new CliDownloader());
+            $connection = static::newProcessSession($workingDir, $loadWorkspaceModules, new CliDownloader());
         }
 
         return $connection;
@@ -47,9 +47,9 @@ abstract class Connection
      * dagger modules will always have the environment variables set
      * so we don't need to download a CLI Client
      */
-    public static function newProcessSession(string $workDir, CliDownloader $cliDownloader): ProcessSessionConnection
+    public static function newProcessSession(string $workDir, bool $loadWorkspaceModules, CliDownloader $cliDownloader): ProcessSessionConnection
     {
-        return new ProcessSessionConnection($workDir, $cliDownloader);
+        return new ProcessSessionConnection($workDir, $loadWorkspaceModules, $cliDownloader);
     }
 
     protected static function createGraphQlClient(int $port, string $token): Client

--- a/sdk/php/src/Connection.php
+++ b/sdk/php/src/Connection.php
@@ -47,8 +47,11 @@ abstract class Connection
      * dagger modules will always have the environment variables set
      * so we don't need to download a CLI Client
      */
-    public static function newProcessSession(string $workDir, bool $loadWorkspaceModules, CliDownloader $cliDownloader): ProcessSessionConnection
-    {
+    public static function newProcessSession(
+        string $workDir,
+        bool $loadWorkspaceModules,
+        CliDownloader $cliDownloader
+    ): ProcessSessionConnection {
         return new ProcessSessionConnection($workDir, $loadWorkspaceModules, $cliDownloader);
     }
 

--- a/sdk/php/src/Connection/ProcessSessionConnection.php
+++ b/sdk/php/src/Connection/ProcessSessionConnection.php
@@ -23,6 +23,7 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
 
     public function __construct(
         private readonly string $workDir,
+        private readonly bool $loadWorkspaceModules,
         private readonly CliDownloader $cliDownloader
     ) {
         $this->logger = new NullLogger();
@@ -48,6 +49,19 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
             '--label',
             "dagger.io/sdk.version:{$sdkVersion}",
         ]);
+        if ($this->loadWorkspaceModules) {
+            $process = new Process([
+                $cliBinPath,
+                'session',
+                '--workdir',
+                $this->workDir,
+                '--label',
+                'dagger.io/sdk.name:php',
+                '--label',
+                "dagger.io/sdk.version:{$sdkVersion}",
+                '--load-workspace-modules',
+            ]);
+        }
 
         $process->setTimeout(null);
         $process->setInput(new InputStream());

--- a/sdk/php/src/Dagger.php
+++ b/sdk/php/src/Dagger.php
@@ -19,13 +19,13 @@ class Dagger
         return self::$client;
     }
 
-    public static function connect(string $workingDir = ''): Client
+    public static function connect(string $workingDir = '', bool $loadWorkspaceModules = false): Client
     {
         if (!class_exists('Dagger\\Client')) {
             throw new CompileError('Missing code generated dagger client');
         }
 
-        $connection = Connection::get($workingDir);
+        $connection = Connection::get($workingDir, $loadWorkspaceModules);
 
         return new Client($connection);
     }

--- a/sdk/python/src/dagger/provisioning/_config.py
+++ b/sdk/python/src/dagger/provisioning/_config.py
@@ -26,6 +26,9 @@ class Config(ConnectConfig):
         Project config file.
     log_output:
         A TextIO object to send the logs from the engine.
+    load_workspace_modules:
+        Opt into loading workspace modules for this connection. By default,
+        only the core API is exposed.
     execute_timeout:
         The maximum time in seconds for the execution of a request before an
         ExecuteTimeoutError is raised. Passing None results in waiting forever for a
@@ -35,6 +38,7 @@ class Config(ConnectConfig):
     workdir: PathLike[str] | str = ""
     config_path: PathLike[str] | str = ""
     log_output: TextIO | None = None
+    load_workspace_modules: bool = False
     execute_timeout: Any = UNSET
     console: Console = dataclasses.field(init=False)
 

--- a/sdk/python/src/dagger/provisioning/_session.py
+++ b/sdk/python/src/dagger/provisioning/_session.py
@@ -110,6 +110,8 @@ def run(cfg: Config, path: str) -> subprocess.Popen[str]:
         args.extend(["--workdir", str(Path(cfg.workdir).absolute())])
     if cfg.config_path:
         args.extend(["--project", str(Path(cfg.config_path).absolute())])
+    if cfg.load_workspace_modules:
+        args.append("--load-workspace-modules")
 
     # Determine stderr target. If the stream doesn't have a file descriptor
     # (e.g. StringIO), use a PIPE and forward via a background thread so that

--- a/sdk/python/tests/provisioning/test_cli.py
+++ b/sdk/python/tests/provisioning/test_cli.py
@@ -20,6 +20,27 @@ def test_getting_connect_params(fp: FakeProcess):
         assert conn.session_token == "abc"
 
 
+def test_load_workspace_modules_flag(fp: FakeProcess):
+    fp.register(
+        [
+            "dagger",
+            "session",
+            "--label",
+            fp.any(),
+            "--label",
+            fp.any(),
+            "--load-workspace-modules",
+        ],
+        stdout=['{"port":50004,"session_token":"abc"}', ""],
+    )
+    with session.start_cli_session_sync(
+        dagger.Config(load_workspace_modules=True),
+        "dagger",
+    ) as conn:
+        assert conn.port == 50004
+        assert conn.session_token == "abc"
+
+
 @pytest.mark.parametrize("config_args", [{"log_output": sys.stderr}, {}])
 @pytest.mark.parametrize(
     "call_kwargs",

--- a/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
@@ -12,6 +12,7 @@ async fn main() -> eyre::Result<()> {
             workdir_path: None,
             config_path: None,
             timeout_ms: 1000,
+            load_workspace_modules: false,
             execute_timeout_ms: None,
             logger: Some(Arc::new(TracingLogger::default())),
         },

--- a/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
@@ -98,6 +98,9 @@ impl InnerCliSession {
             let abs_path = canonicalize(config_path)?;
             args.extend(["--project".into(), abs_path.to_string_lossy().to_string()])
         }
+        if config.load_workspace_modules {
+            args.push("--load-workspace-modules".into());
+        }
 
         args.extend(["--label".into(), "dagger.io/sdk.name:rust".into()]);
         args.extend([

--- a/sdk/rust/crates/dagger-sdk/src/core/config.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
     /// The maximum time in milliseconds for establishing a connection to the server.
     /// Defaults to 10 seconds.
     pub timeout_ms: u64,
+    #[builder(default = "false")]
+    /// Opt into loading workspace modules for this connection.
+    pub load_workspace_modules: bool,
     #[builder(default = "None")]
     /// The maximum time in milliseconds for executing a request.
     /// Defaults to no timeout.
@@ -38,6 +41,7 @@ impl Default for Config {
             workdir_path: None,
             config_path: None,
             timeout_ms: 10 * 1000,
+            load_workspace_modules: false,
             execute_timeout_ms: None,
             logger: None,
         }
@@ -56,6 +60,7 @@ impl Config {
             workdir_path,
             config_path,
             timeout_ms: timeout_ms.unwrap_or(10 * 1000),
+            load_workspace_modules: false,
             execute_timeout_ms,
             logger,
         }

--- a/sdk/typescript/src/connectOpts.ts
+++ b/sdk/typescript/src/connectOpts.ts
@@ -11,6 +11,12 @@ export interface ConnectOpts {
   Workdir?: string
 
   /**
+   * Opt into loading workspace modules for this connection.
+   * By default, only the core API is exposed.
+   */
+  LoadWorkspaceModules?: boolean
+
+  /**
      * Enable logs output
      * @example
      * LogOutput

--- a/sdk/typescript/src/provisioning/bin.ts
+++ b/sdk/typescript/src/provisioning/bin.ts
@@ -190,6 +190,10 @@ export class Bin implements EngineConn {
       }
     })
 
+    if (opts.LoadWorkspaceModules) {
+      args.push("--load-workspace-modules")
+    }
+
     if (opts.LogOutput) {
       opts.LogOutput.write("Creating new Engine session... ")
     }

--- a/sdk/typescript/src/provisioning/engineconn.ts
+++ b/sdk/typescript/src/provisioning/engineconn.ts
@@ -5,6 +5,7 @@ export interface ConnectOpts {
   Workdir?: string
   Project?: string
   LogOutput?: Writable
+  LoadWorkspaceModules?: boolean
   Timeout?: number
 }
 


### PR DESCRIPTION
## Summary
- make workspace module loading opt-in by introducing `LoadWorkspaceModules`
- default plain connections to the core API only
- keep `SkipWorkspaceModules` as a legacy compatibility input at the boundary

Closes #12982.

## Verification
- targeted Go tests for engine and Go SDK option/session wiring
- Python syntax check
- Rust formatting check
