### PR TITLE
fix(core/schema): include toolchains in module codegen schema

### DIFF
--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -176,6 +176,34 @@ func (ToolchainSuite) TestToolchainsWithSDK(ctx context.Context, t *testctx.T) {
 		require.Contains(t, out, "hello from blueprint")
 	})
 
+	// Regression test: a module must be able to call its toolchain through
+	// the generated SDK bindings, i.e. the toolchain's types must be present
+	// in the module's codegen schema. This worked in v0.20.3, broke in
+	// v0.20.4 when toolchains stopped being loaded as codegen deps.
+	t.Run("module code can call toolchain through generated bindings", func(ctx context.Context, t *testctx.T) {
+		setup := toolchainTestEnv(t, c).
+			WithWorkdir("app").
+			With(daggerExec("init", "--sdk=go", "--name=app", "--source=.")).
+			With(daggerExec("toolchain", "install", "../hello")).
+			WithNewFile("main.go", `package main
+
+import "context"
+
+type App struct{}
+
+// GreetFromToolchain invokes the toolchain's Message() through the Go
+// bindings, which requires the toolchain's types to be in the codegen schema.
+func (m *App) GreetFromToolchain(ctx context.Context) (string, error) {
+	return dag.Hello().Message(ctx)
+}
+`)
+		out, err := setup.
+			With(daggerExec("call", "greet-from-toolchain")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from blueprint")
+	})
+
 	// Verify that the parent fields of the top level module is not invading
 	// toolchains state.
 	t.Run("use checks with sdk that have a constructor", func(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
Re-add toolchain modules to loadDependencyModules so a module's generated SDK bindings expose toolchain types — restoring the v0.20.3 behavior that was removed in the workspace refactor (db59252ad / 70bf9851b).

Without this, a module that installs a toolchain cannot reference the toolchain's types from its own code: dagger develop produces bindings with no constructor for the toolchain, so code like dag.MyToolchain() fails to compile with 'dag.MyToolchain undefined'. Runtime is already covered by the workspace session layer, which continues to serve toolchains independently; this change only affects codegen.

Minimal patch — it does not restore the IsToolchain flag or the validation escape hatch that previously allowed a module to expose toolchain types in its own public signatures. That narrower case (func (m *M) Foo() *dagger.SomeToolchainType) still fails validation; this patch is scoped to the common case of calling toolchains from within module code.