### PR TITLE
core: expose vault dev service port in secret provider tests

### DIFF
--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -707,6 +707,9 @@ func startVaultDevServer(ctx context.Context, t *testctx.T, c *dagger.Client, bi
 		WithEnvVariable("VAULT_DEV_ROOT_TOKEN_ID", "myroot").
 		WithEnvVariable("VAULT_DEV_LISTEN_ADDRESS", "0.0.0.0:8200").
 		WithEnvVariable("SKIP_SETCAP", "1").
+		// Image EXPOSE metadata is introspection-only; services need an explicit
+		// exposed port to get Dagger's port healthcheck.
+		WithExposedPort(8200).
 		AsService(dagger.ContainerAsServiceOpts{
 			Args: []string{"vault", "server", "-dev"},
 		}).Start(ctx)


### PR DESCRIPTION
The Vault secret provider helper starts hashicorp/vault:1.18 as a Dagger service and then talks to it on port 8200. That image has OCI EXPOSE metadata for 8200/tcp, but Dagger does not currently promote image EXPOSE metadata into Container.Ports for service healthchecks or service port introspection.

This matches the existing note in core/integration/container_test.go around line 4831: after Import or container.From, ports can show up under image config, but do not actually get set up as Dagger container ports and must be re-exposed before AsService.

Add an explicit WithExposedPort(8200) to the Vault dev server helper so service startup waits for Vault's port healthcheck instead of relying on image metadata that is currently introspection-only.

This fixes what appears to be a long-standing flake where you could occasionally try connecting to vault and get connection refused in these secret provider integ tests.