### PR TITLE
test: fix helm check filtered workspace

### DIFF
--- a/e2e/helm/helm_test.go
+++ b/e2e/helm/helm_test.go
@@ -1,5 +1,6 @@
 // Package helm contains e2e contract tests for Dagger's Helm chart.
 //
+// workspace:include dagger.json
 // workspace:include k3s-entrypoint.sh
 // workspace:include ../../helm/dagger
 // workspace:include ../../.changes/.next

--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:54:6)
+type VersionID string // version (../../../../version/main.go:57:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:54:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:54:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -101,7 +101,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:54:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:197:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:176:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -142,7 +142,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:57:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -200,7 +200,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:150:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:265:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -226,7 +226,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:67:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:54:6)
+type VersionID string // version (../../../../version/main.go:57:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:54:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:54:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -101,7 +101,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:54:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:197:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:176:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -142,7 +142,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:57:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -200,7 +200,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:150:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:265:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -226,7 +226,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:67:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:54:6)
+type VersionID string // version (../../../../version/main.go:57:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:54:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:54:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:54:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -101,7 +101,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:54:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:197:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:176:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -142,7 +142,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:57:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -200,7 +200,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:150:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:265:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -226,7 +226,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:67:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/version/main.go
+++ b/version/main.go
@@ -44,8 +44,11 @@ func New(
 	}
 
 	if git, err := gitParent.Directory(".git").Sync(ctx); err == nil {
-		v.Git = git.AsGit()
-		v.GitDir = git
+		repo := git.AsGit()
+		if _, err := repo.Head().Commit(ctx); err == nil {
+			v.Git = repo
+			v.GitDir = git
+		}
 	}
 
 	return v


### PR DESCRIPTION
## What changed

This fixes the Helm e2e package under the filtered `golang:check` workspace.

- Include `e2e/helm/dagger.json` in the Helm test workspace inputs so the runtime module config matches the generated Go client.
- Harden `version.New` so it only stores a Git repository when the provided `.git` directory can actually resolve `HEAD`; otherwise it uses the existing fallback version path.

## Why

`TestInstallK3S` mounts `dag.DaggerCli().Binary()` into the Helm/kubectl container. The generated client has that field because `e2e/helm/dagger.json` declares the `dagger-cli` dependency, but the selected-module Golang check was not including that config file in its filtered workspace. The test therefore connected to a schema without `daggerCli` and failed with:

```text
Cannot query field "daggerCli" on type "Query".
```

Adding the config exposed a second filtered-workspace issue: the `dagger-cli` dependency asks the `version` module for version/tag values, and `version.New` was treating a present-but-unusable `.git` directory as a valid repository. In filtered contexts without real Git metadata, that bypassed the fallback path and failed later with `git error: not a git repository`.

## Validation

```sh
dagger --progress=plain call golang --select-module e2e/helm check
```

Result: passed, `ok github.com/dagger/dagger/e2e/helm 115.785s`.

Trace: https://dagger.cloud/dagger/traces/45472bc0ee590bcde6131f4bed510e84
