### PR TITLE
Normalize Git checkout mtimes to one second

### DIFF
--- a/core/git.go
+++ b/core/git.go
@@ -514,12 +514,14 @@ func doGitCheckout(
 	if err != nil {
 		return fmt.Errorf("could not find worktree: %w", err)
 	}
-	epoch := []unix.Timespec{{}, {}}
+	// Use a deterministic non-zero timestamp. Some build tools treat missing
+	// outputs as epoch and skip initial copies when sources are also epoch.
+	normalizedTime := []unix.Timespec{{Sec: 1}, {Sec: 1}}
 	if err := filepath.WalkDir(checkoutDir, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		return unix.UtimesNanoAt(unix.AT_FDCWD, path, epoch, unix.AT_SYMLINK_NOFOLLOW)
+		return unix.UtimesNanoAt(unix.AT_FDCWD, path, normalizedTime, unix.AT_SYMLINK_NOFOLLOW)
 	}); err != nil {
 		return fmt.Errorf("failed to normalize checkout timestamps: %w", err)
 	}

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -334,6 +334,17 @@ func (GitSuite) TestDiscardGitDir(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (GitSuite) TestRemoteGitTreeNormalizesTimestamps(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	file := c.Git("https://github.com/dagger/dagger").
+		Commit("7bed576fbc61fff0015f5bf9c85f17c43102a4a3").
+		Tree(dagger.GitRefTreeOpts{DiscardGitDir: true}).
+		File("README.md")
+
+	require.Equal(t, 1, getFileTimestamp(ctx, t, c, file))
+}
+
 func (GitSuite) TestKeepGitDir(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCLIUtils.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCLIUtils.java
@@ -1,14 +1,29 @@
 package io.dagger.codegen;
 
 import com.ongres.process.FluentProcess;
-import com.ongres.process.FluentProcessBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,8 +42,14 @@ public class DaggerCLIUtils {
     return bin;
   }
 
-  public static InputStream query(InputStream query, String binPath) {
+  public static InputStream query(InputStream query, String binPath)
+      throws IOException, InterruptedException {
+    if (query == null) {
+      throw new IOException("missing introspection query resource");
+    }
+
     ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
 
     // The introspection query response is >20k lines, save our
     // telemetry from the burden of sending/storing it by unsetting
@@ -39,17 +60,235 @@ public class DaggerCLIUtils {
     envVars.remove("OTEL_EXPORTER_OTLP_ENDPOINT");
     envVars.remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
 
-    FluentProcessBuilder builder = new FluentProcessBuilder(binPath);
-    builder
-        .args("query", "-s", "-M")
-        .noStderr()
-        .clearEnvironment()
-        .environment(envVars)
-        .start()
-        .withTimeout(Duration.of(60, ChronoUnit.SECONDS))
-        .inputStream(query)
-        .writeToOutputStream(out);
+    ProcessBuilder builder = new ProcessBuilder(binPath, "query", "-s", "-M");
+    builder.environment().clear();
+    builder.environment().putAll(envVars);
+
+    Process process = builder.start();
+    CompletableFuture<Void> stdin =
+        copyAsync(
+            () -> {
+              try (InputStream queryInput = query;
+                  OutputStream processStdin = process.getOutputStream()) {
+                queryInput.transferTo(processStdin);
+              }
+            });
+    CompletableFuture<Void> stdout =
+        copyAsync(
+            () -> {
+              try (InputStream processStdout = process.getInputStream()) {
+                processStdout.transferTo(out);
+              }
+            });
+    CompletableFuture<Void> stderr =
+        copyAsync(
+            () -> {
+              try (InputStream processStderr = process.getErrorStream()) {
+                processStderr.transferTo(err);
+              }
+            });
+
+    boolean exited = process.waitFor(60, TimeUnit.SECONDS);
+    if (!exited) {
+      process.destroyForcibly();
+      throw new IOException("dagger query timed out after 60 seconds");
+    }
+
+    waitForCopies(stdout, stderr);
+    if (process.exitValue() != 0) {
+      throw new IOException(
+          "dagger query failed with exit code "
+              + process.exitValue()
+              + "\n"
+              + formatProcessOutput("stderr", err)
+              + "\n"
+              + formatProcessOutput("stdout", out));
+    }
+    waitForCopies(stdin);
+
     return new ByteArrayInputStream(out.toByteArray());
+  }
+
+  public static InputStream introspectionQuery(Class<?> anchorClass) throws IOException {
+    String resource = "introspection/introspection.graphql";
+    InputStream stream = getResource(anchorClass.getClassLoader(), resource);
+    if (stream != null) {
+      return stream;
+    }
+
+    throw new IOException(
+        "missing introspection query resource "
+            + resource
+            + "\n"
+            + resourceDiagnostics(anchorClass, resource));
+  }
+
+  private static InputStream getResource(ClassLoader classLoader, String resource) {
+    if (classLoader == null) {
+      return null;
+    }
+    return classLoader.getResourceAsStream(resource);
+  }
+
+  private static String resourceDiagnostics(Class<?> anchorClass, String resource) {
+    StringBuilder diagnostics = new StringBuilder();
+    diagnostics.append("anchorClass=").append(anchorClass.getName()).append('\n');
+    diagnostics.append("anchorCodeSource=").append(codeSource(anchorClass)).append('\n');
+    diagnostics.append("utilsCodeSource=").append(codeSource(DaggerCLIUtils.class)).append('\n');
+    diagnostics
+        .append("anchorCodeSourceResourceEntries=")
+        .append(codeSourceResourceEntries(anchorClass, resource))
+        .append('\n');
+    diagnostics
+        .append("utilsCodeSourceResourceEntries=")
+        .append(codeSourceResourceEntries(DaggerCLIUtils.class, resource))
+        .append('\n');
+    diagnostics
+        .append("anchorTargetClassesResource=")
+        .append(targetClassesResource(anchorClass, resource))
+        .append('\n');
+    diagnostics.append(
+        describeClassLoader("anchorClassLoader", anchorClass.getClassLoader(), resource));
+    diagnostics.append(
+        describeClassLoader("utilsClassLoader", DaggerCLIUtils.class.getClassLoader(), resource));
+    diagnostics.append(
+        describeClassLoader(
+            "threadContextClassLoader", Thread.currentThread().getContextClassLoader(), resource));
+    return diagnostics.toString();
+  }
+
+  private static String describeClassLoader(String name, ClassLoader classLoader, String resource) {
+    StringBuilder description = new StringBuilder();
+    description.append(name).append('=').append(classLoader).append('\n');
+    if (classLoader == null) {
+      description.append(name).append(".resources=<bootstrap>\n");
+      return description.toString();
+    }
+    try {
+      List<String> resources = new ArrayList<>();
+      Enumeration<URL> urls = classLoader.getResources(resource);
+      while (urls.hasMoreElements()) {
+        resources.add(urls.nextElement().toString());
+      }
+      description.append(name).append(".resources=").append(resources).append('\n');
+    } catch (IOException e) {
+      description.append(name).append(".resources=<failed: ").append(e).append(">\n");
+    }
+    return description.toString();
+  }
+
+  private static String codeSource(Class<?> clazz) {
+    try {
+      URL location = codeSourceLocation(clazz);
+      if (location == null) {
+        return "<none>";
+      }
+      return location.toString();
+    } catch (SecurityException e) {
+      return "<failed: " + e + ">";
+    }
+  }
+
+  private static URL codeSourceLocation(Class<?> clazz) {
+    CodeSource source = clazz.getProtectionDomain().getCodeSource();
+    if (source == null) {
+      return null;
+    }
+    return source.getLocation();
+  }
+
+  private static List<String> codeSourceResourceEntries(Class<?> clazz, String resource) {
+    try {
+      URL location = codeSourceLocation(clazz);
+      if (location == null) {
+        return List.of("<none>");
+      }
+      Path path = Path.of(location.toURI());
+      if (Files.isDirectory(path)) {
+        Path resourcePath = path.resolve(resource);
+        if (!Files.exists(resourcePath)) {
+          return List.of(resourcePath + " missing");
+        }
+        return List.of(resourcePath + " size=" + Files.size(resourcePath));
+      }
+      if (!Files.isRegularFile(path)) {
+        return List.of(path + " is not a regular file");
+      }
+      try (JarFile jar = new JarFile(path.toFile())) {
+        return jar.stream()
+            .filter(entry -> entry.getName().startsWith("introspection/"))
+            .map(entry -> entry.getName() + " size=" + entry.getSize())
+            .toList();
+      }
+    } catch (IOException | IllegalArgumentException | SecurityException | URISyntaxException e) {
+      return List.of("<failed: " + e + ">");
+    }
+  }
+
+  private static String targetClassesResource(Class<?> clazz, String resource) {
+    try {
+      URL location = codeSourceLocation(clazz);
+      if (location == null) {
+        return "<none>";
+      }
+      Path codeSource = Path.of(location.toURI());
+      Path target = codeSource.getParent();
+      if (target == null) {
+        return codeSource + " has no parent";
+      }
+      Path resourcePath = target.resolve("classes").resolve(resource);
+      if (!Files.exists(resourcePath)) {
+        return resourcePath + " missing";
+      }
+      return resourcePath + " size=" + Files.size(resourcePath);
+    } catch (IOException | IllegalArgumentException | SecurityException | URISyntaxException e) {
+      return "<failed: " + e + ">";
+    }
+  }
+
+  private static CompletableFuture<Void> copyAsync(IoRunnable runnable) {
+    return CompletableFuture.runAsync(
+        () -> {
+          try {
+            runnable.run();
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+  }
+
+  @SafeVarargs
+  private static void waitForCopies(CompletableFuture<Void>... copies)
+      throws IOException, InterruptedException {
+    try {
+      CompletableFuture.allOf(copies).get();
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof UncheckedIOException) {
+        throw ((UncheckedIOException) cause).getCause();
+      }
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new IOException("failed to collect dagger query output", cause);
+    }
+  }
+
+  private static String formatProcessOutput(String name, ByteArrayOutputStream stream) {
+    String output = stream.toString(StandardCharsets.UTF_8).trim();
+    if (output.isEmpty()) {
+      return name + ": <empty>";
+    }
+    int maxLength = 8192;
+    if (output.length() > maxLength) {
+      output = output.substring(0, maxLength) + "\n... output truncated ...";
+    }
+    return name + ":\n" + output;
+  }
+
+  @FunctionalInterface
+  private interface IoRunnable {
+    void run() throws IOException;
   }
 
   private static boolean isStandardVersionFormat(String input) {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCodegenMojo.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCodegenMojo.java
@@ -128,9 +128,7 @@ public class DaggerCodegenMojo extends AbstractMojo {
     getLog()
         .info(String.format("Querying local dagger CLI for schema (version=%s)", actualVersion));
     this.version = actualVersion;
-    return DaggerCLIUtils.query(
-        getClass().getClassLoader().getResourceAsStream("introspection/introspection.graphql"),
-        this.bin);
+    return DaggerCLIUtils.query(DaggerCLIUtils.introspectionQuery(getClass()), this.bin);
   }
 
   public File getOutputDirectory() {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerSchemaGeneratorMojo.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerSchemaGeneratorMojo.java
@@ -51,8 +51,7 @@ public class DaggerSchemaGeneratorMojo extends AbstractMojo {
     getLog().info(String.format("Set Dagger CLI to %s", this.bin));
 
     Path dest = outputDir.toPath();
-    try (InputStream query =
-            getClass().getClassLoader().getResourceAsStream("introspection/introspection.graphql");
+    try (InputStream query = DaggerCLIUtils.introspectionQuery(getClass());
         OutputStream outputFile = new FileOutputStream(new File(outputDir, "schema.json"))) {
       getLog().info("Querying Dagger CLI for schema");
       InputStream schema = DaggerCLIUtils.query(query, this.bin);

--- a/toolchains/java-sdk-dev/main.dang
+++ b/toolchains/java-sdk-dev/main.dang
@@ -60,45 +60,8 @@ type JavaSdkDev {
   Test the Java SDK
   """
   pub test: Void @check {
-    let resourceProbeScript = [
-      "set -eu",
-      "src='dagger-codegen-maven-plugin/src/main/resources/introspection/introspection.graphql'",
-      "target='dagger-codegen-maven-plugin/target/classes/introspection/introspection.graphql'",
-      "jar='dagger-codegen-maven-plugin/target/dagger-codegen-maven-plugin-0.20.6.jar'",
-      "probe() {",
-      "  if [ -e $src ]; then src_state=$(stat -c 'src exists size=%s inode=%i links=%h mtime=%Y' $src); else src_state='src missing'; fi",
-      "  if [ -e $target ]; then target_state=$(stat -c 'target exists size=%s inode=%i links=%h mtime=%Y' $target); else target_state='target missing'; fi",
-      "  if [ -e $jar ]; then",
-      "    jar_size=$(stat -c '%s' $jar)",
-      "    jar_entries=$(unzip -l $jar 2>/dev/null | awk 'index($4, \"introspection/\")==1 || index($4, \"schemas/\")==1 {printf \"%s,\", $4}' || true)",
-      "    jar_state=jar_exists_size:${jar_size}:entries:${jar_entries}",
-      "  else",
-      "    jar_state='jar missing'",
-      "  fi",
-      "  printf '%s | %s | %s' \"$src_state\" \"$target_state\" \"$jar_state\"",
-      "}",
-      "(",
-      "  last=''",
-      "  while :; do",
-      "    current=$(probe)",
-      "    if [ \"$current\" != \"$last\" ]; then",
-      "      echo \"RESOURCE_PROBE $(date -Iseconds) | $current\"",
-      "      last=\"$current\"",
-      "    fi",
-      "    sleep 0.2",
-      "  done",
-      ") &",
-      "watcher=$!",
-      "status=0",
-      "mvn clean verify -Ddaggerengine.version=local || status=$?",
-      "echo \"RESOURCE_PROBE_FINAL $(date -Iseconds) | $(probe)\"",
-      "kill \"$watcher\" || true",
-      "wait \"$watcher\" 2>/dev/null || true",
-      "exit \"$status\"",
-    ].join("\n")
-
     devContainer
-      .withExec(["sh", "-lc", resourceProbeScript])
+      .withExec(["mvn", "clean", "verify", "-Ddaggerengine.version=local"])
       .sync
 
     null

--- a/toolchains/java-sdk-dev/main.dang
+++ b/toolchains/java-sdk-dev/main.dang
@@ -60,8 +60,45 @@ type JavaSdkDev {
   Test the Java SDK
   """
   pub test: Void @check {
+    let resourceProbeScript = [
+      "set -eu",
+      "src='dagger-codegen-maven-plugin/src/main/resources/introspection/introspection.graphql'",
+      "target='dagger-codegen-maven-plugin/target/classes/introspection/introspection.graphql'",
+      "jar='dagger-codegen-maven-plugin/target/dagger-codegen-maven-plugin-0.20.6.jar'",
+      "probe() {",
+      "  if [ -e $src ]; then src_state=$(stat -c 'src exists size=%s inode=%i links=%h mtime=%Y' $src); else src_state='src missing'; fi",
+      "  if [ -e $target ]; then target_state=$(stat -c 'target exists size=%s inode=%i links=%h mtime=%Y' $target); else target_state='target missing'; fi",
+      "  if [ -e $jar ]; then",
+      "    jar_size=$(stat -c '%s' $jar)",
+      "    jar_entries=$(unzip -l $jar 2>/dev/null | awk 'index($4, \"introspection/\")==1 || index($4, \"schemas/\")==1 {printf \"%s,\", $4}' || true)",
+      "    jar_state=jar_exists_size:${jar_size}:entries:${jar_entries}",
+      "  else",
+      "    jar_state='jar missing'",
+      "  fi",
+      "  printf '%s | %s | %s' \"$src_state\" \"$target_state\" \"$jar_state\"",
+      "}",
+      "(",
+      "  last=''",
+      "  while :; do",
+      "    current=$(probe)",
+      "    if [ \"$current\" != \"$last\" ]; then",
+      "      echo \"RESOURCE_PROBE $(date -Iseconds) | $current\"",
+      "      last=\"$current\"",
+      "    fi",
+      "    sleep 0.2",
+      "  done",
+      ") &",
+      "watcher=$!",
+      "status=0",
+      "mvn clean verify -Ddaggerengine.version=local || status=$?",
+      "echo \"RESOURCE_PROBE_FINAL $(date -Iseconds) | $(probe)\"",
+      "kill \"$watcher\" || true",
+      "wait \"$watcher\" 2>/dev/null || true",
+      "exit \"$status\"",
+    ].join("\n")
+
     devContainer
-      .withExec(["mvn", "clean", "verify", "-Ddaggerengine.version=local"])
+      .withExec(["sh", "-lc", resourceProbeScript])
       .sync
 
     null


### PR DESCRIPTION
## What changed

This PR fixes the remote Git checkout timestamp regression that made native CI's Java SDK checks lose a bundled Maven plugin resource.

Engine/cache behavior:
- keep remote Git checkout mtimes deterministic, but normalize them to Unix second `1` instead of Unix epoch `0`
- add an integration test asserting that a remote Git tree materializes files with mtime `1`

Java SDK diagnostics:
- make the Maven plugin load `introspection/introspection.graphql` through a shared `DaggerCLIUtils.introspectionQuery(...)` helper
- fail early with diagnostics when that bundled resource is missing, including code source, jar entries, `target/classes`, and classloader resource lookup details
- run `dagger query` with `ProcessBuilder` so stderr/stdout, timeout, and non-zero exit failures are surfaced instead of being collapsed into an unclear downstream failure
- update both Java schema/codegen Mojos to use the shared helper

The temporary Maven resource workaround is intentionally not included here. There is no `<overwrite>true</overwrite>` change in the Java SDK POMs.

## Root cause

Native CI started failing after the outer Dagger engine was bumped from `31f3266e` to `7728acf1`. That crossed `45aa29642`, which made remote Git checkout materialization deterministic by setting every checked-out path to epoch mtime.

That interacted badly with Maven Resources Plugin 3.3.1's default `overwrite=false` behavior. In the failing Java SDK checks, `sdk/java/dagger-codegen-maven-plugin/src/main/resources/introspection/introspection.graphql` arrived from the outer engine with `mtime=0`. Maven then skipped the initial copy into `target/classes`, so the built plugin jar contained the `introspection/` directory but not `introspection/introspection.graphql`.

The classloader was not the real cause. It correctly could not find a resource that had never been copied into the plugin jar. The previous Java code also masked this by not checking the null resource stream up front and by hiding useful process output, which is why the original CI symptom looked like an unclear NPE-style failure.

Normalizing to second `1` preserves deterministic Git checkout metadata while avoiding the epoch/missing-destination collision in tools that treat epoch as a sentinel value.

## Validation

- Compared old and new native-CI outer engines before the fix:
  - `31f3266e`: the Java introspection resource had a normal non-zero checkout mtime
  - `7728acf1`: the same resource had `mtime=0`
- Reproduced the Maven behavior locally with the source resource set to `mtime=1` and no `overwrite=true`; Maven copied the file into `target/classes` and the plugin jar included `introspection/introspection.graphql`.
- Built a dev engine from this branch and verified remote Git tree materialization reports `mtime=1`.
- Ran a closer replay through `engine-dev playground` with a dev engine built from this branch, loading `github.com/sipsma/dagger@codex/java-query-error-reporting` as a remote module and running `java-sdk test`; it passed with Maven `BUILD SUCCESS`.
  - trace: https://dagger.cloud/dagger/traces/e18a6bd78e598621fbeb51d7f51da35a

## CI status

The current Java failures on this PR are expected while native CI is still using the pre-fix outer engine. That outer engine materializes the PR workspace before this branch's code can run, so it still writes the Java resource with `mtime=0`.

Once this PR is merged and native CI's outer engine image is bumped to a commit that includes it, the Java checks should no longer hit this missing-resource failure. The replay above verifies the two required pieces together: the fixed outer engine materializes the remote Git workspace with mtime `1`, and the Java SDK test passes without the Maven overwrite workaround.

There is also a current `test-split:test-base` failure on this PR. The trace points at `TestEnvFile/TestSecretFile` expecting `"doodoo"` and receiving `""`; that is separate from this Git timestamp / Java resource issue.
