### PR TITLE
fix: allow configuring Helm StatefulSet replicas

### DIFF
--- a/helm/dagger/.changes/unreleased/Fixed-20260508-083117.yaml
+++ b/helm/dagger/.changes/unreleased/Fixed-20260508-083117.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |
+  Allow configuring Helm chart StatefulSet engine replicas.
+time: 2026-05-08T08:31:17.194139480+04:00
+custom:
+    Author: immanuwell
+    PR: "13116"

--- a/helm/dagger/templates/engine-statefulset.yaml
+++ b/helm/dagger/templates/engine-statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   # DO NOT RUN MORE THAN 1 REPLICA IF USING HOSTPATH.
   # Only one (1) Engine is able to hold the lock, other replicas will not be able to start.
   # If using persistent volumes, this is not an issue. Use more than 1 replica if you know that you need it.
-  replicas: 1
+  replicas: {{ .Values.engine.statefulSet.replicas }}
   podManagementPolicy: {{ .Values.engine.statefulSet.podManagementPolicy }}
   selector:
     matchLabels:

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -38,6 +38,10 @@ engine:
   ### StatefulSet specific configuration
   #
   statefulSet:
+    # Number of Dagger Engine replicas.
+    # Only increase this when using persistent volumes, not hostPath.
+    replicas: 1
+
     # PVC retention policy (applies to all PVCs)
     # Only available in Kubernetes 1.23+
     persistentVolumeClaimRetentionPolicy:


### PR DESCRIPTION
Closes #13066.

Tiny fix, but useful imo: `StatefulSet.spec.replicas` was hardcoded to `1`, so the chart could not scale StatefulSet engines even when users passed a replicas value.

Repro before this patch:

```sh
helm template repro helm/dagger \
  --set engine.kind=StatefulSet \
  --set engine.statefulSet.replicas=3
```

Expected `spec.replicas: 3`, got `spec.replicas: 1` because the template had the value baked in.

This adds `engine.statefulSet.replicas` with the same default of `1`, so existing installs stay chill, and PVC-backed StatefulSet users can opt into more replicas.

Related context: #9249 and #9845 added the StatefulSet/PVC path, this just fills the small gap.

Checked:
- `git diff --check`
- parsed `helm/dagger/values.yaml` and confirmed the default stays `1`
