### PR TITLE
Add NixOS-style support to custom CA cert installer

### DIFF
--- a/.changes/unreleased/Added-20260508-220000.yaml
+++ b/.changes/unreleased/Added-20260508-220000.yaml
@@ -1,0 +1,16 @@
+kind: Added
+body: |
+  Automatically install custom CA certificates in NixOS-style containers.
+
+  Triggered by an `/etc/NIXOS` marker file or `ID=nixos`/`ID_LIKE=nixos` in
+  `/etc/os-release`. The bundle path is read from `$SSL_CERT_FILE` if set,
+  otherwise `/etc/ssl/certs/ca-certificates.crt`. When the chosen path is a
+  symlink into a read-only `/nix/store` target, the installer replaces it with
+  a writable regular file containing the original content, appends the cert via
+  the no-update-command fallback path, and restores the symlink on uninstall.
+  Every TLS client that reads the chosen path (Go, OpenSSL/curl, python `ssl`,
+  …) sees the augmented bundle.
+time: 2026-05-08T22:00:00.000000000+00:00
+custom:
+    Author: chasecaleb
+    PR: "13137"

--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -348,6 +348,151 @@ func (ContainerSuite) TestSystemCACerts(ctx context.Context, t *testctx.T) {
 			require.Equal(t, initialBundleContents, bundleContents)
 		}},
 
+		caCertsTest{"nixos-like basic", func(ctx context.Context, t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := nixosLikeContainer(c, c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "ca-certificates", "curl"}))
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, initialBundleContents)
+
+			ctr, err = ctr.
+				WithExec([]string{"curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"nixos-like ca-certificates not installed", func(ctx context.Context, t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {
+			// golangImage is alpine-based — strip its ca-certificates+update-ca-certificates so
+			// the no-update-cmd fallback path is the only one available, mirroring "alpine
+			// ca-certificates not installed".
+			ctr := nixosLikeContainer(c, c.Container().From(golangImage).
+				WithExec([]string{"apk", "update"}).
+				WithExec([]string{"apk", "del", "ca-certificates"}))
+
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, initialBundleContents)
+			require.NotContains(t, initialBundleContents, f.caCertContents)
+
+			ctr, err = ctr.
+				WithNewFile("/src/main.go", `package main
+
+					import (
+						"fmt"
+						"net/http"
+						"io"
+					)
+
+					func main() {
+						resp, err := http.Get("https://server")
+						if err != nil {
+							panic(err)
+						}
+						if resp.StatusCode != 200 {
+							panic(fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
+						}
+						bs, err := io.ReadAll(resp.Body)
+						if err != nil {
+							panic(err)
+						}
+						if string(bs) != "hello" {
+							panic("unexpected response: " + string(bs))
+						}
+					}
+                    `,
+				).
+				WithWorkdir("/src").
+				WithExec([]string{"go", "mod", "init", "test"}).
+				WithExec([]string{"go", "run", "main.go"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			_, err = ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			requireErrOut(t, err, "no such file or directory")
+
+			// Bundle path should resolve through the restored symlink to the original
+			// content (no test CA leaked). Equal-with-initial implicitly validates
+			// that nixosLike.Uninstall restored the symlink to the same target; if
+			// the swap path had been bypassed and a different installer had written
+			// through to a regular file, the contents wouldn't match initial state.
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, initialBundleContents, bundleContents)
+			require.NotContains(t, bundleContents, f.caCertContents)
+		}},
+
+		caCertsTest{"nixos-like non-root user", func(ctx context.Context, t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := nixosLikeContainer(c, c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "ca-certificates", "curl"}))
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithUser("nobody").
+				WithExec([]string{"/usr/bin/curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"nixos-like SSL_CERT_FILE override", func(ctx context.Context, t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {
+			// SSL_CERT_FILE honoring works via commonInstaller's no-update-cmd
+			// fallback path — that path appends directly to bundlePath. The
+			// update-cmd path can't honor SSL_CERT_FILE because update-ca-certificates
+			// writes to its own hard-coded output path. So this test deliberately
+			// uses an image without `ca-certificates` installed, putting the bundle
+			// at a non-canonical path the image points at via SSL_CERT_FILE.
+			bundleSrc := c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "ca-certificates"}).
+				File("/etc/ssl/certs/ca-certificates.crt")
+
+			ctr := c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "curl"}).
+				WithoutFile("/etc/alpine-release").
+				WithNewFile("/etc/NIXOS", "").
+				WithNewFile("/etc/os-release", "ID=nixos\n").
+				WithSymlink("/opt/ro-bundle/ca-bundle.crt", "/opt/custom/bundle.crt").
+				WithFile("/opt/ro-bundle/ca-bundle.crt", bundleSrc).
+				WithEnvVariable("SSL_CERT_FILE", "/opt/custom/bundle.crt")
+
+			// Alpine ships /etc/ssl/certs/ca-certificates.crt via libcrypto/openssl
+			// even when ca-certificates isn't installed, so the canonical path
+			// exists baseline. The honoring-SSL_CERT_FILE invariant is that the
+			// installer (running via the no-update-cmd fallback) only touches
+			// bundlePath = $SSL_CERT_FILE — the canonical bundle's bytes must
+			// be identical before and after the exec.
+			canonicalBundleBefore, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, canonicalBundleBefore)
+			require.NotContains(t, canonicalBundleBefore, f.caCertContents,
+				"fixture invariant: canonical bundle must not contain the test CA up front")
+
+			ctr, err = ctr.WithExec([]string{"curl", "https://server"}).Sync(ctx)
+			require.NoError(t, err)
+
+			canonicalBundleAfter, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, canonicalBundleBefore, canonicalBundleAfter,
+				"installer wrote to the canonical bundle path instead of honoring SSL_CERT_FILE")
+			require.NotContains(t, canonicalBundleAfter, f.caCertContents,
+				"installer leaked the test CA into the canonical bundle")
+		}},
+
 		caCertsTest{"go module", func(ctx context.Context, t *testctx.T, c *dagger.Client, f caCertsTestFixtures) {
 			out, err := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -550,6 +695,26 @@ type caCertsTest struct {
 type caCertsTestFixtures struct {
 	caCertContents string
 	engineEndpoint string
+}
+
+// nixosLikeContainer turns an existing container into one that detects as
+// NixOS-style and exposes /etc/ssl/certs/ca-certificates.crt as a symlink to
+// a baked-in bundle file. All ops are layer-level (no exec) so the
+// synthesis doesn't itself trigger the cacerts install path mid-setup.
+// WithFile (not WithMountedFile) for the bundle target — mounts aren't
+// visible to client-side File reads or to the engine-side cacerts
+// installer's rootfs view, so a mounted target makes the symlink unresolvable.
+func nixosLikeContainer(c *dagger.Client, base *dagger.Container) *dagger.Container {
+	bundleSrc := c.Container().From(alpineImage).
+		WithExec([]string{"apk", "add", "ca-certificates"}).
+		File("/etc/ssl/certs/ca-certificates.crt")
+	return base.
+		WithoutFile("/etc/alpine-release").
+		WithNewFile("/etc/NIXOS", "").
+		WithNewFile("/etc/os-release", "ID=nixos\nID_LIKE=nixos\n").
+		WithoutFile("/etc/ssl/certs/ca-certificates.crt").
+		WithSymlink("/opt/ro-bundle/ca-bundle.crt", "/etc/ssl/certs/ca-certificates.crt").
+		WithFile("/opt/ro-bundle/ca-bundle.crt", bundleSrc)
 }
 
 func customCACertTests(

--- a/docs/current_docs/reference/configuration/custom-ca.mdx
+++ b/docs/current_docs/reference/configuration/custom-ca.mdx
@@ -58,6 +58,15 @@ the following base distributions:
 - Alpine
 - Debian-based (e.g. `debian` and `ubuntu`)
 - Redhat-based (e.g. `rhel`, `fedora`, `centos`, etc.)
+- NixOS-style (NixOS itself, plus Nix-built distroless images that opt in by
+  creating an `/etc/NIXOS` marker file or declaring `ID=nixos`/`ID_LIKE=nixos`
+  in `/etc/os-release`)
+
+For NixOS-style images, Dagger looks at `$SSL_CERT_FILE` to locate the bundle
+(only when `update-ca-certificates` isn't installed), falling back to
+`/etc/ssl/certs/ca-certificates.crt`. This handles Nix-built images that put
+the bundle at a non-canonical path (e.g. under `/nix/store` or
+`/nix/var/nix/profiles/default/...`) without any image-side configuration.
 
 If custom CAs are installed and Dagger detects that one of these base images is
 being used, it will attempt to install the custom CAs into the container before

--- a/engine/engineutil/cacerts/cacerts.go
+++ b/engine/engineutil/cacerts/cacerts.go
@@ -66,6 +66,7 @@ func NewInstaller(
 	for _, installer := range []Installer{
 		&debianLike{},
 		&rhelLike{},
+		&nixosLike{},
 	} {
 		eg.Go(func() error {
 			if err := installer.initialize(ctrFS); err != nil {

--- a/engine/engineutil/cacerts/distros.go
+++ b/engine/engineutil/cacerts/distros.go
@@ -22,7 +22,6 @@ import (
 More distros to handle:
 * Arch Linux
 * OpenSUSE/sles
-* NiXOS
 * BusyBox
 * Wolfi
 */
@@ -161,6 +160,127 @@ func (d *rhelLike) detect() (bool, error) {
 			[]byte("fedora"),
 		},
 	)
+}
+
+/*
+nixosLike handles NixOS and Nix-built distroless images. The bundle (typically
+/etc/ssl/certs/ca-certificates.crt, or whatever path the image declares via
+$SSL_CERT_FILE) is usually a symlink into a read-only /nix/store target, so
+commonInstaller's append path can't write through it. We replace the symlink
+with a regular file containing the target's content for the duration of the
+exec, then restore the symlink on uninstall.
+*/
+type nixosLike struct {
+	*commonInstaller
+	origSymlinkTarget string // empty if Install didn't replace a symlink
+}
+
+func (d *nixosLike) initialize(ctrFS *containerfs.ContainerFS) error {
+	// Prefer the path the image declares via SSL_CERT_FILE (Nix-built images
+	// commonly point this at a /nix/store-backed bundle). Fall back to the
+	// Debian/Alpine canonical path. Deliberately do NOT call EvaluateSymlinks
+	// here — we want the immediate path so the symlink swap and the subsequent
+	// append target the same location.
+	bundlePath := "/etc/ssl/certs/ca-certificates.crt"
+	if v, ok := ctrFS.EnvVar("SSL_CERT_FILE"); ok && filepath.IsAbs(v) {
+		bundlePath = v
+	}
+
+	d.commonInstaller = &commonInstaller{
+		ctrFS:           ctrFS,
+		bundlePath:      bundlePath,
+		customCACertDir: "/usr/local/share/ca-certificates",
+		// Most Nix-distroless images don't ship update-ca-certificates, so
+		// commonInstaller's no-update-cmd fallback path is the one that
+		// actually runs. If the binary is present, the cmd path works too.
+		updateCmd: []string{"update-ca-certificates"},
+	}
+
+	return nil
+}
+
+func (d *nixosLike) detect() (bool, error) {
+	if exists, err := d.ctrFS.AnyPathExists([]string{"/etc/NIXOS"}); err != nil {
+		return false, err
+	} else if exists {
+		return true, nil
+	}
+
+	return d.ctrFS.OSReleaseFileContains(
+		[][]byte{[]byte("nixos")},
+		[][]byte{[]byte("nixos")},
+	)
+}
+
+func (d *nixosLike) Install(ctx context.Context) (rerr error) {
+	defer func() {
+		if rerr == nil || d.origSymlinkTarget == "" {
+			return
+		}
+		// commonInstaller.Install failed after we swapped the symlink — restore it.
+		target := d.origSymlinkTarget
+		d.origSymlinkTarget = ""
+		if err := d.ctrFS.Remove(d.bundlePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to remove materialized bundle: %w", err))
+		}
+		if err := d.ctrFS.Symlink(target, d.bundlePath); err != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to restore symlink %s -> %s: %w", d.bundlePath, target, err))
+		}
+	}()
+
+	info, err := d.ctrFS.Lstat(d.bundlePath)
+	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0:
+		target, err := d.ctrFS.Readlink(d.bundlePath)
+		if err != nil {
+			return fmt.Errorf("failed to readlink %s: %w", d.bundlePath, err)
+		}
+		// Resolve the target through ContainerFS rather than passing the
+		// symlink path to ReadFile. ctrFS.ReadFile(d.bundlePath) would call
+		// os.ReadFile, which lets the kernel follow the symlink in the
+		// engine's namespace — absolute targets like /nix/store/... then
+		// resolve against the engine's "/" instead of the container rootfs.
+		targetPath := target
+		if !filepath.IsAbs(targetPath) {
+			targetPath = filepath.Join(filepath.Dir(d.bundlePath), targetPath)
+		}
+		content, err := d.ctrFS.ReadFile(targetPath)
+		if err != nil {
+			return fmt.Errorf("failed to read symlink target %s for %s: %w", targetPath, d.bundlePath, err)
+		}
+		if err := d.ctrFS.Remove(d.bundlePath); err != nil {
+			return fmt.Errorf("failed to remove symlink %s: %w", d.bundlePath, err)
+		}
+		if err := d.ctrFS.WriteFile(d.bundlePath, content, 0o644); err != nil {
+			return fmt.Errorf("failed to materialize %s: %w", d.bundlePath, err)
+		}
+		d.origSymlinkTarget = target
+	case errors.Is(err, os.ErrNotExist):
+		// No bundle yet — commonInstaller will create one.
+	case err != nil:
+		return fmt.Errorf("failed to lstat %s: %w", d.bundlePath, err)
+	}
+	return d.commonInstaller.Install(ctx)
+}
+
+func (d *nixosLike) Uninstall(ctx context.Context) error {
+	// Run commonInstaller's uninstall regardless of whether we swapped the
+	// symlink. Capture its error and keep going — the symlink restore below
+	// is the only thing that frees up the materialized bundle (which may still
+	// contain the cert if commonInstaller.Uninstall failed).
+	rerr := d.commonInstaller.Uninstall(ctx)
+	if d.origSymlinkTarget == "" {
+		return rerr
+	}
+	target := d.origSymlinkTarget
+	d.origSymlinkTarget = ""
+	if err := d.ctrFS.Remove(d.bundlePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		rerr = errors.Join(rerr, fmt.Errorf("failed to remove materialized bundle %s: %w", d.bundlePath, err))
+	}
+	if err := d.ctrFS.Symlink(target, d.bundlePath); err != nil {
+		rerr = errors.Join(rerr, fmt.Errorf("failed to restore symlink %s -> %s: %w", d.bundlePath, target, err))
+	}
+	return rerr
 }
 
 // so far, the existing installers follow a common enough pattern that we can

--- a/engine/engineutil/containerfs/fs.go
+++ b/engine/engineutil/containerfs/fs.go
@@ -216,19 +216,25 @@ func (ctrFS *ContainerFS) SetMtime(path string, t int64) error {
 	return os.Chtimes(hostPath, time.Time{}, time.Unix(0, t))
 }
 
+// EnvVar returns the value of the named environment variable from the
+// container's process spec, plus a bool indicating whether the variable was set.
+func (ctrFS *ContainerFS) EnvVar(name string) (string, bool) {
+	prefix := name + "="
+	for _, kv := range ctrFS.spec.Process.Env {
+		if v, ok := strings.CutPrefix(kv, prefix); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
 func (ctrFS *ContainerFS) LookPath(cmd string) (string, error) {
 	if filepath.IsAbs(cmd) {
 		return cmd, nil
 	}
 
 	// TODO: caller may need to augment PATH with sbins when user not root?
-	var pathEnvVal string
-	for _, env := range ctrFS.spec.Process.Env {
-		if after, ok := strings.CutPrefix(env, "PATH="); ok {
-			pathEnvVal = after
-			break
-		}
-	}
+	pathEnvVal, _ := ctrFS.EnvVar("PATH")
 	if pathEnvVal == "" {
 		pathEnvVal = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	}


### PR DESCRIPTION
NixOS and Nix-built distroless images expose the system CA bundle as a symlink into a read-only /nix/store target, so commonInstaller's append path can't write through it. Add a nixosLike installer that detects NixOS via /etc/NIXOS or ID=nixos/ID_LIKE=nixos, locates the bundle via $SSL_CERT_FILE (falling back to /etc/ssl/certs/ca-certificates.crt), materializes the symlink as a writable regular file for the duration of the exec, and restores the symlink on uninstall.

Also adds a small ContainerFS.EnvVar helper for reading container process env vars, used to honor SSL_CERT_FILE.