### PR TITLE
remove progress plain from hack/build script

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S dagger --progress=plain shell --no-mod
+#!/usr/bin/env -S dagger shell --no-mod
 
 # hack/build builds the engine and cli from local code, and additionally starts
 # the engine in the host's docker runtime.


### PR DESCRIPTION
seems like this was accidentally added in a previous commit. Reverting to its originally intended state.