### PR TITLE
ci: add TypeScript SDK smoke coverage to bootstrap

### DIFF
--- a/toolchains/ci/bootstrap.dang
+++ b/toolchains/ci/bootstrap.dang
@@ -18,7 +18,11 @@ type CI {
     """
     Which checks to run
     """
-    checks: [String!]! = ["**:*lint*"],
+    checks: [String!]! = [
+      "**:*lint*",
+      # Exercises a downstream SDK's provisioned CLI path without dragging in a large test matrix.
+      "typescript-sdk:test-nodejs-lts",
+    ],
   ): Void @check {
     let source = source.directory("/", gitignore: true)
     engineDev


### PR DESCRIPTION
Add `typescript-sdk:test-nodejs-lts` to the default `ci:bootstrap` smoke set.

This keeps bootstrap small while covering a downstream SDK path that exercises the provisioned CLI.