### PR TITLE
fix(toolchains): use locked caches for nested runtimes

### DIFF
--- a/toolchains/engine-dev/main.go
+++ b/toolchains/engine-dev/main.go
@@ -247,10 +247,9 @@ func (dev *EngineDev) Service(
 	devEngine = devEngine.
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
 		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume(cacheVolumeName), dagger.ContainerWithMountedCacheOpts{
-			// only one engine can run off it's local state dir at a time; Private means that we will attempt to re-use
-			// these cache volumes if they are not already locked to another running engine but otherwise will create a new
-			// one, which gets us best-effort cache re-use for these nested engine services
-			Sharing: dagger.CacheSharingModePrivate,
+			// Only one engine can safely use a state dir at a time. LOCKED keeps the
+			// cache identity stable while serializing concurrent users.
+			Sharing: dagger.CacheSharingModeLocked,
 		})
 
 	if metrics {

--- a/toolchains/python-sdk-dev/dockerd/main.go
+++ b/toolchains/python-sdk-dev/dockerd/main.go
@@ -48,7 +48,7 @@ func (t *Dockerd) Service(
 			"/var/lib/docker",
 			dag.CacheVolume(dockerVersion+"-docker-lib"),
 			dagger.ContainerWithMountedCacheOpts{
-				Sharing: dagger.CacheSharingModePrivate,
+				Sharing: dagger.CacheSharingModeLocked,
 			}).
 		WithExposedPort(port).
 		WithExec([]string{


### PR DESCRIPTION
The dagql cache migration exposed a bad interaction between `PRIVATE` cache mounts and lazy service identity (#13060).
`PRIVATE` currently injects a fresh dagql cache key input, so a service can resolve one hostname through `Endpoint` and another through `WithServiceBinding`.

This change does not remove or redesign `PRIVATE`, it is a small internal unblocker for bumping our CI to use Theseus: just dont use `Private` cache mode anymore, just `Locked`

I verified this in a temporary worktree by building the engine with `./hack/dev` and running `dagger check -l` inside engine-dev playground. It connected successfully