### PR TITLE
fix(sdk/python): discover @function methods inherited from base classes

### DIFF
--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -1535,6 +1535,56 @@ func (PythonSuite) TestInheritance(ctx context.Context, t *testctx.T) {
 
 		require.Equal(t, "Inheritance.", obj.Get("constructor.description").String())
 	})
+
+	t.Run("inherited functions", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := pythonModInit(t, c, `
+from typing import Annotated, Self
+
+from dagger import Doc, function, object_type
+
+class Base:
+    """Base class with inherited @function methods."""
+
+    @function
+    def with_component(self, name: Annotated[str, Doc("component name")]) -> Self:
+        """Inherited function that should be visible."""
+        return self
+
+    @function
+    async def with_context(self) -> Self:
+        """Another inherited function that should be visible."""
+        return self
+
+@object_type
+class Test(Base):
+    @function
+    def my_own_function(self) -> str:
+        """This function IS visible."""
+        return "ok"
+`)
+
+		obj := inspectModuleObjects(ctx, t, modGen).Get("#(name=Test)")
+
+		require.ElementsMatch(t,
+			[]any{"myOwnFunction", "withComponent", "withContext"},
+			obj.Get("functions.#.name").Value(),
+		)
+
+		require.Equal(t,
+			"Inherited function that should be visible.",
+			obj.Get("functions.#(name=withComponent).description").String(),
+		)
+		require.Equal(t,
+			"Another inherited function that should be visible.",
+			obj.Get("functions.#(name=withContext).description").String(),
+		)
+		require.Equal(t,
+			"component name",
+			obj.Get("functions.#(name=withComponent).args.0.description").String(),
+		)
+	})
 }
 
 func (PythonSuite) TestNameConflicts(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -1475,32 +1475,6 @@ func (PythonSuite) TestDocs(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "factory constructor", obj.Get("functions.#(name=external).description").String())
 	})
 
-	t.Run("inheritance", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
-
-		modGen := pythonModInit(t, c, `
-            from typing import Annotated, Self
-
-            from dagger import Doc, function, object_type
-
-            class Base:
-                """What's the object-oriented way to become wealthy?"""
-
-                @classmethod
-                def create(cls) -> Self:
-                    """Inheritance."""
-                    return cls()
-
-            @object_type
-            class Test(Base):
-                ...
-        `)
-
-		obj := inspectModuleObjects(ctx, t, modGen).Get("#(name=Test)")
-
-		require.Equal(t, "Inheritance.", obj.Get("constructor.description").String())
-	})
-
 	t.Run("interface", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
@@ -1532,6 +1506,34 @@ func (PythonSuite) TestDocs(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "A simple Duck interface", o.Get("description").String())
 		require.Equal(t, "A quack sound", f.Get("description").String())
 		require.Equal(t, "A word for the duck to speak", a.Get("description").String())
+	})
+}
+
+func (PythonSuite) TestInheritance(ctx context.Context, t *testctx.T) {
+	t.Run("inherited create constructor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := pythonModInit(t, c, `
+            from typing import Annotated, Self
+
+            from dagger import Doc, function, object_type
+
+            class Base:
+                """What's the object-oriented way to become wealthy?"""
+
+                @classmethod
+                def create(cls) -> Self:
+                    """Inheritance."""
+                    return cls()
+
+            @object_type
+            class Test(Base):
+                ...
+        `)
+
+		obj := inspectModuleObjects(ctx, t, modGen).Get("#(name=Test)")
+
+		require.Equal(t, "Inheritance.", obj.Get("constructor.description").String())
 	})
 }
 

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -444,6 +444,9 @@ class ModuleParser:
                     func = self._parse_function(item, file_path, node.name)
                     functions.append(func)
 
+        seen_names = {f.python_name for f in functions}
+        functions.extend(self._find_inherited_functions(node, node.name, seen_names))
+
         return fields, functions, init_params, constructor
 
     def _process_annotated_assign(
@@ -871,11 +874,69 @@ class ModuleParser:
 
     def _find_class_def(self, class_name: str) -> ast.ClassDef | None:
         """Find a class definition by name in all parsed ASTs."""
-        for tree in self._asts.values():
+        found = self._find_class_def_with_file(class_name)
+        return found[0] if found else None
+
+    def _find_class_def_with_file(
+        self, class_name: str
+    ) -> tuple[ast.ClassDef, Path] | None:
+        """Find a class definition (and its source file) in all parsed ASTs."""
+        for path, tree in self._asts.items():
             for ast_node in ast.iter_child_nodes(tree):
                 if isinstance(ast_node, ast.ClassDef) and ast_node.name == class_name:
-                    return ast_node
+                    return ast_node, path
         return None
+
+    def _find_inherited_functions(
+        self,
+        node: ast.ClassDef,
+        class_name: str,
+        seen_names: set[str],
+        visited: set[str] | None = None,
+    ) -> list[FunctionMetadata]:
+        """Collect ``@function``-decorated methods from base classes via MRO.
+
+        ``class_name`` is the originating (child) class — used so resolution
+        of ``Self`` returns the child type, matching Python's runtime
+        behavior. ``seen_names`` accumulates Python names already discovered
+        on the child or earlier-walked bases so that overrides win.
+        """
+        if visited is None:
+            visited = {node.name}
+
+        inherited: list[FunctionMetadata] = []
+        for base in node.bases:
+            base_name = None
+            if isinstance(base, ast.Name):
+                base_name = base.id
+            elif isinstance(base, ast.Attribute):
+                base_name = base.attr
+
+            if base_name is None or base_name in visited:
+                continue
+            visited.add(base_name)
+
+            found = self._find_class_def_with_file(base_name)
+            if found is None:
+                continue
+            base_class, base_file = found
+
+            for item in base_class.body:
+                if (
+                    isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and has_decorator(item, "function")
+                    and item.name not in seen_names
+                ):
+                    func = self._parse_function(item, base_file, class_name)
+                    inherited.append(func)
+                    seen_names.add(item.name)
+
+            inherited.extend(
+                self._find_inherited_functions(
+                    base_class, class_name, seen_names, visited
+                )
+            )
+        return inherited
 
     def _parse_function(
         self,

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -990,6 +990,87 @@ class Foo(Base):
     assert ctor.is_constructor is True
 
 
+def test_ast_inherited_functions_from_base_class():
+    """``@function``-decorated methods on a base class are inherited (issue #13089)."""
+    metadata = _analyze("""
+import dagger
+from typing import Self
+
+class Base:
+    @dagger.function
+    def with_component(self, name: str) -> Self:
+        '''Inherited function that should be visible.'''
+        return self
+
+    @dagger.function
+    async def with_context(self) -> Self:
+        '''Another inherited function that should be visible.'''
+        return self
+
+@dagger.object_type
+class Foo(Base):
+    @dagger.function
+    def my_own_function(self) -> str:
+        '''This function IS visible.'''
+        return "ok"
+""")
+    funcs = {f.python_name: f for f in metadata.objects["Foo"].functions}
+    assert set(funcs) == {"my_own_function", "with_component", "with_context"}
+    assert funcs["with_component"].doc == ("Inherited function that should be visible.")
+    assert funcs["with_context"].doc == (
+        "Another inherited function that should be visible."
+    )
+    assert funcs["with_context"].is_async is True
+
+
+def test_ast_inherited_function_override_wins():
+    """A child's ``@function`` override is preferred over the base's."""
+    metadata = _analyze("""
+import dagger
+
+class Base:
+    @dagger.function
+    def greet(self) -> str:
+        '''base docstring'''
+        return "base"
+
+@dagger.object_type
+class Foo(Base):
+    @dagger.function
+    def greet(self) -> str:
+        '''child docstring'''
+        return "child"
+""")
+    funcs = [f for f in metadata.objects["Foo"].functions if f.python_name == "greet"]
+    assert len(funcs) == 1
+    assert funcs[0].doc == "child docstring"
+
+
+def test_ast_inherited_functions_multilevel():
+    """Functions from grandparent classes are also discovered."""
+    metadata = _analyze("""
+import dagger
+
+class Grandparent:
+    @dagger.function
+    def from_grandparent(self) -> str:
+        return ""
+
+class Parent(Grandparent):
+    @dagger.function
+    def from_parent(self) -> str:
+        return ""
+
+@dagger.object_type
+class Foo(Parent):
+    @dagger.function
+    def from_child(self) -> str:
+        return ""
+""")
+    names = {f.python_name for f in metadata.objects["Foo"].functions}
+    assert names == {"from_child", "from_parent", "from_grandparent"}
+
+
 def test_ast_external_constructor_simple():
     """``alt = function(Other)`` copies the target's constructor signature."""
     metadata = _analyze("""


### PR DESCRIPTION
## Summary

- Fixes #13089. Inherited `@function` methods stopped showing up in `dagger functions` / `dagger call --help` when the Python SDK switched from runtime introspection to a static AST analyzer in v0.20.7 (#11803). The new analyzer iterated only over a class's own `node.body` and never walked base classes for `@function` methods, while `inspect.getmembers()` previously discovered them via Python's MRO.
- The fix mirrors the existing `_find_inherited_constructor` pattern: a new `_find_inherited_functions` recursively walks `node.bases`, skips names already defined on the child (overrides win), and uses a `visited` set for cycle safety. Inherited functions are parsed with the child's class name so `Self` resolves to the child type — matching runtime behavior. `_find_class_def` is split so the parent's file path can also be recovered, giving inherited functions accurate location metadata.
- Refactors the existing `inheritance` subtest out of `TestDocs` into a dedicated `TestInheritance` suite (first patch, no behavior change), then adds the new integration test next to it (second patch).

## Test plan

- [x] `pytest sdk/python/tests/mod/` — 178 passed (existing 175 + 3 new analyzer tests covering: issue repro, child override of an inherited `@function`, grandparent inheritance).
- [x] `ruff check` clean.
- [x] `go vet ./core/integration/...` clean.
- [x] `go test ./core/integration/ -run 'TestPython/TestInheritance'` — runs the two integration subtests (`inherited create constructor`, `inherited functions`) end-to-end against the dev engine.