### PR TITLE
sdk(python): disable OTel metrics exporter

### DIFF
--- a/sdk/python/src/dagger/telemetry.py
+++ b/sdk/python/src/dagger/telemetry.py
@@ -1,14 +1,12 @@
 import logging
 import os
-from collections.abc import Callable
-from typing import Final, Literal
+from typing import Final
 
 from opentelemetry import context, propagate, trace
 from opentelemetry._logs import get_logger_provider
 from opentelemetry.environment_variables import (
     _OTEL_PYTHON_LOGGER_PROVIDER,
     OTEL_LOGS_EXPORTER,
-    OTEL_METRICS_EXPORTER,
     OTEL_PYTHON_TRACER_PROVIDER,
     OTEL_TRACES_EXPORTER,
 )
@@ -25,15 +23,12 @@ from opentelemetry.sdk._configuration import (
     _get_exporter_names,
     _import_exporters,
     _init_logging,
-    _init_metrics,
 )
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_INSECURE,
-    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_METRICS_INSECURE,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     OTEL_EXPORTER_OTLP_TRACES_INSECURE,
     OTEL_SDK_DISABLED,
@@ -206,13 +201,11 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
         for name in (
             OTEL_TRACES_EXPORTER,
             OTEL_LOGS_EXPORTER,
-            OTEL_METRICS_EXPORTER,
         ):
             os.environ.setdefault(name, ",".join(self.exporters))
 
         _vars = {
             OTEL_EXPORTER_OTLP_ENDPOINT: OTEL_EXPORTER_OTLP_INSECURE,
-            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: OTEL_EXPORTER_OTLP_METRICS_INSECURE,
             OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: OTEL_EXPORTER_OTLP_LOGS_INSECURE,
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: OTEL_EXPORTER_OTLP_TRACES_INSECURE,
         }
@@ -221,25 +214,24 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
                 os.environ.setdefault(insecure, "true")
 
     def _initialize(self):
-        # NB: Fixed order, based on _import_exporters arguments.
-        initializers: dict[Literal["traces", "metrics", "logs"], Callable] = {
-            "traces": _init_tracing,
-            "metrics": _init_metrics,
-            "logs": _init_logging,
-        }
-        all_exporters = _import_exporters(
-            *(_get_exporter_names(t) for t in initializers)
+        # NB: Dagger's engine only accepts Gauge metrics today (engine-side
+        # exec resource monitoring). Emitting counters/histograms from modules
+        # produces 500s and retry noise, so skip metric initialization by
+        # passing an empty list for the metrics slot of _import_exporters.
+        trace_exporters, _, log_exporters = _import_exporters(
+            _get_exporter_names("traces"),
+            [],
+            _get_exporter_names("logs"),
         )
-
-        for (kind, init), exporters in zip(
-            initializers.items(), all_exporters, strict=True
+        for kind, init, exporters in (
+            ("traces", _init_tracing, trace_exporters),
+            ("logs", _init_logging, log_exporters),
         ):
             logger.debug(
                 "Initializing %s telemetry with exporters: %s",
                 kind,
                 ", ".join(exporters) if exporters else "none",
             )
-
             init(exporters)
 
         # The logging instrumentor injects the trace context into logs


### PR DESCRIPTION
Fixes #13008.

## What you were seeing

Starting a Python Dagger module produces a stream of warnings and an ~8s stall per invocation:

```
WARNING [opentelemetry.exporter.otlp.proto.http.metric_exporter]: Transient error Internal Server Error encountered while exporting metrics batch, retrying in 0.84s.
WARNING [...] retrying in 1.65s.
WARNING [...] retrying in 3.82s.
ERROR [...] Failed to export metrics batch due to timeout, max retries or shutdown.
```

It happens twice per call — once while the engine loads type definitions, once during the function call itself — and setting `OTEL_METRICS_EXPORTER=none` from the user side doesn't help because `telemetry.initialize()` runs before any user code.

## What's actually going on

Two things meeting in the middle:

1. **Upstream OTel Python 1.40.0** (released 2026-03-04) added span start/end self-metrics in [`opentelemetry-python#4880`](https://github.com/open-telemetry/opentelemetry-python/pull/4880). Every `Tracer` instance now creates `otel.sdk.span.started` (Counter) and `otel.sdk.span.live` (UpDownCounter), both of which serialize as `Sum`. Before 1.40, the Python SDK's `Tracer` had no instruments, so the `PeriodicExportingMetricReader`'s collect returned `None` and nothing was ever POSTed. After 1.40, every span emits data that the reader then flushes.

2. **Dagger's `dagger/otel-go` fork** has an incomplete `metricFromPB` in `transform.go:1119-1140`: only `Metric_Gauge` is implemented, everything else returns `"unknown aggregation from pb"`. The engine's `MetricsHandler` turns that error into HTTP 500, and the Python OTLP HTTP exporter retries on its built-in exponential backoff schedule (~0.9s → 2.3s → 4.7s → timeout). The Gauge-only implementation was fine for the one real use case it was written for — engine-side exec resource monitoring (cgroup CPU/mem/IO), added in #8506 — but Sum/Histogram never had a path through.

Since the Dagger Python SDK pins `opentelemetry-sdk>=1.23.0` with no upper bound, any lockfile regen after early March picks up 1.40+ and trips this.

## The fix

Align the Python SDK with the TypeScript SDK, which sets up only traces (see `sdk/typescript/src/telemetry/init.ts`). No `MeterProvider`, no `PeriodicExportingMetricReader`, no background thread, no shutdown flush. Concretely, two small changes in `_DaggerOtelConfigurator`:

- Drop `OTEL_METRICS_EXPORTER` and `OTEL_EXPORTER_OTLP_METRICS_*` from the env-prep step.
- In `_initialize`, pass an empty list for the metrics slot of `_import_exporters` (it's a required positional argument, so we can't skip it outright), and only call `_init_tracing` / `_init_logging`.

User-emitted metrics become silent no-ops rather than 500 loops. This isn't a regression: any `meter.create_counter(...)` a module added today was already being rejected by the engine — the difference is that it fails quietly instead of spending 8 seconds shouting about it. When the engine-side `metricFromPB` gains support for Sum/Histogram/etc., reverting this is a three-line change.

## What's not affected

- Traces and the `dagger.cloud` trace URL: separate init path, untouched.
- Log streaming / stdio-as-logs: separate init path, untouched.
- `traceparent` propagation into sub-execs: handled in `_DaggerPropagationConfigurator`, untouched.
- Engine's cgroup resource monitoring gauges in the UI: emitted by the engine itself through `clientMetrics`, never touches module Python processes.
- Env vars inherited by containers spawned via `.with_exec(...)`: set by the engine's `executor_spec.go`, independent of what the SDK does.

## Testing

Verified end-to-end via `skills/engine-dev-testing` playground — built a dev engine from this branch, initialized a fresh `python` SDK module, called a function. Before: ~8s stall per call with the warning block. After: clean output, no metric-exporter lines, function runs in under a second.