### PR TITLE
Fix nested client session race

### DIFF
--- a/auth/registry.go
+++ b/auth/registry.go
@@ -20,11 +20,10 @@ const defaultDockerDomain = "docker.io"
 // RegistryAuthProvider is a custom auth provider for image's registry
 // authentication from dynamic user provided secrets.
 // Adapted from: https://github.com/dagger/dagger/blob/v0.2.36/solver/registryauth.go
-// and merge with Buildkit DockerAuthProvider from
+// and merged with the Docker auth provider from
 // https://github.com/dagger/dagger/internal/buildkit/blob/master/session/auth/authprovider/authprovider.go#L42
 //
-// RegistryAuthProvider implements session.Attachable to be used by Buildkit as
-// credential provider.
+// RegistryAuthProvider registers as a credential provider.
 // It also implements auth.AuthServer to merge dockerAuthProvider capabilities
 // with in memory storage.
 type RegistryAuthProvider struct {

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -17,7 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"golang.org/x/sys/unix"
 
 	"github.com/dagger/dagger/engine/client"
@@ -270,7 +269,7 @@ func mainSession() error {
 		return fmt.Errorf("failed to connect to session server: %w", err)
 	}
 
-	attachables := []bksession.Attachable{
+	attachables := []client.SessionAttachable{
 		// secrets
 		secretprovider.NewSecretProvider(),
 		// sockets
@@ -287,7 +286,7 @@ func mainSession() error {
 	}
 	attachables = append(attachables, filesyncer.AsSource(), filesyncer.AsTarget())
 
-	sessionSrv, err := client.ConnectBuildkitSession(ctx, conn, http.Header{}, attachables...)
+	sessionSrv, err := client.ConnectSessionAttachables(ctx, conn, http.Header{}, attachables...)
 	if err != nil {
 		return err
 	}

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -14,7 +14,6 @@ import (
 	bkconfig "github.com/dagger/dagger/engine/snapshots/config"
 	snapshot "github.com/dagger/dagger/engine/snapshots/snapshotter"
 	"github.com/dagger/dagger/internal/buildkit/client"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -157,14 +156,6 @@ func (*cacheVolumeTestImmutableRef) ExportChain(context.Context, bkconfig.RefCon
 
 func (*cacheVolumeTestImmutableRef) Finalize(context.Context) error {
 	panic("unexpected Finalize call")
-}
-
-func (*cacheVolumeTestImmutableRef) Extract(context.Context, bksession.Group) error {
-	panic("unexpected Extract call")
-}
-
-func (*cacheVolumeTestImmutableRef) FileList(context.Context, bksession.Group) ([]string, error) {
-	panic("unexpected FileList call")
 }
 
 func (*cacheVolumeTestImmutableRef) GetDescription() string {

--- a/core/query.go
+++ b/core/query.go
@@ -43,7 +43,7 @@ var (
 // APIs from the server+session+client that are needed by core APIs
 type Server interface {
 	// Handle an HTTP request from a nested Dagger client.
-	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
+	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
 
 	// Stitch in the given module to the list being served to the current client
 	ServeModule(ctx context.Context, mod dagql.ObjectResult[*Module], includeDependencies bool, entrypoint bool) error

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -86,7 +86,7 @@ func (s *currentTypeDefsTestServer) MuxEndpoint(context.Context, string, http.Ha
 	return nil
 }
 
-func (s *currentTypeDefsTestServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
+func (s *currentTypeDefsTestServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
 }
 
 func (s *currentTypeDefsTestServer) Auth(context.Context) (*auth.RegistryAuthProvider, error) {

--- a/core/sdk/dang_helpers.go
+++ b/core/sdk/dang_helpers.go
@@ -30,6 +30,7 @@ func (r *DangRuntime) eval(
 	schemaFile dagql.Result[*core.File],
 	nestedClientMetadata *engine.ClientMetadata,
 	callerClientID string,
+	hostServiceProxyToCaller bool,
 	fnCall *core.FunctionCall,
 	moduleContext dagql.ObjectResult[*core.Module],
 	envContext dagql.ObjectResult[*core.Env],
@@ -44,7 +45,7 @@ func (r *DangRuntime) eval(
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			telemetry.Propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
-			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, moduleContext, fnCall, envContext)
+			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, moduleContext, fnCall, envContext)
 		}),
 	}
 	defer func() {

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -119,7 +119,7 @@ func (r *DangRuntime) Call(
 	if err != nil {
 		return nil, fmt.Errorf("get schema introspection: %w", err)
 	}
-	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, fnCall, moduleContext, envContext)
+	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, fnCall, moduleContext, envContext)
 	if err != nil {
 		return nil, err
 	}

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -49,7 +49,7 @@ type mockServer struct {
 	clientMetadata *engine.ClientMetadata
 }
 
-func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
+func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
 }
 
 func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*Module], includeDependencies bool, entrypoint bool) error {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/session/filesync"
 	"github.com/dagger/dagger/internal/buildkit/session/secrets"
 	"github.com/dagger/dagger/internal/buildkit/session/sshforward"
-	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
 	"github.com/docker/cli/cli/config"
 	"github.com/google/uuid"
 	"github.com/vito/go-sse/sse"
@@ -45,6 +44,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"dagger.io/dagger"
@@ -742,12 +742,7 @@ func ConnectSessionAttachables(
 }
 
 func NewSessionAttachablesServer(ctx context.Context, conn net.Conn, attachables ...SessionAttachable) *SessionAttachablesServer {
-	sessionSrvOpts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
-		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
-	}
-
-	srv := grpc.NewServer(sessionSrvOpts...)
+	srv := grpc.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, health.NewServer())
 	for _, attachable := range attachables {
 		attachable.Register(srv)
@@ -1243,7 +1238,7 @@ func (c *Client) serveHijackedHTTP(ctx context.Context, cancel context.CancelCau
 		defer serverConn.Close()
 		defer clientConn.Close()
 		_, err := io.Copy(serverConn, clientConn)
-		if errors.Is(err, io.EOF) || grpcerrors.Code(err) == codes.Canceled {
+		if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
 			err = nil
 		}
 		if err != nil {
@@ -1255,7 +1250,7 @@ func (c *Client) serveHijackedHTTP(ctx context.Context, cancel context.CancelCau
 		defer serverConn.Close()
 		defer clientConn.Close()
 		_, err := io.Copy(clientConn, serverConn)
-		if errors.Is(err, io.EOF) || grpcerrors.Code(err) == codes.Canceled {
+		if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
 			err = nil
 		}
 		if err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -23,7 +23,6 @@ import (
 	controlapi "github.com/dagger/dagger/internal/buildkit/api/services/control"
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
 	"github.com/dagger/dagger/internal/buildkit/identity"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	bkauth "github.com/dagger/dagger/internal/buildkit/session/auth"
 	"github.com/dagger/dagger/internal/buildkit/session/auth/authprovider"
 	"github.com/dagger/dagger/internal/buildkit/session/filesync"
@@ -68,6 +67,10 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
+
+type SessionAttachable interface {
+	Register(*grpc.Server)
+}
 
 const (
 	// cache configs that should be applied to be import and export
@@ -162,7 +165,7 @@ type Client struct {
 	bkVersion  string
 	bkName     string
 	numCPU     int
-	sessionSrv *BuildkitSessionServer
+	sessionSrv *SessionAttachablesServer
 
 	// A client for the dagger API that is directly hooked up to this engine client.
 	// Currently used for the dagger CLI so it can avoid making a subprocess of itself...
@@ -550,7 +553,7 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 	clientMetadata := c.clientMetadata()
 	c.internalCtx = engine.ContextWithClientMetadata(c.internalCtx, &clientMetadata)
 
-	attachables := []bksession.Attachable{
+	attachables := []SessionAttachable{
 		// sockets
 		SocketProvider{EnableHostNetworkAccess: true},
 		// secrets
@@ -598,13 +601,13 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 		}
 	}()
 
-	c.sessionSrv, err = ConnectBuildkitSession(ctx,
+	c.sessionSrv, err = ConnectSessionAttachables(ctx,
 		sessionConn,
 		c.AppendHTTPRequestHeaders(http.Header{}),
 		attachables...,
 	)
 	if err != nil {
-		return fmt.Errorf("connect buildkit session: %w", err)
+		return fmt.Errorf("connect session attachables: %w", err)
 	}
 
 	c.eg.Go(func() error {
@@ -633,7 +636,7 @@ func (c *Client) startE2ESession(ctx context.Context, callerSessionConn *grpc.Cl
 	c.internalCtx = engine.ContextWithClientMetadata(c.internalCtx, &clientMetadata)
 
 	// session attachables that proxy back to the original caller's session
-	attachables := []bksession.Attachable{
+	attachables := []SessionAttachable{
 		FilesyncSourceProxy{
 			Client: filesync.NewFileSyncClient(callerSessionConn),
 		},
@@ -661,13 +664,13 @@ func (c *Client) startE2ESession(ctx context.Context, callerSessionConn *grpc.Cl
 		}
 	}()
 
-	c.sessionSrv, err = ConnectBuildkitSession(ctx,
+	c.sessionSrv, err = ConnectSessionAttachables(ctx,
 		sessionConn,
 		c.AppendHTTPRequestHeaders(http.Header{}),
 		attachables...,
 	)
 	if err != nil {
-		return fmt.Errorf("connect buildkit session: %w", err)
+		return fmt.Errorf("connect session attachables: %w", err)
 	}
 
 	c.eg.Go(func() error {
@@ -687,13 +690,13 @@ func (c *Client) startE2ESession(ctx context.Context, callerSessionConn *grpc.Cl
 	return nil
 }
 
-func ConnectBuildkitSession(
+func ConnectSessionAttachables(
 	ctx context.Context,
 	conn net.Conn,
 	headers http.Header,
-	attachables ...bksession.Attachable,
-) (*BuildkitSessionServer, error) {
-	sessionSrv := NewBuildkitSessionServer(ctx, conn, attachables...)
+	attachables ...SessionAttachable,
+) (*SessionAttachablesServer, error) {
+	sessionSrv := NewSessionAttachablesServer(ctx, conn, attachables...)
 	for _, methodURL := range sessionSrv.MethodURLs {
 		headers.Add(engine.SessionMethodNameMetaKey, methodURL)
 	}
@@ -738,7 +741,7 @@ func ConnectBuildkitSession(
 	return sessionSrv, nil
 }
 
-func NewBuildkitSessionServer(ctx context.Context, conn net.Conn, attachables ...bksession.Attachable) *BuildkitSessionServer {
+func NewSessionAttachablesServer(ctx context.Context, conn net.Conn, attachables ...SessionAttachable) *SessionAttachablesServer {
 	sessionSrvOpts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
 		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
@@ -753,11 +756,11 @@ func NewBuildkitSessionServer(ctx context.Context, conn net.Conn, attachables ..
 	var methodURLs []string
 	for name, svc := range srv.GetServiceInfo() {
 		for _, method := range svc.Methods {
-			methodURLs = append(methodURLs, bksession.MethodURL(name, method.Name))
+			methodURLs = append(methodURLs, sessionMethodURL(name, method.Name))
 		}
 	}
 
-	return &BuildkitSessionServer{
+	return &SessionAttachablesServer{
 		Server:      srv,
 		Attachables: attachables,
 		MethodURLs:  methodURLs,
@@ -765,14 +768,18 @@ func NewBuildkitSessionServer(ctx context.Context, conn net.Conn, attachables ..
 	}
 }
 
-type BuildkitSessionServer struct {
+func sessionMethodURL(service, method string) string {
+	return "/" + service + "/" + method
+}
+
+type SessionAttachablesServer struct {
 	*grpc.Server
 	MethodURLs  []string
 	Conn        net.Conn
-	Attachables []bksession.Attachable
+	Attachables []SessionAttachable
 }
 
-func (srv *BuildkitSessionServer) Run(ctx context.Context) {
+func (srv *SessionAttachablesServer) Run(ctx context.Context) {
 	defer srv.Conn.Close()
 	defer srv.Stop()
 

--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -28,7 +28,6 @@ import (
 	snapshot "github.com/dagger/dagger/engine/snapshots/snapshotter"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
 	bkgw "github.com/dagger/dagger/internal/buildkit/frontend/gateway/client"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/entitlements"
@@ -48,6 +47,11 @@ import (
 	"github.com/dagger/dagger/engine/session/store"
 	"github.com/dagger/dagger/engine/session/terminal"
 )
+
+type SessionCaller interface {
+	Conn() *grpc.ClientConn
+	Supports(method string) bool
+}
 
 // Opts combines server-scoped runtime dependencies with per-client session plumbing.
 // Server-scoped fields are initialized once with NewOpts and shallow-copied for each client.
@@ -77,11 +81,10 @@ type Opts struct {
 	HostMntNS  *os.File
 	CleanMntNS *os.File
 
-	SessionManager       *bksession.Manager
 	Dialer               *net.Dialer
-	GetClientCaller      func(string) (bksession.Caller, error)
-	GetHostServiceCaller func(string) (bksession.Caller, error)
-	GetMainClientCaller  func() (bksession.Caller, error)
+	GetClientCaller      func(context.Context, string) (SessionCaller, error)
+	GetHostServiceCaller func(context.Context, string) (SessionCaller, error)
+	GetMainClientCaller  func(context.Context) (SessionCaller, error)
 	GetRegistryResolver  func(context.Context) (*serverresolver.Resolver, error)
 
 	Interactive        bool
@@ -216,7 +219,7 @@ func RunInNetNS[T any](
 	return runInNetNS(ctx, runState, fn)
 }
 
-func (c *Client) GetSessionCaller(ctx context.Context, wait bool) (_ bksession.Caller, rerr error) {
+func (c *Client) GetSessionCaller(ctx context.Context) (_ SessionCaller, rerr error) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -227,12 +230,12 @@ func (c *Client) GetSessionCaller(ctx context.Context, wait bool) (_ bksession.C
 		bklog.G(ctx).WithError(rerr).Tracef("got session for %q", clientMetadata.ClientID)
 	}()
 
-	caller, err := c.SessionManager.Get(ctx, clientMetadata.ClientID, !wait)
+	caller, err := c.GetClientCaller(ctx, clientMetadata.ClientID)
 	if err != nil {
 		return nil, err
 	}
 	if caller == nil {
-		return nil, fmt.Errorf("session for %q not found", clientMetadata.ClientID)
+		return nil, fmt.Errorf("session attachables for client %q not found", clientMetadata.ClientID)
 	}
 	return caller, nil
 }
@@ -246,7 +249,7 @@ func (c *Client) ListenHostToContainer(
 		return nil, nil, err
 	}
 
-	clientCaller, err := c.GetSessionCaller(ctx, false)
+	clientCaller, err := c.GetSessionCaller(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to get requester session: %w", err)
 		cancel(fmt.Errorf("listen host to container error: %w", err))
@@ -388,7 +391,7 @@ func (c *Client) GetCredential(ctx context.Context, protocol, host, path string)
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetHostServiceCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(ctx, md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller for %q: %w", md.ClientID, err)
 	}
@@ -414,7 +417,7 @@ func (c *Client) GetCredential(ctx context.Context, protocol, host, path string)
 
 func (c *Client) PromptAllowLLM(ctx context.Context, moduleRepoURL string) error {
 	// the flag hasn't allowed this LLM call, so prompt the user
-	caller, err := c.GetMainClientCaller()
+	caller, err := c.GetMainClientCaller(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get main client caller to prompt for allow llm: %w", err)
 	}
@@ -436,7 +439,7 @@ func (c *Client) PromptAllowLLM(ctx context.Context, moduleRepoURL string) error
 }
 
 func (c *Client) PromptHumanHelp(ctx context.Context, title, question string) (string, error) {
-	caller, err := c.GetMainClientCaller()
+	caller, err := c.GetMainClientCaller(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get main client caller to prompt user for human help: %w", err)
 	}
@@ -457,7 +460,7 @@ func (c *Client) GetGitConfig(ctx context.Context) ([]*git.GitConfigEntry, error
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetHostServiceCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(ctx, md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller for %q: %w", md.ClientID, err)
 	}
@@ -497,7 +500,7 @@ type TerminalClient struct {
 func (c *Client) OpenTerminal(
 	ctx context.Context,
 ) (*TerminalClient, error) {
-	caller, err := c.GetMainClientCaller()
+	caller, err := c.GetMainClientCaller(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get main client caller: %w", err)
 	}
@@ -626,7 +629,7 @@ func (c *Client) OpenTerminal(
 func (c *Client) OpenPipe(
 	ctx context.Context,
 ) (io.ReadWriteCloser, error) {
-	caller, err := c.GetMainClientCaller()
+	caller, err := c.GetMainClientCaller(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get main client caller: %w", err)
 	}
@@ -648,7 +651,7 @@ func (c *Client) WriteImage(
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetHostServiceCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(ctx, md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller: %w", err)
 	}
@@ -690,7 +693,7 @@ func (c *Client) ReadImage(
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetHostServiceCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(ctx, md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller: %w", err)
 	}
@@ -721,7 +724,7 @@ func (c *Client) ReadImage(
 	return nil, fmt.Errorf("client has no supported api for loading image")
 }
 
-func callerSupports(caller bksession.Caller, desc *grpc.ServiceDesc) bool {
+func callerSupports(caller SessionCaller, desc *grpc.ServiceDesc) bool {
 	for _, method := range desc.Methods {
 		if !caller.Supports(fmt.Sprintf("/%s/%s", desc.ServiceName, method.MethodName)) {
 			return false

--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -77,11 +77,12 @@ type Opts struct {
 	HostMntNS  *os.File
 	CleanMntNS *os.File
 
-	SessionManager      *bksession.Manager
-	Dialer              *net.Dialer
-	GetClientCaller     func(string) (bksession.Caller, error)
-	GetMainClientCaller func() (bksession.Caller, error)
-	GetRegistryResolver func(context.Context) (*serverresolver.Resolver, error)
+	SessionManager       *bksession.Manager
+	Dialer               *net.Dialer
+	GetClientCaller      func(string) (bksession.Caller, error)
+	GetHostServiceCaller func(string) (bksession.Caller, error)
+	GetMainClientCaller  func() (bksession.Caller, error)
+	GetRegistryResolver  func(context.Context) (*serverresolver.Resolver, error)
 
 	Interactive        bool
 	InteractiveCommand []string
@@ -101,7 +102,7 @@ type Client struct {
 }
 
 type sessionHandler interface {
-	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
+	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
 }
 
 func NewOpts(opts Opts) (*Opts, error) {
@@ -139,6 +140,9 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 	}
 	if opts.runningMu == nil {
 		opts.runningMu = &sync.RWMutex{}
+	}
+	if opts.GetHostServiceCaller == nil {
+		opts.GetHostServiceCaller = opts.GetClientCaller
 	}
 
 	// override the outer cancel, we will manage cancellation ourselves here
@@ -384,7 +388,7 @@ func (c *Client) GetCredential(ctx context.Context, protocol, host, path string)
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetClientCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller for %q: %w", md.ClientID, err)
 	}
@@ -453,7 +457,7 @@ func (c *Client) GetGitConfig(ctx context.Context) ([]*git.GitConfigEntry, error
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetClientCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller for %q: %w", md.ClientID, err)
 	}
@@ -644,7 +648,7 @@ func (c *Client) WriteImage(
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetClientCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller: %w", err)
 	}
@@ -686,7 +690,7 @@ func (c *Client) ReadImage(
 	if err != nil {
 		return nil, err
 	}
-	caller, err := c.GetClientCaller(md.ClientID)
+	caller, err := c.GetHostServiceCaller(md.ClientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client caller: %w", err)
 	}

--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
 	bkgw "github.com/dagger/dagger/internal/buildkit/frontend/gateway/client"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
-	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/entitlements"
 	"github.com/dagger/dagger/internal/buildkit/util/network"
 	"github.com/docker/docker/pkg/idtools"
@@ -46,6 +45,7 @@ import (
 	"github.com/dagger/dagger/engine/session/prompt"
 	"github.com/dagger/dagger/engine/session/store"
 	"github.com/dagger/dagger/engine/session/terminal"
+	"github.com/dagger/dagger/engine/slog"
 )
 
 type SessionCaller interface {
@@ -225,9 +225,9 @@ func (c *Client) GetSessionCaller(ctx context.Context) (_ SessionCaller, rerr er
 		return nil, err
 	}
 
-	bklog.G(ctx).Tracef("getting session for %q", clientMetadata.ClientID)
+	slog.TraceContext(ctx, "getting session", "clientID", clientMetadata.ClientID)
 	defer func() {
-		bklog.G(ctx).WithError(rerr).Tracef("got session for %q", clientMetadata.ClientID)
+		slog.TraceContext(ctx, "got session", "clientID", clientMetadata.ClientID, "err", rerr)
 	}()
 
 	caller, err := c.GetClientCaller(ctx, clientMetadata.ClientID)
@@ -295,7 +295,7 @@ func (c *Client) ListenHostToContainer(
 		for {
 			res, err := listener.Recv()
 			if err != nil {
-				bklog.G(ctx).Warnf("listener recv err: %s", err)
+				slog.WarnContext(ctx, "listener recv err", "err", err)
 				return
 			}
 
@@ -311,7 +311,7 @@ func (c *Client) ListenHostToContainer(
 			if !found {
 				conn, err = c.Dialer.Dial(proto, upstream)
 				if err != nil {
-					bklog.G(ctx).Warnf("failed to dial %s %s: %s", proto, upstream, err)
+					slog.WarnContext(ctx, "failed to dial", "proto", proto, "upstream", upstream, "err", err)
 					sendL.Lock()
 					err = listener.Send(&h2c.ListenRequest{
 						ConnId: connID,
@@ -580,7 +580,7 @@ func (c *Client) OpenTerminal(
 			res, err := term.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					bklog.G(ctx).Warnf("terminal recv err: %v", err)
+					slog.WarnContext(ctx, "terminal recv err", "err", err)
 					errCh <- err
 				}
 				return
@@ -589,7 +589,7 @@ func (c *Client) OpenTerminal(
 			case *terminal.SessionResponse_Stdin:
 				_, err := stdinW.Write(msg.Stdin)
 				if err != nil {
-					bklog.G(ctx).Warnf("failed to write stdin: %v", err)
+					slog.WarnContext(ctx, "failed to write stdin", "err", err)
 					errCh <- err
 					return
 				}

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -71,9 +71,6 @@ const (
 	DaggerSessionTokenEnv = "DAGGER_SESSION_TOKEN"
 	DaggerEngineNumCPUEnv = "DAGGER_ENGINE_NUM_CPU"
 
-	// this is set by buildkit, we cannot change
-	BuildkitSessionIDHeader = "x-docker-expose-session-uuid"
-
 	BuildkitQemuEmulatorMountPoint = "/dev/.buildkit_qemu_emulator"
 
 	cgroupSampleInterval     = 5 * time.Second

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -1066,7 +1066,7 @@ func (c *Client) setupNestedClient(ctx context.Context, state *execState) (rerr 
 	httpSrv := &http.Server{
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler: h2c.NewHandler(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			c.SessionHandler.ServeHTTPToNestedClient(resp, req, state.nestedClientMetadata, state.callerClientID, state.nestedClientModule, state.nestedClientFunctionCall, state.nestedClientEnv)
+			c.SessionHandler.ServeHTTPToNestedClient(resp, req, state.nestedClientMetadata, state.callerClientID, false, state.nestedClientModule, state.nestedClientFunctionCall, state.nestedClientEnv)
 		}), http2Srv),
 	}
 	if err := http2.ConfigureServer(httpSrv, http2Srv); err != nil {

--- a/engine/engineutil/filesync.go
+++ b/engine/engineutil/filesync.go
@@ -11,11 +11,11 @@ import (
 	"path/filepath"
 
 	"github.com/dagger/dagger/internal/buildkit/session/filesync"
-	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/fsutil"
 	fsutiltypes "github.com/dagger/dagger/internal/fsutil/types"
 
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/slog"
 )
 
 func (c *Client) diffcopy(ctx context.Context, opts engine.LocalImportOpts, msg any) error {
@@ -90,14 +90,10 @@ func (c *Client) LocalDirExport(
 	merge bool,
 	removePaths []string,
 ) (rerr error) {
-	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("export_path", destPath))
-	bklog.G(ctx).Debug("exporting local dir")
+	ctx = slog.WithLogger(ctx, slog.FromContext(ctx).With("export_path", destPath))
+	slog.DebugContext(ctx, "exporting local dir")
 	defer func() {
-		lg := bklog.G(ctx)
-		if rerr != nil {
-			lg = lg.WithError(rerr)
-		}
-		lg.Trace("finished exporting local dir")
+		slog.TraceContext(ctx, "finished exporting local dir", "err", rerr)
 	}()
 
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
@@ -144,18 +140,14 @@ func (c *Client) LocalFileExport(
 	destPath string,
 	allowParentDirPath bool,
 ) (rerr error) {
-	ctx = bklog.WithLogger(ctx, bklog.G(ctx).
-		WithField("export_path", destPath).
-		WithField("file_path", filePath).
-		WithField("allow_parent_dir_path", allowParentDirPath),
-	)
-	bklog.G(ctx).Debug("exporting local file")
+	ctx = slog.WithLogger(ctx, slog.FromContext(ctx).With(
+		"export_path", destPath,
+		"file_path", filePath,
+		"allow_parent_dir_path", allowParentDirPath,
+	))
+	slog.DebugContext(ctx, "exporting local file")
 	defer func() {
-		lg := bklog.G(ctx)
-		if rerr != nil {
-			lg = lg.WithError(rerr)
-		}
-		lg.Trace("finished exporting local file")
+		slog.TraceContext(ctx, "finished exporting local file", "err", rerr)
 	}()
 
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
@@ -230,14 +222,10 @@ func (c *Client) LocalFileExport(
 // IOReaderExport exports the contents of an io.Reader to the caller's local fs as a file
 // TODO: de-dupe this with the above method to extent possible
 func (c *Client) IOReaderExport(ctx context.Context, r io.Reader, destPath string, destMode os.FileMode) (rerr error) {
-	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("export_path", destPath))
-	bklog.G(ctx).Debug("exporting bytes")
+	ctx = slog.WithLogger(ctx, slog.FromContext(ctx).With("export_path", destPath))
+	slog.DebugContext(ctx, "exporting bytes")
 	defer func() {
-		lg := bklog.G(ctx)
-		if rerr != nil {
-			lg = lg.WithError(rerr)
-		}
-		lg.Trace("finished exporting bytes")
+		slog.TraceContext(ctx, "finished exporting bytes", "err", rerr)
 	}()
 
 	ctx = engine.LocalExportOpts{

--- a/engine/engineutil/filesync.go
+++ b/engine/engineutil/filesync.go
@@ -27,7 +27,7 @@ func (c *Client) diffcopy(ctx context.Context, opts engine.LocalImportOpts, msg 
 
 	ctx = opts.AppendToOutgoingContext(ctx)
 
-	clientCaller, err := c.GetSessionCaller(ctx, false)
+	clientCaller, err := c.GetSessionCaller(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get requester session: %w", err)
 	}
@@ -111,28 +111,30 @@ func (c *Client) LocalDirExport(
 		return err
 	}
 
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	caller, err := c.GetSessionCaller(ctx)
 	if err != nil {
-		return err
-	}
-
-	caller, err := c.SessionManager.Get(ctx, clientMetadata.ClientID, false)
-	if err != nil {
-		return err
+		return fmt.Errorf("failed to get requester session attachables: %w", err)
 	}
 
 	destPath = path.Clean(destPath)
+	method := "/moby.filesync.v1.FileSend/DiffCopy"
+	if !caller.Supports(method) {
+		return fmt.Errorf("method %s not supported by the client", method)
+	}
+
 	ctx = engine.LocalExportOpts{
 		Path:        destPath,
 		Merge:       merge,
 		RemovePaths: removePaths,
 	}.AppendToOutgoingContext(ctx)
 
-	if err := filesync.CopyToCaller(ctx, outputFS, 0, caller, nil); err != nil {
-		return err
+	diffCopyClient, err := filesync.NewFileSendClient(caller.Conn()).DiffCopy(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create diff copy client: %w", err)
 	}
+	defer diffCopyClient.CloseSend()
 
-	return nil
+	return sendDiffCopyToCaller(diffCopyClient, outputFS, nil)
 }
 
 func (c *Client) LocalFileExport(
@@ -182,7 +184,7 @@ func (c *Client) LocalFileExport(
 		FileMode:           stat.Mode().Perm(),
 	}.AppendToOutgoingContext(ctx)
 
-	clientCaller, err := c.GetSessionCaller(ctx, false)
+	clientCaller, err := c.GetSessionCaller(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get requester session: %w", err)
 	}
@@ -245,7 +247,7 @@ func (c *Client) IOReaderExport(ctx context.Context, r io.Reader, destPath strin
 		FileMode:         destMode,
 	}.AppendToOutgoingContext(ctx)
 
-	clientCaller, err := c.GetSessionCaller(ctx, false)
+	clientCaller, err := c.GetSessionCaller(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get requester session: %w", err)
 	}

--- a/engine/engineutil/filesync_send_unix.go
+++ b/engine/engineutil/filesync_send_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package engineutil
+
+import (
+	"github.com/dagger/dagger/internal/buildkit/session/filesync"
+	"github.com/dagger/dagger/internal/fsutil"
+)
+
+func sendDiffCopyToCaller(stream filesync.FileSend_DiffCopyClient, fs fsutil.FS, progress func(int, bool)) error {
+	return fsutil.Send(stream.Context(), stream, fs, progress)
+}

--- a/engine/engineutil/filesync_send_windows.go
+++ b/engine/engineutil/filesync_send_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package engineutil
+
+import (
+	"github.com/Microsoft/go-winio"
+	"github.com/dagger/dagger/internal/buildkit/session/filesync"
+	"github.com/dagger/dagger/internal/fsutil"
+)
+
+func sendDiffCopyToCaller(stream filesync.FileSend_DiffCopyClient, fs fsutil.FS, progress func(int, bool)) error {
+	winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege})
+	defer winio.DisableProcessPrivileges([]string{winio.SeBackupPrivilege})
+	return fsutil.Send(stream.Context(), stream, fs, progress)
+}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -363,7 +363,7 @@ func decodeMeta(md metadata.MD, key string, dest any) error {
 	return nil
 }
 
-// encodeOpts comes from buildkit session/filesync/filesync.go
+// encodeOpts preserves the existing filesync metadata header encoding.
 func encodeOpts(opts map[string][]string) map[string][]string {
 	md := make(map[string][]string, len(opts))
 	for k, v := range opts {
@@ -376,7 +376,7 @@ func encodeOpts(opts map[string][]string) map[string][]string {
 	return md
 }
 
-// decodeOpts comes from buildkit session/filesync/filesync.go
+// decodeOpts preserves the existing filesync metadata header decoding.
 func decodeOpts(opts map[string][]string) map[string][]string {
 	md := make(map[string][]string, len(opts))
 	for k, v := range opts {
@@ -402,7 +402,7 @@ func decodeOpts(opts map[string][]string) map[string][]string {
 // encodeStringForHeader encodes a string value so it can be used in grpc header. This encoding
 // is backwards compatible and avoids encoding ASCII characters.
 //
-// encodeStringForHeader comes from buildkit session/filesync/filesync.go
+// encodeStringForHeader preserves the existing filesync metadata header encoding.
 func encodeStringForHeader(inputs []string) ([]string, bool) {
 	var encode bool
 loop:

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -35,7 +35,6 @@ import (
 	apitypes "github.com/dagger/dagger/internal/buildkit/api/types"
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/archutil"
 	"github.com/dagger/dagger/internal/buildkit/util/disk"
@@ -91,8 +90,6 @@ type Server struct {
 	workerCache           bkcache.SnapshotManager
 	workerGCPolicies      []dagql.CachePrunePolicy
 	workerDefaultGCPolicy *dagql.CachePrunePolicy
-
-	bkSessionManager *bksession.Manager
 
 	containerdMetaBoltDB *bolt.DB
 	containerdMetaDB     *ctdmetadata.DB
@@ -276,11 +273,6 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	}
 
 	srv.leaseManager = leaseutil.WithNamespace(ctdmetadata.NewLeaseManager(srv.containerdMetaDB), "dagger")
-
-	srv.bkSessionManager, err = bksession.NewManager()
-	if err != nil {
-		return nil, err
-	}
 
 	srv.contentStore = containerdsnapshot.NewContentStore(srv.containerdMetaDB.ContentStore(), "dagger")
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -171,9 +171,11 @@ type daggerClient struct {
 	env dagql.ObjectResult[*core.Env]
 
 	// engine utility job-related state/config
-	getClientCaller  func(string) (bksession.Caller, error)
-	dialer           *net.Dialer
-	engineUtilClient *engineutil.Client
+	hostServiceProxyClientID string
+	getClientCaller          func(string) (bksession.Caller, error)
+	getHostServiceCaller     func(string) (bksession.Caller, error)
+	dialer                   *net.Dialer
+	engineUtilClient         *engineutil.Client
 
 	// SQLite database storing telemetry + anything else
 	tracerProvider *sdktrace.TracerProvider
@@ -498,6 +500,10 @@ type ClientInitOpts struct {
 	// If this is a nested client, the client ID of the caller that created it
 	CallerClientID string
 
+	// If set, host-backed services for this client may proxy through this
+	// ancestor when this client has no session attachables of its own.
+	HostServiceProxyClientID string
+
 	// If the client is running from a function in a module, this is that module.
 	ModuleContext dagql.ObjectResult[*core.Module]
 
@@ -531,7 +537,11 @@ func (srv *Server) initializeDaggerClient(
 		return caller, err
 	}
 	client.getClientCaller = func(id string) (bksession.Caller, error) {
-		return client.resolveClientCaller(id, getClientCaller)
+		return getClientCaller(id, false)
+	}
+	client.hostServiceProxyClientID = opts.HostServiceProxyClientID
+	client.getHostServiceCaller = func(id string) (bksession.Caller, error) {
+		return client.resolveHostServiceCaller(id, getClientCaller)
 	}
 
 	var err error
@@ -563,6 +573,7 @@ func (srv *Server) initializeDaggerClient(
 	engineUtilOpts.SessionManager = srv.bkSessionManager
 	engineUtilOpts.Dialer = client.dialer
 	engineUtilOpts.GetClientCaller = client.getClientCaller
+	engineUtilOpts.GetHostServiceCaller = client.getHostServiceCaller
 	engineUtilOpts.GetMainClientCaller = client.getMainClientCaller
 	engineUtilOpts.GetRegistryResolver = srv.RegistryResolver
 	engineUtilOpts.Interactive = client.daggerSession.interactive
@@ -702,22 +713,27 @@ func (srv *Server) initializeDaggerClient(
 	return nil
 }
 
-func (client *daggerClient) resolveClientCaller(
+func (client *daggerClient) resolveHostServiceCaller(
 	id string,
 	getClientCaller func(string, bool) (bksession.Caller, error),
 ) (bksession.Caller, error) {
-	if id == client.clientID && len(client.parents) > 0 {
+	if id == client.clientID && client.hostServiceProxyClientID != "" {
 		// Synthetic nested clients (e.g. builtin dang evaluation) do not
 		// establish their own session attachables. When host-backed services
 		// such as git config are requested through the current client ID, fall
-		// back to the immediate parent client chain.
+		// back to the explicit proxy client chain.
 		caller, err := getClientCaller(id, true)
 		if err != nil || caller != nil {
 			return caller, err
 		}
 
-		parent := client.parents[len(client.parents)-1]
-		return parent.getClientCaller(parent.clientID)
+		for i := len(client.parents) - 1; i >= 0; i-- {
+			parent := client.parents[i]
+			if parent.clientID == client.hostServiceProxyClientID {
+				return parent.getHostServiceCaller(parent.clientID)
+			}
+		}
+		return nil, fmt.Errorf("host service proxy client %q not found for client %q", client.hostServiceProxyClientID, client.clientID)
 	}
 
 	return getClientCaller(id, false)
@@ -899,6 +915,15 @@ func (srv *Server) getOrInitClient(
 		if opts.LoadWorkspaceModules {
 			client.clientMetadata.LoadWorkspaceModules = true
 		}
+		if opts.HostServiceProxyClientID != "" {
+			switch client.hostServiceProxyClientID {
+			case "":
+				client.hostServiceProxyClientID = opts.HostServiceProxyClientID
+			case opts.HostServiceProxyClientID:
+			default:
+				return nil, nil, fmt.Errorf("client %q already exists with different host service proxy client %q", clientID, client.hostServiceProxyClientID)
+			}
+		}
 		if client.clientMetadata.Workspace == nil && !client.workspaceLoaded {
 			if workspaceRef, ok := workspaceRefFromClientMetadata(opts.ClientMetadata); ok {
 				ref := workspaceRef
@@ -975,6 +1000,7 @@ func (srv *Server) ServeHTTPToNestedClient(
 	r *http.Request,
 	nestedClientMetadata *engine.ClientMetadata,
 	callerClientID string,
+	hostServiceProxyToCaller bool,
 	moduleCtx dagql.AnyObjectResult,
 	functionCall dagql.Typed,
 	envCtx dagql.AnyObjectResult,
@@ -1019,12 +1045,18 @@ func (srv *Server) ServeHTTPToNestedClient(
 		}
 	}
 
+	var hostServiceProxyClientID string
+	if hostServiceProxyToCaller {
+		hostServiceProxyClientID = callerClientID
+	}
+
 	httpHandlerFunc(srv.serveHTTPToClient, &ClientInitOpts{
-		ClientMetadata: clientMetadata,
-		CallerClientID: callerClientID,
-		ModuleContext:  moduleContext,
-		FunctionCall:   fnCall,
-		EnvContext:     envContext,
+		ClientMetadata:           clientMetadata,
+		CallerClientID:           callerClientID,
+		HostServiceProxyClientID: hostServiceProxyClientID,
+		ModuleContext:            moduleContext,
+		FunctionCall:             fnCall,
+		EnvContext:               envContext,
 	}).ServeHTTP(w, r)
 }
 
@@ -1313,6 +1345,12 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	ctx = core.ContextWithQuery(ctx, client.dagqlRoot)
 
 	r = r.WithContext(ctx)
+
+	if client.hostServiceProxyClientID == "" {
+		if _, err := client.getClientCaller(client.clientID); err != nil {
+			return gqlErr(fmt.Errorf("waiting for client session: %w", err), http.StatusInternalServerError)
+		}
+	}
 
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1199,10 +1199,9 @@ func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opt
 
 func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
 	ctx := r.Context()
-	bklog.G(ctx).Debugf("session attachables handling conn %s", client.clientID)
+	slog.DebugContext(ctx, "session attachables handling conn", "clientID", client.clientID)
 	defer func() {
-		bklog.G(ctx).WithError(rerr).Debugf("session attachables handle conn done %s", client.clientID)
-		slog.ExtraDebug("session attachables handle conn done",
+		slog.DebugContext(ctx, "session attachables handle conn done",
 			"err", rerr,
 			"ctxErr", ctx.Err(),
 			"clientID", client.clientID,

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -780,6 +780,7 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 // initialize session+client if needed, return:
 // * the initialized client
 // * a cleanup func to run when the call is done
+//
 //nolint:gocyclo // session/client initialization is an intentionally linear state machine.
 func (srv *Server) getOrInitClient(
 	ctx context.Context,

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
 	bkgw "github.com/dagger/dagger/internal/buildkit/frontend/gateway/client"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/dagger/dagger/internal/buildkit/util/leaseutil"
@@ -67,6 +66,8 @@ type daggerSession struct {
 
 	clients  map[string]*daggerClient // clientID -> client
 	clientMu sync.RWMutex
+
+	attachables *sessionAttachableManager
 
 	closingCtx       context.Context
 	cancelClosing    context.CancelCauseFunc
@@ -172,8 +173,8 @@ type daggerClient struct {
 
 	// engine utility job-related state/config
 	hostServiceProxyClientID string
-	getClientCaller          func(string) (bksession.Caller, error)
-	getHostServiceCaller     func(string) (bksession.Caller, error)
+	getClientCaller          func(context.Context, string) (engineutil.SessionCaller, error)
+	getHostServiceCaller     func(context.Context, string) (engineutil.SessionCaller, error)
 	dialer                   *net.Dialer
 	engineUtilClient         *engineutil.Client
 
@@ -284,8 +285,8 @@ func (client *daggerClient) ShutdownTelemetry(ctx context.Context) error {
 	return errs
 }
 
-func (client *daggerClient) getMainClientCaller() (bksession.Caller, error) {
-	return client.getClientCaller(client.daggerSession.mainClientCallerID)
+func (client *daggerClient) getMainClientCaller(ctx context.Context) (engineutil.SessionCaller, error) {
+	return client.getClientCaller(ctx, client.daggerSession.mainClientCallerID)
 }
 
 func (sess *daggerSession) LoadOrStoreTelemetrySeenKey(key string) bool {
@@ -321,6 +322,7 @@ func (srv *Server) initializeDaggerSession(
 	sess.sessionID = clientMetadata.SessionID
 	sess.mainClientCallerID = clientMetadata.ClientID
 	sess.clients = map[string]*daggerClient{}
+	sess.attachables = newSessionAttachableManager()
 	sess.endpoints = map[string]http.Handler{}
 	sess.closingCtx, sess.cancelClosing = context.WithCancelCause(context.Background())
 	sess.shutdownCh = make(chan struct{})
@@ -527,21 +529,18 @@ func (srv *Server) initializeDaggerClient(
 		"mainClientID", client.daggerSession.mainClientCallerID,
 	)
 	slog.Info("initializing new client")
-	var callerG singleflight.Group[string, bksession.Caller]
-	getClientCaller := func(id string, noWait bool) (bksession.Caller, error) {
+	var callerG singleflight.Group[string, engineutil.SessionCaller]
+	client.getClientCaller = func(ctx context.Context, id string) (engineutil.SessionCaller, error) {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
-		caller, _, err := callerG.Do(ctx, id, func(ctx context.Context) (bksession.Caller, error) {
-			return srv.bkSessionManager.Get(ctx, id, noWait)
+		caller, _, err := callerG.Do(ctx, id, func(ctx context.Context) (engineutil.SessionCaller, error) {
+			return client.daggerSession.attachables.Wait(ctx, id)
 		})
 		return caller, err
 	}
-	client.getClientCaller = func(id string) (bksession.Caller, error) {
-		return getClientCaller(id, false)
-	}
 	client.hostServiceProxyClientID = opts.HostServiceProxyClientID
-	client.getHostServiceCaller = func(id string) (bksession.Caller, error) {
-		return client.resolveHostServiceCaller(id, getClientCaller)
+	client.getHostServiceCaller = func(ctx context.Context, id string) (engineutil.SessionCaller, error) {
+		return client.resolveHostServiceCaller(ctx, id)
 	}
 
 	var err error
@@ -570,7 +569,6 @@ func (srv *Server) initializeDaggerClient(
 	}
 
 	engineUtilOpts := *srv.engineUtilOpts
-	engineUtilOpts.SessionManager = srv.bkSessionManager
 	engineUtilOpts.Dialer = client.dialer
 	engineUtilOpts.GetClientCaller = client.getClientCaller
 	engineUtilOpts.GetHostServiceCaller = client.getHostServiceCaller
@@ -714,29 +712,28 @@ func (srv *Server) initializeDaggerClient(
 }
 
 func (client *daggerClient) resolveHostServiceCaller(
+	ctx context.Context,
 	id string,
-	getClientCaller func(string, bool) (bksession.Caller, error),
-) (bksession.Caller, error) {
+) (engineutil.SessionCaller, error) {
 	if id == client.clientID && client.hostServiceProxyClientID != "" {
 		// Synthetic nested clients (e.g. builtin dang evaluation) do not
 		// establish their own session attachables. When host-backed services
 		// such as git config are requested through the current client ID, fall
 		// back to the explicit proxy client chain.
-		caller, err := getClientCaller(id, true)
-		if err != nil || caller != nil {
-			return caller, err
+		if caller, ok := client.daggerSession.attachables.Lookup(id); ok {
+			return caller, nil
 		}
 
 		for i := len(client.parents) - 1; i >= 0; i-- {
 			parent := client.parents[i]
 			if parent.clientID == client.hostServiceProxyClientID {
-				return parent.getHostServiceCaller(parent.clientID)
+				return parent.getHostServiceCaller(ctx, parent.clientID)
 			}
 		}
 		return nil, fmt.Errorf("host service proxy client %q not found for client %q", client.hostServiceProxyClientID, client.clientID)
 	}
 
-	return getClientCaller(id, false)
+	return client.getClientCaller(ctx, id)
 }
 
 func (srv *Server) clientFromContext(ctx context.Context) (*daggerClient, error) {
@@ -783,6 +780,7 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 // initialize session+client if needed, return:
 // * the initialized client
 // * a cleanup func to run when the call is done
+//nolint:gocyclo // session/client initialization is an intentionally linear state machine.
 func (srv *Server) getOrInitClient(
 	ctx context.Context,
 	opts *ClientInitOpts,
@@ -1201,10 +1199,10 @@ func (srv *Server) serveHTTPToClient(w http.ResponseWriter, r *http.Request, opt
 
 func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
 	ctx := r.Context()
-	bklog.G(ctx).Debugf("session manager handling conn %s", client.clientID)
+	bklog.G(ctx).Debugf("session attachables handling conn %s", client.clientID)
 	defer func() {
-		bklog.G(ctx).WithError(rerr).Debugf("session manager handle conn done %s", client.clientID)
-		slog.ExtraDebug("session manager handle conn done",
+		bklog.G(ctx).WithError(rerr).Debugf("session attachables handle conn done %s", client.clientID)
+		slog.ExtraDebug("session attachables handle conn done",
 			"err", rerr,
 			"ctxErr", ctx.Err(),
 			"clientID", client.clientID,
@@ -1212,9 +1210,8 @@ func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Reques
 	}()
 
 	// verify this isn't overwriting an existing active session
-	existingCaller, err := srv.bkSessionManager.Get(ctx, client.clientID, true)
-	if err == nil && existingCaller != nil {
-		err := fmt.Errorf("buildkit session %q already exists", client.clientID)
+	if _, ok := client.daggerSession.attachables.Lookup(client.clientID); ok {
+		err := fmt.Errorf("session attachables for client %q already exist", client.clientID)
 		return httpErr(err, http.StatusBadRequest)
 	}
 
@@ -1261,14 +1258,9 @@ func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Reques
 	// they add noticeable memory allocation overhead, especially for heavy filesync use cases.
 	ctx = trace.ContextWithSpan(ctx, trace.SpanFromContext(nil)) //nolint:staticcheck // we have to provide a nil context...
 
-	err = srv.bkSessionManager.HandleConn(ctx, conn, map[string][]string{
-		engine.SessionIDMetaKey:         {client.clientID},
-		engine.SessionNameMetaKey:       {client.clientID},
-		engine.SessionSharedKeyMetaKey:  {""},
-		engine.SessionMethodNameMetaKey: r.Header.Values(engine.SessionMethodNameMetaKey),
-	})
+	err = client.daggerSession.attachables.Register(ctx, client.clientID, conn, r.Header.Values(engine.SessionMethodNameMetaKey))
 	if err != nil {
-		panic(fmt.Errorf("handleConn: %w", err))
+		panic(fmt.Errorf("handle session attachables: %w", err))
 	}
 	return nil
 }
@@ -1347,14 +1339,14 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	r = r.WithContext(ctx)
 
 	if client.hostServiceProxyClientID == "" {
-		if _, err := client.getClientCaller(client.clientID); err != nil {
-			return gqlErr(fmt.Errorf("waiting for client session: %w", err), http.StatusInternalServerError)
+		if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+			return gqlErr(fmt.Errorf("waiting for client session attachables: %w", err), http.StatusInternalServerError)
 		}
 	}
 
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's
-	// buildkit session, which only becomes available after the session
+	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
 	if err := srv.ensureWorkspaceLoaded(ctx, client); err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
@@ -1917,7 +1909,7 @@ func (srv *Server) SpecificClientAttachableConn(ctx context.Context, clientID st
 	if err != nil {
 		return nil, err
 	}
-	caller, err := client.getClientCaller(clientID)
+	caller, err := client.getClientCaller(ctx, clientID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session attachable caller for client %q: %w", clientID, err)
 	}
@@ -1940,7 +1932,7 @@ func (srv *Server) sessionMainClientConn(ctx context.Context, sess *daggerSessio
 	if err != nil {
 		return nil, fmt.Errorf("failed to get main client %q: %w", sess.mainClientCallerID, err)
 	}
-	caller, err := client.getClientCaller(sess.mainClientCallerID)
+	caller, err := client.getClientCaller(ctx, sess.mainClientCallerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get main client caller %q: %w", sess.mainClientCallerID, err)
 	}
@@ -2128,7 +2120,7 @@ func (srv *Server) CloudEngineClient(
 		return nil, false, err
 	}
 	parentCallerCtx := engine.ContextWithClientMetadata(ctx, parentClient.clientMetadata)
-	parentSession, err := parentClient.engineUtilClient.GetSessionCaller(parentCallerCtx, false)
+	parentSession, err := parentClient.engineUtilClient.GetSessionCaller(parentCallerCtx)
 	if err != nil {
 		return nil, false, err
 	}

--- a/engine/server/session_attachables.go
+++ b/engine/server/session_attachables.go
@@ -1,0 +1,265 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/dagger/dagger/internal/buildkit/util/bklog"
+	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
+	"github.com/dagger/dagger/internal/buildkit/util/tracing"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/dagger/dagger/engine/engineutil"
+)
+
+var sessionAttachablePropagators = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+
+type sessionAttachableManager struct {
+	mu      sync.Mutex
+	callers map[string]*sessionAttachableCaller
+	waiters map[string][]chan struct{}
+}
+
+type sessionAttachableCaller struct {
+	ctx       context.Context
+	conn      *grpc.ClientConn
+	supported map[string]struct{}
+}
+
+func newSessionAttachableManager() *sessionAttachableManager {
+	return &sessionAttachableManager{
+		callers: map[string]*sessionAttachableCaller{},
+		waiters: map[string][]chan struct{}{},
+	}
+}
+
+func (m *sessionAttachableManager) Register(ctx context.Context, clientID string, conn net.Conn, methodURLs []string) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
+
+	ctx, cc, err := attachableClientConn(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	caller := &sessionAttachableCaller{
+		ctx:       ctx,
+		conn:      cc,
+		supported: map[string]struct{}{},
+	}
+	for _, methodURL := range methodURLs {
+		caller.supported[strings.ToLower(methodURL)] = struct{}{}
+	}
+
+	m.mu.Lock()
+	if existing, ok := m.callers[clientID]; ok && existing.active() {
+		m.mu.Unlock()
+		return fmt.Errorf("session attachables for client %q already exist", clientID)
+	}
+	m.callers[clientID] = caller
+	m.wakeWaitersLocked(clientID)
+	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		if m.callers[clientID] == caller {
+			delete(m.callers, clientID)
+			m.wakeWaitersLocked(clientID)
+		}
+		m.mu.Unlock()
+	}()
+
+	<-caller.ctx.Done()
+	conn.Close()
+	return nil
+}
+
+func (m *sessionAttachableManager) Lookup(clientID string) (engineutil.SessionCaller, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	caller, ok := m.callers[clientID]
+	if !ok || !caller.active() {
+		return nil, false
+	}
+	return caller, true
+}
+
+func (m *sessionAttachableManager) Wait(ctx context.Context, clientID string) (engineutil.SessionCaller, error) {
+	for {
+		m.mu.Lock()
+		if caller, ok := m.callers[clientID]; ok && caller.active() {
+			m.mu.Unlock()
+			return caller, nil
+		}
+
+		waiter := make(chan struct{})
+		m.waiters[clientID] = append(m.waiters[clientID], waiter)
+		m.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			m.removeWaiter(clientID, waiter)
+			if caller, ok := m.Lookup(clientID); ok {
+				return caller, nil
+			}
+			return nil, fmt.Errorf("no active session attachables for client %q: %w", clientID, context.Cause(ctx))
+		case <-waiter:
+		}
+	}
+}
+
+func (m *sessionAttachableManager) removeWaiter(clientID string, waiter chan struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	waiters := m.waiters[clientID]
+	for i, candidate := range waiters {
+		if candidate == waiter {
+			waiters = append(waiters[:i], waiters[i+1:]...)
+			break
+		}
+	}
+	if len(waiters) == 0 {
+		delete(m.waiters, clientID)
+		return
+	}
+	m.waiters[clientID] = waiters
+}
+
+func (m *sessionAttachableManager) wakeWaitersLocked(clientID string) {
+	waiters := m.waiters[clientID]
+	delete(m.waiters, clientID)
+	for _, waiter := range waiters {
+		close(waiter)
+	}
+}
+
+func (caller *sessionAttachableCaller) active() bool {
+	select {
+	case <-caller.ctx.Done():
+		return false
+	default:
+		return true
+	}
+}
+
+func (caller *sessionAttachableCaller) Supports(method string) bool {
+	_, ok := caller.supported[strings.ToLower(method)]
+	return ok
+}
+
+func (caller *sessionAttachableCaller) Conn() *grpc.ClientConn {
+	return caller.conn
+}
+
+func attachableClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.ClientConn, error) {
+	var dialCount int64
+	dialer := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		if c := atomic.AddInt64(&dialCount, 1); c > 1 {
+			return nil, fmt.Errorf("only one connection allowed")
+		}
+		return conn, nil
+	})
+
+	dialOpts := []grpc.DialOption{
+		dialer,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
+	}
+
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		statsHandler := tracing.ClientStatsHandler(
+			otelgrpc.WithTracerProvider(span.TracerProvider()),
+			otelgrpc.WithPropagators(sessionAttachablePropagators),
+		)
+		dialOpts = append(dialOpts, grpc.WithStatsHandler(statsHandler))
+	}
+
+	cc, err := grpc.DialContext(ctx, "localhost", dialOpts...)
+	if err != nil {
+		return ctx, nil, fmt.Errorf("failed to create grpc client: %w", err)
+	}
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	go monitorAttachableHealth(ctx, cc, cancel)
+
+	return ctx, cc, nil
+}
+
+func monitorAttachableHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(error)) {
+	defer cancelConn(context.Canceled)
+	defer cc.Close()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	healthClient := grpc_health_v1.NewHealthClient(cc)
+
+	failedBefore := false
+	consecutiveSuccessful := 0
+	defaultHealthcheckDuration := 30 * time.Second
+	lastHealthcheckDuration := time.Duration(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			healthcheckStart := time.Now()
+			timeout := time.Duration(math.Max(float64(defaultHealthcheckDuration), float64(lastHealthcheckDuration)*1.5))
+
+			checkCtx, cancel := context.WithCancelCause(ctx)
+			checkCtx, _ = context.WithTimeoutCause(checkCtx, timeout, context.DeadlineExceeded)
+			_, err := healthClient.Check(checkCtx, &grpc_health_v1.HealthCheckRequest{})
+			cancel(context.Canceled)
+
+			lastHealthcheckDuration = time.Since(healthcheckStart)
+			logFields := logrus.Fields{
+				"timeout":        timeout,
+				"actualDuration": lastHealthcheckDuration,
+			}
+
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					bklog.G(ctx).Debug("context done, skipping healthcheck error")
+					return
+				default:
+				}
+				if failedBefore {
+					bklog.G(ctx).Debug("healthcheck failed fatally")
+					return
+				}
+
+				failedBefore = true
+				consecutiveSuccessful = 0
+				bklog.G(ctx).WithFields(logFields).Debug("healthcheck failed")
+			} else {
+				consecutiveSuccessful++
+
+				if consecutiveSuccessful >= 5 && failedBefore {
+					failedBefore = false
+					bklog.G(ctx).WithFields(logFields).Debug("reset healthcheck failure")
+				}
+			}
+
+			bklog.G(ctx).WithFields(logFields).Trace("healthcheck completed")
+		}
+	}
+}

--- a/engine/server/session_attachables.go
+++ b/engine/server/session_attachables.go
@@ -11,21 +11,13 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/dagger/dagger/internal/buildkit/util/bklog"
-	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
-	"github.com/dagger/dagger/internal/buildkit/util/tracing"
-	"github.com/sirupsen/logrus"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/engine/slog"
 )
-
-var sessionAttachablePropagators = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 
 type sessionAttachableManager struct {
 	mu      sync.Mutex
@@ -180,22 +172,13 @@ func attachableClientConn(ctx context.Context, conn net.Conn) (context.Context, 
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
-		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
-		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
 	}
 
-	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
-		statsHandler := tracing.ClientStatsHandler(
-			otelgrpc.WithTracerProvider(span.TracerProvider()),
-			otelgrpc.WithPropagators(sessionAttachablePropagators),
-		)
-		dialOpts = append(dialOpts, grpc.WithStatsHandler(statsHandler))
-	}
-
-	cc, err := grpc.DialContext(ctx, "localhost", dialOpts...)
+	cc, err := grpc.NewClient("passthrough:localhost", dialOpts...)
 	if err != nil {
 		return ctx, nil, fmt.Errorf("failed to create grpc client: %w", err)
 	}
+	cc.Connect()
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	go monitorAttachableHealth(ctx, cc, cancel)
@@ -230,36 +213,41 @@ func monitorAttachableHealth(ctx context.Context, cc *grpc.ClientConn, cancelCon
 			cancel(context.Canceled)
 
 			lastHealthcheckDuration = time.Since(healthcheckStart)
-			logFields := logrus.Fields{
-				"timeout":        timeout,
-				"actualDuration": lastHealthcheckDuration,
-			}
 
 			if err != nil {
 				select {
 				case <-ctx.Done():
-					bklog.G(ctx).Debug("context done, skipping healthcheck error")
+					slog.DebugContext(ctx, "context done, skipping healthcheck error")
 					return
 				default:
 				}
 				if failedBefore {
-					bklog.G(ctx).Debug("healthcheck failed fatally")
+					slog.DebugContext(ctx, "healthcheck failed fatally")
 					return
 				}
 
 				failedBefore = true
 				consecutiveSuccessful = 0
-				bklog.G(ctx).WithFields(logFields).Debug("healthcheck failed")
+				slog.DebugContext(ctx, "healthcheck failed",
+					"timeout", timeout,
+					"actualDuration", lastHealthcheckDuration,
+				)
 			} else {
 				consecutiveSuccessful++
 
 				if consecutiveSuccessful >= 5 && failedBefore {
 					failedBefore = false
-					bklog.G(ctx).WithFields(logFields).Debug("reset healthcheck failure")
+					slog.DebugContext(ctx, "reset healthcheck failure",
+						"timeout", timeout,
+						"actualDuration", lastHealthcheckDuration,
+					)
 				}
 			}
 
-			bklog.G(ctx).WithFields(logFields).Trace("healthcheck completed")
+			slog.TraceContext(ctx, "healthcheck completed",
+				"timeout", timeout,
+				"actualDuration", lastHealthcheckDuration,
+			)
 		}
 	}
 }

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -12,17 +12,14 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine"
-	bksession "github.com/dagger/dagger/internal/buildkit/session"
+	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
 type fakeSessionCaller struct {
-	id string
-}
-
-func (caller *fakeSessionCaller) Context() context.Context {
-	return context.Background()
+	id   string
+	conn *grpc.ClientConn
 }
 
 func (caller *fakeSessionCaller) Supports(string) bool {
@@ -30,11 +27,7 @@ func (caller *fakeSessionCaller) Supports(string) bool {
 }
 
 func (caller *fakeSessionCaller) Conn() *grpc.ClientConn {
-	return nil
-}
-
-func (caller *fakeSessionCaller) SharedKey() string {
-	return caller.id
+	return caller.conn
 }
 
 func TestPendingLegacyModule(t *testing.T) {
@@ -308,7 +301,7 @@ func TestResolveHostServiceCallerFallsBackToParentForSyntheticNestedClient(t *te
 
 	parentCaller := &fakeSessionCaller{id: "parent"}
 	parent := &daggerClient{clientID: "parent"}
-	parent.getHostServiceCaller = func(id string) (bksession.Caller, error) {
+	parent.getHostServiceCaller = func(ctx context.Context, id string) (engineutil.SessionCaller, error) {
 		require.Equal(t, "parent", id)
 		return parentCaller, nil
 	}
@@ -319,49 +312,36 @@ func TestResolveHostServiceCallerFallsBackToParentForSyntheticNestedClient(t *te
 		parents:                  []*daggerClient{parent},
 	}
 
-	var calls []struct {
-		id     string
-		noWait bool
-	}
+	child.daggerSession = &daggerSession{attachables: newSessionAttachableManager()}
 
-	caller, err := child.resolveHostServiceCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
-		calls = append(calls, struct {
-			id     string
-			noWait bool
-		}{id: id, noWait: noWait})
-		return nil, nil
-	})
+	caller, err := child.resolveHostServiceCaller(context.Background(), "child")
 	require.NoError(t, err)
 	require.Same(t, parentCaller, caller)
-	require.Equal(t, []struct {
-		id     string
-		noWait bool
-	}{
-		{id: "child", noWait: true},
-	}, calls)
 }
 
 func TestResolveHostServiceCallerPrefersCurrentClientAttachable(t *testing.T) {
 	t.Parallel()
 
-	currentCaller := &fakeSessionCaller{id: "child"}
+	currentCaller := &sessionAttachableCaller{
+		ctx:       context.Background(),
+		supported: map[string]struct{}{},
+	}
 	parent := &daggerClient{clientID: "parent"}
-	parent.getHostServiceCaller = func(string) (bksession.Caller, error) {
+	parent.getHostServiceCaller = func(context.Context, string) (engineutil.SessionCaller, error) {
 		t.Fatal("unexpected parent fallback")
 		return nil, nil
 	}
+	attachables := newSessionAttachableManager()
+	attachables.callers["child"] = currentCaller
 
 	child := &daggerClient{
 		clientID:                 "child",
 		hostServiceProxyClientID: "parent",
 		parents:                  []*daggerClient{parent},
+		daggerSession:            &daggerSession{attachables: attachables},
 	}
 
-	caller, err := child.resolveHostServiceCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
-		require.Equal(t, "child", id)
-		require.True(t, noWait)
-		return currentCaller, nil
-	})
+	caller, err := child.resolveHostServiceCaller(context.Background(), "child")
 	require.NoError(t, err)
 	require.Same(t, currentCaller, caller)
 }
@@ -371,12 +351,12 @@ func TestResolveHostServiceCallerUsesBlockingLookupForOtherClients(t *testing.T)
 
 	otherCaller := &fakeSessionCaller{id: "other"}
 	child := &daggerClient{clientID: "child"}
-
-	caller, err := child.resolveHostServiceCaller("other", func(id string, noWait bool) (bksession.Caller, error) {
+	child.getClientCaller = func(ctx context.Context, id string) (engineutil.SessionCaller, error) {
 		require.Equal(t, "other", id)
-		require.False(t, noWait)
 		return otherCaller, nil
-	})
+	}
+
+	caller, err := child.resolveHostServiceCaller(context.Background(), "other")
 	require.NoError(t, err)
 	require.Same(t, otherCaller, caller)
 }

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -303,19 +303,20 @@ func TestEnsureWorkspaceLoadedKeepsExistingWorkspaceBinding(t *testing.T) {
 	require.Same(t, existing, child.workspace)
 }
 
-func TestResolveClientCallerFallsBackToParentForSyntheticNestedClient(t *testing.T) {
+func TestResolveHostServiceCallerFallsBackToParentForSyntheticNestedClient(t *testing.T) {
 	t.Parallel()
 
 	parentCaller := &fakeSessionCaller{id: "parent"}
 	parent := &daggerClient{clientID: "parent"}
-	parent.getClientCaller = func(id string) (bksession.Caller, error) {
+	parent.getHostServiceCaller = func(id string) (bksession.Caller, error) {
 		require.Equal(t, "parent", id)
 		return parentCaller, nil
 	}
 
 	child := &daggerClient{
-		clientID: "child",
-		parents:  []*daggerClient{parent},
+		clientID:                 "child",
+		hostServiceProxyClientID: "parent",
+		parents:                  []*daggerClient{parent},
 	}
 
 	var calls []struct {
@@ -323,7 +324,7 @@ func TestResolveClientCallerFallsBackToParentForSyntheticNestedClient(t *testing
 		noWait bool
 	}
 
-	caller, err := child.resolveClientCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
+	caller, err := child.resolveHostServiceCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
 		calls = append(calls, struct {
 			id     string
 			noWait bool
@@ -340,22 +341,23 @@ func TestResolveClientCallerFallsBackToParentForSyntheticNestedClient(t *testing
 	}, calls)
 }
 
-func TestResolveClientCallerPrefersCurrentClientAttachable(t *testing.T) {
+func TestResolveHostServiceCallerPrefersCurrentClientAttachable(t *testing.T) {
 	t.Parallel()
 
 	currentCaller := &fakeSessionCaller{id: "child"}
 	parent := &daggerClient{clientID: "parent"}
-	parent.getClientCaller = func(string) (bksession.Caller, error) {
+	parent.getHostServiceCaller = func(string) (bksession.Caller, error) {
 		t.Fatal("unexpected parent fallback")
 		return nil, nil
 	}
 
 	child := &daggerClient{
-		clientID: "child",
-		parents:  []*daggerClient{parent},
+		clientID:                 "child",
+		hostServiceProxyClientID: "parent",
+		parents:                  []*daggerClient{parent},
 	}
 
-	caller, err := child.resolveClientCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
+	caller, err := child.resolveHostServiceCaller("child", func(id string, noWait bool) (bksession.Caller, error) {
 		require.Equal(t, "child", id)
 		require.True(t, noWait)
 		return currentCaller, nil
@@ -364,13 +366,13 @@ func TestResolveClientCallerPrefersCurrentClientAttachable(t *testing.T) {
 	require.Same(t, currentCaller, caller)
 }
 
-func TestResolveClientCallerUsesBlockingLookupForOtherClients(t *testing.T) {
+func TestResolveHostServiceCallerUsesBlockingLookupForOtherClients(t *testing.T) {
 	t.Parallel()
 
 	otherCaller := &fakeSessionCaller{id: "other"}
 	child := &daggerClient{clientID: "child"}
 
-	caller, err := child.resolveClientCaller("other", func(id string, noWait bool) (bksession.Caller, error) {
+	caller, err := child.resolveHostServiceCaller("other", func(id string, noWait bool) (bksession.Caller, error) {
 		require.Equal(t, "other", id)
 		require.False(t, noWait)
 		return otherCaller, nil

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -54,7 +54,7 @@ func canonicalModuleReference(src *core.ModuleSource) string {
 
 // ensureWorkspaceLoaded detects the workspace from the client's working directory
 // and loads all configured modules onto the dagql server. Called from serveQuery
-// (not initializeDaggerClient) because it requires the client's buildkit session
+// (not initializeDaggerClient) because it requires the client's session attachables
 // to access the client's filesystem for workspace detection.
 func (srv *Server) ensureWorkspaceLoaded(ctx context.Context, client *daggerClient) error {
 	mode, workspaceRef := workspaceBindingMode(client)
@@ -69,10 +69,10 @@ func (srv *Server) ensureWorkspaceLoaded(ctx context.Context, client *daggerClie
 		return client.workspaceErr
 	}
 
-	// Wait for the client's buildkit session to be available.
+	// Wait for the client's session attachables to be available.
 	// Don't mark as loaded on failure — allow retry on next request.
-	if _, err := client.getClientCaller(client.clientID); err != nil {
-		return fmt.Errorf("waiting for client session: %w", err)
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
 	var err error
@@ -665,10 +665,10 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		return client.modulesErr
 	}
 
-	// Wait for the client's buildkit session to be available.
+	// Wait for the client's session attachables to be available.
 	// Don't mark as loaded on failure — allow retry on next request.
-	if _, err := client.getClientCaller(client.clientID); err != nil {
-		return fmt.Errorf("waiting for client session: %w", err)
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
 	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)

--- a/engine/session/h2c/h2c.go
+++ b/engine/session/h2c/h2c.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 
 	"github.com/dagger/dagger/engine/slog"
-	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
 	"github.com/dagger/dagger/util/grpcutil"
 	"google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -126,7 +126,7 @@ func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error 
 	for {
 		req, err := srv.Recv()
 		if err != nil {
-			if errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled {
+			if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 				// canceled
 				return nil
 			}
@@ -136,7 +136,7 @@ func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error 
 				return nil
 			}
 
-			if grpcerrors.Code(err) == codes.Unavailable {
+			if status.Code(err) == codes.Unavailable {
 				// client disconnected (i.e. quitting Dagger out)
 				return nil
 			}

--- a/engine/session/pipe/pipe.go
+++ b/engine/session/pipe/pipe.go
@@ -6,10 +6,10 @@ import (
 	fmt "fmt"
 	io "io"
 
-	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
 	"github.com/dagger/dagger/util/grpcutil"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -77,7 +77,7 @@ func (pio *PipeIO) Read(p []byte) (n int, err error) {
 		// The reason for discrepancy is because this is an attempt to simplify the logic using io.Copy, io.Reader
 		// interfaces which mandate io.EOF here.
 		// In the future, terminal session attachable may also get refactored using this simplified logic.
-		if errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled {
+		if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 			// canceled
 			return 0, io.EOF
 		}
@@ -85,7 +85,7 @@ func (pio *PipeIO) Read(p []byte) (n int, err error) {
 			// stopped
 			return 0, io.EOF
 		}
-		if grpcerrors.Code(err) == codes.Unavailable {
+		if status.Code(err) == codes.Unavailable {
 			// client disconnected (i.e. quitting Dagger out)
 			return 0, io.EOF
 		}

--- a/engine/session/store/store.go
+++ b/engine/session/store/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/plugins/services/content/contentserver"
 	"github.com/dagger/dagger/engine/client/imageload"
-	"github.com/dagger/dagger/internal/buildkit/session"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,7 +21,11 @@ import (
 	"github.com/containerd/errdefs/pkg/errgrpc"
 )
 
-func NewImageLoaderAttachable(loader *imageload.Loader) (session.Attachable, error) {
+type Attachable interface {
+	Register(*grpc.Server)
+}
+
+func NewImageLoaderAttachable(loader *imageload.Loader) (Attachable, error) {
 	if loader == nil {
 		return nil, errors.New("cannot attach nil loader")
 	}

--- a/engine/session/terminal/terminal.go
+++ b/engine/session/terminal/terminal.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"os"
 
-	"github.com/dagger/dagger/internal/buildkit/util/grpcerrors"
 	"github.com/dagger/dagger/util/grpcutil"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 	"google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -70,7 +70,7 @@ func (s TerminalAttachable) session(srv Terminal_SessionServer, stdin io.Reader,
 	for {
 		req, err := srv.Recv()
 		if err != nil {
-			if errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled {
+			if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 				// canceled
 				return nil
 			}
@@ -80,7 +80,7 @@ func (s TerminalAttachable) session(srv Terminal_SessionServer, stdin io.Reader,
 				return nil
 			}
 
-			if grpcerrors.Code(err) == codes.Unavailable {
+			if status.Code(err) == codes.Unavailable {
 				// client disconnected (i.e. quitting Dagger out)
 				return nil
 			}


### PR DESCRIPTION
  ## Fix nested client session resolution

Main goal here is to fix a regression introduced by [fix: builtin dang dependency module loading (#13007)](https://github.com/dagger/dagger/pull/13007).
* It resulted in occasional errors like `Error: failed to load module source dependencies: loading workspace: workspace detection: failed to stat path: failed to get requester session: session for "v51anobcgxoitkmvey93jzs6z" not found`

The first commit is the direct fix: it separates exact client session lookup from host-service fallback lookup. The bug was that normal nested clients could briefly miss their own session attachables while startup was still in progress, and the broader fallback added in #13007 could resolve through an ancestor session instead. That made timing-sensitive paths such as workspace/module loading fail with missing requester sessions. Exact session operations now wait for the nested client’s own attachables, while only the synthetic builtin Dang path opts into host-service proxying through an ancestor.

  ## Clean up session attachables plumbing

  The second commit cleans up the surrounding session plumbing to make this area less confusing. We were still using a small Buildkit session manager abstraction for Dagger client attachables, even though the ownership model here is now Dagger session state. This replaces that dangling dependency with Dagger-owned session attachables tracking in `engine/server`, while preserving the existing attachable protocols.

  This should make the exact-client vs host-service distinction clearer and reduce the chance of accidentally reintroducing broad fallback behavior in the future.