### PR TITLE
trace: honor frontend flags in replay

### DIFF
--- a/cmd/dagger/trace.go
+++ b/cmd/dagger/trace.go
@@ -38,10 +38,7 @@ func init() {
 func Trace(cmd *cobra.Command, args []string) error {
 	traceID := args[0]
 
-	return Frontend.Run(cmd.Context(), dagui.FrontendOpts{
-		Verbosity: dagui.ShowCompletedVerbosity,
-		NoExit:    true,
-	}, func(ctx context.Context) (cleanups.CleanupF, error) {
+	return Frontend.Run(cmd.Context(), opts, func(ctx context.Context) (cleanups.CleanupF, error) {
 		cloudAuth, err := auth.GetCloudAuth(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cloud auth: %w", err)
@@ -62,7 +59,9 @@ func Trace(cmd *cobra.Command, args []string) error {
 		}
 
 		spanExp := Frontend.SpanExporter()
+		defer spanExp.Shutdown(ctx)
 		logExp := Frontend.LogExporter()
+		defer logExp.Shutdown(ctx)
 
 		noop := func() error { return nil }
 

--- a/cmd/dagger/trace_test.go
+++ b/cmd/dagger/trace_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/dagql/dagui"
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/dagger/util/cleanups"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceUsesGlobalFrontendOpts(t *testing.T) {
+	prevFrontend := Frontend
+	prevOpts := opts
+	t.Cleanup(func() {
+		Frontend = prevFrontend
+		opts = prevOpts
+	})
+
+	opts = dagui.FrontendOpts{
+		Debug:             true,
+		Silent:            true,
+		Verbosity:         dagui.ShowSpammyVerbosity,
+		RevealNoisySpans:  true,
+		ExpandCompleted:   true,
+		OpenWeb:           true,
+		DotOutputFilePath: "trace.dot",
+		DotFocusField:     "focus",
+		DotShowInternal:   true,
+	}
+
+	var gotOpts dagui.FrontendOpts
+	Frontend = &idtui.FrontendMock{
+		RunFunc: func(ctx context.Context, runOpts dagui.FrontendOpts, f func(context.Context) (cleanups.CleanupF, error)) error {
+			gotOpts = runOpts
+			return nil
+		},
+	}
+
+	err := Trace(&cobra.Command{}, []string{"2f123ba77bf7bd2d4db2f70ed20613e8"})
+	require.NoError(t, err)
+
+	require.Equal(t, opts, gotOpts)
+}


### PR DESCRIPTION
## Problem

`dagger trace` replayed recorded progress through the frontend, but it constructed fresh frontend options instead of using the global CLI options. That meant replay ignored verbosity and debug flags such as `-v`, `-vvvv`, and `--debug`.

The replay path also did not shut down the frontend span/log exporters on exit, which could leave the UI open after telemetry finished.

## Fix

Use the global frontend options for trace replay directly, so replay behaves like other commands and honors the normal frontend flags. Also shut down the span and log exporters when replay exits.

## Test

- `dagger --progress=plain call engine-dev test --pkg ./cmd/dagger --run TestTraceUsesGlobalFrontendOpts`
