### PR TITLE
Fix Dagger repository link in examples.mdx

### DIFF
--- a/docs/current_docs/introduction/examples.mdx
+++ b/docs/current_docs/introduction/examples.mdx
@@ -22,9 +22,7 @@ This page showcases real-world examples of Dagger in action, with a focus on wor
 
 ## Monorepos
 
-- [Dagger](https://github.com/openmeterio/openmeter/tree/main/.dagger): Dagger's own CI pipelines, used to test, lint, build, and release multiple assets, includings the Dagger CLI, Dagger SDKs, and Dagger documentation.
-
-- [OpenMeter](https://github.com/openmeterio/openmeter/tree/main/.dagger): A set of pipelines to test, lint, scan, publish and release multiple assets, includings SDKs, binaries, Helm charts and container images
+- [Dagger](https://github.com/dagger/dagger/tree/main/.dagger): Dagger's own CI pipelines, used to test, lint, build, and release multiple assets, includings the Dagger CLI, Dagger SDKs, and Dagger documentation.
 
 ## Agents and agentic CI
 


### PR DESCRIPTION
The Dagger example linked also linked to OpenMeter, now it points to the correct repo.

Also removed OpenMeter from the list of examples as they no longer use Dagger, could alternatively link to an older revision of OpenMeter.