### PR TITLE
cache: move `PRIVATE` isolation out of graph identity

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -28,6 +28,15 @@ type CacheVolume struct {
 	selector string
 }
 
+type cacheVolumeMount struct {
+	ref      bkcache.MutableRef
+	selector string
+}
+
+func (mount *cacheVolumeMount) release(context.Context) error {
+	return nil
+}
+
 func (*CacheVolume) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "CacheVolume",
@@ -227,6 +236,22 @@ func (cache *CacheVolume) invalidateSnapshotSize(ctx context.Context) error {
 
 func (cache *CacheVolume) Sync(ctx context.Context) error {
 	return cache.InitializeSnapshot(ctx)
+}
+
+func (cache *CacheVolume) acquireMount(ctx context.Context) (*cacheVolumeMount, error) {
+	if cache.getSnapshot() == nil {
+		if err := cache.InitializeSnapshot(ctx); err != nil {
+			return nil, err
+		}
+	}
+	snapshot := cache.getSnapshot()
+	if snapshot == nil {
+		return nil, fmt.Errorf("cache volume %q has nil snapshot", cache.Key)
+	}
+	return &cacheVolumeMount{
+		ref:      snapshot,
+		selector: cache.getSnapshotSelector(),
+	}, nil
 }
 
 func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {

--- a/core/cache.go
+++ b/core/cache.go
@@ -3,7 +3,10 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -23,10 +26,18 @@ type CacheVolume struct {
 	Sharing   CacheSharingMode
 	Owner     string
 
-	mu       sync.Mutex
-	snapshot bkcache.MutableRef
+	mu sync.Mutex
+	// Shared and locked caches use the first snapshot. Private caches keep
+	// extra backing snapshots so concurrent writers do not mount the same ref.
+	snapshots []bkcache.MutableRef
+
+	// selector is the subpath inside each backing snapshot to mount. Most
+	// cache volumes mount the snapshot root; source-backed cache volumes can
+	// point at a subdirectory of the source snapshot.
 	selector string
 }
+
+const cacheVolumeRootSelector = "/"
 
 type cacheVolumeMount struct {
 	ref      bkcache.MutableRef
@@ -70,65 +81,77 @@ func (cache *CacheVolume) OnRelease(ctx context.Context) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if cache.snapshot == nil {
-		return nil
+	var rerr error
+	for _, ref := range cache.snapshots {
+		if ref == nil {
+			continue
+		}
+		rerr = errors.Join(rerr, ref.Release(ctx))
 	}
-	err := cache.snapshot.Release(ctx)
-	cache.snapshot = nil
-	return err
+	cache.snapshots = nil
+	return rerr
 }
 
 func (cache *CacheVolume) getSnapshot() bkcache.MutableRef {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
-	return cache.snapshot
+	if len(cache.snapshots) == 0 {
+		return nil
+	}
+	return cache.snapshots[0]
 }
 
 func (cache *CacheVolume) getSnapshotSelector() string {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
-	if cache.selector == "" {
-		return "/"
-	}
-	return cache.selector
+	return cache.snapshotSelectorLocked()
 }
 
 func (cache *CacheVolume) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
 	cache.mu.Lock()
-	snapshot := cache.snapshot
+	snapshots := append([]bkcache.MutableRef(nil), cache.snapshots...)
 	cache.mu.Unlock()
-	if snapshot == nil || snapshot.SnapshotID() != identity {
-		return 0, false, nil
+	for _, ref := range snapshots {
+		if ref == nil || ref.SnapshotID() != identity {
+			continue
+		}
+		size, err := ref.Size(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+		return size, true, nil
 	}
-	size, err := snapshot.Size(ctx)
-	if err != nil {
-		return 0, false, err
-	}
-	return size, true, nil
+	return 0, false, nil
 }
 
 func (cache *CacheVolume) CacheUsageIdentities() []string {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
-	if cache.snapshot == nil {
-		return nil
+	identities := make([]string, 0, len(cache.snapshots))
+	for _, ref := range cache.snapshots {
+		if ref == nil {
+			continue
+		}
+		identities = append(identities, ref.SnapshotID())
 	}
-	return []string{cache.snapshot.SnapshotID()}
+	return identities
 }
 
 func (cache *CacheVolume) PersistedSnapshotRefLinks() []dagql.PersistedSnapshotRefLink {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if cache.snapshot == nil {
-		return nil
+	links := make([]dagql.PersistedSnapshotRefLink, 0, len(cache.snapshots))
+	for i, ref := range cache.snapshots {
+		if ref == nil {
+			continue
+		}
+		links = append(links, dagql.PersistedSnapshotRefLink{
+			RefKey: ref.SnapshotID(),
+			Role:   "snapshot:" + strconv.Itoa(i),
+		})
 	}
-	return []dagql.PersistedSnapshotRefLink{
-		{
-			RefKey: cache.snapshot.SnapshotID(),
-			Role:   "snapshot",
-		},
-	}
+	return links
 }
 
 type persistedCacheVolumePayload struct {
@@ -193,6 +216,7 @@ func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server
 		persisted.Sharing,
 		persisted.Owner,
 	)
+	cache.selector = persisted.Selector
 	if resultID == 0 {
 		return cache, nil
 	}
@@ -200,24 +224,38 @@ func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server
 	if err != nil {
 		return nil, err
 	}
+	type snapshotLink struct {
+		index int
+		link  dagql.PersistedSnapshotRefLink
+	}
+	snapshotLinks := make([]snapshotLink, 0, len(links))
 	for _, link := range links {
-		if link.Role != "snapshot" {
+		index, ok := strings.CutPrefix(link.Role, "snapshot:")
+		if !ok {
 			continue
 		}
+		i, err := strconv.Atoi(index)
+		if err != nil || i < 0 {
+			return nil, fmt.Errorf("decode persisted cache volume snapshot role %q", link.Role)
+		}
+		snapshotLinks = append(snapshotLinks, snapshotLink{
+			index: i,
+			link:  link,
+		})
+	}
+	sort.Slice(snapshotLinks, func(i, j int) bool {
+		return snapshotLinks[i].index < snapshotLinks[j].index
+	})
+	for _, snapshotLink := range snapshotLinks {
 		query, err := persistedDecodeQuery(dag)
 		if err != nil {
 			return nil, err
 		}
-		ref, err := query.SnapshotManager().GetMutableBySnapshotID(ctx, link.RefKey, bkcache.NoUpdateLastUsed)
+		ref, err := query.SnapshotManager().GetMutableBySnapshotID(ctx, snapshotLink.link.RefKey, bkcache.NoUpdateLastUsed)
 		if err != nil {
-			return nil, fmt.Errorf("reopen persisted cache volume snapshot %q: %w", link.RefKey, err)
+			return nil, fmt.Errorf("reopen persisted cache volume snapshot %q: %w", snapshotLink.link.RefKey, err)
 		}
-		cache.snapshot = ref
-		cache.selector = persisted.Selector
-		if cache.selector == "" {
-			cache.selector = "/"
-		}
-		break
+		cache.snapshots = append(cache.snapshots, ref)
 	}
 	return cache, nil
 }
@@ -227,11 +265,17 @@ func (cache *CacheVolume) CacheUsageMayChange() bool {
 }
 
 func (cache *CacheVolume) invalidateSnapshotSize(ctx context.Context) error {
-	snapshot := cache.getSnapshot()
-	if snapshot == nil {
-		return nil
+	cache.mu.Lock()
+	snapshots := append([]bkcache.MutableRef(nil), cache.snapshots...)
+	cache.mu.Unlock()
+	var rerr error
+	for _, ref := range snapshots {
+		if ref == nil {
+			continue
+		}
+		rerr = errors.Join(rerr, ref.InvalidateSize(ctx))
 	}
-	return snapshot.InvalidateSize(ctx)
+	return rerr
 }
 
 func (cache *CacheVolume) Sync(ctx context.Context) error {
@@ -239,18 +283,27 @@ func (cache *CacheVolume) Sync(ctx context.Context) error {
 }
 
 func (cache *CacheVolume) acquireMount(ctx context.Context) (*cacheVolumeMount, error) {
-	if cache.getSnapshot() == nil {
-		if err := cache.InitializeSnapshot(ctx); err != nil {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if len(cache.snapshots) == 0 {
+		ref, err := cache.appendSnapshotLocked(ctx)
+		if err != nil {
 			return nil, err
 		}
+		return &cacheVolumeMount{
+			ref:      ref,
+			selector: cache.snapshotSelectorLocked(),
+		}, nil
 	}
-	snapshot := cache.getSnapshot()
-	if snapshot == nil {
+
+	ref := cache.snapshots[0]
+	if ref == nil {
 		return nil, fmt.Errorf("cache volume %q has nil snapshot", cache.Key)
 	}
 	return &cacheVolumeMount{
-		ref:      snapshot,
-		selector: cache.getSnapshotSelector(),
+		ref:      ref,
+		selector: cache.snapshotSelectorLocked(),
 	}, nil
 }
 
@@ -258,24 +311,28 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if cache.snapshot != nil {
+	if len(cache.snapshots) > 0 {
 		return nil
 	}
+	_, err := cache.appendSnapshotLocked(ctx)
+	return err
+}
 
+func (cache *CacheVolume) appendSnapshotLocked(ctx context.Context) (bkcache.MutableRef, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var source dagql.ObjectResult[*Directory]
 	if cache.Source.Valid {
 		srv, err := CurrentDagqlServer(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		source, err = cache.Source.Value.Load(ctx, srv)
 		if err != nil {
-			return fmt.Errorf("failed to load cache volume source: %w", err)
+			return nil, fmt.Errorf("failed to load cache volume source: %w", err)
 		}
 	}
 
@@ -283,16 +340,16 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 		if source.Self() == nil {
 			srv, err := CurrentDagqlServer(ctx)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if err := srv.Select(ctx, srv.Root(), &source, dagql.Selector{Field: "directory"}); err != nil {
-				return fmt.Errorf("failed to create scratch source directory for cache owner: %w", err)
+				return nil, fmt.Errorf("failed to create scratch source directory for cache owner: %w", err)
 			}
 		}
 
 		srv, err := CurrentDagqlServer(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		chowned := dagql.ObjectResult[*Directory]{}
 		if err := srv.Select(ctx, source, &chowned, dagql.Selector{
@@ -302,31 +359,31 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 				{Name: "owner", Value: dagql.String(cache.Owner)},
 			},
 		}); err != nil {
-			return fmt.Errorf("failed to chown cache source directory: %w", err)
+			return nil, fmt.Errorf("failed to chown cache source directory: %w", err)
 		}
 		source = chowned
 	}
 
-	sourceSelector := "/"
+	sourceSelector := cacheVolumeRootSelector
 	var sourceRef bkcache.ImmutableRef
 	if source.Self() != nil {
 		dagCache, err := dagql.EngineCache(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := dagCache.Evaluate(ctx, source); err != nil {
-			return fmt.Errorf("evaluate cache source directory: %w", err)
+			return nil, fmt.Errorf("evaluate cache source directory: %w", err)
 		}
 		sourceSelector, err = source.Self().Dir.GetOrEval(ctx, source.Result)
 		if err != nil {
-			return fmt.Errorf("failed to get cache source selector: %w", err)
+			return nil, fmt.Errorf("failed to get cache source selector: %w", err)
 		}
 		if sourceSelector == "" {
-			sourceSelector = "/"
+			sourceSelector = cacheVolumeRootSelector
 		}
 		sourceRef, err = source.Self().Snapshot.GetOrEval(ctx, source.Result)
 		if err != nil {
-			return fmt.Errorf("failed to get cache source snapshot: %w", err)
+			return nil, fmt.Errorf("failed to get cache source snapshot: %w", err)
 		}
 	}
 
@@ -338,15 +395,19 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 		bkcache.WithDescription(fmt.Sprintf("cache volume %q", cache.Key)),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to initialize cache volume snapshot: %w", err)
+		return nil, fmt.Errorf("failed to initialize cache volume snapshot: %w", err)
 	}
 
-	cache.snapshot = newRef
-	if sourceSelector == "" {
-		sourceSelector = "/"
-	}
 	cache.selector = sourceSelector
-	return nil
+	cache.snapshots = append(cache.snapshots, newRef)
+	return newRef, nil
+}
+
+func (cache *CacheVolume) snapshotSelectorLocked() string {
+	if cache.selector == "" {
+		return cacheVolumeRootSelector
+	}
+	return cache.selector
 }
 
 type CacheSharingMode string

--- a/core/cache.go
+++ b/core/cache.go
@@ -39,12 +39,67 @@ type CacheVolume struct {
 
 const cacheVolumeRootSelector = "/"
 
+// CacheVolumeActiveMounts tracks which cache-volume snapshots are mounted by
+// running execs. SnapshotManager still owns the refs; this only answers whether
+// a private cache mount should reuse an idle ref or create another one.
+type CacheVolumeActiveMounts struct {
+	mu     sync.Mutex
+	active map[string]struct{}
+}
+
+func NewCacheVolumeActiveMounts() *CacheVolumeActiveMounts {
+	return &CacheVolumeActiveMounts{
+		active: map[string]struct{}{},
+	}
+}
+
+func (active *CacheVolumeActiveMounts) acquire(ref bkcache.MutableRef) (string, bool) {
+	if active == nil || ref == nil {
+		return "", false
+	}
+	key := ref.SnapshotID()
+	if key == "" {
+		key = ref.ID()
+	}
+	if key == "" {
+		return "", false
+	}
+
+	active.mu.Lock()
+	defer active.mu.Unlock()
+	if _, ok := active.active[key]; ok {
+		return "", false
+	}
+	active.active[key] = struct{}{}
+	return key, true
+}
+
+func (active *CacheVolumeActiveMounts) release(key string) {
+	if active == nil || key == "" {
+		return
+	}
+	active.mu.Lock()
+	defer active.mu.Unlock()
+	delete(active.active, key)
+}
+
 type cacheVolumeMount struct {
+	active   *CacheVolumeActiveMounts
+	leaseKey string
 	ref      bkcache.MutableRef
 	selector string
+	released bool
 }
 
 func (mount *cacheVolumeMount) release(context.Context) error {
+	if mount == nil {
+		return nil
+	}
+	if mount.released {
+		return nil
+	}
+	mount.released = true
+	mount.active.release(mount.leaseKey)
 	return nil
 }
 
@@ -283,15 +338,49 @@ func (cache *CacheVolume) Sync(ctx context.Context) error {
 }
 
 func (cache *CacheVolume) acquireMount(ctx context.Context) (*cacheVolumeMount, error) {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activeMounts := query.CacheVolumeActiveMounts()
+
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if len(cache.snapshots) == 0 {
+	if cache.Sharing == CacheSharingModePrivate {
+		for _, ref := range cache.snapshots {
+			if ref == nil {
+				continue
+			}
+			leaseKey, ok := activeMounts.acquire(ref)
+			if !ok {
+				continue
+			}
+			return &cacheVolumeMount{
+				active:   activeMounts,
+				leaseKey: leaseKey,
+				ref:      ref,
+				selector: cache.snapshotSelectorLocked(),
+			}, nil
+		}
+	}
+
+	if len(cache.snapshots) == 0 || cache.Sharing == CacheSharingModePrivate {
 		ref, err := cache.appendSnapshotLocked(ctx)
 		if err != nil {
 			return nil, err
 		}
+		var leaseKey string
+		if cache.Sharing == CacheSharingModePrivate {
+			var ok bool
+			leaseKey, ok = activeMounts.acquire(ref)
+			if !ok {
+				return nil, fmt.Errorf("acquire new private cache volume snapshot %q", ref.SnapshotID())
+			}
+		}
 		return &cacheVolumeMount{
+			active:   activeMounts,
+			leaseKey: leaseKey,
 			ref:      ref,
 			selector: cache.snapshotSelectorLocked(),
 		}, nil
@@ -302,6 +391,7 @@ func (cache *CacheVolume) acquireMount(ctx context.Context) (*cacheVolumeMount, 
 		return nil, fmt.Errorf("cache volume %q has nil snapshot", cache.Key)
 	}
 	return &cacheVolumeMount{
+		active:   activeMounts,
 		ref:      ref,
 		selector: cache.snapshotSelectorLocked(),
 	}, nil

--- a/core/cache.go
+++ b/core/cache.go
@@ -91,16 +91,15 @@ type cacheVolumeMount struct {
 	released bool
 }
 
-func (mount *cacheVolumeMount) release(context.Context) error {
+func (mount *cacheVolumeMount) release() {
 	if mount == nil {
-		return nil
+		return
 	}
 	if mount.released {
-		return nil
+		return
 	}
 	mount.released = true
 	mount.active.release(mount.leaseKey)
-	return nil
 }
 
 func (*CacheVolume) Type() *ast.Type {

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -265,7 +265,7 @@ func TestCacheVolumeUsageIdentityUsesLiveSnapshotID(t *testing.T) {
 		},
 	}
 	cache := NewCache("cache-key", "ns", dagql.Optional[DirectoryID]{}, CacheSharingModeShared, "")
-	cache.snapshot = ref
+	cache.snapshots = []bkcache.MutableRef{ref}
 
 	require.Equal(t, []string{"snapshot-123"}, cache.CacheUsageIdentities())
 }
@@ -279,7 +279,7 @@ func TestCacheVolumeUsageSizeUsesLiveSnapshotID(t *testing.T) {
 		size:       42,
 	}
 	cache := NewCache("cache-key", "ns", dagql.Optional[DirectoryID]{}, CacheSharingModeShared, "")
-	cache.snapshot = &cacheVolumeTestMutableRef{cacheVolumeTestImmutableRef: *ref}
+	cache.snapshots = []bkcache.MutableRef{&cacheVolumeTestMutableRef{cacheVolumeTestImmutableRef: *ref}}
 
 	size, ok, err := cache.CacheUsageSize(context.Background(), "snapshot-123")
 	require.NoError(t, err)

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -31,6 +31,7 @@ type cacheVolumeTestSnapshotManager struct {
 	immutableBySnapshotID map[string]bkcache.ImmutableRef
 	mutableBySnapshotID   map[string]bkcache.MutableRef
 	newResult             bkcache.MutableRef
+	newResults            []bkcache.MutableRef
 
 	getBySnapshotIDCalls        []string
 	getMutableBySnapshotIDCalls []string
@@ -61,6 +62,11 @@ func (m *cacheVolumeTestSnapshotManager) GetBySnapshotID(ctx context.Context, sn
 
 func (m *cacheVolumeTestSnapshotManager) New(_ context.Context, parent bkcache.ImmutableRef, _ ...bkcache.RefOption) (bkcache.MutableRef, error) {
 	m.newCalls = append(m.newCalls, parent)
+	if len(m.newResults) > 0 {
+		ref := m.newResults[0]
+		m.newResults = m.newResults[1:]
+		return ref, nil
+	}
 	if m.newResult == nil {
 		return nil, context.Canceled
 	}
@@ -348,6 +354,87 @@ func TestCacheVolumeInitializeSnapshotCreatesMutableSnapshot(t *testing.T) {
 	require.Nil(t, manager.newCalls[0])
 	require.Equal(t, ref, cache.getSnapshot())
 	require.Equal(t, "/", cache.getSnapshotSelector())
+}
+
+func TestPrivateCacheVolumeAcquireMountReusesIdleSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ref := &cacheVolumeTestMutableRef{
+		cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+			id:         "mutable-1",
+			snapshotID: "snapshot-1",
+		},
+	}
+	manager := &cacheVolumeTestSnapshotManager{
+		newResult: ref,
+	}
+	query := &Query{
+		Server: &cacheVolumeTestQueryServer{
+			mockServer:   &mockServer{},
+			cacheManager: manager,
+		},
+	}
+	ctx := ContextWithQuery(context.Background(), query)
+
+	cache := NewCache("cache-key", "ns", dagql.Optional[DirectoryID]{}, CacheSharingModePrivate, "")
+
+	mount1, err := cache.acquireMount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ref, mount1.ref)
+	require.NoError(t, mount1.release(ctx))
+
+	mount2, err := cache.acquireMount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ref, mount2.ref)
+	require.NoError(t, mount2.release(ctx))
+	require.Len(t, manager.newCalls, 1)
+}
+
+func TestPrivateCacheVolumeAcquireMountCreatesSnapshotWhenActive(t *testing.T) {
+	t.Parallel()
+
+	ref1 := &cacheVolumeTestMutableRef{
+		cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+			id:         "mutable-1",
+			snapshotID: "snapshot-1",
+		},
+	}
+	ref2 := &cacheVolumeTestMutableRef{
+		cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+			id:         "mutable-2",
+			snapshotID: "snapshot-2",
+		},
+	}
+	manager := &cacheVolumeTestSnapshotManager{
+		newResults: []bkcache.MutableRef{ref1, ref2},
+	}
+	query := &Query{
+		Server: &cacheVolumeTestQueryServer{
+			mockServer:   &mockServer{},
+			cacheManager: manager,
+		},
+	}
+	ctx := ContextWithQuery(context.Background(), query)
+
+	cache := NewCache("cache-key", "ns", dagql.Optional[DirectoryID]{}, CacheSharingModePrivate, "")
+
+	mount1, err := cache.acquireMount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ref1, mount1.ref)
+
+	mount2, err := cache.acquireMount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ref2, mount2.ref)
+	require.Len(t, manager.newCalls, 2)
+
+	require.NoError(t, mount1.release(ctx))
+	require.NoError(t, mount2.release(ctx))
+
+	mount3, err := cache.acquireMount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ref1, mount3.ref)
+	require.NoError(t, mount3.release(ctx))
+	require.Len(t, manager.newCalls, 2)
 }
 
 var _ bkcache.ImmutableRef = (*cacheVolumeTestImmutableRef)(nil)

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -381,12 +381,12 @@ func TestPrivateCacheVolumeAcquireMountReusesIdleSnapshot(t *testing.T) {
 	mount1, err := cache.acquireMount(ctx)
 	require.NoError(t, err)
 	require.Equal(t, ref, mount1.ref)
-	require.NoError(t, mount1.release(ctx))
+	mount1.release()
 
 	mount2, err := cache.acquireMount(ctx)
 	require.NoError(t, err)
 	require.Equal(t, ref, mount2.ref)
-	require.NoError(t, mount2.release(ctx))
+	mount2.release()
 	require.Len(t, manager.newCalls, 1)
 }
 
@@ -427,13 +427,13 @@ func TestPrivateCacheVolumeAcquireMountCreatesSnapshotWhenActive(t *testing.T) {
 	require.Equal(t, ref2, mount2.ref)
 	require.Len(t, manager.newCalls, 2)
 
-	require.NoError(t, mount1.release(ctx))
-	require.NoError(t, mount2.release(ctx))
+	mount1.release()
+	mount2.release()
 
 	mount3, err := cache.acquireMount(ctx)
 	require.NoError(t, err)
 	require.Equal(t, ref1, mount3.ref)
-	require.NoError(t, mount3.release(ctx))
+	mount3.release()
 	require.Len(t, manager.newCalls, 2)
 }
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -706,6 +706,10 @@ func prepareMounts(
 			}
 		}
 		if err := materializeState(mountState); err != nil {
+			if mountState.CacheMount != nil {
+				err = errors.Join(err, mountState.CacheMount.release(context.WithoutCancel(ctx)))
+				mountState.CacheMount = nil
+			}
 			return materialized, err
 		}
 	}
@@ -1492,6 +1496,10 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				mountState.ApplyOutput = output
 			}
 			if err := materializeState(mountState); err != nil {
+				if mountState.CacheMount != nil {
+					err = errors.Join(err, mountState.CacheMount.release(context.WithoutCancel(ctx)))
+					mountState.CacheMount = nil
+				}
 				return failPrepare(err)
 			}
 		}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -430,7 +430,7 @@ func (plan *materializedExecPlan) releaseActives(ctx context.Context) error {
 	for i := len(plan.States) - 1; i >= 0; i-- {
 		cacheMount := plan.States[i].CacheMount
 		if cacheMount != nil {
-			rerr = errors.Join(rerr, cacheMount.release(ctx))
+			cacheMount.release()
 			plan.States[i].CacheMount = nil
 		}
 		active := plan.States[i].ActiveRef
@@ -707,7 +707,7 @@ func prepareMounts(
 		}
 		if err := materializeState(mountState); err != nil {
 			if mountState.CacheMount != nil {
-				err = errors.Join(err, mountState.CacheMount.release(context.WithoutCancel(ctx)))
+				mountState.CacheMount.release()
 				mountState.CacheMount = nil
 			}
 			return materialized, err
@@ -1212,7 +1212,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			for i := len(mountStates) - 1; i >= 0; i-- {
 				cacheMount := mountStates[i].CacheMount
 				if cacheMount != nil {
-					releaseErr = errors.Join(releaseErr, cacheMount.release(context.WithoutCancel(ctx)))
+					cacheMount.release()
 					mountStates[i].CacheMount = nil
 				}
 				active := mountStates[i].ActiveRef
@@ -1497,7 +1497,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			}
 			if err := materializeState(mountState); err != nil {
 				if mountState.CacheMount != nil {
-					err = errors.Join(err, mountState.CacheMount.release(context.WithoutCancel(ctx)))
+					mountState.CacheMount.release()
 					mountState.CacheMount = nil
 				}
 				return failPrepare(err)

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -372,6 +372,7 @@ type execMountState struct {
 	ActiveRef       bkcache.MutableRef
 	OutputMutable   bkcache.MutableRef
 	OutputImmutable bkcache.ImmutableRef
+	CacheMount      *cacheVolumeMount
 }
 
 type materializedExecPlan struct {
@@ -427,6 +428,11 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 func (plan *materializedExecPlan) releaseActives(ctx context.Context) error {
 	var rerr error
 	for i := len(plan.States) - 1; i >= 0; i-- {
+		cacheMount := plan.States[i].CacheMount
+		if cacheMount != nil {
+			rerr = errors.Join(rerr, cacheMount.release(ctx))
+			plan.States[i].CacheMount = nil
+		}
 		active := plan.States[i].ActiveRef
 		if active == nil {
 			continue
@@ -673,17 +679,16 @@ func prepareMounts(
 			if cacheSrc.Volume.Self() == nil {
 				return materialized, fmt.Errorf("mount %d has nil cache volume source", i)
 			}
-			if cacheSrc.Volume.Self().getSnapshot() == nil {
-				if err := cacheSrc.Volume.Self().InitializeSnapshot(ctx); err != nil {
-					return materialized, fmt.Errorf("initialize cache volume snapshot for mount %d: %w", i, err)
-				}
+			cacheMount, err := cacheSrc.Volume.Self().acquireMount(ctx)
+			if err != nil {
+				return materialized, fmt.Errorf("acquire cache volume snapshot for mount %d: %w", i, err)
 			}
-			cacheSnapshot := cacheSrc.Volume.Self().getSnapshot()
-			if cacheSnapshot == nil {
+			if cacheMount.ref == nil {
 				return materialized, fmt.Errorf("mount %d has nil cache volume snapshot", i)
 			}
-			mountState.SourceRef = cacheSnapshot
-			mountState.Selector = cacheSrc.Volume.Self().getSnapshotSelector()
+			mountState.SourceRef = cacheMount.ref
+			mountState.Selector = cacheMount.selector
+			mountState.CacheMount = cacheMount
 
 		case ctrMount.TmpfsSource != nil:
 			mountState.MountType = pb.MountType_TMPFS
@@ -1201,6 +1206,11 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		releaseActives := func() error {
 			var releaseErr error
 			for i := len(mountStates) - 1; i >= 0; i-- {
+				cacheMount := mountStates[i].CacheMount
+				if cacheMount != nil {
+					releaseErr = errors.Join(releaseErr, cacheMount.release(context.WithoutCancel(ctx)))
+					mountStates[i].CacheMount = nil
+				}
 				active := mountStates[i].ActiveRef
 				if active == nil {
 					continue
@@ -1457,17 +1467,16 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				if cacheSrc.Volume.Self() == nil {
 					return failPrepare(fmt.Errorf("mount %d has nil cache volume source", i))
 				}
-				if cacheSrc.Volume.Self().getSnapshot() == nil {
-					if err := cacheSrc.Volume.Self().InitializeSnapshot(ctx); err != nil {
-						return failPrepare(fmt.Errorf("initialize cache volume snapshot for mount %d: %w", i, err))
-					}
+				cacheMount, err := cacheSrc.Volume.Self().acquireMount(ctx)
+				if err != nil {
+					return failPrepare(fmt.Errorf("acquire cache volume snapshot for mount %d: %w", i, err))
 				}
-				cacheSnapshot := cacheSrc.Volume.Self().getSnapshot()
-				if cacheSnapshot == nil {
+				if cacheMount.ref == nil {
 					return failPrepare(fmt.Errorf("mount %d has nil cache volume snapshot", i))
 				}
-				mountState.SourceRef = cacheSnapshot
-				mountState.Selector = cacheSrc.Volume.Self().getSnapshotSelector()
+				mountState.SourceRef = cacheMount.ref
+				mountState.Selector = cacheMount.selector
+				mountState.CacheMount = cacheMount
 
 			case ctrMount.TmpfsSource != nil:
 				mountState.MountType = pb.MountType_TMPFS

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -137,6 +137,116 @@ rmdir /cache/in-use`,
 	require.Len(t, strings.Fields(strings.TrimSpace(out)), writers)
 }
 
+func (CacheSuite) TestPrivateCacheVolumeReusesSequentialWriter(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	cacheKey := "private-cache-" + identity.NewID()
+	content := "first-writer-" + identity.NewID()
+
+	_, err := c.Container().
+		From(alpineImage).
+		WithMountedCache("/cache", c.CacheVolume(cacheKey, dagger.CacheVolumeOpts{
+			Sharing: dagger.CacheSharingModePrivate,
+		})).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("echo %q > /cache/value", content)}).
+		Sync(ctx)
+	require.NoError(t, err)
+
+	out, err := c.Container().
+		From(alpineImage).
+		WithMountedCache("/cache", c.CacheVolume(cacheKey, dagger.CacheVolumeOpts{
+			Sharing: dagger.CacheSharingModePrivate,
+		})).
+		WithExec([]string{"cat", "/cache/value"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, content, strings.TrimSpace(out))
+}
+
+func (CacheSuite) TestPrivateCacheVolumeSplitsConcurrentWriters(ctx context.Context, t *testctx.T) {
+	const writers = 3
+
+	cacheKey := "private-cache-" + identity.NewID()
+	clients := make([]*dagger.Client, writers)
+	for i := range clients {
+		clients[i] = connect(ctx, t)
+	}
+
+	start := make(chan struct{})
+	var eg errgroup.Group
+	for i := range writers {
+		i := i
+		eg.Go(func() error {
+			<-start
+			_, err := clients[i].
+				Container().
+				From(alpineImage).
+				WithEnvVariable("RUN_ID", fmt.Sprint(i)).
+				WithEnvVariable("CACHEBUSTER", identity.NewID()).
+				WithMountedCache("/cache", clients[i].CacheVolume(cacheKey, dagger.CacheVolumeOpts{
+					Sharing: dagger.CacheSharingModePrivate,
+				})).
+				WithExec([]string{
+					"sh",
+					"-euxc",
+					`mkdir /cache/in-use
+echo "$RUN_ID" > /cache/in-use/writer
+sleep 1
+test "$(cat /cache/in-use/writer)" = "$RUN_ID"
+rm /cache/in-use/writer
+rmdir /cache/in-use`,
+				}).
+				Sync(ctx)
+			return err
+		})
+	}
+
+	close(start)
+	require.NoError(t, eg.Wait())
+}
+
+func (CacheSuite) TestMountedCachePrivateSharingSplitsConcurrentWriters(ctx context.Context, t *testctx.T) {
+	const writers = 3
+
+	cacheKey := "private-mounted-cache-" + identity.NewID()
+	clients := make([]*dagger.Client, writers)
+	for i := range clients {
+		clients[i] = connect(ctx, t)
+	}
+
+	start := make(chan struct{})
+	var eg errgroup.Group
+	for i := range writers {
+		i := i
+		eg.Go(func() error {
+			<-start
+			_, err := clients[i].
+				Container().
+				From(alpineImage).
+				WithEnvVariable("RUN_ID", fmt.Sprint(i)).
+				WithEnvVariable("CACHEBUSTER", identity.NewID()).
+				WithMountedCache("/cache", clients[i].CacheVolume(cacheKey), dagger.ContainerWithMountedCacheOpts{
+					Sharing: dagger.CacheSharingModePrivate,
+				}).
+				WithExec([]string{
+					"sh",
+					"-euxc",
+					`mkdir /cache/in-use
+echo "$RUN_ID" > /cache/in-use/writer
+sleep 1
+test "$(cat /cache/in-use/writer)" = "$RUN_ID"
+rm /cache/in-use/writer
+rmdir /cache/in-use`,
+				}).
+				Sync(ctx)
+			return err
+		})
+	}
+
+	close(start)
+	require.NoError(t, eg.Wait())
+}
+
 func (CacheSuite) TestLocalImportCacheReuse(ctx context.Context, t *testctx.T) {
 	hostDirPath := t.TempDir()
 	err := os.WriteFile(filepath.Join(hostDirPath, "foo"), []byte("bar"), 0o644)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -170,6 +170,34 @@ func (ServiceSuite) TestHostnameEndpoint(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ServiceSuite) TestEndpointMatchesBindingForPrivateCacheService(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	content := "private-cache-service-" + identity.NewID()
+	srv := c.Container().
+		From(busyboxImage).
+		WithMountedCache("/cache", c.CacheVolume("private-cache-service-"+identity.NewID()), dagger.ContainerWithMountedCacheOpts{
+			Sharing: dagger.CacheSharingModePrivate,
+		}).
+		WithNewFile("/srv/index.html", content).
+		WithWorkdir("/srv").
+		WithExposedPort(8080).
+		WithDefaultArgs([]string{"httpd", "-f", "-p", "8080"}).
+		AsService()
+
+	endpoint, err := srv.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "http"})
+	require.NoError(t, err)
+
+	out, err := c.Container().
+		From(alpineImage).
+		WithExec([]string{"apk", "add", "curl"}).
+		WithServiceBinding("www", srv).
+		WithExec([]string{"curl", "--fail", "--show-error", "--connect-timeout", "2", "--max-time", "5", endpoint}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, content, out)
+}
+
 func (ServiceSuite) TestWithHostname(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/query.go
+++ b/core/query.go
@@ -140,6 +140,10 @@ type Server interface {
 	// shared resources between multiple potentially concurrent calls.
 	Locker() *locker.Locker
 
+	// Tracks cache-volume snapshots mounted by running execs across all
+	// materialized instances of the same logical cache volume.
+	CacheVolumeActiveMounts() *CacheVolumeActiveMounts
+
 	// A shared engine-wide salt used when creating cache keys for secrets based on their plaintext
 	SecretSalt() []byte
 

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 
 	"github.com/dagger/dagger/core"
@@ -60,14 +59,6 @@ func (s *cacheSchema) cacheVolumeCacheKey(
 		}
 		args.Namespace = namespaceKey
 		if err := req.SetArgInput(ctx, "namespace", dagql.NewString(namespaceKey), false); err != nil {
-			return err
-		}
-	}
-
-	if args.Sharing == core.CacheSharingModePrivate {
-		// For now, PRIVATE means "always unique cache volume" to avoid
-		// surprising cross-call sharing behavior.
-		if err := req.SetArgInput(ctx, "privateNonce", dagql.NewString(rand.Text()), false); err != nil {
 			return err
 		}
 	}

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -125,6 +125,10 @@ func (s *currentTypeDefsTestServer) SnapshotManager() bkcache.SnapshotManager { 
 
 func (s *currentTypeDefsTestServer) Locker() *locker.Locker { return nil }
 
+func (s *currentTypeDefsTestServer) CacheVolumeActiveMounts() *core.CacheVolumeActiveMounts {
+	return core.NewCacheVolumeActiveMounts()
+}
+
 func (s *currentTypeDefsTestServer) SecretSalt() []byte { return nil }
 
 func (s *currentTypeDefsTestServer) FlushSessionTelemetry(context.Context) error {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -43,9 +43,10 @@ func testResultCall(field string, typ dagql.Typed, receiver *dagql.ResultCall) *
 }
 
 type mockServer struct {
-	moduleSource   *ModuleSource
-	functionCall   *FunctionCall
-	clientMetadata *engine.ClientMetadata
+	moduleSource            *ModuleSource
+	functionCall            *FunctionCall
+	clientMetadata          *engine.ClientMetadata
+	cacheVolumeActiveMounts *CacheVolumeActiveMounts
 }
 
 func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engineutil.ExecutionMetadata) {
@@ -167,8 +168,14 @@ func (ms *mockServer) PruneEngineLocalCacheEntries(context.Context, EngineCacheP
 func (ms *mockServer) EngineLocalCachePolicy() *dagql.CachePrunePolicy { return nil }
 func (ms *mockServer) SnapshotManager() bkcache.SnapshotManager        { return nil }
 func (ms *mockServer) Locker() *locker.Locker                          { return nil }
-func (ms *mockServer) SecretSalt() []byte                              { return nil }
-func (ms *mockServer) FlushSessionTelemetry(context.Context) error     { return nil }
+func (ms *mockServer) CacheVolumeActiveMounts() *CacheVolumeActiveMounts {
+	if ms.cacheVolumeActiveMounts == nil {
+		ms.cacheVolumeActiveMounts = NewCacheVolumeActiveMounts()
+	}
+	return ms.cacheVolumeActiveMounts
+}
+func (ms *mockServer) SecretSalt() []byte                          { return nil }
+func (ms *mockServer) FlushSessionTelemetry(context.Context) error { return nil }
 func (ms *mockServer) ClientTelemetry(ctc context.Context, sessID, clientID string) (*clientdb.DB, error) {
 	return nil, nil
 }

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/diff/walking"
 	"github.com/containerd/go-runc"
 	"github.com/containerd/platforms"
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/schema"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/config"
@@ -155,7 +156,8 @@ type Server struct {
 	daggerSessionsMu sync.RWMutex
 	clientDBs        *clientdb.DBs
 
-	locker *locker.Locker
+	locker                  *locker.Locker
+	cacheVolumeActiveMounts *core.CacheVolumeActiveMounts
 
 	secretSalt []byte
 }
@@ -190,7 +192,8 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 
 		daggerSessions: make(map[string]*daggerSession),
 
-		locker: locker.New(),
+		locker:                  locker.New(),
+		cacheVolumeActiveMounts: core.NewCacheVolumeActiveMounts(),
 	}
 	srv.shutdownCtx, srv.shutdownCancel = context.WithCancelCause(context.Background())
 
@@ -832,6 +835,10 @@ func (srv *Server) CorruptDBReset() bool {
 
 func (srv *Server) Locker() *locker.Locker {
 	return srv.locker
+}
+
+func (srv *Server) CacheVolumeActiveMounts() *core.CacheVolumeActiveMounts {
+	return srv.cacheVolumeActiveMounts
 }
 
 func (srv *Server) gcClientDBs() {


### PR DESCRIPTION
Fixes #13060

### Why

`PRIVATE` cache mounts should isolate concurrent writers. They should not make the same lazy graph resolve to a different service identity each time it is evaluated.

After the dagql cache migration, service hostnames come from the resolved service graph. That exposed a bad interaction with `PRIVATE` caches: `cacheVolume(sharing: PRIVATE)` injected a fresh `privateNonce` into dagql cache-key construction on every evaluation.

So this shape could split:
```go
srv := dag.Container().
    WithMountedCache("/var/lib/dagger", dag.CacheVolume("engine-state"),
dagger.ContainerWithMountedCacheOpts{
        Sharing: dagger.CacheSharingModePrivate,
    }).
    AsService()

endpoint := srv.Endpoint(ctx)

ctr := dag.Container().
    WithServiceBinding("dagger-engine", srv)
```

`Endpoint(ctx)` could compute `hostname A`, while `WithServiceBinding` started and bound `hostname B`. The service was up; the client was just told to dial the wrong host.

### What changed

This PR removes `privateNonce` from dagql cache-key construction. A `PRIVATE` cache volume now has stable graph identity like any other cache volume.

The privacy behavior moved to the place where it actually matters: **runtime mount acquisition**.

A `CacheVolume` now keeps a pool of mutable backing refs:
- `SHARED` and `LOCKED` use the first backing ref
- `PRIVATE` reuses an idle backing ref
- if all private backing refs are currently mounted by running execs, it creates another one
- active private mounts are released when the exec/mount is cleaned up
- all backing refs are persisted with the cache volume, so rehydration does not lose private lanes

This preserves both sides of the intended behavior:
- repeated evaluation of the same lazy graph gets the same service identity
- concurrent private writers do not share the same mutable cache contents

`WithMountedCache(..., sharing: PRIVATE)` still works as before at the API level: the mount argument is rewritten to an effective `CacheVolume` with private sharing. The original shared cache value is not mutated.

### Validation

Added a service regression test for the original failure shape:
1. build a service with a `PRIVATE` cache mount
2. call `Service.Endpoint(ctx)`
3. bind the same lazy service with `WithServiceBinding`
4. curl the endpoint from the bound container


This also adds very important runtime cache tests for the private cache semantics:
- sequential private writers reuse cache contents
- concurrent direct `CacheVolume(..., sharing: PRIVATE)` writers are isolated
- concurrent `WithMountedCache(..., sharing: PRIVATE)` writers are isolated
