### PR TITLE
Parallelize Go runtime generation

### DIFF
--- a/.dagger/internal/dagger/go.gen.go
+++ b/.dagger/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../toolchains
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../toolchain
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../toolchains/go/main.go:77:2)
 }
 

--- a/modules/daggerverse/internal/dagger/go.gen.go
+++ b/modules/daggerverse/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../../toolcha
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../../toolch
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../../toolchains/go/main.go:77:2)
 }
 

--- a/modules/dev/internal/dagger/go.gen.go
+++ b/modules/dev/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../../toolcha
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../../toolch
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../../toolchains/go/main.go:77:2)
 }
 

--- a/toolchains/cli-dev/internal/dagger/go.gen.go
+++ b/toolchains/cli-dev/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../../toolcha
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../../toolch
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../../toolchains/go/main.go:77:2)
 }
 

--- a/toolchains/docs-dev/internal/dagger/go.gen.go
+++ b/toolchains/docs-dev/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../../toolcha
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../../toolch
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../../toolchains/go/main.go:77:2)
 }
 

--- a/toolchains/engine-dev/internal/dagger/go.gen.go
+++ b/toolchains/engine-dev/internal/dagger/go.gen.go
@@ -207,13 +207,13 @@ func (r *Go) Cgo(ctx context.Context) (bool, error) { // go (../../../../toolcha
 
 // GoCheckTidyOpts contains options for Go.CheckTidy
 type GoCheckTidyOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:561:2)
+	Include []string // go (../../../../toolchains/go/main.go:655:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:562:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:656:2)
 }
 
 // Check if 'go mod tidy' is up-to-date
-func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:559:1)
+func (r *Go) CheckTidy(ctx context.Context, opts ...GoCheckTidyOpts) error { // go (../../../../toolchains/go/main.go:653:1)
 	if r.checkTidy != nil {
 		return nil
 	}
@@ -283,7 +283,7 @@ func (r *Go) Experiment(ctx context.Context) ([]string, error) { // go (../../..
 	return response, q.Execute(ctx)
 }
 
-func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:686:1)
+func (r *Go) GenerateDaggerRuntime(start string) *Go { // go (../../../../toolchains/go/main.go:578:1)
 	q := r.query.Select("generateDaggerRuntime")
 	q = q.Arg("start", start)
 
@@ -384,13 +384,13 @@ func (r *Go) Limit(ctx context.Context) (int, error) { // go (../../../../toolch
 
 // GoLintOpts contains options for Go.Lint
 type GoLintOpts struct {
-	Include []string // go (../../../../toolchains/go/main.go:631:2)
+	Include []string // go (../../../../toolchains/go/main.go:725:2)
 
-	Exclude []string // go (../../../../toolchains/go/main.go:632:2)
+	Exclude []string // go (../../../../toolchains/go/main.go:726:2)
 }
 
 // Lint the project
-func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:629:1)
+func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../../../toolchains/go/main.go:723:1)
 	if r.lint != nil {
 		return nil
 	}
@@ -409,7 +409,7 @@ func (r *Go) Lint(ctx context.Context, opts ...GoLintOpts) error { // go (../../
 	return q.Execute(ctx)
 }
 
-func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:657:1)
+func (r *Go) LintModule(ctx context.Context, module string) error { // go (../../../../toolchains/go/main.go:751:1)
 	if r.lintModule != nil {
 		return nil
 	}
@@ -738,10 +738,10 @@ type GoOpts struct {
 	//
 	ExtraPackages []string // go (../../../../toolchains/go/main.go:73:2)
 	//
-	// max number of parallel jobs to run for tidy/check tidy/lint
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
 	//
 	//
-	// Default: 3
+	// Default: 10
 	Limit int // go (../../../../toolchains/go/main.go:77:2)
 }
 

--- a/toolchains/go/main.go
+++ b/toolchains/go/main.go
@@ -72,8 +72,8 @@ func New(
 	// +optional
 	extraPackages []string,
 
-	// max number of parallel jobs to run for tidy/check tidy/lint
-	// +default=3
+	// max number of parallel jobs to run for tidy/check tidy/lint/runtime generation
+	// +default=10
 	limit int,
 ) *Go {
 	if source == nil {
@@ -545,13 +545,107 @@ func (p *Go) GenerateDaggerRuntimes(ctx context.Context) (*dagger.Changeset, err
 	if err != nil {
 		return nil, err
 	}
-	for _, module := range modules {
-		p, err = p.GenerateDaggerRuntime(ctx, module)
-		if err != nil {
-			return nil, err
+
+	layers := make([]*dagger.Directory, len(modules))
+	jobs := parallel.New().
+		WithLimit(p.Limit)
+	for i, module := range modules {
+		i, module := i, module
+		jobs = jobs.WithJob(module, func(ctx context.Context) error {
+			layer, ok, err := p.generateDaggerRuntimeLayer(ctx, module)
+			if err != nil {
+				return err
+			}
+			if ok {
+				layers[i] = layer
+			}
+			return nil
+		})
+	}
+	if err := jobs.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	after := before
+	for _, layer := range layers {
+		if layer != nil {
+			after = after.WithDirectory("", layer)
 		}
 	}
-	return p.Source.Changes(before), nil
+	return after.Changes(before), nil
+}
+
+func (p *Go) GenerateDaggerRuntime(ctx context.Context, start string) (*Go, error) {
+	layer, ok, err := p.generateDaggerRuntimeLayer(ctx, start)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		p.Source = p.Source.WithDirectory("", layer)
+	}
+	return p, nil
+}
+
+func (p *Go) generateDaggerRuntimeLayer(ctx context.Context, start string) (*dagger.Directory, bool, error) {
+	var isInside bool
+	var daggerModPath string
+	if err := parallel.Run(ctx, "check for dagger runtime", func(ctx context.Context) error {
+		// 1. Are we in a dagger module?
+		daggerJSONPath, err := p.Source.FindUp(ctx, "dagger.json", start)
+		if err != nil {
+			return err
+		}
+		if daggerJSONPath == "" {
+			return nil
+		}
+		daggerJSONContents, err := p.Source.File(daggerJSONPath).Contents(ctx)
+		if err != nil {
+			return err
+		}
+		daggerJSON := dag.JSON().WithContents(dagger.JSON(daggerJSONContents))
+		sdk, err := daggerJSON.Field([]string{"sdk", "source"}).AsString(ctx)
+		if err != nil {
+			// It's valid for a dagger.json to not have a source field
+			return nil //nolint:nilerr
+		}
+		daggerModPath = path.Clean(strings.TrimSuffix(daggerJSONPath, "dagger.json"))
+
+		// 2. Is the dagger module using the Go SDK?
+		if sdk != "go" {
+			return nil
+		}
+		// 3. Are we in the dagger module's *source* directory?
+		sourceField, err := daggerJSON.Field([]string{"source"}).AsString(ctx)
+		if err != nil {
+			// If no source field, default to "."
+			sourceField = "."
+		}
+		runtimeSourcePath := path.Clean(path.Join(daggerModPath, sourceField))
+		rel, err := filepath.Rel(path.Clean("/"+runtimeSourcePath), path.Clean("/"+start))
+		if err != nil {
+			return err
+		}
+		isInside = !strings.HasPrefix(rel, "..")
+		return nil
+	}); err != nil {
+		return nil, false, err
+	}
+	if !isInside {
+		return nil, false, nil
+	}
+
+	var layer *dagger.Directory
+	if err := parallel.Run(ctx, "generate dagger runtime: "+daggerModPath, func(ctx context.Context) error {
+		// 4. Match! Load the module and generate its files
+		var err error
+		layer, err = p.Source.
+			AsModule(dagger.DirectoryAsModuleOpts{SourceRootPath: daggerModPath}).
+			GeneratedContextDirectory().Sync(ctx)
+		return err
+	}); err != nil {
+		return nil, false, err
+	}
+	return layer, true, nil
 }
 
 // Check if 'go mod tidy' is up-to-date
@@ -681,66 +775,4 @@ func (p *Go) LintModule(ctx context.Context, module string) error {
 			Sync(ctx)
 		return err
 	})
-}
-
-func (p *Go) GenerateDaggerRuntime(ctx context.Context, start string) (*Go, error) {
-	var isInside bool
-	var daggerModPath string
-	if err := parallel.Run(ctx, "check for dagger runtime", func(ctx context.Context) error {
-		// 1. Are we in a dagger module?
-		daggerJSONPath, err := p.Source.FindUp(ctx, "dagger.json", start)
-		if err != nil {
-			return err
-		}
-		if daggerJSONPath == "" {
-			return nil
-		}
-		daggerJSONContents, err := p.Source.File(daggerJSONPath).Contents(ctx)
-		if err != nil {
-			return err
-		}
-		daggerJSON := dag.JSON().WithContents(dagger.JSON(daggerJSONContents))
-		sdk, err := daggerJSON.Field([]string{"sdk", "source"}).AsString(ctx)
-		if err != nil {
-			// It's valid for a dagger.json to not have a source field
-			return nil //nolint:nilerr
-		}
-		daggerModPath = path.Clean(strings.TrimSuffix(daggerJSONPath, "dagger.json"))
-
-		// 2. Is the dagger module using the Go SDK?
-		if sdk != "go" {
-			return nil
-		}
-		// 3. Are we in the dagger module's *source* directory?
-		sourceField, err := daggerJSON.Field([]string{"source"}).AsString(ctx)
-		if err != nil {
-			// If no source field, default to "."
-			sourceField = "."
-		}
-		runtimeSourcePath := path.Clean(path.Join(daggerModPath, sourceField))
-		rel, err := filepath.Rel(path.Clean("/"+runtimeSourcePath), path.Clean("/"+start))
-		if err != nil {
-			return err
-		}
-		isInside = !strings.HasPrefix(rel, "..")
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	if isInside {
-		if err := parallel.Run(ctx, "generate dagger runtime: "+daggerModPath, func(ctx context.Context) error {
-			// 4. Match! Load the module and generate its files
-			layer, err := p.Source.
-				AsModule(dagger.DirectoryAsModuleOpts{SourceRootPath: daggerModPath}).
-				GeneratedContextDirectory().Sync(ctx)
-			if err != nil {
-				return err
-			}
-			p.Source = p.Source.WithDirectory("", layer)
-			return nil
-		}); err != nil {
-			return nil, err
-		}
-	}
-	return p, nil
 }


### PR DESCRIPTION
## Summary

`dagger check dagger-dev:generated` spends a lot of time in `go:generate-dagger-runtimes`, but the Go runtime generation work was being forced serially across modules.

This changes `GenerateDaggerRuntimes` to generate per-module runtime layers in parallel, using the existing Go toolchain `limit` setting. The default limit is bumped to 10, and generated layers are applied back in module order so the final changeset remains deterministic.

The generated Go bindings were updated for the new default/comment and source annotations.

## Testing

- `GOCACHE=/tmp/dagger-toolchains-go-build-cache go test ./...` in `toolchains/go`
- `git diff --check`
- `dagger --progress=plain check dagger-dev:generated`
  - `go:generate-dagger-runtimes` dropped from ~6m54s locally to ~1m17s on a warmed rerun.
  - The check still reports the known local generated schema drift from running Dagger v0.20.7 while v0.20.8 is available; no remaining `go.gen.go` drift from this change.

## Draft note

This is a draft because we're still waiting on confirmation about fixes to memory usage, but we're testing this in the meantime.
