### PR TITLE
fix: revalidate inline contextual runtime deps

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -279,8 +279,8 @@ type changesetJSONEnvelope struct {
 }
 
 type persistedChangesetPayload struct {
-	BeforeResultID uint64 `json:"beforeResultID,omitempty"`
-	AfterResultID  uint64 `json:"afterResultID,omitempty"`
+	BeforeResultID uint64 `json:"beforeResultID"`
+	AfterResultID  uint64 `json:"afterResultID"`
 }
 
 // MarshalJSON implements custom JSON marshaling that stores directory IDs
@@ -362,7 +362,12 @@ func (*Changeset) DecodePersistedObject(
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return nil, fmt.Errorf("decode persisted changeset payload: %w", err)
 	}
-
+	if persisted.BeforeResultID == 0 {
+		return nil, fmt.Errorf("decode persisted changeset: missing before result")
+	}
+	if persisted.AfterResultID == 0 {
+		return nil, fmt.Errorf("decode persisted changeset: missing after result")
+	}
 	before, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.BeforeResultID, "changeset before")
 	if err != nil {
 		return nil, err
@@ -411,9 +416,9 @@ func (*Changeset) TypeDescription() string {
 }
 
 var _ Syncable = (*Changeset)(nil)
+var _ dagql.HasDependencyResults = (*Changeset)(nil)
 var _ dagql.PersistedObject = (*Changeset)(nil)
 var _ dagql.PersistedObjectDecoder = (*Changeset)(nil)
-var _ dagql.HasDependencyResults = (*Changeset)(nil)
 
 func (ch *Changeset) Evaluate(context.Context) error {
 	return nil

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -2038,6 +2038,9 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				LockMode:              clientMetadata.LockMode,
 				UseRecipeIDsByDefault: execMD != nil && execMD.UseRecipeIDsByDefault,
 			}
+			if execMD != nil {
+				nestedClientMetadata.RuntimeCallDigest = execMD.CallDigest
+			}
 		}
 
 		procInfo := executor.ProcessInfo{Meta: meta}

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -1229,6 +1230,93 @@ func (*Test) Rand(
 	require.NotEmpty(t, res3.Test.Rand)
 
 	require.NotEqual(t, res1.Test.Rand, res3.Test.Rand)
+}
+
+func (ModuleSuite) TestCrossSessionInlineDependencyContextualDirChange(ctx context.Context, t *testctx.T) {
+	tmpdir := t.TempDir()
+	depDir := filepath.Join(tmpdir, "dep")
+	modDir := filepath.Join(tmpdir, "mod")
+	dataDir := filepath.Join(tmpdir, "data")
+	require.NoError(t, os.MkdirAll(depDir, 0755))
+	require.NoError(t, os.MkdirAll(modDir, 0755))
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	gitInitCmd := exec.Command("git", "init")
+	gitInitCmd.Dir = tmpdir
+	gitInitOutput, err := gitInitCmd.CombinedOutput()
+	require.NoError(t, err, string(gitInitOutput))
+
+	initDepCmd := hostDaggerCommand(ctx, t, tmpdir, "init", "--source=dep", "--name=dep", "--sdk=go", "dep")
+	initDepOutput, err := initDepCmd.CombinedOutput()
+	require.NoError(t, err, string(initDepOutput))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "value.txt"), []byte("one"), 0644))
+
+	err = os.WriteFile(filepath.Join(depDir, "main.go"), []byte(`package main
+import (
+	"context"
+
+	"dagger/dep/internal/dagger"
+)
+
+type Dep struct {
+	Dir *dagger.Directory
+}
+
+func New(
+	// +defaultPath="/data"
+	dir *dagger.Directory,
+) *Dep {
+	return &Dep{Dir: dir}
+}
+
+func (d *Dep) Read(ctx context.Context) (string, error) {
+	return d.Dir.File("value.txt").Contents(ctx)
+}
+`), 0644)
+	require.NoError(t, err)
+
+	initModCmd := hostDaggerCommand(ctx, t, tmpdir, "init", "--source=mod", "--name=test", "--sdk=go", "mod")
+	initModOutput, err := initModCmd.CombinedOutput()
+	require.NoError(t, err, string(initModOutput))
+
+	installDepCmd := hostDaggerCommand(ctx, t, tmpdir, "install", "-m=mod", "dep")
+	installDepOutput, err := installDepCmd.CombinedOutput()
+	require.NoError(t, err, string(installDepOutput))
+
+	err = os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+import "context"
+
+type Test struct {}
+
+func (*Test) Read(ctx context.Context) (string, error) {
+	return dag.Dep().Read(ctx)
+}
+`), 0644)
+	require.NoError(t, err)
+
+	read := func(c *dagger.Client) string {
+		mod, err := c.ModuleSource(modDir).AsModule().Sync(ctx)
+		require.NoError(t, err)
+		require.NoError(t, mod.Serve(ctx))
+
+		res, err := testutil.QueryWithClient[struct {
+			Test struct {
+				Read string
+			}
+		}](c, t, `{test{read}}`, nil)
+		require.NoError(t, err)
+		return res.Test.Read
+	}
+
+	c1 := connect(ctx, t)
+	require.Equal(t, "one", read(c1))
+	require.NoError(t, c1.Close())
+
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "value.txt"), []byte("two"), 0644))
+
+	c2 := connect(ctx, t)
+	require.Equal(t, "two", read(c2))
 }
 
 func (SecretSuite) TestCrossSessionSecretURICaching(ctx context.Context, t *testctx.T) {

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -694,12 +694,12 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 		// Process "contextual arguments", aka objects with a `defaultPath`
 		ctxArgVals := make([]*argInput, len(ctxArgs))
 		for i, arg := range ctxArgs {
+			i, arg := i, arg
 			eg.Go(func() error {
 				ctxVal, err := fn.loadContextualArg(ctx, srv, arg)
 				if err != nil {
 					return fmt.Errorf("load contextual arg %q: %w", arg.Name, err)
 				}
-
 				ctxArgVals[i] = &argInput{
 					argName: arg.Name,
 					val:     ctxVal,
@@ -712,12 +712,12 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 		// Process workspace arguments - automatically inject workspace when not set
 		workspaceArgVals := make([]*argInput, len(workspaceArgs))
 		for i, arg := range workspaceArgs {
+			i, arg := i, arg
 			eg.Go(func() error {
 				wsVal, err := fn.loadWorkspaceArg(ctx, srv)
 				if err != nil {
 					return fmt.Errorf("load workspace arg %q: %w", arg.Name, err)
 				}
-
 				workspaceArgVals[i] = &argInput{
 					argName: arg.Name,
 					val:     wsVal,

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -104,7 +104,7 @@ func (sdk *dangSDK) ModuleTypes(
 		return inst, fmt.Errorf("current query: %w", err)
 	}
 
-	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx)
+	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx, nil)
 	if err != nil {
 		return inst, err
 	}
@@ -129,7 +129,7 @@ func (sdk *dangSDK) ModuleTypes(
 	return inst, nil
 }
 
-func newDangNestedClientMetadata(ctx context.Context) (*engine.ClientMetadata, *engine.ClientMetadata, error) {
+func newDangNestedClientMetadata(ctx context.Context, execMD *engineutil.ExecutionMetadata) (*engine.ClientMetadata, *engine.ClientMetadata, error) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -143,6 +143,9 @@ func newDangNestedClientMetadata(ctx context.Context) (*engine.ClientMetadata, *
 		ClientVersion:     engine.Version,
 		AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
 		LockMode:          clientMetadata.LockMode,
+	}
+	if execMD != nil {
+		nestedClientMetadata.RuntimeCallDigest = execMD.CallDigest
 	}
 
 	return clientMetadata, nestedClientMetadata, nil
@@ -161,7 +164,7 @@ func (r *DangRuntime) AsContainer() (dagql.ObjectResult[*core.Container], bool) 
 
 func (r *DangRuntime) Call(
 	ctx context.Context,
-	_ *engineutil.ExecutionMetadata,
+	execMD *engineutil.ExecutionMetadata,
 	fnCall *core.FunctionCall,
 	moduleContext dagql.ObjectResult[*core.Module],
 	envContext dagql.ObjectResult[*core.Env],
@@ -172,7 +175,7 @@ func (r *DangRuntime) Call(
 		}
 	}()
 
-	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx)
+	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx, execMD)
 	if err != nil {
 		return nil, err
 	}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -85,10 +85,20 @@ type persistedEdge struct {
 	unpruneable       bool
 }
 
-const cachePersistenceSchemaVersion = "16"
+const cachePersistenceSchemaVersion = "17"
 
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrPersistStateNotReady = errors.New("persist state not ready")
+var ErrCacheValidationFailed = errors.New("cache validation failed")
+
+type runtimeResultDependency struct {
+	ResultID      uint64                     `json:"resultID,omitempty"`
+	Frame         *ResultCall                `json:"frame,omitempty"`
+	Digest        digest.Digest              `json:"digest,omitempty"`
+	FreshnessDeps runtimeResultDependencySet `json:"-"`
+}
+
+type runtimeResultDependencySet []runtimeResultDependency
 
 type CachePersistenceResetReason string
 
@@ -244,6 +254,32 @@ func (c *Cache) trackSessionResult(ctx context.Context, sessionID string, res An
 	}
 }
 
+func (c *Cache) rollbackTrackedHit(
+	ctx context.Context,
+	sessionID string,
+	hitShared *sharedResult,
+	alreadyTracked bool,
+	err error,
+) error {
+	if alreadyTracked {
+		return err
+	}
+
+	c.egraphMu.Lock()
+	c.sessionMu.Lock()
+	if resultIDs := c.sessionResultIDsBySession[sessionID]; resultIDs != nil {
+		delete(resultIDs, hitShared.id)
+		if len(resultIDs) == 0 {
+			delete(c.sessionResultIDsBySession, sessionID)
+		}
+	}
+	c.sessionMu.Unlock()
+	queue, decErr := c.decrementIncomingOwnershipLocked(ctx, hitShared, nil)
+	collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
+	c.egraphMu.Unlock()
+	return errors.Join(err, decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases))
+}
+
 func (c *Cache) recomputeRequiredSessionResourcesLocked(res *sharedResult) error {
 	if res == nil {
 		return nil
@@ -274,6 +310,101 @@ func (c *Cache) recomputeRequiredSessionResourcesLocked(res *sharedResult) error
 	}
 	res.requiredSessionResources = reqs
 	return nil
+}
+
+func (c *Cache) recordRuntimeResultDependency(ctx context.Context, req *CallRequest, res AnyResult, freshnessDeps runtimeResultDependencySet) {
+	if c == nil || req == nil || req.ResultCall == nil || res == nil {
+		return
+	}
+	shared := res.cacheSharedResult()
+	if shared == nil || shared.id == 0 {
+		return
+	}
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil || clientMetadata.RuntimeCallDigest == "" {
+		return
+	}
+	if clientMetadata.SessionID == "" {
+		return
+	}
+	requestDigest, err := req.deriveRecipeDigest(c)
+	if err == nil && requestDigest == clientMetadata.RuntimeCallDigest {
+		return
+	}
+	resultFrame, err := res.ResultCall()
+	if err != nil || resultFrame == nil {
+		return
+	}
+	observedDigest, err := resultFrame.deriveContentPreferredDigest(c)
+	if err != nil || observedDigest == "" {
+		return
+	}
+	depFrame := req.ResultCall.clone()
+	depRecipeDigest, err := depFrame.deriveRecipeDigest(c)
+	if err != nil || depRecipeDigest == "" {
+		return
+	}
+	dep := runtimeResultDependency{
+		ResultID:      uint64(shared.id),
+		Frame:         depFrame,
+		Digest:        observedDigest,
+		FreshnessDeps: cloneRuntimeResultDependencySet(freshnessDeps),
+	}
+	parentKey := runtimeDependencyKey(clientMetadata.SessionID, clientMetadata.RuntimeCallDigest)
+	c.runtimeDepsMu.Lock()
+	if c.runtimeDepsByCallDigest == nil {
+		c.runtimeDepsByCallDigest = make(map[string]map[string]runtimeResultDependency)
+	}
+	if c.runtimeDepsByCallDigest[parentKey] == nil {
+		c.runtimeDepsByCallDigest[parentKey] = make(map[string]runtimeResultDependency)
+	}
+	c.runtimeDepsByCallDigest[parentKey][depRecipeDigest.String()] = dep
+	c.runtimeDepsMu.Unlock()
+}
+
+func (c *Cache) drainRuntimeResultDependencies(sessionID string, parentDigest digest.Digest) runtimeResultDependencySet {
+	if c == nil || sessionID == "" || parentDigest == "" {
+		return nil
+	}
+	parentKey := runtimeDependencyKey(sessionID, parentDigest)
+	c.runtimeDepsMu.Lock()
+	deps := c.runtimeDepsByCallDigest[parentKey]
+	delete(c.runtimeDepsByCallDigest, parentKey)
+	c.runtimeDepsMu.Unlock()
+	if len(deps) == 0 {
+		return nil
+	}
+	depKeys := make([]string, 0, len(deps))
+	for depKey := range deps {
+		depKeys = append(depKeys, depKey)
+	}
+	slices.Sort(depKeys)
+	out := make(runtimeResultDependencySet, 0, len(depKeys))
+	for _, depKey := range depKeys {
+		out = append(out, deps[depKey])
+	}
+	return out
+}
+
+func (c *Cache) discardRuntimeResultDependencies(req *CallRequest, sessionID string) {
+	if c == nil || req == nil || req.ResultCall == nil {
+		return
+	}
+	if sessionID == "" {
+		return
+	}
+	parentDigest, err := req.deriveRecipeDigest(c)
+	if err != nil || parentDigest == "" {
+		return
+	}
+	parentKey := runtimeDependencyKey(sessionID, parentDigest)
+	c.runtimeDepsMu.Lock()
+	delete(c.runtimeDepsByCallDigest, parentKey)
+	c.runtimeDepsMu.Unlock()
+}
+
+func runtimeDependencyKey(sessionID string, parentDigest digest.Digest) string {
+	return sessionID + "\x00" + parentDigest.String()
 }
 
 func (c *Cache) BindSessionResource(_ context.Context, sessionID string, clientID string, handle SessionResourceHandle, value any) error {
@@ -1240,6 +1371,13 @@ type Cache struct {
 	ongoingArbitraryCalls   map[string]*sharedArbitraryResult
 	completedArbitraryCalls map[string]*sharedArbitraryResult
 
+	// runtimeDepsByCallDigest records exact cache results selected by a nested
+	// module runtime while executing the module function identified by the key.
+	// The parent function result retains the observed call/digest dependency
+	// set on the e-graph association it publishes.
+	runtimeDepsMu           sync.Mutex
+	runtimeDepsByCallDigest map[string]map[string]runtimeResultDependency
+
 	sessionResultIDsBySession         map[string]map[sharedResultID]struct{}
 	sessionArbitraryCallKeysBySession map[string]map[string]struct{}
 	sessionLazySpansBySession         map[string]map[sharedResultID]trace.SpanContext
@@ -1683,7 +1821,8 @@ type ongoingCall struct {
 	releaseSharedWorkLeaseFn   func(context.Context) error
 	releaseSharedWorkLeaseOnce sync.Once
 
-	res *sharedResult
+	res         *sharedResult
+	runtimeDeps runtimeResultDependencySet
 }
 
 func (oc *ongoingCall) releaseSharedWorkLease(ctx context.Context) error {
@@ -1735,7 +1874,7 @@ func (c *Cache) canonicalEquivalentSharedResultLocked(sessionID string, res *sha
 	if candidates.Empty() {
 		return res
 	}
-	if canonical := c.selectLookupCandidateForSessionLocked(sessionID, candidates); canonical != nil {
+	if canonical := c.selectLookupCandidateForSessionLocked(sessionID, candidates, nil); canonical != nil {
 		return canonical
 	}
 	return res
@@ -1893,7 +2032,7 @@ func (c *Cache) attachResult(ctx context.Context, sessionID string, resolver Typ
 		requestInputs = append(requestInputs, dig)
 	}
 
-	hitRes, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
+	hitRes, _, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
 	if err != nil {
 		return nil, fmt.Errorf("attach dependency result: %w", err)
 	}
@@ -2151,6 +2290,51 @@ func (r Result[T]) ContentPreferredDigest(ctx context.Context) (digest.Digest, e
 		return "", err
 	}
 	return call.deriveContentPreferredDigest(c)
+}
+
+func ContentPreferredDigestForID(ctx context.Context, input IDType) (digest.Digest, error) {
+	if input == nil {
+		return "", fmt.Errorf("content-preferred digest for ID: nil input")
+	}
+	id, err := input.ID()
+	if err != nil {
+		return "", fmt.Errorf("content-preferred digest for ID: %w", err)
+	}
+	if id == nil {
+		return "", fmt.Errorf("content-preferred digest for ID: nil ID")
+	}
+	if !id.IsHandle() {
+		if contentDigest := id.ContentDigest(); contentDigest != "" {
+			return contentDigest, nil
+		}
+		return id.Digest(), nil
+	}
+
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("content-preferred digest for ID %q: current client metadata: %w", idInputDebugString(id), err)
+	}
+	if clientMetadata.SessionID == "" {
+		return "", fmt.Errorf("content-preferred digest for ID %q: empty session ID", idInputDebugString(id))
+	}
+	cache, err := EngineCache(ctx)
+	if err != nil {
+		return "", fmt.Errorf("content-preferred digest for ID %q: current dagql cache: %w", idInputDebugString(id), err)
+	}
+	shared, _, _, err := cache.sharedResultByResultID(
+		ctx,
+		clientMetadata.SessionID,
+		sharedResultID(id.EngineResultID()),
+		sharedResultLookupCanonicalEquivalent,
+	)
+	if err != nil {
+		return "", fmt.Errorf("content-preferred digest for ID %q: %w", idInputDebugString(id), err)
+	}
+	frame := shared.loadResultCall()
+	if frame == nil {
+		return "", fmt.Errorf("content-preferred digest for ID %q: missing result call frame", idInputDebugString(id))
+	}
+	return frame.deriveContentPreferredDigest(cache)
 }
 
 func (r Result[T]) ResultCall() (*ResultCall, error) {
@@ -3472,6 +3656,7 @@ func (c *Cache) getOrInitCall(
 			}
 			c.trackSessionResult(ctx, sessionID, normalized, false)
 			c.captureSessionResultInstallSpan(ctx, sessionID, normalized)
+			c.recordRuntimeResultDependency(ctx, req, normalized, nil)
 			return normalized, nil
 		}
 		if lazyEval := lazyEvalFuncOfResult(val); lazyEval != nil {
@@ -3531,13 +3716,14 @@ func (c *Cache) getOrInitCall(
 		concurrencyKey: req.ConcurrencyKey,
 	}
 
-	hitRes, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
+	hitRes, matchedRuntimeDeps, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
 	if err != nil {
 		return nil, err
 	}
 	if hit {
 		c.captureSessionLazySpanContext(ctx, sessionID, hitRes)
 		c.captureSessionResultInstallSpan(ctx, sessionID, hitRes)
+		c.recordRuntimeResultDependency(ctx, req, hitRes, matchedRuntimeDeps)
 		return hitRes, nil
 	}
 
@@ -3597,6 +3783,7 @@ func (c *Cache) getOrInitCall(
 		noWaiters := oc.waiters == 0
 		c.callsMu.Unlock()
 		if err != nil || noWaiters {
+			c.discardRuntimeResultDependencies(req, sessionID)
 			_ = oc.releaseSharedWorkLease(context.WithoutCancel(oc.sharedWorkCtx))
 		}
 	}()
@@ -3638,7 +3825,7 @@ func (c *Cache) lookupCallRequest(
 		requestInputs = append(requestInputs, dig)
 	}
 
-	hitRes, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
+	hitRes, _, hit, err := c.lookupCacheForRequest(ctx, sessionID, resolver, req, callDigest, requestSelf, requestInputs, requestInputRefs)
 	if err != nil {
 		return nil, false, err
 	}
@@ -3665,77 +3852,64 @@ func (c *Cache) lookupCacheForDigests(
 		return nil, false, nil
 	}
 
-	c.egraphMu.Lock()
-	now := time.Now()
-	nowUnix := now.Unix()
-	match := c.lookupMatchForDigestsLocked(recipeDigest, extraDigests, nowUnix)
-	c.traceLookupAttempt(ctx, recipeDigest.String(), "", nil, false)
-	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
-	if hitRes == nil {
-		c.traceLookupMissNoMatch(ctx, recipeDigest.String(), false, -1, "", 0)
-		c.egraphMu.Unlock()
-		return nil, false, nil
-	}
-
-	hitRes.expiresAtUnix = mergeSharedResultExpiryUnix(
-		hitRes.expiresAtUnix,
-		candidateSharedResultExpiryUnix(nowUnix, 0),
-	)
-	touchSharedResultLastUsed(hitRes, now.UnixNano())
-	retRes := Result[Typed]{
-		shared:   hitRes,
-		hitCache: true,
-	}
-	c.traceLookupHit(ctx, recipeDigest.String(), hitRes, match.termDigest)
-	hitShared := retRes.cacheSharedResult()
-	if hitShared == nil || hitShared.id == 0 {
-		c.egraphMu.Unlock()
-		return nil, false, fmt.Errorf("lookup cache for digests: hit missing shared result ID")
-	}
-
-	trackedCount := 0
-	alreadyTracked := false
-	c.sessionMu.Lock()
-	if c.sessionResultIDsBySession == nil {
-		c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
-	}
-	if c.sessionResultIDsBySession[sessionID] == nil {
-		c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
-	}
-	if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
-		alreadyTracked = true
-	} else {
-		c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
-		c.incrementIncomingOwnershipLocked(ctx, hitShared)
-	}
-	trackedCount = len(c.sessionResultIDsBySession[sessionID])
-	c.sessionMu.Unlock()
-	c.egraphMu.Unlock()
-
-	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
-	if err != nil {
+	skipped := map[sharedResultID]struct{}{}
+	for {
 		c.egraphMu.Lock()
+		now := time.Now()
+		nowUnix := now.Unix()
+		match := c.lookupMatchForDigestsLocked(recipeDigest, extraDigests, nowUnix)
+		c.traceLookupAttempt(ctx, recipeDigest.String(), "", nil, false)
+		hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates, skipped)
+		if hitRes == nil {
+			c.traceLookupMissNoMatch(ctx, recipeDigest.String(), false, -1, "", 0)
+			c.egraphMu.Unlock()
+			return nil, false, nil
+		}
+
+		hitRes.expiresAtUnix = mergeSharedResultExpiryUnix(
+			hitRes.expiresAtUnix,
+			candidateSharedResultExpiryUnix(nowUnix, 0),
+		)
+		touchSharedResultLastUsed(hitRes, now.UnixNano())
+		retRes := Result[Typed]{
+			shared:   hitRes,
+			hitCache: true,
+		}
+		c.traceLookupHit(ctx, recipeDigest.String(), hitRes, match.termDigest)
+		hitShared := retRes.cacheSharedResult()
+		if hitShared == nil || hitShared.id == 0 {
+			c.egraphMu.Unlock()
+			return nil, false, fmt.Errorf("lookup cache for digests: hit missing shared result ID")
+		}
+
+		trackedCount := 0
+		alreadyTracked := false
 		c.sessionMu.Lock()
-		if resultIDs := c.sessionResultIDsBySession[sessionID]; resultIDs != nil {
-			delete(resultIDs, hitShared.id)
-			if len(resultIDs) == 0 {
-				delete(c.sessionResultIDsBySession, sessionID)
-			}
+		if c.sessionResultIDsBySession == nil {
+			c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
 		}
+		if c.sessionResultIDsBySession[sessionID] == nil {
+			c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
+		}
+		if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
+			alreadyTracked = true
+		} else {
+			c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
+			c.incrementIncomingOwnershipLocked(ctx, hitShared)
+		}
+		trackedCount = len(c.sessionResultIDsBySession[sessionID])
 		c.sessionMu.Unlock()
-		queue := []*sharedResult(nil)
-		var decErr error
-		if !alreadyTracked {
-			queue, decErr = c.decrementIncomingOwnershipLocked(ctx, hitShared, nil)
-		}
-		collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
 		c.egraphMu.Unlock()
-		return nil, false, errors.Join(err, decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases))
+
+		loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
+		if err != nil {
+			return nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
+		}
+		if c.traceEnabled() {
+			c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
+		}
+		return loadedHit, true, nil
 	}
-	if c.traceEnabled() {
-		c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
-	}
-	return loadedHit, true, nil
 }
 
 func (c *Cache) wait(
@@ -3770,6 +3944,7 @@ func (c *Cache) wait(
 		if lastWaiter {
 			delete(c.ongoingCalls, oc.callConcurrencyKeys)
 			oc.cancel(canceledErr)
+			c.discardRuntimeResultDependencies(req, sessionID)
 		}
 		c.callsMu.Unlock()
 		if releaseHandoff && oc.res != nil {
@@ -3786,6 +3961,7 @@ func (c *Cache) wait(
 	}
 
 	if completionErr != nil {
+		c.discardRuntimeResultDependencies(req, sessionID)
 		c.callsMu.Lock()
 		oc.waiters--
 		lastWaiter := oc.waiters == 0
@@ -3809,6 +3985,7 @@ func (c *Cache) wait(
 	// TODO there's a race condition here: thread one enters the .Do() above but hasn't finished calling initCompletedResult(....), the second thread will skip over the Do(),
 	// then check the err below before it's actually written to
 	if oc.initCompletedResultErr != nil {
+		c.discardRuntimeResultDependencies(req, sessionID)
 		c.callsMu.Lock()
 		oc.waiters--
 		lastWaiter := oc.waiters == 0
@@ -3871,6 +4048,7 @@ func (c *Cache) wait(
 	if err != nil {
 		return nil, fmt.Errorf("wait: normalize returned result: %w", err)
 	}
+	c.recordRuntimeResultDependency(ctx, req, retResAny, oc.runtimeDeps)
 	return retResAny, nil
 }
 
@@ -4007,6 +4185,9 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		}
 		requestInputs = append(requestInputs, dig)
 	}
+	allRuntimeDeps := c.drainRuntimeResultDependencies(sessionID, requestDigest)
+	runtimeDeps := c.liveRuntimeDependencies(allRuntimeDeps)
+	oc.runtimeDeps = cloneRuntimeResultDependencySet(runtimeDeps)
 	var responseDigest digest.Digest
 	if resultCall := oc.res.loadResultCall(); resultCall != nil {
 		responseDigest, err = resultCall.deriveRecipeDigest(c)
@@ -4149,6 +4330,7 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		resultTermRefs,
 		hasResultTerm,
 		oc.res,
+		runtimeDeps,
 	)
 	if indexErr != nil {
 		c.egraphMu.Unlock()
@@ -4171,6 +4353,26 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		c.rememberDependencyEdgeLocked(oc.res, depRes)
 		c.incrementIncomingOwnershipLocked(ctx, depRes)
 		c.traceResultCallDepAdded(ctx, oc.res.id, depID, dep.path)
+	}
+	for _, runtimeDep := range allRuntimeDeps {
+		depID := sharedResultID(runtimeDep.ResultID)
+		if depID == oc.res.id {
+			continue
+		}
+		depRes := c.resultsByID[depID]
+		if depRes == nil {
+			c.egraphMu.Unlock()
+			return fmt.Errorf("retain runtime dep result %d: missing cached result", depID)
+		}
+		if oc.res.deps == nil {
+			oc.res.deps = make(map[sharedResultID]struct{})
+		}
+		if _, alreadyHeld := oc.res.deps[depID]; alreadyHeld {
+			continue
+		}
+		oc.res.deps[depID] = struct{}{}
+		c.incrementIncomingOwnershipLocked(ctx, depRes)
+		c.traceExplicitDepAdded(ctx, oc.res.id, depID, "module_runtime_call")
 	}
 	if err := c.recomputeRequiredSessionResourcesLocked(oc.res); err != nil {
 		c.egraphMu.Unlock()

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -92,8 +92,12 @@ var ErrPersistStateNotReady = errors.New("persist state not ready")
 var ErrCacheValidationFailed = errors.New("cache validation failed")
 
 type runtimeResultDependency struct {
-	ResultID      uint64                     `json:"resultID,omitempty"`
-	Frame         *ResultCall                `json:"frame,omitempty"`
+	ResultID uint64      `json:"resultID,omitempty"`
+	Frame    *ResultCall `json:"frame,omitempty"`
+	// FrameDigest is the recipe digest for Frame. Runtime dependency equality
+	// must be a pure comparison because egraph indexing compares dependency
+	// sets while holding egraph locks.
+	FrameDigest   digest.Digest              `json:"frameDigest,omitempty"`
 	Digest        digest.Digest              `json:"digest,omitempty"`
 	FreshnessDeps runtimeResultDependencySet `json:"-"`
 }
@@ -347,6 +351,7 @@ func (c *Cache) recordRuntimeResultDependency(ctx context.Context, req *CallRequ
 	dep := runtimeResultDependency{
 		ResultID:      uint64(shared.id),
 		Frame:         depFrame,
+		FrameDigest:   depRecipeDigest,
 		Digest:        observedDigest,
 		FreshnessDeps: cloneRuntimeResultDependencySet(freshnessDeps),
 	}
@@ -3852,64 +3857,61 @@ func (c *Cache) lookupCacheForDigests(
 		return nil, false, nil
 	}
 
-	skipped := map[sharedResultID]struct{}{}
-	for {
-		c.egraphMu.Lock()
-		now := time.Now()
-		nowUnix := now.Unix()
-		match := c.lookupMatchForDigestsLocked(recipeDigest, extraDigests, nowUnix)
-		c.traceLookupAttempt(ctx, recipeDigest.String(), "", nil, false)
-		hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates, skipped)
-		if hitRes == nil {
-			c.traceLookupMissNoMatch(ctx, recipeDigest.String(), false, -1, "", 0)
-			c.egraphMu.Unlock()
-			return nil, false, nil
-		}
-
-		hitRes.expiresAtUnix = mergeSharedResultExpiryUnix(
-			hitRes.expiresAtUnix,
-			candidateSharedResultExpiryUnix(nowUnix, 0),
-		)
-		touchSharedResultLastUsed(hitRes, now.UnixNano())
-		retRes := Result[Typed]{
-			shared:   hitRes,
-			hitCache: true,
-		}
-		c.traceLookupHit(ctx, recipeDigest.String(), hitRes, match.termDigest)
-		hitShared := retRes.cacheSharedResult()
-		if hitShared == nil || hitShared.id == 0 {
-			c.egraphMu.Unlock()
-			return nil, false, fmt.Errorf("lookup cache for digests: hit missing shared result ID")
-		}
-
-		trackedCount := 0
-		alreadyTracked := false
-		c.sessionMu.Lock()
-		if c.sessionResultIDsBySession == nil {
-			c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
-		}
-		if c.sessionResultIDsBySession[sessionID] == nil {
-			c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
-		}
-		if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
-			alreadyTracked = true
-		} else {
-			c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
-			c.incrementIncomingOwnershipLocked(ctx, hitShared)
-		}
-		trackedCount = len(c.sessionResultIDsBySession[sessionID])
-		c.sessionMu.Unlock()
+	c.egraphMu.Lock()
+	now := time.Now()
+	nowUnix := now.Unix()
+	match := c.lookupMatchForDigestsLocked(recipeDigest, extraDigests, nowUnix)
+	c.traceLookupAttempt(ctx, recipeDigest.String(), "", nil, false)
+	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates, nil)
+	if hitRes == nil {
+		c.traceLookupMissNoMatch(ctx, recipeDigest.String(), false, -1, "", 0)
 		c.egraphMu.Unlock()
-
-		loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
-		if err != nil {
-			return nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
-		}
-		if c.traceEnabled() {
-			c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
-		}
-		return loadedHit, true, nil
+		return nil, false, nil
 	}
+
+	hitRes.expiresAtUnix = mergeSharedResultExpiryUnix(
+		hitRes.expiresAtUnix,
+		candidateSharedResultExpiryUnix(nowUnix, 0),
+	)
+	touchSharedResultLastUsed(hitRes, now.UnixNano())
+	retRes := Result[Typed]{
+		shared:   hitRes,
+		hitCache: true,
+	}
+	c.traceLookupHit(ctx, recipeDigest.String(), hitRes, match.termDigest)
+	hitShared := retRes.cacheSharedResult()
+	if hitShared == nil || hitShared.id == 0 {
+		c.egraphMu.Unlock()
+		return nil, false, fmt.Errorf("lookup cache for digests: hit missing shared result ID")
+	}
+
+	trackedCount := 0
+	alreadyTracked := false
+	c.sessionMu.Lock()
+	if c.sessionResultIDsBySession == nil {
+		c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
+	}
+	if c.sessionResultIDsBySession[sessionID] == nil {
+		c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
+	}
+	if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
+		alreadyTracked = true
+	} else {
+		c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
+		c.incrementIncomingOwnershipLocked(ctx, hitShared)
+	}
+	trackedCount = len(c.sessionResultIDsBySession[sessionID])
+	c.sessionMu.Unlock()
+	c.egraphMu.Unlock()
+
+	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
+	if err != nil {
+		return nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
+	}
+	if c.traceEnabled() {
+		c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
+	}
+	return loadedHit, true, nil
 }
 
 func (c *Cache) wait(
@@ -4186,7 +4188,10 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		requestInputs = append(requestInputs, dig)
 	}
 	allRuntimeDeps := c.drainRuntimeResultDependencies(sessionID, requestDigest)
-	runtimeDeps := c.liveRuntimeDependencies(allRuntimeDeps)
+	runtimeDeps, err := c.liveRuntimeDependencies(allRuntimeDeps)
+	if err != nil {
+		return fmt.Errorf("normalize runtime dependencies: %w", err)
+	}
 	oc.runtimeDeps = cloneRuntimeResultDependencySet(runtimeDeps)
 	var responseDigest digest.Digest
 	if resultCall := oc.res.loadResultCall(); resultCall != nil {
@@ -4200,116 +4205,126 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		path     string
 	}
 	var resultCallDeps []resultCallDep
-	if !resWasCacheBacked {
-		if resultCall := oc.res.loadResultCall(); resultCall != nil {
-			seenResults := map[sharedResultID]struct{}{}
-			seenCalls := map[*ResultCall]struct{}{}
+	if !resWasCacheBacked || len(runtimeDeps) > 0 {
+		seenResults := map[sharedResultID]struct{}{}
+		seenCalls := map[*ResultCall]struct{}{}
 
-			var joinPath func(string, string) string
-			var walkFrame func(string, *ResultCall) error
-			var walkRef func(string, *ResultCallRef) error
-			var walkLiteral func(string, *ResultCallLiteral) error
+		var joinPath func(string, string) string
+		var walkFrame func(string, *ResultCall) error
+		var walkRef func(string, *ResultCallRef) error
+		var walkLiteral func(string, *ResultCallLiteral) error
 
-			joinPath = func(prefix string, segment string) string {
-				switch {
-				case prefix == "":
-					return segment
-				case segment == "":
-					return prefix
-				default:
-					return prefix + "." + segment
-				}
+		joinPath = func(prefix string, segment string) string {
+			switch {
+			case prefix == "":
+				return segment
+			case segment == "":
+				return prefix
+			default:
+				return prefix + "." + segment
 			}
+		}
 
-			walkRef = func(path string, ref *ResultCallRef) error {
-				if ref == nil {
-					return nil
-				}
-				if ref.Call != nil {
-					return walkFrame(path, ref.Call)
-				}
-				if ref.ResultID == 0 {
-					return nil
-				}
-				resultID := sharedResultID(ref.ResultID)
-				if resultID == oc.res.id {
-					return nil
-				}
-				if _, seen := seenResults[resultID]; seen {
-					return nil
-				}
-				seenResults[resultID] = struct{}{}
-				resultCallDeps = append(resultCallDeps, resultCallDep{
-					resultID: resultID,
-					path:     path,
-				})
+		walkRef = func(path string, ref *ResultCallRef) error {
+			if ref == nil {
 				return nil
 			}
-
-			walkLiteral = func(path string, lit *ResultCallLiteral) error {
-				if lit == nil {
-					return nil
-				}
-				switch lit.Kind {
-				case ResultCallLiteralKindResultRef:
-					return walkRef(path, lit.ResultRef)
-				case ResultCallLiteralKindList:
-					for i, item := range lit.ListItems {
-						if err := walkLiteral(fmt.Sprintf("%s[%d]", path, i), item); err != nil {
-							return err
-						}
-					}
-				case ResultCallLiteralKindObject:
-					for _, field := range lit.ObjectFields {
-						if field == nil {
-							continue
-						}
-						if err := walkLiteral(joinPath(path, field.Name), field.Value); err != nil {
-							return err
-						}
-					}
-				}
+			if ref.Call != nil {
+				return walkFrame(path, ref.Call)
+			}
+			if ref.ResultID == 0 {
 				return nil
 			}
+			resultID := sharedResultID(ref.ResultID)
+			if resultID == oc.res.id {
+				return nil
+			}
+			if _, seen := seenResults[resultID]; seen {
+				return nil
+			}
+			seenResults[resultID] = struct{}{}
+			resultCallDeps = append(resultCallDeps, resultCallDep{
+				resultID: resultID,
+				path:     path,
+			})
+			return nil
+		}
 
-			walkFrame = func(path string, frame *ResultCall) error {
-				if frame == nil {
-					return nil
-				}
-				if _, seen := seenCalls[frame]; seen {
-					return nil
-				}
-				seenCalls[frame] = struct{}{}
-
-				if err := walkRef(joinPath(path, "receiver"), frame.Receiver); err != nil {
-					return fmt.Errorf("receiver: %w", err)
-				}
-				if frame.Module != nil {
-					if err := walkRef(joinPath(path, "module"), frame.Module.ResultRef); err != nil {
-						return fmt.Errorf("module: %w", err)
+		walkLiteral = func(path string, lit *ResultCallLiteral) error {
+			if lit == nil {
+				return nil
+			}
+			switch lit.Kind {
+			case ResultCallLiteralKindResultRef:
+				return walkRef(path, lit.ResultRef)
+			case ResultCallLiteralKindList:
+				for i, item := range lit.ListItems {
+					if err := walkLiteral(fmt.Sprintf("%s[%d]", path, i), item); err != nil {
+						return err
 					}
 				}
-				for _, arg := range frame.Args {
-					if arg == nil {
+			case ResultCallLiteralKindObject:
+				for _, field := range lit.ObjectFields {
+					if field == nil {
 						continue
 					}
-					if err := walkLiteral(joinPath(path, "arg:"+arg.Name), arg.Value); err != nil {
-						return fmt.Errorf("arg %q: %w", arg.Name, err)
+					if err := walkLiteral(joinPath(path, field.Name), field.Value); err != nil {
+						return err
 					}
 				}
-				for _, input := range frame.ImplicitInputs {
-					if input == nil {
-						continue
-					}
-					if err := walkLiteral(joinPath(path, "implicit_input:"+input.Name), input.Value); err != nil {
-						return fmt.Errorf("implicit input %q: %w", input.Name, err)
-					}
-				}
+			}
+			return nil
+		}
+
+		walkFrame = func(path string, frame *ResultCall) error {
+			if frame == nil {
 				return nil
 			}
+			if _, seen := seenCalls[frame]; seen {
+				return nil
+			}
+			seenCalls[frame] = struct{}{}
 
-			if err := walkFrame("", resultCall); err != nil {
-				return fmt.Errorf("collect result call dependencies: %w", err)
+			if err := walkRef(joinPath(path, "receiver"), frame.Receiver); err != nil {
+				return fmt.Errorf("receiver: %w", err)
+			}
+			if frame.Module != nil {
+				if err := walkRef(joinPath(path, "module"), frame.Module.ResultRef); err != nil {
+					return fmt.Errorf("module: %w", err)
+				}
+			}
+			for _, arg := range frame.Args {
+				if arg == nil {
+					continue
+				}
+				if err := walkLiteral(joinPath(path, "arg:"+arg.Name), arg.Value); err != nil {
+					return fmt.Errorf("arg %q: %w", arg.Name, err)
+				}
+			}
+			for _, input := range frame.ImplicitInputs {
+				if input == nil {
+					continue
+				}
+				if err := walkLiteral(joinPath(path, "implicit_input:"+input.Name), input.Value); err != nil {
+					return fmt.Errorf("implicit input %q: %w", input.Name, err)
+				}
+			}
+			return nil
+		}
+
+		if !resWasCacheBacked {
+			if resultCall := oc.res.loadResultCall(); resultCall != nil {
+				if err := walkFrame("", resultCall); err != nil {
+					return fmt.Errorf("collect result call dependencies: %w", err)
+				}
+			}
+		}
+		for _, runtimeDep := range runtimeDeps {
+			if runtimeDep.Frame == nil {
+				continue
+			}
+			if err := walkFrame(fmt.Sprintf("runtime:%d", runtimeDep.ResultID), runtimeDep.Frame); err != nil {
+				return fmt.Errorf("collect runtime dependency frame refs for result %d: %w", runtimeDep.ResultID, err)
 			}
 		}
 	}
@@ -4353,26 +4368,6 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		c.rememberDependencyEdgeLocked(oc.res, depRes)
 		c.incrementIncomingOwnershipLocked(ctx, depRes)
 		c.traceResultCallDepAdded(ctx, oc.res.id, depID, dep.path)
-	}
-	for _, runtimeDep := range allRuntimeDeps {
-		depID := sharedResultID(runtimeDep.ResultID)
-		if depID == oc.res.id {
-			continue
-		}
-		depRes := c.resultsByID[depID]
-		if depRes == nil {
-			c.egraphMu.Unlock()
-			return fmt.Errorf("retain runtime dep result %d: missing cached result", depID)
-		}
-		if oc.res.deps == nil {
-			oc.res.deps = make(map[sharedResultID]struct{})
-		}
-		if _, alreadyHeld := oc.res.deps[depID]; alreadyHeld {
-			continue
-		}
-		oc.res.deps[depID] = struct{}{}
-		c.incrementIncomingOwnershipLocked(ctx, depRes)
-		c.traceExplicitDepAdded(ctx, oc.res.id, depID, "module_runtime_call")
 	}
 	if err := c.recomputeRequiredSessionResourcesLocked(oc.res); err != nil {
 		c.egraphMu.Unlock()

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -81,9 +81,10 @@ func cloneRuntimeResultDependencySet(deps runtimeResultDependencySet) runtimeRes
 	cp := make(runtimeResultDependencySet, 0, len(deps))
 	for _, dep := range deps {
 		cp = append(cp, runtimeResultDependency{
-			ResultID: dep.ResultID,
-			Frame:    dep.Frame.clone(),
-			Digest:   dep.Digest,
+			ResultID:    dep.ResultID,
+			Frame:       dep.Frame.clone(),
+			FrameDigest: dep.FrameDigest,
+			Digest:      dep.Digest,
 		})
 	}
 	return cp
@@ -100,12 +101,12 @@ func cloneRuntimeResultDependencySets(depSets []runtimeResultDependencySet) []ru
 	return cp
 }
 
-func sameRuntimeResultDependencySet(c *Cache, a, b runtimeResultDependencySet) bool {
+func sameRuntimeResultDependencySet(a, b runtimeResultDependencySet) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if runtimeResultDependencyValidationKey(c, a[i]) != runtimeResultDependencyValidationKey(c, b[i]) {
+		if runtimeResultDependencyValidationKey(a[i]) != runtimeResultDependencyValidationKey(b[i]) {
 			return false
 		}
 	}
@@ -887,11 +888,10 @@ func (c *Cache) lookupCacheForRequestLocked(
 	requestDigest digest.Digest,
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
-	requestInputRefs []ResultCallStructuralInputRef,
 	skip map[sharedResultID]struct{},
-) (AnyResult, []runtimeResultDependencySet, bool, error) {
+) (AnyResult, []runtimeResultDependencySet, bool) {
 	if req == nil || req.ResultCall == nil {
-		return nil, nil, false, nil
+		return nil, nil, false
 	}
 	now := time.Now()
 	nowUnix := now.Unix()
@@ -901,7 +901,7 @@ func (c *Cache) lookupCacheForRequestLocked(
 
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, requestDigest.String(), match.primaryLookupPossible, match.missingInputIndex, match.termDigest, match.termSetSize)
-		return nil, nil, false, nil
+		return nil, nil, false
 	}
 	runtimeDepSets := c.runtimeDepSetsForRequestAssociationLocked(hitRes.id, requestSelf, requestInputs)
 
@@ -910,7 +910,7 @@ func (c *Cache) lookupCacheForRequestLocked(
 		hitCache: true,
 	}
 	c.traceLookupHit(ctx, requestDigest.String(), hitRes, match.termDigest)
-	return retRes, runtimeDepSets, true, nil
+	return retRes, runtimeDepSets, true
 }
 
 func (c *Cache) lookupCacheForRequest(
@@ -936,10 +936,10 @@ func (c *Cache) lookupCacheForRequest(
 	skipped := map[sharedResultID]struct{}{}
 	for {
 		c.egraphMu.Lock()
-		retRes, runtimeDepSets, hit, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs, skipped)
-		if err != nil || !hit {
+		retRes, runtimeDepSets, hit := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, skipped)
+		if !hit {
 			c.egraphMu.Unlock()
-			return retRes, nil, hit, err
+			return retRes, nil, hit, nil
 		}
 
 		hitShared := retRes.cacheSharedResult()
@@ -1326,7 +1326,7 @@ func (c *Cache) associateResultWithTermLocked(
 		if len(runtimeDeps) > 0 {
 			seen := false
 			for _, existing := range assoc.runtimeDepSets {
-				if sameRuntimeResultDependencySet(c, existing, runtimeDeps) {
+				if sameRuntimeResultDependencySet(existing, runtimeDeps) {
 					seen = true
 					break
 				}

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -53,15 +53,13 @@ const (
 )
 
 // egraphResultTermAssoc stores metadata for one result<->term association.
-// Today this is just per-input provenance indicating whether each input slot
-// was result-backed or digest-only when the association was created.
-//
-// NOTE: we intentionally assume for now that a congruent term will not be
-// observed with conflicting provenance for the same input slot. If that ever
-// does happen, the most recently observed provenance simply replaces the older
-// one.
+// Input provenance indicates whether each input slot was result-backed or
+// digest-only when the association was created. Runtime dependency sets are
+// the live-source freshness conditions observed for this exact call/result
+// association; they do not belong to the globally canonical shared payload.
 type egraphResultTermAssoc struct {
 	inputProvenance []egraphInputProvenanceKind
+	runtimeDepSets  []runtimeResultDependencySet
 }
 
 func sameInputProvenance(a, b []egraphInputProvenanceKind) bool {
@@ -70,6 +68,44 @@ func sameInputProvenance(a, b []egraphInputProvenanceKind) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneRuntimeResultDependencySet(deps runtimeResultDependencySet) runtimeResultDependencySet {
+	if len(deps) == 0 {
+		return nil
+	}
+	cp := make(runtimeResultDependencySet, 0, len(deps))
+	for _, dep := range deps {
+		cp = append(cp, runtimeResultDependency{
+			ResultID: dep.ResultID,
+			Frame:    dep.Frame.clone(),
+			Digest:   dep.Digest,
+		})
+	}
+	return cp
+}
+
+func cloneRuntimeResultDependencySets(depSets []runtimeResultDependencySet) []runtimeResultDependencySet {
+	if len(depSets) == 0 {
+		return nil
+	}
+	cp := make([]runtimeResultDependencySet, 0, len(depSets))
+	for _, deps := range depSets {
+		cp = append(cp, cloneRuntimeResultDependencySet(deps))
+	}
+	return cp
+}
+
+func sameRuntimeResultDependencySet(c *Cache, a, b runtimeResultDependencySet) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if runtimeResultDependencyValidationKey(c, a[i]) != runtimeResultDependencyValidationKey(c, b[i]) {
 			return false
 		}
 	}
@@ -643,14 +679,56 @@ func (c *Cache) sessionSatisfiesResourceRequirementsLocked(sessionID string, res
 	return available.Subset(res.requiredSessionResources)
 }
 
-func (c *Cache) selectLookupCandidateForSessionLocked(sessionID string, candidates *set.TreeSet[*sharedResult]) *sharedResult {
+func (c *Cache) selectLookupCandidateForSessionLocked(
+	sessionID string,
+	candidates *set.TreeSet[*sharedResult],
+	skip map[sharedResultID]struct{},
+) *sharedResult {
 	if candidates == nil {
 		return nil
 	}
 	for res := range candidates.Items() {
+		if _, skipped := skip[res.id]; skipped {
+			continue
+		}
 		if c.sessionSatisfiesResourceRequirementsLocked(sessionID, res) {
 			return res
 		}
+	}
+	return nil
+}
+
+func (c *Cache) runtimeDepSetsForRequestAssociationLocked(
+	resID sharedResultID,
+	requestSelf digest.Digest,
+	requestInputs []digest.Digest,
+) []runtimeResultDependencySet {
+	if resID == 0 || requestSelf == "" {
+		return nil
+	}
+	inputEqIDs := make([]eqClassID, len(requestInputs))
+	for i, inDig := range requestInputs {
+		classID, ok := c.egraphDigestToClass[inDig.String()]
+		if !ok {
+			return nil
+		}
+		root := c.findEqClassLocked(classID)
+		if root == 0 {
+			return nil
+		}
+		inputEqIDs[i] = root
+	}
+	termDigest := calcEgraphTermDigest(requestSelf, inputEqIDs)
+	termSet := c.egraphTermsByTermDigest[termDigest]
+	if termSet == nil {
+		return nil
+	}
+	for termID := range termSet.Items() {
+		assoc, ok := c.termResults[termID][resID]
+		if !ok {
+			continue
+		}
+		return cloneRuntimeResultDependencySets(assoc.runtimeDepSets)
 	}
 	return nil
 }
@@ -810,54 +888,29 @@ func (c *Cache) lookupCacheForRequestLocked(
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
 	requestInputRefs []ResultCallStructuralInputRef,
-) (AnyResult, bool, error) {
+	skip map[sharedResultID]struct{},
+) (AnyResult, []runtimeResultDependencySet, bool, error) {
 	if req == nil || req.ResultCall == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 	now := time.Now()
 	nowUnix := now.Unix()
 	match := c.lookupMatchForCallLocked(req.ResultCall, requestDigest, requestSelf, requestInputs, nowUnix)
 	c.traceLookupAttempt(ctx, requestDigest.String(), match.selfDigest.String(), match.inputDigests, req.IsPersistable)
-	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
+	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates, skip)
 
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, requestDigest.String(), match.primaryLookupPossible, match.missingInputIndex, match.termDigest, match.termSetSize)
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
+	runtimeDepSets := c.runtimeDepSetsForRequestAssociationLocked(hitRes.id, requestSelf, requestInputs)
 
-	// fast-path: if we got a very simple recipe-digest hit we can skip trying to teach the egraph anything new
-	if requestDigest != "" && len(req.ResultCall.ExtraDigests) == 0 && req.TTL == 0 && !req.IsPersistable && match.hitRecipeDigest {
-		touchSharedResultLastUsed(hitRes, now.UnixNano())
-		retRes := Result[Typed]{
-			shared:   hitRes,
-			hitCache: true,
-		}
-		c.traceLookupHit(ctx, requestDigest.String(), hitRes, match.termDigest)
-		return retRes, true, nil
-	}
-
-	// We have a cache hit. Teach this request identity onto the existing shared
-	// result so any raw ID we hand back is itself resolvable by the cache later.
-	res := hitRes
-	// A TTL-bearing call can alias an existing result on lookup; apply the same
-	// conservative expiry merge policy here so TTL remains effective on hits.
-	res.expiresAtUnix = mergeSharedResultExpiryUnix(
-		res.expiresAtUnix,
-		candidateSharedResultExpiryUnix(nowUnix, req.TTL),
-	)
-	touchSharedResultLastUsed(res, now.UnixNano())
-	if req.IsPersistable {
-		c.upsertPersistedEdgeLocked(ctx, res, candidateSharedResultExpiryUnix(nowUnix, req.TTL), false)
-	}
-	if err := c.teachResultIdentityLocked(ctx, res, req.ResultCall, requestDigest, requestSelf, requestInputs, requestInputRefs); err != nil {
-		return nil, false, err
-	}
 	retRes := Result[Typed]{
-		shared:   res,
+		shared:   hitRes,
 		hitCache: true,
 	}
-	c.traceLookupHit(ctx, requestDigest.String(), res, match.termDigest)
-	return retRes, true, nil
+	c.traceLookupHit(ctx, requestDigest.String(), hitRes, match.termDigest)
+	return retRes, runtimeDepSets, true, nil
 }
 
 func (c *Cache) lookupCacheForRequest(
@@ -869,74 +922,91 @@ func (c *Cache) lookupCacheForRequest(
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
 	requestInputRefs []ResultCallStructuralInputRef,
-) (AnyResult, bool, error) {
+) (AnyResult, runtimeResultDependencySet, bool, error) {
 	if sessionID == "" {
-		return nil, false, errors.New("lookup cache for request: empty session ID")
+		return nil, nil, false, errors.New("lookup cache for request: empty session ID")
 	}
 	if resolver == nil {
-		return nil, false, errors.New("lookup cache for request: type resolver is nil")
+		return nil, nil, false, errors.New("lookup cache for request: type resolver is nil")
 	}
 	if req == nil || req.ResultCall == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 
-	c.egraphMu.Lock()
-	retRes, hit, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs)
-	if err != nil || !hit {
-		c.egraphMu.Unlock()
-		return retRes, hit, err
-	}
-
-	hitShared := retRes.cacheSharedResult()
-	if hitShared == nil || hitShared.id == 0 {
-		c.egraphMu.Unlock()
-		return nil, false, fmt.Errorf("lookup cache for request: hit missing shared result ID")
-	}
-
-	trackedCount := 0
-	alreadyTracked := false
-	c.sessionMu.Lock()
-	if c.sessionResultIDsBySession == nil {
-		c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
-	}
-	if c.sessionResultIDsBySession[sessionID] == nil {
-		c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
-	}
-	if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
-		alreadyTracked = true
-	} else {
-		c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
-		c.incrementIncomingOwnershipLocked(ctx, hitShared)
-	}
-	trackedCount = len(c.sessionResultIDsBySession[sessionID])
-	c.sessionMu.Unlock()
-	c.egraphMu.Unlock()
-
-	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
-	if err != nil {
+	skipped := map[sharedResultID]struct{}{}
+	for {
 		c.egraphMu.Lock()
-		c.sessionMu.Lock()
-		if resultIDs := c.sessionResultIDsBySession[sessionID]; resultIDs != nil {
-			delete(resultIDs, hitShared.id)
-			if len(resultIDs) == 0 {
-				delete(c.sessionResultIDsBySession, sessionID)
-			}
+		retRes, runtimeDepSets, hit, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs, skipped)
+		if err != nil || !hit {
+			c.egraphMu.Unlock()
+			return retRes, nil, hit, err
 		}
-		c.sessionMu.Unlock()
-		queue := []*sharedResult(nil)
-		var decErr error
-		if !alreadyTracked {
-			queue, decErr = c.decrementIncomingOwnershipLocked(ctx, hitShared, nil)
-		}
-		collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
-		c.egraphMu.Unlock()
-		return nil, false, errors.Join(err, decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases))
-	}
 
-	if c.traceEnabled() {
-		c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
+		hitShared := retRes.cacheSharedResult()
+		if hitShared == nil || hitShared.id == 0 {
+			c.egraphMu.Unlock()
+			return nil, nil, false, fmt.Errorf("lookup cache for request: hit missing shared result ID")
+		}
+
+		trackedCount := 0
+		alreadyTracked := false
+		c.sessionMu.Lock()
+		if c.sessionResultIDsBySession == nil {
+			c.sessionResultIDsBySession = make(map[string]map[sharedResultID]struct{})
+		}
+		if c.sessionResultIDsBySession[sessionID] == nil {
+			c.sessionResultIDsBySession[sessionID] = make(map[sharedResultID]struct{})
+		}
+		if _, found := c.sessionResultIDsBySession[sessionID][hitShared.id]; found {
+			alreadyTracked = true
+		} else {
+			c.sessionResultIDsBySession[sessionID][hitShared.id] = struct{}{}
+			c.incrementIncomingOwnershipLocked(ctx, hitShared)
+		}
+		trackedCount = len(c.sessionResultIDsBySession[sessionID])
+		c.sessionMu.Unlock()
+		c.egraphMu.Unlock()
+
+		loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
+		if err != nil {
+			return nil, nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
+		}
+		matchedRuntimeDeps, err := c.validateRuntimeDependencySets(ctx, runtimeDepSets)
+		if err != nil {
+			if errors.Is(err, ErrCacheValidationFailed) {
+				if cleanupErr := c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, nil); cleanupErr != nil {
+					return nil, nil, false, cleanupErr
+				}
+				skipped[hitShared.id] = struct{}{}
+				continue
+			}
+			return nil, nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
+		}
+		c.egraphMu.Lock()
+		if c.resultsByID[hitShared.id] != hitShared {
+			c.egraphMu.Unlock()
+			return nil, nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, fmt.Errorf("lookup cache for request: hit result %d no longer indexed", hitShared.id))
+		}
+		nowUnix := time.Now().Unix()
+		hitShared.expiresAtUnix = mergeSharedResultExpiryUnix(
+			hitShared.expiresAtUnix,
+			candidateSharedResultExpiryUnix(nowUnix, req.TTL),
+		)
+		touchSharedResultLastUsed(hitShared, time.Now().UnixNano())
+		if req.IsPersistable {
+			c.upsertPersistedEdgeLocked(ctx, hitShared, candidateSharedResultExpiryUnix(nowUnix, req.TTL), false)
+		}
+		if err := c.teachResultIdentityLocked(ctx, hitShared, req.ResultCall, requestDigest, requestSelf, requestInputs, requestInputRefs, matchedRuntimeDeps); err != nil {
+			c.egraphMu.Unlock()
+			return nil, nil, false, c.rollbackTrackedHit(ctx, sessionID, hitShared, alreadyTracked, err)
+		}
+		c.egraphMu.Unlock()
+
+		if c.traceEnabled() {
+			c.traceSessionResultTracked(ctx, sessionID, loadedHit, true, trackedCount)
+		}
+		return loadedHit, matchedRuntimeDeps, true, nil
 	}
-	return loadedHit, true, nil
 }
 
 func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID string, frame *ResultCall, res AnyResult) error {
@@ -982,7 +1052,7 @@ func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID strin
 
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
-	return c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs)
+	return c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs, nil)
 }
 
 func (c *Cache) TeachContentDigest(ctx context.Context, res AnyResult, contentDigest digest.Digest) error {
@@ -1057,7 +1127,7 @@ func (c *Cache) TeachContentDigest(ctx context.Context, res AnyResult, contentDi
 			continue
 		}
 		c.traceTeachContentDigest(ctx, shared, oldContentDigest.String(), contentDigest.String(), requestDigest.String(), requestSelf.String(), requestInputs, frame)
-		if err := c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs); err != nil {
+		if err := c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs, nil); err != nil {
 			c.egraphMu.Unlock()
 			return err
 		}
@@ -1204,6 +1274,7 @@ func (c *Cache) associateResultWithTermLocked(
 	res *sharedResult,
 	termID egraphTermID,
 	inputProvenance []egraphInputProvenanceKind,
+	runtimeDeps runtimeResultDependencySet,
 ) {
 	if res == nil || res.id == 0 || termID == 0 {
 		return
@@ -1246,15 +1317,38 @@ func (c *Cache) associateResultWithTermLocked(
 	}
 	assoc, ok := termResults[res.id]
 	if ok {
+		updated := false
 		if !sameInputProvenance(assoc.inputProvenance, inputProvenance) {
 			assoc.inputProvenance = slices.Clone(inputProvenance)
-			termResults[res.id] = assoc
+			updated = true
 			c.traceResultTermAssocUpdated(ctx, res.id, termID, inputProvenance)
+		}
+		if len(runtimeDeps) > 0 {
+			seen := false
+			for _, existing := range assoc.runtimeDepSets {
+				if sameRuntimeResultDependencySet(c, existing, runtimeDeps) {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				assoc.runtimeDepSets = append(assoc.runtimeDepSets, cloneRuntimeResultDependencySet(runtimeDeps))
+				updated = true
+			}
+		}
+		if updated {
+			termResults[res.id] = assoc
 		}
 		return
 	}
 	termResults[res.id] = egraphResultTermAssoc{
 		inputProvenance: slices.Clone(inputProvenance),
+		runtimeDepSets: func() []runtimeResultDependencySet {
+			if len(runtimeDeps) == 0 {
+				return nil
+			}
+			return []runtimeResultDependencySet{cloneRuntimeResultDependencySet(runtimeDeps)}
+		}(),
 	}
 	resultTerms[termID] = struct{}{}
 	c.traceResultTermAssocAdded(ctx, res.id, termID, inputProvenance)
@@ -1269,6 +1363,7 @@ func (c *Cache) teachResultIdentityLocked(
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
 	requestInputRefs []ResultCallStructuralInputRef,
+	runtimeDeps runtimeResultDependencySet,
 ) error {
 	if res == nil || res.id == 0 || requestFrame == nil {
 		return nil
@@ -1318,13 +1413,19 @@ func (c *Cache) teachResultIdentityLocked(
 
 	switch {
 	case c.termForResultByDigestLocked(res.id, termDigest) != nil:
+		resultTerm := c.termForResultByDigestLocked(res.id, termDigest)
+		inputProvenance, err := c.inputProvenanceForRefs(requestInputRefs)
+		if err != nil {
+			return fmt.Errorf("derive input provenance for request term %s: %w", requestSelf, err)
+		}
+		c.associateResultWithTermLocked(ctx, res, resultTerm.id, inputProvenance, runtimeDeps)
 		c.mergeOutputsForTermDigestLocked(ctx, termDigest, outputEqID)
 	case existingTerm != nil:
 		inputProvenance, err := c.inputProvenanceForRefs(requestInputRefs)
 		if err != nil {
 			return fmt.Errorf("derive input provenance for request term %s: %w", requestSelf, err)
 		}
-		c.associateResultWithTermLocked(ctx, res, existingTerm.id, inputProvenance)
+		c.associateResultWithTermLocked(ctx, res, existingTerm.id, inputProvenance, runtimeDeps)
 		c.mergeOutputsForTermDigestLocked(ctx, termDigest, outputEqID)
 	default:
 		mergedOutputEqID := c.mergeOutputsForTermDigestLocked(ctx, termDigest, outputEqID)
@@ -1365,7 +1466,7 @@ func (c *Cache) teachResultIdentityLocked(
 		}
 		outputTerms[termID] = struct{}{}
 
-		c.associateResultWithTermLocked(ctx, res, termID, inputProvenance)
+		c.associateResultWithTermLocked(ctx, res, termID, inputProvenance, runtimeDeps)
 	}
 
 	if err := c.indexResultDigestsLocked(res, requestFrame, nil); err != nil {
@@ -1411,6 +1512,7 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 	resultTermInputRefs []ResultCallStructuralInputRef,
 	hasResultTerm bool,
 	res *sharedResult,
+	runtimeDeps runtimeResultDependencySet,
 ) error {
 	c.initEgraphLocked()
 
@@ -1487,11 +1589,13 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 		selfDigest   digest.Digest
 		inputDigests []digest.Digest
 		inputRefs    []ResultCallStructuralInputRef
+		runtimeDeps  runtimeResultDependencySet
 	}{
 		{
 			selfDigest:   requestSelf,
 			inputDigests: requestInputs,
 			inputRefs:    requestInputRefs,
+			runtimeDeps:  runtimeDeps,
 		},
 	}
 	// Only index both input+return terms if they are actually different
@@ -1504,6 +1608,7 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 			selfDigest   digest.Digest
 			inputDigests []digest.Digest
 			inputRefs    []ResultCallStructuralInputRef
+			runtimeDeps  runtimeResultDependencySet
 		}{
 			selfDigest:   resultTermSelf,
 			inputDigests: resultTermInputs,
@@ -1525,6 +1630,7 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 			// we already setup this res with this term, just ensure that the output eq class
 			// (which is the merged eq class containing all input req digests + return val digests)
 			// is associated as the output eq class for this term; doing a merge+replair if needed.
+			c.associateResultWithTermLocked(ctx, res, existingTerm.id, inputProvenance, term.runtimeDeps)
 			c.mergeOutputsForTermDigestLocked(ctx, termDigest, outputEqID)
 			continue
 		}
@@ -1532,7 +1638,7 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 			// we ended up with a duplicate term that has the same digest; just associate this
 			// result with that term and merge the output eq class as needed, no need to create
 			// a new term
-			c.associateResultWithTermLocked(ctx, res, existingTerm.id, inputProvenance)
+			c.associateResultWithTermLocked(ctx, res, existingTerm.id, inputProvenance, term.runtimeDeps)
 			c.mergeOutputsForTermDigestLocked(ctx, termDigest, outputEqID)
 			continue
 		}
@@ -1578,7 +1684,7 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 		}
 		outputTerms[termID] = struct{}{}
 
-		c.associateResultWithTermLocked(ctx, res, termID, inputProvenance)
+		c.associateResultWithTermLocked(ctx, res, termID, inputProvenance, term.runtimeDeps)
 	}
 
 	if err := c.indexResultDigestsLocked(res, requestFrame, responseFrame); err != nil {

--- a/dagql/cache_live_sources.go
+++ b/dagql/cache_live_sources.go
@@ -10,49 +10,63 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-func (c *Cache) liveRuntimeDependencies(deps runtimeResultDependencySet) runtimeResultDependencySet {
+func (c *Cache) liveRuntimeDependencies(deps runtimeResultDependencySet) (runtimeResultDependencySet, error) {
 	if len(deps) == 0 {
-		return nil
+		return nil, nil
 	}
 	live := make(runtimeResultDependencySet, 0, len(deps))
 	seen := make(map[string]struct{}, len(deps))
-	appendLive := func(dep runtimeResultDependency) {
+	appendLive := func(dep runtimeResultDependency) error {
 		if dep.Frame == nil || dep.Digest == "" {
-			return
+			return nil
 		}
-		key := runtimeResultDependencyValidationKey(c, dep)
+		frameDigest := dep.FrameDigest
+		if frameDigest == "" {
+			dig, err := dep.Frame.deriveRecipeDigest(c)
+			if err != nil {
+				return fmt.Errorf("derive runtime dependency frame digest for result %d: %w", dep.ResultID, err)
+			}
+			frameDigest = dig
+		}
+		if frameDigest == "" {
+			return fmt.Errorf("runtime dependency for result %d has empty frame digest", dep.ResultID)
+		}
+		key := runtimeResultDependencyValidationKey(runtimeResultDependency{
+			FrameDigest: frameDigest,
+			Digest:      dep.Digest,
+		})
 		if _, ok := seen[key]; ok {
-			return
+			return nil
 		}
 		seen[key] = struct{}{}
 		live = append(live, runtimeResultDependency{
-			ResultID: dep.ResultID,
-			Frame:    dep.Frame.clone(),
-			Digest:   dep.Digest,
+			ResultID:    dep.ResultID,
+			Frame:       dep.Frame.clone(),
+			FrameDigest: frameDigest,
+			Digest:      dep.Digest,
 		})
+		return nil
 	}
 	for _, dep := range deps {
 		if c.resultCallRequiresLiveSourceValidation(dep.Frame) {
-			appendLive(dep)
+			if err := appendLive(dep); err != nil {
+				return nil, err
+			}
 		}
 		for _, freshnessDep := range dep.FreshnessDeps {
-			appendLive(freshnessDep)
+			if err := appendLive(freshnessDep); err != nil {
+				return nil, err
+			}
 		}
 	}
 	slices.SortFunc(live, func(a, b runtimeResultDependency) int {
-		return cmp.Compare(runtimeResultDependencyValidationKey(c, a), runtimeResultDependencyValidationKey(c, b))
+		return cmp.Compare(runtimeResultDependencyValidationKey(a), runtimeResultDependencyValidationKey(b))
 	})
-	return live
+	return live, nil
 }
 
-func runtimeResultDependencyValidationKey(c *Cache, dep runtimeResultDependency) string {
-	frameDigest := ""
-	if dep.Frame != nil {
-		if dig, err := dep.Frame.deriveRecipeDigest(c); err == nil {
-			frameDigest = dig.String()
-		}
-	}
-	return fmt.Sprintf("%s\x00%d\x00%s", frameDigest, dep.ResultID, dep.Digest)
+func runtimeResultDependencyValidationKey(dep runtimeResultDependency) string {
+	return fmt.Sprintf("%s\x00%s", dep.FrameDigest, dep.Digest)
 }
 
 func (c *Cache) resultCallRequiresLiveSourceValidation(frame *ResultCall) bool {
@@ -231,7 +245,7 @@ func (c *Cache) validateRuntimeDependencySet(ctx context.Context, deps runtimeRe
 		}
 		current, err := c.refreshRuntimeDependencyDigest(ctx, dep)
 		if err != nil {
-			return fmt.Errorf("%w: refresh runtime dependency result %d: %v", ErrCacheValidationFailed, dep.ResultID, err)
+			return fmt.Errorf("%w: refresh runtime dependency result %d: %w", ErrCacheValidationFailed, dep.ResultID, err)
 		}
 		if current != dep.Digest {
 			return fmt.Errorf("%w: runtime dependency result %d expected %s got %s", ErrCacheValidationFailed, dep.ResultID, dep.Digest, current)
@@ -280,7 +294,7 @@ func (c *Cache) refreshResultCall(
 			return nil, fmt.Errorf("receiver: %w", err)
 		}
 	}
-	baseObj, err := srv.toSelectable(base)
+	baseObj, err := srv.toSelectable(ctx, base)
 	if err != nil {
 		return nil, fmt.Errorf("instantiate base: %w", err)
 	}

--- a/dagql/cache_live_sources.go
+++ b/dagql/cache_live_sources.go
@@ -1,0 +1,406 @@
+package dagql
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/opencontainers/go-digest"
+)
+
+func (c *Cache) liveRuntimeDependencies(deps runtimeResultDependencySet) runtimeResultDependencySet {
+	if len(deps) == 0 {
+		return nil
+	}
+	live := make(runtimeResultDependencySet, 0, len(deps))
+	seen := make(map[string]struct{}, len(deps))
+	appendLive := func(dep runtimeResultDependency) {
+		if dep.Frame == nil || dep.Digest == "" {
+			return
+		}
+		key := runtimeResultDependencyValidationKey(c, dep)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		live = append(live, runtimeResultDependency{
+			ResultID: dep.ResultID,
+			Frame:    dep.Frame.clone(),
+			Digest:   dep.Digest,
+		})
+	}
+	for _, dep := range deps {
+		if c.resultCallRequiresLiveSourceValidation(dep.Frame) {
+			appendLive(dep)
+		}
+		for _, freshnessDep := range dep.FreshnessDeps {
+			appendLive(freshnessDep)
+		}
+	}
+	slices.SortFunc(live, func(a, b runtimeResultDependency) int {
+		return cmp.Compare(runtimeResultDependencyValidationKey(c, a), runtimeResultDependencyValidationKey(c, b))
+	})
+	return live
+}
+
+func runtimeResultDependencyValidationKey(c *Cache, dep runtimeResultDependency) string {
+	frameDigest := ""
+	if dep.Frame != nil {
+		if dig, err := dep.Frame.deriveRecipeDigest(c); err == nil {
+			frameDigest = dig.String()
+		}
+	}
+	return fmt.Sprintf("%s\x00%d\x00%s", frameDigest, dep.ResultID, dep.Digest)
+}
+
+func (c *Cache) resultCallRequiresLiveSourceValidation(frame *ResultCall) bool {
+	if frame == nil || !c.resultCallDependsOnLiveSource(frame) {
+		return false
+	}
+	if frame.Type != nil {
+		switch frame.Type.NamedType {
+		case "Directory", "File":
+			return true
+		}
+	}
+	return frame.Field == "contents" && c.resultCallRefDependsOnLiveSource(frame.Receiver)
+}
+
+func (c *Cache) resultCallDependsOnLiveSource(frame *ResultCall) bool {
+	return c.resultCallDependsOnLiveSourceWithSeen(frame, map[*ResultCall]struct{}{}, map[sharedResultID]struct{}{})
+}
+
+func (c *Cache) resultCallDependsOnLiveSourceWithSeen(
+	frame *ResultCall,
+	seenCalls map[*ResultCall]struct{},
+	seenResults map[sharedResultID]struct{},
+) bool {
+	if frame == nil {
+		return false
+	}
+	if _, seen := seenCalls[frame]; seen {
+		return false
+	}
+	seenCalls[frame] = struct{}{}
+
+	if c.resultCallIsLiveSourceRoot(frame) {
+		return true
+	}
+	if c.resultCallRefDependsOnLiveSourceWithSeen(frame.Receiver, seenCalls, seenResults) {
+		return true
+	}
+	if frame.Module != nil && c.resultCallRefDependsOnLiveSourceWithSeen(frame.Module.ResultRef, seenCalls, seenResults) {
+		return true
+	}
+	for _, arg := range frame.Args {
+		if arg != nil && c.resultCallLiteralDependsOnLiveSource(arg.Value, seenCalls, seenResults) {
+			return true
+		}
+	}
+	for _, input := range frame.ImplicitInputs {
+		if input != nil && c.resultCallLiteralDependsOnLiveSource(input.Value, seenCalls, seenResults) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Cache) resultCallIsLiveSourceRoot(frame *ResultCall) bool {
+	if frame == nil {
+		return false
+	}
+	if frame.Field == "currentWorkspace" {
+		return true
+	}
+	if (frame.Field == "directory" || frame.Field == "file") &&
+		resultCallBoolArg(frame.Args, "noCache") &&
+		c.resultCallRefIsHost(frame.Receiver) {
+		return true
+	}
+	return false
+}
+
+func (c *Cache) resultCallRefIsHost(ref *ResultCallRef) bool {
+	frame := c.resultCallFrameForRef(ref)
+	return frame != nil && ((frame.Type != nil && frame.Type.NamedType == "Host") || frame.Field == "host")
+}
+
+func resultCallBoolArg(args []*ResultCallArg, name string) bool {
+	for _, arg := range args {
+		if arg == nil || arg.Name != name || arg.Value == nil {
+			continue
+		}
+		return arg.Value.Kind == ResultCallLiteralKindBool && arg.Value.BoolValue
+	}
+	return false
+}
+
+func (c *Cache) resultCallRefDependsOnLiveSource(ref *ResultCallRef) bool {
+	return c.resultCallRefDependsOnLiveSourceWithSeen(ref, map[*ResultCall]struct{}{}, map[sharedResultID]struct{}{})
+}
+
+func (c *Cache) resultCallRefDependsOnLiveSourceWithSeen(
+	ref *ResultCallRef,
+	seenCalls map[*ResultCall]struct{},
+	seenResults map[sharedResultID]struct{},
+) bool {
+	frame := c.resultCallFrameForRefWithSeen(ref, seenResults)
+	return c.resultCallDependsOnLiveSourceWithSeen(frame, seenCalls, seenResults)
+}
+
+func (c *Cache) resultCallLiteralDependsOnLiveSource(
+	lit *ResultCallLiteral,
+	seenCalls map[*ResultCall]struct{},
+	seenResults map[sharedResultID]struct{},
+) bool {
+	if lit == nil {
+		return false
+	}
+	switch lit.Kind {
+	case ResultCallLiteralKindResultRef:
+		return c.resultCallRefDependsOnLiveSourceWithSeen(lit.ResultRef, seenCalls, seenResults)
+	case ResultCallLiteralKindList:
+		for _, item := range lit.ListItems {
+			if c.resultCallLiteralDependsOnLiveSource(item, seenCalls, seenResults) {
+				return true
+			}
+		}
+	case ResultCallLiteralKindObject:
+		for _, field := range lit.ObjectFields {
+			if field != nil && c.resultCallLiteralDependsOnLiveSource(field.Value, seenCalls, seenResults) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Cache) resultCallFrameForRef(ref *ResultCallRef) *ResultCall {
+	return c.resultCallFrameForRefWithSeen(ref, map[sharedResultID]struct{}{})
+}
+
+func (c *Cache) resultCallFrameForRefWithSeen(ref *ResultCallRef, seenResults map[sharedResultID]struct{}) *ResultCall {
+	if ref == nil {
+		return nil
+	}
+	if ref.Call != nil {
+		return ref.Call
+	}
+	resultID := sharedResultID(ref.ResultID)
+	if resultID == 0 {
+		return nil
+	}
+	if _, seen := seenResults[resultID]; seen {
+		return nil
+	}
+	seenResults[resultID] = struct{}{}
+	defer delete(seenResults, resultID)
+	return c.resultCallByResultID(resultID)
+}
+
+func (c *Cache) validateRuntimeDependencySets(ctx context.Context, depSets []runtimeResultDependencySet) (runtimeResultDependencySet, error) {
+	if len(depSets) == 0 {
+		return nil, nil
+	}
+	var staleErr error
+	for _, deps := range depSets {
+		err := c.validateRuntimeDependencySet(ctx, deps)
+		if err == nil {
+			return deps, nil
+		}
+		if !isCacheValidationFailed(err) {
+			return nil, err
+		}
+		staleErr = err
+	}
+	if staleErr == nil {
+		return nil, nil
+	}
+	return nil, staleErr
+}
+
+func (c *Cache) validateRuntimeDependencySet(ctx context.Context, deps runtimeResultDependencySet) error {
+	for _, dep := range deps {
+		if dep.Frame == nil {
+			return fmt.Errorf("runtime dependency for result %d has nil frame", dep.ResultID)
+		}
+		if dep.Digest == "" {
+			return fmt.Errorf("runtime dependency for result %d has empty digest", dep.ResultID)
+		}
+		current, err := c.refreshRuntimeDependencyDigest(ctx, dep)
+		if err != nil {
+			return fmt.Errorf("%w: refresh runtime dependency result %d: %v", ErrCacheValidationFailed, dep.ResultID, err)
+		}
+		if current != dep.Digest {
+			return fmt.Errorf("%w: runtime dependency result %d expected %s got %s", ErrCacheValidationFailed, dep.ResultID, dep.Digest, current)
+		}
+	}
+	return nil
+}
+
+func isCacheValidationFailed(err error) bool {
+	return errors.Is(err, ErrCacheValidationFailed)
+}
+
+func (c *Cache) refreshRuntimeDependencyDigest(ctx context.Context, dep runtimeResultDependency) (digest.Digest, error) {
+	refreshed, err := c.refreshResultCall(ctx, dep.Frame, map[sharedResultID]struct{}{})
+	if err != nil {
+		return "", err
+	}
+	frame, err := refreshed.ResultCall()
+	if err != nil {
+		return "", err
+	}
+	current, err := frame.deriveContentPreferredDigest(c)
+	if err != nil {
+		return "", err
+	}
+	return current, nil
+}
+
+func (c *Cache) refreshResultCall(
+	ctx context.Context,
+	frame *ResultCall,
+	seenResults map[sharedResultID]struct{},
+) (AnyResult, error) {
+	if frame == nil {
+		return nil, fmt.Errorf("nil result call")
+	}
+	srv := CurrentDagqlServer(ctx)
+	if srv == nil {
+		return nil, fmt.Errorf("current dagql server not found")
+	}
+	var base AnyResult = srv.root
+	var err error
+	if frame.Receiver != nil {
+		base, err = c.refreshResultCallRef(ctx, frame.Receiver, seenResults)
+		if err != nil {
+			return nil, fmt.Errorf("receiver: %w", err)
+		}
+	}
+	baseObj, err := srv.toSelectable(base)
+	if err != nil {
+		return nil, fmt.Errorf("instantiate base: %w", err)
+	}
+	sel, err := c.selectorFromResultCallForRefresh(ctx, frame, baseObj, seenResults)
+	if err != nil {
+		return nil, err
+	}
+	return baseObj.Select(ctx, srv, sel)
+}
+
+func (c *Cache) refreshResultCallRef(
+	ctx context.Context,
+	ref *ResultCallRef,
+	seenResults map[sharedResultID]struct{},
+) (AnyResult, error) {
+	if ref == nil {
+		return nil, fmt.Errorf("nil result ref")
+	}
+	if ref.Call != nil {
+		return c.refreshResultCall(ctx, ref.Call, seenResults)
+	}
+	resultID := sharedResultID(ref.ResultID)
+	if resultID == 0 {
+		return nil, fmt.Errorf("result ref has no result ID")
+	}
+	if _, seen := seenResults[resultID]; seen {
+		return nil, fmt.Errorf("cycle while refreshing result %d", resultID)
+	}
+	seenResults[resultID] = struct{}{}
+	defer delete(seenResults, resultID)
+	frame := c.resultCallByResultID(resultID)
+	if frame == nil {
+		return nil, fmt.Errorf("result %d has no call frame", resultID)
+	}
+	return c.refreshResultCall(ctx, frame, seenResults)
+}
+
+func (c *Cache) selectorFromResultCallForRefresh(
+	ctx context.Context,
+	frame *ResultCall,
+	baseObj AnyObjectResult,
+	seenResults map[sharedResultID]struct{},
+) (Selector, error) {
+	view := frame.View
+	fieldSpec, ok := baseObj.ObjectType().FieldSpec(frame.Field, view)
+	if !ok {
+		return Selector{}, fmt.Errorf("field %q not found on %s", frame.Field, baseObj.Type().Name())
+	}
+	args := make([]NamedInput, 0, len(frame.Args))
+	for _, argSpec := range fieldSpec.Args.Inputs(view) {
+		var frameArg *ResultCallArg
+		for _, arg := range frame.Args {
+			if arg != nil && arg.Name == argSpec.Name {
+				frameArg = arg
+				break
+			}
+		}
+		if frameArg == nil {
+			continue
+		}
+		inputVal, err := c.inputValueFromResultCallLiteralForRefresh(ctx, frameArg.Value, seenResults)
+		if err != nil {
+			return Selector{}, fmt.Errorf("request arg %q literal input: %w", argSpec.Name, err)
+		}
+		input, err := argSpec.Type.Decoder().DecodeInput(inputVal)
+		if err != nil {
+			return Selector{}, fmt.Errorf("request arg %q value as %T (%s) using %T: %w", argSpec.Name, argSpec.Type, argSpec.Type.Type(), argSpec.Type.Decoder(), err)
+		}
+		args = append(args, NamedInput{Name: argSpec.Name, Value: input})
+	}
+	return Selector{
+		Field: frame.Field,
+		Args:  args,
+		Nth:   int(frame.Nth),
+		View:  view,
+	}, nil
+}
+
+func (c *Cache) inputValueFromResultCallLiteralForRefresh(
+	ctx context.Context,
+	lit *ResultCallLiteral,
+	seenResults map[sharedResultID]struct{},
+) (any, error) {
+	if lit == nil {
+		return nil, nil
+	}
+	switch lit.Kind {
+	case ResultCallLiteralKindResultRef:
+		if c.resultCallRefDependsOnLiveSource(lit.ResultRef) {
+			refreshed, err := c.refreshResultCallRef(ctx, lit.ResultRef, seenResults)
+			if err != nil {
+				return nil, err
+			}
+			return refreshed.ID()
+		}
+		return handleIDFromResultCallRef(ctx, lit.ResultRef)
+	case ResultCallLiteralKindList:
+		values := make([]any, 0, len(lit.ListItems))
+		for _, item := range lit.ListItems {
+			val, err := c.inputValueFromResultCallLiteralForRefresh(ctx, item, seenResults)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, val)
+		}
+		return values, nil
+	case ResultCallLiteralKindObject:
+		values := make(map[string]any, len(lit.ObjectFields))
+		for _, field := range lit.ObjectFields {
+			if field == nil {
+				continue
+			}
+			val, err := c.inputValueFromResultCallLiteralForRefresh(ctx, field.Value, seenResults)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", field.Name, err)
+			}
+			values[field.Name] = val
+		}
+		return values, nil
+	default:
+		return inputValueFromResultCallLiteral(ctx, lit)
+	}
+}

--- a/dagql/cache_persistence_contracts.go
+++ b/dagql/cache_persistence_contracts.go
@@ -48,6 +48,7 @@ type persistStateSnapshot struct {
 	eqClassDigests        []persistdb.MirrorEqClassDigest
 	terms                 []persistdb.MirrorTerm
 	termInputs            []persistdb.MirrorTermInput
+	resultTermAssocs      []persistdb.MirrorResultTermAssoc
 	resultOutputEqClasses []persistdb.MirrorResultOutputEqClass
 	results               []persistResultSnapshot
 	snapshotContentLinks  []persistdb.MirrorSnapshotContentLink

--- a/dagql/cache_persistence_import.go
+++ b/dagql/cache_persistence_import.go
@@ -38,6 +38,10 @@ func (c *Cache) importPersistedState(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list mirror term_inputs: %w", err)
 	}
+	resultTermAssocRows, err := c.pdb.ListMirrorResultTermAssocs(ctx)
+	if err != nil {
+		return fmt.Errorf("list mirror result_term_assocs: %w", err)
+	}
 	resultOutputEqClassRows, err := c.pdb.ListMirrorResultOutputEqClasses(ctx)
 	if err != nil {
 		return fmt.Errorf("list mirror result_output_eq_classes: %w", err)
@@ -301,6 +305,38 @@ func (c *Cache) importPersistedState(ctx context.Context) error {
 			}
 			outputTerms[termID] = struct{}{}
 			c.traceTermCreated(ctx, "import", importRunID, term)
+		}
+
+		for _, row := range resultTermAssocRows {
+			termID := egraphTermID(row.TermID)
+			if c.egraphTerms[termID] == nil {
+				return fmt.Errorf("import result_term_assoc: missing term %d", row.TermID)
+			}
+			resultID := sharedResultID(row.ResultID)
+			if c.resultsByID[resultID] == nil {
+				return fmt.Errorf("import result_term_assoc: missing result %d", row.ResultID)
+			}
+			var runtimeDepSets []runtimeResultDependencySet
+			if row.RuntimeDepsJSON != "" {
+				if err := json.Unmarshal([]byte(row.RuntimeDepsJSON), &runtimeDepSets); err != nil {
+					return fmt.Errorf("import result_term_assoc (%d,%d) runtime deps: %w", row.TermID, row.ResultID, err)
+				}
+			}
+			termResults := c.termResults[termID]
+			if termResults == nil {
+				termResults = make(map[sharedResultID]egraphResultTermAssoc)
+				c.termResults[termID] = termResults
+			}
+			resultTerms := c.resultTerms[resultID]
+			if resultTerms == nil {
+				resultTerms = make(map[egraphTermID]struct{})
+				c.resultTerms[resultID] = resultTerms
+			}
+			termResults[resultID] = egraphResultTermAssoc{
+				inputProvenance: slices.Clone(c.termInputProvenance[termID]),
+				runtimeDepSets:  cloneRuntimeResultDependencySets(runtimeDepSets),
+			}
+			resultTerms[termID] = struct{}{}
 		}
 
 		for _, row := range resultOutputEqClassRows {

--- a/dagql/cache_persistence_import_test.go
+++ b/dagql/cache_persistence_import_test.go
@@ -211,10 +211,14 @@ func TestCachePersistenceImportRoundTripResultTermRuntimeDeps(t *testing.T) {
 	requestSelf, requestInputRefs, err := key.selfDigestAndInputRefs(cA)
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(requestInputRefs))
+	depFrame := cacheTestIntCall("persist-import-runtime-dep")
+	depFrameDigest, err := depFrame.deriveRecipeDigest(cA)
+	assert.NilError(t, err)
 	depSet := runtimeResultDependencySet{{
-		ResultID: uint64(sharedA.id),
-		Frame:    cacheTestIntCall("persist-import-runtime-dep"),
-		Digest:   digest.FromString("persist-import-runtime-dep-content"),
+		ResultID:    uint64(sharedA.id),
+		Frame:       depFrame,
+		FrameDigest: depFrameDigest,
+		Digest:      digest.FromString("persist-import-runtime-dep-content"),
 	}}
 
 	cA.egraphMu.Lock()
@@ -263,6 +267,7 @@ func TestCachePersistenceImportRoundTripResultTermRuntimeDeps(t *testing.T) {
 	assert.Equal(t, 1, len(importedAssoc.runtimeDepSets[0]))
 	importedDep := importedAssoc.runtimeDepSets[0][0]
 	assert.Equal(t, uint64(sharedA.id), importedDep.ResultID)
+	assert.Equal(t, depSet[0].FrameDigest.String(), importedDep.FrameDigest.String())
 	assert.Equal(t, depSet[0].Digest.String(), importedDep.Digest.String())
 	assert.Assert(t, importedDep.Frame != nil)
 	assert.Equal(t, depSet[0].Frame.Field, importedDep.Frame.Field)

--- a/dagql/cache_persistence_import_test.go
+++ b/dagql/cache_persistence_import_test.go
@@ -187,6 +187,87 @@ func TestCachePersistenceImportRoundTripAcrossRestart(t *testing.T) {
 	cacheTestReleaseSession(t, cB, ctx)
 }
 
+func TestCachePersistenceImportRoundTripResultTermRuntimeDeps(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+
+	cacheA, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	cA := cacheA
+
+	key := cacheTestIntCall("persist-import-runtime-deps")
+	resA, err := cA.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+		ResultCall:    key,
+		IsPersistable: true,
+	}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(key, 456), nil
+	})
+	assert.NilError(t, err)
+	sharedA := resA.cacheSharedResult()
+	assert.Assert(t, sharedA != nil)
+
+	requestSelf, requestInputRefs, err := key.selfDigestAndInputRefs(cA)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(requestInputRefs))
+	depSet := runtimeResultDependencySet{{
+		ResultID: uint64(sharedA.id),
+		Frame:    cacheTestIntCall("persist-import-runtime-dep"),
+		Digest:   digest.FromString("persist-import-runtime-dep-content"),
+	}}
+
+	cA.egraphMu.Lock()
+	termDigest := calcEgraphTermDigest(requestSelf, nil)
+	var termID egraphTermID
+	if termSet := cA.egraphTermsByTermDigest[termDigest]; termSet != nil {
+		for candidateID := range termSet.Items() {
+			if _, ok := cA.termResults[candidateID][sharedA.id]; ok {
+				termID = candidateID
+				break
+			}
+		}
+	}
+	assert.Assert(t, termID != 0)
+	assoc := cA.termResults[termID][sharedA.id]
+	assoc.runtimeDepSets = []runtimeResultDependencySet{cloneRuntimeResultDependencySet(depSet)}
+	cA.termResults[termID][sharedA.id] = assoc
+	cA.egraphMu.Unlock()
+
+	cacheTestReleaseSession(t, cA, ctx)
+	assert.NilError(t, cA.persistCurrentState(ctx))
+	assert.NilError(t, cA.Close(context.Background()))
+
+	cacheB, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	cB := cacheB
+	defer func() {
+		assert.NilError(t, cB.Close(context.Background()))
+	}()
+
+	cB.egraphMu.RLock()
+	termDigest = calcEgraphTermDigest(requestSelf, nil)
+	var importedAssoc egraphResultTermAssoc
+	if termSet := cB.egraphTermsByTermDigest[termDigest]; termSet != nil {
+		for candidateID := range termSet.Items() {
+			assoc, ok := cB.termResults[candidateID][sharedA.id]
+			if ok {
+				importedAssoc = assoc
+				break
+			}
+		}
+	}
+	cB.egraphMu.RUnlock()
+
+	assert.Equal(t, 1, len(importedAssoc.runtimeDepSets))
+	assert.Equal(t, 1, len(importedAssoc.runtimeDepSets[0]))
+	importedDep := importedAssoc.runtimeDepSets[0][0]
+	assert.Equal(t, uint64(sharedA.id), importedDep.ResultID)
+	assert.Equal(t, depSet[0].Digest.String(), importedDep.Digest.String())
+	assert.Assert(t, importedDep.Frame != nil)
+	assert.Equal(t, depSet[0].Frame.Field, importedDep.Frame.Field)
+}
+
 func TestCachePersistenceImportRoundTripObjectResult(t *testing.T) {
 	t.Parallel()
 

--- a/dagql/cache_persistence_self.go
+++ b/dagql/cache_persistence_self.go
@@ -106,11 +106,11 @@ func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCac
 	if _, ok := res.(AnyObjectResult); ok {
 		isObject = true
 	}
-	if shared := res.cacheSharedResult(); shared != nil && shared.isObject {
+	if shared := res.cacheSharedResult(); shared != nil && shared.loadPayloadState().isObject {
 		isObject = true
 	}
 
-	if isObject {
+	encodeObject := func() (PersistedResultEncoding, error) {
 		encoder, ok := res.Unwrap().(PersistedObject)
 		if !ok {
 			return PersistedResultEncoding{}, fmt.Errorf("encode persisted object payload: type %q does not implement persisted object encoding", res.Type().Name())
@@ -131,22 +131,12 @@ func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCac
 			SnapshotLinks: objectEncoding.SnapshotLinks,
 		}, nil
 	}
-	if encoder, ok := res.Unwrap().(PersistedObject); ok {
-		objectEncoding, err := encoder.EncodePersistedObject(ctx, cache)
-		if err != nil {
-			return PersistedResultEncoding{}, fmt.Errorf("encode persisted object payload: %w", err)
-		}
-		return PersistedResultEncoding{
-			Envelope: PersistedResultEnvelope{
-				Version:               2,
-				Kind:                  persistedResultKindObject,
-				TypeName:              res.Type().Name(),
-				ResultID:              resultID,
-				SessionResourceHandle: sessionResourceHandle,
-				ObjectJSON:            objectEncoding.JSON,
-			},
-			SnapshotLinks: objectEncoding.SnapshotLinks,
-		}, nil
+
+	if isObject {
+		return encodeObject()
+	}
+	if _, ok := res.Unwrap().(PersistedObject); ok {
+		return encodeObject()
 	}
 
 	if enumerable, ok := res.Unwrap().(Enumerable); ok {

--- a/dagql/cache_persistence_self_test.go
+++ b/dagql/cache_persistence_self_test.go
@@ -166,6 +166,33 @@ func TestPersistedSelfCodecUsesSharedObjectClassification(t *testing.T) {
 	assert.Check(t, is.Equal(string(env.ObjectJSON), `{"name":"x"}`))
 }
 
+func TestPersistedSelfCodecRejectsTypedObjectResultWithoutPersistedObjectCodec(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	srv := cacheTestServer(t)
+
+	objectCall := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&cacheTestObject{}).Type()),
+		Field: "obj",
+	}
+	original, err := c.GetOrInitCall(ctx, "test-session", srv, &CallRequest{ResultCall: objectCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResult(t, srv, objectCall, 42, nil), nil
+	})
+	assert.NilError(t, err)
+
+	wrapped := Result[Typed]{
+		shared: original.cacheSharedResult(),
+	}
+	_, err = DefaultPersistedSelfCodec.EncodeResult(ctx, nil, wrapped)
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, `type "CacheTestObject" does not implement persisted object encoding`)
+}
+
 func TestObjectCacheHitPreservesObjectResultShape(t *testing.T) {
 	t.Parallel()
 

--- a/dagql/cache_persistence_worker.go
+++ b/dagql/cache_persistence_worker.go
@@ -84,6 +84,33 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		})
 	}
 
+	for _, termID := range termIDs {
+		termResults := c.termResults[termID]
+		if len(termResults) == 0 {
+			continue
+		}
+		resultIDs := make([]sharedResultID, 0, len(termResults))
+		for resultID := range termResults {
+			resultIDs = append(resultIDs, resultID)
+		}
+		slices.Sort(resultIDs)
+		for _, resultID := range resultIDs {
+			if c.resultsByID[resultID] == nil {
+				continue
+			}
+			depsJSON, err := json.Marshal(termResults[resultID].runtimeDepSets)
+			if err != nil {
+				c.egraphMu.RUnlock()
+				return persistStateSnapshot{}, fmt.Errorf("persist result-term assoc (%d,%d): runtime deps JSON: %w", termID, resultID, err)
+			}
+			snapshot.resultTermAssocs = append(snapshot.resultTermAssocs, persistdb.MirrorResultTermAssoc{
+				TermID:          int64(termID),
+				ResultID:        int64(resultID),
+				RuntimeDepsJSON: string(depsJSON),
+			})
+		}
+	}
+
 	resultIDs := make([]sharedResultID, 0, len(c.resultsByID))
 	for resultID := range c.resultsByID {
 		resultIDs = append(resultIDs, resultID)
@@ -307,6 +334,12 @@ func (c *Cache) applyPersistStateSnapshot(ctx context.Context, snapshot persistS
 		if err := q.InsertMirrorTermInput(ctx, row); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("insert term_input (%d,%d): %w", row.TermID, row.Position, err)
+		}
+	}
+	for _, row := range snapshot.resultTermAssocs {
+		if err := q.InsertMirrorResultTermAssoc(ctx, row); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("insert result_term_assoc (%d,%d): %w", row.TermID, row.ResultID, err)
 		}
 	}
 	for _, row := range snapshot.resultOutputEqClasses {

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -3636,6 +3636,52 @@ func TestCacheDoNotCacheNormalizesNestedHitMetadata(t *testing.T) {
 	assert.Equal(t, 1, c.Size())
 }
 
+func TestRuntimeDependencyFreshnessPropagatesThroughScalarNestedCall(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	liveFileFrame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(&ast.Type{NamedType: "File", NonNull: true}),
+		Field: "file",
+		Receiver: &ResultCallRef{Call: &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType(&ast.Type{NamedType: "Host", NonNull: true}),
+			Field: "host",
+		}},
+		Args: []*ResultCallArg{{
+			Name: "noCache",
+			Value: &ResultCallLiteral{
+				Kind:      ResultCallLiteralKindBool,
+				BoolValue: true,
+			},
+		}},
+	}
+	liveFileDep := runtimeResultDependency{
+		ResultID: 12,
+		Frame:    liveFileFrame,
+		Digest:   digest.FromString("runtime-transitive-live-file"),
+	}
+	scalarDep := runtimeResultDependency{
+		ResultID: 34,
+		Frame:    cacheTestIntCall("runtime-transitive-scalar"),
+		Digest:   digest.FromString("runtime-transitive-scalar"),
+		FreshnessDeps: runtimeResultDependencySet{
+			liveFileDep,
+		},
+	}
+
+	live := c.liveRuntimeDependencies(runtimeResultDependencySet{scalarDep})
+	assert.Equal(t, 1, len(live))
+	assert.Equal(t, liveFileDep.ResultID, live[0].ResultID)
+	assert.Equal(t, liveFileDep.Digest.String(), live[0].Digest.String())
+	assert.Assert(t, live[0].Frame != nil)
+	assert.Equal(t, "file", live[0].Frame.Field)
+}
+
 func TestCacheDoNotCachePreservesAttachedReturnedObject(t *testing.T) {
 	t.Parallel()
 	ctx := cacheTestContext(t.Context())

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -3674,12 +3674,168 @@ func TestRuntimeDependencyFreshnessPropagatesThroughScalarNestedCall(t *testing.
 		},
 	}
 
-	live := c.liveRuntimeDependencies(runtimeResultDependencySet{scalarDep})
+	live, err := c.liveRuntimeDependencies(runtimeResultDependencySet{scalarDep})
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(live))
 	assert.Equal(t, liveFileDep.ResultID, live[0].ResultID)
 	assert.Equal(t, liveFileDep.Digest.String(), live[0].Digest.String())
 	assert.Assert(t, live[0].Frame != nil)
 	assert.Equal(t, "file", live[0].Frame.Field)
+	assert.Assert(t, live[0].FrameDigest != "")
+}
+
+func TestRuntimeDependencyFreshnessDedupesByValidationFact(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	liveFileFrame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(&ast.Type{NamedType: "File", NonNull: true}),
+		Field: "file",
+		Receiver: &ResultCallRef{Call: &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType(&ast.Type{NamedType: "Host", NonNull: true}),
+			Field: "host",
+		}},
+		Args: []*ResultCallArg{{
+			Name: "noCache",
+			Value: &ResultCallLiteral{
+				Kind:      ResultCallLiteralKindBool,
+				BoolValue: true,
+			},
+		}},
+	}
+	observedDigest := digest.FromString("runtime-dedupe-live-file")
+	live, err := c.liveRuntimeDependencies(runtimeResultDependencySet{
+		{
+			ResultID: 12,
+			Frame:    liveFileFrame,
+			Digest:   observedDigest,
+		},
+		{
+			ResultID: 34,
+			Frame:    liveFileFrame,
+			Digest:   observedDigest,
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(live))
+	assert.Assert(t, live[0].ResultID == 12 || live[0].ResultID == 34)
+	assert.Assert(t, live[0].FrameDigest != "")
+	assert.Equal(t, observedDigest.String(), live[0].Digest.String())
+}
+
+func TestRuntimeDependencyValidationKeyUsesStoredFrameDigest(t *testing.T) {
+	t.Parallel()
+
+	frameDigest := digest.FromString("runtime-key-frame")
+	observedDigest := digest.FromString("runtime-key-content")
+	key := runtimeResultDependencyValidationKey(runtimeResultDependency{
+		ResultID: 17,
+		Frame: &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType(&ast.Type{NamedType: "File", NonNull: true}),
+			Field: "file",
+			Receiver: &ResultCallRef{
+				ResultID: 999,
+			},
+		},
+		FrameDigest: frameDigest,
+		Digest:      observedDigest,
+	})
+	assert.Equal(t, fmt.Sprintf("%s\x00%s", frameDigest, observedDigest), key)
+}
+
+func TestRuntimeDependencyRetentionKeepsOnlyLiveValidationFrameRefs(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	hostFrame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(&ast.Type{NamedType: "Host", NonNull: true}),
+		Field: "host",
+	}
+	hostRes, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: hostFrame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(hostFrame, 1), nil
+	})
+	assert.NilError(t, err)
+	hostID := hostRes.cacheSharedResult().id
+
+	liveFileFrame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(&ast.Type{NamedType: "File", NonNull: true}),
+		Field: "file",
+		Receiver: &ResultCallRef{
+			ResultID: uint64(hostID),
+		},
+		Args: []*ResultCallArg{{
+			Name: "noCache",
+			Value: &ResultCallLiteral{
+				Kind:      ResultCallLiteralKindBool,
+				BoolValue: true,
+			},
+		}},
+	}
+	liveFileRes, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: liveFileFrame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(liveFileFrame, 2), nil
+	})
+	assert.NilError(t, err)
+	liveFileID := liveFileRes.cacheSharedResult().id
+
+	scalarFrame := cacheTestIntCall("runtime-retention-scalar")
+	scalarRes, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: scalarFrame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(scalarFrame, 3), nil
+	})
+	assert.NilError(t, err)
+	scalarID := scalarRes.cacheSharedResult().id
+
+	liveFileDep := runtimeResultDependency{
+		ResultID: uint64(liveFileID),
+		Frame:    liveFileFrame,
+		Digest:   digest.FromString("runtime-retention-live-file"),
+	}
+	scalarDep := runtimeResultDependency{
+		ResultID: uint64(scalarID),
+		Frame:    scalarFrame,
+		Digest:   digest.FromString("runtime-retention-scalar"),
+		FreshnessDeps: runtimeResultDependencySet{
+			liveFileDep,
+		},
+	}
+
+	outerFrame := cacheTestIntCall("runtime-retention-outer")
+	outerDigest, err := outerFrame.deriveRecipeDigest(c)
+	assert.NilError(t, err)
+	scalarDigest, err := scalarFrame.deriveRecipeDigest(c)
+	assert.NilError(t, err)
+	c.runtimeDepsMu.Lock()
+	c.runtimeDepsByCallDigest = map[string]map[string]runtimeResultDependency{
+		runtimeDependencyKey("test-session", outerDigest): {
+			scalarDigest.String(): scalarDep,
+		},
+	}
+	c.runtimeDepsMu.Unlock()
+
+	outerRes, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: outerFrame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(outerFrame, 4), nil
+	})
+	assert.NilError(t, err)
+	outerShared := outerRes.cacheSharedResult()
+	assert.Assert(t, outerShared != nil)
+	assert.Assert(t, outerShared.deps != nil)
+
+	_, retainedScalar := outerShared.deps[scalarID]
+	_, retainedLiveFile := outerShared.deps[liveFileID]
+	_, retainedHost := outerShared.deps[hostID]
+	assert.Assert(t, !retainedScalar)
+	assert.Assert(t, !retainedLiveFile)
+	assert.Assert(t, retainedHost)
 }
 
 func TestCacheDoNotCachePreservesAttachedReturnedObject(t *testing.T) {

--- a/dagql/call_request.go
+++ b/dagql/call_request.go
@@ -1,6 +1,8 @@
 package dagql
 
-import "context"
+import (
+	"context"
+)
 
 // CallRequest is the mutable planning-time wrapper around the semantic
 // ResultCall shape, plus request-only cache policy that does not belong in

--- a/dagql/persistdb/mirror_state.go
+++ b/dagql/persistdb/mirror_state.go
@@ -38,6 +38,12 @@ type MirrorTermInput struct {
 	ProvenanceKind string
 }
 
+type MirrorResultTermAssoc struct {
+	TermID          int64
+	ResultID        int64
+	RuntimeDepsJSON string
+}
+
 type MirrorResultOutputEqClass struct {
 	ResultID  int64
 	EqClassID int64
@@ -85,6 +91,7 @@ const clearMirrorResultSnapshotLinks = `DELETE FROM result_snapshot_links`
 const clearMirrorPersistedEdges = `DELETE FROM persisted_edges`
 const clearMirrorResultDeps = `DELETE FROM result_deps`
 const clearMirrorResultOutputEqClasses = `DELETE FROM result_output_eq_classes`
+const clearMirrorResultTermAssocs = `DELETE FROM result_term_assocs`
 const clearMirrorTermInputs = `DELETE FROM term_inputs`
 const clearMirrorTerms = `DELETE FROM terms`
 const clearMirrorEqClassDigests = `DELETE FROM eq_class_digests`
@@ -100,6 +107,7 @@ func (q *Queries) ClearMirrorState(ctx context.Context) error {
 		clearMirrorPersistedEdges,
 		clearMirrorResultDeps,
 		clearMirrorResultOutputEqClasses,
+		clearMirrorResultTermAssocs,
 		clearMirrorTermInputs,
 		clearMirrorTerms,
 		clearMirrorEqClassDigests,
@@ -161,6 +169,15 @@ INSERT INTO term_inputs (term_id, position, input_eq_class_id, provenance_kind) 
 
 func (q *Queries) InsertMirrorTermInput(ctx context.Context, arg MirrorTermInput) error {
 	_, err := q.exec(ctx, nil, insertMirrorTermInput, arg.TermID, arg.Position, arg.InputEqClassID, arg.ProvenanceKind)
+	return err
+}
+
+const insertMirrorResultTermAssoc = `
+INSERT INTO result_term_assocs (term_id, result_id, runtime_deps_json) VALUES (?, ?, ?)
+`
+
+func (q *Queries) InsertMirrorResultTermAssoc(ctx context.Context, arg MirrorResultTermAssoc) error {
+	_, err := q.exec(ctx, nil, insertMirrorResultTermAssoc, arg.TermID, arg.ResultID, arg.RuntimeDepsJSON)
 	return err
 }
 
@@ -353,6 +370,25 @@ func (q *Queries) ListMirrorTermInputs(ctx context.Context) ([]MirrorTermInput, 
 	for rows.Next() {
 		var row MirrorTermInput
 		if err := rows.Scan(&row.TermID, &row.Position, &row.InputEqClassID, &row.ProvenanceKind); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+const listMirrorResultTermAssocs = `SELECT term_id, result_id, runtime_deps_json FROM result_term_assocs`
+
+func (q *Queries) ListMirrorResultTermAssocs(ctx context.Context) ([]MirrorResultTermAssoc, error) {
+	rows, err := q.db.QueryContext(ctx, listMirrorResultTermAssocs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []MirrorResultTermAssoc
+	for rows.Next() {
+		var row MirrorResultTermAssoc
+		if err := rows.Scan(&row.TermID, &row.ResultID, &row.RuntimeDepsJSON); err != nil {
 			return nil, err
 		}
 		out = append(out, row)

--- a/dagql/persistdb/schema.sql
+++ b/dagql/persistdb/schema.sql
@@ -45,6 +45,15 @@ CREATE TABLE IF NOT EXISTS term_inputs (
     FOREIGN KEY(input_eq_class_id) REFERENCES eq_classes(id) ON DELETE CASCADE
 ) STRICT, WITHOUT ROWID;
 
+CREATE TABLE IF NOT EXISTS result_term_assocs (
+    term_id INTEGER NOT NULL,
+    result_id INTEGER NOT NULL,
+    runtime_deps_json TEXT NOT NULL DEFAULT '[]',
+    PRIMARY KEY(term_id, result_id),
+    FOREIGN KEY(term_id) REFERENCES terms(id) ON DELETE CASCADE,
+    FOREIGN KEY(result_id) REFERENCES results(id) ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
 CREATE TABLE IF NOT EXISTS result_output_eq_classes (
     result_id INTEGER NOT NULL,
     eq_class_id INTEGER NOT NULL,

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -14,6 +14,7 @@ import (
 
 	controlapi "github.com/dagger/dagger/internal/buildkit/api/services/control"
 	"github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/opencontainers/go-digest"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -138,6 +139,11 @@ type ClientMetadata struct {
 	// request explicitly passes a recipe argument. This is engine-internal
 	// nested-client state and must not be forwarded through client headers.
 	UseRecipeIDsByDefault bool `json:"-"`
+
+	// RuntimeCallDigest identifies the module-function call currently being
+	// executed by an engine-owned nested client. It is engine-internal state and
+	// must not be forwarded through client headers.
+	RuntimeCallDigest digest.Digest `json:"-"`
 }
 
 type clientMetadataCtxKey struct{}


### PR DESCRIPTION
## Problem

@tiborvass reported a false cache hit where an outer module function could reuse a cached scalar result even though a nested call had loaded a contextual directory whose contents changed later.

The core mismatch is that contextual/workspace directory loads are live-source validations, but nested calls can collapse their result down to a scalar before the outer function result is cached. At that point the outer result no longer has a direct object reference to the directory load, so the cache needs to retain and replay the live-source validation fact separately.

## Current state

This PR adds an integration reproduction for the nested contextual directory case and a first-pass implementation for the fix.

The implementation carries live runtime dependency validation facts through completed results. Runtime dependencies are keyed by the frame recipe digest that can replay the live-source load plus the observed content digest. Result IDs are intentionally excluded from equality so the e-graph compares the validation fact itself, not local ownership details.

It also makes object persistence stricter as part of the hard cutover: object-shaped results must encode through object persistence, and Changeset now persists through before/after directory references instead of falling through to scalar JSON.

## Validation

- `GOTOOLCHAIN=go1.26.3 go test ./dagql -run 'Test(RuntimeDependencyFreshness|RuntimeDependencyRetention|RuntimeDependencyValidationKey|PersistedSelfCodecRejects|CachePersistenceImportRoundTripResultTermRuntimeDeps)'`
- `GOTOOLCHAIN=go1.26.3 go test ./dagql`
- `GOTOOLCHAIN=go1.26.3 go test ./core -run TestModuleFunctionCacheImplicitInputs`
- `git diff --check`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart/engine-dev_container_build_survives_restart'`

Keeping this draft while CI shakes out the full test surface.
