### PR TITLE
chore: engine-dev test-telemetry --update

### DIFF
--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -164,12 +164,9 @@ func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 		{Function: "fail-multi", Fail: true},
 		{Name: "fail-multi-noexpand", Function: "fail-multi", Fail: true, NoExpand: true},
 
-		// FIXME: these constantly fail in CI/Dagger, but not against a local
-		// engine. spent a day investigating, don't have a good explanation. it
-		// fails because despite the warmup running to completion, the test gets a
-		// cache miss.
-		{Function: "cached-execs", Flaky: "nested Dagger causes cache misses"},
-		{Function: "use-cached-exec-service", Flaky: "nested Dagger causes cache misses"},
+		// Used to be marked as flaky
+		{Function: "cached-execs"},
+		{Function: "use-cached-exec-service"},
 
 		// Python SDK tests
 		{Module: "./viztest/python", Function: "pending", Fail: true, RevealNoisySpans: true},

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -11,14 +11,12 @@ Expected stderr:
 
 ✔ parsing command line arguments X.Xs
 
-✔ viztest: Viztest! X.Xs
+$ viztest: Viztest! X.Xs CACHED
 ✔ .cachedExecs: Void X.Xs
-├╴✔ container: Container! X.Xs
+├╴$ container: Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
-├╴✔ withExec echo 'cached-execs cached for good' X.Xs
-│ ┃ cached-execs cached for good
-├╴✔ withExec echo 'im also cached for good' X.Xs
-│ ┃ im also cached for good
+├╴$ withExec echo 'cached-execs cached for good' X.Xs CACHED
+├╴$ withExec echo 'im also cached for good' X.Xs CACHED
 ├╴✔ withExec echo 'im a buster' '20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
 │ ┃ im a buster 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -11,10 +11,10 @@ Expected stderr:
 
 ✔ parsing command line arguments X.Xs
 
-✔ viztest: Viztest! X.Xs
+$ viztest: Viztest! X.Xs CACHED
 ✔ .useCachedExecService: Void X.Xs
-├╴✔ container: Container! X.Xs
-├╴$ .from(address: "busybox"): Container! X.Xs CACHED
+├╴$ container: Container! X.Xs CACHED
+├╴✔ .from(address: "busybox"): Container! X.Xs
 ├╴$ withExec echo 'exec-service cached for good' X.Xs CACHED
 ├╴$ withExec echo 'im also cached for good' X.Xs CACHED
 ├╴✔ withExec echo 'im a buster' '20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
@@ -26,6 +26,10 @@ Expected stderr:
 ├╴✔ .withExposedPort(port: 80): Container! X.Xs
 ├╴✔ .asService(args: ["httpd", "-v", "-h", "/srv", "-f"]): Service! X.Xs ✔ 1
 │ ┃ [::ffff:10.XX.XX.XX]:XXXXX: response:200
+│ ╰╴✔ exec httpd -v -h /srv -f X.Xs
+│   ╰╴✔ 80/tcp X.Xs
+│     ┃ XX:XX:XX WRN port not ready host=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local error="dial tcp 10.XX.XX.XX:80: connect: connection refused" elapsed=X.Xs
+│     ┃ XX:XX:XX INF port is healthy host=xxxxxxxxxxxxx.xxxxxxxxxxxxx.dagger.local endpoint=10.XX.XX.XX:80
 │
 ├╴$ Container.from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ .withServiceBinding(


### PR DESCRIPTION
cached-execs and use-cached-exec-service also needed an update but the corresponding tests were passing because their failure was silenced when they were marked as flaky in 6fdf164c7f.

This commit removes the mark and updates the golden tests.