### PR TITLE
mcp: restore served module methods in static mode

### DIFF
--- a/core/integration/mcp_test.go
+++ b/core/integration/mcp_test.go
@@ -1,0 +1,206 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagger/testctx"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+type MCPSuite struct{}
+
+func TestMCP(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(MCPSuite{})
+}
+
+func (MCPSuite) TestModuleWithoutPrivilegedExposesModuleMethods(ctx context.Context, t *testctx.T) {
+	modDir := initMCPTestModule(ctx, t)
+	cli := startMCPClient(ctx, t, modDir)
+
+	methods := listMethodNames(ctx, t, cli)
+	require.Contains(t, methods, "greeting")
+	require.NotContains(t, methods, "container")
+
+	selectMethods(ctx, t, cli, "greeting")
+	require.Equal(t, "hello from module", callMethodText(ctx, t, cli, "greeting", nil, map[string]any{}))
+}
+
+func (MCPSuite) TestWithoutModuleAndWithoutPrivilegedFails(ctx context.Context, t *testctx.T) {
+	emptyDir := t.TempDir()
+
+	_, err := hostDaggerExec(ctx, t, emptyDir, "--progress=plain", "mcp")
+	require.Error(t, err)
+	requireErrOut(t, err, "no module found and --env-privileged not specified")
+}
+
+func (MCPSuite) TestWithoutModuleAndWithPrivilegedExposesCoreMethods(ctx context.Context, t *testctx.T) {
+	emptyDir := t.TempDir()
+	cli := startMCPClient(ctx, t, emptyDir, "--env-privileged")
+
+	methods := listMethodNames(ctx, t, cli)
+	require.Contains(t, methods, "container")
+
+	selectMethods(ctx, t, cli, "container")
+	require.Contains(t, callMethodText(ctx, t, cli, "container", nil, map[string]any{}), "Container#")
+}
+
+func (MCPSuite) TestModuleWithPrivilegedExposesModuleAndCoreMethods(ctx context.Context, t *testctx.T) {
+	modDir := initMCPTestModule(ctx, t)
+	cli := startMCPClient(ctx, t, modDir, "--env-privileged")
+
+	methods := listMethodNames(ctx, t, cli)
+	require.Contains(t, methods, "greeting")
+	require.Contains(t, methods, "container")
+
+	selectMethods(ctx, t, cli, "greeting", "container")
+	require.Equal(t, "hello from module", callMethodText(ctx, t, cli, "greeting", nil, map[string]any{}))
+	require.Contains(t, callMethodText(ctx, t, cli, "container", nil, map[string]any{}), "Container#")
+}
+
+func initMCPTestModule(ctx context.Context, t testing.TB) string {
+	t.Helper()
+
+	modDir := t.TempDir()
+
+	_, err := hostDaggerExec(ctx, t, modDir, "init", "--name=test", "--sdk=go", "--source=.")
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+
+type Test struct{}
+
+func (m *Test) Greeting() string {
+	return "hello from module"
+}
+`), 0o644))
+
+	functionsOut, err := hostDaggerExec(ctx, t, modDir, "functions")
+	require.NoError(t, err)
+	require.Contains(t, string(functionsOut), "greeting")
+
+	return modDir
+}
+
+// MCP tests run the CLI on the host so the stdio transport can talk directly
+// to the subprocess.
+func startMCPClient(ctx context.Context, t testing.TB, workdir string, extraArgs ...string) *mcpclient.Client {
+	t.Helper()
+
+	args := append([]string{"--progress=plain", "mcp"}, extraArgs...)
+	stdio := transport.NewStdioWithOptions(
+		daggerCliPath(t),
+		nil,
+		args,
+		transport.WithCommandFunc(func(ctx context.Context, command string, env []string, args []string) (*exec.Cmd, error) {
+			cmd := exec.CommandContext(ctx, command, args...)
+			cleanupExec(t, cmd)
+			cmd.Dir = workdir
+			cmd.Env = append(os.Environ(), env...)
+			return cmd, nil
+		}),
+	)
+	cli := mcpclient.NewClient(stdio)
+	t.Cleanup(func() {
+		_ = cli.Close()
+	})
+
+	require.NoError(t, cli.Start(ctx))
+
+	_, err := cli.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{
+				Name:    "dagger-integration-test",
+				Version: "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return cli
+}
+
+func listMethodNames(ctx context.Context, t testing.TB, cli *mcpclient.Client) []string {
+	t.Helper()
+
+	listMethods, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "ListMethods",
+			Arguments: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, listMethods.IsError)
+
+	var methods []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, listMethods)), &methods))
+
+	names := make([]string, 0, len(methods))
+	for _, method := range methods {
+		names = append(names, method.Name)
+	}
+	return names
+}
+
+func selectMethods(ctx context.Context, t testing.TB, cli *mcpclient.Client, methods ...string) {
+	t.Helper()
+
+	_, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "SelectMethods",
+			Arguments: map[string]any{
+				"methods": methods,
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func callMethodText(
+	ctx context.Context,
+	t testing.TB,
+	cli *mcpclient.Client,
+	method string,
+	self any,
+	args map[string]any,
+) string {
+	t.Helper()
+
+	callMethod, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "CallMethod",
+			Arguments: map[string]any{
+				"method": method,
+				"self":   self,
+				"args":   args,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, callMethod.IsError)
+
+	return strings.TrimSpace(toolResultText(t, callMethod))
+}
+
+func toolResultText(t testing.TB, result *mcp.CallToolResult) string {
+	t.Helper()
+
+	var content strings.Builder
+	for _, item := range result.Content {
+		text, ok := item.(mcp.TextContent)
+		require.Truef(t, ok, "unexpected MCP content type %T", item)
+		content.WriteString(text.Text)
+	}
+
+	return content.String()
+}

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -272,20 +272,40 @@ func (m *MCP) Tools(ctx context.Context) ([]LLMTool, error) {
 	if err := m.loadMCPTools(ctx, allTools); err != nil {
 		return nil, err
 	}
-	if err := m.loadModuleTools(srv, allTools); err != nil {
+
+	callMethods := NewLLMToolSet()
+	if m.staticTools {
+		if err := m.loadServedModuleQueryTools(ctx, srv, callMethods); err != nil {
+			return nil, err
+		}
+	} else if err := m.loadServedModuleQueryTools(ctx, srv, allTools); err != nil {
 		return nil, err
 	}
+	if m.staticTools {
+		if err := m.loadModuleTools(srv, callMethods); err != nil {
+			return nil, err
+		}
+	} else if err := m.loadModuleTools(srv, allTools); err != nil {
+		return nil, err
+	}
+
 	objectMethods := NewLLMToolSet()
 	if err := m.loadReachableObjectMethods(ctx, srv, objectMethods); err != nil {
 		return nil, err
 	}
-	if !m.staticTools {
+	if m.staticTools {
+		for _, t := range objectMethods.Order {
+			callMethods.Add(t)
+		}
+	} else {
 		// directly expose object methods as a dynamic toolchain
 		for _, t := range objectMethods.Order {
 			allTools.Add(t)
 		}
+		callMethods = objectMethods
 	}
-	m.loadBuiltins(srv, allTools, objectMethods)
+
+	m.loadBuiltins(srv, allTools, callMethods)
 	return allTools.Order, nil
 }
 
@@ -475,6 +495,85 @@ func (m *MCP) loadModuleTools(srv *dagql.Server, allTools *LLMToolSet) error {
 			}
 		}
 	}
+	return nil
+}
+
+func (m *MCP) loadServedModuleQueryTools(ctx context.Context, srv *dagql.Server, allTools *LLMToolSet) error {
+	var typeDefs dagql.ObjectResultArray[*TypeDef]
+	if err := srv.Select(ctx, srv.Root(), &typeDefs, dagql.Selector{
+		Field: "currentTypeDefs",
+		Args: []dagql.NamedInput{
+			{Name: "hideCore", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return fmt.Errorf("load current type defs: %w", err)
+	}
+
+	var queryTypeDef *ObjectTypeDef
+	for _, typeDef := range typeDefs {
+		typeDefSelf := typeDef.Self()
+		if typeDefSelf == nil ||
+			typeDefSelf.Kind != TypeDefKindObject ||
+			!typeDefSelf.AsObject.Valid ||
+			typeDefSelf.AsObject.Value.Self() == nil ||
+			typeDefSelf.AsObject.Value.Self().Name != "Query" {
+			continue
+		}
+		queryTypeDef = typeDefSelf.AsObject.Value.Self()
+		break
+	}
+	if queryTypeDef == nil {
+		return nil
+	}
+
+	schema := srv.Schema()
+	queryDef, ok := schema.Types[schema.Query.Name]
+	if !ok {
+		return fmt.Errorf("type %q not found", schema.Query.Name)
+	}
+
+	for _, fn := range queryTypeDef.Functions {
+		fnSelf := fn.Self()
+		if fnSelf == nil || fnSelf.SourceModuleName == "" && fnSelf.Name != "with" {
+			continue
+		}
+
+		fieldDef := queryDef.Fields.ForName(fnSelf.Name)
+		if fieldDef == nil {
+			return fmt.Errorf("query field %q not found in schema", fnSelf.Name)
+		}
+		if fieldDef.Directives.ForName(deprecatedDirectiveName) != nil {
+			continue
+		}
+		if references(fieldDef, TypesHiddenFromEnvExtensions...) {
+			continue
+		}
+
+		toolSchema, err := m.fieldArgsToJSONSchema(schema, queryDef, fieldDef, nil)
+		if err != nil {
+			return fmt.Errorf("query field %q: %w", fieldDef.Name, err)
+		}
+
+		toolField := fieldDef
+		allTools.Add(LLMTool{
+			Name:        toolField.Name,
+			Field:       toolField,
+			Description: strings.TrimSpace(toolField.Description),
+			Schema:      toolSchema,
+			Strict:      false,
+			HideSelf:    true,
+			ReadOnly:    toolField.Type.NamedType != "Env" && toolField.Type.NamedType != "Changeset",
+			Call: func(ctx context.Context, args any) (_ any, rerr error) {
+				argsMap, ok := args.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("invalid arguments type: %T", args)
+				}
+				ctx = dagql.WithRepeatedTelemetry(ctx)
+				return m.call(ctx, srv, schema, queryDef.Name, toolField, argsMap, nil)
+			},
+		})
+	}
+
 	return nil
 }
 
@@ -1513,7 +1612,7 @@ func (m *MCP) saveTool(srv *dagql.Server) LLMTool {
 	}
 }
 
-func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, objectMethods *LLMToolSet) {
+func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, callMethods *LLMToolSet) {
 	schema := srv.Schema()
 
 	if m.env.Self().writable {
@@ -1637,7 +1736,7 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools, objectMethods *LLMToolSe
 	}
 
 	if m.staticTools {
-		m.loadStaticMethodCallingTools(srv, allTools, objectMethods)
+		m.loadStaticMethodCallingTools(srv, allTools, callMethods)
 	}
 
 	allTools.Add(LLMTool{
@@ -1748,7 +1847,7 @@ func (m *MCP) readLogsTool(srv *dagql.Server) LLMToolFunc {
 	})
 }
 
-func (m *MCP) loadStaticMethodCallingTools(srv *dagql.Server, allTools *LLMToolSet, objectMethods *LLMToolSet) {
+func (m *MCP) loadStaticMethodCallingTools(srv *dagql.Server, allTools *LLMToolSet, callMethods *LLMToolSet) {
 	allTools.Add(LLMTool{
 		Name:        "ListMethods",
 		Description: "List the methods that can be selected.",
@@ -1760,7 +1859,7 @@ func (m *MCP) loadStaticMethodCallingTools(srv *dagql.Server, allTools *LLMToolS
 			"additionalProperties": false,
 		},
 		Strict: true,
-		Call:   m.listMethodsTool(srv, objectMethods),
+		Call:   m.listMethodsTool(srv, callMethods),
 	})
 
 	allTools.Add(LLMTool{
@@ -1782,7 +1881,7 @@ func (m *MCP) loadStaticMethodCallingTools(srv *dagql.Server, allTools *LLMToolS
 			"additionalProperties": false,
 		},
 		Strict: true,
-		Call:   m.selectMethodsTool(srv, objectMethods),
+		Call:   m.selectMethodsTool(srv, callMethods),
 	})
 
 	allTools.Add(LLMTool{
@@ -1811,7 +1910,7 @@ func (m *MCP) loadStaticMethodCallingTools(srv *dagql.Server, allTools *LLMToolS
 			"additionalProperties": false,
 		},
 		Strict: false,
-		Call:   m.callMethodTool(objectMethods),
+		Call:   m.callMethodTool(callMethods),
 	})
 
 	allTools.Add(LLMTool{
@@ -1852,11 +1951,11 @@ NOTE: you must select methods before chaining them`,
 			"additionalProperties": false,
 		},
 		Strict: false,
-		Call:   m.chainMethodsTool(srv, objectMethods),
+		Call:   m.chainMethodsTool(srv, callMethods),
 	})
 }
 
-func (m *MCP) listMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLMToolFunc {
+func (m *MCP) listMethodsTool(srv *dagql.Server, callMethods *LLMToolSet) LLMToolFunc {
 	return ToolFunc(srv, func(ctx context.Context, args struct{}) (any, error) {
 		type toolDesc struct {
 			Name         string            `json:"name"`
@@ -1864,7 +1963,7 @@ func (m *MCP) listMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLMT
 			RequiredArgs map[string]string `json:"required_args,omitempty"`
 		}
 		var methods []toolDesc
-		for _, method := range objectMethods.Order {
+		for _, method := range callMethods.Order {
 			reqArgs := map[string]string{}
 			var returns string
 			if method.Field != nil {
@@ -1890,7 +1989,7 @@ func (m *MCP) listMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLMT
 	})
 }
 
-func (m *MCP) selectMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLMToolFunc {
+func (m *MCP) selectMethodsTool(srv *dagql.Server, callMethods *LLMToolSet) LLMToolFunc {
 	return ToolFunc(srv, func(ctx context.Context, args struct {
 		Methods []string
 	}) (any, error) {
@@ -1914,7 +2013,7 @@ func (m *MCP) selectMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LL
 		var selectedMethods []methodDef
 		var unknownMethods []string
 		for methodName := range methodCounts {
-			method, found := objectMethods.Map[methodName]
+			method, found := callMethods.Map[methodName]
 			if found {
 				var returns string
 				if method.Field != nil {
@@ -1949,7 +2048,7 @@ func (m *MCP) selectMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LL
 	})
 }
 
-func (m *MCP) callMethodTool(objectMethods *LLMToolSet) LLMToolFunc {
+func (m *MCP) callMethodTool(callMethods *LLMToolSet) LLMToolFunc {
 	return func(ctx context.Context, argsAny any) (_ any, rerr error) {
 		var call struct {
 			Self   string         `json:"self"`
@@ -1981,7 +2080,7 @@ func (m *MCP) callMethodTool(objectMethods *LLMToolSet) LLMToolFunc {
 			}
 		}
 		var method LLMTool
-		method, found := objectMethods.Map[call.Method]
+		method, found := callMethods.Map[call.Method]
 		if !found {
 			return nil, fmt.Errorf("method not defined: %q; use ListMethods first", call.Method)
 		}
@@ -1992,7 +2091,7 @@ func (m *MCP) callMethodTool(objectMethods *LLMToolSet) LLMToolFunc {
 	}
 }
 
-func (m *MCP) chainMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLMToolFunc {
+func (m *MCP) chainMethodsTool(srv *dagql.Server, callMethods *LLMToolSet) LLMToolFunc {
 	schema := srv.Schema()
 	return func(ctx context.Context, argsAny any) (_ any, rerr error) {
 		var toolArgs struct {
@@ -2006,13 +2105,13 @@ func (m *MCP) chainMethodsTool(srv *dagql.Server, objectMethods *LLMToolSet) LLM
 		if err := json.Unmarshal(pl, &toolArgs); err != nil {
 			return nil, err
 		}
-		if err := m.validateAndNormalizeChain(ctx, toolArgs.Self, toolArgs.Chain, objectMethods, schema); err != nil {
+		if err := m.validateAndNormalizeChain(ctx, toolArgs.Self, toolArgs.Chain, callMethods, schema); err != nil {
 			return nil, err
 		}
 		var res any
 		for i, call := range toolArgs.Chain {
 			var tool LLMTool
-			tool, found := objectMethods.Map[call.Method]
+			tool, found := callMethods.Map[call.Method]
 			if !found {
 				return nil, fmt.Errorf("tool not found: %q", call.Method)
 			}
@@ -2047,7 +2146,7 @@ type ChainedCall struct {
 	Args   map[string]any `json:"args"`
 }
 
-func (m *MCP) validateAndNormalizeChain(ctx context.Context, self string, calls []ChainedCall, objectMethods *LLMToolSet, schema *ast.Schema) error {
+func (m *MCP) validateAndNormalizeChain(ctx context.Context, self string, calls []ChainedCall, callMethods *LLMToolSet, schema *ast.Schema) error {
 	if len(calls) == 0 {
 		return errors.New("no methods called")
 	}
@@ -2070,7 +2169,7 @@ func (m *MCP) validateAndNormalizeChain(ctx context.Context, self string, calls 
 			call.Method = currentType.Name() + "_" + call.Method
 			calls[i] = call
 		}
-		method, found := objectMethods.Map[call.Method]
+		method, found := callMethods.Map[call.Method]
 		if !found {
 			errs = errors.Join(errs, fmt.Errorf("calls[%d]: unknown method: %q", i, call.Method))
 			continue


### PR DESCRIPTION
## Summary

`dagger mcp` stopped exposing methods from the current workspace module in static mode.

This makes static MCP load workspace module query methods from the served schema.
It also adds integration tests for the four module and privileged mode combinations.

## Testing

`dagger -m github.com/dagger/dagger@pull/head/13029 call engine-dev test --pkg=./core/integration --run='TestMCP'`
