### PR TITLE
fix(core): propagate service exits to dependents

### DIFF
--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -349,13 +349,14 @@ func isServiceBindingExitError(err error) bool {
 	return errors.As(err, &svcErr)
 }
 
-// monitorServiceBindings reports the first bound service that exits while an
-// exec is still running and cancels the exec with the service error as the cause.
+// monitorServiceBindings reports the first bound service that exits while a
+// dependent operation is still running. If cancel is set, it is called with the
+// service error as the cause.
 func monitorServiceBindings(
 	ctx context.Context,
 	bindings ServiceBindings,
 	running []*RunningService,
-	cancelExec context.CancelCauseFunc,
+	cancel context.CancelCauseFunc,
 ) (<-chan error, func()) {
 	monitorCtx, stopMonitor := context.WithCancel(ctx)
 	serviceErrCh := make(chan error, 1)
@@ -391,8 +392,8 @@ func monitorServiceBindings(
 			case serviceErrCh <- svcErr:
 			default:
 			}
-			if cancelExec != nil {
-				cancelExec(svcErr)
+			if cancel != nil {
+				cancel(svcErr)
 			}
 		}()
 	}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	ctrdmount "github.com/containerd/containerd/v2/core/mount"
 	containerdfs "github.com/containerd/continuity/fs"
@@ -315,6 +316,96 @@ func execNetMode(opts ContainerExecOpts) (pb.NetMode, error) {
 		return pb.NetMode_HOST, nil
 	}
 	return pb.NetMode_UNSET, nil
+}
+
+type serviceBindingExitError struct {
+	binding ServiceBinding
+	err     error
+}
+
+func (e *serviceBindingExitError) Error() string {
+	if e == nil {
+		return "bound service exited"
+	}
+	name := e.binding.Hostname
+	if name == "" {
+		name = "unknown"
+	}
+	if e.err == nil {
+		return fmt.Sprintf("bound service %s (%s) exited", name, e.binding.Aliases)
+	}
+	return fmt.Sprintf("bound service %s (%s) exited: %v", name, e.binding.Aliases, e.err)
+}
+
+func (e *serviceBindingExitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func isServiceBindingExitError(err error) bool {
+	var svcErr *serviceBindingExitError
+	return errors.As(err, &svcErr)
+}
+
+// monitorServiceBindings reports the first bound service that exits while an
+// exec is still running and cancels the exec with the service error as the cause.
+func monitorServiceBindings(
+	ctx context.Context,
+	bindings ServiceBindings,
+	running []*RunningService,
+	cancelExec context.CancelCauseFunc,
+) (<-chan error, func()) {
+	monitorCtx, stopMonitor := context.WithCancel(ctx)
+	serviceErrCh := make(chan error, 1)
+
+	var wg sync.WaitGroup
+	for i, runningSvc := range running {
+		if runningSvc == nil || runningSvc.Wait == nil {
+			continue
+		}
+
+		binding := ServiceBinding{}
+		if i < len(bindings) {
+			binding = bindings[i]
+		}
+		if binding.Hostname == "" {
+			binding.Hostname = runningSvc.Host
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			err := runningSvc.Wait(monitorCtx)
+			if monitorCtx.Err() != nil {
+				return
+			}
+
+			svcErr := &serviceBindingExitError{
+				binding: binding,
+				err:     err,
+			}
+			select {
+			case serviceErrCh <- svcErr:
+			default:
+			}
+			if cancelExec != nil {
+				cancelExec(svcErr)
+			}
+		}()
+	}
+
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			stopMonitor()
+			wg.Wait()
+			close(serviceErrCh)
+		})
+	}
+	return serviceErrCh, stop
 }
 
 func (container *Container) secretEnvValues(ctx context.Context) ([]string, error) {
@@ -1643,13 +1734,19 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				}
 			}
 
+			// A bound service exiting is the primary failure. Don't turn it into an
+			// ExecError for the command we canceled in response, or the user sees the
+			// command's forced exit code instead of the service failure.
+			serviceBindingExited := isServiceBindingExitError(rerr)
+
 			execMDPresent := execMD != nil
 			execInternal := false
 			hasMetaSpec := metaSpec != nil
 			if execMDPresent {
 				execInternal = execMD.Internal
 			}
-			if engineClient.Interactive &&
+			if !serviceBindingExited &&
+				engineClient.Interactive &&
 				execMDPresent &&
 				!execInternal &&
 				hasMetaSpec {
@@ -1826,15 +1923,17 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				terminalContainerNeedsRelease = false
 			}
 
-			var existingExecErr *ExecError
-			if !errors.As(rerr, &existingExecErr) {
-				execErr, ok, err := execErrorFromMetaRef(ctx, engineClient, causeCtx, rerr, metaSpec, metaRef)
-				if err != nil {
-					rerr = errors.Join(err, rerr)
-					return
-				}
-				if ok {
-					rerr = execErr
+			if !serviceBindingExited {
+				var existingExecErr *ExecError
+				if !errors.As(rerr, &existingExecErr) {
+					execErr, ok, err := execErrorFromMetaRef(ctx, engineClient, causeCtx, rerr, metaSpec, metaRef)
+					if err != nil {
+						rerr = errors.Join(err, rerr)
+						return
+					}
+					if ok {
+						rerr = execErr
+					}
 				}
 			}
 
@@ -1867,11 +1966,22 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		if err != nil {
 			return fmt.Errorf("failed to get services: %w", err)
 		}
-		detach, _, err := svcs.StartBindings(ctx, container.Services)
+		detach, runningSvcs, err := svcs.StartBindings(ctx, container.Services)
 		if err != nil {
 			return err
 		}
 		defer detach()
+
+		execCtx := ctx
+		var cancelExec context.CancelCauseFunc
+		var serviceErrCh <-chan error
+		stopServiceMonitors := func() {}
+		if len(runningSvcs) > 0 {
+			execCtx, cancelExec = context.WithCancelCause(ctx)
+			serviceErrCh, stopServiceMonitors = monitorServiceBindings(ctx, container.Services, runningSvcs, cancelExec)
+			defer cancelExec(nil)
+			defer stopServiceMonitors()
+		}
 
 		var nestedClientMetadata *engine.ClientMetadata
 		if opts.ExperimentalPrivilegedNesting {
@@ -1899,22 +2009,50 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				envContext = env
 			}
 		}
-		execErr := engineClient.Run(
-			ctx,
-			"",
-			rootMount,
-			execMounts,
-			procInfo,
-			nil,
-			causeCtx,
-			execMD,
-			clientMetadata.SessionID,
-			clientMetadata.ClientID,
-			nestedClientMetadata,
-			state.ModuleContext,
-			state.FunctionCall,
-			envContext,
-		)
+
+		execErrCh := make(chan error, 1)
+		go func() {
+			execErrCh <- engineClient.Run(
+				execCtx,
+				"",
+				rootMount,
+				execMounts,
+				procInfo,
+				nil,
+				causeCtx,
+				execMD,
+				clientMetadata.SessionID,
+				clientMetadata.ClientID,
+				nestedClientMetadata,
+				state.ModuleContext,
+				state.FunctionCall,
+				envContext,
+			)
+		}()
+
+		var execErr error
+		select {
+		case execErr = <-execErrCh:
+			if execErr != nil {
+				select {
+				case serviceErr := <-serviceErrCh:
+					if serviceErr != nil {
+						execErr = serviceErr
+					}
+				default:
+				}
+			}
+		case serviceErr := <-serviceErrCh:
+			if serviceErr == nil {
+				serviceErr = fmt.Errorf("bound service exited")
+			}
+			execErr = serviceErr
+			if cancelExec != nil {
+				cancelExec(serviceErr)
+			}
+			<-execErrCh
+		}
+		stopServiceMonitors()
 
 		var invalidateErr error
 		for i, ctrMount := range inputMounts {

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -112,6 +112,82 @@ type Test struct {
 		require.NoError(t, err)
 	})
 
+	t.Run("bound service crash keeps terminal open", func(ctx context.Context, t *testctx.T) {
+		modDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), fmt.Appendf(nil, `package main
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+
+func New(ctx context.Context) *Test {
+	dep := dag.Container().
+		From("%s").
+		WithDefaultArgs([]string{"sh", "-c", "sleep 1; echo dependency crashed >&2; exit 42"}).
+		AsService()
+
+	return &Test{
+		Ctr: dag.Container().
+			From("%s").
+			WithWorkdir("/coolworkdir").
+			WithServiceBinding("dep", dep),
+	}
+}
+
+type Test struct {
+	Ctr *dagger.Container
+}
+`, alpineImage, alpineImage), 0644)
+		require.NoError(t, err)
+
+		_, err = hostDaggerExec(ctx, t, modDir, "init", "--source=.", "--name=test", "--sdk=go")
+		require.NoError(t, err)
+
+		// cache the module load itself so there's less to wait for in the shell invocation below
+		_, err = hostDaggerExec(ctx, t, modDir, "functions")
+		require.NoError(t, err)
+
+		console, err := newTUIConsole(t, 60*time.Second)
+		require.NoError(t, err)
+		defer console.Close()
+
+		tty := console.Tty()
+		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 16})
+		require.NoError(t, err)
+
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "terminal")
+		cmd.Stdin = tty
+		cmd.Stdout = tty
+		cmd.Stderr = tty
+
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		prompt := fmt.Sprintf("/coolworkdir%s $ ", resetSeq)
+
+		_, err = console.ExpectString(prompt)
+		require.NoError(t, err)
+
+		time.Sleep(2 * time.Second)
+
+		_, err = console.SendLine("echo still here")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString("still here\r\n")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString(prompt)
+		require.NoError(t, err)
+
+		_, err = console.SendLine("exit")
+		require.NoError(t, err)
+
+		go console.ExpectEOF()
+
+		err = cmd.Wait()
+		require.NoError(t, err)
+	})
+
 	t.Run("basic", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), fmt.Appendf(nil, `package main

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -1058,6 +1058,34 @@ func (ServiceSuite) TestExecServicesError(ctx context.Context, t *testctx.T) {
 	require.Contains(t, execErr.Stdout, "nope\n")
 }
 
+func (ServiceSuite) TestExecServiceExitShortCircuits(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	srv := c.Container().
+		From(alpineImage).
+		WithDefaultArgs([]string{"sh", "-c", "while [ ! -f /checked ]; do sleep 1; done; sleep 1; echo service crashed >&2; exit 42"}).
+		WithDockerHealthcheck([]string{"touch", "/checked"}, dagger.ContainerWithDockerHealthcheckOpts{
+			Interval:      "1s",
+			Timeout:       "1s",
+			StartInterval: "100ms",
+			Retries:       3,
+		}).
+		AsService()
+
+	host, err := srv.Hostname(ctx)
+	require.NoError(t, err)
+
+	_, err = c.Container().
+		From(alpineImage).
+		WithEnvVariable("CACHEBUST", identity.NewID()).
+		WithServiceBinding("www", srv).
+		WithExec([]string{"sh", "-c", "sleep 10; echo should-not-run"}).
+		Sync(ctx)
+	require.Error(t, err)
+	requireErrOut(t, err, "bound service "+host+" (aliased as www) exited")
+	requireErrOut(t, err, "exit code: 42")
+}
+
 func (ServiceSuite) TestStartExecError(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -1086,6 +1086,38 @@ func (ServiceSuite) TestExecServiceExitShortCircuits(ctx context.Context, t *tes
 	requireErrOut(t, err, "exit code: 42")
 }
 
+func (ServiceSuite) TestServiceDependencyExitShortCircuits(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	dep := c.Container().
+		From(alpineImage).
+		WithDefaultArgs([]string{"sh", "-c", "sleep 1; echo dependency crashed >&2; exit 42"}).
+		AsService()
+
+	depHost, err := dep.Hostname(ctx)
+	require.NoError(t, err)
+
+	srv := c.Container().
+		From(alpineImage).
+		WithServiceBinding("dep", dep).
+		WithDefaultArgs([]string{"sh", "-c", "sleep 30"}).
+		AsService()
+
+	host, err := srv.Hostname(ctx)
+	require.NoError(t, err)
+
+	_, err = c.Container().
+		From(alpineImage).
+		WithEnvVariable("CACHEBUST", identity.NewID()).
+		WithServiceBinding("app", srv).
+		WithExec([]string{"sh", "-c", "sleep 10; echo should-not-run"}).
+		Sync(ctx)
+	require.Error(t, err)
+	requireErrOut(t, err, "bound service "+host+" (aliased as app) exited")
+	requireErrOut(t, err, "bound service "+depHost+" (aliased as dep) exited")
+	requireErrOut(t, err, "exit code: 42")
+}
+
 func (ServiceSuite) TestStartExecError(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/service.go
+++ b/core/service.go
@@ -371,11 +371,22 @@ func (svc *Service) startContainer(
 	if err != nil {
 		return err
 	}
-	detachDeps, _, err := svcs.StartBindings(ctx, ctr.Services)
+	detachDeps, runningDeps, err := svcs.StartBindings(ctx, ctr.Services)
 	if err != nil {
 		return fmt.Errorf("start dependent services: %w", err)
 	}
 	cleanup.Add("detach deps", cleanups.Infallible(detachDeps))
+
+	propagateDependencyExits := len(runningDeps) > 0 &&
+		!opts.DisableDependencyPropagation &&
+		running.Key.Kind != ServiceRuntimeInteractive &&
+		(opts.IO == nil || !opts.IO.Interactive)
+	var dependencyErrCh <-chan error
+	if propagateDependencyExits {
+		var stopDependencyMonitors func()
+		dependencyErrCh, stopDependencyMonitors = monitorServiceBindings(ctx, ctr.Services, runningDeps, nil)
+		cleanup.Add("stop dependent service monitors", cleanups.Infallible(stopDependencyMonitors))
+	}
 
 	var domain string
 	if mod, err := query.ModuleParent(ctx); err == nil && svc.CustomHostname != "" {
@@ -570,6 +581,23 @@ func (svc *Service) startContainer(
 	}
 
 	var stopped atomic.Bool
+	var serviceErrMu sync.Mutex
+	var serviceErr error
+	setServiceErr := func(err error) {
+		if err == nil {
+			return
+		}
+		serviceErrMu.Lock()
+		defer serviceErrMu.Unlock()
+		if serviceErr == nil {
+			serviceErr = err
+		}
+	}
+	getServiceErr := func() error {
+		serviceErrMu.Lock()
+		defer serviceErrMu.Unlock()
+		return serviceErr
+	}
 
 	var exitErr error
 	go func() {
@@ -586,7 +614,9 @@ func (svc *Service) startContainer(
 		var telemetryErr error
 		defer telemetry.EndWithCause(span, &telemetryErr)
 		defer func() {
-			if !stopped.Load() {
+			if err := getServiceErr(); err != nil {
+				telemetryErr = err
+			} else if !stopped.Load() {
 				// we only care about the exit result (likely 137) if we weren't stopped
 				telemetryErr = exitErr
 			}
@@ -615,6 +645,9 @@ func (svc *Service) startContainer(
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-exited:
+			if err := getServiceErr(); err != nil {
+				return err
+			}
 			return exitErr
 		}
 	}
@@ -637,6 +670,17 @@ func (svc *Service) startContainer(
 			slog.Info("service exited in stop", "err", exitErr)
 			return nil
 		}
+	}
+
+	stopDueToDependencyExit := func(depErr error) error {
+		if depErr == nil {
+			depErr = fmt.Errorf("dependent service exited")
+		}
+		setServiceErr(depErr)
+		if err := stopSvc(context.Background(), true); err != nil {
+			return errors.Join(depErr, err)
+		}
+		return depErr
 	}
 
 	execSvc := func(ctx context.Context, cmd []string, env []string, sio *ServiceIO) error {
@@ -668,35 +712,55 @@ func (svc *Service) startContainer(
 		return err
 	}
 
-	select {
-	case err := <-checked:
-		if err != nil {
-			return fmt.Errorf("health check errored: %w", err)
-		}
-
-		running.Host = fullHost
-		running.Ports = ctr.Ports
-		running.Stop = stopSvc
-		running.Wait = waitSvc
-		running.Exec = execSvc
-		running.ContainerID = svcID
-		return nil
-	case <-exited:
-		if exitErr != nil {
-			var gwErr *gwpb.ExitError
-			if errors.As(exitErr, &gwErr) {
-				// Create ExecError with available service information
-				return &ExecError{
-					Err:      telemetry.TrackOrigin(gwErr, span.SpanContext()),
-					Cmd:      meta.Args,
-					ExitCode: int(gwErr.ExitCode),
-					Stdout:   stdoutBuf.String(),
-					Stderr:   stderrBuf.String(),
-				}
+	for {
+		select {
+		case err := <-checked:
+			if err != nil {
+				return fmt.Errorf("health check errored: %w", err)
 			}
-			return exitErr
+
+			running.Host = fullHost
+			running.Ports = ctr.Ports
+			running.Stop = stopSvc
+			running.Wait = waitSvc
+			running.Exec = execSvc
+			running.ContainerID = svcID
+			if dependencyErrCh != nil {
+				go func() {
+					depErr, ok := <-dependencyErrCh
+					if !ok {
+						return
+					}
+					if err := running.waitDependencyPropagationUnsuppressed(context.Background()); err != nil {
+						return
+					}
+					_ = stopDueToDependencyExit(depErr)
+				}()
+			}
+			return nil
+		case depErr, ok := <-dependencyErrCh:
+			if !ok {
+				dependencyErrCh = nil
+				continue
+			}
+			return stopDueToDependencyExit(depErr)
+		case <-exited:
+			if exitErr != nil {
+				var gwErr *gwpb.ExitError
+				if errors.As(exitErr, &gwErr) {
+					// Create ExecError with available service information
+					return &ExecError{
+						Err:      telemetry.TrackOrigin(gwErr, span.SpanContext()),
+						Cmd:      meta.Args,
+						ExitCode: int(gwErr.ExitCode),
+						Stdout:   stdoutBuf.String(),
+						Stderr:   stderrBuf.String(),
+					}
+				}
+				return exitErr
+			}
+			return fmt.Errorf("service exited before healthcheck")
 		}
-		return fmt.Errorf("service exited before healthcheck")
 	}
 }
 

--- a/core/service.go
+++ b/core/service.go
@@ -378,7 +378,6 @@ func (svc *Service) startContainer(
 	cleanup.Add("detach deps", cleanups.Infallible(detachDeps))
 
 	propagateDependencyExits := len(runningDeps) > 0 &&
-		!opts.DisableDependencyPropagation &&
 		running.Key.Kind != ServiceRuntimeInteractive &&
 		(opts.IO == nil || !opts.IO.Interactive)
 	var dependencyErrCh <-chan error
@@ -683,6 +682,33 @@ func (svc *Service) startContainer(
 		return depErr
 	}
 
+	// If a dependency exits while exit propagation is suppressed (e.g. during a
+	// service terminal), remember it and stop this service when suppression lifts.
+	var pendingDependencyErr error
+	var havePendingDependencyErr bool
+	deferDependencyExitIfSuppressed := func(depErr error) bool {
+		if !running.isDependencyExitPropagationSuppressed() {
+			return false
+		}
+		pendingDependencyErr = depErr
+		havePendingDependencyErr = true
+		return true
+	}
+
+	propagateDependencyExitAfterSuppression := func(depErr error, haveDepErr bool, depErrCh <-chan error) {
+		if !haveDepErr {
+			var ok bool
+			depErr, ok = <-depErrCh
+			if !ok {
+				return
+			}
+		}
+		if err := running.waitDependencyExitPropagationUnsuppressed(context.Background()); err != nil {
+			return
+		}
+		_ = stopDueToDependencyExit(depErr)
+	}
+
 	execSvc := func(ctx context.Context, cmd []string, env []string, sio *ServiceIO) error {
 		meta := *meta
 		meta.Args = cmd
@@ -725,21 +751,16 @@ func (svc *Service) startContainer(
 			running.Wait = waitSvc
 			running.Exec = execSvc
 			running.ContainerID = svcID
-			if dependencyErrCh != nil {
-				go func() {
-					depErr, ok := <-dependencyErrCh
-					if !ok {
-						return
-					}
-					if err := running.waitDependencyPropagationUnsuppressed(context.Background()); err != nil {
-						return
-					}
-					_ = stopDueToDependencyExit(depErr)
-				}()
+			if havePendingDependencyErr || dependencyErrCh != nil {
+				go propagateDependencyExitAfterSuppression(pendingDependencyErr, havePendingDependencyErr, dependencyErrCh)
 			}
 			return nil
 		case depErr, ok := <-dependencyErrCh:
 			if !ok {
+				dependencyErrCh = nil
+				continue
+			}
+			if deferDependencyExitIfSuppressed(depErr) {
 				dependencyErrCh = nil
 				continue
 			}

--- a/core/services.go
+++ b/core/services.go
@@ -89,9 +89,9 @@ type RunningService struct {
 
 	workspaceMu sync.Mutex
 
-	dependencyPropagationMu         sync.Mutex
-	dependencyPropagationSuppressed int
-	dependencyPropagationChanged    chan struct{}
+	dependencyExitPropagationMu         sync.Mutex
+	dependencyExitPropagationSuppressed int
+	dependencyExitPropagationChanged    chan struct{}
 
 	manager *Services
 
@@ -181,12 +181,6 @@ type ServiceStartOpts struct {
 	ClientSpecific bool
 	IO             *ServiceIO
 
-	// DisableDependencyPropagation prevents a container-backed service from being
-	// stopped automatically when one of its own service bindings exits. This is
-	// used for interactive terminals so a crashing dependency doesn't kill the
-	// user's shell.
-	DisableDependencyPropagation bool
-
 	LogTargetCallDigest digest.Digest
 }
 
@@ -225,12 +219,23 @@ func (ss *Services) StartWithOpts(
 	svc Startable,
 	opts ServiceStartOpts,
 ) (*RunningService, error) {
+	running, _, err := ss.startWithOpts(ctx, dig, svc, opts, false)
+	return running, err
+}
+
+func (ss *Services) startWithOpts(
+	ctx context.Context,
+	dig digest.Digest,
+	svc Startable,
+	opts ServiceStartOpts,
+	suppressDependencyExitPropagation bool,
+) (_ *RunningService, release func(), _ error) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if dig == "" {
-		return nil, fmt.Errorf("service digest is empty")
+		return nil, nil, fmt.Errorf("service digest is empty")
 	}
 	key := ServiceKey{
 		Digest:    dig,
@@ -241,8 +246,7 @@ func (ss *Services) StartWithOpts(
 		key.ClientID = clientMetadata.ClientID
 	}
 
-	running, _, err := ss.startWithKey(ctx, key, svc, opts)
-	return running, err
+	return ss.startWithKey(ctx, key, svc, opts, suppressDependencyExitPropagation)
 }
 
 func (ss *Services) StartResultWithIO(
@@ -262,21 +266,40 @@ func (ss *Services) StartResultWithOpts(
 	svc dagql.ObjectResult[*Service],
 	opts ServiceStartOpts,
 ) (*RunningService, error) {
+	running, _, err := ss.startResultWithOpts(ctx, svc, opts, false)
+	return running, err
+}
+
+// StartResultWithDependencyExitPropagationSuppressed starts a shared service while
+// deferring dependency-exit propagation until the returned release is called.
+func (ss *Services) StartResultWithDependencyExitPropagationSuppressed(
+	ctx context.Context,
+	svc dagql.ObjectResult[*Service],
+) (_ *RunningService, release func(), _ error) {
+	return ss.startResultWithOpts(ctx, svc, ServiceStartOpts{}, true)
+}
+
+func (ss *Services) startResultWithOpts(
+	ctx context.Context,
+	svc dagql.ObjectResult[*Service],
+	opts ServiceStartOpts,
+	suppressDependencyExitPropagation bool,
+) (_ *RunningService, release func(), _ error) {
 	if svc.Self() == nil {
-		return nil, fmt.Errorf("service result is nil")
+		return nil, nil, fmt.Errorf("service result is nil")
 	}
 	serviceDig, err := svc.ContentPreferredDigest(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("service digest: %w", err)
+		return nil, nil, fmt.Errorf("service digest: %w", err)
 	}
 	if opts.LogTargetCallDigest == "" {
 		callDig, err := svc.RecipeDigest(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("service recipe digest: %w", err)
+			return nil, nil, fmt.Errorf("service recipe digest: %w", err)
 		}
 		opts.LogTargetCallDigest = callDig
 	}
-	return ss.StartWithOpts(ctx, serviceDig, svc.Self(), opts)
+	return ss.startWithOpts(ctx, serviceDig, svc.Self(), opts, suppressDependencyExitPropagation)
 }
 
 func (ss *Services) StartInteractive(
@@ -302,7 +325,7 @@ func (ss *Services) StartInteractive(
 	return ss.startWithKey(ctx, key, svc, ServiceStartOpts{
 		ClientSpecific: true,
 		IO:             sio,
-	})
+	}, false)
 }
 
 // StartBindings starts each of the bound services in parallel and returns a
@@ -482,48 +505,58 @@ func (ss *Services) Detach(ctx context.Context, svc *RunningService) {
 	go ss.stopGraceful(context.WithoutCancel(ctx), running, TerminateGracePeriod)
 }
 
-func (svc *RunningService) suppressDependencyPropagation() func() {
+func (svc *RunningService) suppressDependencyExitPropagation() func() {
 	if svc == nil {
 		return func() {}
 	}
 
-	svc.dependencyPropagationMu.Lock()
-	svc.dependencyPropagationSuppressed++
-	if svc.dependencyPropagationChanged == nil {
-		svc.dependencyPropagationChanged = make(chan struct{})
+	svc.dependencyExitPropagationMu.Lock()
+	svc.dependencyExitPropagationSuppressed++
+	if svc.dependencyExitPropagationChanged == nil {
+		svc.dependencyExitPropagationChanged = make(chan struct{})
 	}
-	svc.dependencyPropagationMu.Unlock()
+	svc.dependencyExitPropagationMu.Unlock()
 
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			svc.dependencyPropagationMu.Lock()
-			defer svc.dependencyPropagationMu.Unlock()
-			if svc.dependencyPropagationSuppressed > 0 {
-				svc.dependencyPropagationSuppressed--
+			svc.dependencyExitPropagationMu.Lock()
+			defer svc.dependencyExitPropagationMu.Unlock()
+			if svc.dependencyExitPropagationSuppressed > 0 {
+				svc.dependencyExitPropagationSuppressed--
 			}
-			if svc.dependencyPropagationChanged == nil {
-				svc.dependencyPropagationChanged = make(chan struct{})
+			if svc.dependencyExitPropagationChanged == nil {
+				svc.dependencyExitPropagationChanged = make(chan struct{})
 			}
-			close(svc.dependencyPropagationChanged)
-			svc.dependencyPropagationChanged = make(chan struct{})
+			close(svc.dependencyExitPropagationChanged)
+			svc.dependencyExitPropagationChanged = make(chan struct{})
 		})
 	}
 }
 
-func (svc *RunningService) waitDependencyPropagationUnsuppressed(ctx context.Context) error {
+func (svc *RunningService) isDependencyExitPropagationSuppressed() bool {
+	if svc == nil {
+		return false
+	}
+
+	svc.dependencyExitPropagationMu.Lock()
+	defer svc.dependencyExitPropagationMu.Unlock()
+	return svc.dependencyExitPropagationSuppressed > 0
+}
+
+func (svc *RunningService) waitDependencyExitPropagationUnsuppressed(ctx context.Context) error {
 	if svc == nil {
 		return nil
 	}
 
 	for {
-		svc.dependencyPropagationMu.Lock()
-		suppressed := svc.dependencyPropagationSuppressed > 0
-		if svc.dependencyPropagationChanged == nil {
-			svc.dependencyPropagationChanged = make(chan struct{})
+		svc.dependencyExitPropagationMu.Lock()
+		suppressed := svc.dependencyExitPropagationSuppressed > 0
+		if svc.dependencyExitPropagationChanged == nil {
+			svc.dependencyExitPropagationChanged = make(chan struct{})
 		}
-		changed := svc.dependencyPropagationChanged
-		svc.dependencyPropagationMu.Unlock()
+		changed := svc.dependencyExitPropagationChanged
+		svc.dependencyExitPropagationMu.Unlock()
 
 		if !suppressed {
 			return nil
@@ -640,7 +673,24 @@ func (ss *Services) startWithKey(
 	key ServiceKey,
 	svc Startable,
 	opts ServiceStartOpts,
+	suppressDependencyExitPropagation bool,
 ) (_ *RunningService, release func(), err error) {
+	var suppressedRunning *RunningService
+	resumeDependencyExitPropagation := func() {}
+	suppress := func(running *RunningService) {
+		if !suppressDependencyExitPropagation || running == nil || suppressedRunning == running {
+			return
+		}
+		resumeDependencyExitPropagation()
+		suppressedRunning = running
+		resumeDependencyExitPropagation = running.suppressDependencyExitPropagation()
+	}
+	releaseSuppression := func() {
+		resumeDependencyExitPropagation()
+		resumeDependencyExitPropagation = func() {}
+		suppressedRunning = nil
+	}
+
 	for {
 		ss.l.Lock()
 		starting, isStarting := ss.starting[key]
@@ -649,17 +699,26 @@ func (ss *Services) startWithKey(
 		switch {
 		case isRunning && isStopping:
 			ss.l.Unlock()
+			if suppressedRunning == running {
+				releaseSuppression()
+			}
 			if running.Wait != nil {
 				_ = running.Wait(ctx)
 			}
 		case isRunning:
 			ss.bindings[key]++
+			suppress(running)
 			ss.l.Unlock()
-			return running, func() { ss.Detach(ctx, running) }, nil
+			return running, func() {
+				releaseSuppression()
+				ss.Detach(ctx, running)
+			}, nil
 		case isStarting:
+			suppress(starting.running)
 			ss.l.Unlock()
 			select {
 			case <-ctx.Done():
+				releaseSuppression()
 				return nil, nil, context.Cause(ctx)
 			case <-starting.done:
 			}
@@ -668,6 +727,7 @@ func (ss *Services) startWithKey(
 				Key:     key,
 				manager: ss,
 			}
+			suppress(running)
 			svcCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 			start := &startingService{
 				running: running,
@@ -682,6 +742,7 @@ func (ss *Services) startWithKey(
 
 			if err := svc.Start(svcCtx, running, key.Digest, opts); err != nil {
 				start.err = err
+				releaseSuppression()
 				_ = running.releaseTrackedRefsOnce(context.WithoutCancel(ctx))
 				ss.l.Lock()
 				delete(ss.starting, key)
@@ -692,6 +753,7 @@ func (ss *Services) startWithKey(
 			if running.Wait == nil {
 				err := fmt.Errorf("service %s started without Wait callback", network.HostHash(key.Digest))
 				start.err = err
+				releaseSuppression()
 				_ = running.stopFromManager(context.WithoutCancel(ctx), true)
 				ss.l.Lock()
 				delete(ss.starting, key)
@@ -704,6 +766,7 @@ func (ss *Services) startWithKey(
 			delete(ss.starting, key)
 			if context.Cause(svcCtx) != nil {
 				ss.l.Unlock()
+				releaseSuppression()
 				_ = running.stopFromManager(context.WithoutCancel(ctx), true)
 				return nil, nil, context.Cause(svcCtx)
 			}
@@ -719,7 +782,10 @@ func (ss *Services) startWithKey(
 				ss.handleExit(running, running.Wait(context.Background()))
 			}()
 
-			return running, func() { ss.Detach(ctx, running) }, nil
+			return running, func() {
+				releaseSuppression()
+				ss.Detach(ctx, running)
+			}, nil
 		}
 	}
 }

--- a/core/services.go
+++ b/core/services.go
@@ -89,6 +89,10 @@ type RunningService struct {
 
 	workspaceMu sync.Mutex
 
+	dependencyPropagationMu         sync.Mutex
+	dependencyPropagationSuppressed int
+	dependencyPropagationChanged    chan struct{}
+
 	manager *Services
 
 	releaseOnce sync.Once
@@ -174,8 +178,15 @@ type Startable interface {
 }
 
 type ServiceStartOpts struct {
-	ClientSpecific      bool
-	IO                  *ServiceIO
+	ClientSpecific bool
+	IO             *ServiceIO
+
+	// DisableDependencyPropagation prevents a container-backed service from being
+	// stopped automatically when one of its own service bindings exits. This is
+	// used for interactive terminals so a crashing dependency doesn't kill the
+	// user's shell.
+	DisableDependencyPropagation bool
+
 	LogTargetCallDigest digest.Digest
 }
 
@@ -469,6 +480,61 @@ func (ss *Services) Detach(ctx context.Context, svc *RunningService) {
 
 	// we should avoid blocking, and return immediately
 	go ss.stopGraceful(context.WithoutCancel(ctx), running, TerminateGracePeriod)
+}
+
+func (svc *RunningService) suppressDependencyPropagation() func() {
+	if svc == nil {
+		return func() {}
+	}
+
+	svc.dependencyPropagationMu.Lock()
+	svc.dependencyPropagationSuppressed++
+	if svc.dependencyPropagationChanged == nil {
+		svc.dependencyPropagationChanged = make(chan struct{})
+	}
+	svc.dependencyPropagationMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			svc.dependencyPropagationMu.Lock()
+			defer svc.dependencyPropagationMu.Unlock()
+			if svc.dependencyPropagationSuppressed > 0 {
+				svc.dependencyPropagationSuppressed--
+			}
+			if svc.dependencyPropagationChanged == nil {
+				svc.dependencyPropagationChanged = make(chan struct{})
+			}
+			close(svc.dependencyPropagationChanged)
+			svc.dependencyPropagationChanged = make(chan struct{})
+		})
+	}
+}
+
+func (svc *RunningService) waitDependencyPropagationUnsuppressed(ctx context.Context) error {
+	if svc == nil {
+		return nil
+	}
+
+	for {
+		svc.dependencyPropagationMu.Lock()
+		suppressed := svc.dependencyPropagationSuppressed > 0
+		if svc.dependencyPropagationChanged == nil {
+			svc.dependencyPropagationChanged = make(chan struct{})
+		}
+		changed := svc.dependencyPropagationChanged
+		svc.dependencyPropagationMu.Unlock()
+
+		if !suppressed {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-changed:
+		}
+	}
 }
 
 func (svc *RunningService) TrackRef(ref bkcache.Ref) {

--- a/core/services_internal_test.go
+++ b/core/services_internal_test.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+type dependencyExitPropagationStartable struct {
+	depExited chan struct{}
+	stopped   chan struct{}
+	stopOnce  sync.Once
+}
+
+func newDependencyExitPropagationStartable() *dependencyExitPropagationStartable {
+	return &dependencyExitPropagationStartable{
+		depExited: make(chan struct{}),
+		stopped:   make(chan struct{}),
+	}
+}
+
+func (s *dependencyExitPropagationStartable) Start(_ context.Context, running *RunningService, _ digest.Digest, _ ServiceStartOpts) error {
+	depErr := errors.New("dependency exited")
+
+	select {
+	case <-s.depExited:
+		if !running.isDependencyExitPropagationSuppressed() {
+			return depErr
+		}
+	default:
+	}
+
+	running.Stop = func(context.Context, bool) error {
+		s.stopOnce.Do(func() {
+			close(s.stopped)
+		})
+		return nil
+	}
+	running.Wait = func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-s.stopped:
+			return depErr
+		}
+	}
+
+	go func() {
+		<-s.depExited
+		if err := running.waitDependencyExitPropagationUnsuppressed(context.Background()); err != nil {
+			return
+		}
+		_ = running.Stop(context.Background(), true)
+	}()
+
+	return nil
+}
+
+func TestStartWithKeySuppressesDependencyExitPropagationUntilRelease(t *testing.T) {
+	services := NewServices()
+	svc := newDependencyExitPropagationStartable()
+	close(svc.depExited)
+
+	key := ServiceKey{
+		Digest:    digest.FromString("suppressed-dependency"),
+		SessionID: "test-session",
+		Kind:      ServiceRuntimeShared,
+	}
+	running, release, err := services.startWithKey(context.Background(), key, svc, ServiceStartOpts{}, true)
+	require.NoError(t, err)
+	require.NotNil(t, running)
+
+	otherRunning, otherRelease, err := services.startWithKey(context.Background(), key, svc, ServiceStartOpts{}, false)
+	require.NoError(t, err)
+	defer otherRelease()
+	require.Same(t, running, otherRunning)
+
+	select {
+	case <-svc.stopped:
+		t.Fatal("dependency-exit propagation was not suppressed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Releasing the suppressed start should resume dependency-exit propagation. The
+	// other binding is still attached, so a plain detach would not stop the service.
+	release()
+	require.Eventually(t, func() bool {
+		select {
+		case <-svc.stopped:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -375,16 +375,18 @@ func (*Service) Terminal(
 	if err != nil {
 		return err
 	}
-	detach, runnings, err := svcs.StartBindings(ctx, ServiceBindings{{Service: svc}})
+	running, err := svcs.StartResultWithOpts(ctx, svc, ServiceStartOpts{
+		DisableDependencyPropagation: true,
+	})
 	if err != nil {
 		return err
 	}
-	defer detach()
-
-	running := runnings[0]
+	defer svcs.Detach(ctx, running)
 	if running.Exec == nil {
 		return fmt.Errorf("service %s does not support terminal", svcID.Path())
 	}
+	resumeDependencyPropagation := running.suppressDependencyPropagation()
+	defer resumeDependencyPropagation()
 	return running.Exec(ctx, args.Cmd, env, &ServiceIO{
 		Stdin:       term.Stdin,
 		Stdout:      term.Stdout,

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -375,18 +375,14 @@ func (*Service) Terminal(
 	if err != nil {
 		return err
 	}
-	running, err := svcs.StartResultWithOpts(ctx, svc, ServiceStartOpts{
-		DisableDependencyPropagation: true,
-	})
+	running, release, err := svcs.StartResultWithDependencyExitPropagationSuppressed(ctx, svc)
 	if err != nil {
 		return err
 	}
-	defer svcs.Detach(ctx, running)
+	defer release()
 	if running.Exec == nil {
 		return fmt.Errorf("service %s does not support terminal", svcID.Path())
 	}
-	resumeDependencyPropagation := running.suppressDependencyPropagation()
-	defer resumeDependencyPropagation()
 	return running.Exec(ctx, args.Cmd, env, &ServiceIO{
 		Stdin:       term.Stdin,
 		Stdout:      term.Stdout,


### PR DESCRIPTION
## Summary

- cancel `withExec` calls when a bound service exits so the service failure is surfaced
- propagate bound-service exits through container-backed services
- suppress service-exit propagation for interactive terminals so the user's shell stays open

## Tests

- `dagger call --progress=dots engine-dev test --run 'TestServices/TestServiceDependencyExitShortCircuits' --pkg ./core/integration/`
- `dagger call --progress=dots engine-dev test --run 'TestModule/TestDaggerTerminal/bound service crash keeps terminal open' --pkg ./core/integration/`
