### PR TITLE
chore: remove leftover WithSkipWorkspaceModules references

### DIFF
--- a/cmd/codegen/generator/typescript/templates/functions_test.go
+++ b/cmd/codegen/generator/typescript/templates/functions_test.go
@@ -16,7 +16,7 @@ var currentSchema *introspection.Schema
 func init() {
 	ctx := context.Background()
 
-	c, err := dagger.Connect(ctx, dagger.WithSkipWorkspaceModules())
+	c, err := dagger.Connect(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -66,7 +66,6 @@ func connect(ctx context.Context, t testing.TB, opts ...dagger.ClientOpt) *dagge
 	opts = append([]dagger.ClientOpt{
 		// FIXME: test spans are easier to read in the TUI when this is silenced
 		dagger.WithLogOutput(io.Discard),
-		dagger.WithSkipWorkspaceModules(),
 	}, opts...)
 	client, err := dagger.Connect(ctx, opts...)
 	require.NoError(t, err)

--- a/sdk/go/provision_test.go
+++ b/sdk/go/provision_test.go
@@ -104,7 +104,7 @@ func TestProvision(t *testing.T) {
 	f.Close()
 
 	run := func() error {
-		c, err := Connect(ctx, WithLogOutput(os.Stderr), WithSkipWorkspaceModules())
+		c, err := Connect(ctx, WithLogOutput(os.Stderr))
 		if err != nil {
 			return fmt.Errorf("failed to connect: %w", err)
 		}


### PR DESCRIPTION
Fixes this [go:lint](https://dagger.cloud/dagger/checks/github.com/dagger/dagger@e004ad8f81ac206313fb704ac6567b1e23670b9e?check=go%3Alint&listen=a4ebf6aefa2ae466#a4ebf6aefa2ae466:L2) CI error

The opt-in / opt-out PR changes the default workspace loading, and we forgot to remote those