### PR TITLE
fix: builtin dang dependency module loading

### DIFF
--- a/core/integration/module_builtin_dang_test.go
+++ b/core/integration/module_builtin_dang_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/testctx"
+)
+
+func (ModuleSuite) TestBuiltinDangDependencyModules(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen := goGitBase(t, c).
+		WithWorkdir("/work").
+		WithExec([]string{"mkdir", "-p", "gochild", "pychild", "tschild", "dangchild"}).
+		With(withModInitAt("gochild", "go", `package main
+
+type Gochild struct{}
+
+func (m *Gochild) Value() string {
+	return "go"
+}
+`)).
+		With(withModInitAt("pychild", "python", `
+from dagger import function, object_type
+
+
+@object_type
+class Pychild:
+    @function
+    def value(self) -> str:
+        return "python"
+`)).
+		With(withModInitAt("tschild", "typescript", `
+import { object, func } from "@dagger.io/dagger"
+
+@object()
+export class Tschild {
+  @func()
+  value(): string {
+    return "typescript"
+  }
+}
+`)).
+		With(withModInitAt("dangchild", "dang", `
+type Dangchild {
+  pub value: String! {
+    "dang"
+  }
+}
+`)).
+		With(withModInit("dang", `
+type Test {
+  pub local: String! {
+    "local"
+  }
+
+  pub viaGo: String! {
+    gochild.value
+  }
+
+  pub viaPython: String! {
+    pychild.value
+  }
+
+  pub viaTypescript: String! {
+    tschild.value
+  }
+
+  pub viaDang: String! {
+    dangchild.value
+  }
+}
+`)).
+		With(daggerExec("install", "./gochild")).
+		With(daggerExec("install", "./pychild")).
+		With(daggerExec("install", "./tschild")).
+		With(daggerExec("install", "./dangchild"))
+
+	for _, tc := range []struct {
+		name string
+		call string
+		want string
+	}{
+		{name: "local", call: "local", want: "local"},
+		{name: "dang child", call: "via-dang", want: "dang"},
+		{name: "python child", call: "via-python", want: "python"},
+		{name: "go child", call: "via-go", want: "go"},
+		{name: "typescript child", call: "via-typescript", want: "typescript"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			out, err := modGen.With(daggerCall(tc.call)).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, out)
+		})
+	}
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -505,13 +505,16 @@ func (srv *Server) initializeDaggerClient(
 	)
 	slog.Info("initializing new client")
 	var callerG singleflight.Group[string, bksession.Caller]
-	client.getClientCaller = func(id string) (bksession.Caller, error) {
+	getClientCaller := func(id string, noWait bool) (bksession.Caller, error) {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
 		caller, _, err := callerG.Do(ctx, id, func(ctx context.Context) (bksession.Caller, error) {
-			return srv.bkSessionManager.Get(ctx, id, false)
+			return srv.bkSessionManager.Get(ctx, id, noWait)
 		})
 		return caller, err
+	}
+	client.getClientCaller = func(id string) (bksession.Caller, error) {
+		return client.resolveClientCaller(id, getClientCaller)
 	}
 
 	var err error
@@ -675,6 +678,27 @@ func (srv *Server) initializeDaggerClient(
 
 	client.state = clientStateInitialized
 	return nil
+}
+
+func (client *daggerClient) resolveClientCaller(
+	id string,
+	getClientCaller func(string, bool) (bksession.Caller, error),
+) (bksession.Caller, error) {
+	if id == client.clientID && len(client.parents) > 0 {
+		// Synthetic nested clients (e.g. builtin dang evaluation) do not
+		// establish their own session attachables. When host-backed services
+		// such as git config are requested through the current client ID, fall
+		// back to the immediate parent client chain.
+		caller, err := getClientCaller(id, true)
+		if err != nil || caller != nil {
+			return caller, err
+		}
+
+		parent := client.parents[len(client.parents)-1]
+		return parent.getClientCaller(parent.clientID)
+	}
+
+	return getClientCaller(id, false)
 }
 
 func (srv *Server) clientFromContext(ctx context.Context) (*daggerClient, error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -11,8 +11,30 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine"
+	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
+
+type fakeSessionCaller struct {
+	id string
+}
+
+func (caller *fakeSessionCaller) Context() context.Context {
+	return context.Background()
+}
+
+func (caller *fakeSessionCaller) Supports(string) bool {
+	return false
+}
+
+func (caller *fakeSessionCaller) Conn() *grpc.ClientConn {
+	return nil
+}
+
+func (caller *fakeSessionCaller) SharedKey() string {
+	return caller.id
+}
 
 func TestPendingLegacyModule(t *testing.T) {
 	t.Parallel()
@@ -278,6 +300,82 @@ func TestEnsureWorkspaceLoadedKeepsExistingWorkspaceBinding(t *testing.T) {
 
 	require.NoError(t, srv.ensureWorkspaceLoaded(context.Background(), child))
 	require.Same(t, existing, child.workspace)
+}
+
+func TestResolveClientCallerFallsBackToParentForSyntheticNestedClient(t *testing.T) {
+	t.Parallel()
+
+	parentCaller := &fakeSessionCaller{id: "parent"}
+	parent := &daggerClient{clientID: "parent"}
+	parent.getClientCaller = func(id string) (bksession.Caller, error) {
+		require.Equal(t, "parent", id)
+		return parentCaller, nil
+	}
+
+	child := &daggerClient{
+		clientID: "child",
+		parents:  []*daggerClient{parent},
+	}
+
+	var calls []struct {
+		id     string
+		noWait bool
+	}
+
+	caller, err := child.resolveClientCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
+		calls = append(calls, struct {
+			id     string
+			noWait bool
+		}{id: id, noWait: noWait})
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Same(t, parentCaller, caller)
+	require.Equal(t, []struct {
+		id     string
+		noWait bool
+	}{
+		{id: "child", noWait: true},
+	}, calls)
+}
+
+func TestResolveClientCallerPrefersCurrentClientAttachable(t *testing.T) {
+	t.Parallel()
+
+	currentCaller := &fakeSessionCaller{id: "child"}
+	parent := &daggerClient{clientID: "parent"}
+	parent.getClientCaller = func(string) (bksession.Caller, error) {
+		t.Fatal("unexpected parent fallback")
+		return nil, nil
+	}
+
+	child := &daggerClient{
+		clientID: "child",
+		parents:  []*daggerClient{parent},
+	}
+
+	caller, err := child.resolveClientCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
+		require.Equal(t, "child", id)
+		require.True(t, noWait)
+		return currentCaller, nil
+	})
+	require.NoError(t, err)
+	require.Same(t, currentCaller, caller)
+}
+
+func TestResolveClientCallerUsesBlockingLookupForOtherClients(t *testing.T) {
+	t.Parallel()
+
+	otherCaller := &fakeSessionCaller{id: "other"}
+	child := &daggerClient{clientID: "child"}
+
+	caller, err := child.resolveClientCaller("other", func(id string, noWait bool) (bksession.Caller, error) {
+		require.Equal(t, "other", id)
+		require.False(t, noWait)
+		return otherCaller, nil
+	})
+	require.NoError(t, err)
+	require.Same(t, otherCaller, caller)
 }
 
 func TestWorkspaceBindingMode(t *testing.T) {


### PR DESCRIPTION
## Summary

Re-apply the fix from #12975 (reverted in b30af043d) on top of the
egraph merge (#11856), which reshaped `engine/server/session.go`
enough that the original patch no longer applied cleanly.

## Background

When a module uses the builtin `dang` SDK and depends on other modules
(go / python / typescript / dang), loading those dependencies fails.

Internally, evaluating a builtin dang module spawns a **synthetic
nested client**. Unlike a "real" client, a synthetic client does not
establish its own buildkit session attachables. So when code looks up
the session caller for that client's own ID (e.g. to resolve host-
backed services like git config) the lookup blocks for 10s and then
times out, and dependency loading never completes.

## Fix

In `resolveClientCaller`, when the requested ID is the current
client's own ID **and** the client has parents:

1. Try a non-blocking (`noWait=true`) lookup for the current client's
   session. If it exists, use it.
2. Otherwise, fall back to the immediate parent's `getClientCaller`.

For all other IDs, behavior is unchanged (blocking lookup).

## Tests

- Unit tests in `engine/server/session_test.go` covering the three
  branches of `resolveClientCaller`.
- Integration test `core/integration/module_builtin_dang_test.go`
  exercising a builtin dang module with go / python / typescript /
  dang child dependencies.

## References

- Original PR: https://github.com/dagger/dagger/pull/12975
- Revert: b30af043d ("Revert \"fix: builtin dang dependency module loading (#12975)\" (#12994)")
- Egraph merge that required the reimplementation: aa719a10d (#11856)

## Test plan

- [x] `dagger call engine-dev test --pkg=./engine/server --run='^TestResolveClientCaller'` passes
- [x] `dagger call engine-dev test --pkg=./core/integration --run='^TestModule/TestBuiltinDangDependencyModules$'` passes
- [ ] CI green