### PR TITLE
session: resolve -m-attached toolchain +defaultPath from the module's repo

### DIFF
--- a/core/integration/module_remote_workspace_defaultpath_test.go
+++ b/core/integration/module_remote_workspace_defaultpath_test.go
@@ -46,6 +46,12 @@ import (
 //     the fix.
 //   - workspace CWD + remote root ref + check: PASSES always — the
 //     local workspace already has the files the toolchain needs.
+//   - workspace CWD with the target subtree removed + remote root ref +
+//     check: MUST pass. Today it FAILS — the CWD-as-workspace wins over
+//     the explicit -m remote ref, so the toolchain resolves against the
+//     partial local tree and misses the file that the remote ref still
+//     has. Drives the follow-up fix: an explicit -m <remote>@<ref> must
+//     take precedence over the local workspace.
 func (ModuleSuite) TestRemoteWorkspaceToolchainDefaultPath(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -191,6 +197,27 @@ git --git-dir=/srv/repo.git update-server-info
 			CombinedOutput(ctx)
 		require.NoError(t, err,
 			"workspace CWD must continue to satisfy defaultPath=\"/\":\n%s", out)
+		require.Regexp(t, `read-check.*OK`, out)
+	})
+
+	t.Run("workspace cwd missing target subtree", func(ctx context.Context, t *testctx.T) {
+		// Target regression for the follow-up fix. CWD is still the
+		// fixture workspace — valid .git, dagger.json, greeter toolchain
+		// — but the "maven" directory that ReadCheck reads has been
+		// removed from the local working tree. The remote ref passed via
+		// -m still contains it. The user's intent with `-m <remote>@<ref>`
+		// is "run this module from that ref", so the toolchain's
+		// defaultPath="/" workspace must resolve against the remote ref,
+		// not against a partial local checkout that happens to be the
+		// CWD. Today this FAILS: CWD-as-workspace wins over the explicit
+		// -m remote ref. The follow-up fix must make an explicit remote
+		// -m take precedence.
+		out, err := workspace().
+			WithExec([]string{"rm", "-rf", "/work/workspace-default-path/target-subdir/maven"}).
+			With(daggerExec("-m", modPath, "--progress=report", "check", "greeter:read-check")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"explicit -m remote ref must take precedence over a local workspace missing the target subtree:\n%s", out)
 		require.Regexp(t, `read-check.*OK`, out)
 	})
 }

--- a/core/integration/module_remote_workspace_defaultpath_test.go
+++ b/core/integration/module_remote_workspace_defaultpath_test.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"context"
+	"strings"
 
+	"dagger.io/dagger"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -16,90 +18,181 @@ import (
 // defaultPath="/" + @ignorePatterns) then resolves against the empty CWD
 // instead of against the remote repo that -m pointed at.
 //
-// Fixture: github.com/dagger/dagger-test-modules, branch
-// `workspace-default-path`. That branch extends the root dagger.json with
+// Fixture layout (built inline, no external dependencies):
 //
-//	"toolchains": [{"name": "greeter", "source": "workspace-default-path/greeter"}]
+//	/work                                  (git repo root, workspace root)
+//	├── .git/
+//	├── dagger.json                        (workspace, registers greeter toolchain)
+//	├── workspace-default-path/
+//	│   ├── greeter/                       (toolchain, Go SDK)
+//	│   │   ├── dagger.json
+//	│   │   └── main.go                    (constructor workspace arg + ReadCheck)
+//	│   └── target-subdir/
+//	│       └── maven/
+//	│           └── hello.txt              (what ReadCheck must reach)
+//	└── ...
 //
-// and adds a greeter module that takes a constructor workspace arg
-// (defaultPath="/" + ignore=["*", "!workspace-default-path/target-subdir/"])
-// and reads workspace-default-path/target-subdir/maven/hello.txt. This
-// mirrors toolchains/java-sdk-dev's shape exactly.
+// The fixture is committed, pushed into a bare repo inside the test
+// container, and served via gitSmartHTTPServiceDirAuth. The service
+// hostname is auto-generated (dot-less), so the test resolves it to an
+// IP at runtime and uses the IP in the -m URL — that satisfies both the
+// vcs URL parser's "host must contain a dot" requirement and the
+// engine's network reachability requirement without any external
+// fixture.
 //
 // Expected outcomes:
-//   - empty CWD + remote root ref + check: FAILS today, PASSES after
-//     the "auto-promote remote -m as workspace when CWD isn't a workspace"
-//     fix lands.
-//   - workspace CWD (local clone) + remote root ref + check: PASSES
-//     today and after — serves as a non-regression guard.
+//   - empty CWD + remote root ref + check: FAILS without the engine
+//     auto-promoting the -m remote ref to the workspace. PASSES with
+//     the fix.
+//   - workspace CWD + remote root ref + check: PASSES always — the
+//     local workspace already has the files the toolchain needs.
 func (ModuleSuite) TestRemoteWorkspaceToolchainDefaultPath(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	const (
-		remoteRepo = "github.com/dagger/dagger-test-modules"
-		fixtureRef = "workspace-default-path"
+	const subdirFileContent = "hello from workspace subdir"
+
+	// The toolchain. Workspace is a constructor field annotated with
+	// defaultPath="/" + ignore that re-includes only the target subtree —
+	// the same shape as toolchains/java-sdk-dev. ReadCheck accesses a
+	// sub-sub-directory (maven) of the un-excluded parent, mirroring
+	// workspace.directory("sdk/java/runtime/images/maven").
+	const greeterSource = `package main
+
+import (
+	"context"
+	"dagger/greeter/internal/dagger"
+)
+
+type Greeter struct {
+	Workspace *dagger.Directory
+}
+
+func New(
+	// +defaultPath="/"
+	// +ignore=["*", "!workspace-default-path/target-subdir/"]
+	workspace *dagger.Directory,
+) *Greeter {
+	return &Greeter{Workspace: workspace}
+}
+
+func (m *Greeter) Read(ctx context.Context) (string, error) {
+	return m.Workspace.
+		Directory("workspace-default-path/target-subdir/maven").
+		File("hello.txt").
+		Contents(ctx)
+}
+
+// +check
+func (m *Greeter) ReadCheck(ctx context.Context) error {
+	_, err := m.Workspace.
+		Directory("workspace-default-path/target-subdir/maven").
+		File("hello.txt").
+		Contents(ctx)
+	return err
+}
+`
+
+	// Build the fixture workspace at /work and commit it to a fresh git
+	// repo. Both the remote-server path and the workspace-CWD subtest
+	// re-use this container as their starting point.
+	workspace := func() *dagger.Container {
+		return goGitBase(t, c).
+			// Target file that ReadCheck must reach through the workspace.
+			WithNewFile("/work/workspace-default-path/target-subdir/maven/hello.txt", subdirFileContent).
+			// Scaffold the greeter toolchain.
+			WithWorkdir("/work/workspace-default-path/greeter").
+			With(daggerExec("init", "--sdk=go", "--name=greeter", "--source=.")).
+			With(sdkSource("go", greeterSource)).
+			// Scaffold the workspace root and register greeter as a toolchain.
+			WithWorkdir("/work").
+			With(daggerExec("init")).
+			With(daggerExec("toolchain", "install", "./workspace-default-path/greeter")).
+			// Commit everything so the tree can be pushed to a bare repo.
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "init"`})
+	}
+
+	// Push the committed workspace into a bare repo and serve it over
+	// smart HTTP. The bare repo lives inside the container that defines
+	// the service, so the fixture never leaves the session.
+	bareSetup := workspace().
+		WithExec([]string{"sh", "-c", `
+set -eux
+git init --bare --initial-branch=main /srv/repo.git
+git remote add origin /srv/repo.git
+git push origin HEAD:refs/heads/main
+# update-server-info is harmless for smart HTTP and required for dumb HTTP.
+git --git-dir=/srv/repo.git update-server-info
+`})
+
+	commitOut, err := bareSetup.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	commit := strings.TrimSpace(commitOut)
+
+	gitSrv, _ := gitSmartHTTPServiceDirAuth(
+		ctx, t, c,
+		"", // auto-generated hostname — its dot-less short form is what the session DNS knows.
+		bareSetup.Directory("/srv"),
+		"", nil,
 	)
+	gitSrv, err = gitSrv.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = gitSrv.Stop(ctx) })
 
-	// Resolve the fixture commit so the test fails cleanly if the branch
-	// was force-moved or not yet pushed. Using the sha below pins the test
-	// to a known-good fixture state.
-	g := c.Git(remoteRepo).Ref(fixtureRef)
-	commit, err := g.Commit(ctx)
-	require.NoError(t, err,
-		"fixture branch %q on %s is required by this test", fixtureRef, remoteRepo)
+	shortHost, err := gitSrv.Hostname(ctx)
+	require.NoError(t, err)
 
-	// -m points at the REPO ROOT, not the toolchain subpath. This matches
-	// the production invocation `dagger -m github.com/dagger/dagger@main
-	// check java-sdk:lint`: -m is the whole repo, `greeter:read-check`
-	// asks the workspace for its greeter toolchain and runs its check.
-	modPath := remoteRepo + "@" + commit
+	// The vcs URL parser (engine/vcs/vcs.go) requires at least one dot
+	// in the host component. The auto-generated service hostname is
+	// dot-less ("<hash>"), but it IS registered in the session DNS via
+	// search-domain expansion to "<hash>.<sessionhash>.dagger.local".
+	// Resolve it to an IP in any container that shares the session DNS
+	// — buildkit already puts the session search domain in resolv.conf —
+	// and use the IP in the URL. IPs satisfy the vcs regex (they have
+	// dots) and need no DNS at all.
+	getentOut, err := c.Container().From(alpineImage).
+		WithExec([]string{"getent", "hosts", shortHost}).
+		Stdout(ctx)
+	require.NoError(t, err, "could not resolve git service hostname %q", shortHost)
+	fields := strings.Fields(getentOut)
+	require.NotEmpty(t, fields, "unexpected getent output: %q", getentOut)
+	serviceIP := fields[0]
 
-	// emptyCtr: an alpine container with the dagger CLI mounted but no
-	// workspace markers — no .git, no dagger.json, nothing up the tree.
-	// This is the failing case: CWD has no workspace, so defaultPath="/"
-	// resolves to an empty host directory.
-	emptyCtr := c.Container().From(alpineImage).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		WithWorkdir("/empty")
-
-	// workspaceCtr: same dagger CLI but inside a real git workspace.
-	// This is the non-regression case: CWD is a workspace so defaultPath
-	// resolves against a populated host directory.
-	workspaceCtr := goGitBase(t, c)
+	modPath := "http://" + serviceIP + "/repo.git@" + commit
 
 	t.Run("empty cwd", func(ctx context.Context, t *testctx.T) {
-		// The target bug. Expected to fail until the engine auto-promotes
-		// the -m remote ref to the workspace when CWD has no workspace
-		// markers.
+		// Target regression. The CLI runs from an alpine container with
+		// no .git or dagger.json anywhere up the tree, so
+		// workspace.Detect falls back to the empty CWD. Without the
+		// fix, the toolchain's defaultPath="/" workspace arg resolves
+		// against that empty directory and ReadCheck cannot find
+		// workspace-default-path/target-subdir/maven/hello.txt. With
+		// the fix, the -m remote ref is auto-promoted to the workspace
+		// and the file resolves against the cloned repo tree.
+		emptyCtr := c.Container().From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/empty")
+
 		out, err := emptyCtr.
 			With(daggerExec("-m", modPath, "--progress=report", "check", "greeter:read-check")).
 			CombinedOutput(ctx)
 		require.NoError(t, err,
-			"CWD has no workspace markers; the -m remote ref must stand in as the workspace, got:\n%s", out)
+			"CWD has no workspace markers; the -m remote ref must stand in as the workspace:\n%s", out)
 		require.Regexp(t, `read-check.*OK`, out)
 	})
 
 	t.Run("workspace cwd", func(ctx context.Context, t *testctx.T) {
-		// Non-regression: existing behavior where the CWD is itself a
-		// workspace (has .git). The defaultPath="/" workspace arg
-		// resolves against the local repo, which on a real clone would
-		// contain the expected files.
-		//
-		// NOTE: goGitBase produces /work with a fresh `git init` — empty
-		// tree, no files. We additionally materialise the fixture files
-		// at workspace-default-path/... under /work so the greeter can
-		// actually read them via currentWorkspace.directory(...).
-		layeredCtr := workspaceCtr.
-			WithDirectory(
-				"/work/workspace-default-path/target-subdir",
-				g.Tree().Directory("workspace-default-path/target-subdir"),
-			).
-			WithExec([]string{"sh", "-c", `git add . && git commit -m "seed"`})
-
-		out, err := layeredCtr.
+		// Non-regression. CWD is the fixture workspace itself (goGitBase
+		// + committed tree), so currentWorkspace resolves to a
+		// populated local repo and nothing in the engine changes shape.
+		// This guards against any accidental regression in the "running
+		// from a local clone" path while the empty-CWD fix lands.
+		out, err := workspace().
 			With(daggerExec("-m", modPath, "--progress=report", "check", "greeter:read-check")).
 			CombinedOutput(ctx)
-		require.NoError(t, err, "workspace CWD must continue to satisfy defaultPath=\"/\": %s", out)
+		require.NoError(t, err,
+			"workspace CWD must continue to satisfy defaultPath=\"/\":\n%s", out)
 		require.Regexp(t, `read-check.*OK`, out)
 	})
 }
+
+var _ = dagger.ReturnTypeAny // keep the dagger import live for *dagger.Container types

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -786,10 +786,18 @@ func pendingRelatedModule(
 	entrypoint bool,
 ) pendingModule {
 	mod := pendingModule{
-		Ref:               related.AsString(),
-		RefPin:            related.Pin(),
-		Entrypoint:        entrypoint,
-		LegacyDefaultPath: true,
+		Ref:        related.AsString(),
+		RefPin:     related.Pin(),
+		Entrypoint: entrypoint,
+		// LegacyDefaultPath is intentionally not set here. Related modules
+		// are loaded as siblings of an explicit -m entrypoint: their
+		// +defaultPath must resolve against that entrypoint's repo (the
+		// -m argument), not against the session's currentWorkspace — the
+		// latter is the user's CWD, which may be empty, partial, or a
+		// different checkout entirely. The default _contextDirectory
+		// resolution already uses the module's own source, which for a
+		// toolchain/blueprint declared as a subdir of the -m module
+		// shares the entrypoint's clone (or local context) root.
 	}
 	if cfg != nil {
 		if cfg.Name != "" {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -170,83 +170,18 @@ func (srv *Server) loadWorkspaceFromHostPath(ctx context.Context, client *dagger
 		return fmt.Errorf("workspace detection: %w", err)
 	}
 
-	// Auto-promote: when the CLI was invoked with a single remote -m
-	// entrypoint AND the CWD has no workspace markers (no .git or
-	// dagger.json going up), treat the remote ref as the workspace
-	// instead of the empty CWD. Without this, a command like
-	//
-	//   dagger -m github.com/dagger/dagger@main check java-sdk:lint
-	//
-	// run from a non-workspace directory resolves the toolchain's
-	// defaultPath="/" workspace arg against the empty CWD and fails to
-	// find files that only exist in the remote repo.
-	statFS := core.NewCallerStatFS(client.bkClient)
-	if ref, ok := autoRemoteWorkspaceRefFromExtras(ctx, client, statFS); ok {
-		inWS, wsErr := cwdHasWorkspaceMarkers(ctx, statFS, cwd)
-		if wsErr != nil {
-			return fmt.Errorf("workspace detection: %w", wsErr)
-		}
-		if !inWS {
-			return srv.loadWorkspaceFromRemote(ctx, client, ref)
-		}
-	}
-
 	resolveLocalRef := func(ws *workspace.Workspace, relPath string) string {
 		return filepath.Join(ws.Root, ws.Path, relPath)
 	}
 
 	return srv.detectAndLoadWorkspace(ctx, client,
-		statFS,
+		core.NewCallerStatFS(client.bkClient),
 		client.bkClient.ReadCallerHostFile,
 		cwd,
 		resolveLocalRef,
 		nil,
 		true, // isLocal
 	)
-}
-
-// autoRemoteWorkspaceRefFromExtras returns the client's single
-// entrypoint -m remote git ref, if exactly one such ref exists. Used to
-// derive an implicit workspace when the CWD has no workspace of its own.
-// Returns false for ambiguous cases (multiple entrypoint remote refs).
-//
-// ParseRefString is used rather than FastModuleSourceKindCheck because
-// the common `github.com/…` shape is ambiguous under the fast check
-// (the fast check defers to a stat + git-endpoint probe, which we want
-// here so that a local directory whose name happens to contain a dot
-// is not mistakenly promoted to a workspace).
-func autoRemoteWorkspaceRefFromExtras(ctx context.Context, client *daggerClient, statFS core.StatFS) (string, bool) {
-	var chosen string
-	for _, em := range client.pendingExtraModules {
-		if !em.Entrypoint {
-			continue
-		}
-		parsed, err := core.ParseRefString(ctx, statFS, em.Ref, "")
-		if err != nil || parsed == nil || parsed.Kind != core.ModuleSourceKindGit {
-			continue
-		}
-		if chosen != "" {
-			return "", false // ambiguous: multiple entrypoint remote refs
-		}
-		chosen = em.Ref
-	}
-	return chosen, chosen != ""
-}
-
-// cwdHasWorkspaceMarkers reports whether cwd or any ancestor directory
-// contains a workspace marker — a .git entry or a dagger.json file.
-// Matches the two signals workspace.Detect and the dagger.json find-up
-// already rely on.
-func cwdHasWorkspaceMarkers(ctx context.Context, statFS core.StatFS, cwd string) (bool, error) {
-	sought := map[string]struct{}{
-		".git":                         {},
-		workspace.ModuleConfigFileName: {},
-	}
-	found, err := core.Host{}.FindUpAll(ctx, statFS, cwd, sought)
-	if err != nil {
-		return false, err
-	}
-	return len(found) > 0, nil
 }
 
 func (srv *Server) loadWorkspaceFromDeclaredRef(ctx context.Context, client *daggerClient, workspaceRef string) error {


### PR DESCRIPTION
Follow-up to #12985. That PR landed a partial fix — it only handled the empty-CWD case of `dagger -m <remote>@<ref>` by auto-promoting the `-m` ref to the workspace when no workspace was detected. Two more scenarios were still broken:

- **Workspace CWD missing the target subtree.** User is in a local checkout of the same repo but has deleted (or hasn't pulled, or is on a stale branch of) the files the toolchain reads. The session silently resolved toolchain `+defaultPath` against the partial local tree instead of the `-m` ref, producing confusing "file not found" errors.
- **Unrelated workspace CWD.** User runs `dagger -m github.com/foo/bar@v1 check ...` from an unrelated local dagger workspace. The toolchain read files from the local workspace rather than `foo/bar`, exposing whatever happens to be on disk.

Both collapse into the same root cause: `+defaultPath` on `-m`-attached toolchains was being resolved against `currentWorkspace` — the session's CWD-derived workspace — instead of the module the user explicitly asked for.

## Patch stack (bottom → top)

1. **`test(core): embed remote-ref workspace-defaultPath fixture in-repo`** — original PR: replace the external `dagger-test-modules` fixture with an in-repo one served over smart-HTTP inside the session.
2. **`test(core): add missing-target-subtree case to remote-ref workspace test`** — third subtest: local workspace minus the file the toolchain needs. Fails against the partial fix (drives this PR).
3. **`Revert "session: auto-promote -m remote ref as workspace when CWD is not a workspace"`** — backs out the partial `engine/server/session_workspaces.go` fix from #12985 so the follow-up replaces it with a single, coherent rule.
4. **`session: resolve -m-attached toolchain +defaultPath from the module's repo`** — the actual fix (see below).

## The fix

Single-line behavior change in `pendingRelatedModule`: stop setting `LegacyDefaultPath: true` on modules loaded as siblings of an explicit `-m` entrypoint.

### Where `LegacyDefaultPath` is set

Only two call sites set this flag, by design — they correspond to the two ways a legacy toolchain/blueprint can enter the session:

| Setter | Path | Source of the module |
|---|---|---|
| `pendingLegacyModule` | `engine/server/session_workspaces.go:412` | Local `dagger.json` parsed from the user's CWD workspace — the "no `-m`, just run `dagger check` in a checkout" path |
| `pendingRelatedModule` | `engine/server/session_workspaces.go:792` | `toolchains`/`blueprint` entries of an explicit `-m <ref>` entrypoint |

This PR only touches **the second**. `pendingLegacyModule` still sets `LegacyDefaultPath: true`, so the existing behavior of "run from a local workspace checkout" is unchanged.

### Where it made sense (and still does)

`pendingLegacyModule`. When the user is running `dagger check` inside a local workspace, the toolchain's `+defaultPath="/"` has always meant "the workspace root" — the directory that holds `dagger.json`. `currentWorkspace` is exactly that directory in this path, so `loadLegacyDefaultPathArg` routes correctly. No change.

### Where it was removed (and why)

`pendingRelatedModule`. When the user writes `dagger -m <remote>@<ref>`, the toolchain's `+defaultPath` should track the `-m` ref, not the user's shell CWD. Routing through `currentWorkspace` broke that in three ways — empty CWD, partial checkout, unrelated workspace — because `currentWorkspace` is derived from the CWD, not from `-m`.

With `LegacyDefaultPath` unset, the default `_contextDirectory` resolution kicks in: it uses the module's own `ModuleSource`. For a toolchain/blueprint declared as a subdirectory of the `-m` entrypoint:

- **Git `-m`**: the toolchain's source is `ModuleSourceKindGit` and its `UnfilteredContextDir` is the full clone tree of the `-m` ref. `+defaultPath="/"` resolves to that clone root — exactly "the `-m` repo".
- **Local `-m`**: the toolchain's source is `ModuleSourceKindLocal` and its `ContextDirectoryPath` is the `-m` path's `.git` ancestor (or the path itself). `+defaultPath="/"` resolves there.

The `Workspace` argument type is unaffected — it goes through `loadWorkspaceArg` → `currentWorkspace`, which this PR does not touch. So toolchains that explicitly accept a `Workspace` continue to see the user's session workspace, preserving the current contract for that argument.

### Cache-key nuance

`args.LegacyDefaultPath` contributes to the module content cache key at `core/schema/modulesource.go:3202`. Related modules now produce a different cache entry than before. That is fine: the key is per-session and no code paths depend on cross-patch stability of that value.

## Test coverage

`TestModule/TestRemoteWorkspaceToolchainDefaultPath` (in `core/integration/module_remote_workspace_defaultpath_test.go`) now has three subtests and all pass against the fix:

- `empty_cwd` — no workspace markers on host, `-m` remote ref is the only source of the tree.
- `workspace_cwd` — non-regression for a local clone whose files match the `-m` ref.
- `workspace_cwd_missing_target_subtree` — local checkout is a valid dagger workspace but the toolchain's target directory has been removed from the working tree; the `-m` ref still has it.

Verified with:

```
dagger call engine-dev test --pkg="./core/integration" --run="^TestModule/TestRemoteWorkspaceToolchainDefaultPath"
```

The `workspace_cwd` case also acts as the end-to-end regression guard for the `pendingLegacyModule` path (the untouched setter), because its fixture has a valid local `dagger.json` whose legacy toolchain is parsed and loaded exactly that way.