### PR TITLE
Hide synthetic `with` field from `dagger functions` listings

### DIFF
--- a/core/integration/workspace_test.go
+++ b/core/integration/workspace_test.go
@@ -1300,3 +1300,50 @@ type HelloWorld {
 		require.Equal(t, "hello, dagger!", out)
 	})
 }
+
+// TestEntrypointWithFieldHidden verifies that the synthetic `with` field
+// installed on Query for entrypoint constructors with arguments is hidden
+// from user-facing CLI listings (`dagger functions`, `dagger call --help`)
+// while remaining callable and introspectable.
+func (WorkspaceSuite) TestEntrypointWithFieldHidden(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceBase(t, c).
+		With(initDangBlueprint("greeter", `
+type Greeter {
+  pub msg: String!
+
+  new(name: String!) {
+    self.msg = "hello, " + name + "!"
+    self
+  }
+
+  pub greet: String! {
+    msg
+  }
+}
+`))
+
+	t.Run("dagger functions omits with", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		// The blueprint's real functions should appear.
+		require.Contains(t, out, "greet")
+		// The synthetic `with` field must not leak into user listings.
+		require.NotRegexp(t, `(?m)^with\b`, out)
+	})
+
+	t.Run("dagger call routes constructor args through with", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerCall("--name=world", "greet")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello, world!", strings.TrimSpace(out))
+	})
+
+	t.Run("with remains in graphql introspection", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerQuery(`{ __type(name: "Query") { fields { name } } }`)).Stdout(ctx)
+		require.NoError(t, err)
+		// `with` is callable via raw GraphQL; only user-facing CLI
+		// listings filter it.
+		require.Contains(t, out, `"name": "with"`)
+	})
+}

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -162,6 +162,9 @@ func ShouldSkipFunction(obj, field string) bool {
 			// not useful until the CLI accepts ID inputs
 			"cacheVolume",
 			"setSecret",
+			// entrypoint routing — synthetic, the CLI reads its args
+			// directly to build root flags; users never call it
+			"with",
 			// deprecated
 			"pipeline",
 		},


### PR DESCRIPTION
When a module has a constructor with arguments and is used as a workspace
entrypoint, the engine installs a synthetic `with` field on `Query` to carry
those args through. It's plumbing — users don't call it, the CLI reads its
args to build root flags — but it showed up in `dagger functions` right next
to their real functions.

`dagui.ShouldSkipFunction` already hides a handful of synthetic Query fields
(`typeDef`, `generatedCode`, `currentModule`, …). Adding `with` there is the
smallest change that does the job: the field is dropped from `dagger functions`
and the `dagger call --help` subcommand list, but it stays in the schema and
the CLI still routes constructor args through it in `selectWith`.

## Before / after

Entrypoint blueprint with `new(name: String!)`:

**Before**
```
Name    Description
greet   -
msg     -
with    Configure the greeter constructor arguments.
ws      -
```

**After**
```
Name    Description
greet   -
msg     -
ws      -
```

## Test plan

- [x] New integration test `WorkspaceSuite.TestEntrypointWithFieldHidden` — asserts `with` is absent from `dagger functions`, `dagger call --name=world greet` still works, and `with` is still in `__type(name: "Query")`.
- [x] Manual verification in the playground.