### PR TITLE
Update AWS CodeBuild runner reference in documentation

### DIFF
--- a/docs/current_docs/getting-started/ci-integrations/aws-codebuild.mdx
+++ b/docs/current_docs/getting-started/ci-integrations/aws-codebuild.mdx
@@ -16,7 +16,7 @@ When running a CI pipeline with Dagger using AWS CodeBuild, the general workflow
 1. AWS CodeBuild begins processing the build instructions in the `buildspec.yml` file.
 1. AWS CodeBuild downloads the Dagger CLI.
 1. AWS CodeBuild executes one (or more) Dagger CLI commands, such as `dagger call ...`.
-1. The Dagger CLI attempts to find an existing Dagger Engine or spins up a new one inside the GitLab runner.
+1. The Dagger CLI attempts to find an existing Dagger Engine or spins up a new one inside AWS CodeBuild runner.
 1. The Dagger CLI calls the specified Dagger Function and sends telemetry to Dagger Cloud if the `DAGGER_CLOUD_TOKEN` environment variable is set.
 1. The AWS CodePipeline completes with success or failure. Logs appear in the AWS CodeBuild interface as usual.
 


### PR DESCRIPTION
disclaimer: I have no understanding of how dagger works and I have never used it. 

I was browsing through the documentation to better understand what dagger is and whether its a good fit for my project, I found this weird thing on the docs that tripped me off. At first, I thought it meant that I had to have a persistent Dagger Engine running somewhere else, which would make this not a good fit for me. I didn't give up and as I was learning more, I thought this might have been a typo, which would drastically change the context: if I can have AWS CodeBuild downloading, installing and running Dagger in an ephemeral nature without a persistent Dagger Engine, it would mean its a lot easier to replace Docker Engine with Dagger Engine without having to maintain external resources.

If this is not a typo, I'd love to know where my understanding is going wrong and why GitLab would be important to run Dagger on AWS CodeBuild