### PR TITLE
fixes issue where user defaults are incorrectly expanded

### DIFF
--- a/core/envfile.go
+++ b/core/envfile.go
@@ -141,7 +141,8 @@ func (ef *EnvFile) variables(ctx context.Context, allowUnboundVariables bool) (v
 //	TOKEN=topsecret
 //	NAME=hello
 func (ef *EnvFile) Namespace(ctx context.Context, prefix string) (*EnvFile, error) {
-	vars, err := ef.Variables(ctx, false)
+	// use raw variables here given that they'll get expanded later when used
+	vars, err := ef.Variables(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("Evaluate env file: %w", err)
 	}

--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -739,6 +739,18 @@ DEFAULTS_MESSAGE_NAME=monde
 			"bonjour, monde!",
 			nil,
 		},
+		{
+			"preserve quotes",
+			".env",
+			`
+DEFAULTS_GREETING='{"foo":"bar"}'
+`,
+			"",
+			[]string{"dagger", "-m", "./defaults", "call", "greeting"},
+			dagger.ReturnTypeSuccess,
+			`{"foo":"bar"}`,
+			nil,
+		},
 	} {
 		tc := tc
 		t.Run(tc.description, func(ctx context.Context, t *testctx.T) {

--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -751,6 +751,18 @@ DEFAULTS_GREETING='{"foo":"bar"}'
 			`{"foo":"bar"}`,
 			nil,
 		},
+		{
+			"preserve quotes without namespace",
+			"./defaults/.env",
+			`
+GREETING='{"hello":"world"}'
+`,
+			"defaults",
+			[]string{"dagger", "call", "greeting"},
+			dagger.ReturnTypeSuccess,
+			`{"hello":"world"}`,
+			nil,
+		},
 	} {
 		tc := tc
 		t.Run(tc.description, func(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
avoids double expanding envfile values when using a Namespace.

fixes #12855
closes #12014