### PR TITLE
cli: add experimental `dagger module-checks` command

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -140,6 +140,7 @@ func init() {
 		queryCmd,
 		runCmd,
 		traceCmd,
+		moduleChecksCmd,
 		lockCmd,
 		configCmd,
 		checksCmd,

--- a/cmd/dagger/module_checks.go
+++ b/cmd/dagger/module_checks.go
@@ -1,0 +1,886 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/juju/ansiterm/tabwriter"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
+
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/dagger/internal/cloud"
+	"github.com/dagger/dagger/internal/cloud/auth"
+)
+
+var (
+	moduleChecksOrgFlag   string
+	moduleChecksJSONFlag  bool
+	moduleChecksWatchFlag bool
+)
+
+const moduleChecksWatchInterval = 5 * time.Second
+
+var moduleChecksCmd = &cobra.Command{
+	Use:    "module-checks <module-ref>@<version>",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		"experimental": "true",
+	},
+	Short:   "View the checks running on Dagger Cloud for a module ref + version.",
+	GroupID: cloudGroup.ID,
+	Example: `dagger module-checks github.com/dagger/dagger@c49835decf45479a5e83e3e1372442b2ddceeef2`,
+	RunE:    ModuleChecks,
+}
+
+func init() {
+	moduleChecksCmd.Flags().StringVar(&moduleChecksOrgFlag, "org", "",
+		"Dagger Cloud org name (defaults to current org)")
+	moduleChecksCmd.Flags().BoolVar(&moduleChecksJSONFlag, "json", false,
+		"Emit the matched commit and its checks as JSON (agent-friendly)")
+	moduleChecksCmd.Flags().BoolVar(&moduleChecksWatchFlag, "watch", false,
+		"After the initial fetch, refetch and redraw every 5 seconds until interrupted")
+}
+
+func ModuleChecks(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	cloudAuth, err := auth.GetCloudAuth(ctx)
+	if err != nil {
+		return fmt.Errorf("cloud auth: %w", err)
+	}
+	if cloudAuth == nil || cloudAuth.Token == nil {
+		return fmt.Errorf("not authenticated; run 'dagger login' or set DAGGER_CLOUD_TOKEN")
+	}
+
+	orgName, err := resolveOrgName(cloudAuth)
+	if err != nil {
+		return err
+	}
+
+	client, err := cloud.NewClient(ctx, cloudAuth)
+	if err != nil {
+		return fmt.Errorf("cloud client: %w", err)
+	}
+
+	moduleRef, commitSHA, err := splitModuleRefVersion(args[0])
+	if err != nil {
+		return err
+	}
+
+	var matched *cloud.CheckCommit
+	if moduleChecksWatchFlag {
+		matched, err = pollForMatch(ctx, client, cmd.ErrOrStderr(), orgName, moduleRef, commitSHA)
+	} else {
+		matched, err = findMatch(ctx, client, orgName, moduleRef, commitSHA)
+		if err == nil && matched == nil {
+			err = fmt.Errorf("no checks found in %s for commit %s", moduleRef, shortSHA(commitSHA))
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	if moduleChecksJSONFlag {
+		if err := renderModuleChecksJSON(cmd.OutOrStdout(), orgName, moduleRef, matched.CommitSHA, matched); err != nil {
+			return err
+		}
+	} else {
+		renderModuleChecks(cmd.OutOrStdout(), orgName, moduleRef, matched.CommitSHA, []cloud.CheckCommit{*matched})
+	}
+
+	if !moduleChecksWatchFlag {
+		return nil
+	}
+	if allChecksTerminal(matched.Checks) {
+		return nil
+	}
+
+	// The cloud stores its own (moduleRef, moduleVersion) on each check — for
+	// PRs that pair points at the integration commit, not the user-supplied
+	// SHA. Pull it off the matched commit so the watch loop's targeted
+	// ModuleChecks call is keyed correctly.
+	checksRef, checksVer := moduleRef, commitSHA
+	for _, c := range matched.Checks {
+		if c.ModuleRef != "" && c.ModuleVersion != "" {
+			checksRef, checksVer = c.ModuleRef, c.ModuleVersion
+			break
+		}
+	}
+	return watchModuleChecks(ctx, client, cmd.OutOrStdout(), cmd.ErrOrStderr(), orgName, moduleRef, checksRef, checksVer, matched.CommitSHA)
+}
+
+// findMatch makes a single OrgChecks call and returns the CheckCommit whose
+// CommitSHA matches the user-supplied SHA, or (nil, nil) if no match.
+func findMatch(ctx context.Context, client *cloud.Client, orgName, moduleRef, commitSHA string) (*cloud.CheckCommit, error) {
+	candidates, err := client.OrgChecks(ctx, orgName, []string{moduleRef}, 50)
+	if err != nil {
+		return nil, fmt.Errorf("fetch recent checks for %s: %w", moduleRef, err)
+	}
+	return matchCommitBySHA(candidates, commitSHA), nil
+}
+
+// pollForMatch repeatedly calls findMatch every moduleChecksWatchInterval
+// until a match appears or ctx is cancelled (Ctrl+C). Transient fetch errors
+// are logged to errW and don't terminate the loop — so the command can be
+// invoked before the cloud has recorded the checks.
+func pollForMatch(ctx context.Context, client *cloud.Client, errW io.Writer, orgName, moduleRef, commitSHA string) (*cloud.CheckCommit, error) {
+	announced := false
+	for {
+		matched, err := findMatch(ctx, client, orgName, moduleRef, commitSHA)
+		if err == nil && matched != nil {
+			return matched, nil
+		}
+		if err != nil && ctx.Err() == nil {
+			fmt.Fprintf(errW, "resolve: %v\n", err)
+		}
+		if !announced {
+			fmt.Fprintf(errW, "no checks yet for %s@%s; waiting...\n", moduleRef, shortSHA(commitSHA))
+			announced = true
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(moduleChecksWatchInterval):
+		}
+	}
+}
+
+// watchModuleChecks refetches and redraws the matched commit every
+// moduleChecksWatchInterval, until ctx is cancelled (e.g. Ctrl+C). Uses the
+// targeted ModuleChecks endpoint (keyed on the resolved checksRef/checksVer)
+// so we don't repeatedly scan the org-wide recent-checks window. displayRef
+// is the user-facing ref passed to the renderer; commitSHA is used to
+// disambiguate if ModuleChecks happens to return multiple commits.
+// Transient fetch errors are logged to errW and don't terminate the loop.
+func watchModuleChecks(ctx context.Context, client *cloud.Client, outW, errW io.Writer, orgName, displayRef, checksRef, checksVer, commitSHA string) error {
+	ticker := time.NewTicker(moduleChecksWatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		commits, err := client.ModuleChecks(ctx, orgName, checksRef, checksVer)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			fmt.Fprintf(errW, "watch: refetch failed: %v\n", err)
+			continue
+		}
+		matched := matchCommitBySHA(commits, commitSHA)
+		if matched == nil {
+			if len(commits) == 0 {
+				fmt.Fprintf(errW, "watch: no checks returned for %s@%s\n", checksRef, shortSHA(checksVer))
+				continue
+			}
+			// moduleChecks should only return commits for the requested
+			// (ref, version) pair; if it returns something but the SHA
+			// doesn't line up, fall back to the first entry.
+			matched = &commits[0]
+		}
+		if moduleChecksJSONFlag {
+			_ = renderModuleChecksJSON(outW, orgName, displayRef, matched.CommitSHA, matched)
+		} else {
+			fmt.Fprint(outW, "\x1b[H\x1b[2J")
+			renderModuleChecks(outW, orgName, displayRef, matched.CommitSHA, []cloud.CheckCommit{*matched})
+		}
+		if allChecksTerminal(matched.Checks) {
+			return nil
+		}
+	}
+}
+
+// allChecksTerminal reports whether every (deduped) visible check has reached
+// a terminal state. Mirrors the renderer's internal-check policy: public
+// checks count when any exist, otherwise the internal ones do. Used by
+// --watch to know when there's nothing left to poll for.
+func allChecksTerminal(checks []cloud.Check) bool {
+	var public, internal []cloud.Check
+	for _, c := range checks {
+		if c.Internal {
+			internal = append(internal, c)
+		} else {
+			public = append(public, c)
+		}
+	}
+	visible := public
+	if len(visible) == 0 {
+		visible = internal
+	}
+	visible = latestChecksByName(visible)
+	if len(visible) == 0 {
+		return false
+	}
+	for _, c := range visible {
+		if statusBucketFor(c.Status).isPending() {
+			return false
+		}
+	}
+	return true
+}
+
+// splitModuleRefVersion splits "<ref>@<version>" on the last '@', so that
+// refs containing '@' (e.g. `git@github.com:org/repo`) are handled correctly.
+func splitModuleRefVersion(arg string) (string, string, error) {
+	idx := strings.LastIndex(arg, "@")
+	if idx <= 0 || idx == len(arg)-1 {
+		return "", "", fmt.Errorf("expected <module-ref>@<version>, got %q", arg)
+	}
+	return arg[:idx], arg[idx+1:], nil
+}
+
+// matchCommitBySHA finds the commit in commits whose CommitSHA matches sha.
+// Allows prefix matches in either direction, so a short SHA on the input or
+// the server side still resolves. Returns nil on no match.
+func matchCommitBySHA(commits []cloud.CheckCommit, sha string) *cloud.CheckCommit {
+	sha = strings.ToLower(strings.TrimSpace(sha))
+	if sha == "" {
+		return nil
+	}
+	for i := range commits {
+		got := strings.ToLower(commits[i].CommitSHA)
+		if got == sha || strings.HasPrefix(got, sha) || strings.HasPrefix(sha, got) {
+			return &commits[i]
+		}
+	}
+	return nil
+}
+
+// JSON output types. These describe a stable contract for agent consumers
+// independent of the cloud GraphQL schema.
+
+type checksJSON struct {
+	Org           string      `json:"org"`
+	ModuleRef     string      `json:"moduleRef"`
+	ModuleVersion string      `json:"moduleVersion"`
+	ChecksURL     string      `json:"checksUrl"`
+	Commit        jsonCommit  `json:"commit"`
+	Refs          []jsonRef   `json:"refs"`
+	Summary       jsonSummary `json:"summary"`
+	Checks        []jsonCheck `json:"checks"`
+}
+
+type jsonCommit struct {
+	SHA         string     `json:"sha"`
+	Message     string     `json:"message"`
+	AuthorName  string     `json:"authorName"`
+	AuthorEmail string     `json:"authorEmail"`
+	Repo        string     `json:"repo"`
+	Timestamp   *time.Time `json:"timestamp,omitempty"`
+}
+
+type jsonRef struct {
+	Type              string `json:"type"`
+	Name              string `json:"name,omitempty"`
+	URL               string `json:"url,omitempty"`
+	Number            int    `json:"number,omitempty"`
+	Title             string `json:"title,omitempty"`
+	State             string `json:"state,omitempty"`
+	IntegrationCommit string `json:"integrationCommit,omitempty"`
+}
+
+type jsonSummary struct {
+	Total      int `json:"total"`
+	Failure    int `json:"failure"`
+	Cancelled  int `json:"cancelled"`
+	InProgress int `json:"inProgress"`
+	Success    int `json:"success"`
+}
+
+type jsonCheck struct {
+	Name            string     `json:"name"`
+	Status          string     `json:"status"`
+	StatusBucket    string     `json:"statusBucket"`
+	DurationSeconds int        `json:"durationSeconds"`
+	TraceID         string     `json:"traceId"`
+	SpanID          string     `json:"spanId"`
+	TraceURL        string     `json:"traceUrl"`
+	StartedAt       *time.Time `json:"startedAt,omitempty"`
+	EndTime         *time.Time `json:"endTime,omitempty"`
+	Internal        bool       `json:"internal,omitempty"`
+}
+
+// renderModuleChecksJSON emits the matched commit as a single JSON object.
+// Mirrors the human renderer's internal-check policy: public checks are
+// preferred; internal checks are only included when no public checks exist
+// (each carrying internal: true so consumers can tell).
+func renderModuleChecksJSON(w io.Writer, orgName, moduleRef, moduleVersion string, commit *cloud.CheckCommit) error {
+	out := checksJSON{
+		Org:           orgName,
+		ModuleRef:     moduleRef,
+		ModuleVersion: moduleVersion,
+		ChecksURL:     checksURL(orgName, moduleRef, mergedCommitSHA(*commit)),
+		Commit: jsonCommit{
+			SHA:         commit.CommitSHA,
+			Message:     commit.CommitMessage,
+			AuthorName:  commit.AuthorName,
+			AuthorEmail: commit.AuthorEmail,
+			Repo:        commit.Repo,
+			Timestamp:   timePtr(commit.Timestamp),
+		},
+		Refs:   make([]jsonRef, 0, len(commit.Refs)),
+		Checks: make([]jsonCheck, 0, len(commit.Checks)),
+	}
+
+	for _, r := range commit.Refs {
+		ref := jsonRef{Name: r.Name, URL: r.URL}
+		switch r.Typename {
+		case "CheckCommitBranchRef":
+			ref.Type = "branch"
+		case "CheckCommitTagRef":
+			ref.Type = "tag"
+		case "CheckCommitPullRequestRef":
+			ref.Type = "pr"
+			ref.Number = r.Number
+			ref.Title = r.Title
+			ref.State = r.State
+			ref.IntegrationCommit = r.IntegrationCommit
+			// PR refs don't have a `name` field; clear the zero value.
+			ref.Name = ""
+		default:
+			ref.Type = r.Typename
+		}
+		out.Refs = append(out.Refs, ref)
+	}
+
+	// Public checks are preferred. Fall back to internal only if no public
+	// check exists for this commit. Either way, dedupe by name.
+	var public, internal []cloud.Check
+	for _, c := range commit.Checks {
+		if c.Internal {
+			internal = append(internal, c)
+		} else {
+			public = append(public, c)
+		}
+	}
+	raw := public
+	if len(raw) == 0 {
+		raw = internal
+	}
+	for _, c := range latestChecksByName(raw) {
+		b := statusBucketFor(c.Status)
+		duration := 0
+		if c.Duration != nil {
+			duration = *c.Duration
+		} else if d := c.DurationAsTime(); d > 0 {
+			duration = int(d / time.Second)
+		}
+		out.Checks = append(out.Checks, jsonCheck{
+			Name:            c.Name,
+			Status:          c.Status,
+			StatusBucket:    b.jsonName(),
+			DurationSeconds: duration,
+			TraceID:         c.TraceID,
+			SpanID:          c.SpanID,
+			TraceURL:        traceURL(orgName, c.TraceID),
+			StartedAt:       c.StartedAt,
+			EndTime:         c.EndTime,
+			Internal:        c.Internal,
+		})
+		switch {
+		case b == bucketFailure:
+			out.Summary.Failure++
+		case b == bucketCancelled:
+			out.Summary.Cancelled++
+		case b.isPending(): // queued + running both count toward inProgress
+			out.Summary.InProgress++
+		case b == bucketSuccess:
+			out.Summary.Success++
+		}
+	}
+	out.Summary.Total = len(out.Checks)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func timePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// latestChecksByName keeps a single entry per Check.Name — the one with the
+// most recent StartedAt — so re-runs (e.g. auto-retried failures) don't show
+// up as duplicate rows. Display order matches the first occurrence of each
+// name in the input.
+func latestChecksByName(checks []cloud.Check) []cloud.Check {
+	byName := make(map[string]cloud.Check, len(checks))
+	order := make([]string, 0, len(checks))
+	for _, c := range checks {
+		existing, ok := byName[c.Name]
+		if !ok {
+			order = append(order, c.Name)
+			byName[c.Name] = c
+			continue
+		}
+		if checkStartTime(c).After(checkStartTime(existing)) {
+			byName[c.Name] = c
+		}
+	}
+	out := make([]cloud.Check, 0, len(order))
+	for _, name := range order {
+		out = append(out, byName[name])
+	}
+	return out
+}
+
+func checkStartTime(c cloud.Check) time.Time {
+	if c.StartedAt == nil {
+		return time.Time{}
+	}
+	return *c.StartedAt
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func resolveOrgName(cloudAuth *auth.Cloud) (string, error) {
+	if moduleChecksOrgFlag != "" {
+		return moduleChecksOrgFlag, nil
+	}
+	if cloudAuth.Org != nil && cloudAuth.Org.Name != "" {
+		return cloudAuth.Org.Name, nil
+	}
+	// DAGGER_CLOUD_TOKEN doesn't populate cloudAuth.Org; the org name is
+	// embedded in the token itself.
+	if name, err := auth.CurrentOrgName(); err == nil && name != "" {
+		return name, nil
+	}
+	return "", fmt.Errorf("no org specified; use --org or run 'dagger login' to set a default org")
+}
+
+// statusBucket categorises a Check.Status string into one of four display
+// buckets. Falls back to the in-progress bucket for unknown values, since a
+// missing status is most likely a not-yet-complete run.
+type statusBucket int
+
+const (
+	bucketFailure statusBucket = iota
+	bucketCancelled
+	bucketQueued
+	bucketRunning
+	bucketSuccess
+)
+
+// isPending reports whether the bucket represents a non-terminal state
+// (queued or running). Used by --watch and the bar/summary, which collapse
+// the two into a single "in progress" segment.
+func (b statusBucket) isPending() bool {
+	return b == bucketQueued || b == bucketRunning
+}
+
+func statusBucketFor(status string) statusBucket {
+	switch strings.ToLower(status) {
+	case "success", "succeeded", "passed", "ok":
+		return bucketSuccess
+	case "failure", "failed", "error", "errored":
+		return bucketFailure
+	case "cancelled", "canceled":
+		return bucketCancelled
+	case "queued", "pending":
+		return bucketQueued
+	default:
+		// Unknown / "running" / anything still active.
+		return bucketRunning
+	}
+}
+
+func (b statusBucket) color() termenv.Color {
+	switch b {
+	case bucketFailure:
+		return termenv.ANSIRed
+	case bucketCancelled:
+		// idtui's color profile is capped at 16-color ANSI; gray reads as
+		// "inactive/stopped" and stays distinct from the in-progress yellow.
+		return termenv.ANSIBrightBlack
+	case bucketQueued:
+		// Light grey — clearly distinct from both the dark grey of
+		// cancelled and the yellow of running.
+		return termenv.ANSIWhite
+	case bucketRunning:
+		return termenv.ANSIYellow
+	case bucketSuccess:
+		return termenv.ANSIGreen
+	}
+	return termenv.ANSIWhite
+}
+
+// label is the human-readable display name. The camelCase form used in JSON
+// output is jsonName().
+func (b statusBucket) label() string {
+	switch b {
+	case bucketFailure:
+		return "failure"
+	case bucketCancelled:
+		return "cancelled"
+	case bucketQueued:
+		return "queued"
+	case bucketRunning:
+		return "running"
+	case bucketSuccess:
+		return "success"
+	}
+	return "unknown"
+}
+
+// jsonName is the camelCase identifier used in the JSON output schema.
+// Queued and running both collapse to "inProgress" — that's the umbrella
+// "still active" bucket the JSON contract exposes; the raw `status` field
+// preserves the fine-grained distinction for consumers that need it.
+func (b statusBucket) jsonName() string {
+	if b.isPending() {
+		return "inProgress"
+	}
+	return b.label()
+}
+
+func (b statusBucket) icon() string {
+	switch b {
+	case bucketFailure:
+		return "✗"
+	case bucketCancelled:
+		return "⊘"
+	case bucketQueued:
+		return "○"
+	case bucketRunning:
+		return "●"
+	case bucketSuccess:
+		return "✓"
+	}
+	return "·"
+}
+
+func renderModuleChecks(w io.Writer, orgName, moduleRef, moduleVersion string, commits []cloud.CheckCommit) {
+	out := idtui.NewOutput(w)
+
+	fmt.Fprintf(w, "%s %s@%s\n",
+		out.String("Module:").Bold(),
+		moduleRef, moduleVersion,
+	)
+
+	// Split internal vs public checks. Public is preferred; internal is shown
+	// only as a last resort (i.e. when no public checks are recorded yet).
+	var public, internal []cloud.Check
+	for _, commit := range commits {
+		for _, c := range commit.Checks {
+			if c.Internal {
+				internal = append(internal, c)
+			} else {
+				public = append(public, c)
+			}
+		}
+	}
+
+	raw := public
+	showingInternal := false
+	if len(raw) == 0 && len(internal) > 0 {
+		raw = internal
+		showingInternal = true
+	}
+
+	if len(raw) == 0 {
+		fmt.Fprintf(w, "\n%s\n",
+			out.String(fmt.Sprintf("No checks found for %s@%s", moduleRef, moduleVersion)).Faint())
+		return
+	}
+
+	// Dedupe by name (latest StartedAt wins) for everything except the
+	// duration bar; the bar wants to show every iteration.
+	latest, iterations := groupChecksByName(raw)
+
+	// Header: commit metadata for each commit returned (usually one).
+	for _, commit := range commits {
+		fmt.Fprintln(w)
+		renderCommitHeader(w, out, orgName, moduleRef, commit)
+	}
+
+	if showingInternal {
+		fmt.Fprintf(w, "\n%s\n",
+			out.String(fmt.Sprintf("No public checks found; showing %d internal check(s).", len(latest))).Faint())
+	}
+
+	// Progress bar and per-bucket counts.
+	fmt.Fprintln(w)
+	renderProgressBar(w, out, latest)
+
+	// Per-check table.
+	fmt.Fprintln(w)
+	renderCheckTableGrouped(w, out, orgName, latest, iterations)
+}
+
+// groupChecksByName collapses a check list by name. Returns:
+//   - latest: one entry per name (the run with the most recent StartedAt),
+//     preserving first-occurrence order from the input;
+//   - iterations: every run per name, sorted by StartedAt ascending — used
+//     by the multi-block duration bar to visualise re-runs.
+func groupChecksByName(checks []cloud.Check) (latest []cloud.Check, iterations map[string][]cloud.Check) {
+	iterations = make(map[string][]cloud.Check)
+	pos := make(map[string]int)
+	for _, c := range checks {
+		iterations[c.Name] = append(iterations[c.Name], c)
+		if i, ok := pos[c.Name]; ok {
+			if checkStartTime(c).After(checkStartTime(latest[i])) {
+				latest[i] = c
+			}
+			continue
+		}
+		pos[c.Name] = len(latest)
+		latest = append(latest, c)
+	}
+	for name, runs := range iterations {
+		sort.Slice(runs, func(i, j int) bool {
+			return checkStartTime(runs[i]).Before(checkStartTime(runs[j]))
+		})
+		iterations[name] = runs
+	}
+	return
+}
+
+func renderCommitHeader(w io.Writer, out *termenv.Output, orgName, moduleRef string, commit cloud.CheckCommit) {
+	sha := shortSHA(commit.CommitSHA)
+	firstLine := commit.CommitMessage
+	if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
+		firstLine = firstLine[:idx]
+	}
+
+	author := commit.AuthorName
+	if author != "" && commit.AuthorEmail != "" {
+		author = fmt.Sprintf("%s <%s>", commit.AuthorName, commit.AuthorEmail)
+	} else if commit.AuthorEmail != "" {
+		author = commit.AuthorEmail
+	}
+
+	fmt.Fprintf(w, "%s  %s", out.String("Commit:").Bold(), out.String(sha).Foreground(termenv.ANSICyan))
+	if firstLine != "" {
+		fmt.Fprintf(w, " %s %s", out.String("—").Faint(), firstLine)
+	}
+	fmt.Fprintln(w)
+	if author != "" {
+		fmt.Fprintf(w, "%s  %s\n", out.String("Author:").Bold(), author)
+	}
+	if commit.Repo != "" {
+		fmt.Fprintf(w, "%s    %s\n", out.String("Repo:").Bold(), commit.Repo)
+	}
+	fmt.Fprintf(w, "%s  %s\n", out.String("Checks:").Bold(), checksURL(orgName, moduleRef, mergedCommitSHA(commit)))
+}
+
+func checksURL(orgName, moduleRef, commitSHA string) string {
+	return fmt.Sprintf("https://dagger.cloud/%s/checks/%s@%s", orgName, moduleRef, commitSHA)
+}
+
+// mergedCommitSHA returns the SHA the cloud uses to key this commit's checks
+// — i.e. the integration/merge commit for PRs, or the pushed commit SHA for
+// plain pushes. Read off any check's moduleVersion; falls back to CommitSHA
+// if no checks are recorded yet.
+func mergedCommitSHA(commit cloud.CheckCommit) string {
+	for _, c := range commit.Checks {
+		if c.ModuleVersion != "" {
+			return c.ModuleVersion
+		}
+	}
+	return commit.CommitSHA
+}
+
+// bucketOrder is the left-to-right display order for the per-bucket check
+// list. Queued is listed separately from running so the user can see what's
+// waiting vs. actively executing.
+var bucketOrder = []statusBucket{bucketFailure, bucketCancelled, bucketQueued, bucketRunning, bucketSuccess}
+
+// bucketBarOrder is the simpler order used for the top progress bar and
+// summary line, which collapse queued + running into a single "in progress"
+// segment (counted under bucketRunning).
+var bucketBarOrder = []statusBucket{bucketFailure, bucketCancelled, bucketRunning, bucketSuccess}
+
+func renderProgressBar(w io.Writer, out *termenv.Output, checks []cloud.Check) {
+	counts := make(map[statusBucket]int, len(bucketBarOrder))
+	for _, c := range checks {
+		b := statusBucketFor(c.Status)
+		if b == bucketQueued {
+			b = bucketRunning // bar treats queued and running as one segment
+		}
+		counts[b]++
+	}
+
+	var bar strings.Builder
+	var summary []string
+	for _, b := range bucketBarOrder {
+		n := counts[b]
+		if n == 0 {
+			continue
+		}
+		bar.WriteString(out.String(strings.Repeat("█", n)).Foreground(b.color()).String())
+		summary = append(summary, fmt.Sprintf("%s %d",
+			out.String(b.icon()).Foreground(b.color()).String(),
+			n,
+		))
+	}
+	fmt.Fprintln(w, bar.String())
+	fmt.Fprintln(w, strings.Join(summary, "  "))
+}
+
+// renderCheckTableGrouped renders the checks grouped by status bucket, with a
+// colored heading per group. Optimized for humans reading the output.
+// durationBarWidth caps the duration bar at this many "█" cells; the slowest
+// check across the whole table gets the full width, everything else scales
+// linearly.
+const durationBarWidth = 10
+
+func renderCheckTableGrouped(w io.Writer, out *termenv.Output, orgName string, checks []cloud.Check, iterations map[string][]cloud.Check) {
+	grouped := make(map[statusBucket][]cloud.Check, 4)
+	var maxDuration time.Duration
+	for _, c := range checks {
+		grouped[statusBucketFor(c.Status)] = append(grouped[statusBucketFor(c.Status)], c)
+		// Scale the bar against the slowest single iteration across the
+		// table, so retried checks render as a series of comparable blocks.
+		for _, iter := range iterations[c.Name] {
+			if d, _ := effectiveDuration(iter); d > maxDuration {
+				maxDuration = d
+			}
+		}
+	}
+
+	// One tabwriter spans the whole table so columns align across groups.
+	// Group headers go through it too — as a single-column row with empty
+	// trailing cells — which the tabwriter pads invisibly.
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	first := true
+	for _, b := range bucketOrder {
+		group := grouped[b]
+		if len(group) == 0 {
+			continue
+		}
+		if !first {
+			// Empty row with the same cell shape as other rows; a bare
+			// "\n" would have fewer cells and terminate the alignment
+			// block, defeating cross-group column alignment.
+			fmt.Fprint(tw, "\t\t\t\n")
+		}
+		first = false
+		fmt.Fprintf(tw, "%s %s (%d)\t\t\t\n",
+			out.String(b.icon()).Foreground(b.color()).String(),
+			out.String(strings.ToUpper(b.label())).Foreground(b.color()).Bold().String(),
+			len(group),
+		)
+
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].Name < group[j].Name
+		})
+
+		for _, c := range group {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				c.Name,
+				formatCheckTime(c),
+				durationBars(out, iterations[c.Name], maxDuration, durationBarWidth),
+				traceURL(orgName, c.TraceID),
+			)
+		}
+	}
+	_ = tw.Flush()
+}
+
+// effectiveDuration returns the check's elapsed time and whether the check
+// is still running (in which case the value is "time since started" rather
+// than total duration).
+func effectiveDuration(c cloud.Check) (time.Duration, bool) {
+	if d := c.DurationAsTime(); d > 0 {
+		return d, false
+	}
+	if c.StartedAt != nil {
+		return time.Since(*c.StartedAt), true
+	}
+	return 0, false
+}
+
+// formatCheckTime renders the duration column for a check. Finished checks
+// show their total elapsed time; still-running checks show "<elapsed> ago"
+// computed from StartedAt so the user can see how long they've been going.
+func formatCheckTime(c cloud.Check) string {
+	d, running := effectiveDuration(c)
+	if d == 0 {
+		return "—"
+	}
+	if running {
+		return formatDuration(d) + " ago"
+	}
+	return formatDuration(d)
+}
+
+// partialBlocks maps an "eighths" value 0..7 to the corresponding left-aligned
+// partial-block glyph from the Unicode Block Elements range (U+258F..U+2589),
+// used to render the last cell of a duration bar at sub-cell precision.
+// Index 0 means "no partial cell" (the bar ends on a full-block boundary).
+var partialBlocks = [8]string{"", "▏", "▎", "▍", "▌", "▋", "▊", "▉"}
+
+// durationBars renders one block per iteration of a check, separated by
+// spaces. Each block is sized linearly against max and colored by the
+// iteration's own status bucket. The last cell of each block uses a partial
+// "Block Elements" glyph for sub-cell precision (eighths), so a 6.5-cell
+// duration draws as "██████▌" rather than "██████" or "███████".
+func durationBars(out *termenv.Output, iterations []cloud.Check, max time.Duration, width int) string {
+	if max <= 0 || len(iterations) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(iterations))
+	for _, iter := range iterations {
+		d, _ := effectiveDuration(iter)
+		if d <= 0 {
+			continue
+		}
+		// Eighths of a cell — gives 8× finer resolution than whole cells.
+		eighths := int(float64(d) / float64(max) * float64(width) * 8)
+		if eighths < 1 {
+			eighths = 1
+		}
+		if eighths > width*8 {
+			eighths = width * 8
+		}
+		full := eighths / 8
+		bar := strings.Repeat("█", full) + partialBlocks[eighths%8]
+		b := statusBucketFor(iter.Status)
+		parts = append(parts, out.String(bar).Foreground(b.color()).String())
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "—"
+	}
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		m := int(d / time.Minute)
+		s := int((d % time.Minute) / time.Second)
+		return fmt.Sprintf("%dm %ds", m, s)
+	default:
+		h := int(d / time.Hour)
+		m := int((d % time.Hour) / time.Minute)
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+}
+
+func traceURL(orgName, traceID string) string {
+	if traceID == "" {
+		return "—"
+	}
+	return fmt.Sprintf("https://dagger.cloud/%s/traces/%s", orgName, traceID)
+}

--- a/internal/cloud/checks.go
+++ b/internal/cloud/checks.go
@@ -1,0 +1,273 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// expandRepoForms duplicates each repo into both bare and "https://"-prefixed
+// forms (deduplicated) so the cloud's commits.repository filter matches
+// regardless of whether the caller passed the scheme.
+func expandRepoForms(repos []string) []string {
+	if len(repos) == 0 {
+		return repos
+	}
+	seen := make(map[string]struct{}, len(repos)*2)
+	out := make([]string, 0, len(repos)*2)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, r := range repos {
+		add(r)
+		switch {
+		case strings.HasPrefix(r, "https://"), strings.HasPrefix(r, "http://"):
+			// already a URL — also try the bare form
+			add(strings.TrimPrefix(strings.TrimPrefix(r, "https://"), "http://"))
+		default:
+			add("https://" + r)
+		}
+	}
+	return out
+}
+
+// GraphQL queries against an org's checks. GetOrgChecks scans recent commits
+// (used for SHA resolution); GetModuleChecks targets a specific (moduleRef,
+// moduleVersion) pair (used for cheap refetches once we know the answer).
+// Both mirror the operations used by the Dagger Cloud UI.
+
+const getOrgChecksOperation = `
+query GetOrgChecks ($org: String!, $repos: [String!], $first: Int) {
+    org(name: $org) {
+        checks(repos: $repos, first: $first) {
+            nodes {
+                ... CheckCommitProps
+            }
+        }
+    }
+}
+` + checkCommitFragments
+
+const getModuleChecksOperation = `
+query GetModuleChecks ($org: String!, $moduleRef: String!, $moduleVersion: String!) {
+    org(name: $org) {
+        moduleChecks(moduleRef: $moduleRef, moduleVersion: $moduleVersion) {
+            ... CheckCommitProps
+        }
+    }
+}
+` + checkCommitFragments
+
+const checkCommitFragments = `
+fragment CheckCommitProps on CheckCommit {
+    repo
+    commitSHA
+    commitMessage
+    timestamp
+    authorName
+    authorEmail
+    events {
+        provider
+        type
+        timestamp
+        actor {
+            id
+            login
+            name
+            avatarUrl
+        }
+    }
+    refs {
+        __typename
+        ... on CheckCommitTagRef {
+            name
+            url
+        }
+        ... on CheckCommitBranchRef {
+            name
+            url
+        }
+        ... on CheckCommitPullRequestRef {
+            number
+            url
+            title
+            state
+            integrationCommit
+        }
+    }
+    checks {
+        ... CheckProps
+    }
+}
+fragment CheckProps on Check {
+    id
+    name
+    status
+    startedAt
+    endTime
+    duration
+    traceId
+    spanId
+    moduleRef
+    moduleVersion
+    internal
+}
+`
+
+// CheckCommit groups the checks recorded for a single commit, together with
+// the commit metadata and any refs (branches, tags, PRs) pointing at it.
+type CheckCommit struct {
+	Repo          string           `json:"repo"`
+	CommitSHA     string           `json:"commitSHA"`
+	CommitMessage string           `json:"commitMessage"`
+	Timestamp     time.Time        `json:"timestamp"`
+	AuthorName    string           `json:"authorName"`
+	AuthorEmail   string           `json:"authorEmail"`
+	Events        []CheckEvent     `json:"events"`
+	Refs          []CheckCommitRef `json:"refs"`
+	Checks        []Check          `json:"checks"`
+}
+
+// CheckEvent is a provider event (e.g. GitHub push, PR sync) associated with
+// the commit.
+type CheckEvent struct {
+	Provider  string     `json:"provider"`
+	Type      string     `json:"type"`
+	Timestamp time.Time  `json:"timestamp"`
+	Actor     CheckActor `json:"actor"`
+}
+
+// CheckActor identifies the user (or bot) that triggered a CheckEvent.
+type CheckActor struct {
+	ID        string `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatarUrl"`
+}
+
+// CheckCommitRef is a union of tag, branch and pull-request refs. The
+// concrete type is identified by Typename; only the matching subset of fields
+// is populated.
+type CheckCommitRef struct {
+	Typename string `json:"__typename"`
+
+	// CheckCommitTagRef / CheckCommitBranchRef
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+
+	// CheckCommitPullRequestRef
+	Number            int    `json:"number,omitempty"`
+	Title             string `json:"title,omitempty"`
+	State             string `json:"state,omitempty"`
+	IntegrationCommit string `json:"integrationCommit,omitempty"`
+}
+
+// Check is a single check execution for a module ref + version. Duration is
+// in seconds (see schema: `Check.duration: Int  # in seconds`); nil means the
+// check hasn't finished yet.
+type Check struct {
+	ID            string     `json:"id"`
+	Name          string     `json:"name"`
+	Status        string     `json:"status"`
+	StartedAt     *time.Time `json:"startedAt"`
+	EndTime       *time.Time `json:"endTime"`
+	Duration      *int       `json:"duration"`
+	TraceID       string     `json:"traceId"`
+	SpanID        string     `json:"spanId"`
+	ModuleRef     string     `json:"moduleRef"`
+	ModuleVersion string     `json:"moduleVersion"`
+	Internal      bool       `json:"internal"`
+}
+
+// DurationAsTime returns the check's elapsed time. Prefers the server-supplied
+// Duration (in seconds), falling back to EndTime - StartedAt when Duration is
+// absent (e.g. running checks).
+func (c *Check) DurationAsTime() time.Duration {
+	if c.Duration != nil {
+		return time.Duration(*c.Duration) * time.Second
+	}
+	if c.StartedAt == nil || c.EndTime == nil {
+		return 0
+	}
+	return c.EndTime.Sub(*c.StartedAt)
+}
+
+// OrgChecks fetches the most recent CheckCommits for an org, optionally
+// filtered by repo. Accepts repos in the moduleRef form (e.g.
+// "github.com/dagger/dagger"); the cloud stores full HTTPS URLs in its
+// commits table, so we pass both forms to the filter to match either
+// convention. first caps the number of returned commits; pass 0 to use the
+// server's default.
+func (c *Client) OrgChecks(
+	ctx context.Context,
+	org string,
+	repos []string,
+	first int,
+) ([]CheckCommit, error) {
+	vars := map[string]any{
+		"org":   org,
+		"repos": expandRepoForms(repos),
+	}
+	if first > 0 {
+		vars["first"] = first
+	}
+	var resp struct {
+		Org *struct {
+			Checks struct {
+				Nodes []CheckCommit `json:"nodes"`
+			} `json:"checks"`
+		} `json:"org"`
+	}
+	err := c.queryGraphQL(ctx, &graphqlRequest{
+		OpName:    "GetOrgChecks",
+		Query:     getOrgChecksOperation,
+		Variables: vars,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Org == nil {
+		return nil, fmt.Errorf("org %q not found", org)
+	}
+	return resp.Org.Checks.Nodes, nil
+}
+
+// ModuleChecks fetches the checks recorded for an exact (moduleRef,
+// moduleVersion) pair. Cheaper than OrgChecks for repeated polling once the
+// SHA has been resolved.
+func (c *Client) ModuleChecks(
+	ctx context.Context,
+	org string,
+	moduleRef string,
+	moduleVersion string,
+) ([]CheckCommit, error) {
+	var resp struct {
+		Org *struct {
+			ModuleChecks []CheckCommit `json:"moduleChecks"`
+		} `json:"org"`
+	}
+	err := c.queryGraphQL(ctx, &graphqlRequest{
+		OpName: "GetModuleChecks",
+		Query:  getModuleChecksOperation,
+		Variables: map[string]any{
+			"org":           org,
+			"moduleRef":     moduleRef,
+			"moduleVersion": moduleVersion,
+		},
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Org == nil {
+		return nil, fmt.Errorf("org %q not found", org)
+	}
+	return resp.Org.ModuleChecks, nil
+}

--- a/internal/cloud/trace.go
+++ b/internal/cloud/trace.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/dagger/dagger/engine/slog"
@@ -212,6 +213,63 @@ func (c *Client) StreamLogs(
 		handler(logs)
 		return nil
 	})
+}
+
+// queryGraphQL POSTs a one-shot GraphQL request to the Cloud /query endpoint
+// and unmarshals the `data` field of the response into out. Surfaces GraphQL
+// errors (HTTP 200 with non-empty `errors`) as Go errors.
+func (c *Client) queryGraphQL(ctx context.Context, gqlReq *graphqlRequest, out any) error {
+	body, err := json.Marshal(gqlReq)
+	if err != nil {
+		return fmt.Errorf("marshal graphql request: %w", err)
+	}
+
+	endpoint := c.u.JoinPath("/query").String()
+	slog.Debug("cloud GraphQL query", "url", endpoint, "op", gqlReq.OpName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.h.Do(req)
+	if err != nil {
+		return fmt.Errorf("query %s: %w", gqlReq.OpName, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", gqlReq.OpName, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: %s: %s", gqlReq.OpName, resp.Status, string(respBody))
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &envelope); err != nil {
+		return fmt.Errorf("unmarshal %s response: %w", gqlReq.OpName, err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, len(envelope.Errors))
+		for i, e := range envelope.Errors {
+			msgs[i] = e.Message
+		}
+		return fmt.Errorf("%s: %s", gqlReq.OpName, strings.Join(msgs, "; "))
+	}
+	if out != nil && len(envelope.Data) > 0 {
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("unmarshal %s data: %w", gqlReq.OpName, err)
+		}
+	}
+	return nil
 }
 
 // streamGraphQL connects to the Cloud GraphQL SSE endpoint and streams

--- a/skills/ci-debug/SKILL.md
+++ b/skills/ci-debug/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: ci-debug
+description: >
+  Investigate Dagger CI check failures for a given commit on the dagger/dagger
+  repository. Pulls the check list from Dagger Cloud, fetches traces for the
+  failing ones, and produces a triage summary that separates real test
+  regressions from cascading kills, infra hiccups, and intentional negative-
+  test noise. Use this whenever the user asks about CI status, failing checks,
+  "what's failing on my PR", "why did CI fail", "is the build green", check
+  retries, trace investigation, or anything similar in the context of the
+  dagger/dagger repo — even if they don't say the word "CI". Also triggers on
+  /ci-debug.
+---
+
+# CI Debug
+
+Diagnose Dagger CI check failures for a commit. The point of this skill is to turn the noisy bubble of errors that comes out of `dagger trace` into a *triage* the user can act on: "these 2 are real failures worth investigating, these 4 are cascading kills, ignore them."
+
+## When this skill applies
+
+- "What's failing on CI?" / "Why did the checks fail on my PR?"
+- "Is the build green for commit X?"
+- "Investigate the CI failures for the current commit."
+- The user pastes a commit SHA and asks what's wrong.
+- The user has just pushed and wants a quick read on what broke.
+
+It assumes the user is working in (or near) a checkout of the dagger/dagger repo and that they have `dagger` on their PATH and are authenticated to Dagger Cloud.
+
+## Inputs
+
+Figure out **which commit** to investigate:
+
+- If the user gave an explicit SHA, use that.
+- Otherwise default to `git rev-parse HEAD` in the current repo. Confirm with the user only if HEAD looks suspicious (e.g. an unpushed local commit on `main`).
+
+The **module ref** is almost always the canonical upstream path `github.com/dagger/dagger`. **Do not** read it from `git remote get-url origin` — that may be a fork (e.g. `git@github.com:<you>/dagger.git`), and Dagger Cloud records checks against the upstream repository, not the fork. Pass the upstream form unless the user explicitly says otherwise.
+
+## Workflow
+
+### 1. Fetch the check list
+
+```sh
+dagger module-checks --json github.com/dagger/dagger@<sha>
+```
+
+Notes:
+- `dagger module-checks` is hidden / experimental — that's fine. Just call it.
+- The JSON output is the stable contract; don't try to parse the human-rendered form.
+- If you see an error like `no checks found in github.com/dagger/dagger for commit <short-sha>`, the cloud hasn't recorded this commit yet (e.g. the user just pushed seconds ago). Wait a bit and retry, or suggest the user runs with `--watch` to poll.
+
+### 2. Parse the JSON
+
+Top-level fields you care about:
+
+- `summary.{total,failure,cancelled,inProgress,success}` — headline counts.
+- `checksUrl` — the Dagger Cloud UI link for this commit's full check view. **Always include this in your final summary** so the user can click through.
+- `commit.{sha,message,authorName}` and `refs[].{type,number,title}` for context (which PR is this, what's the commit about).
+- `checks[]` — one entry per (deduped, most-recent) check. Fields:
+  - `name`, `status` (raw uppercase enum: `SUCCESS`, `FAILURE`, `CANCELLED`, `RUNNING`, `QUEUED`, `SKIPPED`), `statusBucket` (normalized camelCase: `failure` / `cancelled` / `inProgress` / `success`).
+  - `durationSeconds`, `startedAt`, `endTime`.
+  - `traceId`, `spanId`, `traceUrl`.
+  - Optional `internal: true` — only present when the only available checks are internal ones (rare).
+
+Filter to `statusBucket == "failure"` to get the list to investigate. If there's a single `cancelled` and zero `failure`s, also investigate the cancelled one — see "Timeouts" below.
+
+### 3. Fetch each failing trace
+
+For each failing trace ID:
+
+```sh
+dagger trace <traceId>
+```
+
+**Important: do not pass `--progress=logs`.** It currently produces no output locally — likely a bug in the streaming-logs path. The default progress mode prints the trace tree with bubbled-up error lines (`! ...`), which is what you want.
+
+Capture the tail (`| tail -40` is usually enough) and look for the patterns described below.
+
+### 4. Categorize each failure
+
+The output of `dagger trace` is a fire-hose of errors. Many of those errors come from *intentional negative-test cases* — the test suite exercises bad inputs and asserts that they fail with specific messages. Those error lines bubble up into the trace summary and look identical to real failures unless you know what to look for.
+
+Categorize each failing check into one of:
+
+**(a) Cascading kill.** The check ended in `context canceled` / `context deadline exceeded`, *or* its duration is way shorter than typical (e.g. `go test ./...` ending at 33s when it normally takes 5+ minutes). Almost certainly killed by an upstream timeout or by the orchestrator after a sibling failure. Not a real test failure — investigate the upstream cancellation, not this one.
+
+**(b) Timeout.** Status `CANCELLED` and duration around 30 minutes (1800s ± a bit). That's the CI step timeout. Worth investigating because the test legitimately ran too long — but the cause is "took too long", not "assertion failed". The trace usually doesn't show a specific failure.
+
+**(c) Infra hiccup.** Trace contains `exit code: 137` on bound services (SIGKILL — usually OOM), `dial unix /run/dagger/engine.sock: ... no such file or directory` across many sibling spans, or `connection error: ...` repeated. The test infra crashed; the code under test may or may not have a real issue. Worth a retry before deeper investigation.
+
+**(d) Real test failure.** Look for:
+- `package had failures` (Go test summary — at least one subtest in the package failed).
+- A specific assertion error (`expected ..., got ...`, etc.).
+- `dagger checks '<glob>'` with non-zero exit code reporting `Nx exit code: 1` summaries from `ci:bootstrap` (real lint regressions or test failures across the suite).
+- `failed to <do-something>` errors that aren't obviously test-fixture noise — like `failed to sync go module type defs generation container: exit code: 1` or `failed to run codegen: ...`.
+
+**(e) Negative-test noise.** Patterns that *look* alarming but are part of the test design:
+- `unknown flag: --matrix`, `unknown command "fn-a" for "dagger call"` — testing the CLI's error reporting.
+- `path "../foo" escapes workdir`, `workdir path "/rootfile.txt" escapes workdir` — testing safety guards.
+- `dockerfile parse error on line 1: unknown instruction: FRO (did you mean FROM?)` — testing Dockerfile parsing errors.
+- `failed to determine Git URL protocol`, `repository does not contain ref "refs/heads/main"` — testing missing-ref handling.
+- `module requires dagger v0.9.0, but support for that version has been removed` — testing version-gating.
+- Long lists of `stat <path>/.gitignore: no such file or directory` — testing file-stat error reporting in module loading.
+
+A useful heuristic: if a failed check's trace contains **dozens** of distinct error messages, most of them are likely (e). The actual failing assertion is usually mixed in among them. Look for a single distinct error (categories a–d) rather than getting lost in the list.
+
+### 5. Write the summary
+
+Group your findings by category, not by check. Within each group, list the checks with their trace IDs and durations. End with a one-sentence "bottom line" the user can act on.
+
+Use this exact template:
+
+```markdown
+## CI summary — `github.com/dagger/dagger@<short-sha>` (<PR ref if any>)
+
+**<total> checks: <success> pass / <failure> fail / <cancelled> cancelled / <inProgress> running**
+
+Cloud UI: <checksUrl>
+
+### Cascading kills (ignore, root cause is elsewhere)
+- `<check-name>` — <durationSeconds>s — trace `<traceId>`
+  Likely killed by <upstream check or timeout>.
+
+### Timeouts
+- `<check-name>` — ~<durationSeconds>s (≈ CI step timeout) — trace `<traceId>`
+
+### Infra issues (consider retrying)
+- `<check-name>` — <durationSeconds>s — trace `<traceId>`
+  Signal: <exit 137 on service X / engine.sock disconnects / etc.>
+
+### Real failures (worth investigating)
+- `<check-name>` — <durationSeconds>s — trace `<traceId>`
+  Failing signal: `<one-line excerpt that suggests a real regression>`
+
+### Bottom line
+<One sentence>. Examples:
+"Nothing to investigate — everything failing is cascade or infra. Retry the run."
+"Two real failures worth looking at: `<a>` and `<b>`. The other 4 are cascades."
+"Investigate `<a>` first — the others all cancelled after it timed out."
+```
+
+Omit any section that's empty. If every failure is in the "real" bucket, just one section + bottom line is fine. The point of the categorization is to *save the user time*, not to fill in every header.
+
+## Failure modes of the skill itself
+
+- **Auth.** If `dagger module-checks` fails with `not authenticated`, tell the user to run `dagger login` (or set `DAGGER_CLOUD_TOKEN`) and stop — don't try to invent traces.
+- **Wrong ref.** If the cloud says "no checks found in github.com/dagger/dagger for commit X", the user may have pushed to a personal fork that doesn't have its checks recorded against the upstream — verify by checking `git remote -v` and `git log <sha>` to confirm the commit is on a branch with a PR open against upstream. If not, the cloud genuinely has no data for this SHA.
+- **`dagger trace` returns nothing.** If you pass `--progress=logs`, you'll get an empty output and exit 1 — that's the bug mentioned above. Re-run without `--progress=logs`.
+- **Too much output.** Some traces are tens of thousands of lines. Pipe through `| tail -50` or `| grep -E "ERROR|! "` to keep the working set small. Don't dump the full trace into your response.
+
+## Anti-patterns
+
+- Don't paste raw `dagger trace` output into the summary. The user wants the *triage*, not the raw firehose.
+- Don't claim a check is "real" just because the trace looks scary — re-read the negative-test patterns above. The dagger test suite intentionally produces a lot of error output.
+- Don't run `--progress=logs` "to be thorough" — it's a known-empty code path right now.
+- Don't auto-retry, push fixes, or open PRs without being asked. This skill is for *investigation*; acting on the findings is a separate decision.
+
+## Example invocation, end to end
+
+User: "Check what's failing on my current PR."
+
+1. `git rev-parse HEAD` → `57847777f9ae3425c6c25df91cc58e09c0ff69c5`
+2. `dagger module-checks --json github.com/dagger/dagger@57847777f9ae3425c6c25df91cc58e09c0ff69c5`
+3. Parse JSON: `summary = {total:60, failure:6, cancelled:1, success:53, inProgress:0}`. 6 failing trace IDs + 1 cancelled.
+4. For each of the 7, `dagger trace <id> 2>&1 | tail -40` — categorize.
+5. Write the summary in the template above. Example bottom line: *"Investigate `test-split:test-call-and-shell` and `test-split:test-cli-engine` — both show real `failed to sync ... exit code 1` errors. The other 4 failures plus the cancellation look like a cascade from `test-split:test-base` hitting the 30-min timeout."*


### PR DESCRIPTION
## Summary

- Adds `dagger module-checks <module-ref>@<version>` — an experimental Cloud-discovery subcommand that fetches the recorded checks for a given commit and renders a colored progress bar + grouped per-check table.
- Two flags for non-interactive consumers:
  - `--json` emits a stable JSON document (matched commit, refs, summary counts, per-check status/duration/traceId/traceUrl).
  - `--watch` refetches and redraws every 5 seconds until interrupted; works for both human and JSON output.
- Factors a reusable `(*cloud.Client).queryGraphQL` helper next to the existing `streamGraphQL` for any future one-shot Cloud queries.

Hidden under the `experimental` annotation while the UX settles. Patterned after the existing `dagger trace` command.

Quick example of the output. Command is `dagger module-checks github.com/dagger/dagger@3ff7a1d23867732ec453d3ac35c4769239af5185 --watch`

<img width="1397" height="1591" alt="image" src="https://github.com/user-attachments/assets/214cb71a-31df-478d-b474-e6cc37aa52e1" />


## Test plan

- [x] `dagger module-checks github.com/dagger/dagger@<sha>` against a known commit returns the expected per-check rows and bar.
- [x] `--json` output validates against the documented schema (e.g. `jq '.summary'`, `jq '.checks[].statusBucket'`).
- [x] `--watch` redraws cleanly every ~5s; Ctrl+C exits without leaving the terminal in a bad state.
- [x] On a SHA with no matching commit, the candidate list is dumped to stderr and the command exits non-zero.
- [ ] `--org` flag and the `DAGGER_CLOUD_TOKEN`-derived org both work without explicit login.