### PR TITLE
session: use -m remote ref as workspace when CWD isn't a workspace

### DIFF
--- a/core/integration/module_remote_workspace_defaultpath_test.go
+++ b/core/integration/module_remote_workspace_defaultpath_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"context"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteWorkspaceToolchainDefaultPath reproduces the bug where
+//
+//	dagger -m <remote-repo-root>@<ref> check <toolchain>:<check>
+//
+// fails when the CLI runs from a directory that is NOT itself a dagger
+// workspace. The toolchain's Workspace argument (annotated with
+// defaultPath="/" + @ignorePatterns) then resolves against the empty CWD
+// instead of against the remote repo that -m pointed at.
+//
+// Fixture: github.com/dagger/dagger-test-modules, branch
+// `workspace-default-path`. That branch extends the root dagger.json with
+//
+//	"toolchains": [{"name": "greeter", "source": "workspace-default-path/greeter"}]
+//
+// and adds a greeter module that takes a constructor workspace arg
+// (defaultPath="/" + ignore=["*", "!workspace-default-path/target-subdir/"])
+// and reads workspace-default-path/target-subdir/maven/hello.txt. This
+// mirrors toolchains/java-sdk-dev's shape exactly.
+//
+// Expected outcomes:
+//   - empty CWD + remote root ref + check: FAILS today, PASSES after
+//     the "auto-promote remote -m as workspace when CWD isn't a workspace"
+//     fix lands.
+//   - workspace CWD (local clone) + remote root ref + check: PASSES
+//     today and after — serves as a non-regression guard.
+func (ModuleSuite) TestRemoteWorkspaceToolchainDefaultPath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const (
+		remoteRepo = "github.com/dagger/dagger-test-modules"
+		fixtureRef = "workspace-default-path"
+	)
+
+	// Resolve the fixture commit so the test fails cleanly if the branch
+	// was force-moved or not yet pushed. Using the sha below pins the test
+	// to a known-good fixture state.
+	g := c.Git(remoteRepo).Ref(fixtureRef)
+	commit, err := g.Commit(ctx)
+	require.NoError(t, err,
+		"fixture branch %q on %s is required by this test", fixtureRef, remoteRepo)
+
+	// -m points at the REPO ROOT, not the toolchain subpath. This matches
+	// the production invocation `dagger -m github.com/dagger/dagger@main
+	// check java-sdk:lint`: -m is the whole repo, `greeter:read-check`
+	// asks the workspace for its greeter toolchain and runs its check.
+	modPath := remoteRepo + "@" + commit
+
+	// emptyCtr: an alpine container with the dagger CLI mounted but no
+	// workspace markers — no .git, no dagger.json, nothing up the tree.
+	// This is the failing case: CWD has no workspace, so defaultPath="/"
+	// resolves to an empty host directory.
+	emptyCtr := c.Container().From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/empty")
+
+	// workspaceCtr: same dagger CLI but inside a real git workspace.
+	// This is the non-regression case: CWD is a workspace so defaultPath
+	// resolves against a populated host directory.
+	workspaceCtr := goGitBase(t, c)
+
+	t.Run("empty cwd", func(ctx context.Context, t *testctx.T) {
+		// The target bug. Expected to fail until the engine auto-promotes
+		// the -m remote ref to the workspace when CWD has no workspace
+		// markers.
+		out, err := emptyCtr.
+			With(daggerExec("-m", modPath, "--progress=report", "check", "greeter:read-check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"CWD has no workspace markers; the -m remote ref must stand in as the workspace, got:\n%s", out)
+		require.Regexp(t, `read-check.*OK`, out)
+	})
+
+	t.Run("workspace cwd", func(ctx context.Context, t *testctx.T) {
+		// Non-regression: existing behavior where the CWD is itself a
+		// workspace (has .git). The defaultPath="/" workspace arg
+		// resolves against the local repo, which on a real clone would
+		// contain the expected files.
+		//
+		// NOTE: goGitBase produces /work with a fresh `git init` — empty
+		// tree, no files. We additionally materialise the fixture files
+		// at workspace-default-path/... under /work so the greeter can
+		// actually read them via currentWorkspace.directory(...).
+		layeredCtr := workspaceCtr.
+			WithDirectory(
+				"/work/workspace-default-path/target-subdir",
+				g.Tree().Directory("workspace-default-path/target-subdir"),
+			).
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "seed"`})
+
+		out, err := layeredCtr.
+			With(daggerExec("-m", modPath, "--progress=report", "check", "greeter:read-check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, "workspace CWD must continue to satisfy defaultPath=\"/\": %s", out)
+		require.Regexp(t, `read-check.*OK`, out)
+	})
+}

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -170,18 +170,83 @@ func (srv *Server) loadWorkspaceFromHostPath(ctx context.Context, client *dagger
 		return fmt.Errorf("workspace detection: %w", err)
 	}
 
+	// Auto-promote: when the CLI was invoked with a single remote -m
+	// entrypoint AND the CWD has no workspace markers (no .git or
+	// dagger.json going up), treat the remote ref as the workspace
+	// instead of the empty CWD. Without this, a command like
+	//
+	//   dagger -m github.com/dagger/dagger@main check java-sdk:lint
+	//
+	// run from a non-workspace directory resolves the toolchain's
+	// defaultPath="/" workspace arg against the empty CWD and fails to
+	// find files that only exist in the remote repo.
+	statFS := core.NewCallerStatFS(client.bkClient)
+	if ref, ok := autoRemoteWorkspaceRefFromExtras(ctx, client, statFS); ok {
+		inWS, wsErr := cwdHasWorkspaceMarkers(ctx, statFS, cwd)
+		if wsErr != nil {
+			return fmt.Errorf("workspace detection: %w", wsErr)
+		}
+		if !inWS {
+			return srv.loadWorkspaceFromRemote(ctx, client, ref)
+		}
+	}
+
 	resolveLocalRef := func(ws *workspace.Workspace, relPath string) string {
 		return filepath.Join(ws.Root, ws.Path, relPath)
 	}
 
 	return srv.detectAndLoadWorkspace(ctx, client,
-		core.NewCallerStatFS(client.bkClient),
+		statFS,
 		client.bkClient.ReadCallerHostFile,
 		cwd,
 		resolveLocalRef,
 		nil,
 		true, // isLocal
 	)
+}
+
+// autoRemoteWorkspaceRefFromExtras returns the client's single
+// entrypoint -m remote git ref, if exactly one such ref exists. Used to
+// derive an implicit workspace when the CWD has no workspace of its own.
+// Returns false for ambiguous cases (multiple entrypoint remote refs).
+//
+// ParseRefString is used rather than FastModuleSourceKindCheck because
+// the common `github.com/…` shape is ambiguous under the fast check
+// (the fast check defers to a stat + git-endpoint probe, which we want
+// here so that a local directory whose name happens to contain a dot
+// is not mistakenly promoted to a workspace).
+func autoRemoteWorkspaceRefFromExtras(ctx context.Context, client *daggerClient, statFS core.StatFS) (string, bool) {
+	var chosen string
+	for _, em := range client.pendingExtraModules {
+		if !em.Entrypoint {
+			continue
+		}
+		parsed, err := core.ParseRefString(ctx, statFS, em.Ref, "")
+		if err != nil || parsed == nil || parsed.Kind != core.ModuleSourceKindGit {
+			continue
+		}
+		if chosen != "" {
+			return "", false // ambiguous: multiple entrypoint remote refs
+		}
+		chosen = em.Ref
+	}
+	return chosen, chosen != ""
+}
+
+// cwdHasWorkspaceMarkers reports whether cwd or any ancestor directory
+// contains a workspace marker — a .git entry or a dagger.json file.
+// Matches the two signals workspace.Detect and the dagger.json find-up
+// already rely on.
+func cwdHasWorkspaceMarkers(ctx context.Context, statFS core.StatFS, cwd string) (bool, error) {
+	sought := map[string]struct{}{
+		".git":                         {},
+		workspace.ModuleConfigFileName: {},
+	}
+	found, err := core.Host{}.FindUpAll(ctx, statFS, cwd, sought)
+	if err != nil {
+		return false, err
+	}
+	return len(found) > 0, nil
 }
 
 func (srv *Server) loadWorkspaceFromDeclaredRef(ctx context.Context, client *daggerClient, workspaceRef string) error {


### PR DESCRIPTION
## Summary
- Auto-promote the `-m` remote git ref to the workspace in `loadWorkspaceFromHostPath` when CWD has no workspace markers (no `.git` or `dagger.json` going up). Without this, `dagger -m github.com/dagger/dagger@main check java-sdk:lint` from a non-workspace directory resolves the toolchain's `defaultPath="/"` workspace arg against the empty CWD and can't find files that only exist in the remote repo.
- Adds `ModuleSuite.TestRemoteWorkspaceToolchainDefaultPath` with two subtests — `empty cwd` (the target regression) and `workspace cwd` (non-regression) — both invoking the production shape `dagger -m <repo-root>@<sha> check <toolchain>:<check>` against a new fixture at `github.com/dagger/dagger-test-modules`, branch `workspace-default-path`.
- Short write-up under `hack/designs/remote-toolchain-defaultpath-bug.md` explaining the symptom, why it happens, the fix, and why `c41d6707d` / `b35e37b0e` exposed but did not introduce the gap.

## Test plan
- [ ] CI runs `TestModule.TestRemoteWorkspaceToolchainDefaultPath/empty_cwd` against the patched engine and it passes (would have failed without the fix)
- [ ] CI runs `TestModule.TestRemoteWorkspaceToolchainDefaultPath/workspace_cwd` and it continues to pass (non-regression)
- [ ] Manually reproduce the original report: `cd /tmp/empty && dagger -m github.com/dagger/dagger@main check java-sdk:lint` succeeds with this engine and fails without it
- [ ] Manually verify behaviour when CWD *is* a workspace is unchanged (local workspace still wins; the auto-promotion does not fire)

Depends on fixture branch `workspace-default-path` of `github.com/dagger/dagger-test-modules` (already pushed).