### PR TITLE
Fix quadratic withDirectory materialization regression

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -307,6 +307,13 @@ type ContainerWithDirectoryLazy struct {
 	Owner  string
 }
 
+type containerWithDirectoryOp struct {
+	Path   string
+	Source dagql.ObjectResult[*Directory]
+	Filter CopyFilter
+	Owner  string
+}
+
 type ContainerWithFileLazy struct {
 	LazyState
 	Parent      dagql.ObjectResult[*Container]
@@ -3258,21 +3265,94 @@ func (*ContainerFileLazy) EncodePersisted(context.Context, dagql.PersistedObject
 	return nil, fmt.Errorf("encode persisted container file lazy: unsupported top-level form")
 }
 
+func containerWithDirectoryOpFromLazy(lazy *ContainerWithDirectoryLazy) containerWithDirectoryOp {
+	return containerWithDirectoryOp{
+		Path:   lazy.Path,
+		Source: lazy.Source,
+		Filter: lazy.Filter,
+		Owner:  lazy.Owner,
+	}
+}
+
+func containerWithDirectoryOwnerRequiresParentFS(owner string) bool {
+	if owner == "" {
+		return false
+	}
+
+	uidOrName, gidOrName, hasGroup := strings.Cut(owner, ":")
+	if _, err := parseUID(uidOrName); err != nil {
+		return true
+	}
+	if hasGroup {
+		if _, err := parseUID(gidOrName); err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func collectContainerWithDirectoryChain(lazy *ContainerWithDirectoryLazy) (dagql.ObjectResult[*Container], []containerWithDirectoryOp) {
+	ops := []containerWithDirectoryOp{containerWithDirectoryOpFromLazy(lazy)}
+	base := lazy.Parent
+
+	for {
+		parent := base.Self()
+		if parent == nil {
+			break
+		}
+		parentLazy, ok := parent.Lazy.(*ContainerWithDirectoryLazy)
+		if !ok || parentLazy.LazyInitComplete || containerWithDirectoryOwnerRequiresParentFS(parentLazy.Owner) {
+			break
+		}
+		ops = append(ops, containerWithDirectoryOpFromLazy(parentLazy))
+		base = parentLazy.Parent
+	}
+
+	slices.Reverse(ops)
+	return base, ops
+}
+
 func (lazy *ContainerWithDirectoryLazy) Evaluate(ctx context.Context, container *Container) error {
 	return lazy.LazyState.Evaluate(ctx, "Container.withDirectory", func(ctx context.Context) error {
+		if containerWithDirectoryOwnerRequiresParentFS(lazy.Owner) {
+			cache, err := dagql.EngineCache(ctx)
+			if err != nil {
+				return err
+			}
+			if err := cache.Evaluate(ctx, lazy.Parent, lazy.Source); err != nil {
+				return err
+			}
+			if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+				return err
+			}
+			_, err = container.WithDirectory(ctx, lazy.Parent, lazy.Path, lazy.Source, lazy.Filter, lazy.Owner)
+			if err != nil {
+				return err
+			}
+			container.Lazy = nil
+			return nil
+		}
+
+		base, ops := collectContainerWithDirectoryChain(lazy)
 		cache, err := dagql.EngineCache(ctx)
 		if err != nil {
 			return err
 		}
-		if err := cache.Evaluate(ctx, lazy.Parent, lazy.Source); err != nil {
+		evaluate := make([]dagql.AnyResult, 0, 1+len(ops))
+		evaluate = append(evaluate, base)
+		for _, op := range ops {
+			evaluate = append(evaluate, op.Source)
+		}
+		if err := cache.Evaluate(ctx, evaluate...); err != nil {
 			return err
 		}
-		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+		if err := materializeContainerStateFromParent(ctx, container, base); err != nil {
 			return err
 		}
-		_, err = container.WithDirectory(ctx, lazy.Parent, lazy.Path, lazy.Source, lazy.Filter, lazy.Owner)
-		if err != nil {
-			return err
+		for _, op := range ops {
+			if _, err := container.withDirectoryFromCurrentState(ctx, base, op.Path, op.Source, op.Filter, op.Owner); err != nil {
+				return err
+			}
 		}
 		container.Lazy = nil
 		return nil
@@ -4954,6 +5034,97 @@ func (container *Container) WithDirectory(
 	}
 	container.ImageRef = ""
 	return container, nil
+}
+
+// mutates container caller must have handled cloning or creating a new child.
+func (container *Container) withDirectoryFromCurrentState(
+	ctx context.Context,
+	parentForOwnership dagql.ObjectResult[*Container],
+	subdir string,
+	src dagql.ObjectResult[*Directory],
+	filter CopyFilter,
+	owner string,
+) (*Container, error) {
+	mnt, mntSubpath, err := locatePath(container, subdir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate path %s: %w", subdir, err)
+	}
+
+	if mnt != nil && mnt.FileSource != nil && (mntSubpath == "/" || mntSubpath == "" || mntSubpath == ".") {
+		container, err = container.WithoutMount(ctx, mnt.Target)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmount %s: %w", mnt.Target, err)
+		}
+		return container.withDirectoryFromCurrentState(ctx, parentForOwnership, subdir, src, filter, owner)
+	}
+
+	resolvedOwner := owner
+	if owner != "" {
+		if containerWithDirectoryOwnerRequiresParentFS(owner) {
+			return nil, fmt.Errorf("container withDirectory chain replay requires numeric owner, got %q", owner)
+		}
+		ownership, err := container.ownership(ctx, parentForOwnership, owner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve ownership for %s: %w", owner, err)
+		}
+		resolvedOwner = strconv.Itoa(ownership.UID) + ":" + strconv.Itoa(ownership.GID)
+	}
+
+	if mnt == nil {
+		if container.FS == nil {
+			container.FS = new(LazyAccessor[*Directory, *Container])
+		}
+		if _, ok := container.FS.Peek(); !ok {
+			scratchDir, scratchSnapshot, err := loadCanonicalScratchDirectory(ctx)
+			if err != nil {
+				return nil, err
+			}
+			rootfs := &Directory{
+				Platform: container.Platform,
+				Services: slices.Clone(container.Services),
+				Dir:      new(LazyAccessor[string, *Directory]),
+				Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
+			}
+			rootfs.Dir.setValue(scratchDir)
+			rootfs.Snapshot.setValue(scratchSnapshot)
+			container.FS.setValue(rootfs)
+		}
+	}
+
+	targetParent, err := materializedTargetParentDirectoryForContainerPath(ctx, container, subdir)
+	if err != nil {
+		return nil, err
+	}
+	if targetParentRef, ok := targetParent.Snapshot.Peek(); ok && targetParentRef != nil {
+		defer targetParentRef.Release(context.WithoutCancel(ctx))
+	}
+	dir, err := bareDirectoryForContainerPath(container, subdir)
+	if err != nil {
+		return nil, err
+	}
+	if err := dir.evaluateWithDirectoryChainFromMaterializedBase(ctx, targetParent, []directoryWithDirectoryOp{
+		{
+			DestDir: mntSubpath,
+			Source:  src,
+			Filter:  filter,
+			Owner:   resolvedOwner,
+		},
+	}); err != nil {
+		return nil, err
+	}
+	container.ImageRef = ""
+	return container, nil
+}
+
+func materializedTargetParentDirectoryForContainerPath(ctx context.Context, current *Container, targetPath string) (*Directory, error) {
+	if current == nil {
+		return nil, fmt.Errorf("container lazy current state is nil")
+	}
+	dir, err := bareDirectoryForContainerPath(current, targetPath)
+	if err != nil {
+		return nil, err
+	}
+	return cloneDetachedDirectoryForContainerResult(ctx, dir)
 }
 
 // mutates container caller must have handled cloning or creating a new child.

--- a/core/container.go
+++ b/core/container.go
@@ -3349,10 +3349,8 @@ func (lazy *ContainerWithDirectoryLazy) Evaluate(ctx context.Context, container 
 		if err := materializeContainerStateFromParent(ctx, container, base); err != nil {
 			return err
 		}
-		for _, op := range ops {
-			if _, err := container.withDirectoryFromCurrentState(ctx, base, op.Path, op.Source, op.Filter, op.Owner); err != nil {
-				return err
-			}
+		if _, err := container.withDirectoryChainFromCurrentState(ctx, base, ops); err != nil {
+			return err
 		}
 		container.Lazy = nil
 		return nil
@@ -4967,6 +4965,30 @@ func (container *Container) WithRootFS(ctx context.Context, dir dagql.ObjectResu
 	return container, nil
 }
 
+func (container *Container) ensureRootFS(ctx context.Context) error {
+	if container.FS == nil {
+		container.FS = new(LazyAccessor[*Directory, *Container])
+	}
+	if _, ok := container.FS.Peek(); ok {
+		return nil
+	}
+
+	scratchDir, scratchSnapshot, err := loadCanonicalScratchDirectory(ctx)
+	if err != nil {
+		return err
+	}
+	rootfs := &Directory{
+		Platform: container.Platform,
+		Services: slices.Clone(container.Services),
+		Dir:      new(LazyAccessor[string, *Directory]),
+		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
+	}
+	rootfs.Dir.setValue(scratchDir)
+	rootfs.Snapshot.setValue(scratchSnapshot)
+	container.FS.setValue(rootfs)
+	return nil
+}
+
 // mutates container caller must have handled cloning or creating a new child.
 func (container *Container) WithDirectory(
 	ctx context.Context,
@@ -5001,23 +5023,8 @@ func (container *Container) WithDirectory(
 	}
 
 	if mnt == nil {
-		if container.FS == nil {
-			container.FS = new(LazyAccessor[*Directory, *Container])
-		}
-		if _, ok := container.FS.Peek(); !ok {
-			scratchDir, scratchSnapshot, err := loadCanonicalScratchDirectory(ctx)
-			if err != nil {
-				return nil, err
-			}
-			rootfs := &Directory{
-				Platform: container.Platform,
-				Services: slices.Clone(container.Services),
-				Dir:      new(LazyAccessor[string, *Directory]),
-				Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
-			}
-			rootfs.Dir.setValue(scratchDir)
-			rootfs.Snapshot.setValue(scratchSnapshot)
-			container.FS.setValue(rootfs)
+		if err := container.ensureRootFS(ctx); err != nil {
+			return nil, err
 		}
 	}
 
@@ -5033,6 +5040,114 @@ func (container *Container) WithDirectory(
 		return nil, err
 	}
 	container.ImageRef = ""
+	return container, nil
+}
+
+// mutates container caller must have handled cloning or creating a new child.
+func (container *Container) withDirectoryChainFromCurrentState(
+	ctx context.Context,
+	parentForOwnership dagql.ObjectResult[*Container],
+	ops []containerWithDirectoryOp,
+) (*Container, error) {
+	type batch struct {
+		target *LazyAccessor[*Directory, *Container]
+		path   string
+		ops    []directoryWithDirectoryOp
+	}
+
+	var current batch
+	flush := func() error {
+		if len(current.ops) == 0 {
+			return nil
+		}
+
+		targetParent, err := materializedTargetParentDirectoryForContainerPath(ctx, container, current.path)
+		if err != nil {
+			return err
+		}
+		if targetParentRef, ok := targetParent.Snapshot.Peek(); ok && targetParentRef != nil {
+			defer targetParentRef.Release(context.WithoutCancel(ctx))
+		}
+		dir, err := bareDirectoryForContainerPath(container, current.path)
+		if err != nil {
+			return err
+		}
+		if err := dir.evaluateWithDirectoryChainFromMaterializedBase(ctx, targetParent, current.ops); err != nil {
+			return err
+		}
+
+		current = batch{}
+		container.ImageRef = ""
+		return nil
+	}
+
+	for _, op := range ops {
+		mnt, mntSubpath, err := locatePath(container, op.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to locate path %s: %w", op.Path, err)
+		}
+
+		if mnt != nil && mnt.FileSource != nil && (mntSubpath == "/" || mntSubpath == "" || mntSubpath == ".") {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			if _, err := container.withDirectoryFromCurrentState(ctx, parentForOwnership, op.Path, op.Source, op.Filter, op.Owner); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		var target *LazyAccessor[*Directory, *Container]
+		switch {
+		case mnt == nil:
+			if err := container.ensureRootFS(ctx); err != nil {
+				return nil, err
+			}
+			target = container.FS
+		case mnt.DirectorySource != nil:
+			target = mnt.DirectorySource
+		default:
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			if _, err := container.withDirectoryFromCurrentState(ctx, parentForOwnership, op.Path, op.Source, op.Filter, op.Owner); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		resolvedOwner := op.Owner
+		if op.Owner != "" {
+			if containerWithDirectoryOwnerRequiresParentFS(op.Owner) {
+				return nil, fmt.Errorf("container withDirectory chain replay requires numeric owner, got %q", op.Owner)
+			}
+			ownership, err := container.ownership(ctx, parentForOwnership, op.Owner)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve ownership for %s: %w", op.Owner, err)
+			}
+			resolvedOwner = strconv.Itoa(ownership.UID) + ":" + strconv.Itoa(ownership.GID)
+		}
+
+		if len(current.ops) != 0 && current.target != target {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+		if len(current.ops) == 0 {
+			current.target = target
+			current.path = op.Path
+		}
+		current.ops = append(current.ops, directoryWithDirectoryOp{
+			DestDir: mntSubpath,
+			Source:  op.Source,
+			Filter:  op.Filter,
+			Owner:   resolvedOwner,
+		})
+	}
+
+	if err := flush(); err != nil {
+		return nil, err
+	}
 	return container, nil
 }
 
@@ -5071,23 +5186,8 @@ func (container *Container) withDirectoryFromCurrentState(
 	}
 
 	if mnt == nil {
-		if container.FS == nil {
-			container.FS = new(LazyAccessor[*Directory, *Container])
-		}
-		if _, ok := container.FS.Peek(); !ok {
-			scratchDir, scratchSnapshot, err := loadCanonicalScratchDirectory(ctx)
-			if err != nil {
-				return nil, err
-			}
-			rootfs := &Directory{
-				Platform: container.Platform,
-				Services: slices.Clone(container.Services),
-				Dir:      new(LazyAccessor[string, *Directory]),
-				Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
-			}
-			rootfs.Dir.setValue(scratchDir)
-			rootfs.Snapshot.setValue(scratchSnapshot)
-			container.FS.setValue(rootfs)
+		if err := container.ensureRootFS(ctx); err != nil {
+			return nil, err
 		}
 	}
 

--- a/core/directory.go
+++ b/core/directory.go
@@ -1896,7 +1896,6 @@ func (dir *Directory) WithDirectory(
 	})
 }
 
-//nolint:gocyclo
 func (dir *Directory) evaluateWithDirectoryChain(
 	ctx context.Context,
 	base dagql.ObjectResult[*Directory],
@@ -1923,7 +1922,6 @@ func (dir *Directory) evaluateWithDirectoryChain(
 	return dir.evaluateWithDirectoryChainFromMaterializedBase(ctx, baseDir, ops)
 }
 
-//nolint:gocyclo
 func (dir *Directory) evaluateWithDirectoryChainFromMaterializedBase(
 	ctx context.Context,
 	baseDir *Directory,

--- a/core/directory.go
+++ b/core/directory.go
@@ -317,6 +317,19 @@ type DirectoryWithDirectoryLazy struct {
 	Permissions *int
 }
 
+type directoryWithDirectoryOp struct {
+	DestDir     string
+	Source      dagql.ObjectResult[*Directory]
+	Filter      CopyFilter
+	Owner       string
+	Permissions *int
+}
+
+type directoryWithDirectoryMergeRef struct {
+	Ref   bkcache.ImmutableRef
+	Owned bool
+}
+
 type DirectoryWithDirectoryDockerfileCompatLazy struct {
 	LazyState
 	Parent                           dagql.ObjectResult[*Directory]
@@ -746,7 +759,8 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 
 func (lazy *DirectoryWithDirectoryLazy) Evaluate(ctx context.Context, dir *Directory) error {
 	return lazy.LazyState.Evaluate(ctx, "Directory.withDirectory", func(ctx context.Context) error {
-		return dir.WithDirectory(ctx, lazy.Parent, lazy.DestDir, lazy.Source, lazy.Filter, lazy.Owner, lazy.Permissions)
+		base, ops := collectDirectoryWithDirectoryChain(lazy)
+		return dir.evaluateWithDirectoryChain(ctx, base, ops)
 	})
 }
 
@@ -1831,7 +1845,37 @@ func (cf *CopyFilter) IsEmpty() bool {
 	return len(cf.Exclude) == 0 && len(cf.Include) == 0 && !cf.Gitignore
 }
 
-//nolint:gocyclo
+func directoryWithDirectoryOpFromLazy(lazy *DirectoryWithDirectoryLazy) directoryWithDirectoryOp {
+	return directoryWithDirectoryOp{
+		DestDir:     lazy.DestDir,
+		Source:      lazy.Source,
+		Filter:      lazy.Filter,
+		Owner:       lazy.Owner,
+		Permissions: lazy.Permissions,
+	}
+}
+
+func collectDirectoryWithDirectoryChain(lazy *DirectoryWithDirectoryLazy) (dagql.ObjectResult[*Directory], []directoryWithDirectoryOp) {
+	ops := []directoryWithDirectoryOp{directoryWithDirectoryOpFromLazy(lazy)}
+	base := lazy.Parent
+
+	for {
+		parent := base.Self()
+		if parent == nil {
+			break
+		}
+		parentLazy, ok := parent.Lazy.(*DirectoryWithDirectoryLazy)
+		if !ok || parentLazy.LazyInitComplete {
+			break
+		}
+		ops = append(ops, directoryWithDirectoryOpFromLazy(parentLazy))
+		base = parentLazy.Parent
+	}
+
+	slices.Reverse(ops)
+	return base, ops
+}
+
 func (dir *Directory) WithDirectory(
 	ctx context.Context,
 	parent dagql.ObjectResult[*Directory],
@@ -1841,197 +1885,175 @@ func (dir *Directory) WithDirectory(
 	owner string,
 	permissions *int,
 ) error {
+	return dir.evaluateWithDirectoryChain(ctx, parent, []directoryWithDirectoryOp{
+		{
+			DestDir:     destDir,
+			Source:      src,
+			Filter:      filter,
+			Owner:       owner,
+			Permissions: permissions,
+		},
+	})
+}
+
+//nolint:gocyclo
+func (dir *Directory) evaluateWithDirectoryChain(
+	ctx context.Context,
+	base dagql.ObjectResult[*Directory],
+	ops []directoryWithDirectoryOp,
+) error {
 	dagqlCache, err := dagql.EngineCache(ctx)
 	if err != nil {
 		return err
 	}
 
-	// explicit parallel evaluation for better perf
-	if err := dagqlCache.Evaluate(ctx, parent, src); err != nil {
+	evaluate := make([]dagql.AnyResult, 0, 1+len(ops))
+	evaluate = append(evaluate, base)
+	for _, op := range ops {
+		evaluate = append(evaluate, op.Source)
+	}
+	if err := dagqlCache.Evaluate(ctx, evaluate...); err != nil {
 		return err
 	}
 
-	dirRef, err := parent.Self().Snapshot.GetOrEval(ctx, parent.Result)
-	if err != nil {
-		return fmt.Errorf("failed to get directory ref: %w", err)
+	baseDir := base.Self()
+	if baseDir == nil {
+		return fmt.Errorf("directory withDirectory base: nil directory")
 	}
-	ourDir, err := parent.Self().Dir.GetOrEval(ctx, parent.Result)
+	return dir.evaluateWithDirectoryChainFromMaterializedBase(ctx, baseDir, ops)
+}
+
+//nolint:gocyclo
+func (dir *Directory) evaluateWithDirectoryChainFromMaterializedBase(
+	ctx context.Context,
+	baseDir *Directory,
+	ops []directoryWithDirectoryOp,
+) error {
+	dirRef, ourDir, err := materializedDirectorySnapshotAndPath(baseDir)
 	if err != nil {
-		return fmt.Errorf("failed to get directory path: %w", err)
+		return err
 	}
 	dir.Dir.setValue(ourDir)
-
-	srcRef, err := src.Self().Snapshot.GetOrEval(ctx, src.Result)
-	if err != nil {
-		return fmt.Errorf("failed to get source directory ref: %w", err)
-	}
-	srcDir, err := src.Self().Dir.GetOrEval(ctx, src.Result)
-	if err != nil {
-		return fmt.Errorf("failed to get source directory path: %w", err)
-	}
 
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current query: %w", err)
 	}
+
+	mergeRefs := make([]directoryWithDirectoryMergeRef, 0, 1+len(ops))
+	if dirRef != nil {
+		mergeRefs = append(mergeRefs, directoryWithDirectoryMergeRef{Ref: dirRef})
+	}
+
+	for _, op := range ops {
+		srcDirObj := op.Source.Self()
+		if srcDirObj == nil {
+			return fmt.Errorf("directory withDirectory source: nil directory")
+		}
+		srcRef, err := srcDirObj.Snapshot.GetOrEval(ctx, op.Source.Result)
+		if err != nil {
+			return fmt.Errorf("failed to get source directory ref: %w", err)
+		}
+		srcDir, err := srcDirObj.Dir.GetOrEval(ctx, op.Source.Result)
+		if err != nil {
+			return fmt.Errorf("failed to get source directory path: %w", err)
+		}
+
+		destDir := directoryWithDirectoryDest(ourDir, op.DestDir)
+		if canDirectMergeDirectoryWithDirectory(op.Filter, destDir, srcDir, op.Owner, op.Permissions) {
+			if srcRef != nil {
+				mergeRefs = append(mergeRefs, directoryWithDirectoryMergeRef{Ref: srcRef})
+			}
+			continue
+		}
+
+		rebasedSrcRef, err := copyDirectorySourceToScratch(
+			ctx,
+			query,
+			destDir,
+			srcRef,
+			srcDir,
+			op.Filter,
+			op.Owner,
+			op.Permissions,
+		)
+		if err != nil {
+			return err
+		}
+		mergeRefs = append(mergeRefs, directoryWithDirectoryMergeRef{Ref: rebasedSrcRef, Owned: true})
+	}
+
+	return dir.setWithDirectoryMergeRefs(ctx, query, mergeRefs)
+}
+
+func materializedDirectorySnapshotAndPath(dir *Directory) (bkcache.ImmutableRef, string, error) {
+	if dir == nil {
+		return nil, "", fmt.Errorf("materialized directory: nil directory")
+	}
+	if dir.Lazy != nil {
+		return nil, "", fmt.Errorf("materialized directory: still lazy %T", dir.Lazy)
+	}
+	dirRef, ok := dir.Snapshot.Peek()
+	if !ok {
+		return nil, "", fmt.Errorf("materialized directory: missing snapshot")
+	}
+	dirPath, ok := dir.Dir.Peek()
+	if !ok {
+		return nil, "", fmt.Errorf("materialized directory: missing path")
+	}
+	return dirRef, dirPath, nil
+}
+
+func directoryWithDirectoryDest(baseDir, destDir string) string {
 	destDirTrailingSlash := strings.HasSuffix(destDir, "/") || strings.HasSuffix(destDir, "/.")
-	destDir = path.Join(ourDir, destDir)
+	destDir = path.Join(baseDir, destDir)
 	if destDirTrailingSlash && !strings.HasSuffix(destDir, "/") {
 		destDir += "/"
 	}
+	return destDir
+}
 
-	canDoDirectMerge :=
-		filter.IsEmpty() &&
-			destDir == "/" &&
-			srcDir == "/" &&
-			owner == ""
+func canDirectMergeDirectoryWithDirectory(filter CopyFilter, destDir, srcDir, owner string, permissions *int) bool {
+	return filter.IsEmpty() &&
+		destDir == "/" &&
+		srcDir == "/" &&
+		owner == "" &&
+		permissions == nil
+}
 
-	copySourceToScratch := func() (bkcache.ImmutableRef, error) {
-		newRef, err := query.SnapshotManager().New(
-			ctx,
-			nil,
-			bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
-			bkcache.WithDescription("Directory.withDirectory source"),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("snapshotmanager.New failed: %w", err)
-		}
-		defer newRef.Release(context.WithoutCancel(ctx))
-
-		err = MountRef(ctx, newRef, func(copyDest string, destMnt *mount.Mount) error {
-			var ownership *Ownership
-			if owner != "" {
-				var err error
-				ownership, err = resolveDirectoryOwner(copyDest, owner)
-				if err != nil {
-					return fmt.Errorf("failed to parse ownership %s: %w", owner, err)
-				}
-			}
-
-			resolvedCopyDest, err := containerdfs.RootPath(copyDest, destDir)
-			if err != nil {
-				return err
-			}
-			if srcRef == nil {
-				err = os.MkdirAll(resolvedCopyDest, 0755)
-				if err != nil {
-					return err
-				}
-				if ownership != nil {
-					if err := os.Chown(resolvedCopyDest, ownership.UID, ownership.GID); err != nil {
-						return fmt.Errorf("failed to set chown %s: err", resolvedCopyDest)
-					}
-				}
-				return nil
-			}
-			mounter, err := srcRef.Mount(ctx, true)
-			if err != nil {
-				return fmt.Errorf("failed to mount source directory: %w", err)
-			}
-			ms, unmountSrc, err := mounter.Mount()
-			if err != nil {
-				return fmt.Errorf("failed to mount source directory: %w", err)
-			}
-			defer unmountSrc()
-			if len(ms) == 0 {
-				return fmt.Errorf("no mounts returned for source directory")
-			}
-			srcMnt := ms[0]
-			lm := bkcache.LocalMounterWithMounts(ms)
-			mntedSrcPath, err := lm.Mount()
-			if err != nil {
-				return fmt.Errorf("failed to mount source directory: %w", err)
-			}
-			defer lm.Unmount()
-			resolvedSrcPath, err := containerdfs.RootPath(mntedSrcPath, srcDir)
-			if err != nil {
-				return err
-			}
-			srcResolver, err := pathResolverForMount(&srcMnt, mntedSrcPath)
-			if err != nil {
-				return fmt.Errorf("failed to create source path resolver: %w", err)
-			}
-			destResolver, err := pathResolverForMount(destMnt, copyDest)
-			if err != nil {
-				return fmt.Errorf("failed to create destination path resolver: %w", err)
-			}
-
-			var opts []fscopy.Opt
-			opts = append(opts, fscopy.WithCopyInfo(fscopy.CopyInfo{
-				AlwaysReplaceExistingDestPaths: true,
-				CopyDirContents:                true,
-				EnableHardlinkOptimization:     true,
-				SourcePathResolver:             srcResolver,
-				DestPathResolver:               destResolver,
-				Mode:                           permissions,
-			}))
-			for _, pattern := range filter.Include {
-				opts = append(opts, fscopy.WithIncludePattern(pattern))
-			}
-			for _, pattern := range filter.Exclude {
-				opts = append(opts, fscopy.WithExcludePattern(pattern))
-			}
-			if filter.Gitignore {
-				opts = append(opts, fscopy.WithGitignore())
-			}
-			if ownership != nil {
-				opts = append(opts, fscopy.WithChown(ownership.UID, ownership.GID))
-			}
-
-			if err := fscopy.Copy(ctx, resolvedSrcPath, ".", resolvedCopyDest, ".", opts...); err != nil {
-				return fmt.Errorf("failed to copy source directory: %w", err)
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		ref, err := newRef.Commit(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to commit copied directory: %w", err)
-		}
-		return ref, nil
-	}
-
-	if dirRef == nil {
-		if canDoDirectMerge && srcRef != nil {
-			ref, err := query.SnapshotManager().GetBySnapshotID(ctx, srcRef.SnapshotID(), bkcache.NoUpdateLastUsed)
-			if err != nil {
-				return err
-			}
-			dir.Snapshot.setValue(ref)
-			return nil
-		}
-
-		rebasedSrcRef, err := copySourceToScratch()
+func (dir *Directory) setWithDirectoryMergeRefs(
+	ctx context.Context,
+	query *Query,
+	refs []directoryWithDirectoryMergeRef,
+) error {
+	switch len(refs) {
+	case 0:
+		emptyRef, err := copyDirectorySourceToScratch(ctx, query, "/", nil, "/", CopyFilter{}, "", nil)
 		if err != nil {
 			return err
 		}
-		dir.Snapshot.setValue(rebasedSrcRef)
+		dir.Snapshot.setValue(emptyRef)
+		return nil
+	case 1:
+		if refs[0].Owned {
+			dir.Snapshot.setValue(refs[0].Ref)
+			return nil
+		}
+		ref, err := query.SnapshotManager().GetBySnapshotID(ctx, refs[0].Ref.SnapshotID(), bkcache.NoUpdateLastUsed)
+		if err != nil {
+			return err
+		}
+		dir.Snapshot.setValue(ref)
 		return nil
 	}
 
-	mergeRefs := []bkcache.ImmutableRef{dirRef}
-	if canDoDirectMerge {
-		if srcRef == nil {
-			ref, err := query.SnapshotManager().GetBySnapshotID(ctx, dirRef.SnapshotID(), bkcache.NoUpdateLastUsed)
-			if err != nil {
-				return err
-			}
-			dir.Snapshot.setValue(ref)
-			return nil
+	mergeRefs := make([]bkcache.ImmutableRef, 0, len(refs))
+	for _, ref := range refs {
+		mergeRefs = append(mergeRefs, ref.Ref)
+		if ref.Owned {
+			defer ref.Ref.Release(context.WithoutCancel(ctx))
 		}
-		mergeRefs = append(mergeRefs, srcRef)
-	} else {
-		rebasedSrcRef, err := copySourceToScratch()
-		if err != nil {
-			return err
-		}
-		defer rebasedSrcRef.Release(context.WithoutCancel(ctx))
-		mergeRefs = append(mergeRefs, rebasedSrcRef)
 	}
-
 	ref, err := query.SnapshotManager().Merge(
 		ctx,
 		mergeRefs,
@@ -2043,6 +2065,123 @@ func (dir *Directory) WithDirectory(
 	}
 	dir.Snapshot.setValue(ref)
 	return nil
+}
+
+func copyDirectorySourceToScratch(
+	ctx context.Context,
+	query *Query,
+	destDir string,
+	srcRef bkcache.ImmutableRef,
+	srcDir string,
+	filter CopyFilter,
+	owner string,
+	permissions *int,
+) (bkcache.ImmutableRef, error) {
+	newRef, err := query.SnapshotManager().New(
+		ctx,
+		nil,
+		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
+		bkcache.WithDescription("Directory.withDirectory source"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshotmanager.New failed: %w", err)
+	}
+	defer newRef.Release(context.WithoutCancel(ctx))
+
+	err = MountRef(ctx, newRef, func(copyDest string, destMnt *mount.Mount) error {
+		var ownership *Ownership
+		if owner != "" {
+			var err error
+			ownership, err = resolveDirectoryOwner(copyDest, owner)
+			if err != nil {
+				return fmt.Errorf("failed to parse ownership %s: %w", owner, err)
+			}
+		}
+
+		resolvedCopyDest, err := containerdfs.RootPath(copyDest, destDir)
+		if err != nil {
+			return err
+		}
+		if srcRef == nil {
+			err = os.MkdirAll(resolvedCopyDest, 0755)
+			if err != nil {
+				return err
+			}
+			if ownership != nil {
+				if err := os.Chown(resolvedCopyDest, ownership.UID, ownership.GID); err != nil {
+					return fmt.Errorf("failed to set chown %s: err", resolvedCopyDest)
+				}
+			}
+			return nil
+		}
+		mounter, err := srcRef.Mount(ctx, true)
+		if err != nil {
+			return fmt.Errorf("failed to mount source directory: %w", err)
+		}
+		ms, unmountSrc, err := mounter.Mount()
+		if err != nil {
+			return fmt.Errorf("failed to mount source directory: %w", err)
+		}
+		defer unmountSrc()
+		if len(ms) == 0 {
+			return fmt.Errorf("no mounts returned for source directory")
+		}
+		srcMnt := ms[0]
+		lm := bkcache.LocalMounterWithMounts(ms)
+		mntedSrcPath, err := lm.Mount()
+		if err != nil {
+			return fmt.Errorf("failed to mount source directory: %w", err)
+		}
+		defer lm.Unmount()
+		resolvedSrcPath, err := containerdfs.RootPath(mntedSrcPath, srcDir)
+		if err != nil {
+			return err
+		}
+		srcResolver, err := pathResolverForMount(&srcMnt, mntedSrcPath)
+		if err != nil {
+			return fmt.Errorf("failed to create source path resolver: %w", err)
+		}
+		destResolver, err := pathResolverForMount(destMnt, copyDest)
+		if err != nil {
+			return fmt.Errorf("failed to create destination path resolver: %w", err)
+		}
+
+		var opts []fscopy.Opt
+		opts = append(opts, fscopy.WithCopyInfo(fscopy.CopyInfo{
+			AlwaysReplaceExistingDestPaths: true,
+			CopyDirContents:                true,
+			EnableHardlinkOptimization:     true,
+			SourcePathResolver:             srcResolver,
+			DestPathResolver:               destResolver,
+			Mode:                           permissions,
+		}))
+		for _, pattern := range filter.Include {
+			opts = append(opts, fscopy.WithIncludePattern(pattern))
+		}
+		for _, pattern := range filter.Exclude {
+			opts = append(opts, fscopy.WithExcludePattern(pattern))
+		}
+		if filter.Gitignore {
+			opts = append(opts, fscopy.WithGitignore())
+		}
+		if ownership != nil {
+			opts = append(opts, fscopy.WithChown(ownership.UID, ownership.GID))
+		}
+
+		if err := fscopy.Copy(ctx, resolvedSrcPath, ".", resolvedCopyDest, ".", opts...); err != nil {
+			return fmt.Errorf("failed to copy source directory: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := newRef.Commit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit copied directory: %w", err)
+	}
+	return ref, nil
 }
 
 //nolint:gocyclo

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1647,6 +1647,50 @@ func (ContainerSuite) TestWithDirectory(ctx context.Context, t *testctx.T) {
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "some-content", contents)
+
+	t.Run("chains preserve layered semantics", func(ctx context.Context, t *testctx.T) {
+		srcA := c.Directory().
+			WithNewFile("a.txt", "a").
+			WithNewFile("conflict.txt", "a").
+			WithNewFile("skip.txt", "skip")
+		srcB := c.Directory().
+			WithNewFile("b.txt", "b")
+		srcC := c.Directory().
+			WithNewFile("c.txt", "c").
+			WithNewFile("conflict.txt", "c")
+
+		ctr := c.Container().
+			From(alpineImage).
+			WithDirectory("/work", srcA, dagger.ContainerWithDirectoryOpts{Exclude: []string{"skip.txt"}}).
+			WithDirectory("/work/nested", srcB).
+			WithDirectory("/work", srcC)
+
+		out, err := ctr.WithExec([]string{"sh", "-lc", "cat /work/a.txt /work/nested/b.txt /work/c.txt /work/conflict.txt"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "abcc", out)
+
+		_, err = ctr.WithExec([]string{"cat", "/work/skip.txt"}).Sync(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("chains into mounted directory", func(ctx context.Context, t *testctx.T) {
+		mount := c.Directory().
+			WithNewFile("base.txt", "base")
+		srcA := c.Directory().
+			WithNewFile("a.txt", "a")
+		srcB := c.Directory().
+			WithNewFile("b.txt", "b")
+
+		ctr := c.Container().
+			From(alpineImage).
+			WithMountedDirectory("/mnt", mount).
+			WithDirectory("/mnt/a", srcA).
+			WithDirectory("/mnt/b", srcB)
+
+		out, err := ctr.WithExec([]string{"sh", "-lc", "cat /mnt/base.txt /mnt/a/a.txt /mnt/b/b.txt"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "baseab", out)
+	})
 }
 
 func (ContainerSuite) TestWithFile(ctx context.Context, t *testctx.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -293,6 +293,49 @@ func (DirectorySuite) TestWithDirectory(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().WithDirectory("/", c.Directory()).Sync(ctx)
 		require.NoError(t, err)
 	})
+
+	t.Run("chains preserve layered semantics", func(ctx context.Context, t *testctx.T) {
+		base := c.Directory().
+			WithNewFile("keep.txt", "base").
+			WithNewFile("conflict.txt", "base")
+		srcA := c.Directory().
+			WithNewFile("a.txt", "a").
+			WithNewFile("conflict.txt", "a").
+			WithNewFile("skip.txt", "skip")
+		srcB := c.Directory().
+			WithNewFile("b.txt", "b")
+		srcC := c.Directory().
+			WithNewFile("c.txt", "c").
+			WithNewFile("conflict.txt", "c")
+
+		dir := base.
+			WithDirectory("/", srcA, dagger.DirectoryWithDirectoryOpts{Exclude: []string{"skip.txt"}}).
+			WithDirectory("nested", srcB).
+			WithDirectory("/", srcC)
+
+		contents, err := dir.File("keep.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "base", contents)
+
+		contents, err = dir.File("a.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "a", contents)
+
+		contents, err = dir.File("nested/b.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "b", contents)
+
+		contents, err = dir.File("c.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "c", contents)
+
+		contents, err = dir.File("conflict.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "c", contents)
+
+		_, err = dir.File("skip.txt").Contents(ctx)
+		require.Error(t, err)
+	})
 }
 
 func (DirectorySuite) TestWithDirectoryPermissionsOverride(ctx context.Context, t *testctx.T) {
@@ -314,6 +357,17 @@ func (DirectorySuite) TestWithDirectoryPermissionsOverride(ctx context.Context, 
 	require.Contains(t, stdout, "751 /out/nested")
 	require.Contains(t, stdout, "751 /out/nested/file.txt")
 	require.Contains(t, stdout, "751 /out/root.txt")
+
+	dir = c.Directory().WithDirectory("/", src, dagger.DirectoryWithDirectoryOpts{
+		Permissions: 0o751,
+	})
+
+	ctr = c.Container().From(alpineImage).WithDirectory("/", dir)
+	stdout, err = ctr.WithExec([]string{"sh", "-lc", "stat -c '%a %n' /nested /nested/file.txt /root.txt"}).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout, "751 /nested")
+	require.Contains(t, stdout, "751 /nested/file.txt")
+	require.Contains(t, stdout, "751 /root.txt")
 }
 
 func (DirectorySuite) TestWithDirectoryUnion(ctx context.Context, t *testctx.T) {

--- a/core/lazy_state.go
+++ b/core/lazy_state.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/slog"
 )
 
 type Lazy[T dagql.Typed] interface {
@@ -26,7 +28,7 @@ func NewLazyState() LazyState {
 	}
 }
 
-func (lazy *LazyState) Evaluate(ctx context.Context, typeName string, run func(context.Context) error) error {
+func (lazy *LazyState) Evaluate(ctx context.Context, typeName string, run func(context.Context) error) (rerr error) {
 	if lazy.LazyInitComplete {
 		return nil
 	}
@@ -45,8 +47,24 @@ func (lazy *LazyState) Evaluate(ctx context.Context, typeName string, run func(c
 	if lazy.LazyInitComplete {
 		return nil
 	}
-	if err := run(ctx); err != nil {
-		return err
+
+	start := time.Now()
+	slog.InfoContext(ctx, "start lazy evaluation",
+		"field", typeName,
+	)
+	defer func() {
+		args := []any{
+			"field", typeName,
+			"duration", time.Since(start),
+		}
+		if rerr != nil {
+			args = append(args, "err", rerr)
+		}
+		slog.InfoContext(ctx, "end lazy evaluation", args...)
+	}()
+
+	if rerr = run(ctx); rerr != nil {
+		return rerr
 	}
 	lazy.LazyInitComplete = true
 	return nil

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
@@ -37,14 +37,14 @@ $ viztest: Viztest! X.Xs CACHED
 │   ): Directory! X.Xs CACHED
 │
 ├╴$ container: Container! X.Xs CACHED
-├╴$ .withDirectory(
+├╴○ .withDirectory(
 │   ┆ path: "/level-1"
 │   ┆ source: Directory.withFile(
 │   ┆ ┆ path: "file"
 │   ┆ ┆ source: file(name: "file", contents: "hey"): File!
 │   ┆ ┆ permissions: 420
 │   ┆ ): Directory!
-│   ): Container! X.Xs CACHED
+│   ): Container! X.Xs
 ├╴$ .withDirectory(
 │   ┆ path: "/level-2"
 │   ┆ source: Directory.withDirectory(


### PR DESCRIPTION
## Summary

- Fix an e-graph merge performance regression where long `withDirectory` chains could become quadratic when only the final value was evaluated.
- Batch lazy `Directory.withDirectory` replay so a collected chain materializes the base once and applies all directory merges in one pass.
- Batch `Container.withDirectory` replay for contiguous operations targeting the same rootfs or mounted directory, while preserving the existing fallback boundaries for exact file-mount replacement and named owner lookup.
- Add lazy evaluation start/done logs and update telemetry golden output for the nested call spans.

## Root cause

The e-graph migration made `withDirectory` operations lazy, but the lazy replay path still had to preserve the old merge-coalescing behavior. `Directory.withDirectory` now does that directly. Before this PR, `Container.withDirectory` collected its parent chain but then replayed each operation through the single-op path, which physically materialized a new accumulated rootfs at every step.

For a chain like `a`, `a+b`, `a+b+c`, ..., evaluating only the final container could still re-walk and re-hardlink each growing prefix. That is the triangle-number behavior this fixes. The container path now groups compatible operations by target filesystem and applies each group through the same batched directory merge path, so evaluating the final value performs one materialization per compatible target group instead of one per chain node.

Named owners such as `alice:staff` remain a chain boundary because they require reading `/etc/passwd` and `/etc/group` from the parent filesystem at that point in the chain. Numeric owners do not need that lookup and can remain inside the batch.

## Validation

- `go test ./core ./engine/snapshots -run '^$'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestContainer/(TestWithDirectory|TestWithDirectoryToMount|TestWithDirectoryOwner)$|TestDirectory/TestWithDirectory$'`

## Performance

Fresh dev-engine cache for every measured run. Each run removed `dagger-engine.dev` and its Docker volume, started a fresh dev engine with `./hack/dev true`, then ran the measured command through `./hack/with-dev`. The comparison is `upstream/main` at `31f3266e44b1f03ea19823e7a4fc4b60b8bd339e` versus this branch at `3222da3159fb17752b944f7c84970c3e724e574c`. The CNI pooling fix from #13144 is not included in these numbers.

| Scenario | Main | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Wolfi package repro, full command wall time | 58.32s | 45.22s | 13.10s faster, 22.5% reduction, 1.29x speedup |
| Wolfi package repro, `Wolfi.container` span | 39.5s | 28.8s | 10.7s faster, 27.1% reduction, 1.37x speedup |
| Engine build trigger, full command wall time | 189.30s | 173.37s | 15.93s faster, 8.4% reduction, 1.09x speedup |
| Engine build trigger, `EngineDev.container` span | 2m10s | 1m56s | 14s faster, 10.8% reduction, 1.12x speedup |

Trace links:

- Main Wolfi repro: https://dagger.cloud/dagger/traces/61ef0885640d3b4bcfa95d8f5c77e5f7
- This PR Wolfi repro: https://dagger.cloud/dagger/traces/5b6c6606499aa8665c950092142bb039
- Main engine build trigger: https://dagger.cloud/dagger/traces/43a294110ea0e23ad0b3fcda531a61a4
- This PR engine build trigger: https://dagger.cloud/dagger/traces/1181280d36f65d6654d2daabe981c88d
