### PR TITLE
Fix defaultPath context for remote toolchains

### DIFF
--- a/core/integration/module_remote_workspace_defaultpath_test.go
+++ b/core/integration/module_remote_workspace_defaultpath_test.go
@@ -147,21 +147,7 @@ git --git-dir=/srv/repo.git update-server-info
 	shortHost, err := gitSrv.Hostname(ctx)
 	require.NoError(t, err)
 
-	// The vcs URL parser (engine/vcs/vcs.go) requires at least one dot
-	// in the host component. The auto-generated service hostname is
-	// dot-less ("<hash>"), but it IS registered in the session DNS via
-	// search-domain expansion to "<hash>.<sessionhash>.dagger.local".
-	// Resolve it to an IP in any container that shares the session DNS
-	// — buildkit already puts the session search domain in resolv.conf —
-	// and use the IP in the URL. IPs satisfy the vcs regex (they have
-	// dots) and need no DNS at all.
-	getentOut, err := c.Container().From(alpineImage).
-		WithExec([]string{"getent", "hosts", shortHost}).
-		Stdout(ctx)
-	require.NoError(t, err, "could not resolve git service hostname %q", shortHost)
-	fields := strings.Fields(getentOut)
-	require.NotEmpty(t, fields, "unexpected getent output: %q", getentOut)
-	serviceIP := fields[0]
+	serviceIP := resolveServiceIP(ctx, t, c, shortHost)
 
 	modPath := "http://" + serviceIP + "/repo.git@" + commit
 
@@ -220,6 +206,248 @@ git --git-dir=/srv/repo.git update-server-info
 			"explicit -m remote ref must take precedence over a local workspace missing the target subtree:\n%s", out)
 		require.Regexp(t, `read-check.*OK`, out)
 	})
+}
+
+// TestRemoteModuleSameRepoToolchainDefaultPath covers the remote-module shape
+// where the toolchain lives in the same repo as the module targeted by -m. No
+// Workspace argument is involved; this is plain +defaultPath resolution.
+func (ModuleSuite) TestRemoteModuleSameRepoToolchainDefaultPath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const moduleFileContent = "hello from the remote module repo"
+	const localWorkspaceFileContent = "hello from the local workspace"
+
+	const greeterSource = `package main
+
+import (
+	"context"
+	"dagger/greeter/internal/dagger"
+)
+
+type Greeter struct {
+	Workspace *dagger.Directory
+}
+
+func New(
+	// +defaultPath="/"
+	workspace *dagger.Directory,
+) *Greeter {
+	return &Greeter{Workspace: workspace}
+}
+
+func (m *Greeter) Read(ctx context.Context) (string, error) {
+	return m.Workspace.
+		Directory("target-subdir/maven").
+		File("hello.txt").
+		Contents(ctx)
+}
+`
+
+	moduleRepo := func() *dagger.Container {
+		return goGitBase(t, c).
+			WithNewFile("/work/target-subdir/maven/hello.txt", moduleFileContent).
+			WithWorkdir("/work/toolchains/greeter").
+			With(daggerExec("init", "--sdk=go", "--name=greeter", "--source=.")).
+			With(sdkSource("go", greeterSource)).
+			WithWorkdir("/work").
+			With(daggerExec("init")).
+			With(daggerExec("toolchain", "install", "./toolchains/greeter")).
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "init module"`})
+	}
+
+	moduleBareSetup := moduleRepo().
+		WithExec([]string{"sh", "-c", `
+set -eux
+git init --bare --initial-branch=main /srv/module.git
+git remote add origin /srv/module.git
+git push origin HEAD:refs/heads/main
+git --git-dir=/srv/module.git update-server-info
+`})
+
+	moduleCommitOut, err := moduleBareSetup.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	moduleCommit := strings.TrimSpace(moduleCommitOut)
+
+	moduleSrv, _ := gitSmartHTTPServiceDirAuth(
+		ctx, t, c,
+		"",
+		moduleBareSetup.Directory("/srv"),
+		"", nil,
+	)
+	moduleSrv, err = moduleSrv.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = moduleSrv.Stop(ctx) })
+
+	moduleHost, err := moduleSrv.Hostname(ctx)
+	require.NoError(t, err)
+	modPath := "http://" + resolveServiceIP(ctx, t, c, moduleHost) + "/module.git@" + moduleCommit
+
+	t.Run("empty cwd", func(ctx context.Context, t *testctx.T) {
+		out, err := c.Container().From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/empty").
+			With(daggerExec("-m", modPath, "--progress=report", "call", "greeter", "read")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"module-local toolchain +defaultPath must resolve from the remote -m module repo:\n%s", out)
+		require.Contains(t, out, moduleFileContent)
+	})
+
+	t.Run("workspace cwd", func(ctx context.Context, t *testctx.T) {
+		out, err := moduleRepo().
+			WithNewFile("/work/target-subdir/maven/hello.txt", localWorkspaceFileContent).
+			With(daggerExec("-m", modPath, "--progress=report", "call", "greeter", "read")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"explicit -m remote module must beat the local workspace for module-local toolchain +defaultPath:\n%s", out)
+		require.Contains(t, out, moduleFileContent)
+		require.NotContains(t, out, localWorkspaceFileContent)
+	})
+}
+
+// TestRemoteModuleCrossRepoToolchainDefaultPath covers the remote-module shape
+// where the toolchain is another remote git module from a different repo. No
+// Workspace argument is involved; plain +defaultPath must still resolve from
+// the remote module repo the user targeted with -m, not from the toolchain
+// repo.
+func (ModuleSuite) TestRemoteModuleCrossRepoToolchainDefaultPath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const moduleFileContent = "hello from the remote module repo"
+	const toolchainFileContent = "hello from the remote toolchain repo"
+	const localWorkspaceFileContent = "hello from the local workspace"
+
+	const greeterSource = `package main
+
+import (
+	"context"
+	"dagger/greeter/internal/dagger"
+)
+
+type Greeter struct {
+	Workspace *dagger.Directory
+}
+
+func New(
+	// +defaultPath="/"
+	workspace *dagger.Directory,
+) *Greeter {
+	return &Greeter{Workspace: workspace}
+}
+
+func (m *Greeter) Read(ctx context.Context) (string, error) {
+	return m.Workspace.
+		Directory("target-subdir/maven").
+		File("hello.txt").
+		Contents(ctx)
+}
+`
+
+	toolchainBareSetup := goGitBase(t, c).
+		WithNewFile("/work/target-subdir/maven/hello.txt", toolchainFileContent).
+		With(daggerExec("init", "--sdk=go", "--name=greeter", "--source=.")).
+		With(sdkSource("go", greeterSource)).
+		WithExec([]string{"sh", "-c", `git add . && git commit -m "init toolchain"`}).
+		WithExec([]string{"sh", "-c", `
+set -eux
+git init --bare --initial-branch=main /srv/toolchain.git
+git remote add origin /srv/toolchain.git
+git push origin HEAD:refs/heads/main
+git --git-dir=/srv/toolchain.git update-server-info
+`})
+
+	toolchainCommitOut, err := toolchainBareSetup.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	toolchainCommit := strings.TrimSpace(toolchainCommitOut)
+
+	toolchainSrv, _ := gitSmartHTTPServiceDirAuth(
+		ctx, t, c,
+		"",
+		toolchainBareSetup.Directory("/srv"),
+		"", nil,
+	)
+	toolchainSrv, err = toolchainSrv.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = toolchainSrv.Stop(ctx) })
+
+	toolchainHost, err := toolchainSrv.Hostname(ctx)
+	require.NoError(t, err)
+	toolchainRef := "http://" + resolveServiceIP(ctx, t, c, toolchainHost) + "/toolchain.git@" + toolchainCommit
+
+	moduleRepo := func() *dagger.Container {
+		return goGitBase(t, c).
+			WithNewFile("/work/target-subdir/maven/hello.txt", moduleFileContent).
+			With(daggerExec("init")).
+			With(daggerExec("toolchain", "install", "--name", "greeter", toolchainRef)).
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "init module"`})
+	}
+
+	moduleBareSetup := moduleRepo().
+		WithExec([]string{"sh", "-c", `
+set -eux
+git init --bare --initial-branch=main /srv/module.git
+git remote add origin /srv/module.git
+git push origin HEAD:refs/heads/main
+git --git-dir=/srv/module.git update-server-info
+`})
+
+	moduleCommitOut, err := moduleBareSetup.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	moduleCommit := strings.TrimSpace(moduleCommitOut)
+
+	moduleSrv, _ := gitSmartHTTPServiceDirAuth(
+		ctx, t, c,
+		"",
+		moduleBareSetup.Directory("/srv"),
+		"", nil,
+	)
+	moduleSrv, err = moduleSrv.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = moduleSrv.Stop(ctx) })
+
+	moduleHost, err := moduleSrv.Hostname(ctx)
+	require.NoError(t, err)
+	modPath := "http://" + resolveServiceIP(ctx, t, c, moduleHost) + "/module.git@" + moduleCommit
+
+	t.Run("empty cwd", func(ctx context.Context, t *testctx.T) {
+		out, err := c.Container().From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/empty").
+			With(daggerExec("-m", modPath, "--progress=report", "call", "greeter", "read")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"remote toolchain +defaultPath must resolve from the -m module repo, not the toolchain repo:\n%s", out)
+		require.Contains(t, out, moduleFileContent)
+		require.NotContains(t, out, toolchainFileContent)
+	})
+
+	t.Run("workspace cwd", func(ctx context.Context, t *testctx.T) {
+		out, err := moduleRepo().
+			WithNewFile("/work/target-subdir/maven/hello.txt", localWorkspaceFileContent).
+			With(daggerExec("-m", modPath, "--progress=report", "call", "greeter", "read")).
+			CombinedOutput(ctx)
+		require.NoError(t, err,
+			"explicit -m remote module must beat both the local workspace and the remote toolchain repo for +defaultPath:\n%s", out)
+		require.Contains(t, out, moduleFileContent)
+		require.NotContains(t, out, toolchainFileContent)
+		require.NotContains(t, out, localWorkspaceFileContent)
+	})
+}
+
+func resolveServiceIP(ctx context.Context, t *testctx.T, c *dagger.Client, hostname string) string {
+	t.Helper()
+
+	// The vcs URL parser (engine/vcs/vcs.go) requires at least one dot in the
+	// host component. Auto-generated service hostnames are dot-less, but they
+	// are registered in the session DNS via search-domain expansion. Resolve
+	// them to an IP so the URL is both parser-compatible and reachable.
+	getentOut, err := c.Container().From(alpineImage).
+		WithExec([]string{"getent", "hosts", hostname}).
+		Stdout(ctx)
+	require.NoError(t, err, "could not resolve git service hostname %q", hostname)
+	fields := strings.Fields(getentOut)
+	require.NotEmpty(t, fields, "unexpected getent output: %q", getentOut)
+	return fields[0]
 }
 
 var _ = dagger.ReturnTypeAny // keep the dagger import live for *dagger.Container types

--- a/core/integration/module_remote_workspace_defaultpath_test.go
+++ b/core/integration/module_remote_workspace_defaultpath_test.go
@@ -208,6 +208,91 @@ git --git-dir=/srv/repo.git update-server-info
 	})
 }
 
+// TestLocalModuleRemoteToolchainDefaultPath covers the local-module shape
+// where the toolchain is a remote git module from another repo and the user
+// explicitly targets the local module with -m. The toolchain's +defaultPath
+// must resolve from that local module's source root, not from the parent
+// workspace or the remote toolchain repo.
+func (ModuleSuite) TestLocalModuleRemoteToolchainDefaultPath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const moduleFileContent = "hello from the local module repo"
+	const parentWorkspaceFileContent = "hello from the parent workspace"
+	const toolchainFileContent = "hello from the remote toolchain repo"
+
+	const greeterSource = `package main
+
+import (
+	"context"
+	"dagger/greeter/internal/dagger"
+)
+
+type Greeter struct {
+	Workspace *dagger.Directory
+}
+
+func New(
+	// +defaultPath="."
+	workspace *dagger.Directory,
+) *Greeter {
+	return &Greeter{Workspace: workspace}
+}
+
+func (m *Greeter) Read(ctx context.Context) (string, error) {
+	return m.Workspace.
+		Directory("target-subdir/nested").
+		File("hello.txt").
+		Contents(ctx)
+}
+`
+
+	toolchainBareSetup := goGitBase(t, c).
+		WithNewFile("/work/target-subdir/nested/hello.txt", toolchainFileContent).
+		With(daggerExec("init", "--sdk=go", "--name=greeter", "--source=.")).
+		With(sdkSource("go", greeterSource)).
+		WithExec([]string{"sh", "-c", `git add . && git commit -m "init toolchain"`}).
+		WithExec([]string{"sh", "-c", `
+set -eux
+git init --bare --initial-branch=main /srv/toolchain.git
+git remote add origin /srv/toolchain.git
+git push origin HEAD:refs/heads/main
+git --git-dir=/srv/toolchain.git update-server-info
+`})
+
+	toolchainCommitOut, err := toolchainBareSetup.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	toolchainCommit := strings.TrimSpace(toolchainCommitOut)
+
+	toolchainSrv, _ := gitSmartHTTPServiceDirAuth(
+		ctx, t, c,
+		"",
+		toolchainBareSetup.Directory("/srv"),
+		"", nil,
+	)
+	toolchainSrv, err = toolchainSrv.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = toolchainSrv.Stop(ctx) })
+
+	toolchainHost, err := toolchainSrv.Hostname(ctx)
+	require.NoError(t, err)
+	toolchainRef := "http://" + resolveServiceIP(ctx, t, c, toolchainHost) + "/toolchain.git@" + toolchainCommit
+
+	out, err := goGitBase(t, c).
+		WithNewFile("/work/target-subdir/nested/hello.txt", parentWorkspaceFileContent).
+		WithWorkdir("/work/local-module").
+		WithNewFile("/work/local-module/target-subdir/nested/hello.txt", moduleFileContent).
+		With(daggerExec("init")).
+		With(daggerExec("toolchain", "install", "--name", "greeter", toolchainRef)).
+		WithWorkdir("/work").
+		With(daggerExec("-m", "./local-module", "--progress=report", "call", "greeter", "read")).
+		CombinedOutput(ctx)
+	require.NoError(t, err,
+		"explicit -m ./local-module must resolve +defaultPath from the local module source root, not the parent workspace or remote toolchain repo:\n%s", out)
+	require.Contains(t, out, moduleFileContent)
+	require.NotContains(t, out, parentWorkspaceFileContent)
+	require.NotContains(t, out, toolchainFileContent)
+}
+
 // TestRemoteModuleSameRepoToolchainDefaultPath covers the remote-module shape
 // where the toolchain lives in the same repo as the module targeted by -m. No
 // Workspace argument is involved; this is plain +defaultPath resolution.

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2315,7 +2315,7 @@ func (s *moduleSourceSchema) runCodegen(
 	}
 
 	// load the deps as actual Modules
-	deps, err := s.loadDependencyModules(ctx, srcInst)
+	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
 	if err != nil {
 		return res, fmt.Errorf("failed to load dependencies as modules: %w", err)
 	}
@@ -2515,7 +2515,7 @@ func (s *moduleSourceSchema) runClientGenerator(
 		return genDirInst, fmt.Errorf("failed to add module source required files: %w", err)
 	}
 
-	deps, err := s.loadDependencyModules(ctx, srcInst)
+	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
 	if err != nil {
 		return genDirInst, fmt.Errorf("failed to load dependencies of this modules: %w", err)
 	}
@@ -2875,7 +2875,7 @@ func (s *moduleSourceSchema) moduleSourceIntrospectionSchemaJSON(
 	src dagql.ObjectResult[*core.ModuleSource],
 	args struct{},
 ) (inst dagql.Result[*core.File], rerr error) {
-	deps, err := s.loadDependencyModules(ctx, src)
+	deps, err := s.loadDependencyModules(ctx, src, src)
 	if err != nil {
 		return inst, err
 	}
@@ -2954,6 +2954,13 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 		// LegacyDefaultsFromDotEnv, when true and workspace config is set,
 		// also load .env defaults for args not found in WorkspaceConfig.
 		LegacyDefaultsFromDotEnv bool `internal:"true" default:"false"`
+
+		// DefaultPathContextSourceRef, when set, loads implementation code from
+		// the receiver but resolves +defaultPath inputs from this source ref.
+		DefaultPathContextSourceRef string `internal:"true" default:""`
+
+		// DefaultPathContextSourcePin pins DefaultPathContextSourceRef when set.
+		DefaultPathContextSourcePin string `internal:"true" default:""`
 	},
 ) (inst dagql.ObjectResult[*core.Module], err error) {
 	dag, err := core.CurrentDagqlServer(ctx)
@@ -2976,10 +2983,26 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 	originalSrc := src
 	execSrc := src
-	contextSrc := src
+	defaultPathContextSrc := src
+	if args.DefaultPathContextSourceRef != "" {
+		contextSourceArgs := []dagql.NamedInput{
+			{Name: "refString", Value: dagql.String(args.DefaultPathContextSourceRef)},
+		}
+		if args.DefaultPathContextSourcePin != "" {
+			contextSourceArgs = append(contextSourceArgs, dagql.NamedInput{
+				Name: "refPin", Value: dagql.String(args.DefaultPathContextSourcePin),
+			})
+		}
+		err = dag.Select(ctx, dag.Root(), &defaultPathContextSrc, dagql.Selector{
+			Field: "moduleSource",
+			Args:  contextSourceArgs,
+		})
+		if err != nil {
+			return inst, fmt.Errorf("failed to load defaultPath context source: %w", err)
+		}
+	}
 	if src.Self().Blueprint.Self() != nil {
 		execSrc = src.Self().Blueprint
-		contextSrc = src
 		if len(originalSrc.Self().Toolchains) > 0 {
 			var sourceIDs []core.ModuleSourceID
 			for _, toolchainSrc := range originalSrc.Self().Toolchains {
@@ -3005,7 +3028,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 	mod := &core.Module{
 		Source:                        dagql.NonNull(execSrc),
-		ContextSource:                 dagql.NonNull(contextSrc),
+		ContextSource:                 dagql.NonNull(defaultPathContextSrc),
 		NameField:                     originalSrc.Self().ModuleName,
 		OriginalName:                  execSrc.Self().ModuleOriginalName,
 		SDKConfig:                     execSrc.Self().SDK,
@@ -3015,7 +3038,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 		mod.SDKConfig = &core.SDKConfig{}
 	}
 
-	mod.Deps, err = s.loadDependencyModules(ctx, execSrc)
+	mod.Deps, err = s.loadDependencyModules(ctx, execSrc, defaultPathContextSrc)
 	if err != nil {
 		return inst, fmt.Errorf("failed to load dependencies as modules: %w", err)
 	}
@@ -3024,10 +3047,18 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	if args.ForceDefaultFunctionCaching {
 		mod.DisableDefaultFunctionCaching = false
 	}
+	defaultPathContextSourceVariant := ""
+	if args.DefaultPathContextSourceRef != "" {
+		defaultPathContextSourceVariant = hashutil.HashStrings(
+			args.DefaultPathContextSourceRef,
+			args.DefaultPathContextSourcePin,
+		).String()
+	}
 	// Keep the per-session content cache distinct for module variants produced
 	// from the same source with different internal asModule options.
 	mod.AsModuleVariantDigest = hashutil.HashStrings(
 		"asModuleVariant",
+		defaultPathContextSourceVariant,
 		fmt.Sprintf("%t", args.ForceDefaultFunctionCaching),
 		args.LegacyNameOverride,
 		fmt.Sprintf("%t", args.LegacyDefaultPath),
@@ -3091,7 +3122,11 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 }
 
 // load the given module source's dependencies as modules
-func (s *moduleSourceSchema) loadDependencyModules(ctx context.Context, src dagql.ObjectResult[*core.ModuleSource]) (_ *core.SchemaBuilder, rerr error) {
+func (s *moduleSourceSchema) loadDependencyModules(
+	ctx context.Context,
+	src dagql.ObjectResult[*core.ModuleSource],
+	defaultPathContextSrc dagql.ObjectResult[*core.ModuleSource],
+) (_ *core.SchemaBuilder, rerr error) {
 	ctx, span := core.Tracer(ctx).Start(ctx, "load dep modules", telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
 
@@ -3116,8 +3151,23 @@ func (s *moduleSourceSchema) loadDependencyModules(ctx context.Context, src dagq
 	tcMods := make([]dagql.ObjectResult[*core.Module], len(src.Self().Toolchains))
 	for i, tcSrc := range src.Self().Toolchains {
 		eg.Go(func() error {
+			var toolchainAsModuleArgs []dagql.NamedInput
+			if defaultPathContextSrc.Self() != nil {
+				toolchainAsModuleArgs = []dagql.NamedInput{
+					{
+						Name:  "defaultPathContextSourceRef",
+						Value: dagql.String(defaultPathContextSrc.Self().AsString()),
+					},
+				}
+				if defaultPathContextSrc.Self().Pin() != "" {
+					toolchainAsModuleArgs = append(toolchainAsModuleArgs, dagql.NamedInput{
+						Name:  "defaultPathContextSourcePin",
+						Value: dagql.String(defaultPathContextSrc.Self().Pin()),
+					})
+				}
+			}
 			return dag.Select(ctx, tcSrc, &tcMods[i],
-				dagql.Selector{Field: "asModule"},
+				dagql.Selector{Field: "asModule", Args: toolchainAsModuleArgs},
 			)
 		})
 	}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1343,16 +1343,22 @@ func (srv *Server) ServeModule(ctx context.Context, mod dagql.ObjectResult[*core
 
 		// Also serve toolchains so their functions are available in the
 		// client schema (e.g. when `dagger shell` `.cd`s into a module).
-		if src := mod.Self().GetSource(); src != nil {
-			for i, tcSrc := range src.Toolchains {
+		if mod.Self().Source.Valid && mod.Self().Source.Value.Self() != nil {
+			src := mod.Self().Source.Value
+			defaultPathContextSrc := src
+			if mod.Self().ContextSource.Valid && mod.Self().ContextSource.Value.Self() != nil {
+				defaultPathContextSrc = mod.Self().ContextSource.Value
+			}
+			for i, tcSrc := range src.Self().Toolchains {
 				if tcSrc.Self() == nil {
 					continue
 				}
 				var cfg *modules.ModuleConfigDependency
-				if i < len(src.ConfigToolchains) {
-					cfg = src.ConfigToolchains[i]
+				if i < len(src.Self().ConfigToolchains) {
+					cfg = src.Self().ConfigToolchains[i]
 				}
-				tcMod, err := srv.resolveModuleSourceAsModule(ctx, client.dag, tcSrc, pendingRelatedModule(src, tcSrc.Self(), cfg, false))
+				pending := pendingRelatedModule(defaultPathContextSrc, tcSrc.Self(), cfg, false)
+				tcMod, err := srv.resolveModuleSourceAsModule(ctx, client.dag, tcSrc, pending)
 				if err != nil {
 					return fmt.Errorf("error resolving toolchain module: %w", err)
 				}

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -351,6 +351,11 @@ type pendingModule struct {
 	DefaultsFromDotEnv bool
 	ArgCustomizations  []*modules.ModuleConfigArgument
 
+	// If set, load this module's implementation from Ref but resolve
+	// +defaultPath inputs from this source ref instead.
+	DefaultPathContextSourceRef string
+	DefaultPathContextSourcePin string
+
 	// For legacy blueprints, the caller module's own .env should still behave
 	// like the "inner" env file even though the code now loads from the
 	// blueprint source tree.
@@ -731,20 +736,25 @@ func (srv *Server) resolveModuleLoad(
 		return resolved, nil
 	}
 
-	src := primary.Self().GetSource()
-	if src == nil {
+	if !primary.Self().Source.Valid || primary.Self().Source.Value.Self() == nil {
 		return resolved, nil
 	}
+	src := primary.Self().Source.Value
+	defaultPathContextSrc := src
+	if primary.Self().ContextSource.Valid && primary.Self().ContextSource.Value.Self() != nil {
+		defaultPathContextSrc = primary.Self().ContextSource.Value
+	}
 
-	for i, toolchainSrc := range src.Toolchains {
+	for i, toolchainSrc := range src.Self().Toolchains {
 		if toolchainSrc.Self() == nil {
 			continue
 		}
 		var cfg *modules.ModuleConfigDependency
-		if i < len(src.ConfigToolchains) {
-			cfg = src.ConfigToolchains[i]
+		if i < len(src.Self().ConfigToolchains) {
+			cfg = src.Self().ConfigToolchains[i]
 		}
-		toolchainMod, err := srv.resolveModuleSourceAsModule(ctx, dag, toolchainSrc, pendingRelatedModule(src, toolchainSrc.Self(), cfg, false))
+		pending := pendingRelatedModule(defaultPathContextSrc, toolchainSrc.Self(), cfg, false)
+		toolchainMod, err := srv.resolveModuleSourceAsModule(ctx, dag, toolchainSrc, pending)
 		if err != nil {
 			return resolvedModuleLoad{}, fmt.Errorf("resolving toolchain module: %w", err)
 		}
@@ -754,8 +764,9 @@ func (srv *Server) resolveModuleLoad(
 		})
 	}
 
-	if src.Blueprint.Self() != nil {
-		blueprintMod, err := srv.resolveModuleSourceAsModule(ctx, dag, src.Blueprint, pendingRelatedModule(src, src.Blueprint.Self(), src.ConfigBlueprint, true))
+	if src.Self().Blueprint.Self() != nil {
+		pending := pendingRelatedModule(defaultPathContextSrc, src.Self().Blueprint.Self(), src.Self().ConfigBlueprint, true)
+		blueprintMod, err := srv.resolveModuleSourceAsModule(ctx, dag, src.Self().Blueprint, pending)
 		if err != nil {
 			return resolvedModuleLoad{}, fmt.Errorf("resolving blueprint module: %w", err)
 		}
@@ -779,8 +790,13 @@ func (srv *Server) resolveModuleLoad(
 // dependencies but still need the same legacy compat handling as modules loaded
 // from workspace discovery, such as legacy default-path resolution and
 // dagger.json argument customizations.
+//
+// defaultPathContextSrc is the consuming module source for +defaultPath
+// arguments. For a plain module this is the module source itself; for a module
+// already resolving +defaultPath through another source, it is that outer
+// ContextSource.
 func pendingRelatedModule(
-	parent *core.ModuleSource,
+	defaultPathContextSrc dagql.ObjectResult[*core.ModuleSource],
 	related *core.ModuleSource,
 	cfg *modules.ModuleConfigDependency,
 	entrypoint bool,
@@ -794,10 +810,11 @@ func pendingRelatedModule(
 		// +defaultPath must resolve against that entrypoint's repo (the
 		// -m argument), not against the session's currentWorkspace — the
 		// latter is the user's CWD, which may be empty, partial, or a
-		// different checkout entirely. The default _contextDirectory
-		// resolution already uses the module's own source, which for a
-		// toolchain/blueprint declared as a subdir of the -m module
-		// shares the entrypoint's clone (or local context) root.
+		// different checkout entirely.
+	}
+	if defaultPathContextSrc.Self() != nil {
+		mod.DefaultPathContextSourceRef = defaultPathContextSrc.Self().AsString()
+		mod.DefaultPathContextSourcePin = defaultPathContextSrc.Self().Pin()
 	}
 	if cfg != nil {
 		if cfg.Name != "" {
@@ -806,8 +823,8 @@ func pendingRelatedModule(
 		mod.ConfigDefaults = legacyConfigDefaults(cfg.Customizations)
 		mod.ArgCustomizations = cfg.Customizations
 	}
-	if entrypoint && parent != nil && parent.Kind == core.ModuleSourceKindLocal {
-		mod.LegacyCallerModuleDir = parent.AsString()
+	if entrypoint && defaultPathContextSrc.Self() != nil && defaultPathContextSrc.Self().Kind == core.ModuleSourceKindLocal {
+		mod.LegacyCallerModuleDir = defaultPathContextSrc.Self().AsString()
 	}
 	return mod
 }
@@ -871,6 +888,16 @@ func asModuleArgsForPendingModule(mod pendingModule) ([]dagql.NamedInput, error)
 		asModuleArgs = append(asModuleArgs, dagql.NamedInput{
 			Name: "legacyDefaultPath", Value: dagql.Boolean(true),
 		})
+	}
+	if mod.DefaultPathContextSourceRef != "" {
+		asModuleArgs = append(asModuleArgs, dagql.NamedInput{
+			Name: "defaultPathContextSourceRef", Value: dagql.String(mod.DefaultPathContextSourceRef),
+		})
+		if mod.DefaultPathContextSourcePin != "" {
+			asModuleArgs = append(asModuleArgs, dagql.NamedInput{
+				Name: "defaultPathContextSourcePin", Value: dagql.String(mod.DefaultPathContextSourcePin),
+			})
+		}
 	}
 	if len(mod.ConfigDefaults) > 0 {
 		wsJSON, err := json.Marshal(mod.ConfigDefaults)


### PR DESCRIPTION
Fixes #13018.

A remote module can install a toolchain from another repo. The toolchain
code should still load from the toolchain repo, but +defaultPath inputs
should resolve from the module that installed it.

Pass a private defaultPathContextSourceRef/defaultPathContextSourcePin
through asModule when loading related modules and toolchain dependencies.
Inside moduleSourceAsModule, reload that source with moduleSource(ref,
pin) and store it on the resulting module as its context source so later
toolchain loads keep using the same defaultPath source.

Include the defaultPath context ref+pin in the asModule variant digest so
module variants with the same implementation source but different
defaultPath contexts do not alias in cache.

## Testing

`dagger -m github.com/dagger/dagger/pull/13020/head call engine-dev test --pkg=./core/integration --run 'TestModule/TestRemote'`