### PR TITLE
cli: allow testing unreleased builds with --x-release

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -52,16 +52,27 @@ func init() {
 }
 
 func defaultRunnerHost() string {
-	tag := engine.Tag
+	tag := engineVersion(engine.Tag)
 	if tag == "" {
 		// can happen during naive dev builds (so just fallback to something
 		// semi-reasonable)
 		return "container://" + distconsts.EngineContainerName
 	}
+	return runnerHostForEngineVersion(tag)
+}
+
+func engineVersion(tag string) string {
+	if tag == "" {
+		return ""
+	}
 	if os.Getenv(GPUSupportEnv) != "" {
 		tag += "-gpu"
 	}
-	return fmt.Sprintf("image://%s:%s", engine.EngineImageRepo, tag)
+	return tag
+}
+
+func runnerHostForEngineVersion(version string) string {
+	return fmt.Sprintf("image://%s:%s", engine.EngineImageRepo, version)
 }
 
 type runClientCallback func(context.Context, *client.Client) error

--- a/cmd/dagger/exec_nonunix.go
+++ b/cmd/dagger/exec_nonunix.go
@@ -3,7 +3,24 @@
 
 package main
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 func ensureChildProcessesAreKilled(cmd *exec.Cmd) {
+}
+
+func execCLI(binPath string, args, env []string) error {
+	cmd := exec.Command(binPath, args[1:]...)
+	cmd.Args = args
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		} 
+    return err
 }

--- a/cmd/dagger/exec_unix.go
+++ b/cmd/dagger/exec_unix.go
@@ -17,3 +17,7 @@ func ensureChildProcessesAreKilled(cmd *exec.Cmd) {
 	}
 	cmd.WaitDelay = waitDelay
 }
+
+func execCLI(binPath string, args, env []string) error {
+	return syscall.Exec(binPath, args, env)
+}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"iter"
 	"maps"
+	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"runtime/pprof"
@@ -35,10 +37,12 @@ import (
 	"golang.org/x/term"
 	"mvdan.cc/sh/v3/interp"
 
+	"dagger.io/dagger/engineconn"
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/client/drivers"
 	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
@@ -69,6 +73,7 @@ var (
 	interactiveCommandParsed []string
 	web                      bool
 	noExit                   bool
+	xRelease                 string
 	_, useCloudEngine        = os.LookupEnv("DAGGER_CLOUD_ENGINE")
 	enableScaleOut           bool
 
@@ -83,6 +88,10 @@ var (
 
 	Frontend idtui.Frontend
 )
+
+const daggerXReleaseEnv = "DAGGER_X_RELEASE"
+
+var githubCommitAPI = "https://api.github.com/repos/dagger/dagger/commits/"
 
 func init() {
 	// allow user explicitly setting progress via env, but default it to "auto"
@@ -346,6 +355,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")
 	flags.BoolVarP(&noExit, "no-exit", "E", false, "Leave the TUI running after completion")
 	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
+	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
 
 	flags.StringVar(&dotOutputFilePath, "dot-output", "", "If set, write the calls made during execution to a dot file at the given path before exiting")
 	flags.StringVar(&dotFocusField, "dot-focus-field", "", "In dot output, filter out vertices that aren't this field or descendents of this field")
@@ -382,7 +392,124 @@ func disableFlagsInUseLine(cmd *cobra.Command) {
 	}
 }
 
-func parseGlobalFlags() {
+func execXRelease(ctx context.Context) error {
+	ref := strings.TrimSpace(xRelease)
+	commit, resolved, err := resolveXReleaseRef(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("resolve experimental release %q: %w", ref, err)
+	}
+
+	downloader := engineconn.CLIDownloader{
+		Ref:       commit,
+		LogOutput: stderr,
+	}
+	binPath, err := downloader.Download(ctx)
+	if err != nil {
+		return fmt.Errorf("download experimental release CLI: %w", err)
+	}
+
+	msg := fmt.Sprintf("running build from %s", ref)
+	if resolved {
+		msg += fmt.Sprintf("; resolved to %s; pin with %s=%s or --x-release=%s", commit, daggerXReleaseEnv, commit, commit)
+	}
+	fmt.Fprintln(stderr, xReleaseLogLine(msg))
+
+	if shouldCleanupOldEngines() {
+		_ = drivers.CleanupOldEngines(ctx, []string{
+			engineVersion(engine.Tag),
+			engineVersion(commit),
+		})
+	}
+
+	args := xReleaseProcessArgs(os.Args[1:])
+	env := xReleaseProcessEnv(os.Environ())
+	execArgs := append([]string{binPath}, args...)
+	if err := execCLI(binPath, execArgs, env); err != nil {
+		return fmt.Errorf("exec experimental release CLI: %w", err)
+	}
+	return nil
+}
+
+func resolveXReleaseRef(ctx context.Context, ref string) (string, bool, error) {
+	if ref == "" {
+		return "", false, fmt.Errorf("ref must not be empty")
+	}
+	if len(ref) == 40 {
+		return strings.ToLower(ref), false, nil
+	}
+
+	commitURL := githubCommitAPI + url.PathEscape(ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, commitURL, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("create GitHub commit request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve git ref from GitHub: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", false, fmt.Errorf("resolve git ref from GitHub: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&commit); err != nil {
+		return "", false, fmt.Errorf("decode GitHub commit response: %w", err)
+	}
+	return strings.ToLower(commit.SHA), true, nil
+}
+
+func xReleaseProcessArgs(args []string) []string {
+	rewritten := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return append(rewritten, args[i:]...)
+		}
+		switch {
+		case arg == "--x-release":
+			if i+1 < len(args) {
+				i++
+			}
+		case strings.HasPrefix(arg, "--x-release="):
+		default:
+			rewritten = append(rewritten, arg)
+		}
+	}
+	return rewritten
+}
+
+func xReleaseProcessEnv(environ []string) []string {
+	env := make([]string, 0, len(environ)+1)
+	hasLeaveOldEngine := false
+	for _, kv := range environ {
+		key, _, _ := strings.Cut(kv, "=")
+		if key == daggerXReleaseEnv {
+			continue
+		}
+		if key == "DAGGER_LEAVE_OLD_ENGINE" {
+			hasLeaveOldEngine = true
+		}
+		env = append(env, kv)
+	}
+	if !hasLeaveOldEngine {
+		env = append(env, "DAGGER_LEAVE_OLD_ENGINE=1")
+	}
+	return env
+}
+
+func shouldCleanupOldEngines() bool {
+	val, ok := os.LookupEnv("DAGGER_LEAVE_OLD_ENGINE")
+	if !ok {
+		return true
+	}
+	leaveOldEngine, _ := strconv.ParseBool(val)
+	return !leaveOldEngine
+}
+
+func parseGlobalFlags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("global", pflag.ContinueOnError)
 	flags.Usage = func() {}
 	flags.ParseErrorsAllowlist.UnknownFlags = true
@@ -391,6 +518,19 @@ func parseGlobalFlags() {
 		fmt.Fprintln(stderr, err)
 		os.Exit(1)
 	}
+	if !flags.Changed("x-release") {
+		xRelease = os.Getenv(daggerXReleaseEnv)
+	}
+	xRelease = strings.TrimSpace(xRelease)
+	return flags
+}
+
+func xReleaseLogLine(msg string) string {
+	line := "[dagger x-release] " + msg
+	if stderrIsTTY {
+		return idtui.NewOutput(stderr).String(line).Bold().Foreground(termenv.ANSIYellow).String()
+	}
+	return line
 }
 
 func Tracer() trace.Tracer {
@@ -425,6 +565,21 @@ var opts dagui.FrontendOpts
 
 func main() {
 	parseGlobalFlags()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	exitWithCode := func(code int) {
+		stop()
+		os.Exit(code)
+	}
+	if xRelease != "" {
+		if err := execXRelease(ctx); err != nil {
+			fmt.Fprintln(stderr, rootCmd.ErrPrefix(), err)
+			exitWithCode(1)
+		}
+		fmt.Fprintln(stderr, rootCmd.ErrPrefix(), "internal error: experimental release exec returned without replacing the current process")
+		exitWithCode(1)
+	}
+
 	opts.Verbosity += dagui.ShowCompletedVerbosity // keep progress by default
 	opts.Verbosity += verbose                      // raise verbosity with -v
 	opts.Verbosity -= quiet                        // lower verbosity with -q
@@ -459,7 +614,7 @@ func main() {
 	case "tty":
 		if !hasTTY {
 			fmt.Fprintf(stderr, "no tty available for progress %q\n", progress)
-			os.Exit(1)
+			exitWithCode(1)
 		}
 		Frontend = idtui.NewPretty(stderr)
 	case "dots":
@@ -470,43 +625,41 @@ func main() {
 		Frontend = idtui.NewReporter(stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown progress type %q\n", progress)
-		os.Exit(1)
+		exitWithCode(1)
 	}
 
 	// Parse the interactive command to support shell-like syntax
 	parsedCommand, err := shlex.Split(interactiveCommand)
 	if err != nil {
 		fmt.Fprintf(stderr, "cannot parse interactive command: %s", err)
-		os.Exit(1)
+		exitWithCode(1)
 	}
 	interactiveCommandParsed = parsedCommand
 
 	installGlobalFlags(rootCmd.PersistentFlags())
 
-	ctx := context.Background()
 	ctx = slog.ContextWithColorMode(ctx, termenv.EnvNoColor())
 	ctx = slog.ContextWithDebugMode(ctx, debugFlag)
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
-		stop()
 		var exit idtui.ExitError
 		switch {
 		case errors.As(err, &exit):
-			os.Exit(exit.Code())
+			exitWithCode(exit.Code())
 		case errors.Is(err, idtui.ErrShellExited):
-			os.Exit(0)
+			exitWithCode(0)
 		case errors.Is(err, context.Canceled) || errors.Is(err, idtui.ErrInterrupted):
-			os.Exit(2)
+			exitWithCode(2)
 		default:
 			fmt.Fprintln(stderr, rootCmd.ErrPrefix(), err)
 			var es interp.ExitStatus
 			if errors.As(err, &es) {
-				os.Exit(int(es))
+				exitWithCode(int(es))
 			}
-			os.Exit(1)
+			exitWithCode(1)
 		}
 	}
+	stop()
 }
 
 func NormalizeWorkdir(workdir string) (string, error) {

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -32,6 +32,7 @@ dagger [options] [subcommand | file...]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -86,6 +87,7 @@ dagger call [options]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -134,6 +136,7 @@ dagger config -m github.com/dagger/hello-dagger
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -169,6 +172,7 @@ dagger core [options]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -232,6 +236,7 @@ dagger develop [options]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -276,6 +281,7 @@ dagger functions [options] [function]...
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -341,6 +347,7 @@ dagger init --sdk=go
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -389,6 +396,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -413,6 +421,7 @@ Manage workspace lockfiles
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -448,6 +457,7 @@ dagger lock update
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -476,6 +486,7 @@ dagger login [options] [org]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -504,6 +515,7 @@ dagger logout
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -571,6 +583,7 @@ EOF
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -632,6 +645,7 @@ dagger run python main.py
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -656,6 +670,7 @@ Manage toolchains
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -708,6 +723,7 @@ dagger toolchain install github.com/dagger/dagger/toolchains/go
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -754,6 +770,7 @@ dagger toolchain list
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -801,6 +818,7 @@ dagger toolchain uninstall mytoolchain
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -848,6 +866,7 @@ dagger toolchain update
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -895,6 +914,7 @@ dagger uninstall hello
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -947,6 +967,7 @@ dagger update [options] [<DEPENDENCY>...]
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -981,6 +1002,7 @@ dagger version
   -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
   -w, --web                          Open trace URL in a web browser
+      --x-release string             Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO

--- a/engine/client/drivers/container.go
+++ b/engine/client/drivers/container.go
@@ -265,7 +265,7 @@ func (d *imageDriver) create(ctx context.Context, opts containerCreateOpts, dopt
 			if err := d.backend.ContainerStart(ctx, leftoverEngine); err != nil {
 				return nil, fmt.Errorf("failed to start container: %w", err)
 			}
-			d.garbageCollectEngines(ctx, opts.cleanup, slices.Delete(leftoverEngines, i, i+1))
+			d.garbageCollectEngines(ctx, opts.cleanup, nil, slices.Delete(leftoverEngines, i, i+1))
 			return &url.URL{Host: containerName}, nil
 		}
 	}
@@ -333,25 +333,54 @@ func (d *imageDriver) create(ctx context.Context, opts containerCreateOpts, dopt
 	// garbage collect any other containers with the same name pattern, which
 	// we assume to be leftover from previous runs of the engine using an older
 	// version
-	d.garbageCollectEngines(ctx, opts.cleanup, leftoverEngines)
+	d.garbageCollectEngines(ctx, opts.cleanup, nil, leftoverEngines)
 
 	return &url.URL{Host: containerName}, nil
 }
 
-func (d *imageDriver) garbageCollectEngines(ctx context.Context, cleanup bool, engines []string) {
+func (d *imageDriver) garbageCollectEngines(ctx context.Context, cleanup bool, preserveNames, engines []string) {
 	if !cleanup {
 		return
 	}
-	for _, engine := range engines {
-		if engine == "" {
+	for _, engineName := range engines {
+		if engineName == "" || slices.Contains(preserveNames, engineName) {
 			continue
 		}
-		if err := d.backend.ContainerRemove(ctx, engine); err != nil {
+		if err := d.backend.ContainerRemove(ctx, engineName); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
 		}
 	}
+}
+
+func engineNames(versions []string) []string {
+	names := make([]string, 0, len(versions))
+	for _, version := range versions {
+		if version != "" {
+			names = append(names, containerNamePrefix+version)
+		}
+	}
+	return names
+}
+
+// CleanupOldEngines removes local engine containers while preserving the
+// versions that are expected to be used by the current command.
+func CleanupOldEngines(ctx context.Context, preserveVersions []string) error {
+	driver, err := GetDriver(ctx, "image")
+	if err != nil {
+		return err
+	}
+	imageDriver, ok := driver.(*imageDriver)
+	if !ok {
+		return nil
+	}
+	leftoverEngines, err := imageDriver.collectLeftoverEngines(ctx)
+	if err != nil {
+		return err
+	}
+	imageDriver.garbageCollectEngines(ctx, true, engineNames(preserveVersions), leftoverEngines)
+	return nil
 }
 
 func (d *imageDriver) collectLeftoverEngines(ctx context.Context, additionalNames ...string) ([]string, error) {

--- a/sdk/go/engineconn/cli.go
+++ b/sdk/go/engineconn/cli.go
@@ -35,6 +35,13 @@ var (
 	OverrideChecksumsURL  string
 )
 
+type CLIDownloader struct {
+	Ref        string
+	Release    bool
+	LogOutput  io.Writer
+	CleanupOld bool
+}
+
 func FromLocalCLI(ctx context.Context, cfg *Config) (EngineConn, bool, error) {
 	binPath, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_CLI_BIN")
 	if !ok {
@@ -57,107 +64,140 @@ func FromLocalCLI(ctx context.Context, cfg *Config) (EngineConn, bool, error) {
 }
 
 func FromDownloadedCLI(ctx context.Context, cfg *Config) (EngineConn, error) {
-	cacheDir := filepath.Join(xdg.CacheHome, "dagger")
-	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+	binPath, err := (CLIDownloader{
+		Ref:        CLIVersion,
+		Release:    true,
+		LogOutput:  cfg.LogOutput,
+		CleanupOld: true,
+	}).Download(ctx)
+	if err != nil {
 		return nil, err
 	}
 
-	binName := daggerCLIBinPrefix + CLIVersion
+	return startCLISession(ctx, binPath, cfg)
+}
+
+func (d CLIDownloader) Download(ctx context.Context) (string, error) {
+	if d.Ref == "" {
+		return "", fmt.Errorf("CLI download ref must not be empty")
+	}
+
+	cacheDir := filepath.Join(xdg.CacheHome, "dagger")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return "", err
+	}
+
+	binName := daggerCLIBinPrefix + d.Ref
 	if runtime.GOOS == windowsPlatform {
 		binName += ".exe"
 	}
 	binPath := filepath.Join(cacheDir, binName)
 
 	if _, err := os.Stat(binPath); os.IsNotExist(err) {
-		if cfg.LogOutput != nil {
-			fmt.Fprintf(cfg.LogOutput, "Downloading CLI... ")
+		if d.LogOutput != nil {
+			fmt.Fprintf(d.LogOutput, "Downloading CLI... ")
 		}
 
 		tmpbin, err := os.CreateTemp(cacheDir, "temp-"+binName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create temp file: %w", err)
+			return "", fmt.Errorf("failed to create temp file: %w", err)
 		}
 		defer tmpbin.Close()
 		defer os.Remove(tmpbin.Name())
 
-		// extract the CLI from the archive and verify it has the expected checksum
-		expected, err := expectedChecksum(ctx)
-		if err != nil {
-			return nil, err
+		var expected string
+		if d.Release {
+			expected, err = d.expectedChecksum(ctx)
+			if err != nil {
+				return "", err
+			}
 		}
 
-		actual, err := extractCLI(ctx, tmpbin)
+		actual, err := d.extract(ctx, tmpbin)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
-		if actual != expected {
-			return nil, fmt.Errorf("checksum mismatch: expected %s, got %s", expected, actual)
+		if d.Release {
+			if actual != expected {
+				return "", fmt.Errorf("checksum mismatch: expected %s, got %s", expected, actual)
+			}
 		}
 
 		// make the temp file executable and move it to its final name
 		if err := tmpbin.Chmod(0o700); err != nil {
-			return nil, err
+			return "", err
 		}
 
 		if err := tmpbin.Close(); err != nil {
-			return nil, fmt.Errorf("failed to close temporary file: %w", err)
+			return "", fmt.Errorf("failed to close temporary file: %w", err)
 		}
 
 		if err := os.Rename(tmpbin.Name(), binPath); err != nil {
-			return nil, fmt.Errorf("failed to rename %q to %q: %w", tmpbin.Name(), binPath, err)
+			return "", fmt.Errorf("failed to rename %q to %q: %w", tmpbin.Name(), binPath, err)
 		}
 
-		if cfg.LogOutput != nil {
-			fmt.Fprintln(cfg.LogOutput, "OK!")
+		if d.LogOutput != nil {
+			fmt.Fprintln(d.LogOutput, "OK!")
 		}
 
 		// cleanup any old CLI binaries
-		entries, err := os.ReadDir(cacheDir)
-		if err != nil {
-			if cfg.LogOutput != nil {
-				fmt.Fprintf(cfg.LogOutput, "failed to list cache dir: %v", err)
-			}
-		} else {
-			for _, entry := range entries {
-				if entry.Name() == binName {
-					continue
-				}
-				if strings.HasPrefix(entry.Name(), daggerCLIBinPrefix) {
-					if err := os.Remove(filepath.Join(cacheDir, entry.Name())); err != nil {
-						if cfg.LogOutput != nil {
-							fmt.Fprintf(cfg.LogOutput, "failed to remove old dagger bin: %v", err)
-						}
-					}
+		if d.CleanupOld {
+			cleanupOldCLIs(cacheDir, binName, d.LogOutput)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("failed to stat %q: %w", binPath, err)
+	}
+
+	return binPath, nil
+}
+
+func cleanupOldCLIs(cacheDir, currentBinName string, logOutput io.Writer) {
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if logOutput != nil {
+			fmt.Fprintf(logOutput, "failed to list cache dir: %v", err)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if entry.Name() == currentBinName {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), daggerCLIBinPrefix) {
+			if err := os.Remove(filepath.Join(cacheDir, entry.Name())); err != nil {
+				if logOutput != nil {
+					fmt.Fprintf(logOutput, "failed to remove old dagger bin: %v", err)
 				}
 			}
 		}
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to stat %q: %w", binPath, err)
 	}
-
-	return startCLISession(ctx, binPath, cfg)
 }
 
 // returns a map of CLI archive name -> checksum for that archive
-func checksumMap(ctx context.Context) (map[string]string, error) {
+func (d CLIDownloader) checksumMap(ctx context.Context) (map[string]string, error) {
+	if !d.Release {
+		return nil, fmt.Errorf("checksums are only available for release CLI downloads")
+	}
+
 	checksums := make(map[string]string)
+	checksumsURL := d.checksumsURL()
 
 	checksumFileContents := bytes.NewBuffer(nil)
-	checksumReq, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumsURL(), nil)
+	checksumReq, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create checksums request: %w", err)
 	}
 	resp, err := http.DefaultClient.Do(checksumReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download checksums from %s: %w", checksumsURL(), err)
+		return nil, fmt.Errorf("failed to download checksums from %s: %w", checksumsURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download checksums from %s: %s", checksumsURL(), resp.Status)
+		return nil, fmt.Errorf("failed to download checksums from %s: %s", checksumsURL, resp.Status)
 	}
 	if _, err := io.Copy(checksumFileContents, resp.Body); err != nil {
-		return nil, fmt.Errorf("failed to download checksums from %s: %w", checksumsURL(), err)
+		return nil, fmt.Errorf("failed to download checksums from %s: %w", checksumsURL, err)
 	}
 
 	scanner := bufio.NewScanner(checksumFileContents)
@@ -169,27 +209,32 @@ func checksumMap(ctx context.Context) (map[string]string, error) {
 		}
 		checksums[parts[1]] = parts[0]
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan checksums from %s: %w", checksumsURL, err)
+	}
 
 	return checksums, nil
 }
 
-func expectedChecksum(ctx context.Context) (string, error) {
-	checksums, err := checksumMap(ctx)
+func (d CLIDownloader) expectedChecksum(ctx context.Context) (string, error) {
+	checksums, err := d.checksumMap(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	expected, ok := checksums[defaultCLIArchiveName()]
+	archiveName := d.archiveName()
+	expected, ok := checksums[archiveName]
 	if !ok {
-		return "", fmt.Errorf("no checksum for %s", defaultCLIArchiveName())
+		return "", fmt.Errorf("no checksum for %s", archiveName)
 	}
 	return expected, nil
 }
 
 // Download the CLI archive and extract the CLI from it into the provided dest.
 // Returns the sha256 hash of the whole archive as read during download.
-func extractCLI(ctx context.Context, dest io.Writer) (string, error) {
-	archiveReq, err := http.NewRequestWithContext(ctx, http.MethodGet, cliArchiveURL(), nil)
+func (d CLIDownloader) extract(ctx context.Context, dest io.Writer) (string, error) {
+	archiveURL := d.archiveURL()
+	archiveReq, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create archive request: %w", err)
 	}
@@ -199,7 +244,7 @@ func extractCLI(ctx context.Context, dest io.Writer) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download CLI archive from %s: %s", cliArchiveURL(), resp.Status)
+		return "", fmt.Errorf("failed to download CLI archive from %s: %s", archiveURL, resp.Status)
 	}
 
 	// the body is either a tar.gz file or (on windows) a zipfile, unpack it and extract the dagger binary
@@ -287,43 +332,62 @@ func extractZip(src io.Reader, dest io.Writer) error {
 	return nil
 }
 
-func defaultCLIArchiveName() string {
-	if OverrideCLIArchiveURL != "" {
-		url, err := url.Parse(OverrideCLIArchiveURL)
-		if err != nil {
-			panic(err)
-		}
-		return filepath.Base(url.Path)
-	}
+func cliArchiveName(version string) string {
 	ext := "tar.gz"
 	if runtime.GOOS == windowsPlatform {
 		ext = "zip"
 	}
-	return fmt.Sprintf("dagger_v%s_%s_%s.%s",
-		CLIVersion,
+	return fmt.Sprintf("dagger_%s_%s_%s.%s",
+		version,
 		runtime.GOOS,
 		runtime.GOARCH,
 		ext,
 	)
 }
 
-func cliArchiveURL() string {
+func (d CLIDownloader) archiveName() string {
+	if OverrideCLIArchiveURL != "" {
+		return archiveNameFromURL(OverrideCLIArchiveURL)
+	}
+	ref := d.Ref
+	if d.Release {
+		ref = "v" + strings.TrimPrefix(ref, "v")
+	}
+	return cliArchiveName(ref)
+}
+
+func archiveNameFromURL(rawURL string) string {
+	url, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Base(url.Path)
+}
+
+func (d CLIDownloader) archiveURL() string {
 	if OverrideCLIArchiveURL != "" {
 		return OverrideCLIArchiveURL
 	}
-	return fmt.Sprintf("https://%s/dagger/releases/%s/%s",
+	if d.Release {
+		return fmt.Sprintf("https://%s/dagger/releases/%s/%s",
+			defaultCLIHost,
+			strings.TrimPrefix(d.Ref, "v"),
+			d.archiveName(),
+		)
+	}
+	return fmt.Sprintf("https://%s/dagger/main/%s/%s",
 		defaultCLIHost,
-		CLIVersion,
-		defaultCLIArchiveName(),
+		d.Ref,
+		d.archiveName(),
 	)
 }
 
-func checksumsURL() string {
+func (d CLIDownloader) checksumsURL() string {
 	if OverrideChecksumsURL != "" {
 		return OverrideChecksumsURL
 	}
 	return fmt.Sprintf("https://%s/dagger/releases/%s/checksums.txt",
 		defaultCLIHost,
-		CLIVersion,
+		strings.TrimPrefix(d.Ref, "v"),
 	)
 }


### PR DESCRIPTION
Add an experimental CLI selection path for testing Dagger builds from a github.com/dagger/dagger git ref.

Users can pass either `--x-release=<ref>` or `DAGGER_X_RELEASE=<ref>` to run a specific unreleased CLI build. Flags take precedence over the environment when both are present. If the ref is not already a full commit SHA, the CLI resolves it through GitHub, prints the resolved SHA, and tells the user how to pin that exact build for repeatable testing.

The selected CLI is downloaded and re-execed before normal command execution, so the requested build handles the command from the beginning. To avoid recursively re-execing the same experimental release, the child process always clears both activation sources: `--x-release` is rewritten in argv and `DAGGER_X_RELEASE` is cleared in the environment.

This keeps `_EXPERIMENTAL_DAGGER_CLI_BIN` orthogonal. That existing escape hatch continues to be handled by the engine connection code; `x-release` simply runs earlier and therefore takes precedence when explicitly requested.

The CLI download path is refactored into a single `engineconn.CLIDownloader` that can fetch either released CLIs or git-SHA-addressed main artifacts. Release downloads keep their existing checksum verification against `checksums.txt`. Experimental downloads use the main artifact URL for the resolved commit SHA and skip checksum-map lookup, since non-release builds are addressed directly by git SHA rather than by a release checksum file.

When `dagger --x-release` reexecs into a downloaded CLI, the second CLI may
start its own engine and run normal old-engine cleanup. That is useful in
general, but dangerous for this flow: the x-release CLI must not accidentally
remove the engine associated with the original requester CLI while it is taking
over execution.
    
Before exec, the requester CLI now performs the cleanup itself when
`DAGGER_LEAVE_OLD_ENGINE` is not set to a truthy value. That cleanup preserves
both the requester engine version and the requested x-release engine version, so
users still get the normal "do not leave old engines around" behavior without
deleting either engine needed by the handoff.
    
The reexec environment then sets `DAGGER_LEAVE_OLD_ENGINE=1` only when the user
did not specify it. This makes older or downloaded x-release CLIs avoid their
own cleanup pass by default, while still respecting an explicit user choice such
as `DAGGER_LEAVE_OLD_ENGINE=0`.

Fixes #12996