### PR TITLE
cli: preserve local no-color after telemetry init

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/dagger/dagger/util/cleanups"
 	telemetry "github.com/dagger/otel-go"
+	"github.com/muesli/termenv"
 	"go.opentelemetry.io/otel"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -166,6 +167,15 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 		telemetryCfg.LiveMetricExporters = append(telemetryCfg.LiveMetricExporters, metrics)
 	}
 	ctx = telemetry.Init(ctx, telemetryCfg)
+	// telemetry.Init extracts inherited OTel baggage from the environment.
+	// Re-apply explicit local process settings afterward so a nested Dagger
+	// command's own NO_COLOR/debug request wins over parent baggage.
+	if termenv.EnvNoColor() {
+		ctx = slog.ContextWithColorMode(ctx, true)
+	}
+	if debugFlag {
+		ctx = slog.ContextWithDebugMode(ctx, true)
+	}
 
 	// Set the full command string as the name of the root span.
 	//


### PR DESCRIPTION
Nested Dagger commands can run with their own process-level presentation settings even when they inherit OpenTelemetry baggage from a parent command. In particular, TestDaggerUp starts an inner dagger CLI with NO_COLOR=true and DAGGER_PROGRESS=logs so it can parse the tunnel log line that contains the random host port.

telemetry.Init extracts trace context and baggage from the environment. When inherited baggage is present, OpenTelemetry baggage extraction replaces the baggage already on the context. That meant the child CLI could observe NO_COLOR=true, add no-color=true to its context, then immediately lose that setting when telemetry.Init imported parent baggage that did not contain no-color=true.

The resulting engine-side tunnel log was colorized as "tunnel started <ansi>port=<ansi>N", so the test's literal "tunnel started port=(\\d+)" regex never matched. Setting NO_COLOR=1 on the outer command masked the problem because the inherited parent baggage already contained no-color=true.

After telemetry.Init, re-apply explicit local process overrides for NO_COLOR and --debug. Only the true cases are re-applied so a nested command still inherits no-color/debug from its parent when it does not make a local request of its own.

---

Note that this only became apparent in the PR that tests upgrade of our CI infra itself to `main`: https://github.com/dagger/dagger/pull/13049, fix verified there and locally.