### PR TITLE
engine(otlp): permit blank schema URL in logs

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -280,7 +280,7 @@ func setupTelemetryProxy(ctx context.Context) ([]string, error) {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
-	return []string{
+	otelEnv := []string{
 		engine.OTelExporterProtocolEnv + "=" + otelProto,
 		engine.OTelExporterEndpointEnv + "=" + otelEndpoint,
 		engine.OTelTracesProtocolEnv + "=" + otelProto,
@@ -293,5 +293,11 @@ func setupTelemetryProxy(ctx context.Context) ([]string, error) {
 		engine.OTelLogsEndpointEnv + "=" + otelEndpoint + "/v1/logs",
 		engine.OTelMetricsProtocolEnv + "=" + otelProto,
 		engine.OTelMetricsEndpointEnv + "=" + otelEndpoint + "/v1/metrics",
-	}, nil
+	}
+	// Signal-specific exporter selection enables auto-configuring SDKs; endpoint
+	// vars alone are not enough. Preserve an explicit user setting, e.g. "none".
+	if _, ok := os.LookupEnv(engine.OTelTracesExporterEnv); !ok {
+		otelEnv = append(otelEnv, engine.OTelTracesExporterEnv+"=otlp")
+	}
+	return otelEnv, nil
 }

--- a/engine/clientdb/log.go
+++ b/engine/clientdb/log.go
@@ -38,10 +38,6 @@ func LogsToPB(dbLog []Log) []*otlplogsv1.ResourceLogs {
 		} else {
 			res = telemetry.ResourceFromPB(sd.ResourceSchemaUrl, &resPb)
 		}
-		if res.SchemaURL() == "" {
-			slog.Error("log has no resource", "log", sd)
-			continue
-		}
 		var scope instrumentation.Scope
 		var scopePb otlpcommonv1.InstrumentationScope
 		if err := protojson.Unmarshal(sd.InstrumentationScope, &scopePb); err != nil {

--- a/engine/clientdb/log_test.go
+++ b/engine/clientdb/log_test.go
@@ -1,0 +1,85 @@
+package clientdb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	otlpcommonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	otlpresourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestLogsToPBAllowsSchemalessResources(t *testing.T) {
+	body, err := proto.Marshal(&otlpcommonv1.AnyValue{
+		Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "hello"},
+	})
+	require.NoError(t, err)
+
+	attrs, err := MarshalProtoJSONs([]*otlpcommonv1.KeyValue{
+		{
+			Key: "stdio.stream",
+			Value: &otlpcommonv1.AnyValue{
+				Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "stdout"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scope, err := protojson.Marshal(&otlpcommonv1.InstrumentationScope{Name: "test-logger"})
+	require.NoError(t, err)
+
+	resource, err := protojson.Marshal(&otlpresourcev1.Resource{
+		Attributes: []*otlpcommonv1.KeyValue{
+			{
+				Key: "service.name",
+				Value: &otlpcommonv1.AnyValue{
+					Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "vitest"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("1112131415161718")
+	require.NoError(t, err)
+
+	logs := LogsToPB([]Log{
+		{
+			TraceID: sql.NullString{
+				String: traceID.String(),
+				Valid:  true,
+			},
+			SpanID: sql.NullString{
+				String: spanID.String(),
+				Valid:  true,
+			},
+			Timestamp:            123,
+			SeverityNumber:       1,
+			SeverityText:         "TRACE",
+			Body:                 body,
+			Attributes:           attrs,
+			InstrumentationScope: scope,
+			Resource:             resource,
+			ResourceSchemaUrl:    "",
+		},
+	})
+
+	require.Len(t, logs, 1)
+	require.Empty(t, logs[0].SchemaUrl)
+	require.Len(t, logs[0].Resource.Attributes, 1)
+	require.Equal(t, "service.name", logs[0].Resource.Attributes[0].Key)
+	require.Equal(t, "vitest", logs[0].Resource.Attributes[0].Value.GetStringValue())
+	require.Len(t, logs[0].ScopeLogs, 1)
+	require.Empty(t, logs[0].ScopeLogs[0].SchemaUrl)
+	require.Len(t, logs[0].ScopeLogs[0].LogRecords, 1)
+
+	record := logs[0].ScopeLogs[0].LogRecords[0]
+	require.Equal(t, "hello", record.Body.GetStringValue())
+	require.Equal(t, traceID[:], record.TraceId)
+	require.Equal(t, spanID[:], record.SpanId)
+}

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -47,6 +47,7 @@ const (
 
 const (
 	OTelTraceParentEnv      = "TRACEPARENT"
+	OTelTracesExporterEnv   = "OTEL_TRACES_EXPORTER"
 	OTelExporterProtocolEnv = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	OTelExporterEndpointEnv = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	OTelTracesProtocolEnv   = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -816,6 +816,11 @@ func (c *Client) setupOTel(ctx context.Context, state *execState) error {
 	// Configure our OpenTelemetry proxy. A lot.
 	otelProto := "http/protobuf"
 	otelEndpoint := "http://" + listener.Addr().String()
+	// Signal-specific exporter selection enables auto-configuring SDKs; endpoint
+	// vars alone are not enough. Preserve an explicit user setting, e.g. "none".
+	if _, ok := state.origEnvMap[engine.OTelTracesExporterEnv]; !ok {
+		state.spec.Process.Env = append(state.spec.Process.Env, engine.OTelTracesExporterEnv+"=otlp")
+	}
 	state.spec.Process.Env = append(state.spec.Process.Env,
 		engine.OTelExporterProtocolEnv+"="+otelProto,
 		engine.OTelExporterEndpointEnv+"="+otelEndpoint,

--- a/sdk/python/src/dagger/telemetry.py
+++ b/sdk/python/src/dagger/telemetry.py
@@ -3,32 +3,22 @@ import os
 from typing import Final
 
 from opentelemetry import context, propagate, trace
-from opentelemetry._logs import get_logger_provider
-from opentelemetry.environment_variables import (
-    _OTEL_PYTHON_LOGGER_PROVIDER,
-    OTEL_LOGS_EXPORTER,
-    OTEL_PYTHON_TRACER_PROVIDER,
-    OTEL_TRACES_EXPORTER,
-)
+from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.instrumentation.logging.environment_variables import (
     OTEL_PYTHON_LOG_CORRELATION,
     OTEL_PYTHON_LOG_FORMAT,
     OTEL_PYTHON_LOG_LEVEL,
 )
-from opentelemetry.sdk import _logs as sdklogs
 from opentelemetry.sdk import trace as sdktrace
 from opentelemetry.sdk._configuration import _BaseConfigurator as _BaseSDKConfigurator
 from opentelemetry.sdk._configuration import (
     _get_exporter_names,
     _import_exporters,
-    _init_logging,
 )
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_INSECURE,
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_LOGS_INSECURE,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     OTEL_EXPORTER_OTLP_TRACES_INSECURE,
     OTEL_SDK_DISABLED,
@@ -70,18 +60,12 @@ def shutdown():
     # TODO: set a timeout
 
     tracer_provider = get_tracer_provider()
-    logger_provider = get_logger_provider()
-
     # Provider shutdown is called automatically on exit, we just need the forced
     # flush but might as well shutdown now too.
 
     if isinstance(tracer_provider, sdktrace.TracerProvider):
         tracer_provider.force_flush()
         tracer_provider.shutdown()
-
-    if isinstance(logger_provider, sdklogs.LoggerProvider):
-        logger_provider.force_flush()
-        logger_provider.shutdown()
 
 
 def otel_configured() -> bool:
@@ -186,7 +170,6 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
 
         # The default is a NoOpProvider.
         os.environ.setdefault(OTEL_PYTHON_TRACER_PROVIDER, "sdk_tracer_provider")
-        os.environ.setdefault(_OTEL_PYTHON_LOGGER_PROVIDER, "sdk_logger_provider")
 
         # Logging instrumentation.
         os.environ.setdefault(OTEL_PYTHON_LOG_CORRELATION, "true")
@@ -196,17 +179,8 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
             "%(levelname)s [%(name)s]: %(message)s",
         )
 
-        # TODO: The rest of the env vars should be set by the shim rather than in the SDK.
-
-        for name in (
-            OTEL_TRACES_EXPORTER,
-            OTEL_LOGS_EXPORTER,
-        ):
-            os.environ.setdefault(name, ",".join(self.exporters))
-
         _vars = {
             OTEL_EXPORTER_OTLP_ENDPOINT: OTEL_EXPORTER_OTLP_INSECURE,
-            OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: OTEL_EXPORTER_OTLP_LOGS_INSECURE,
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: OTEL_EXPORTER_OTLP_TRACES_INSECURE,
         }
         for endpoint, insecure in _vars.items():
@@ -218,21 +192,21 @@ class _DaggerOtelConfigurator(_BaseConfigurator):
         # exec resource monitoring). Emitting counters/histograms from modules
         # produces 500s and retry noise, so skip metric initialization by
         # passing an empty list for the metrics slot of _import_exporters.
-        trace_exporters, _, log_exporters = _import_exporters(
+        #
+        # Also skip OTel log exporting. Dagger already captures module
+        # stdout/stderr and forwards it as logs; installing OTel's logging
+        # handler would duplicate Python logging records in the TUI.
+        trace_exporters, _, _ = _import_exporters(
             _get_exporter_names("traces"),
             [],
-            _get_exporter_names("logs"),
+            [],
         )
-        for kind, init, exporters in (
-            ("traces", _init_tracing, trace_exporters),
-            ("logs", _init_logging, log_exporters),
-        ):
-            logger.debug(
-                "Initializing %s telemetry with exporters: %s",
-                kind,
-                ", ".join(exporters) if exporters else "none",
-            )
-            init(exporters)
+        logger.debug(
+            "Initializing traces telemetry with exporters: %s",
+            ", ".join(trace_exporters) if trace_exporters else "none",
+        )
+        _init_tracing(trace_exporters)
 
-        # The logging instrumentor injects the trace context into logs
+        # The logging instrumentor injects the trace context into logs without
+        # exporting them separately.
         LoggingInstrumentor().instrument()


### PR DESCRIPTION
This was causing log telemetry to be dropped when running Dagger's Vitest integration in `dagger check`, while working fine in `dagger run`.

Not sure if there was a good reason for this check - it's valid to not have a schema URL. Either it mattered at an earlier revision, or was just overly defensive.

In fixing this, telemetry tests started failing because the Python SDK started emitting duplicate logs. Investigation revealed that the OTel logging setup that it was doing was actually just being stripped out. We didn't notice since it was redundant with the existing stdout/stderr forwarding. So, this PR cleans all that up.