### PR TITLE
[workspace] core: add workspace cwd API

### DIFF
--- a/core/integration/contextual_workspace_test.go
+++ b/core/integration/contextual_workspace_test.go
@@ -35,7 +35,7 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceSelection(ctx context.Con
 			WithNewFile("repo.txt", "hello from boundary").
 			WithNewFile("app/app.txt", "hello from workspace").
 			WithWorkdir("/work/app").
-			With(initStandaloneDangModule("paths", `
+			With(initDangBlueprint("paths", `
 type Paths {
   pub workspaceValue: String!
   pub boundaryValue: String!
@@ -107,7 +107,7 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceShape(ctx context.Context
 		ctr := workspaceBase(t, c).
 			WithExec([]string{"mkdir", "-p", "app"}).
 			WithWorkdir("/work/app").
-			With(initStandaloneDangModule("paths", `
+			With(initDangBlueprint("paths", `
 type Paths {
   pub workspacePath: String!
   pub workspaceAddress: String!

--- a/core/integration/workspace_cwd_test.go
+++ b/core/integration/workspace_cwd_test.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceSuite) TestCurrentWorkspaceRootAndCwd(ctx context.Context, t *testctx.T) {
+	fixture := newWorkspaceCwdFixture(t)
+
+	for _, tc := range []struct {
+		name        string
+		clientOpts  []dagger.ClientOpt
+		wantCwdPath string
+	}{
+		{
+			name:        "detection starts at workspace root",
+			clientOpts:  []dagger.ClientOpt{dagger.WithWorkdir(fixture.root)},
+			wantCwdPath: "",
+		},
+		{
+			name:        "detection starts below workspace root",
+			clientOpts:  []dagger.ClientOpt{dagger.WithWorkdir(fixture.cwd)},
+			wantCwdPath: "subdir",
+		},
+		{
+			name:        "explicit local workspace starts below workspace root",
+			clientOpts:  []dagger.ClientOpt{dagger.WithWorkspace(fixture.cwd)},
+			wantCwdPath: "subdir",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			t.Run("workspace root", func(ctx context.Context, t *testctx.T) {
+				res, err := testutil.Query[currentWorkspaceRootResult](t, `{
+					currentWorkspace {
+						path
+						rootFile: file(path: "root.txt") {
+							contents
+						}
+						rootDirectory: directory(path: ".") {
+							entries
+						}
+					}
+				}`, nil, tc.clientOpts...)
+				require.NoError(t, err)
+
+				require.Equal(t, ".", res.CurrentWorkspace.Path)
+				require.Equal(t, "from workspace root", res.CurrentWorkspace.RootFile.Contents)
+				require.Contains(t, res.CurrentWorkspace.RootDirectory.Entries, "root.txt")
+				require.Contains(t, res.CurrentWorkspace.RootDirectory.Entries, "subdir/")
+				require.NotContains(t, res.CurrentWorkspace.RootDirectory.Entries, "cwd.txt")
+			})
+
+			t.Run("workspace cwd", func(ctx context.Context, t *testctx.T) {
+				cwdFilePath := "cwd.txt"
+				wantCwdContents := "from workspace cwd"
+				if tc.wantCwdPath == "" {
+					cwdFilePath = "root.txt"
+					wantCwdContents = "from workspace root"
+				}
+
+				res, err := testutil.Query[currentWorkspaceCwdResult](t, `query WorkspaceCwd($cwdFilePath: String!) {
+					currentWorkspace {
+						path
+						cwd {
+							path
+							cwdFile: file(path: $cwdFilePath) {
+								contents
+							}
+							cwdDirectory: directory(path: ".") {
+								entries
+							}
+						}
+					}
+				}`, &testutil.QueryOptions{
+					Variables: map[string]any{
+						"cwdFilePath": cwdFilePath,
+					},
+				}, tc.clientOpts...)
+				require.NoError(t, err)
+
+				require.Equal(t, ".", res.CurrentWorkspace.Path)
+				require.Equal(t, tc.wantCwdPath, res.CurrentWorkspace.Cwd.Path)
+				require.Equal(t, wantCwdContents, res.CurrentWorkspace.Cwd.CwdFile.Contents)
+				if tc.wantCwdPath == "" {
+					require.Contains(t, res.CurrentWorkspace.Cwd.CwdDirectory.Entries, "root.txt")
+					require.Contains(t, res.CurrentWorkspace.Cwd.CwdDirectory.Entries, "subdir/")
+				} else {
+					require.Contains(t, res.CurrentWorkspace.Cwd.CwdDirectory.Entries, "cwd.txt")
+					require.NotContains(t, res.CurrentWorkspace.Cwd.CwdDirectory.Entries, "root.txt")
+				}
+			})
+		})
+	}
+}
+
+type workspaceCwdFixture struct {
+	root string
+	cwd  string
+}
+
+func newWorkspaceCwdFixture(t *testctx.T) workspaceCwdFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".dagger"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".dagger", "config.toml"), []byte("# workspace\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "root.txt"), []byte("from workspace root"), 0o600))
+
+	cwd := filepath.Join(root, "subdir")
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "cwd.txt"), []byte("from workspace cwd"), 0o600))
+
+	return workspaceCwdFixture{
+		root: root,
+		cwd:  cwd,
+	}
+}
+
+type currentWorkspaceRootResult struct {
+	CurrentWorkspace struct {
+		Path          string
+		RootFile      fileContentsResult
+		RootDirectory directoryEntriesResult
+	}
+}
+
+type currentWorkspaceCwdResult struct {
+	CurrentWorkspace struct {
+		Path string
+		Cwd  struct {
+			Path         string
+			CwdFile      fileContentsResult
+			CwdDirectory directoryEntriesResult
+		}
+	}
+}
+
+type fileContentsResult struct {
+	Contents string
+}
+
+type directoryEntriesResult struct {
+	Entries []string
+}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -55,6 +55,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("name").Doc(`The name of the file or directory to search for.`),
 				dagql.Arg("from").Doc(`Path to start the search from. Relative paths resolve from the workspace directory; absolute paths resolve from the workspace boundary.`),
 			),
+		dagql.Func("cwd", s.cwd).
+			WithInput(dagql.PerClientInput).
+			Doc("The current working directory within the workspace."),
 		dagql.Func("init", s.workspaceInit).
 			DoNotCache("Mutates workspace on host").
 			Doc("Initialize a new workspace, creating .dagger/config.toml."),
@@ -142,6 +145,25 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				"The returned plan has an empty changeset and no steps when no migration is needed."),
 	}.Install(srv)
 
+	dagql.Fields[*core.WorkspaceCwd]{
+		dagql.NodeFunc("directory", s.cwdDirectory).
+			WithInput(dagql.PerClientInput).
+			Doc(`Returns a Directory from the current working directory within the workspace.`,
+				`Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.`).
+			Args(
+				dagql.Arg("path").Doc(`Location of the directory to retrieve. Relative paths (e.g., "src") resolve from the current working directory; absolute paths (e.g., "/src") resolve from the workspace boundary.`),
+				dagql.Arg("exclude").Doc(`Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).`),
+				dagql.Arg("include").Doc(`Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).`),
+				dagql.Arg("gitignore").Doc(`Apply .gitignore filter rules inside the directory.`),
+			),
+		dagql.NodeFunc("file", s.cwdFile).
+			WithInput(dagql.PerClientInput).
+			Doc(`Returns a File from the current working directory within the workspace.`,
+				`Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.`).
+			Args(
+				dagql.Arg("path").Doc(`Location of the file to retrieve. Relative paths (e.g., "go.mod") resolve from the current working directory; absolute paths (e.g., "/go.mod") resolve from the workspace boundary.`),
+			),
+	}.Install(srv)
 	dagql.Fields[*core.WorkspaceModule]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceMigration]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceMigrationStep]{}.Install(srv)
@@ -153,6 +175,21 @@ func (s *workspaceSchema) currentWorkspace(
 	_ struct{},
 ) (*core.Workspace, error) {
 	return parent.Server.CurrentWorkspace(ctx)
+}
+
+func (s *workspaceSchema) cwd(
+	ctx context.Context,
+	ws *core.Workspace,
+	_ struct{},
+) (*core.WorkspaceCwd, error) {
+	cwd := &core.WorkspaceCwd{
+		Path:          ws.Cwd,
+		WorkspacePath: ws.Path,
+		ClientID:      ws.ClientID,
+	}
+	cwd.SetRootfs(ws.Rootfs())
+	cwd.SetHostPath(ws.HostPath())
+	return cwd, nil
 }
 
 type workspaceDirectoryArgs struct {
@@ -280,7 +317,25 @@ func (s *workspaceSchema) directory(
 	args workspaceDirectoryArgs,
 ) (inst dagql.ObjectResult[*core.Directory], _ error) {
 	ws := parent.Self()
-	resolvedPath := resolveWorkspacePath(args.Path, ws.Path)
+	return s.directoryAt(ctx, ws, ws.Path, args)
+}
+
+func (s *workspaceSchema) cwdDirectory(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.WorkspaceCwd],
+	args workspaceDirectoryArgs,
+) (inst dagql.ObjectResult[*core.Directory], _ error) {
+	ws, basePath := workspaceCwdResolution(parent.Self())
+	return s.directoryAt(ctx, ws, basePath, args)
+}
+
+func (s *workspaceSchema) directoryAt(
+	ctx context.Context,
+	ws *core.Workspace,
+	basePath string,
+	args workspaceDirectoryArgs,
+) (inst dagql.ObjectResult[*core.Directory], _ error) {
+	resolvedPath := resolveWorkspacePath(args.Path, basePath)
 	return s.resolveRootfs(ctx, ws, resolvedPath, args.CopyFilter, args.Gitignore)
 }
 
@@ -297,8 +352,25 @@ func (s *workspaceSchema) file(
 	args workspaceFileArgs,
 ) (inst dagql.Result[*core.File], _ error) {
 	ws := parent.Self()
+	return s.fileAt(ctx, ws, ws.Path, args)
+}
 
-	resolvedPath := resolveWorkspacePath(args.Path, ws.Path)
+func (s *workspaceSchema) cwdFile(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.WorkspaceCwd],
+	args workspaceFileArgs,
+) (inst dagql.Result[*core.File], _ error) {
+	ws, basePath := workspaceCwdResolution(parent.Self())
+	return s.fileAt(ctx, ws, basePath, args)
+}
+
+func (s *workspaceSchema) fileAt(
+	ctx context.Context,
+	ws *core.Workspace,
+	basePath string,
+	args workspaceFileArgs,
+) (inst dagql.Result[*core.File], _ error) {
+	resolvedPath := resolveWorkspacePath(args.Path, basePath)
 	parentDir := filepath.Dir(resolvedPath)
 	basename := filepath.Base(resolvedPath)
 
@@ -321,6 +393,17 @@ func (s *workspaceSchema) file(
 	}
 
 	return inst, nil
+}
+
+func workspaceCwdResolution(cwd *core.WorkspaceCwd) (*core.Workspace, string) {
+	ws := &core.Workspace{
+		Path:     cwd.WorkspacePath,
+		Cwd:      cwd.Path,
+		ClientID: cwd.ClientID,
+	}
+	ws.SetRootfs(cwd.Rootfs())
+	ws.SetHostPath(cwd.HostPath())
+	return ws, filepath.Join(cwd.WorkspacePath, cwd.Path)
 }
 
 func (s *workspaceSchema) update(
@@ -363,18 +446,17 @@ func (s *workspaceSchema) update(
 }
 
 // resolveWorkspacePath resolves a workspace API path into a boundary-relative path:
-//   - Relative paths resolve from the workspace directory (workspacePath/).
+//   - Relative paths resolve from the given boundary-relative base path.
 //   - Absolute paths resolve from the workspace boundary (/).
 //
 // Returns a path relative to the workspace boundary.
-func resolveWorkspacePath(pathArg, workspacePath string) string {
+func resolveWorkspacePath(pathArg, basePath string) string {
 	clean := filepath.Clean(pathArg)
 	if filepath.IsAbs(clean) {
 		// Absolute path: relative to workspace boundary (strip leading /).
 		return clean[1:]
 	}
-	// Relative path: relative to workspace directory within boundary.
-	return filepath.Join(workspacePath, clean)
+	return filepath.Join(basePath, clean)
 }
 
 func workspaceAPIPath(resolvedPath string) string {

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -109,6 +109,10 @@ func ensureWorkspaceInitialized(ctx context.Context, bk *engineutil.Client, ws *
 		return err
 	}
 
+	if ws.Cwd != "" {
+		ws.Path = filepath.Join(ws.Path, ws.Cwd)
+		ws.Cwd = ""
+	}
 	ws.ConfigPath = filepath.Join(ws.Path, workspace.LockDirName, workspace.ConfigFileName)
 	ws.Initialized = true
 	ws.HasConfig = true
@@ -116,6 +120,9 @@ func ensureWorkspaceInitialized(ctx context.Context, bk *engineutil.Client, ws *
 }
 
 func configHostPath(ws *core.Workspace) (string, error) {
+	if !ws.HasConfig && ws.Cwd != "" {
+		return workspaceHostPath(ws, ws.Cwd, workspace.LockDirName, workspace.ConfigFileName)
+	}
 	return workspaceHostPath(ws, workspace.LockDirName, workspace.ConfigFileName)
 }
 

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -107,10 +107,11 @@ func (s *workspaceSchema) resolveWorkspaceInstall(
 		return "", "", fmt.Errorf("resolve local module source %q: missing local metadata", ref)
 	}
 
-	workspaceConfigDir, err := workspaceHostPath(ws, workspace.LockDirName)
+	workspaceConfigPath, err := configHostPath(ws)
 	if err != nil {
 		return "", "", err
 	}
+	workspaceConfigDir := filepath.Dir(workspaceConfigPath)
 
 	depAbsPath := filepath.Join(source.Local.ContextDirectoryPath, source.SourceRootSubpath)
 	sourcePath, err = filepath.Rel(workspaceConfigDir, depAbsPath)

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -25,6 +25,10 @@ type Workspace struct {
 	ConfigPath  string `field:"true" doc:"Path to config.toml relative to the workspace boundary (empty if not initialized)."`
 	HasConfig   bool   `field:"true" doc:"Whether a config.toml file exists in the workspace."`
 
+	// Cwd is the current working directory within the workspace. Empty means
+	// the workspace directory itself.
+	Cwd string
+
 	// ClientID is the ID of the client that created this workspace.
 	// Used to route host filesystem operations through the correct session
 	// when the workspace is passed to a module function.
@@ -82,5 +86,57 @@ func (*Workspace) TypeDescription() string {
 
 func (ws *Workspace) Clone() *Workspace {
 	cp := *ws
+	return &cp
+}
+
+// WorkspaceCwd represents the client's current working directory within a
+// detected workspace.
+type WorkspaceCwd struct {
+	// rootfs is the pre-fetched root filesystem for remote workspaces.
+	rootfs dagql.ObjectResult[*Directory]
+
+	// Path is relative to the workspace path. Empty means the workspace path.
+	Path string `field:"true" doc:"Location of the current working directory within the workspace, relative to the workspace."`
+
+	WorkspacePath string
+	ClientID      string
+
+	// hostPath is the host filesystem path for the workspace boundary.
+	hostPath string
+}
+
+// Rootfs returns the pre-fetched root filesystem directory for remote workspaces.
+func (cwd *WorkspaceCwd) Rootfs() dagql.ObjectResult[*Directory] {
+	return cwd.rootfs
+}
+
+// SetRootfs sets the pre-fetched root filesystem.
+func (cwd *WorkspaceCwd) SetRootfs(r dagql.ObjectResult[*Directory]) {
+	cwd.rootfs = r
+}
+
+// HostPath returns the internal host filesystem path for the workspace boundary.
+func (cwd *WorkspaceCwd) HostPath() string {
+	return cwd.hostPath
+}
+
+// SetHostPath sets the internal host filesystem path.
+func (cwd *WorkspaceCwd) SetHostPath(p string) {
+	cwd.hostPath = p
+}
+
+func (*WorkspaceCwd) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "WorkspaceCwd",
+		NonNull:   true,
+	}
+}
+
+func (*WorkspaceCwd) TypeDescription() string {
+	return "The current working directory within the workspace. This is set to the directory where workspace detection started, and cannot be changed."
+}
+
+func (cwd *WorkspaceCwd) Clone() *WorkspaceCwd {
+	cp := *cwd
 	return &cp
 }

--- a/core/workspace/detect.go
+++ b/core/workspace/detect.go
@@ -22,6 +22,10 @@ type Workspace struct {
 	// Path is the workspace location relative to Root (e.g., "apps/frontend" or ".").
 	Path string
 
+	// Cwd is the workspace detection start location relative to Path. Empty means
+	// detection started at the workspace path.
+	Cwd string
+
 	// Initialized is true if .dagger/config.toml was found.
 	Initialized bool
 }
@@ -34,7 +38,7 @@ type PathExistsFunc func(ctx context.Context, path string) (parentDir string, ex
 //
 // Uses a 3-step fallback chain:
 //  1. FindUp .dagger/config.toml → workspace root = parent of .dagger/
-//  2. FindUp .git → workspace root = current directory, sandbox root = directory containing .git
+//  2. FindUp .git → workspace root = directory containing .git
 //  3. No .git → cwd is workspace root
 func Detect(
 	ctx context.Context,
@@ -65,6 +69,13 @@ func Detect(
 		}
 		return rel
 	}
+	relCwd := func(workspaceDir string) string {
+		rel, err := filepath.Rel(workspaceDir, cwd)
+		if err != nil || rel == "." {
+			return ""
+		}
+		return rel
+	}
 
 	// Step 1: config.toml found → workspace = parent of .dagger, sandbox = git root if present
 	if hasConfig {
@@ -73,15 +84,17 @@ func Detect(
 		return &Workspace{
 			Root:        sandbox,
 			Path:        relPath(sandbox, workspaceDir),
+			Cwd:         relCwd(workspaceDir),
 			Initialized: true,
 		}, nil
 	}
 
-	// Step 2: .git found → workspace = CWD, sandbox = git root
+	// Step 2: .git found → workspace = git root, cwd = detection start
 	if hasGit {
 		return &Workspace{
 			Root: gitDir,
-			Path: relPath(gitDir, cwd),
+			Path: ".",
+			Cwd:  relCwd(gitDir),
 		}, nil
 	}
 
@@ -89,6 +102,7 @@ func Detect(
 	return &Workspace{
 		Root: cwd,
 		Path: ".",
+		Cwd:  "",
 	}, nil
 }
 

--- a/core/workspace/detect_test.go
+++ b/core/workspace/detect_test.go
@@ -28,6 +28,30 @@ func TestDetectInitializedWorkspace(t *testing.T) {
 	require.Zero(t, readCalls, "readFile should not be called for structural workspace detection")
 	require.Equal(t, "/repo", ws.Root)
 	require.Equal(t, "app", ws.Path)
+	require.Empty(t, ws.Cwd)
+	require.True(t, ws.Initialized)
+}
+
+func TestDetectInitializedWorkspaceFromNestedCwd(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	existing := map[string]struct{}{
+		"/repo/.dagger":             {},
+		"/repo/.dagger/config.toml": {},
+		"/repo/.git":                {},
+	}
+
+	readCalls := 0
+	ws, err := Detect(ctx, fakePathExists(existing), func(context.Context, string) ([]byte, error) {
+		readCalls++
+		return nil, os.ErrNotExist
+	}, "/repo/app/sub")
+	require.NoError(t, err)
+	require.Zero(t, readCalls, "readFile should not be called for structural workspace detection")
+	require.Equal(t, "/repo", ws.Root)
+	require.Equal(t, ".", ws.Path)
+	require.Equal(t, "app/sub", ws.Cwd)
 	require.True(t, ws.Initialized)
 }
 
@@ -48,7 +72,8 @@ func TestDetectMissingConfigDoesNotChangeBoundary(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, readCalls, "readFile should not be called for structural workspace detection")
 	require.Equal(t, "/repo", ws.Root)
-	require.Equal(t, "app/sub", ws.Path)
+	require.Equal(t, ".", ws.Path)
+	require.Equal(t, "app/sub", ws.Cwd)
 	require.False(t, ws.Initialized)
 }
 
@@ -67,6 +92,7 @@ func TestDetectFallsBackToCwdWithoutGit(t *testing.T) {
 	require.Zero(t, readCalls, "readFile should not be called for structural workspace detection")
 	require.Equal(t, "/repo/app", ws.Root)
 	require.Equal(t, ".", ws.Path)
+	require.Empty(t, ws.Cwd)
 	require.False(t, ws.Initialized)
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -177,6 +177,9 @@ type Binding {
   """Retrieve the binding value, as type Workspace"""
   asWorkspace: Workspace!
 
+  """Retrieve the binding value, as type WorkspaceCwd"""
+  asWorkspaceCwd: WorkspaceCwd!
+
   """Retrieve the binding value, as type WorkspaceMigration"""
   asWorkspaceMigration: WorkspaceMigration!
 
@@ -3129,6 +3132,29 @@ type Env {
     workspace: DirectoryID!
   ): Env!
 
+  """Create or update a binding of type WorkspaceCwd in the environment"""
+  withWorkspaceCwdInput(
+    """The name of the binding"""
+    name: String!
+
+    """The WorkspaceCwd value to assign to the binding"""
+    value: WorkspaceCwdID!
+
+    """The purpose of the input"""
+    description: String!
+  ): Env!
+
+  """
+  Declare a desired WorkspaceCwd output to be assigned in the environment
+  """
+  withWorkspaceCwdOutput(
+    """The name of the binding"""
+    name: String!
+
+    """A description of the desired value of the binding"""
+    description: String!
+  ): Env!
+
   """Create or update a binding of type Workspace in the environment"""
   withWorkspaceInput(
     """The name of the binding"""
@@ -4780,7 +4806,7 @@ type ModuleSource {
   withBlueprint(
     """The blueprint module to set."""
     blueprint: ModuleSourceID!
-  ): ModuleSource!
+  ): ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 
   """Update the module source with a new client to generate."""
   withClient(
@@ -4844,10 +4870,10 @@ type ModuleSource {
   withToolchains(
     """The toolchain modules to add."""
     toolchains: [ModuleSourceID!]!
-  ): ModuleSource!
+  ): ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 
   """Update the blueprint module to the latest version."""
-  withUpdateBlueprint: ModuleSource!
+  withUpdateBlueprint: ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 
   """Update one or more module dependencies."""
   withUpdateDependencies(
@@ -4859,7 +4885,7 @@ type ModuleSource {
   withUpdateToolchains(
     """The toolchains to update."""
     toolchains: [String!]!
-  ): ModuleSource!
+  ): ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 
   """Update one or more clients."""
   withUpdatedClients(
@@ -4868,7 +4894,7 @@ type ModuleSource {
   ): ModuleSource!
 
   """Remove the current blueprint from the module source."""
-  withoutBlueprint: ModuleSource!
+  withoutBlueprint: ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 
   """Remove a client from the module source."""
   withoutClient(
@@ -4894,7 +4920,7 @@ type ModuleSource {
   withoutToolchains(
     """The toolchains to remove."""
     toolchains: [String!]!
-  ): ModuleSource!
+  ): ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.")
 }
 
 """Experimental features of a module"""
@@ -5433,6 +5459,9 @@ type Query {
 
   """Load a UpGroup from its ID."""
   loadUpGroupFromID(id: UpGroupID!): UpGroup!
+
+  """Load a WorkspaceCwd from its ID."""
+  loadWorkspaceCwdFromID(id: WorkspaceCwdID!): WorkspaceCwd!
 
   """Load a Workspace from its ID."""
   loadWorkspaceFromID(id: WorkspaceID!): Workspace!
@@ -6191,6 +6220,9 @@ type Workspace {
     value: String!
   ): String!
 
+  """The current working directory within the workspace."""
+  cwd: WorkspaceCwd!
+
   """
   Returns a Directory from the workspace.
 
@@ -6353,6 +6385,66 @@ type Workspace {
   """
   update: Changeset! @experimental(reason: "Experimental workspace update API currently refreshes existing lockfile entries only.")
 }
+
+"""
+The current working directory within the workspace. This is set to the directory
+where workspace detection started, and cannot be changed.
+"""
+type WorkspaceCwd {
+  """
+  Returns a Directory from the current working directory within the workspace.
+
+  Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.
+  """
+  directory(
+    """
+    Location of the directory to retrieve. Relative paths (e.g., "src") resolve
+    from the current working directory; absolute paths (e.g., "/src") resolve
+    from the workspace boundary.
+    """
+    path: String!
+
+    """
+    Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
+    """
+    exclude: [String!] = []
+
+    """
+    Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
+    """
+    include: [String!] = []
+
+    """Apply .gitignore filter rules inside the directory."""
+    gitignore: Boolean = false
+  ): Directory!
+
+  """
+  Returns a File from the current working directory within the workspace.
+
+  Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.
+  """
+  file(
+    """
+    Location of the file to retrieve. Relative paths (e.g., "go.mod") resolve
+    from the current working directory; absolute paths (e.g., "/go.mod") resolve
+    from the workspace boundary.
+    """
+    path: String!
+  ): File!
+
+  """A unique identifier for this WorkspaceCwd."""
+  id: WorkspaceCwdID!
+
+  """
+  Location of the current working directory within the workspace, relative to the workspace.
+  """
+  path: String!
+}
+
+"""
+The `WorkspaceCwdID` scalar type represents an identifier for an object of type WorkspaceCwd.
+"""
+scalar WorkspaceCwdID
 
 """
 The `WorkspaceID` scalar type represents an identifier for an object of type Workspace.

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -117,6 +117,7 @@
               <li><a href="#query-loadTypeDefFromID">loadTypeDefFromID</a></li>
               <li><a href="#query-loadUpFromID">loadUpFromID</a></li>
               <li><a href="#query-loadUpGroupFromID">loadUpGroupFromID</a></li>
+              <li><a href="#query-loadWorkspaceCwdFromID">loadWorkspaceCwdFromID</a></li>
               <li><a href="#query-loadWorkspaceFromID">loadWorkspaceFromID</a></li>
               <li><a href="#query-loadWorkspaceMigrationFromID">loadWorkspaceMigrationFromID</a></li>
               <li><a href="#query-loadWorkspaceMigrationStepFromID">loadWorkspaceMigrationStepFromID</a></li>
@@ -284,6 +285,8 @@
               <li><a href="#definition-UpID">UpID</a></li>
               <li><a href="#definition-Void">Void</a></li>
               <li><a href="#definition-Workspace">Workspace</a></li>
+              <li><a href="#definition-WorkspaceCwd">WorkspaceCwd</a></li>
+              <li><a href="#definition-WorkspaceCwdID">WorkspaceCwdID</a></li>
               <li><a href="#definition-WorkspaceID">WorkspaceID</a></li>
               <li><a href="#definition-WorkspaceMigration">WorkspaceMigration</a></li>
               <li><a href="#definition-WorkspaceMigrationID">WorkspaceMigrationID</a></li>
@@ -4997,6 +5000,59 @@
               </div>
             </div>
           </section>
+          <section id="query-loadWorkspaceCwdFromID" class="operation operation-query" data-traverse-target="query-loadWorkspaceCwdFromID">
+            <div class="operation-group-name">
+              <a href="#group-Queries">Queries</a>
+            </div>
+            <h2 class="operation-heading ">
+              <code>loadWorkspaceCwdFromID</code>
+            </h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>Load a WorkspaceCwd from its ID.</p>
+                </div>
+              </div>
+            </div>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-response doc-copy-section">
+                  <h5>Type</h5>
+                  <p>
+                    <a href="#definition-WorkspaceCwd"><code>WorkspaceCwd!</code></a>
+                  </p>
+                </div>
+                <div class="operation-arguments test doc-copy-section">
+                  <h5>Arguments</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <span class="property-name"><code>id</code></span> - <span class="property-type"><a href="#definition-WorkspaceCwdID"><code>WorkspaceCwdID!</code></a></span>
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="operation-example doc-copy-section">
+                  <h5>Example</h5>
+                </div>
+              </div>
+            </div>
+          </section>
           <section id="query-loadWorkspaceFromID" class="operation operation-query" data-traverse-target="query-loadWorkspaceFromID">
             <div class="operation-group-name">
               <a href="#group-Queries">Queries</a>
@@ -5836,6 +5892,10 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Binding-asWorkspace" href="#Binding-asWorkspace"><code>asWorkspace</code></a> - <span class="property-type"><a href="#definition-Workspace"><code>Workspace!</code></a></span> </td>
                         <td> Retrieve the binding value, as type Workspace </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Binding-asWorkspaceCwd" href="#Binding-asWorkspaceCwd"><code>asWorkspaceCwd</code></a> - <span class="property-type"><a href="#definition-WorkspaceCwd"><code>WorkspaceCwd!</code></a></span> </td>
+                        <td> Retrieve the binding value, as type WorkspaceCwd </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="Binding-asWorkspaceMigration" href="#Binding-asWorkspaceMigration"><code>asWorkspaceMigration</code></a> - <span class="property-type"><a href="#definition-WorkspaceMigration"><code>WorkspaceMigration!</code></a></span> </td>
@@ -11187,6 +11247,52 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Env-withWorkspaceCwdInput" href="#Env-withWorkspaceCwdInput"><code>withWorkspaceCwdInput</code></a> - <span class="property-type"><a href="#definition-Env"><code>Env!</code></a></span> </td>
+                        <td> Create or update a binding of type WorkspaceCwd in the environment </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the binding</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>value</code></span> - <span class="property-type"><a href="#definition-WorkspaceCwdID"><code>WorkspaceCwdID!</code></a></span></h6>
+                                <p>The WorkspaceCwd value to assign to the binding</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The purpose of the input</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="Env-withWorkspaceCwdOutput" href="#Env-withWorkspaceCwdOutput"><code>withWorkspaceCwdOutput</code></a> - <span class="property-type"><a href="#definition-Env"><code>Env!</code></a></span> </td>
+                        <td> Declare a desired WorkspaceCwd output to be assigned in the environment </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>The name of the binding</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>A description of the desired value of the binding</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Env-withWorkspaceInput" href="#Env-withWorkspaceInput"><code>withWorkspaceInput</code></a> - <span class="property-type"><a href="#definition-Env"><code>Env!</code></a></span> </td>
                         <td> Create or update a binding of type Workspace in the environment </td>
                       </tr>
@@ -14935,8 +15041,9 @@
                         <td> The specified version of the git repo this source points to. </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withBlueprint" href="#ModuleSource-withBlueprint"><code>withBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Set a blueprint for the module source. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withBlueprint" href="#ModuleSource-withBlueprint"><code>withBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Set a blueprint for the module source. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -15092,8 +15199,9 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withToolchains" href="#ModuleSource-withToolchains"><code>withToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Add toolchains to the module source. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withToolchains" href="#ModuleSource-withToolchains"><code>withToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Add toolchains to the module source. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -15109,8 +15217,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withUpdateBlueprint" href="#ModuleSource-withUpdateBlueprint"><code>withUpdateBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Update the blueprint module to the latest version. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withUpdateBlueprint" href="#ModuleSource-withUpdateBlueprint"><code>withUpdateBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Update the blueprint module to the latest version. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="ModuleSource-withUpdateDependencies" href="#ModuleSource-withUpdateDependencies"><code>withUpdateDependencies</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
@@ -15130,8 +15239,9 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withUpdateToolchains" href="#ModuleSource-withUpdateToolchains"><code>withUpdateToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Update one or more toolchains. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withUpdateToolchains" href="#ModuleSource-withUpdateToolchains"><code>withUpdateToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Update one or more toolchains. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -15164,8 +15274,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withoutBlueprint" href="#ModuleSource-withoutBlueprint"><code>withoutBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Remove the current blueprint from the module source. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withoutBlueprint" href="#ModuleSource-withoutBlueprint"><code>withoutBlueprint</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Remove the current blueprint from the module source. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="ModuleSource-withoutClient" href="#ModuleSource-withoutClient"><code>withoutClient</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
@@ -15219,8 +15330,9 @@
                         </td>
                       </tr>
                       <tr class="row-has-field-arguments">
-                        <td data-property-name=""><a class="property-name" id="ModuleSource-withoutToolchains" href="#ModuleSource-withoutToolchains"><code>withoutToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
-                        <td> Remove the provided toolchains from the module source. </td>
+                        <td data-property-name="" class="definition-deprecated"><a class="property-name" id="ModuleSource-withoutToolchains" href="#ModuleSource-withoutToolchains"><code>withoutToolchains</code></a> - <span class="property-type"><a href="#definition-ModuleSource"><code>ModuleSource!</code></a></span> </td>
+                        <td> Remove the provided toolchains from the module source. <span class="deprecation-reason">Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in <code>.dagger/config.toml</code> instead.</span>
+                        </td>
                       </tr>
                       <tr class="row-field-arguments">
                         <td colspan="2">
@@ -17232,6 +17344,10 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="Workspace-cwd" href="#Workspace-cwd"><code>cwd</code></a> - <span class="property-type"><a href="#definition-WorkspaceCwd"><code>WorkspaceCwd!</code></a></span> </td>
+                        <td> The current working directory within the workspace. </td>
+                      </tr>
                       <tr class="row-has-field-arguments">
                         <td data-property-name=""><a class="property-name" id="Workspace-directory" href="#Workspace-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
                         <td>
@@ -17512,6 +17628,107 @@
                       </tr>
                     </tbody>
                   </table>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section id="definition-WorkspaceCwd" class="definition definition-object" data-traverse-target="definition-WorkspaceCwd">
+            <div class="definition-group-name">
+              <a href="#group-Types">Types</a>
+            </div>
+            <h2 class="definition-heading">WorkspaceCwd</h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="definition-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>The current working directory within the workspace. This is set to the directory where workspace detection started, and cannot be changed.</p>
+                </div>
+                <div class="definition-properties doc-copy-section">
+                  <h5>Fields</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Field Name</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="WorkspaceCwd-directory" href="#WorkspaceCwd-directory"><code>directory</code></a> - <span class="property-type"><a href="#definition-Directory"><code>Directory!</code></a></span> </td>
+                        <td>
+                          <p>Returns a Directory from the current working directory within the workspace.</p>
+                          <p>Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.</p>
+                        </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Location of the directory to retrieve. Relative paths (e.g., &quot;src&quot;) resolve from the current working directory; absolute paths (e.g., &quot;/src&quot;) resolve from the workspace boundary.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>exclude</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Exclude artifacts that match the given pattern (e.g., [&quot;node_modules/&quot;, &quot;.git*&quot;]).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Include only artifacts that match the given pattern (e.g., [&quot;app/&quot;, &quot;package.*&quot;]).</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>gitignore</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Apply .gitignore filter rules inside the directory.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="row-has-field-arguments">
+                        <td data-property-name=""><a class="property-name" id="WorkspaceCwd-file" href="#WorkspaceCwd-file"><code>file</code></a> - <span class="property-type"><a href="#definition-File"><code>File!</code></a></span> </td>
+                        <td>
+                          <p>Returns a File from the current working directory within the workspace.</p>
+                          <p>Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.</p>
+                        </td>
+                      </tr>
+                      <tr class="row-field-arguments">
+                        <td colspan="2">
+                          <div class="field-arguments">
+                            <h5 class="field-arguments-heading"> Arguments </h5>
+                            <div class="field-argument-list">
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>path</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
+                                <p>Location of the file to retrieve. Relative paths (e.g., &quot;go.mod&quot;) resolve from the current working directory; absolute paths (e.g., &quot;/go.mod&quot;) resolve from the workspace boundary.</p>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="WorkspaceCwd-id" href="#WorkspaceCwd-id"><code>id</code></a> - <span class="property-type"><a href="#definition-WorkspaceCwdID"><code>WorkspaceCwdID!</code></a></span> </td>
+                        <td> A unique identifier for this WorkspaceCwd. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="WorkspaceCwd-path" href="#WorkspaceCwd-path"><code>path</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Location of the current working directory within the workspace, relative to the workspace. </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section id="definition-WorkspaceCwdID" class="definition definition-scalar" data-traverse-target="definition-WorkspaceCwdID">
+            <div class="definition-group-name">
+              <a href="#group-Types">Types</a>
+            </div>
+            <h2 class="definition-heading">WorkspaceCwdID</h2>
+            <div class="doc-row">
+              <div class="doc-copy">
+                <div class="definition-description doc-copy-section">
+                  <h5>Description</h5>
+                  <p>The <code>WorkspaceCwdID</code> scalar type represents an identifier for an object of type WorkspaceCwd.</p>
                 </div>
               </div>
             </div>

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -182,12 +182,71 @@ func TestModuleResolutionFromSubdirectory(t *testing.T) {
 		true, // isLocal
 	)
 	require.NoError(t, err)
+	require.Equal(t, ".", client.workspace.Path)
+	require.Equal(t, "sdk/go", client.workspace.Cwd)
 
 	// Module source must resolve relative to dagger.json (/repo),
 	// not relative to CWD (/repo/sdk/go).
-	require.Len(t, client.pendingModules, 2) // declared module + implicit module
+	require.Len(t, client.pendingModules, 1)
 	require.Equal(t, "/repo/modules/changelog", client.pendingModules[0].Ref)
 	require.Equal(t, "changelog", client.pendingModules[0].Name)
+}
+
+func TestRemoteWorkspaceCwdUsesDetectionStart(t *testing.T) {
+	t.Parallel()
+
+	existingFiles := map[string]bool{
+		".dagger/config.toml": true,
+	}
+
+	statFS := core.StatFSFunc(func(_ context.Context, path string) (string, *core.Stat, error) {
+		path = filepath.Clean(path)
+		if existingFiles[path] {
+			return filepath.Dir(path), &core.Stat{
+				Name: filepath.Base(path),
+			}, nil
+		}
+		return "", nil, os.ErrNotExist
+	})
+
+	readFile := func(_ context.Context, path string) ([]byte, error) {
+		if filepath.Clean(path) == ".dagger/config.toml" {
+			return []byte("# workspace\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	resolveLocalRef := func(ws *workspace.Workspace, relPath string) string {
+		subPath := filepath.Join(ws.Root, ws.Path, relPath)
+		return core.GitRefString("github.com/acme/repo", subPath, "main")
+	}
+
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID: "test-client",
+	})
+
+	client := &daggerClient{
+		pendingWorkspaceLoad: true,
+		clientMetadata:       &engine.ClientMetadata{},
+	}
+
+	srv := &Server{}
+	err := srv.detectAndLoadWorkspaceWithRootfs(ctx, client,
+		statFS,
+		readFile,
+		"subdir",
+		resolveLocalRef,
+		func(ws *workspace.Workspace) string {
+			return remoteWorkspaceAddress("github.com/acme/repo", ws.Path, "main")
+		},
+		false,
+		dagql.ObjectResult[*core.Directory]{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, ".", client.workspace.Path)
+	require.Equal(t, "subdir", client.workspace.Cwd)
+	require.Equal(t, "github.com/acme/repo@main", client.workspace.Address)
+	require.True(t, client.workspace.Initialized)
 }
 
 func TestDetectAndLoadWorkspaceDoesNotLoadModulesByDefault(t *testing.T) {
@@ -380,11 +439,13 @@ func TestBuildCoreWorkspaceIncludesConfigState(t *testing.T) {
 		ws, err := srv.buildCoreWorkspace(ctx, nil, &workspace.Workspace{
 			Root:        "/repo",
 			Path:        "services/payment",
+			Cwd:         "src",
 			Initialized: true,
 		}, true, dagql.ObjectResult[*core.Directory]{}, "")
 		require.NoError(t, err)
 		require.Equal(t, "file:///repo/services/payment", ws.Address)
 		require.Equal(t, "services/payment", ws.Path)
+		require.Equal(t, "src", ws.Cwd)
 		require.True(t, ws.Initialized)
 		require.True(t, ws.HasConfig)
 		require.Equal(t, filepath.Join("services/payment", workspace.LockDirName, workspace.ConfigFileName), ws.ConfigPath)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -592,6 +592,12 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	if err != nil {
 		return err
 	}
+	if !isLocal {
+		// Remote workspaces always retain the cloned git tree as their rootfs.
+		// Fold the detector's root into Path before converting to core.Workspace.
+		ws.Path = filepath.Join(ws.Root, ws.Path)
+		ws.Root = "."
+	}
 
 	var wsConfig *workspace.Config
 	if ws.Initialized {
@@ -658,13 +664,23 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	var pending []pendingModule
 
 	pending = workspaceConfigPendingModules(ws, wsConfig, resolveLocalRef)
+	resolveCompatRef := resolveLocalRef
+	if compatWorkspace != nil {
+		configWS := *ws
+		configWS.Root = moduleDir
+		configWS.Path = "."
+		configWS.Cwd = ""
+		resolveCompatRef = func(_ *workspace.Workspace, relPath string) string {
+			return resolveLocalRef(&configWS, relPath)
+		}
+	}
 
 	// (1) Ambient compat-workspace modules projected from legacy dagger.json.
 	if compatWorkspace != nil {
 		for _, legacyMod := range compatWorkspace.Modules {
 			mod := pendingLegacyModule(
 				ws,
-				resolveLocalRef,
+				resolveCompatRef,
 				legacyMod.Name,
 				legacyMod.Source,
 				legacyMod.Pin,
@@ -747,6 +763,7 @@ func (srv *Server) buildCoreWorkspace(
 	coreWS := &core.Workspace{
 		Address:     address,
 		Path:        detected.Path,
+		Cwd:         detected.Cwd,
 		Initialized: detected.Initialized,
 		HasConfig:   detected.Initialized,
 		ClientID:    clientMetadata.ClientID,

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -596,6 +596,12 @@ func LoadUpGroupFromID(id dagger.UpGroupID) *dagger.UpGroup {
 	return client.LoadUpGroupFromID(id)
 }
 
+// Load a WorkspaceCwd from its ID.
+func LoadWorkspaceCwdFromID(id dagger.WorkspaceCwdID) *dagger.WorkspaceCwd {
+	client := initClient()
+	return client.LoadWorkspaceCwdFromID(id)
+}
+
 // Load a Workspace from its ID.
 func LoadWorkspaceFromID(id dagger.WorkspaceID) *dagger.Workspace {
 	client := initClient()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -335,6 +335,9 @@ type UpID string
 // A Null Void is used as a placeholder for resolvers that do not return anything.
 type Void string
 
+// The `WorkspaceCwdID` scalar type represents an identifier for an object of type WorkspaceCwd.
+type WorkspaceCwdID string
+
 // The `WorkspaceID` scalar type represents an identifier for an object of type Workspace.
 type WorkspaceID string
 
@@ -870,6 +873,15 @@ func (r *Binding) AsWorkspace() *Workspace {
 	q := r.query.Select("asWorkspace")
 
 	return &Workspace{
+		query: q,
+	}
+}
+
+// Retrieve the binding value, as type WorkspaceCwd
+func (r *Binding) AsWorkspaceCwd() *WorkspaceCwd {
+	q := r.query.Select("asWorkspaceCwd")
+
+	return &WorkspaceCwd{
 		query: q,
 	}
 }
@@ -6596,6 +6608,30 @@ func (r *Env) WithWorkspace(workspace *Directory) *Env {
 	}
 }
 
+// Create or update a binding of type WorkspaceCwd in the environment
+func (r *Env) WithWorkspaceCwdInput(name string, value *WorkspaceCwd, description string) *Env {
+	assertNotNil("value", value)
+	q := r.query.Select("withWorkspaceCwdInput")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
+// Declare a desired WorkspaceCwd output to be assigned in the environment
+func (r *Env) WithWorkspaceCwdOutput(name string, description string) *Env {
+	q := r.query.Select("withWorkspaceCwdOutput")
+	q = q.Arg("name", name)
+	q = q.Arg("description", description)
+
+	return &Env{
+		query: q,
+	}
+}
+
 // Create or update a binding of type Workspace in the environment
 func (r *Env) WithWorkspaceInput(name string, value *Workspace, description string) *Env {
 	assertNotNil("value", value)
@@ -11690,6 +11726,8 @@ func (r *ModuleSource) Version(ctx context.Context) (string, error) {
 }
 
 // Set a blueprint for the module source.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithBlueprint(blueprint *ModuleSource) *ModuleSource {
 	assertNotNil("blueprint", blueprint)
 	q := r.query.Select("withBlueprint")
@@ -11782,6 +11820,8 @@ func (r *ModuleSource) WithSourceSubpath(path string) *ModuleSource {
 }
 
 // Add toolchains to the module source.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithToolchains(toolchains []*ModuleSource) *ModuleSource {
 	q := r.query.Select("withToolchains")
 	q = q.Arg("toolchains", toolchains)
@@ -11792,6 +11832,8 @@ func (r *ModuleSource) WithToolchains(toolchains []*ModuleSource) *ModuleSource 
 }
 
 // Update the blueprint module to the latest version.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithUpdateBlueprint() *ModuleSource {
 	q := r.query.Select("withUpdateBlueprint")
 
@@ -11811,6 +11853,8 @@ func (r *ModuleSource) WithUpdateDependencies(dependencies []string) *ModuleSour
 }
 
 // Update one or more toolchains.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithUpdateToolchains(toolchains []string) *ModuleSource {
 	q := r.query.Select("withUpdateToolchains")
 	q = q.Arg("toolchains", toolchains)
@@ -11831,6 +11875,8 @@ func (r *ModuleSource) WithUpdatedClients(clients []string) *ModuleSource {
 }
 
 // Remove the current blueprint from the module source.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithoutBlueprint() *ModuleSource {
 	q := r.query.Select("withoutBlueprint")
 
@@ -11870,6 +11916,8 @@ func (r *ModuleSource) WithoutExperimentalFeatures(features []ModuleSourceExperi
 }
 
 // Remove the provided toolchains from the module source.
+//
+// Deprecated: Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in `.dagger/config.toml` instead.
 func (r *ModuleSource) WithoutToolchains(toolchains []string) *ModuleSource {
 	q := r.query.Select("withoutToolchains")
 	q = q.Arg("toolchains", toolchains)
@@ -13358,6 +13406,16 @@ func (r *Query) LoadUpGroupFromID(id UpGroupID) *UpGroup {
 	q = q.Arg("id", id)
 
 	return &UpGroup{
+		query: q,
+	}
+}
+
+// Load a WorkspaceCwd from its ID.
+func (r *Query) LoadWorkspaceCwdFromID(id WorkspaceCwdID) *WorkspaceCwd {
+	q := r.query.Select("loadWorkspaceCwdFromID")
+	q = q.Arg("id", id)
+
+	return &WorkspaceCwd{
 		query: q,
 	}
 }
@@ -15480,6 +15538,15 @@ func (r *Workspace) ConfigWrite(ctx context.Context, key string, value string) (
 	return response, q.Execute(ctx)
 }
 
+// The current working directory within the workspace.
+func (r *Workspace) Cwd() *WorkspaceCwd {
+	q := r.query.Select("cwd")
+
+	return &WorkspaceCwd{
+		query: q,
+	}
+}
+
 // WorkspaceDirectoryOpts contains options for Workspace.Directory
 type WorkspaceDirectoryOpts struct {
 	// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
@@ -15901,6 +15968,121 @@ func (r *Workspace) Update() *Changeset {
 	return &Changeset{
 		query: q,
 	}
+}
+
+// The current working directory within the workspace. This is set to the directory where workspace detection started, and cannot be changed.
+type WorkspaceCwd struct {
+	query *querybuilder.Selection
+
+	id   *WorkspaceCwdID
+	path *string
+}
+
+func (r *WorkspaceCwd) WithGraphQLQuery(q *querybuilder.Selection) *WorkspaceCwd {
+	return &WorkspaceCwd{
+		query: q,
+	}
+}
+
+// WorkspaceCwdDirectoryOpts contains options for WorkspaceCwd.Directory
+type WorkspaceCwdDirectoryOpts struct {
+	// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
+	Exclude []string
+	// Include only artifacts that match the given pattern (e.g., ["app/", "package.*"]).
+	Include []string
+	// Apply .gitignore filter rules inside the directory.
+	Gitignore bool
+}
+
+// Returns a Directory from the current working directory within the workspace.
+//
+// Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.
+func (r *WorkspaceCwd) Directory(path string, opts ...WorkspaceCwdDirectoryOpts) *Directory {
+	q := r.query.Select("directory")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `exclude` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Exclude) {
+			q = q.Arg("exclude", opts[i].Exclude)
+		}
+		// `include` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
+		}
+		// `gitignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Gitignore) {
+			q = q.Arg("gitignore", opts[i].Gitignore)
+		}
+	}
+	q = q.Arg("path", path)
+
+	return &Directory{
+		query: q,
+	}
+}
+
+// Returns a File from the current working directory within the workspace.
+//
+// Relative paths resolve from the current working directory. Absolute paths resolve from the workspace boundary.
+func (r *WorkspaceCwd) File(path string) *File {
+	q := r.query.Select("file")
+	q = q.Arg("path", path)
+
+	return &File{
+		query: q,
+	}
+}
+
+// A unique identifier for this WorkspaceCwd.
+func (r *WorkspaceCwd) ID(ctx context.Context) (WorkspaceCwdID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response WorkspaceCwdID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *WorkspaceCwd) XXX_GraphQLType() string {
+	return "WorkspaceCwd"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *WorkspaceCwd) XXX_GraphQLIDType() string {
+	return "WorkspaceCwdID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *WorkspaceCwd) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *WorkspaceCwd) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+
+// Location of the current working directory within the workspace, relative to the workspace.
+func (r *WorkspaceCwd) Path(ctx context.Context) (string, error) {
+	if r.path != nil {
+		return *r.path, nil
+	}
+	q := r.query.Select("path")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A planned workspace migration.


### PR DESCRIPTION
Fixes #13051.

Note: this PR is against the `workspace` branch, not main.

## Summary

`Workspace.path` now always reports the detected workspace path. The directory where detection started is stored separately and exposed through `Workspace.cwd`.

This adds `WorkspaceCwd.path`, `WorkspaceCwd.directory`, and `WorkspaceCwd.file`. Relative paths on those fields resolve from the current working directory within the workspace; absolute paths still resolve from the workspace boundary.

The change also keeps nested uninitialized workspace flows coherent: `workspace init` and `workspace install` still write the config where Dagger was invoked, while initialized workspaces report the actual config boundary as `Workspace.path`.

Generated GraphQL docs and Go SDK bindings are updated.

## Testing

- `dagger call --progress=report engine-dev test --pkg=./core/workspace --run='TestDetect'`
- `dagger call --progress=report engine-dev test --pkg=./engine/server --run='Test(RemoteWorkspaceCwdUsesDetectionStart|ModuleResolutionFromSubdirectory|BuildCoreWorkspaceIncludesConfigState|DetectAndLoadWorkspaceDoesNotLoadModulesByDefault)'`
- `dagger call --progress=report engine-dev test --pkg=./core/integration --run='TestWorkspace/TestCurrentWorkspaceRootAndCwd'`
- `dagger call --progress=report engine-dev test --pkg=./core/integration --run='TestContextualWorkspace/(TestContextualWorkspaceSelection/initialized_workspace_is_inferred_from_nearest_config_boundary|TestContextualWorkspaceShape/workspace_path_and_address_reflect_injected_boundary)'`
- `dagger call --progress=report engine-dev test --pkg=./core/integration --run='TestWorkspaceModules/TestWorkspaceModuleInstall/workspace_install_initializes_a_workspace_when_needed'`
- `dagger --progress=report generate -y engine-dev:generate`
- `dagger --progress=report generate -y go-sdk:generate`
- `dagger --progress=report generate -y docs:references`
- `git diff --check`
