### PR TITLE
fix user defaults parallel test race

### DIFF
--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -648,7 +648,7 @@ class Test:
 
 func (UserDefaultsSuite) TestSimple(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
-	ctr := nestedDaggerContainer(t, c, "go", "defaults")
+	base := nestedDaggerContainer(t, c, "go", "defaults")
 	for _, tc := range []struct {
 		description    string
 		dotEnvPath     string
@@ -742,6 +742,7 @@ DEFAULTS_MESSAGE_NAME=monde
 	} {
 		tc := tc
 		t.Run(tc.description, func(ctx context.Context, t *testctx.T) {
+			ctr := base
 			if tc.prepare != nil {
 				ctr = tc.prepare(ctr)
 			}


### PR DESCRIPTION
Hit a failed run in CI due to race detector going off during test: https://dagger.cloud/dagger/checks/github.com/dagger/dagger@a1fb6be1af1460b4470021e69ba126463cd0fcb6?check=test-split:test-base&span=59440d44c1f434db&viewMode=trace

TestUserDefaults/TestSimple runs table cases under the integration suite's parallel middleware. The test built one shared base container in the outer function scope and then one table case reassigned that shared variable from inside its parallel subtest when applying secret environment preparation.

That made the race detector report a read/write race between the prepare case writing the outer ctr variable and other cases reading it to extend their own Dagger query chain. The generated Go SDK methods then showed additional querybuilder races as downstream evidence of the same shared pointer being published and extended concurrently.

Keep the base container shared as an immutable starting point, but bind a fresh local ctr variable inside each subtest before applying any case-specific preparation. Each parallel case now extends its own local chain and no subtest writes shared state.

Verification:
- dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestUserDefaults/TestSimple' --race