### PR TITLE
Improve go:lint

### DIFF
--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -490,18 +490,18 @@ func (p *Go) Modules(
 	return mods, nil
 }
 
-func (p *Go) TidyModule(ctx context.Context, mod string) (*dagger.Changeset, error) {
-	p, err := p.GenerateDaggerRuntime(ctx, mod)
+func (p *Go) TidyModule(ctx context.Context, module string) (*dagger.Changeset, error) {
+	p, err := p.GenerateDaggerRuntime(ctx, module)
 	if err != nil {
 		return nil, err
 	}
 	tidyModDir := p.Env(defaultPlatform).
-		WithWorkdir(mod).
+		WithWorkdir(module).
 		WithExec([]string{"go", "mod", "tidy"}).
 		Directory(".")
 	return p.Source.
-		WithFile(path.Join(mod, "/go.mod"), tidyModDir.File("go.mod")).
-		WithFile(path.Join(mod, "/go.sum"), tidyModDir.File("go.sum")).
+		WithFile(path.Join(module, "/go.mod"), tidyModDir.File("go.mod")).
+		WithFile(path.Join(module, "/go.sum"), tidyModDir.File("go.sum")).
 		Changes(p.Source), nil
 }
 

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -645,12 +645,12 @@ func (p *Go) Lint(
 	return jobs.Run(ctx)
 }
 
-func (p *Go) LintModule(ctx context.Context, mod string) error {
+func (p *Go) LintModule(ctx context.Context, module string) error {
 	lintImageRepo := "docker.io/golangci/golangci-lint"
 	lintImageTag := "v2.11.4-alpine"
 	lintImageDigest := "sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9"
 	lintImage := lintImageRepo + ":" + lintImageTag + "@" + lintImageDigest
-	p, err := p.GenerateDaggerRuntime(ctx, mod)
+	p, err := p.GenerateDaggerRuntime(ctx, module)
 	if err != nil {
 		return err
 	}
@@ -662,10 +662,10 @@ func (p *Go) LintModule(ctx context.Context, mod string) error {
 			WithMountedCache("/root/.cache/golangci-lint", dag.CacheVolume("golangci-lint")).
 			WithWorkdir("/src").
 			WithMountedDirectory(".", p.Source).
-			WithWorkdir(mod).
+			WithWorkdir(module).
 			WithExec([]string{
 				"golangci-lint", "run",
-				"--path-prefix", mod + "/",
+				"--path-prefix", module + "/",
 				"--output.tab.path=stderr",
 				"--output.tab.print-linter-name=true",
 				"--output.tab.colors=false",

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -507,15 +507,23 @@ func (p *Go) TidyModule(ctx context.Context, mod string) (*dagger.Changeset, err
 
 func (p *Go) Tidy(
 	ctx context.Context,
-	include []string, // +optional
-	exclude []string, // +optional
+	// +optional
+	include []string,
+	// +optional
+	exclude []string,
+	// limit numbers of go mod tidy parallel jobs to run
+	// +default=3
+	limit int,
 ) (*dagger.Changeset, error) {
 	modules, err := p.Modules(ctx, include, exclude)
 	if err != nil {
 		return nil, err
 	}
 	tidyModules := make([]*dagger.Changeset, len(modules))
-	jobs := parallel.New()
+	jobs := parallel.New().
+		// On a large repo this can run dozens of parallel go mod tidy jobs,
+		// which can lead to OOM or extreme CPU usage, so we limit parallelism
+		WithLimit(limit)
 	for i, mod := range modules {
 		jobs = jobs.WithJob(mod, func(ctx context.Context) error {
 			var err error
@@ -526,23 +534,7 @@ func (p *Go) Tidy(
 	if err := jobs.Run(ctx); err != nil {
 		return nil, err
 	}
-	return changesetMerge(tidyModules...), nil
-}
-
-// Merge Changesets together
-// FIXME: move this to core dagger: https://github.com/dagger/dagger/issues/11189
-// FIXME: this duplicates the same function in .dagger/util.go
-// (cross-module function sharing is a PITA)
-func changesetMerge(changesets ...*dagger.Changeset) *dagger.Changeset {
-	before := dag.Directory()
-	for _, changeset := range changesets {
-		before = before.WithDirectory("", changeset.Before())
-	}
-	after := before
-	for _, changeset := range changesets {
-		after = after.WithChanges(changeset)
-	}
-	return after.Changes(before)
+	return dag.Changeset().WithChangesets(tidyModules), nil
 }
 
 // Check if 'go mod tidy' is up-to-date
@@ -562,7 +554,7 @@ func (p *Go) CheckTidy(
 		return err
 	}
 	jobs := parallel.New().
-		// On a large repo this can run dozens of parallel golangci-lint jobs,
+		// On a large repo this can run dozens of parallel go mod tidy jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
 		WithLimit(limit).
 		// For better display in 'dagger checks': logs from all functions below the job will

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -549,8 +549,13 @@ func changesetMerge(changesets ...*dagger.Changeset) *dagger.Changeset {
 // +check
 func (p *Go) CheckTidy(
 	ctx context.Context,
-	include []string, // +optional
-	exclude []string, // +optional
+	// +optional
+	include []string,
+	// +optional
+	exclude []string,
+	// limit numbers of go mod tidy parallel jobs to run
+	// +default=3
+	limit int,
 ) error {
 	modules, err := p.Modules(ctx, include, exclude)
 	if err != nil {
@@ -559,7 +564,7 @@ func (p *Go) CheckTidy(
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel golangci-lint jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
-		WithLimit(3).
+		WithLimit(limit).
 		// For better display in 'dagger checks': logs from all functions below the job will
 		// be printed below the job.
 		// TODO: remove this when dagger has a sub-checks API

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -619,8 +619,13 @@ func filterPath(path string, include, exclude []string) (bool, error) {
 // +check
 func (p *Go) Lint(
 	ctx context.Context,
-	include []string, //+optional
-	exclude []string, //+optional
+	// +optional
+	include []string,
+	// +optional
+	exclude []string,
+	// limit numbers of golangci-lint parallel jobs to run
+	// +default=3
+	limit int,
 ) error {
 	mods, err := p.Modules(ctx, include, exclude)
 	if err != nil {
@@ -629,7 +634,7 @@ func (p *Go) Lint(
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel golangci-lint jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
-		WithLimit(3).
+		WithLimit(limit).
 		// For better display in 'dagger checks': logs from all functions below the job will
 		// be printed below the job.
 		// TODO: remove this when dagger has a sub-checks API

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -71,6 +71,10 @@ func New(
 	// valid if 'base' arg is nil
 	// +optional
 	extraPackages []string,
+
+	// max number of parallel jobs to run for tidy/check tidy/lint
+	// +default=3
+	limit int,
 ) *Go {
 	if source == nil {
 		source = dag.Directory()
@@ -126,6 +130,7 @@ func New(
 		Cgo:         cgo,
 		Race:        race,
 		Experiment:  experiment,
+		Limit:       limit,
 	}
 }
 
@@ -167,6 +172,9 @@ type Go struct {
 	Include []string
 
 	Exclude []string
+
+	// Max number of parallel jobs to run
+	Limit int
 }
 
 type AssociativeArray[T any] []struct {
@@ -507,13 +515,8 @@ func (p *Go) TidyModule(ctx context.Context, module string) (*dagger.Changeset, 
 
 func (p *Go) Tidy(
 	ctx context.Context,
-	// +optional
-	include []string,
-	// +optional
-	exclude []string,
-	// limit numbers of go mod tidy parallel jobs to run
-	// +default=3
-	limit int,
+	include []string, // +optional
+	exclude []string, // +optional
 ) (*dagger.Changeset, error) {
 	modules, err := p.Modules(ctx, include, exclude)
 	if err != nil {
@@ -523,7 +526,7 @@ func (p *Go) Tidy(
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel go mod tidy jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
-		WithLimit(limit)
+		WithLimit(p.Limit)
 	for i, mod := range modules {
 		jobs = jobs.WithJob(mod, func(ctx context.Context) error {
 			var err error
@@ -541,13 +544,8 @@ func (p *Go) Tidy(
 // +check
 func (p *Go) CheckTidy(
 	ctx context.Context,
-	// +optional
-	include []string,
-	// +optional
-	exclude []string,
-	// limit numbers of go mod tidy parallel jobs to run
-	// +default=3
-	limit int,
+	include []string, // +optional
+	exclude []string, // +optional
 ) error {
 	modules, err := p.Modules(ctx, include, exclude)
 	if err != nil {
@@ -556,7 +554,7 @@ func (p *Go) CheckTidy(
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel go mod tidy jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
-		WithLimit(limit).
+		WithLimit(p.Limit).
 		// For better display in 'dagger checks': logs from all functions below the job will
 		// be printed below the job.
 		// TODO: remove this when dagger has a sub-checks API
@@ -616,13 +614,8 @@ func filterPath(path string, include, exclude []string) (bool, error) {
 // +check
 func (p *Go) Lint(
 	ctx context.Context,
-	// +optional
-	include []string,
-	// +optional
-	exclude []string,
-	// limit numbers of golangci-lint parallel jobs to run
-	// +default=3
-	limit int,
+	include []string, // +optional
+	exclude []string, // +optional
 ) error {
 	mods, err := p.Modules(ctx, include, exclude)
 	if err != nil {
@@ -631,7 +624,7 @@ func (p *Go) Lint(
 	jobs := parallel.New().
 		// On a large repo this can run dozens of parallel golangci-lint jobs,
 		// which can lead to OOM or extreme CPU usage, so we limit parallelism
-		WithLimit(limit).
+		WithLimit(p.Limit).
 		// For better display in 'dagger checks': logs from all functions below the job will
 		// be printed below the job.
 		// TODO: remove this when dagger has a sub-checks API


### PR DESCRIPTION
Improve our Go linter module:

- `dagger call go lint-module --module=...`: previously the argument was `mod`, and `--mod` was conflicting with the `-m/--mod` of `dagger` CLI
~~- `dagger call go lint --limit=1`: allow to set the parallelism limit for golangci-lint, very useful on personal machines to not use all the resources~~
~~- `dagger call go check-tidy --limit=1`~~
~~- `dagger call go tidy --limit=1`~~
- `dagger call go tidy-module --module=...`

The `limit` argument is now set at the constructor level. It allows to define it once for all the different calls.
`dagger call go --limit=1 lint`, `dagger call go --limit=1 check-tidy`, `dagger call go --limit=1 tidy`.
But it also allows to easily put it in a `.env` file like:
```sh
GO_LIMIT=1
```

And then use the classical `dagger check go:lint` or `dagger check go:check-tidy` and it will use the user default value, that makes it very convenient to use.

And also removing the custom `Changeset` merge to rely on the one in the engine `dag.Changest().WithChangesets(...)`