### PR TITLE
core: include module variants in function cache identity

### DIFF
--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -108,6 +108,83 @@ func (ToolchainSuite) TestToolchainSemanticIsolation(ctx context.Context, t *tes
 		require.NoError(t, err)
 		require.Contains(t, out, "this is the app configuration")
 	})
+
+	t.Run("constructor customization default changes invalidate omitted arg cache", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		selected := func(out string) string {
+			lines := strings.Split(strings.TrimSpace(out), "\n")
+			if len(lines) == 0 {
+				return ""
+			}
+			return strings.TrimSpace(lines[len(lines)-1])
+		}
+		daggerJSON := func(defaultValue string) string {
+			return fmt.Sprintf(`
+{
+  "name": "default-cache-repro",
+  "engineVersion": "v0.20.6",
+  "toolchains": [
+    {
+      "name": "probe",
+      "source": "tool",
+      "customizations": [
+        {
+          "argument": "value",
+          "default": %q
+        }
+      ]
+    }
+  ]
+}
+			`, defaultValue)
+		}
+
+		base := goGitBase(t, c).
+			WithWorkdir("/work/tool").
+			With(daggerExec("init", "--sdk=go", "--name=probe")).
+			WithNewFile("main.go", `package main
+
+type Probe struct {
+	Value string
+}
+
+func New(
+	// +optional
+	value string,
+) *Probe {
+	return &Probe{Value: value}
+}
+
+func (m *Probe) Selected() string {
+	return m.Value
+}
+`)
+
+		alpha := base.
+			WithWorkdir("/work").
+			WithNewFile("dagger.json", daggerJSON("alpha"))
+
+		out, err := alpha.
+			With(daggerExec("-s", "-m", ".", "call", "probe", "selected")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "alpha", selected(out))
+
+		beta := alpha.WithNewFile("dagger.json", daggerJSON("beta"))
+
+		out, err = beta.
+			With(daggerExec("-s", "-m", ".", "call", "probe", "selected")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "beta", selected(out))
+
+		out, err = beta.
+			With(daggerExec("-s", "-m", ".", "call", "probe", "--value", "beta", "selected")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "beta", selected(out))
+	})
 }
 
 func (ToolchainSuite) TestMultipleToolchains(ctx context.Context, t *testctx.T) {

--- a/core/module.go
+++ b/core/module.go
@@ -874,6 +874,7 @@ type persistedModulePayload struct {
 	WorkspaceConfig               map[string]any `json:"workspaceConfig,omitempty"`
 	DefaultsFromDotEnv            bool           `json:"defaultsFromDotEnv,omitempty"`
 	DisableDefaultFunctionCaching bool           `json:"disableDefaultFunctionCaching,omitempty"`
+	AsModuleVariantDigest         string         `json:"asModuleVariantDigest,omitempty"`
 }
 
 func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
@@ -951,6 +952,7 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 	persisted.WorkspaceConfig = mod.WorkspaceConfig
 	persisted.DefaultsFromDotEnv = mod.DefaultsFromDotEnv
 	persisted.DisableDefaultFunctionCaching = mod.DisableDefaultFunctionCaching
+	persisted.AsModuleVariantDigest = mod.AsModuleVariantDigest
 
 	jsonBytes, err := json.Marshal(persisted)
 	if err != nil {
@@ -1034,6 +1036,7 @@ func (*Module) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ u
 		WorkspaceConfig:               persisted.WorkspaceConfig,
 		DefaultsFromDotEnv:            persisted.DefaultsFromDotEnv,
 		DisableDefaultFunctionCaching: persisted.DisableDefaultFunctionCaching,
+		AsModuleVariantDigest:         persisted.AsModuleVariantDigest,
 	}
 	if mod.SDKConfig == nil {
 		mod.SDKConfig = &SDKConfig{}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -2990,7 +2990,11 @@ func (s *moduleSchema) moduleImplementationScoped(
 	if err != nil {
 		return inst, fmt.Errorf("failed to get source implementation digest for module: %w", err)
 	}
-	scopedDigest := hashutil.HashStrings("Module._implementationScoped", sourceDigest.String())
+	scopedDigestInputs := []string{"Module._implementationScoped", sourceDigest.String()}
+	if parentMod.Self().AsModuleVariantDigest != "" {
+		scopedDigestInputs = append(scopedDigestInputs, parentMod.Self().AsModuleVariantDigest)
+	}
+	scopedDigest := hashutil.HashStrings(scopedDigestInputs...)
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)


### PR DESCRIPTION
## Summary

Fixes #13046 by making the module implementation-scoped cache identity include the `AsModuleVariantDigest` computed by `moduleSource.asModule`. Toolchain constructor customization defaults are part of that variant digest, so changing a default from `alpha` to `beta` now gives omitted-argument calls a distinct function cache key.

The change also persists `AsModuleVariantDigest` in the module payload so imported persisted modules keep the same variant-sensitive identity.

## Testing

- `dagger -m github.com/dagger/dagger@pull/13047/head call engine-dev test --pkg ./core/integration --run='TestToolchain/TestToolchainSemanticIsolation/constructor_customization_default_changes_invalidate_omitted_arg_cache'`
- `dagger -m github.com/dagger/dagger@pull/13047/head call engine-dev test --pkg ./core/integration --run='TestToolchain/TestToolchainSemanticIsolation'`
