### PR TITLE
Disable Python AST Analyzer with Env Var

### DIFF
--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -9,6 +9,7 @@ import typing
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, TypeVar, cast
 
+import anyio
 import cattrs
 import cattrs.gen
 from cattrs.preconf import is_primitive_enum
@@ -18,7 +19,7 @@ from typing_extensions import dataclass_transform, overload
 import dagger
 from dagger import dag
 from dagger.client._core import configure_converter_enum
-from dagger.mod._converter import make_converter
+from dagger.mod._converter import make_converter, to_typedef
 from dagger.mod._exceptions import (
     BadUsageError,
     FunctionError,
@@ -39,7 +40,13 @@ from dagger.mod._resolver import (
     R,
 )
 from dagger.mod._types import APIName, FieldDefinition, FunctionDefinition, PythonName
-from dagger.mod._utils import asyncify, is_annotated
+from dagger.mod._utils import (
+    asyncify,
+    extract_enum_member_doc,
+    get_doc,
+    get_parent_module_doc,
+    is_annotated,
+)
 
 logger = logging.getLogger(__package__)
 
@@ -52,6 +59,15 @@ UP_DEF_KEY: typing.Final[str] = "__dagger_up__"
 MODULE_NAME: typing.Final[str] = os.getenv("DAGGER_MODULE", "")
 MAIN_OBJECT: typing.Final[str] = os.getenv("DAGGER_MAIN_OBJECT", "")
 TYPE_DEF_FILE: typing.Final[str] = os.getenv("DAGGER_MODULE_FILE", "/module.json")
+
+# Escape hatch to fall back to the pre-d3a8152 runtime-reflection
+# registration path, which imports the module and walks live objects
+# instead of static AST analysis. Read at call time so tests can toggle.
+LEGACY_REGISTER_ENV: typing.Final[str] = "DAGGER_PYTHON_SDK_LEGACY"
+
+
+def legacy_register_enabled() -> bool:
+    return os.getenv(LEGACY_REGISTER_ENV, "") != ""
 
 T = TypeVar("T", bound=type)
 
@@ -106,8 +122,25 @@ class Module:
 
         await dag.current_function_call().return_value(dagger.JSON(output))
 
+    async def register(self):
+        """Register the module and its types with the Dagger API.
+
+        Used by the legacy (runtime-reflection) registration path, gated by
+        the DAGGER_PYTHON_SDK_LEGACY env var. The default path uses
+        ``register_with_ast`` in cli.py and never reaches this method.
+        """
+        try:
+            result = await self._typedefs()
+            output = json.dumps(result)
+        except TypeError as e:
+            raise RegistrationError(str(e), e) from e
+        await anyio.Path(TYPE_DEF_FILE).write_text(output)
+
     async def _typedefs(self) -> dagger.ModuleID:
-        """Delegate to AST-based registration, translating RuntimeError."""
+        """Build typedefs via AST or runtime reflection depending on env."""
+        if legacy_register_enabled():
+            return await self._typedefs_legacy()
+
         from dagger.mod._discovery import ast_register
 
         try:
@@ -117,6 +150,154 @@ class Module:
             )
         except RuntimeError as e:
             raise RegistrationError(str(e)) from e
+
+    async def _typedefs_legacy(self) -> dagger.ModuleID:  # noqa: C901, PLR0912, PLR0915
+        if not self._main_name:
+            msg = "Main object name can't be empty"
+            raise ValueError(msg)
+        try:
+            self.get_object(self._main_name)
+        except ObjectNotFoundError as e:
+            msg = (
+                f"Main object with name '{self._main_name}' not found or class not "
+                "decorated with '@dagger.object_type'\n"
+                f"If you believe the module name '{MODULE_NAME}' is incorrectly "
+                "being converted into PascalCase, please file a bug report."
+            )
+            raise ObjectNotFoundError(msg, extra=e.extra) from None
+
+        mod = dag.module()
+
+        # Object types
+        for obj_name, obj_type in self._objects.items():
+            if self.is_main(obj_type):
+                # Only the main object's constructor is needed.
+                # It's the entrypoint to the module.
+                obj_type.get_constructor(self._converter)
+
+                # Module description from main object's parent module
+                if desc := get_parent_module_doc(obj_type.cls):
+                    mod = mod.with_description(desc)
+
+            # Object/interface type
+            type_def = dag.type_def()
+            if obj_type.interface:
+                type_def = type_def.with_interface(
+                    obj_name,
+                    description=get_doc(obj_type.cls),
+                )
+            else:
+                type_def = type_def.with_object(
+                    obj_name,
+                    description=get_doc(obj_type.cls),
+                    deprecated=obj_type.deprecated,
+                )
+
+            # Object fields
+            if obj_type.fields:
+                types = typing.get_type_hints(obj_type.cls)
+
+                for field_name, field in obj_type.fields.items():
+                    ctx = f"type for field '{field.original_name}' in {obj_type}"
+                    type_def = type_def.with_field(
+                        field_name,
+                        to_typedef(types[field.original_name], ctx),
+                        description=get_doc(field.return_type),
+                        deprecated=field.meta.deprecated,
+                    )
+
+            # Object/interface functions
+            for func_name, func in obj_type.functions.items():
+                what = f"function '{func_name}'" if func_name else "constructor"
+
+                func_def = dag.function(
+                    func_name,
+                    to_typedef(
+                        func.return_type,
+                        f"return type for {what} in {obj_type}",
+                    ),
+                )
+
+                if doc := func.doc:
+                    func_def = func_def.with_description(doc)
+
+                if func.cache_policy is not None:
+                    if func.cache_policy == "never":
+                        func_def = func_def.with_cache_policy(
+                            dagger.FunctionCachePolicy.Never,
+                        )
+                    elif func.cache_policy == "session":
+                        func_def = func_def.with_cache_policy(
+                            dagger.FunctionCachePolicy.PerSession,
+                        )
+                    elif func.cache_policy != "":
+                        func_def = func_def.with_cache_policy(
+                            dagger.FunctionCachePolicy.Default,
+                            time_to_live=func.cache_policy,
+                        )
+                if deprecated := func.deprecated:
+                    func_def = func_def.with_deprecated(reason=deprecated)
+                if func.check:
+                    func_def = func_def.with_check()
+                if func.generate:
+                    func_def = func_def.with_generator()
+                if func.service:
+                    func_def = func_def.with_up()
+
+                for param in func.parameters.values():
+                    arg_def = to_typedef(
+                        param.resolved_type,
+                        f"parameter type for '{param.name}' in {what} and {obj_type}",
+                    )
+
+                    if param.is_nullable:
+                        arg_def = arg_def.with_optional(True)
+
+                    func_def = func_def.with_arg(
+                        param.name,
+                        arg_def,
+                        description=param.doc,
+                        default_value=param.default_value,
+                        default_path=param.default_path,
+                        default_address=param.default_address,
+                        ignore=param.ignore,
+                        deprecated=param.deprecated,
+                    )
+
+                type_def = (
+                    type_def.with_constructor(func_def)
+                    if func_name == ""
+                    else type_def.with_function(func_def)
+                )
+
+            # Add object/interface to module
+            mod = (
+                mod.with_interface(type_def)
+                if obj_type.interface
+                else mod.with_object(type_def)
+            )
+
+        # Enum types
+        for name, cls in self._enums.items():
+            enum_def = dag.type_def().with_enum(name, description=get_doc(cls))
+            member_docs = extract_enum_member_doc(cls)
+
+            for member in cls:
+                description = getattr(member, "description", None)
+                meta = member_docs.get(member.name)
+
+                if description is None and meta and meta.description is not None:
+                    description = meta.description
+
+                enum_def = enum_def.with_enum_member(
+                    member.name,
+                    value=str(member.value),
+                    description=description,
+                    deprecated=meta.deprecated if meta else None,
+                )
+            mod = mod.with_enum(enum_def)
+
+        return await mod.id()
 
     async def invoke(self) -> dagger.ModuleID:
         """Invoke a function and return its result.

--- a/sdk/python/src/dagger/mod/cli.py
+++ b/sdk/python/src/dagger/mod/cli.py
@@ -13,7 +13,13 @@ import dagger
 from dagger import telemetry
 from dagger.mod._discovery import IMPORT_PKG, ast_register
 from dagger.mod._exceptions import ModuleError, ModuleLoadError, record_exception
-from dagger.mod._module import MAIN_OBJECT, MODULE_NAME, TYPE_DEF_FILE, Module
+from dagger.mod._module import (
+    MAIN_OBJECT,
+    MODULE_NAME,
+    TYPE_DEF_FILE,
+    Module,
+    legacy_register_enabled,
+)
 
 logger = logging.getLogger(__package__)
 
@@ -37,13 +43,15 @@ async def main(mod: Module | None = None, register: bool = False) -> int | None:
     # should be logged and the traceback shown on the function's stderr output.
     async with await dagger.connect():
         try:
-            if register:
+            if register and not legacy_register_enabled():
                 # Use AST-based registration (doesn't require importing module)
                 return await register_with_ast()
 
-            # For invocation, we need to load the module
+            # For invocation (and legacy registration), we need to load the module
             if mod is None:
                 mod = load_module()
+            if register:
+                return await mod.register()
             return await mod.serve()
         except (ModuleError, dagger.QueryError) as e:
             await record_exception(e)

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1289,3 +1289,33 @@ class Foo:
     fn = metadata.objects["Foo"].functions[0]
     names = [p.python_name for p in fn.parameters]
     assert names == ["x"]
+
+
+# -- Annotated type alias is not followed (DAGGER_PYTHON_SDK_LEGACY escape) -
+
+
+def test_ast_annotated_alias_drops_default_path():
+    """Module-level Annotated aliases lose metadata under AST analysis.
+
+    The runtime-reflection path (gated by DAGGER_PYTHON_SDK_LEGACY) resolves
+    the alias via typing.get_type_hints(..., include_extras=True) and keeps
+    the DefaultPath. The AST parser only inspects the annotation node on the
+    parameter, which is a bare ast.Name, so the metadata is silently dropped.
+    """
+    metadata = _analyze("""
+from typing import Annotated
+import dagger
+from dagger import function, object_type
+
+Source = Annotated[dagger.Directory, dagger.DefaultPath(".")]
+
+@object_type
+class SourceRepro:
+    @function
+    async def grep_dir(self, directory_arg: Source, pattern: str) -> str:
+        return ""
+""", main="SourceRepro")
+    param = metadata.objects["SourceRepro"].functions[0].parameters[0]
+    assert param.python_name == "directory_arg"
+    # Documents the broken behaviour: AST path loses the DefaultPath.
+    assert param.default_path is None

--- a/sdk/python/tests/mod/test_registration.py
+++ b/sdk/python/tests/mod/test_registration.py
@@ -247,3 +247,28 @@ async def test_self_return_type():
     expected = dag.type_def().with_object("Test")
     assert to_typedef(iden.return_type) == expected
     assert to_typedef(seq.return_type) == dag.type_def().with_list_of(expected)
+
+
+def test_annotated_alias_default_path_runtime():
+    """Counterpart to test_ast_annotated_alias_drops_default_path.
+
+    The runtime path resolves the module-level Annotated alias to its
+    underlying Annotated[...] form, so DefaultPath survives. This is the
+    behaviour DAGGER_PYTHON_SDK_LEGACY restores when an AST-incompatible
+    module is encountered.
+    """
+    mod = Module()
+
+    Source = Annotated[dagger.Directory, dagger.DefaultPath(".")]
+
+    @mod.object_type
+    class SourceRepro:
+        @mod.function
+        async def grep_dir(
+            self, directory_arg: Source, pattern: str
+        ) -> str:
+            return ""
+
+    fn = mod.get_object("SourceRepro").functions["grep_dir"]
+    param = fn.parameters["directory_arg"]
+    assert param.default_path == "."


### PR DESCRIPTION
This PR allows us to switch off the new Python module AST analyzer (introduced at commit d3a8152) using an environment variable "DAGGER_PYTHON_SDK_LEGACY". This is a temporary solution to prevent widespread breakage.