### PR TITLE
Fix `up` display of exposed url

### DIFF
--- a/core/modtree.go
+++ b/core/modtree.go
@@ -228,6 +228,13 @@ func (node *ModTreeNode) tryRunCheckScaleOut(ctx context.Context) (_ bool, rerr 
 // github.com/dagger/otel-go package which we cannot modify.
 const ServiceNameAttr = "dagger.io/service.name"
 
+func portScheme(port int) string {
+	if port == 443 {
+		return "https"
+	}
+	return "http"
+}
+
 // RunUp starts the service and returns a result that must be cleaned up.
 // It does NOT block — the caller (UpGroup.Run) handles the blocking wait.
 func (node *ModTreeNode) RunUp(ctx context.Context, include, exclude []string, portMappings []PortForward) (*runUpStartResult, error) {
@@ -276,12 +283,13 @@ func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span
 	if len(portMappings) > 0 {
 		portStrs = make([]string, 0, len(portMappings))
 		for _, pf := range portMappings {
-			portStrs = append(portStrs, fmt.Sprintf(":%d→%d", pf.FrontendOrBackendPort(), pf.Backend))
+			frontend := pf.FrontendOrBackendPort()
+			portStrs = append(portStrs, fmt.Sprintf("%s://localhost:%d→%d", portScheme(frontend), frontend, pf.Backend))
 		}
 	} else if svc := svcResult.Self(); svc != nil && svc.Container.Self() != nil {
 		portStrs = make([]string, 0, len(svc.Container.Self().Ports))
 		for _, p := range svc.Container.Self().Ports {
-			portStrs = append(portStrs, fmt.Sprintf(":%d", p.Port))
+			portStrs = append(portStrs, fmt.Sprintf("%s://localhost:%d", portScheme(p.Port), p.Port))
 		}
 	}
 	if len(portStrs) > 0 {

--- a/toolchains/docs-dev/dagger.gen.go
+++ b/toolchains/docs-dev/dagger.gen.go
@@ -283,6 +283,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*DocsDev).Site(&parent), nil
+		case "Up":
+			var parent DocsDev
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*DocsDev).Up(&parent), nil
 		case "":
 			var parent DocsDev
 			err = json.Unmarshal(parentJSON, &parent)

--- a/toolchains/docs-dev/main.go
+++ b/toolchains/docs-dev/main.go
@@ -71,6 +71,11 @@ func (d DocsDev) Server() *dagger.Container {
 		WithExposedPort(8000)
 }
 
+// +up
+func (d DocsDev) Up() *dagger.Service {
+	return d.Server().AsService()
+}
+
 // +check
 // Lint documentation files
 func (d DocsDev) LintMarkdown(

--- a/toolchains/docs-dev/main.go
+++ b/toolchains/docs-dev/main.go
@@ -67,6 +67,12 @@ func (d DocsDev) Server() *dagger.Container {
 		WithExposedPort(8000)
 }
 
+// Starts the docs server
+// +up
+func (d DocsDev) Up() *dagger.Service {
+	return d.Server().AsService()
+}
+
 // Regenerate the API schema and CLI reference docs
 // +generate
 func (d DocsDev) References(

--- a/toolchains/release/internal/dagger/docs-dev.gen.go
+++ b/toolchains/release/internal/dagger/docs-dev.gen.go
@@ -36,7 +36,7 @@ func (r *DocsDev) WithGraphQLQuery(q *querybuilder.Selection) *DocsDev {
 }
 
 // Bump the Go SDK's Engine dependency
-func (r *DocsDev) Bump(engineVersion string) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:120:1)
+func (r *DocsDev) Bump(engineVersion string) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:126:1)
 	q := r.query.Select("bump")
 	q = q.Arg("engineVersion", engineVersion)
 
@@ -46,7 +46,7 @@ func (r *DocsDev) Bump(engineVersion string) *Changeset { // docs-dev (../../../
 }
 
 // Deploys a current build of the docs.
-func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../toolchains/docs-dev/main.go:135:1)
+func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../toolchains/docs-dev/main.go:141:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.deploy != nil {
 		return *r.deploy, nil
@@ -112,11 +112,11 @@ func (r *DocsDev) UnmarshalJSON(bs []byte) error {
 
 // DocsDevPublishOpts contains options for DocsDev.Publish
 type DocsDevPublishOpts struct {
-	Deployment string // docs-dev (../../../../toolchains/docs-dev/main.go:168:2)
+	Deployment string // docs-dev (../../../../toolchains/docs-dev/main.go:174:2)
 }
 
 // Publish a previous deployment to production - defaults to the latest deployment on the main branch.
-func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../toolchains/docs-dev/main.go:164:1)
+func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../toolchains/docs-dev/main.go:170:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.publish != nil {
 		return nil
@@ -138,11 +138,11 @@ type DocsDevReferencesOpts struct {
 	//
 	// Dagger version to generate API docs for
 	//
-	Version string // docs-dev (../../../../toolchains/docs-dev/main.go:75:2)
+	Version string // docs-dev (../../../../toolchains/docs-dev/main.go:81:2)
 }
 
 // Regenerate the API schema and CLI reference docs
-func (r *DocsDev) References(opts ...DocsDevReferencesOpts) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:72:1)
+func (r *DocsDev) References(opts ...DocsDevReferencesOpts) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:78:1)
 	q := r.query.Select("references")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -178,6 +178,15 @@ func (r *DocsDev) Source() *Directory { // docs-dev (../../../../toolchains/docs
 	q := r.query.Select("source")
 
 	return &Directory{
+		query: q,
+	}
+}
+
+// Starts the docs server
+func (r *DocsDev) Up() *Service { // docs-dev (../../../../toolchains/docs-dev/main.go:72:1)
+	q := r.query.Select("up")
+
+	return &Service{
 		query: q,
 	}
 }


### PR DESCRIPTION
Fixes the display of service exposed by `dagger up`.

Previously:
```
✔ docs:up :8000
```

Now:
```
✔ docs:up http://localhost:8000
```

Also, enabling `+up` for the `toolchains/docs-dev` service, to serve the docs