### PR TITLE
core: synthesize sourceMap with module name when SDK provides none

### DIFF
--- a/core/module.go
+++ b/core/module.go
@@ -1751,7 +1751,29 @@ func (mod *Module) namespaceSourceMap(
 	sourceMap dagql.Nullable[dagql.ObjectResult[*SourceMap]],
 ) (dagql.Nullable[dagql.ObjectResult[*SourceMap]], error) {
 	if !sourceMap.Valid || sourceMap.Value.Self() == nil {
-		return sourceMap, nil
+		// Even if the SDK didn't provide a source map, record the module
+		// name so downstream consumers (CLI, shell, codegen dependency
+		// filtering) can identify which module a type/function belongs to.
+		// Route through dag.Select rather than NewObjectResultForCurrentCall
+		// so the result is attached and callers can read its ID when calling
+		// __withSourceMap.
+		dag, err := CurrentDagqlServer(ctx)
+		if err != nil {
+			return dagql.Nullable[dagql.ObjectResult[*SourceMap]]{}, fmt.Errorf("current dagql server: %w", err)
+		}
+		var synthesized dagql.ObjectResult[*SourceMap]
+		if err := dag.Select(ctx, dag.Root(), &synthesized, dagql.Selector{
+			Field: "sourceMap",
+			Args: []dagql.NamedInput{
+				{Name: "module", Value: dagql.Opt(dagql.String(mod.Name()))},
+				{Name: "filename", Value: dagql.String("")},
+				{Name: "line", Value: dagql.Int(0)},
+				{Name: "column", Value: dagql.Int(0)},
+			},
+		}); err != nil {
+			return dagql.Nullable[dagql.ObjectResult[*SourceMap]]{}, fmt.Errorf("synthesize source map for module %q: %w", mod.Name(), err)
+		}
+		return dagql.NonNull(synthesized), nil
 	}
 	filename := filepath.Join(modPath, sourceMap.Value.Self().Filename)
 	url := sourceMap.Value.Self().URL

--- a/core/module_test.go
+++ b/core/module_test.go
@@ -5,15 +5,67 @@ import (
 	"testing"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNamespaceSourceMap(t *testing.T) {
 	mod := &Module{NameField: "mymod"}
 
-	t.Run("leaves empty source map unchanged", func(t *testing.T) {
-		result, err := mod.namespaceSourceMap(context.Background(), "sub", dagql.Null[dagql.ObjectResult[*SourceMap]]())
+	t.Run("synthesizes module-name-only source map when SDK provides none", func(t *testing.T) {
+		ctx := t.Context()
+
+		cache, err := dagql.NewCache(ctx, "", nil, nil)
 		require.NoError(t, err)
-		require.False(t, result.Valid)
+		ctx = dagql.ContextWithCache(ctx, cache)
+
+		root := &Query{}
+		testSrv := &moduleObjectTestServer{
+			mockServer: &mockServer{},
+			cache:      cache,
+			root:       root,
+		}
+		root.Server = testSrv
+		dag := newCoreDagqlServerForTest(t, root)
+		testSrv.dag = dag
+
+		dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*SourceMap]{Typed: &SourceMap{}}))
+		dagql.Fields[*Query]{
+			dagql.Func("sourceMap", func(_ context.Context, _ *Query, args struct {
+				Module   dagql.Optional[dagql.String] `internal:"true"`
+				Filename string
+				Line     int
+				Column   int
+				URL      dagql.Optional[dagql.String] `internal:"true"`
+			}) (*SourceMap, error) {
+				var module string
+				if args.Module.Valid {
+					module = string(args.Module.Value)
+				}
+				var url string
+				if args.URL.Valid {
+					url = string(args.URL.Value)
+				}
+				return &SourceMap{
+					Module:   module,
+					Filename: args.Filename,
+					Line:     args.Line,
+					Column:   args.Column,
+					URL:      url,
+				}, nil
+			}),
+		}.Install(dag)
+
+		ctx = ContextWithQuery(ctx, root)
+		ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+			ClientID:  "namespace-source-map-test-client",
+			SessionID: "namespace-source-map-test-session",
+		})
+
+		result, err := mod.namespaceSourceMap(ctx, "sub", dagql.Null[dagql.ObjectResult[*SourceMap]]())
+		require.NoError(t, err)
+		require.True(t, result.Valid)
+		require.NotNil(t, result.Value.Self())
+		require.Equal(t, "mymod", result.Value.Self().Module)
 	})
 }


### PR DESCRIPTION
Restore the pre-#11856 behavior where (*Module).namespaceSourceMap records at minimum the module name when the SDK does not attach a source map to a typedef/field/argument.

When commit aa719a10d migrated source-map handling to dagql results, the synthesizing fallback was lost: the new namespaceSourceMap returns the nil sourceMap unchanged, so types/fields contributed by SDKs that don't emit source maps (dang, Java, Python, PHP, Elixir) end up in the schema without any sourceMap directive.

That sourceMap.module directive is what cmd/codegen/introspection/filters.go uses to identify dependency types. With the directive missing, DependencyNames() no longer reports the dep, Exclude() no longer strips its types from the core schema, and Include() no longer produces a per-dep <name>.gen.go. The generated code ends up with the dep's types duplicated between dagger.gen.go (newly inlined) and a stale <name>.gen.go on disk, which the overlay writer leaves untouched because the new memfs no longer contains it.

Re-create a minimal SourceMap whose only filled field is the module name so the downstream filtering logic keeps working for any SDK that does not provide source-position metadata.