### PR TITLE
fix(sdk/python): handle relative imports in AST analyzer

### DIFF
--- a/sdk/python/src/dagger/mod/_analyzer/namespace.py
+++ b/sdk/python/src/dagger/mod/_analyzer/namespace.py
@@ -237,6 +237,30 @@ class StubNamespace:
             )
             self._namespace[key] = StubType(name, module)
 
+    def add_relative_import(
+        self,
+        name: str,
+        alias: str | None,
+        module: str | None,
+        level: int,
+    ) -> None:
+        """Register a name brought in by a relative import as a stub.
+
+        Relative imports (``from . import x``, ``from ..pkg import x``)
+        can't be resolved at static analysis time without the importing
+        package's context, and dispatching them through ``importlib`` is
+        unsafe — an empty module name raises ``ValueError`` and a non-empty
+        one would silently bind the wrong top-level module. Bind the
+        imported name to a stub instead so type annotations referencing
+        it don't ``NameError`` during evaluation. Cross-file decorated
+        classes from the same module are still resolved via
+        ``add_declared_type``.
+        """
+        key = alias or name
+        prefix = "." * level
+        origin = f"{prefix}{module}" if module else prefix
+        self._namespace[key] = StubType(name, origin)
+
     def add_declared_type(self, name: str) -> None:
         """Register a type declared in the module being analyzed.
 

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -287,11 +287,22 @@ class ModuleParser:
                 for alias in node.names:
                     self._namespace.add_import(alias.name, alias.asname)
             elif isinstance(node, ast.ImportFrom):
-                module = node.module or ""
                 for alias in node.names:
-                    if alias.name != "*":
+                    if alias.name == "*":
+                        continue
+                    if node.level > 0:
+                        # Relative imports (``from . import x``,
+                        # ``from .pkg import x``) cannot be resolved without
+                        # the importing package's context, which static
+                        # analysis lacks. Bind the name to a stub so type
+                        # annotations don't NameError; cross-file decorated
+                        # classes are added separately via add_declared_type.
+                        self._namespace.add_relative_import(
+                            alias.name, alias.asname, node.module, node.level
+                        )
+                    else:
                         self._namespace.add_from_import(
-                            module, alias.name, alias.asname
+                            node.module or "", alias.name, alias.asname
                         )
 
     _NON_DAGGER_FIELD_MODULES = frozenset({"dataclasses", "attrs", "attr", "pydantic"})

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1289,3 +1289,108 @@ class Foo:
     fn = metadata.objects["Foo"].functions[0]
     names = [p.python_name for p in fn.parameters]
     assert names == ["x"]
+
+
+# -- Relative imports --------------------------------------------------------
+
+
+def test_ast_relative_import_module():
+    """``from . import sibling`` must not crash the analyzer."""
+    metadata = _analyze("""
+import dagger
+from . import render
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self) -> str:
+        return "hi"
+""")
+    assert "Foo" in metadata.objects
+    assert [f.python_name for f in metadata.objects["Foo"].functions] == ["hello"]
+
+
+def test_ast_relative_import_from_submodule():
+    """``from .submodule import Name`` must not crash the analyzer."""
+    metadata = _analyze("""
+import dagger
+from .helpers import Helper
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self) -> str:
+        return "hi"
+""")
+    assert "Foo" in metadata.objects
+
+
+def test_ast_relative_import_does_not_resolve_top_level_module():
+    """``from .json import X`` must NOT pick up the stdlib ``json`` module.
+
+    A relative import is unambiguously package-internal; resolving it
+    against ``sys.path`` would silently bind the wrong object and break
+    type analysis in surprising ways.
+    """
+    metadata = _analyze("""
+import dagger
+from .json import dumps
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self) -> str:
+        return "hi"
+""")
+    assert "Foo" in metadata.objects
+
+
+def test_ast_relative_import_parent_package():
+    """``from ..pkg import Name`` (multi-dot) must not crash the analyzer."""
+    metadata = _analyze("""
+import dagger
+from ..siblings import Helper
+from ...root import Other
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self) -> str:
+        return "hi"
+""")
+    assert "Foo" in metadata.objects
+
+
+def test_ast_relative_import_resolves_decorated_class(tmp_path):
+    """A decorated class imported relatively is still discovered cross-file."""
+    pkg = tmp_path / "relpkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "helpers.py").write_text(
+        "import dagger\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Helper:\n"
+        '    name: str = dagger.field(default="h")\n',
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from .helpers import Helper\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo:\n"
+        "    @dagger.function\n"
+        "    def get_helper(self) -> Helper:\n"
+        "        return Helper()\n",
+        encoding="utf-8",
+    )
+
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "helpers.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    assert {"Foo", "Helper"} <= set(metadata.objects)
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.python_name == "get_helper"
+    assert fn.resolved_return_type.name == "Helper"


### PR DESCRIPTION
## Summary

The AST analyzer used by `dagger develop` for the Python SDK didn't handle relative imports correctly:

- `from . import x` raised `ValueError` because `importlib.import_module` was called with an empty module name.
- `from .x import y` (and other dotted relative forms) fell through to `importlib`, where they either errored or silently resolved to the wrong top-level module.

This meant a Dagger module split across multiple files using ordinary Python relative imports could fail to load at codegen time.

## Fix

Detect `ImportFrom.level > 0` in the analyzer and bind the imported names as stubs in the local namespace, without dispatching through `importlib`. Cross-file types decorated with `@object_type` / `@enum_type` are still picked up via `add_declared_type`, so type annotations referencing them continue to resolve correctly.

## Test plan

- [x] New tests in `sdk/python/tests/mod/test_ast_analyzer.py` covering `from . import x`, `from .mod import y`, `from ..pkg import z`, and that relative-imported decorated types still resolve in annotations.
- [ ] CI green on the Python SDK test suite.