### PR TITLE
load default values in schema for enum types

### DIFF
--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -1950,3 +1950,57 @@ class Test:
 	require.NoError(t, err)
 	require.Contains(t, out2, "3.18")
 }
+
+// TestEnumDefaultValue verifies that an enum used as a default for a
+// function argument is honored both at call time and in the --help text.
+//
+// Regression test: the --help output used to drop the default for enum-typed
+// args because the engine reconstructed the Query type's typedef from GraphQL
+// introspection, which prints enum defaults as bare identifiers (e.g. RED)
+// rather than JSON strings (e.g. "RED"). The CLI couldn't parse the bare
+// identifier as JSON, so it silently fell back to "no default".
+func (PythonSuite) TestEnumDefaultValue(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen := pythonModInit(t, c, `
+import enum
+import dagger
+
+@dagger.enum_type
+class Color(enum.Enum):
+    RED = "RED"
+    BLUE = "BLUE"
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def pick(self, color: Color = Color.RED) -> str:
+        return color.value
+`)
+
+	t.Run("default value applied at call time", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("pick")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "RED", out)
+	})
+
+	t.Run("explicit value overrides default", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("pick", "--color", "BLUE")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "BLUE", out)
+	})
+
+	t.Run("default shown in --help output", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("pick", "--help")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "default RED",
+			"--help should display the enum default value")
+	})
+
+	t.Run("default registered in module schema", func(ctx context.Context, t *testctx.T) {
+		schema := inspectModule(ctx, t, modGen)
+		got := schema.Get(`objects.#.asObject|#(name=Test).functions.#(name=pick).args.#(name=color).defaultValue`).String()
+		require.Equal(t, `"RED"`, got,
+			"defaultValue must be a JSON-encoded string, not a bare identifier")
+	})
+}

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -353,6 +353,8 @@ func (m *CoreMod) buildTypeDefs(ctx context.Context, dag *dagql.Server) (dagql.O
 				return nil, err
 			}
 
+			objType, _ := dag.ObjectType(introspectionType.Name)
+
 			isIdable := false
 			for _, introspectionField := range introspectionType.Fields {
 				if introspectionField.Name == "id" {
@@ -410,9 +412,17 @@ func (m *CoreMod) buildTypeDefs(ctx context.Context, dag *dagql.Server) (dagql.O
 					if err != nil {
 						return nil, err
 					}
-					var defaultValue core.JSON
-					if introspectionArg.DefaultValue != nil {
-						defaultValue = core.JSON(*introspectionArg.DefaultValue)
+					var resolvedSpec dagql.InputSpec
+					if objType != nil {
+						if fieldSpec, ok := objType.FieldSpec(introspectionField.Name, dag.View); ok {
+							if argSpec, ok := fieldSpec.Args.Input(introspectionArg.Name, dag.View); ok {
+								resolvedSpec = argSpec
+							}
+						}
+					}
+					defaultValue, err := introspectionDefaultToJSON(introspectionArg.DefaultValue, resolvedSpec)
+					if err != nil {
+						return nil, fmt.Errorf("convert default value for arg %q: %w", introspectionArg.Name, err)
 					}
 					var fnArg dagql.ObjectResult[*core.FunctionArg]
 					if err := dag.Select(ctx, dag.Root(), &fnArg, dagql.Selector{

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -15,6 +16,26 @@ import (
 	"github.com/dagger/dagger/util/hashutil"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+// introspectionDefaultToJSON converts a GraphQL default-value literal (as
+// returned by GraphQL introspection) into a JSON-encoded value suitable for
+// FunctionArg.DefaultValue. Most GraphQL literals (strings, numbers, booleans)
+// are already valid JSON, but enum literals are bare identifiers (e.g. RED)
+// and lists/objects can contain enums, so a typed dagql.Input — when
+// available — is the only reliable way to re-encode them.
+func introspectionDefaultToJSON(literal *string, argSpec dagql.InputSpec) (core.JSON, error) {
+	if literal == nil {
+		return nil, nil
+	}
+	if argSpec.Default != nil {
+		encoded, err := json.Marshal(argSpec.Default)
+		if err != nil {
+			return nil, fmt.Errorf("marshal default %q: %w", *literal, err)
+		}
+		return core.JSON(encoded), nil
+	}
+	return core.JSON(*literal), nil
+}
 
 type moduleSchema struct{}
 
@@ -2467,9 +2488,11 @@ func currentQueryTypeDef(ctx context.Context, dag *dagql.Server) (dagql.ObjectRe
 				defaultPath    string
 				defaultAddress string
 				ignore         []string
+				resolvedSpec   dagql.InputSpec
 			)
 			if fieldSpec, ok := queryObjType.FieldSpec(introspectionField.Name, dag.View); ok {
 				if argSpec, ok := fieldSpec.Args.Input(introspectionArg.Name, dag.View); ok {
+					resolvedSpec = argSpec
 					for _, directive := range argSpec.Directives {
 						switch directive.Name {
 						case "defaultPath":
@@ -2492,9 +2515,9 @@ func currentQueryTypeDef(ctx context.Context, dag *dagql.Server) (dagql.ObjectRe
 					}
 				}
 			}
-			var defaultValue core.JSON
-			if introspectionArg.DefaultValue != nil {
-				defaultValue = core.JSON(*introspectionArg.DefaultValue)
+			defaultValue, err := introspectionDefaultToJSON(introspectionArg.DefaultValue, resolvedSpec)
+			if err != nil {
+				return dagql.ObjectResult[*core.TypeDef]{}, fmt.Errorf("convert default value for arg %q: %w", introspectionArg.Name, err)
 			}
 			var fnArg dagql.ObjectResult[*core.FunctionArg]
 			if err := dag.Select(ctx, dag.Root(), &fnArg, dagql.Selector{


### PR DESCRIPTION
Currently argument default values for arguments that are enums do not have the default value loaded in the schema, and therefore also not show in the `--help` text.