### PR TITLE
docs: propose docs-dev reference generation breakouts

### DIFF
--- a/toolchains/docs-dev/BREAKOUT-CLI-REFERENCE.md
+++ b/toolchains/docs-dev/BREAKOUT-CLI-REFERENCE.md
@@ -1,0 +1,270 @@
+# CLI Reference Breakout Implementation Plan
+
+## Target Outcome
+
+CLI reference generation should be a normal Cobra docs generation path, not a hidden
+production CLI command.
+
+The final shape I want:
+
+```text
+cmd/dagger/
+  main.go                 # executable wrapper only
+
+internal/cmd/dagger/
+  root.go                 # importable command constructor
+  docs_generate.go        # source-adjacent generation declaration
+  docs_frontmatter.mdx
+  docsgen/                # private go:generate driver
+  ...
+
+internal/cobradocs/
+  markdown.go             # reusable Cobra docs rendering package
+```
+
+The Dagger repo owns how the `dagger` command is constructed and where its generated
+reference lives. `internal/cobradocs` owns the generic rendering mechanics, but the
+Dagger-specific generator driver stays under `internal/cmd/dagger` so we do not
+publish or imply a stable `dagger-docs` command.
+
+## Decisions
+
+- Use `internal/cmd/dagger`, not `internal/daggercli`.
+  This keeps the pattern open for other `cmd/*` binaries while still making the
+  Dagger CLI implementation importable inside this repo.
+- Use package name `daggercmd`.
+  The import reads cleanly from the wrapper:
+
+  ```go
+  import daggercmd "github.com/dagger/dagger/internal/cmd/dagger"
+  ```
+
+- Keep `cmd/dagger/main.go` as a thin executable wrapper.
+  It should delegate process execution to the internal package and contain no
+  command-tree construction.
+- Delete `cmd/dagger/gen.go`.
+  There should be no hidden `dagger gen` command and no compatibility alias.
+- Keep the docs generator private.
+  Do not add a top-level `cmd/dagger-docs` binary; a `cmd/*` package looks like
+  user-facing executable surface. Use `internal/cmd/dagger/docsgen` as a local
+  `go generate` driver instead.
+- The reference generator must construct the Cobra root directly through:
+
+  ```go
+  func NewRootCommand(opts Options) *cobra.Command
+  ```
+
+- The generated output remains:
+
+  ```text
+  docs/current_docs/reference/cli/index.mdx
+  ```
+
+## Current State
+
+Today the flow is:
+
+```text
+toolchains/docs-dev.References()
+  -> toolchains/cli-dev.Reference()
+    -> go run ./cmd/dagger gen --output cli.mdx --include-experimental
+      -> cmd/dagger/gen.go
+        -> github.com/spf13/cobra/doc
+```
+
+`cmd/dagger/gen.go` is production CLI surface whose only job is documentation.
+That is the wrong ownership boundary.
+
+## Implementation Plan
+
+### 1. Move the CLI implementation package
+
+Move the current `cmd/dagger` implementation files into:
+
+```text
+internal/cmd/dagger
+```
+
+This includes embedded assets such as:
+
+```text
+licenses/Apache-2.0.txt
+*.graphql
+llm_compact.md
+testdata/
+```
+
+The remaining `cmd/dagger/main.go` should call into `daggercmd` only.
+
+### 2. Introduce the command constructor
+
+Add:
+
+```go
+type Options struct {
+    Args   []string
+    Stdin  io.Reader
+    Stdout io.Writer
+    Stderr io.Writer
+}
+
+func NewRootCommand(opts Options) *cobra.Command
+```
+
+The first pass should preserve the CLI's existing runtime behavior, but command
+allocation and command registration should live behind this constructor instead of
+package `init()` wiring. The goal is for docs generation and tests to import the
+command tree without importing an executable package.
+
+Important detail: current command state is heavily process-global. I will avoid a
+cosmetic full state rewrite unless the move proves it is necessary. The required
+hard cutover is the package boundary and docs generation ownership, not making the
+entire CLI multi-instance-safe in one patch.
+
+### 3. Keep executable behavior in one internal entrypoint
+
+Add an internal process entrypoint, for example:
+
+```go
+func Main()
+```
+
+`cmd/dagger/main.go` becomes:
+
+```go
+package main
+
+import daggercmd "github.com/dagger/dagger/internal/cmd/dagger"
+
+func main() {
+    daggercmd.Main()
+}
+```
+
+The current exit-code handling, progress setup, signal handling, and global flag
+preparse behavior should move intact into `daggercmd.Main()`.
+
+### 4. Add source-adjacent docs generation declaration
+
+Add:
+
+```text
+internal/cmd/dagger/docs_generate.go
+internal/cmd/dagger/docs_frontmatter.mdx
+internal/cmd/dagger/docsgen/main.go
+```
+
+Expected shape:
+
+```go
+//go:build generate
+
+package daggercmd
+
+//go:generate go run ./docsgen -out ../../../docs/current_docs/reference/cli/index.mdx -frontmatter docs_frontmatter.mdx -include-experimental
+```
+
+`go generate` runs from the package directory, so `./docsgen` remains source-local
+and private to the CLI implementation.
+
+The local driver should be thin. It should import `daggercmd`, call
+`NewRootCommand`, apply Dagger-specific filtering policy, and pass the command tree
+to `internal/cobradocs`.
+
+`internal/cobradocs` needs to support at least:
+
+- Markdown single-file output
+- output path
+- frontmatter from file
+- same-document Cobra links
+- hidden command handling
+- command filtering hooks
+
+### 5. Move docs rendering behavior out of Dagger CLI
+
+The behavior currently in `cmd/dagger/gen.go` should move out of the production
+CLI. Generic rendering mechanics belong in `internal/cobradocs`; Dagger-specific
+construction and filtering belong in `internal/cmd/dagger/docsgen`.
+
+Behavior to preserve:
+
+- disable Cobra's autogenerated footer
+- prepend CLI docs frontmatter
+- render one Markdown document containing the root and all available subcommands
+- link `SEE ALSO` entries to same-file anchors
+- omit experimental commands unless explicitly included by the driver
+- omit `dagger completion` in the driver because its current long text breaks
+  Docusaurus MDX
+
+### 6. Update docs-dev orchestration
+
+Remove the CLI reference generation edge from:
+
+```go
+toolchains/docs-dev.References()
+```
+
+Specifically, stop calling:
+
+```go
+dag.DaggerCli().Reference(...)
+```
+
+`docs-dev` should remain repo-specific orchestration for the docs changeset, but it
+should not know that CLI docs used to be generated by running the Dagger CLI.
+
+### 7. Remove cli-dev reference generation
+
+Delete or simplify:
+
+```go
+toolchains/cli-dev.Reference()
+```
+
+No Dagger module should call `go run ./cmd/dagger gen`. If generated bindings need
+to be updated after removing the method, regenerate the affected Dagger SDK files.
+
+### 8. Delete hidden CLI generation command
+
+Delete:
+
+```text
+cmd/dagger/gen.go
+```
+
+After this, `dagger gen` should not exist.
+
+## Verification Plan
+
+Use the current generated docs as the behavioral baseline.
+
+1. Before removing the old command, capture current output to `/tmp/cli-reference-old.mdx`.
+2. Generate through `go generate ./internal/cmd/dagger` or `go run ./docsgen`
+   from `internal/cmd/dagger` to `/tmp/cli-reference-new.mdx`.
+3. Diff both files. Expected differences should be zero, except for changes we
+   deliberately make to frontmatter placement or generator metadata.
+4. Compile the executable wrapper and internal command package.
+5. Run focused tests for command construction, completion, and docs generation.
+6. Run the repo generator flow that is expected to own the final artifact:
+
+   ```text
+   dagger generate
+   ```
+
+7. Confirm `docs/current_docs/reference/cli/index.mdx` is updated only by the new
+   generation path.
+
+## Future Extraction
+
+If another repository needs the same Cobra docs generator, extract
+`internal/cobradocs` into a public module at that point. Do not design a public
+`github.com/dagger/cobra` contract until there is a second real consumer.
+
+## Non-Goals
+
+- Do not keep `dagger gen`.
+- Do not add a top-level `cmd/dagger-docs` command.
+- Do not make `docs-dev` project-agnostic.
+- Do not infer the Cobra root by static scanning.
+- Do not promise a stable external Cobra docs CLI or module yet.
+- Do not refactor unrelated CLI runtime state just because the package is moving.

--- a/toolchains/docs-dev/BREAKOUT-GRAPHQL-REFERENCE.md
+++ b/toolchains/docs-dev/BREAKOUT-GRAPHQL-REFERENCE.md
@@ -1,0 +1,157 @@
+# Break Out GraphQL Reference Generation
+
+## Summary
+
+Generate the Engine GraphQL API reference by pointing SpectaQL at a live Dagger engine service.
+
+This removes `docs/docs-graphql/schema.graphqls` from the public generation graph. The schema becomes SpectaQL's internal introspection result, not an explicit docs artifact.
+
+## Current State
+
+Today:
+
+```text
+toolchains/docs-dev.References()
+  -> EngineDev.GraphqlSchema(version)
+    -> docs/docs-graphql/schema.graphqls
+  -> spectaql ./docs-graphql/config.yml -t ./static/api/reference/
+    -> docs/static/api/reference/
+```
+
+The checked-in GraphQL schema is mainly an intermediate input to SpectaQL.
+
+## Proposal
+
+Introduce a reusable `github.com/dagger/spectaql` module that can render docs from a live GraphQL service:
+
+```text
+SpectaQL.RenderEndpoint(service, config, opts) -> Directory
+```
+
+The module owns:
+
+```text
+installing/running SpectaQL
+binding the target service
+setting the introspection URL
+passing headers/secrets
+writing the static output directory
+```
+
+The project owns:
+
+```text
+which service to document
+which SpectaQL config/theme to use
+where the generated output lands
+```
+
+## Checked-In Config
+
+Keep the SpectaQL presentation config in git, because it is docs policy:
+
+```text
+docs/docs-graphql/spectaql.config.yml
+docs/docs-graphql/custom-theme/
+```
+
+Example:
+
+```yaml
+spectaql:
+  logoFile: ../website/static/img/dagger-logo-dark.png
+  faviconFile: ../website/static/img/favicon.png
+  themeDir: ./docs-graphql/custom-theme/
+
+introspection:
+  url: ${SPECTAQL_INTROSPECTION_URL}
+  removeTrailingPeriodFromDescriptions: false
+  fieldExpansionDepth: 1
+  metadatas: true
+  hideMutationsWithUndocumentedReturnType: false
+  hideUnusedTypes: false
+  inputValueDeprecation: true
+
+extensions:
+  graphqlScalarExamples: true
+
+info:
+  title: Dagger GraphQL API Reference
+  docs-url: https://docs.dagger.io
+  x-url: https://api.dagger.cloud/playgrounds
+  x-hideIsDeprecated: false
+  x-hideDeprecationReason: false
+```
+
+The service URL is injected at runtime:
+
+```text
+SPECTAQL_INTROSPECTION_URL=http://target:1234/query
+```
+
+## Dagger Flow
+
+Desired dataflow:
+
+```text
+EngineDev.Service(version) -> Service
+SpectaQL.RenderEndpoint(service, config/theme) -> Directory
+docs/static/api/reference/
+```
+
+In `toolchains/docs-dev`, the generated reference becomes:
+
+```go
+engine := dag.EngineDev().Service(...)
+apiRef := dag.Spectaql().RenderEndpoint(engine, config, opts)
+src = src.WithDirectory("docs/static/api/reference", apiRef)
+```
+
+If workspace/module customization can reference another module's service output, this composition can move from Go glue to config. The important interface remains one edge:
+
+```text
+GraphQL Service -> SpectaQL
+```
+
+not:
+
+```text
+GraphQL Service -> schema file -> SpectaQL
+```
+
+## SpectaQL Requirements
+
+SpectaQL supports live introspection through:
+
+```yaml
+introspection:
+  url: http://target:1234/query
+  headers:
+    Header-Name: value
+```
+
+The reusable module should also support the CLI equivalents:
+
+```text
+--introspection-url
+--headers
+--target-dir
+```
+
+For Dagger engine services, the module or `engine-dev` may need to provide Dagger client metadata headers, or expose a wrapper service that can be introspected without callers knowing Dagger-specific headers.
+
+## Migration
+
+1. Add `github.com/dagger/spectaql` module with `RenderEndpoint`.
+2. Rename `docs/docs-graphql/config.yml` to `docs/docs-graphql/spectaql.config.yml`.
+3. Change the config from `schemaFile` to `${SPECTAQL_INTROSPECTION_URL}`.
+4. Change `toolchains/docs-dev.References()` to call `EngineDev.Service` and `SpectaQL.RenderEndpoint`.
+5. Stop generating `docs/docs-graphql/schema.graphqls`.
+6. Remove `docs/docs-graphql/schema.graphqls` from git if no other workflow needs it.
+
+## Non-Goals
+
+- Do not create a Dagger-specific `EngineApiReference` module unless live-service composition proves insufficient.
+- Do not keep `schema.graphqls` as a public dependency if it is only an intermediate.
+- Do not hardcode a Dagger engine endpoint into the generic SpectaQL module.
+- Do not rely on plain `config.yml` as a scan marker; prefer explicit config or `spectaql.config.yml`.

--- a/toolchains/docs-dev/BREAKOUT-JSON-SCHEMA-REFERENCE.md
+++ b/toolchains/docs-dev/BREAKOUT-JSON-SCHEMA-REFERENCE.md
@@ -1,0 +1,108 @@
+# Break Out JSON Schema Reference Generation
+
+## Summary
+
+Move JSON schema reference generation out of `toolchains/docs-dev` and into source-adjacent Go generation.
+
+The source of truth for these schemas is Go types, so `//go:generate` is the right declaration point.
+
+## Current State
+
+Today:
+
+```text
+toolchains/docs-dev.References()
+  -> EngineDev.ConfigSchema("dagger.json")
+    -> go run ./cmd/json-schema dagger.json
+    -> docs/static/reference/dagger.schema.json
+```
+
+`cmd/json-schema` can generate two schemas:
+
+```text
+dagger.json -> core/modules.ModuleConfigWithUserFields
+engine.json -> engine/config.Config
+```
+
+but `docs-dev.References()` currently writes `dagger.schema.json` twice and does not regenerate `engine.schema.json`.
+
+## Proposal
+
+Make `cmd/json-schema` a normal Go generator and declare schema outputs beside the Go types that define them.
+
+Add explicit output support:
+
+```text
+go run ./cmd/json-schema dagger.json -o docs/static/reference/dagger.schema.json
+go run ./cmd/json-schema engine.json -o docs/static/reference/engine.schema.json
+```
+
+Then add source-adjacent declarations:
+
+```text
+core/modules/generate.go
+engine/config/generate.go
+```
+
+Example:
+
+```go
+package modules
+
+//go:generate go run ../../cmd/json-schema dagger.json -o ../../docs/static/reference/dagger.schema.json
+```
+
+```go
+package config
+
+//go:generate go run ../../cmd/json-schema engine.json -o ../../docs/static/reference/engine.schema.json
+```
+
+## Why `go:generate`
+
+The schemas are derived from Go source:
+
+```text
+Go struct fields
+json tags
+jsonschema tags
+Go comments
+custom JSONSchema() methods
+```
+
+The schema generator already reflects concrete Go values:
+
+```text
+core/modules.ModuleConfigWithUserFields
+engine/config.Config
+```
+
+So the package that owns each type should also declare how its public JSON schema is regenerated.
+
+## Dagger Flow
+
+After this breakout:
+
+```text
+dagger generate
+git add .
+git commit -s -m "re-generate JSON schemas"
+```
+
+`toolchains/docs-dev.References()` should stop calling `EngineDev.ConfigSchema`. The generated JSON schema files become regular generated repo artifacts, updated through the workspace generator flow.
+
+## Migration
+
+1. Add `-o/--output` to `cmd/json-schema`.
+2. Add `core/modules/generate.go` for `dagger.schema.json`.
+3. Add `engine/config/generate.go` for `engine.schema.json`.
+4. Remove JSON schema generation from `toolchains/docs-dev.References()`.
+5. Delete or simplify `EngineDev.ConfigSchema` if no other workflow needs it.
+6. Fix the current duplicate `dagger.schema.json` write in `docs-dev`.
+
+## Non-Goals
+
+- Do not create a generic JSON-schema module just to copy files.
+- Do not keep schema generation in `docs-dev`; the source of truth is not the docs tree.
+- Do not use shell redirection in `//go:generate`; make the generator accept `-o`.
+- Do not infer arbitrary schemas from arbitrary Go packages in this breakout.


### PR DESCRIPTION
## Summary

Moves the docs-dev reference generation breakout proposals onto a clean branch based on latest `main`.

This PR contains planning docs for:

- CLI reference generation via an importable Cobra command tree and a reusable Cobra docs generator
- GraphQL reference generation via live engine service introspection and a reusable SpectaQL module
- JSON schema reference generation via source-adjacent `go:generate` declarations

## Notes

This is documentation only. It does not change generator behavior.

The commits were cherry-picked from `refactor-release` onto a fresh `ci-refactor-docs` branch. The original `refactor-release` branch was not modified.
