### PR TITLE
Fix handling of relative paths in workspace API

### DIFF
--- a/core/integration/workspace_test.go
+++ b/core/integration/workspace_test.go
@@ -160,28 +160,33 @@ type Finder {
 	})
 }
 
-// TestNestedWorkspacePaths verifies that relative paths use the workspace
-// directory while absolute paths and upward search use the workspace boundary.
+// TestNestedWorkspacePaths verifies that Workspace.file and Workspace.directory
+// resolve relative paths from the workspace directory, even when detection
+// starts from a nested current directory.
 func (WorkspaceSuite) TestNestedWorkspacePaths(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	ctr := workspaceBase(t, c).
 		WithExec([]string{"mkdir", "-p", "app"}).
-		WithNewFile("repo.txt", "hello from boundary").
-		WithNewFile("app/app.txt", "hello from workspace").
+		WithNewFile("workspace.txt", "hello from workspace").
+		WithNewFile("app/cwd.txt", "hello from cwd").
 		WithWorkdir("/work/app").
 		With(initStandaloneDangModule("paths", `
 type Paths {
   pub workspaceValue: String!
+  pub directoryValue: String!
+  pub nestedValue: String!
   pub boundaryValue: String!
   pub foundValue: String!
   pub workspacePath: String!
   pub workspaceAddress: String!
 
   new(ws: Workspace!) {
-    self.workspaceValue = ws.file("app.txt").contents
-    self.boundaryValue = ws.file("/repo.txt").contents
-    self.foundValue = ws.findUp(name: "repo.txt", from: ".") ?? ""
+    self.workspaceValue = ws.file("workspace.txt").contents
+    self.directoryValue = ws.directory(".").file("workspace.txt").contents
+    self.nestedValue = ws.file("app/cwd.txt").contents
+    self.boundaryValue = ws.file("/app/cwd.txt").contents
+    self.foundValue = ws.findUp(name: "workspace.txt", from: ".") ?? ""
     self.workspacePath = ws.path
     self.workspaceAddress = ws.address
     self
@@ -193,13 +198,21 @@ type Paths {
 	require.NoError(t, err)
 	require.Equal(t, "hello from workspace", strings.TrimSpace(out))
 
+	out, err = ctr.With(daggerCall("directory-value")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hello from workspace", strings.TrimSpace(out))
+
+	out, err = ctr.With(daggerCall("nested-value")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hello from cwd", strings.TrimSpace(out))
+
 	out, err = ctr.With(daggerCall("boundary-value")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "hello from boundary", strings.TrimSpace(out))
+	require.Equal(t, "hello from cwd", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("found-value")).Stdout(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "/repo.txt", strings.TrimSpace(out))
+	require.Equal(t, "/workspace.txt", strings.TrimSpace(out))
 
 	out, err = ctr.With(daggerCall("workspace-path")).Stdout(ctx)
 	require.NoError(t, err)

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -206,7 +206,7 @@ func (s *workspaceSchema) directory(
 	args workspaceDirectoryArgs,
 ) (inst dagql.ObjectResult[*core.Directory], _ error) {
 	ws := parent.Self()
-	resolvedPath := resolveWorkspacePath(args.Path, ws.Path)
+	resolvedPath := resolveWorkspacePath(args.Path, ws.FilesystemPath())
 	return s.resolveRootfs(ctx, ws, resolvedPath, args.CopyFilter, args.Gitignore)
 }
 
@@ -224,7 +224,7 @@ func (s *workspaceSchema) file(
 ) (inst dagql.Result[*core.File], _ error) {
 	ws := parent.Self()
 
-	resolvedPath := resolveWorkspacePath(args.Path, ws.Path)
+	resolvedPath := resolveWorkspacePath(args.Path, ws.FilesystemPath())
 	parentDir := filepath.Dir(resolvedPath)
 	basename := filepath.Base(resolvedPath)
 

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -19,6 +19,12 @@ type Workspace struct {
 	ConfigPath  string `field:"true" doc:"Path to config.toml relative to the workspace boundary (empty if not initialized)."`
 	HasConfig   bool   `field:"true" doc:"Whether a config.toml file exists in the workspace."`
 
+	// fsPath is the workspace directory used by Workspace.file and
+	// Workspace.directory, relative to the workspace boundary.
+	// Empty preserves the current public Path behavior for callers that
+	// construct Workspaces directly.
+	fsPath string
+
 	// ClientID is the ID of the client that created this workspace.
 	// Used to route host filesystem operations through the correct session
 	// when the workspace is passed to a module function.
@@ -50,6 +56,21 @@ func (ws *Workspace) HostPath() string {
 // SetHostPath sets the internal host filesystem path.
 func (ws *Workspace) SetHostPath(p string) {
 	ws.hostPath = p
+}
+
+// FilesystemPath returns the workspace directory used by Workspace.file and
+// Workspace.directory, relative to the workspace boundary.
+func (ws *Workspace) FilesystemPath() string {
+	if ws.fsPath != "" {
+		return ws.fsPath
+	}
+	return ws.Path
+}
+
+// SetFilesystemPath sets the workspace directory used by Workspace.file and
+// Workspace.directory.
+func (ws *Workspace) SetFilesystemPath(p string) {
+	ws.fsPath = p
 }
 
 func (*Workspace) Type() *ast.Type {

--- a/core/workspace/detect.go
+++ b/core/workspace/detect.go
@@ -18,6 +18,10 @@ type Workspace struct {
 
 	// Path is the workspace location relative to Root (e.g., "apps/frontend" or ".").
 	Path string
+
+	// FilesystemPath is the workspace directory used by Workspace.file and
+	// Workspace.directory, relative to Root.
+	FilesystemPath string
 }
 
 // PathExistsFunc checks whether a filesystem path exists.
@@ -50,18 +54,20 @@ func Detect(
 		return rel
 	}
 
-	// Step 1: .git found → workspace = CWD, sandbox = git root
+	// Step 1: .git found → public path remains CWD, filesystem APIs use git root.
 	if hasGit {
 		return &Workspace{
-			Root: gitDir,
-			Path: relPath(gitDir, cwd),
+			Root:           gitDir,
+			Path:           relPath(gitDir, cwd),
+			FilesystemPath: ".",
 		}, nil
 	}
 
 	// Step 2: nothing found → cwd is both workspace and sandbox root
 	return &Workspace{
-		Root: cwd,
-		Path: ".",
+		Root:           cwd,
+		Path:           ".",
+		FilesystemPath: ".",
 	}, nil
 }
 

--- a/core/workspace/detect_test.go
+++ b/core/workspace/detect_test.go
@@ -28,6 +28,7 @@ func TestDetectIgnoresWorkspaceConfigAndDoesNotReadFile(t *testing.T) {
 	require.Zero(t, readCalls, "readFile should not be called in the no-config split")
 	require.Equal(t, "/repo", ws.Root)
 	require.Equal(t, "app", ws.Path)
+	require.Equal(t, ".", ws.FilesystemPath)
 }
 
 func TestDetectFallsBackToCwdWithoutGit(t *testing.T) {
@@ -45,6 +46,7 @@ func TestDetectFallsBackToCwdWithoutGit(t *testing.T) {
 	require.Zero(t, readCalls, "readFile should not be called in the no-config split")
 	require.Equal(t, "/repo/app", ws.Root)
 	require.Equal(t, ".", ws.Path)
+	require.Equal(t, ".", ws.FilesystemPath)
 }
 
 func fakePathExists(existing map[string]struct{}) PathExistsFunc {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
 	bksession "github.com/dagger/dagger/internal/buildkit/session"
@@ -220,6 +221,35 @@ func TestDetectAndLoadWorkspaceDoesNotLoadModulesByDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client.workspace)
 	require.Empty(t, client.pendingModules)
+}
+
+func TestBuildCoreWorkspaceFilesystemPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID: "test-client",
+	})
+
+	srv := &Server{}
+	localWS, err := srv.buildCoreWorkspace(ctx, nil, &workspace.Workspace{
+		Root:           "/repo",
+		Path:           "app",
+		FilesystemPath: ".",
+	}, true, dagql.ObjectResult[*core.Directory]{}, "")
+	require.NoError(t, err)
+	require.Equal(t, "app", localWS.Path)
+	require.Equal(t, ".", localWS.FilesystemPath())
+	require.Equal(t, "file:///repo/app", localWS.Address)
+
+	remoteWS, err := srv.buildCoreWorkspace(ctx, nil, &workspace.Workspace{
+		Root:           "services/api",
+		Path:           ".",
+		FilesystemPath: ".",
+	}, false, dagql.ObjectResult[*core.Directory]{}, "github.com/acme/repo@main")
+	require.NoError(t, err)
+	require.Equal(t, ".", remoteWS.Path)
+	require.Equal(t, "services/api", remoteWS.FilesystemPath())
+	require.Equal(t, "github.com/acme/repo@main", remoteWS.Address)
 }
 
 func TestIsSameModuleReference(t *testing.T) {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -593,6 +593,16 @@ func (srv *Server) buildCoreWorkspace(
 		Path:     detected.Path,
 		ClientID: clientMetadata.ClientID,
 	}
+	fsPath := detected.FilesystemPath
+	if fsPath == "" {
+		fsPath = detected.Path
+	}
+	if !isLocal {
+		// Remote rootfs is anchored at the cloned repository root, while
+		// workspace detection may use a subdirectory as its Root.
+		fsPath = filepath.Join(detected.Root, fsPath)
+	}
+	coreWS.SetFilesystemPath(fsPath)
 	if coreWS.Address == "" {
 		coreWS.Address = localWorkspaceAddress(detected.Root, detected.Path)
 	}


### PR DESCRIPTION
Refs #13051 (partial fix)

## Summary

`Workspace.file` and `Workspace.directory` now resolve relative paths from the workspace directory, not from the nested cwd where workspace detection started.

This is intentionally narrower than fixing `Workspace.path` on `main`. The public `Workspace.path` behavior is left unchanged for now, while `Workspace` carries an internal filesystem path base for the file and directory APIs.

For remote rootfs-backed workspaces, the internal filesystem path includes the detected root because the rootfs remains anchored at the cloned repository root.

## Behavior

Given workspace root `/repo` and cwd `/repo/app`:

| API call | Input path | Before | After |
| --- | --- | --- | --- |
| `Workspace.file` | `"README.md"` | `/repo/app/README.md` | `/repo/README.md` |
| `Workspace.directory` | `"."` | `/repo/app` | `/repo` |
| `Workspace.file` | `"app/config.json"` | `/repo/app/app/config.json` | `/repo/app/config.json` |
| `Workspace.file` | `"/app/config.json"` | `/repo/app/config.json` | `/repo/app/config.json` |

## Testing

- `dagger -m github.com/dagger/dagger@pull/13053/head call engine-dev test --pkg=./core/workspace --run='TestDetect'`
- `dagger -m github.com/dagger/dagger@pull/13053/head call engine-dev test --pkg=./engine/server --run='Test(BuildCoreWorkspaceFilesystemPath|ModuleResolutionFromSubdirectory|DetectAndLoadWorkspaceDoesNotLoadModulesByDefault)'`
- `dagger -m github.com/dagger/dagger@pull/13053/head call engine-dev test --pkg=./core/integration --run='TestWorkspace/TestNestedWorkspacePaths'`
- `git diff --check`
