### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -127,6 +127,7 @@ const config: Config = {
     "docusaurus-plugin-image-zoom",
     // Thanks to @jharrell and Prisma team. Apache-2.0 content
     llmsTxtPlugin,
+    "docusaurus-plugin-copy-page-button",
     [
       "posthog-docusaurus",
       {

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,7 @@
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "3.x",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-sass": "^0.2.6",
     "docusaurus-plugin-typedoc": "^1.4.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "3.x",
     "clsx": "^2.1.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-sass": "^0.2.6",
     "docusaurus-plugin-typedoc": "^1.4.2",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Dagger docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Dagger

Dagger already ships an [llms.txt plugin](https://github.com/dagger/dagger/blob/main/docs/plugins/llms-txt-plugin.ts) for whole-site AI discovery. This plugin is the complementary piece for single-page handoff: when a developer is on, say, the [Functions reference](https://docs.dagger.io/api/types) and wants to ask Claude "rewrite this in Python", they get a clean markdown copy in one click instead of selecting around the nav and the cookbook partials.

Given Dagger's positioning as the "runtime for composable workflows powering AI agents and CI/CD", this seems on-brand.

## Production users

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, and Chronicle docs. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `docs/package.json` dependencies
- Adds the plugin string to the `plugins` array in `docs/docusaurus.config.ts`, placed next to `llmsTxtPlugin` for thematic grouping

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.