### PR TITLE
toolchains: bump dev engine runc to v1.4.2

### DIFF
--- a/toolchains/engine-dev/consts/consts.go
+++ b/toolchains/engine-dev/consts/consts.go
@@ -16,7 +16,7 @@ const (
 	AlpineVersion = distconsts.AlpineVersion
 	UbuntuVersion = "22.04"
 
-	RuncVersion  = "v1.3.3"
+	RuncVersion  = "v1.4.2"
 	CniVersion   = "v1.9.0"
 	QemuBinImage = "tonistiigi/binfmt@sha256:e06789462ac7e2e096b53bfd9e607412426850227afeb1d0f5dfa48a731e0ba5"
 


### PR DESCRIPTION
We have been investigating rare CI hangs where engine work appeared to stall behind container execution. The strongest captured evidence was not a dagql cache or Directory.Entries deadlock: the goroutine dump showed Dagger blocked inside go-runc's monitor wait for a `runc run`, while ps output showed the corresponding `runc` process still alive and its `.init` child stuck as a zombie.

That zombie process was the key breadcrumb. It pointed the investigation away from Dagger dependency traversal and toward the runtime process lifecycle. Checking the upstream runc release notes then found that [runc v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) explicitly fixes a regression introduced in runc v1.3.0 that can result in a stuck `runc exec` or `runc run` when the container process runs for a short time.

Our dev engine was pinned to runc v1.3.3, which is in the affected series and matches the observed symptom closely: short-lived container process, zombie init, live runc command, and Dagger waiting indefinitely for runc to return.

Bump the dev-engine runc build to v1.4.2 so the dev engine includes the upstream fix for this stuck run/exec regression.