### PR TITLE
New EnvVar DAGGER_GO_SDK_OFFLINE which restores behavior prior to 0.20.4

### DIFF
--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -54,6 +54,16 @@ func (g *GoGenerator) GenerateModule(ctx context.Context, schema *introspection.
 		return nil, fmt.Errorf("bootstrap package: %w", err)
 	}
 
+	// When no LibVersion was passed (offline mode, gated by DAGGER_GO_SDK_OFFLINE
+	// on the engine), use the embedded querybuilder so codegen doesn't fetch
+	// dagger.io/dagger.
+	if moduleConfig.LibVersion == "" {
+		layers = append(layers,
+			&MountedFS{FS: dagger.QueryBuilder, Name: filepath.Join(outDir, "internal")},
+		)
+		pkgInfo.UtilityPkgImport = path.Join(pkgInfo.PackageImport, "internal")
+	}
+
 	genSt.Overlay = layerfs.New(layers...)
 
 	if outDir != "." {
@@ -248,7 +258,7 @@ func (g *GoGenerator) syncModReplaceAndTidy(mod *modfile.File, genSt *generator.
 	// Check if the module go.mod replaces the dagger.io/dagger library with a custom path.
 	// If so, we keep it as is.
 	// Otherwise, we install the given dagger.io/dagger package version.
-	if !isDaggerPkgCustomReplaced(mod.Replace) {
+	if g.Config.ModuleConfig.LibVersion != "" && !isDaggerPkgCustomReplaced(mod.Replace) {
 		genSt.PostCommands = append(genSt.PostCommands,
 			exec.Command("go", "get", "-u", daggerImportPath+"@"+g.Config.ModuleConfig.LibVersion))
 	}

--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -261,6 +261,12 @@ func (g *GoGenerator) syncModReplaceAndTidy(mod *modfile.File, genSt *generator.
 	if g.Config.ModuleConfig.LibVersion != "" && !isDaggerPkgCustomReplaced(mod.Replace) {
 		genSt.PostCommands = append(genSt.PostCommands,
 			exec.Command("go", "get", "-u", daggerImportPath+"@"+g.Config.ModuleConfig.LibVersion))
+	} else if g.Config.ModuleConfig.LibVersion == "" && !isDaggerPkgCustomReplaced(mod.Replace) {
+		// Offline mode: the generated code imports <usermod>/internal/querybuilder
+		// (overlaid from the embedded SDK) and does not import dagger.io/dagger
+		// directly. Drop any pre-existing require so go mod tidy doesn't try to
+		// resolve it from the proxy.
+		_ = mod.DropRequire(daggerImportPath)
 	}
 
 	genSt.PostCommands = append(genSt.PostCommands,

--- a/cmd/codegen/generator/go/generate_typedefs.go
+++ b/cmd/codegen/generator/go/generate_typedefs.go
@@ -7,8 +7,10 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/cmd/codegen/generator"
 	"github.com/dagger/dagger/cmd/codegen/generator/go/templates"
 	"github.com/dagger/dagger/cmd/codegen/introspection"
@@ -31,9 +33,16 @@ func (g *GoGenerator) GenerateTypeDefs(ctx context.Context, schema *introspectio
 	outDir := filepath.Clean(moduleConfig.ModuleSourcePath)
 
 	mfs := memfs.New()
-	var overlay fs.FS = layerfs.New(
-		mfs,
-	)
+	overlayLayers := []fs.FS{mfs}
+	// When no LibVersion was passed (offline mode, gated by DAGGER_GO_SDK_OFFLINE
+	// on the engine), use the embedded querybuilder so codegen doesn't fetch
+	// dagger.io/dagger.
+	if moduleConfig.LibVersion == "" {
+		overlayLayers = append(overlayLayers,
+			&MountedFS{FS: dagger.QueryBuilder, Name: filepath.Join(outDir, "internal")},
+		)
+	}
+	var overlay fs.FS = layerfs.New(overlayLayers...)
 
 	res := &generator.GeneratedState{
 		Overlay: overlay,
@@ -42,6 +51,10 @@ func (g *GoGenerator) GenerateTypeDefs(ctx context.Context, schema *introspectio
 	pkgInfo, partial, err := g.bootstrapMod(mfs, res, true)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap package: %w", err)
+	}
+
+	if moduleConfig.LibVersion == "" {
+		pkgInfo.UtilityPkgImport = path.Join(pkgInfo.PackageImport, "internal")
 	}
 
 	if outDir != "." {

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -30,7 +30,23 @@ const (
 	// change is needed in the generated library.
 	// Otherwise, update it to the latest known commit during release.
 	goSDKLibVersion = "7058e9313c720d82c6a07fefb6ce3fab60c7ec4e" // v0.20.6
+
+	// goSDKOfflineEnv, when set to any non-empty value on the engine
+	// container, omits --lib-version from codegen calls. That makes the Go
+	// codegen fall back to the embedded querybuilder so module init/develop
+	// works without network access to dagger.io / proxy.golang.org / sum.golang.org.
+	goSDKOfflineEnv = "DAGGER_GO_SDK_OFFLINE"
 )
+
+// goSDKLibVersionArgs returns the --lib-version arg pair for codegen, unless
+// the offline env var is set, in which case it returns nil so codegen treats
+// LibVersion as empty and uses the embedded querybuilder.
+func goSDKLibVersionArgs() dagql.ArrayInput[dagql.String] {
+	if os.Getenv(goSDKOfflineEnv) != "" {
+		return nil
+	}
+	return dagql.ArrayInput[dagql.String]{"--lib-version", dagql.String(goSDKLibVersion)}
+}
 
 var goSDKExecMDDigest = digest.FromString("go-sdk-with-exec-execmd")
 
@@ -374,15 +390,14 @@ func (sdk *goSDK) ModuleTypes(
 			Args: []dagql.NamedInput{
 				{
 					Name: "args",
-					Value: dagql.ArrayInput[dagql.String]{
+					Value: append(dagql.ArrayInput[dagql.String]{
 						"codegen",
 						"generate-typedefs",
 						"--module-source-path", dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 						"--module-name", dagql.String(modName),
 						"--introspection-json-path", goSDKIntrospectionJSONPath,
-						"--lib-version", dagql.String(goSDKLibVersion),
 						"--output", GoSDKModuleIDPath,
-					},
+					}, goSDKLibVersionArgs()...),
 				},
 				{
 					Name:  "experimentalPrivilegedNesting",
@@ -601,8 +616,8 @@ func (sdk *goSDK) baseWithCodegen(
 		"--module-source-path", dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 		"--module-name", dagql.String(modName),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
-		"--lib-version", dagql.String(goSDKLibVersion),
 	}
+	codegenArgs = append(codegenArgs, goSDKLibVersionArgs()...)
 	if !src.Self().ConfigExists {
 		codegenArgs = append(codegenArgs, "--is-init")
 	}


### PR DESCRIPTION
A PR merged for 0.20.4 impacted our ability to run Dagger modules behind our airgap [PR #11826](https://github.com/dagger/dagger/pull/11826/). This PR will undo the effect of that PR in the presence of DAGGER_GO_SDK_OFFLINE environment switch.

The underlying cause is the original PR created a "vanity url" for dagger resources which does not resolve through go proxy.

Before the PR, the Go codegen path was self-contained for dagger-side code:

  - The two relevant source files of dagger-go-sdk — querybuilder/marshal.go and querybuilder/querybuilder.go — were  embedded into the codegen binary via Go //go:embed (dagger.QueryBuilder), and the codegen binary was baked into the engine image.
  - When generating a module, codegen overlaid those embedded files into <usermod>/internal/querybuilder/ and rewrote the generated dagger.gen.go to import <usermod>/internal/querybuilder instead of dagger.io/dagger/querybuilder.
  - Result: zero network calls for the dagger-specific portion. Transitive deps (otel, gqlparser, etc.) still went through go mod tidy and could be served by an internal Go proxy.

  The PR replaced that embedded-fallback design with a network-fetched pin:

  - Added a --lib-version <commit> arg to codegen, supplied at engine compile time as a pinned dagger-go-sdk commit hash.
  - Removed the MountedFS{FS: dagger.QueryBuilder} overlay and the UtilityPkgImport rewrite.
  - Added go get dagger.io/dagger@<commit> as a post-command (generate_module.go) and an explicit go get in ensureDaggerPackage (generate_typedefs.go).
  - Generated code now imports the real dagger.io/dagger package, resolved by that go get.

  That go get dagger.io/dagger@<commit> is the regression. It triggers a sequence of network calls that an internal Athens-style proxy typically does not handle gracefully:

  1. Vanity URL resolution — Go fetches https://dagger.io/dagger?go-get=1 to read the <meta name="go-import"> tag that maps dagger.io/dagger to github.com/dagger/dagger-go-sdk. Many internal proxies don't proxy vanity HTML lookups; they expect a known module-path-to-VCS mapping. If dagger.io isn't in the proxy's allowlist, the lookup falls through to direct → blocked by air-gap.

Co-authored-by: @claude 