### PR TITLE
fix(sdk/python): expand TypeAlias inside union annotations (X | None)

### DIFF
--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -582,6 +582,23 @@ class ModuleParser:
                     current = origin_aliases[name]
                     continue
             break
+
+        # Expand aliases inside ``X | Y`` union expressions so that
+        # ``Name | None`` (where ``Name: TypeAlias = str``) reaches the
+        # resolver as ``str | None`` instead of an unresolved "Name" object.
+        # The while loop only handles a bare Name at the top level, so
+        # compound annotations with aliased sub-expressions pass through
+        # unexpanded without this recursion.
+        if isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
+            expanded_left = self._expand_alias(current.left, current_file)
+            expanded_right = self._expand_alias(current.right, current_file)
+            if expanded_left is not current.left or expanded_right is not current.right:
+                new_node = ast.BinOp(
+                    left=expanded_left, op=current.op, right=expanded_right
+                )
+                ast.copy_location(new_node, current)
+                return new_node
+
         return current
 
     def _build_namespace(self) -> None:

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1450,6 +1450,27 @@ class Foo:
     assert param.resolved_type.name == "Directory"
 
 
+def test_ast_type_alias_inside_union():
+    """``Name: TypeAlias = str`` used as ``Name | None`` resolves to optional str."""
+    metadata = _analyze("""
+from typing import TypeAlias
+
+import dagger
+
+Name: TypeAlias = str
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def greet(self, name: Name | None) -> str:
+        ...
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "str"
+    assert param.resolved_type.is_optional is True
+
+
 def test_ast_optional_type_alias():
     """``MaybeDir = dagger.Directory | None`` resolves to optional Directory."""
     metadata = _analyze("""


### PR DESCRIPTION
_expand_alias only walked bare ast.Name nodes via a while loop, so compound annotations like `Name | None` passed through with the alias unexpanded. The resolver then saw "Name" as an unknown type and assumed it was an object, which the engine rejected with "find mod type for function … arg … type: \"Name\"".

After the top-level name-expansion loop, recurse into ast.BinOp BitOr nodes and expand aliases in both operands. An identity check ensures a new node is only allocated when something actually changed, so unaliased unions are unaffected.