### PR TITLE
core: treat private cache sharing as locked

### DIFF
--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -478,7 +478,7 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 			continue
 		}
 		cacheSelf := ctrMount.CacheSource.Volume.Self()
-		if cacheSelf.Sharing != CacheSharingModeLocked {
+		if !cacheSharingModeLocksWrites(cacheSelf.Sharing) {
 			continue
 		}
 		payload, err := cacheSelf.EncodePersistedObject(ctx, nil)
@@ -504,6 +504,11 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 			locker.Unlock(lockKeys[i])
 		}
 	}, nil
+}
+
+func cacheSharingModeLocksWrites(mode CacheSharingMode) bool {
+	// Stop-gap: PRIVATE is implemented with the same serialized writes as LOCKED.
+	return mode == CacheSharingModeLocked || mode == CacheSharingModePrivate
 }
 
 func (plan *materializedExecPlan) releaseActives(ctx context.Context) error {

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 
 	"github.com/dagger/dagger/core"
@@ -60,14 +59,6 @@ func (s *cacheSchema) cacheVolumeCacheKey(
 		}
 		args.Namespace = namespaceKey
 		if err := req.SetArgInput(ctx, "namespace", dagql.NewString(namespaceKey), false); err != nil {
-			return err
-		}
-	}
-
-	if args.Sharing == core.CacheSharingModePrivate {
-		// For now, PRIVATE means "always unique cache volume" to avoid
-		// surprising cross-call sharing behavior.
-		if err := req.SetArgInput(ctx, "privateNonce", dagql.NewString(rand.Text()), false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Remove the private cache nonce so PRIVATE cache volumes keep a stable cache key. As a stop-gap, serialize writes for PRIVATE caches the same way as LOCKED caches so behavior remains correct while avoiding the performance regression from always-unique cache volumes.

Stopgap for #13060