### PR TITLE
fix(sdk/python): make static annotation analysis alias-aware

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -80,7 +80,11 @@ source-include = ["tests/**", "docs/**", "LICENSE"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]
-addopts = ["--import-mode=importlib"]
+addopts = [
+    "--import-mode=importlib",
+    # Show Hypothesis example counts for generated module-source tests.
+    "--hypothesis-show-statistics",
+]
 markers = [
     "slow: mark test as slow (integration)",
     "provision: mark provisioning tests",

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -7,6 +7,7 @@ classes, functions, and fields for Dagger module registration.
 from __future__ import annotations
 
 import ast
+import copy
 import json
 import logging
 from pathlib import Path
@@ -108,6 +109,141 @@ def _parse_docstring_deprecated(raw_doc: str) -> tuple[str | None, str | None]:
     # Get the doc portion before the deprecated directive
     doc_part = raw_doc[: match.start()].strip()
     return doc_part or None, deprecated_msg or ""
+
+
+class _AliasExpander(ast.NodeTransformer):
+    """Expand module-level aliases inside type positions of an annotation.
+
+    Sister to ``ModuleParser._expand_alias``. The transformer walks an
+    annotation as a type expression, replacing each ``Name`` that resolves to
+    a known type alias with the alias's right-hand side. ``Annotated`` is the
+    important boundary: only its first argument is a type. Metadata arguments
+    such as ``Name("Alias")`` or ``DefaultPath(".")`` are value positions and
+    must not be alias-expanded.
+
+    String forward references are parsed only while walking those type
+    positions, so ``"Alias"``, ``"Optional[Alias]"``, and nested quoted
+    references still resolve, without rewriting metadata string literals that
+    merely happen to match an alias name.
+
+    Cross-file aliases (``from .types import Source``) are followed by
+    switching ``current_file`` while expanding inside the imported alias's
+    right-hand side, so chained foreign aliases resolve correctly. A
+    per-(file, name) seen-set prevents infinite recursion on cycles.
+    """
+
+    def __init__(
+        self,
+        aliases_by_file: dict[Path, dict[str, ast.expr]],
+        origins_by_file: dict[Path, dict[str, Path]],
+        current_file: Path,
+    ):
+        super().__init__()
+        self.aliases_by_file = aliases_by_file
+        self.origins_by_file = origins_by_file
+        self.current_file = current_file
+        self.seen: set[tuple[Path, str]] = set()
+
+    def visit_Name(self, node: ast.Name) -> ast.expr:
+        return self._expand_name(node.id, node)
+
+    def visit_Call(self, node: ast.Call) -> ast.expr:
+        # Calls in supported annotations are Annotated metadata values
+        # (Doc(...), Name(...), Ignore(...), etc.), not type expressions.
+        return node
+
+    def visit_Subscript(self, node: ast.Subscript) -> ast.expr:
+        base_name = self._subscript_base_name(node)
+        if base_name == "Annotated":
+            self._visit_annotated_base(node)
+            return node
+        if base_name == "Literal":
+            # Literal[...] arguments are values rather than type positions.
+            # Dagger rejects Literal later; keep the original expression intact.
+            return node
+
+        node.value = self.visit(node.value)
+        node.slice = self.visit(node.slice)  # type: ignore[assignment]
+        return node
+
+    @staticmethod
+    def _subscript_base_name(node: ast.Subscript) -> str | None:
+        value = node.value
+        if isinstance(value, ast.Name):
+            return value.id
+        if isinstance(value, ast.Attribute):
+            return value.attr
+        return None
+
+    def _visit_annotated_base(self, node: ast.Subscript) -> None:
+        slice_node = node.slice
+        if isinstance(slice_node, ast.Tuple):
+            if slice_node.elts:
+                slice_node.elts[0] = self.visit(slice_node.elts[0])
+            return
+        if isinstance(slice_node, ast.Index):
+            value = slice_node.value  # type: ignore[attr-defined]
+            if isinstance(value, ast.Tuple):
+                if value.elts:
+                    value.elts[0] = self.visit(value.elts[0])
+                return
+            slice_node.value = self.visit(value)  # type: ignore[attr-defined]
+            return
+        node.slice = self.visit(slice_node)  # type: ignore[assignment]
+
+    def _expand_name(self, name: str, original: ast.expr) -> ast.expr:
+        target = self._alias_target(name)
+        if target is None:
+            return original
+
+        origin, value = target
+        key = (origin, name)
+        if key in self.seen:
+            return original
+
+        self.seen.add(key)
+        saved_file = self.current_file
+        self.current_file = origin
+        try:
+            expanded = self.visit(copy.deepcopy(value))
+            return ast.copy_location(expanded, original)
+        finally:
+            self.current_file = saved_file
+            self.seen.discard(key)
+
+    def _alias_target(self, name: str) -> tuple[Path, ast.expr] | None:
+        local_aliases = self.aliases_by_file.get(self.current_file, {})
+        if name in local_aliases:
+            return self.current_file, local_aliases[name]
+
+        origin = self.origins_by_file.get(self.current_file, {}).get(name)
+        if origin is not None:
+            origin_aliases = self.aliases_by_file.get(origin, {})
+            if name in origin_aliases:
+                return origin, origin_aliases[name]
+
+        return None
+
+    def visit_Constant(self, node: ast.Constant) -> ast.expr:
+        # String forward references — re-parse the string, recursively
+        # expand any aliases inside it, then return the expanded AST
+        # directly (not re-wrapped in a Constant). The resolver walks
+        # arbitrary AST nodes natively; round-tripping through
+        # ast.unparse + Constant would force the resolver to parse the
+        # string again as a single name, which fails for compound
+        # expressions like ``Optional[str]``.
+        #
+        # Non-string Constants (None, True, numbers used in Literal[…])
+        # pass through untouched.
+        if not isinstance(node.value, str):
+            return node
+        try:
+            inner = ast.parse(node.value, mode="eval").body
+        except SyntaxError:
+            return node
+        expanded = self.visit(inner)
+        ast.copy_location(expanded, node)
+        return expanded
 
 
 class ModuleParser:
@@ -528,7 +664,7 @@ class ModuleParser:
     def _looks_like_type_expr(self, node: ast.expr) -> bool:
         """Return True when ``node`` looks like a type expression.
 
-        We restrict alias expansion to RHS shapes that can plausibly be a
+        We restrict alias expansion to right-hand-side shapes that can plausibly be a
         type — ``Annotated[...]``, generics, ``T | None``, attribute access,
         and bare names — so plain string/number constants stay out of the
         type-resolution path.
@@ -542,64 +678,44 @@ class ModuleParser:
         annotation: ast.expr,
         file_path: Path,
     ) -> ast.expr:
-        """Expand a module-level type alias to its underlying expression.
+        """Expand every module-level type alias anywhere in the annotation.
 
-        Walks chained aliases (``B = A``, ``A = dagger.Directory``) and
-        protects against cycles by tracking the names already seen. Also
-        follows aliases across files — when a name was imported via
-        ``from .types import Source``, expansion continues using
-        ``types.py``'s alias map so the foreign file's
-        ``Source = Annotated[...]`` is honored.
+        Walks the annotation AST via ``_AliasExpander`` and substitutes each
+        type-position ``Name`` that resolves to a known alias with the alias's
+        right-hand side. Chained aliases (``B = A``, ``A = dagger.Directory``)
+        collapse to their final form, and cross-file aliases imported via
+        ``from .types import Source`` are followed by switching the active file
+        context while expanding the foreign alias body.
 
-        If the annotation isn't a known alias (or expansion hits a cycle),
-        returns the most recently expanded node — which may be the
-        original input.
+        The traversal deliberately stops at value positions inside annotations,
+        especially ``Annotated`` metadata arguments, so ``Name("Alias")`` keeps
+        the literal API name even when ``Alias`` is also a type alias.
+
+        - ``Alias | None`` (BinOp.left/right) — PR #13149's symptom
+        - ``Optional[Alias]``, ``list[Alias]``, ``Annotated[Alias, …]``
+          (only the first ``Annotated`` argument is a type position)
+        - ``def f(x: "Alias")`` and forward refs nested inside other
+          types (Constant value when the constant is a string —
+          re-parsed and recursively expanded by ``visit_Constant``)
+        - ``def f(x: "Optional[Alias]")`` where the parsed root node may stay
+          the same while one of its children is expanded in place
+
+        Cycle protection is preserved via a per-(file, name) seen-set
+        so recursive aliases (``A = list[A]``) stop at the first revisit
+        rather than infinite-looping.
         """
-        seen: set[tuple[Path, str]] = set()
-        current = annotation
-        current_file = file_path
-        while isinstance(current, ast.Name):
-            name = current.id
-            local_aliases = self._module_type_aliases.get(current_file, {})
-            if name in local_aliases:
-                key = (current_file, name)
-                if key in seen:
-                    break
-                seen.add(key)
-                current = local_aliases[name]
-                continue
-            origin = self._relative_import_origins.get(current_file, {}).get(name)
-            if origin is not None:
-                origin_aliases = self._module_type_aliases.get(origin, {})
-                if name in origin_aliases:
-                    key = (origin, name)
-                    if key in seen:
-                        break
-                    seen.add(key)
-                    # Switch context: continue expanding inside the origin file
-                    # so any further chained aliases use that file's map.
-                    current_file = origin
-                    current = origin_aliases[name]
-                    continue
-            break
-
-        # Expand aliases inside ``X | Y`` union expressions so that
-        # ``Name | None`` (where ``Name: TypeAlias = str``) reaches the
-        # resolver as ``str | None`` instead of an unresolved "Name" object.
-        # The while loop only handles a bare Name at the top level, so
-        # compound annotations with aliased sub-expressions pass through
-        # unexpanded without this recursion.
-        if isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
-            expanded_left = self._expand_alias(current.left, current_file)
-            expanded_right = self._expand_alias(current.right, current_file)
-            if expanded_left is not current.left or expanded_right is not current.right:
-                new_node = ast.BinOp(
-                    left=expanded_left, op=current.op, right=expanded_right
-                )
-                ast.copy_location(new_node, current)
-                return new_node
-
-        return current
+        # Deep-copy the annotation tree before transforming. NodeTransformer
+        # mutates the nodes it walks (replacing children in-place), and the
+        # alias-target nodes are stored in self._module_type_aliases — we
+        # don't want the cached alias map to develop expanded versions of
+        # itself across calls.
+        cloned = copy.deepcopy(annotation)
+        expander = _AliasExpander(
+            aliases_by_file=self._module_type_aliases,
+            origins_by_file=self._relative_import_origins,
+            current_file=file_path,
+        )
+        return expander.visit(cloned)
 
     def _build_namespace(self) -> None:
         """Build the namespace for type resolution."""

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -166,6 +166,16 @@ def _forward_ref_type(name: str) -> GeneratedType:
     )
 
 
+def _self_type() -> GeneratedType:
+    return GeneratedType(
+        source="Self",
+        base=_BaseType("Foo", None),
+        is_optional=False,
+        is_list=False,
+        has_annotated_outer=False,
+    )
+
+
 def _optional_type(inner: GeneratedType) -> GeneratedType:
     return GeneratedType(
         source=f"Optional[{inner.source}]",
@@ -236,6 +246,8 @@ def _type_leaf(  # type: ignore[no-untyped-def]
 ) -> GeneratedType:
     if aliases and draw(st.booleans()):
         return _alias_as_leaf(draw(st.sampled_from(aliases)))
+    if depth > 0 and draw(st.booleans()):
+        return _self_type()
     if allow_forward_ref and depth > 0 and draw(st.booleans()):
         return _forward_ref_type(draw(st.sampled_from(sorted(_FORWARD_REF_NAMES))))
     return _base_as_type(draw(base_type_strategy))
@@ -597,6 +609,7 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
         [
             "import dagger",
             "from typing import Annotated, Optional, TypeAlias",
+            "from typing_extensions import Self",
             "from dagger import DefaultPath, Deprecated, Doc, Ignore, Name",
             "",
         ]

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -268,8 +268,11 @@ def _type_leaf(  # type: ignore[no-untyped-def]
     aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedType:
     if aliases and draw(st.booleans()):
-        quote = allow_forward_ref and draw(st.booleans())
-        return _alias_as_leaf(draw(st.sampled_from(aliases)), quote=quote)
+        # Keep aliases bare inside larger expressions. Python 3.10's
+        # get_type_hints leaves nested strings in PEP 585 generics unresolved
+        # (e.g. list["Alias"]), while newer Pythons resolve them. Whole-string
+        # annotations still cover quoted aliases in a version-stable way.
+        return _alias_as_leaf(draw(st.sampled_from(aliases)))
     if depth > 0 and draw(st.booleans()):
         return _self_type()
     if allow_forward_ref and depth > 0 and draw(st.booleans()):
@@ -674,9 +677,7 @@ def module_strategy(  # type: ignore[no-untyped-def]  # noqa: C901, PLR0915
             )
         )
         c_value = draw(c_base.default_strategy)
-        constants.append(
-            _RenderedConstant(name=cname, value_expr=c_value, base=c_base)
-        )
+        constants.append(_RenderedConstant(name=cname, value_expr=c_value, base=c_base))
 
     n = draw(st.integers(min_value=1, max_value=max_functions))
     fns: list[GeneratedFunction] = []

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -405,6 +405,7 @@ class GeneratedFunction:
     params: tuple[GeneratedParam, ...]
     return_annotation: str
     body: str
+    method_kind: str = "instance"  # "instance" | "staticmethod" | "classmethod"
 
 
 def _function_name_strategy() -> st.SearchStrategy[str]:
@@ -426,6 +427,9 @@ def function_strategy(  # type: ignore[no-untyped-def]
     aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedFunction:
     name = draw(_function_name_strategy())
+    method_kind = draw(
+        st.sampled_from(["instance", "instance", "staticmethod", "classmethod"])
+    )
     param_count = draw(st.integers(min_value=0, max_value=3))
     params: list[GeneratedParam] = []
     used_names: set[str] = set()
@@ -466,6 +470,7 @@ def function_strategy(  # type: ignore[no-untyped-def]
         params=tuple(params),
         return_annotation=return_type.source,
         body="        ...",
+        method_kind=method_kind,
     )
 
 
@@ -655,10 +660,18 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
                 param_strs.append(f"{p.name}: {p.annotation}")
             else:
                 param_strs.append(f"{p.name}: {p.annotation} = {p.default_expr}")
-        params_rendered = ", ".join(["self", *param_strs])
+        if fn.method_kind == "staticmethod":
+            decorator_lines = ["    @staticmethod", "    @dagger.function"]
+            params_rendered = ", ".join(param_strs)
+        elif fn.method_kind == "classmethod":
+            decorator_lines = ["    @classmethod", "    @dagger.function"]
+            params_rendered = ", ".join(["cls", *param_strs])
+        else:
+            decorator_lines = ["    @dagger.function"]
+            params_rendered = ", ".join(["self", *param_strs])
         lines.extend(
             [
-                "    @dagger.function",
+                *decorator_lines,
                 f"    def {fn.name}({params_rendered}) -> {fn.return_annotation}:",
                 fn.body,
                 "",

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -83,17 +83,32 @@ base_type_strategy = st.sampled_from(ALL_BASES)
 # ---------------------------------------------------------------------------
 
 
-def _doc_meta() -> st.SearchStrategy[str]:
-    return st.text(min_size=1, max_size=20, alphabet="abcdefghijk ").map(
-        lambda s: f"Doc({s!r})"
-    )
+def _metadata_text(
+    *,
+    max_size: int,
+    alphabet: str,
+    extra_values: tuple[str, ...] = (),
+) -> st.SearchStrategy[str]:
+    generated = st.text(min_size=1, max_size=max_size, alphabet=alphabet)
+    if not extra_values:
+        return generated
+    return st.one_of(generated, st.sampled_from(extra_values))
 
 
-def _name_meta() -> st.SearchStrategy[str]:
-    alphabet = "abcdefghijkl"
-    return st.text(min_size=1, max_size=8, alphabet=alphabet).map(
-        lambda s: f"Name({s!r})"
-    )
+def _doc_meta(extra_values: tuple[str, ...] = ()) -> st.SearchStrategy[str]:
+    return _metadata_text(
+        max_size=20,
+        alphabet="abcdefghijk ",
+        extra_values=extra_values,
+    ).map(lambda s: f"Doc({s!r})")
+
+
+def _name_meta(extra_values: tuple[str, ...] = ()) -> st.SearchStrategy[str]:
+    return _metadata_text(
+        max_size=8,
+        alphabet="abcdefghijkl",
+        extra_values=extra_values,
+    ).map(lambda s: f"Name({s!r})")
 
 
 def _default_path_meta() -> st.SearchStrategy[str]:
@@ -144,6 +159,11 @@ def _alias_as_leaf(alias: _AliasLeaf, *, quote: bool = False) -> GeneratedType:
         is_list=alias.is_list,
         has_annotated_outer=False,
     )
+
+
+def _quote_whole_annotation(type_expr: GeneratedType) -> GeneratedType:
+    """Render the whole annotation as a forward-reference string."""
+    return dataclasses.replace(type_expr, source=repr(type_expr.source))
 
 
 def _base_as_type(base: _BaseType) -> GeneratedType:
@@ -218,10 +238,13 @@ def _annotated_type(inner: GeneratedType, metadata: str) -> GeneratedType:
 
 @st.composite
 def _annotated_meta_list(  # type: ignore[no-untyped-def]
-    draw, base: _BaseType, max_items: int = 2
+    draw,
+    base: _BaseType,
+    max_items: int = 2,
+    extra_strings: tuple[str, ...] = (),
 ) -> str:
     """Generate one or more metadata expressions for ``Annotated[…]``."""
-    options = [_doc_meta(), _name_meta()]
+    options = [_doc_meta(extra_strings), _name_meta(extra_strings)]
     if base.accepts_default_path:
         options.append(_default_path_meta())
     if base.accepts_ignore:
@@ -245,7 +268,8 @@ def _type_leaf(  # type: ignore[no-untyped-def]
     aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedType:
     if aliases and draw(st.booleans()):
-        return _alias_as_leaf(draw(st.sampled_from(aliases)))
+        quote = allow_forward_ref and draw(st.booleans())
+        return _alias_as_leaf(draw(st.sampled_from(aliases)), quote=quote)
     if depth > 0 and draw(st.booleans()):
         return _self_type()
     if allow_forward_ref and depth > 0 and draw(st.booleans()):
@@ -255,6 +279,29 @@ def _type_leaf(  # type: ignore[no-untyped-def]
 
 @st.composite
 def _type_expr(  # type: ignore[no-untyped-def]
+    draw,
+    *,
+    max_depth: int = 3,
+    allow_forward_ref: bool = True,
+    allow_whole_string: bool = False,
+    aliases: tuple[_AliasLeaf, ...] = (),
+) -> GeneratedType:
+    """Generate a type expression, optionally quoted as one string."""
+    expr = draw(
+        _type_expr_unquoted(
+            depth=0,
+            max_depth=max_depth,
+            allow_forward_ref=allow_forward_ref,
+            aliases=aliases,
+        )
+    )
+    if allow_whole_string and draw(st.booleans()):
+        return _quote_whole_annotation(expr)
+    return expr
+
+
+@st.composite
+def _type_expr_unquoted(  # type: ignore[no-untyped-def]
     draw,
     *,
     depth: int = 0,
@@ -291,7 +338,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
 
     if wrapper == "optional":
         inner = draw(
-            _type_expr(
+            _type_expr_unquoted(
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=allow_forward_ref,
@@ -305,7 +352,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
         # annotations because typing won't accept a bare string literal
         # as an operand of ``|``. Force the inner to be a real type.
         inner = draw(
-            _type_expr(
+            _type_expr_unquoted(
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=False,
@@ -316,7 +363,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
 
     if wrapper == "list":
         inner = draw(
-            _type_expr(
+            _type_expr_unquoted(
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=allow_forward_ref,
@@ -327,14 +374,19 @@ def _type_expr(  # type: ignore[no-untyped-def]
 
     # Annotated wrapper — last branch.
     inner = draw(
-        _type_expr(
+        _type_expr_unquoted(
             depth=depth + 1,
             max_depth=max_depth,
             allow_forward_ref=allow_forward_ref,
             aliases=aliases,
         )
     )
-    metas = draw(_annotated_meta_list(inner.base))
+    metas = draw(
+        _annotated_meta_list(
+            inner.base,
+            extra_strings=tuple(alias.name for alias in aliases),
+        )
+    )
     return _annotated_type(inner, metas)
 
 
@@ -374,6 +426,7 @@ def param_strategy(  # type: ignore[no-untyped-def]
         _type_expr(
             max_depth=max_depth,
             allow_forward_ref=allow_forward_ref,
+            allow_whole_string=bool(aliases),
             aliases=aliases,
         )
     )
@@ -461,6 +514,7 @@ def function_strategy(  # type: ignore[no-untyped-def]
         _type_expr(
             max_depth=2,
             allow_forward_ref=allow_forward_ref,
+            allow_whole_string=bool(aliases),
             aliases=aliases,
         )
     )

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -489,6 +489,15 @@ class _RenderedAlias:
 
 
 @dataclasses.dataclass(frozen=True)
+class _GeneratedField:
+    """A class-level ``dagger.field(default=...)`` declaration on Foo."""
+
+    name: str
+    annotation: str
+    default_expr: str
+
+
+@dataclasses.dataclass(frozen=True)
 class GeneratedModule:
     """Everything needed to render a complete module source string."""
 
@@ -499,6 +508,7 @@ class GeneratedModule:
     foo_inherits_helper: bool
     functions: tuple[GeneratedFunction, ...]
     dagger_alias: str | None = None
+    fields: tuple[_GeneratedField, ...] = ()
 
 
 def _alias_name_strategy(prefix: str = "Alias") -> st.SearchStrategy[str]:
@@ -517,7 +527,7 @@ def _alias_target(draw) -> GeneratedType:  # type: ignore[no-untyped-def]
 
 
 @st.composite
-def module_strategy(  # type: ignore[no-untyped-def]
+def module_strategy(  # type: ignore[no-untyped-def]  # noqa: PLR0915
     draw, *, max_functions: int = 4
 ) -> str:
     """Strategy that produces a complete Dagger module source string."""
@@ -591,6 +601,30 @@ def module_strategy(  # type: ignore[no-untyped-def]
 
     dagger_alias = draw(st.sampled_from([None, None, "dgr", "dgmod"]))
 
+    field_count = draw(st.integers(min_value=0, max_value=2))
+    fields: list[_GeneratedField] = []
+    used_field_names = {dagger_alias or "dagger", *used_fn_names}
+    field_attempts = 0
+    while len(fields) < field_count and field_attempts < 20:
+        fname = draw(param_name_strategy())
+        field_attempts += 1
+        if fname in used_field_names:
+            continue
+        used_field_names.add(fname)
+        base = draw(
+            st.sampled_from(
+                [b for b in _PRIMITIVE_BASES if b.default_strategy is not None]
+            )
+        )
+        default = draw(base.default_strategy)
+        fields.append(
+            _GeneratedField(
+                name=fname,
+                annotation=base.annotation,
+                default_expr=default,
+            )
+        )
+
     return _render_module(
         GeneratedModule(
             use_future_annotations=use_future_annotations,
@@ -600,6 +634,7 @@ def module_strategy(  # type: ignore[no-untyped-def]
             foo_inherits_helper=foo_inherits_helper,
             functions=tuple(fns),
             dagger_alias=dagger_alias,
+            fields=tuple(fields),
         )
     )
 
@@ -658,8 +693,20 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
     base_clause = "(Helper)" if mod.foo_inherits_helper else ""
     lines.append(f"class Foo{base_clause}:")
 
-    if not mod.functions:
+    lines.extend(
+        (
+            f"    {field.name}: {field.annotation} = "
+            f"{dpkg}.field(default={field.default_expr})"
+        )
+        for field in mod.fields
+    )
+    if mod.fields:
+        lines.append("")
+
+    if not mod.functions and not mod.fields:
         lines.append("    pass")
+        return "\n".join(lines) + "\n"
+    if not mod.functions:
         return "\n".join(lines) + "\n"
 
     for fn in mod.functions:

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -127,6 +127,25 @@ class GeneratedType:
 _FORWARD_REF_NAMES = {"Foo"}  # the always-defined class in render_module
 
 
+@dataclasses.dataclass(frozen=True)
+class _AliasLeaf:
+    """A module-level alias that ``_type_expr`` may pick as a leaf."""
+
+    name: str
+    base: _BaseType
+    is_list: bool
+
+
+def _alias_as_leaf(alias: _AliasLeaf, *, quote: bool = False) -> GeneratedType:
+    return GeneratedType(
+        source=f'"{alias.name}"' if quote else alias.name,
+        base=alias.base,
+        is_optional=False,
+        is_list=alias.is_list,
+        has_annotated_outer=False,
+    )
+
+
 def _base_as_type(base: _BaseType) -> GeneratedType:
     return GeneratedType(
         source=base.annotation,
@@ -213,7 +232,10 @@ def _type_leaf(  # type: ignore[no-untyped-def]
     *,
     depth: int,
     allow_forward_ref: bool,
+    aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedType:
+    if aliases and draw(st.booleans()):
+        return _alias_as_leaf(draw(st.sampled_from(aliases)))
     if allow_forward_ref and depth > 0 and draw(st.booleans()):
         return _forward_ref_type(draw(st.sampled_from(sorted(_FORWARD_REF_NAMES))))
     return _base_as_type(draw(base_type_strategy))
@@ -226,6 +248,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
     depth: int = 0,
     max_depth: int = 3,
     allow_forward_ref: bool = True,
+    aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedType:
     """Generate a (possibly wrapped) type expression.
 
@@ -239,6 +262,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
             _type_leaf(
                 depth=depth,
                 allow_forward_ref=allow_forward_ref,
+                aliases=aliases,
             )
         )
 
@@ -249,6 +273,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
             _type_leaf(
                 depth=depth,
                 allow_forward_ref=allow_forward_ref,
+                aliases=aliases,
             )
         )
 
@@ -258,6 +283,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=allow_forward_ref,
+                aliases=aliases,
             )
         )
         return _optional_type(inner)
@@ -271,6 +297,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=False,
+                aliases=aliases,
             )
         )
         return _pipe_none_type(inner)
@@ -281,6 +308,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
                 depth=depth + 1,
                 max_depth=max_depth,
                 allow_forward_ref=allow_forward_ref,
+                aliases=aliases,
             )
         )
         return _list_type(inner)
@@ -291,6 +319,7 @@ def _type_expr(  # type: ignore[no-untyped-def]
             depth=depth + 1,
             max_depth=max_depth,
             allow_forward_ref=allow_forward_ref,
+            aliases=aliases,
         )
     )
     metas = draw(_annotated_meta_list(inner.base))
@@ -321,11 +350,19 @@ def param_name_strategy() -> st.SearchStrategy[str]:
 
 @st.composite
 def param_strategy(  # type: ignore[no-untyped-def]
-    draw, *, max_depth: int = 3, allow_forward_ref: bool = True
+    draw,
+    *,
+    max_depth: int = 3,
+    allow_forward_ref: bool = True,
+    aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedParam:
     """Generate a single function parameter."""
     type_expr = draw(
-        _type_expr(max_depth=max_depth, allow_forward_ref=allow_forward_ref)
+        _type_expr(
+            max_depth=max_depth,
+            allow_forward_ref=allow_forward_ref,
+            aliases=aliases,
+        )
     )
 
     # Default expression — must be compatible with the (innermost) base.
@@ -371,7 +408,10 @@ def _function_name_strategy() -> st.SearchStrategy[str]:
 
 @st.composite
 def function_strategy(  # type: ignore[no-untyped-def]
-    draw, *, allow_forward_ref: bool = True
+    draw,
+    *,
+    allow_forward_ref: bool = True,
+    aliases: tuple[_AliasLeaf, ...] = (),
 ) -> GeneratedFunction:
     name = draw(_function_name_strategy())
     param_count = draw(st.integers(min_value=0, max_value=3))
@@ -379,7 +419,12 @@ def function_strategy(  # type: ignore[no-untyped-def]
     used_names: set[str] = set()
     attempts = 0
     while len(params) < param_count and attempts < 20:
-        p = draw(param_strategy(allow_forward_ref=allow_forward_ref))
+        p = draw(
+            param_strategy(
+                allow_forward_ref=allow_forward_ref,
+                aliases=aliases,
+            )
+        )
         if p.name not in used_names:
             params.append(p)
             used_names.add(p.name)
@@ -387,7 +432,13 @@ def function_strategy(  # type: ignore[no-untyped-def]
     # Required params must come before defaulted ones (Python rule).
     params.sort(key=lambda p: p.default_expr is not None)
 
-    return_type = draw(_type_expr(max_depth=2, allow_forward_ref=allow_forward_ref))
+    return_type = draw(
+        _type_expr(
+            max_depth=2,
+            allow_forward_ref=allow_forward_ref,
+            aliases=aliases,
+        )
+    )
     # Avoid bytes return — rendering ``return b""`` everywhere is awkward.
     if return_type.base.annotation == "bytes":
         return_type = GeneratedType(
@@ -412,11 +463,20 @@ def function_strategy(  # type: ignore[no-untyped-def]
 
 
 @dataclasses.dataclass(frozen=True)
+class _RenderedAlias:
+    """A module-level alias as it should appear in source."""
+
+    name: str
+    target_source: str
+    explicit_typealias: bool
+
+
+@dataclasses.dataclass(frozen=True)
 class GeneratedModule:
     """Everything needed to render a complete module source string."""
 
     use_future_annotations: bool
-    aliases: tuple[tuple[str, str], ...]  # (alias_name, alias_target_source)
+    aliases: tuple[_RenderedAlias, ...]
     pep695_aliases: tuple[tuple[str, str], ...]  # 3.12+ ``type X = …``
     has_helper_class: bool
     foo_inherits_helper: bool
@@ -430,10 +490,12 @@ def _alias_name_strategy(prefix: str = "Alias") -> st.SearchStrategy[str]:
 
 
 @st.composite
-def _alias_target(draw) -> str:  # type: ignore[no-untyped-def]
-    """Generate a type expression suitable as the RHS of an alias."""
+def _alias_target(draw) -> GeneratedType:  # type: ignore[no-untyped-def]
+    """Generate a type expression suitable as the right-hand side of an alias."""
     expr = draw(_type_expr(max_depth=2, allow_forward_ref=False))
-    return expr.source
+    while expr.has_annotated_outer:
+        expr = draw(_type_expr(max_depth=2, allow_forward_ref=False))
+    return expr
 
 
 @st.composite
@@ -450,16 +512,30 @@ def module_strategy(  # type: ignore[no-untyped-def]
     # keep the property test on legal-Python territory.
     allow_forward_ref = use_future_annotations
 
-    # Module-level type aliases — ``Source = Annotated[…]``.
+    # Module-level type aliases — both implicit (``X = T``) and
+    # explicit PEP 613 (``X: TypeAlias = T``). Each alias is also
+    # exposed as an ``_AliasLeaf`` that ``_type_expr`` can pick.
     alias_count = draw(st.integers(min_value=0, max_value=2))
-    aliases: list[tuple[str, str]] = []
+    aliases: list[_RenderedAlias] = []
+    alias_leaves: list[_AliasLeaf] = []
     used_alias_names: set[str] = set()
     while len(aliases) < alias_count:
         name = draw(_alias_name_strategy())
         if name in used_alias_names:
             continue
         used_alias_names.add(name)
-        aliases.append((name, draw(_alias_target())))
+        target = draw(_alias_target())
+        explicit = draw(st.booleans())
+        aliases.append(
+            _RenderedAlias(
+                name=name,
+                target_source=target.source,
+                explicit_typealias=explicit,
+            )
+        )
+        alias_leaves.append(
+            _AliasLeaf(name=name, base=target.base, is_list=target.is_list)
+        )
 
     # PEP 695 ``type X = …`` aliases — only when the runtime can parse them.
     pep695_aliases: list[tuple[str, str]] = []
@@ -470,7 +546,11 @@ def module_strategy(  # type: ignore[no-untyped-def]
             if name in used_alias_names:
                 continue
             used_alias_names.add(name)
-            pep695_aliases.append((name, draw(_alias_target())))
+            target = draw(_alias_target())
+            pep695_aliases.append((name, target.source))
+            alias_leaves.append(
+                _AliasLeaf(name=name, base=target.base, is_list=target.is_list)
+            )
 
     has_helper_class = draw(st.booleans())
     foo_inherits_helper = has_helper_class and draw(st.booleans())
@@ -480,7 +560,12 @@ def module_strategy(  # type: ignore[no-untyped-def]
     used_fn_names: set[str] = set()
     attempts = 0
     while len(fns) < n and attempts < 30:
-        f = draw(function_strategy(allow_forward_ref=allow_forward_ref))
+        f = draw(
+            function_strategy(
+                allow_forward_ref=allow_forward_ref,
+                aliases=tuple(alias_leaves),
+            )
+        )
         if f.name not in used_fn_names:
             fns.append(f)
             used_fn_names.add(f.name)
@@ -503,7 +588,7 @@ def module_strategy(  # type: ignore[no-untyped-def]
 # ---------------------------------------------------------------------------
 
 
-def _render_module(mod: GeneratedModule) -> str:  # noqa: C901 — straight rendering
+def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
     lines: list[str] = []
     if mod.use_future_annotations:
         lines.append("from __future__ import annotations")
@@ -511,13 +596,16 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901 — straight rend
     lines.extend(
         [
             "import dagger",
-            "from typing import Annotated, Optional",
+            "from typing import Annotated, Optional, TypeAlias",
             "from dagger import DefaultPath, Deprecated, Doc, Ignore, Name",
             "",
         ]
     )
-    for name, target in mod.aliases:
-        lines.append(f"{name} = {target}")
+    for alias in mod.aliases:
+        if alias.explicit_typealias:
+            lines.append(f"{alias.name}: TypeAlias = {alias.target_source}")
+        else:
+            lines.append(f"{alias.name} = {alias.target_source}")
     if mod.aliases:
         lines.append("")
     for name, target in mod.pep695_aliases:

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -127,6 +127,66 @@ class GeneratedType:
 _FORWARD_REF_NAMES = {"Foo"}  # the always-defined class in render_module
 
 
+def _base_as_type(base: _BaseType) -> GeneratedType:
+    return GeneratedType(
+        source=base.annotation,
+        base=base,
+        is_optional=False,
+        is_list=False,
+        has_annotated_outer=False,
+    )
+
+
+def _forward_ref_type(name: str) -> GeneratedType:
+    return GeneratedType(
+        source=f'"{name}"',
+        base=_BaseType(name, None),
+        is_optional=False,
+        is_list=False,
+        has_annotated_outer=False,
+    )
+
+
+def _optional_type(inner: GeneratedType) -> GeneratedType:
+    return GeneratedType(
+        source=f"Optional[{inner.source}]",
+        base=inner.base,
+        is_optional=True,
+        is_list=inner.is_list,
+        has_annotated_outer=False,
+    )
+
+
+def _pipe_none_type(inner: GeneratedType) -> GeneratedType:
+    return GeneratedType(
+        source=f"{inner.source} | None",
+        base=inner.base,
+        is_optional=True,
+        is_list=inner.is_list,
+        has_annotated_outer=False,
+    )
+
+
+def _list_type(inner: GeneratedType) -> GeneratedType:
+    return GeneratedType(
+        source=f"list[{inner.source}]",
+        base=inner.base,
+        is_optional=False,
+        is_list=True,
+        has_annotated_outer=False,
+    )
+
+
+def _annotated_type(inner: GeneratedType, metadata: str) -> GeneratedType:
+    return GeneratedType(
+        source=f"Annotated[{inner.source}, {metadata}]",
+        base=inner.base,
+        is_optional=inner.is_optional,
+        is_list=inner.is_list,
+        has_annotated_outer=True,
+    )
+
+
 @st.composite
 def _annotated_meta_list(  # type: ignore[no-untyped-def]
     draw, base: _BaseType, max_items: int = 2
@@ -143,8 +203,24 @@ def _annotated_meta_list(  # type: ignore[no-untyped-def]
     return ", ".join(metas)
 
 
+def _type_rules() -> tuple[str, ...]:
+    return ("leaf", "optional", "pipe-none", "list", "annotated")
+
+
 @st.composite
-def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dispatch
+def _type_leaf(  # type: ignore[no-untyped-def]
+    draw,
+    *,
+    depth: int,
+    allow_forward_ref: bool,
+) -> GeneratedType:
+    if allow_forward_ref and depth > 0 and draw(st.booleans()):
+        return _forward_ref_type(draw(st.sampled_from(sorted(_FORWARD_REF_NAMES))))
+    return _base_as_type(draw(base_type_strategy))
+
+
+@st.composite
+def _type_expr(  # type: ignore[no-untyped-def]
     draw,
     *,
     depth: int = 0,
@@ -158,44 +234,22 @@ def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dis
     forward reference. Recursion is bounded by ``max_depth`` so the
     generator always terminates in finite time.
     """
-    # Leaf — pick a base type, optionally as a forward reference.
     if depth >= max_depth:
-        if (
-            allow_forward_ref
-            and depth > 0  # don't wrap the very top level in a string
-            and draw(st.booleans())
-        ):
-            name = draw(st.sampled_from(sorted(_FORWARD_REF_NAMES)))
-            base = _BaseType(name, None)
-            return GeneratedType(
-                source=f'"{name}"',
-                base=base,
-                is_optional=False,
-                is_list=False,
-                has_annotated_outer=False,
+        return draw(
+            _type_leaf(
+                depth=depth,
+                allow_forward_ref=allow_forward_ref,
             )
-        base = draw(base_type_strategy)
-        return GeneratedType(
-            source=base.annotation,
-            base=base,
-            is_optional=False,
-            is_list=False,
-            has_annotated_outer=False,
         )
 
-    # Recursive case — pick a wrapper.
-    wrapper = draw(
-        st.sampled_from(["base", "optional", "pipe-none", "list", "annotated"])
-    )
+    wrapper = draw(st.sampled_from(_type_rules()))
 
-    if wrapper == "base":
-        base = draw(base_type_strategy)
-        return GeneratedType(
-            source=base.annotation,
-            base=base,
-            is_optional=False,
-            is_list=False,
-            has_annotated_outer=False,
+    if wrapper == "leaf":
+        return draw(
+            _type_leaf(
+                depth=depth,
+                allow_forward_ref=allow_forward_ref,
+            )
         )
 
     if wrapper == "optional":
@@ -206,13 +260,7 @@ def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dis
                 allow_forward_ref=allow_forward_ref,
             )
         )
-        return GeneratedType(
-            source=f"Optional[{inner.source}]",
-            base=inner.base,
-            is_optional=True,
-            is_list=inner.is_list,
-            has_annotated_outer=False,
-        )
+        return _optional_type(inner)
 
     if wrapper == "pipe-none":
         # ``"Foo" | None`` is invalid even under ``from __future__``
@@ -225,13 +273,7 @@ def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dis
                 allow_forward_ref=False,
             )
         )
-        return GeneratedType(
-            source=f"{inner.source} | None",
-            base=inner.base,
-            is_optional=True,
-            is_list=inner.is_list,
-            has_annotated_outer=False,
-        )
+        return _pipe_none_type(inner)
 
     if wrapper == "list":
         inner = draw(
@@ -241,13 +283,7 @@ def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dis
                 allow_forward_ref=allow_forward_ref,
             )
         )
-        return GeneratedType(
-            source=f"list[{inner.source}]",
-            base=inner.base,
-            is_optional=False,
-            is_list=True,
-            has_annotated_outer=False,
-        )
+        return _list_type(inner)
 
     # Annotated wrapper — last branch.
     inner = draw(
@@ -258,13 +294,7 @@ def _type_expr(  # type: ignore[no-untyped-def]  # noqa: PLR0911 — wrapper dis
         )
     )
     metas = draw(_annotated_meta_list(inner.base))
-    return GeneratedType(
-        source=f"Annotated[{inner.source}, {metas}]",
-        base=inner.base,
-        is_optional=inner.is_optional,
-        is_list=inner.is_list,
-        has_annotated_outer=True,
-    )
+    return _annotated_type(inner, metas)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -498,6 +498,7 @@ class GeneratedModule:
     has_helper_class: bool
     foo_inherits_helper: bool
     functions: tuple[GeneratedFunction, ...]
+    dagger_alias: str | None = None
 
 
 def _alias_name_strategy(prefix: str = "Alias") -> st.SearchStrategy[str]:
@@ -588,6 +589,8 @@ def module_strategy(  # type: ignore[no-untyped-def]
             used_fn_names.add(f.name)
         attempts += 1
 
+    dagger_alias = draw(st.sampled_from([None, None, "dgr", "dgmod"]))
+
     return _render_module(
         GeneratedModule(
             use_future_annotations=use_future_annotations,
@@ -596,6 +599,7 @@ def module_strategy(  # type: ignore[no-untyped-def]
             has_helper_class=has_helper_class,
             foo_inherits_helper=foo_inherits_helper,
             functions=tuple(fns),
+            dagger_alias=dagger_alias,
         )
     )
 
@@ -610,9 +614,14 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
     if mod.use_future_annotations:
         lines.append("from __future__ import annotations")
         lines.append("")
+    dpkg = mod.dagger_alias or "dagger"
+    if mod.dagger_alias:
+        lines.append("import dagger")
+        lines.append(f"import dagger as {mod.dagger_alias}")
+    else:
+        lines.append("import dagger")
     lines.extend(
         [
-            "import dagger",
             "from typing import Annotated, Optional, TypeAlias",
             "from typing_extensions import Self",
             "from dagger import DefaultPath, Deprecated, Doc, Ignore, Name",
@@ -634,18 +643,18 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
     if mod.has_helper_class:
         lines.extend(
             [
-                "@dagger.object_type",
+                f"@{dpkg}.object_type",
                 "class Helper:",
-                '    name: str = dagger.field(default="h")',
+                f'    name: str = {dpkg}.field(default="h")',
                 "",
-                "    @dagger.function",
+                f"    @{dpkg}.function",
                 "    def hello(self) -> str:",
                 "        return self.name",
                 "",
             ]
         )
 
-    lines.append("@dagger.object_type")
+    lines.append(f"@{dpkg}.object_type")
     base_clause = "(Helper)" if mod.foo_inherits_helper else ""
     lines.append(f"class Foo{base_clause}:")
 
@@ -661,13 +670,13 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
             else:
                 param_strs.append(f"{p.name}: {p.annotation} = {p.default_expr}")
         if fn.method_kind == "staticmethod":
-            decorator_lines = ["    @staticmethod", "    @dagger.function"]
+            decorator_lines = ["    @staticmethod", f"    @{dpkg}.function"]
             params_rendered = ", ".join(param_strs)
         elif fn.method_kind == "classmethod":
-            decorator_lines = ["    @classmethod", "    @dagger.function"]
+            decorator_lines = ["    @classmethod", f"    @{dpkg}.function"]
             params_rendered = ", ".join(["cls", *param_strs])
         else:
-            decorator_lines = ["    @dagger.function"]
+            decorator_lines = [f"    @{dpkg}.function"]
             params_rendered = ", ".join(["self", *param_strs])
         lines.extend(
             [

--- a/sdk/python/tests/mod/_strategies.py
+++ b/sdk/python/tests/mod/_strategies.py
@@ -367,6 +367,7 @@ def param_strategy(  # type: ignore[no-untyped-def]
     max_depth: int = 3,
     allow_forward_ref: bool = True,
     aliases: tuple[_AliasLeaf, ...] = (),
+    constants: tuple[_RenderedConstant, ...] = (),
 ) -> GeneratedParam:
     """Generate a single function parameter."""
     type_expr = draw(
@@ -390,7 +391,13 @@ def param_strategy(  # type: ignore[no-untyped-def]
         and type_expr.base.default_strategy is not None
         and draw(st.booleans())
     ):
-        default_expr = draw(type_expr.base.default_strategy)
+        matching_consts = [
+            c for c in constants if c.base.annotation == type_expr.base.annotation
+        ]
+        if matching_consts and draw(st.booleans()):
+            default_expr = draw(st.sampled_from(matching_consts)).name
+        else:
+            default_expr = draw(type_expr.base.default_strategy)
 
     return GeneratedParam(
         name=draw(param_name_strategy()),
@@ -425,6 +432,7 @@ def function_strategy(  # type: ignore[no-untyped-def]
     *,
     allow_forward_ref: bool = True,
     aliases: tuple[_AliasLeaf, ...] = (),
+    constants: tuple[_RenderedConstant, ...] = (),
 ) -> GeneratedFunction:
     name = draw(_function_name_strategy())
     method_kind = draw(
@@ -439,6 +447,7 @@ def function_strategy(  # type: ignore[no-untyped-def]
             param_strategy(
                 allow_forward_ref=allow_forward_ref,
                 aliases=aliases,
+                constants=constants,
             )
         )
         if p.name not in used_names:
@@ -489,6 +498,15 @@ class _RenderedAlias:
 
 
 @dataclasses.dataclass(frozen=True)
+class _RenderedConstant:
+    """A module-level constant declaration like ``MAX = 100``."""
+
+    name: str
+    value_expr: str
+    base: _BaseType
+
+
+@dataclasses.dataclass(frozen=True)
 class _GeneratedField:
     """A class-level ``dagger.field(default=...)`` declaration on Foo."""
 
@@ -507,6 +525,7 @@ class GeneratedModule:
     has_helper_class: bool
     foo_inherits_helper: bool
     functions: tuple[GeneratedFunction, ...]
+    constants: tuple[_RenderedConstant, ...] = ()
     dagger_alias: str | None = None
     fields: tuple[_GeneratedField, ...] = ()
 
@@ -527,7 +546,7 @@ def _alias_target(draw) -> GeneratedType:  # type: ignore[no-untyped-def]
 
 
 @st.composite
-def module_strategy(  # type: ignore[no-untyped-def]  # noqa: PLR0915
+def module_strategy(  # type: ignore[no-untyped-def]  # noqa: C901, PLR0915
     draw, *, max_functions: int = 4
 ) -> str:
     """Strategy that produces a complete Dagger module source string."""
@@ -583,6 +602,28 @@ def module_strategy(  # type: ignore[no-untyped-def]  # noqa: PLR0915
     has_helper_class = draw(st.booleans())
     foo_inherits_helper = has_helper_class and draw(st.booleans())
 
+    constants: list[_RenderedConstant] = []
+    used_const_names: set[str] = set()
+    const_count = draw(st.integers(min_value=0, max_value=2))
+    while len(constants) < const_count:
+        cname = draw(
+            st.text(min_size=2, max_size=6, alphabet="ABCDEFGH").map(
+                lambda s: f"CONST_{s}"
+            )
+        )
+        if cname in used_const_names:
+            continue
+        used_const_names.add(cname)
+        c_base = draw(
+            st.sampled_from(
+                [b for b in _PRIMITIVE_BASES if b.default_strategy is not None]
+            )
+        )
+        c_value = draw(c_base.default_strategy)
+        constants.append(
+            _RenderedConstant(name=cname, value_expr=c_value, base=c_base)
+        )
+
     n = draw(st.integers(min_value=1, max_value=max_functions))
     fns: list[GeneratedFunction] = []
     used_fn_names: set[str] = set()
@@ -592,6 +633,7 @@ def module_strategy(  # type: ignore[no-untyped-def]  # noqa: PLR0915
             function_strategy(
                 allow_forward_ref=allow_forward_ref,
                 aliases=tuple(alias_leaves),
+                constants=tuple(constants),
             )
         )
         if f.name not in used_fn_names:
@@ -633,6 +675,7 @@ def module_strategy(  # type: ignore[no-untyped-def]  # noqa: PLR0915
             has_helper_class=has_helper_class,
             foo_inherits_helper=foo_inherits_helper,
             functions=tuple(fns),
+            constants=tuple(constants),
             dagger_alias=dagger_alias,
             fields=tuple(fields),
         )
@@ -663,6 +706,9 @@ def _render_module(mod: GeneratedModule) -> str:  # noqa: C901, PLR0912
             "",
         ]
     )
+    lines.extend(f"{c.name} = {c.value_expr}" for c in mod.constants)
+    if mod.constants:
+        lines.append("")
     for alias in mod.aliases:
         if alias.explicit_typealias:
             lines.append(f"{alias.name}: TypeAlias = {alias.target_source}")

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1471,6 +1471,49 @@ class Foo:
     assert param.resolved_type.is_optional is True
 
 
+def test_ast_type_alias_does_not_rewrite_annotated_metadata_strings():
+    """``Name("Alias")`` metadata remains a value even when Alias is a type alias."""
+    metadata = _analyze("""
+from typing import Annotated, TypeAlias
+
+import dagger
+from dagger import Name
+
+Alias: TypeAlias = str
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def greet(self, name: Annotated[Alias, Name("Alias")]) -> str:
+        ...
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "str"
+    assert param.api_name == "Alias"
+
+
+def test_ast_type_alias_inside_quoted_compound_annotation():
+    """``"Optional[Alias]"`` expands aliases inside the parsed forward ref."""
+    metadata = _analyze("""
+from typing import Optional, TypeAlias
+
+import dagger
+
+Alias: TypeAlias = str
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def greet(self, name: "Optional[Alias]" = None) -> str:
+        ...
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "str"
+    assert param.resolved_type.is_optional is True
+
+
 def test_ast_optional_type_alias():
     """``MaybeDir = dagger.Directory | None`` resolves to optional Directory."""
     metadata = _analyze("""


### PR DESCRIPTION
### Summary

This PR tightens the Python SDK AST module analyzer around type annotations, especially type aliases, quoted annotations, and `Annotated[...]` metadata.

This code runs during module type registration. When the engine asks the Python SDK runtime for a module's type definitions, the runtime analyzes the module's Python source files without importing the user module. The analyzer builds `ModuleMetadata`, the SDK converts that into Dagger `TypeDef` / `Function` / enum / field definitions through `dag.module()`, and the engine loads the resulting `ModuleID`.

That source-analysis boundary matters because `typing.get_type_hints` works from runtime objects. It requires importing the module, executing decorators and class bodies, and evaluating annotations. That is useful as a test oracle, but not as the production source of truth for static module analysis.

### Why Extra Coverage

Type checker conformance tests are useful, but they mostly test whether annotations are accepted, what type is inferred, or whether diagnostics are emitted. Dagger needs to answer a different question: what API schema should this source produce?

That means preserving `Annotated[...]` metadata, resolving quoted forward references, and handling decorators, fields, defaults, imports, aliases, and constants correctly.

I also kept a separate [typing-conformance exploration branch](https://github.com/dagger/dagger/compare/main...grouville:dagger:python_sdk_typing_conformance_exploration?expand=1) that runs the analyzer against vendored type-checker corpora. It checked 827 annotations and found no real in-scope bugs:

- `typing_conformance`: 517 checked, 214 OK, 300 oracle errors, 3 noisy divergences
- `pyright_samples`: 289 checked, 49 OK, 239 oracle errors, 1 out-of-scope divergence
- `jedi_tests`: 21 checked, 15 OK, 0 oracle errors, 6 harness-limit divergences

That is useful confidence, but it also shows the limit of those suites: many cases cannot produce a runtime oracle, and the remaining divergences were harness or out-of-scope cases.

### Alias Expansion Fix

Alias expansion now only rewrites the actual type annotation, not metadata attached to it.

```python
Alias: TypeAlias = str

@dagger.function
def fn(value: Annotated[Alias, Name("Alias")]) -> None:
    ...
```

Here, the annotation `Alias` should resolve to `str`, but the metadata string `"Alias"` is the Dagger API name and must stay unchanged. Previously, alias expansion could rewrite both.

This PR also fixes quoted compound annotations:

```python
Alias: TypeAlias = str

@dagger.function
def fn(value: "Optional[Alias]" = None) -> None:
    ...
```

That should resolve as `Optional[str]`. Previously, the analyzer could expand the parsed annotation and then discard the expanded AST.

### Hypothesis Coverage

The Hypothesis module-source grammar was refactored to be easier to review and extend. It now covers aliases in simple, nested, quoted, and `Annotated[...]` annotations, plus surrounding module patterns like `Self`, static methods, class methods, fields, import aliases, and module constants used as defaults.

The generated tests compare static analyzer output against runtime introspection output. This does not prove there are no unknown bugs, but it gives broad coverage over the combinations where these bugs appeared.

### Regression Tests

This PR adds focused regressions for:

- preserving `Annotated[...]` metadata strings that match alias names
- expanding aliases inside quoted compound annotations like `"Optional[Alias]"`

Both fail without the analyzer fix.

### Verification

```sh
uv run ruff check src/dagger/mod/_analyzer/parser.py tests/mod/_strategies.py tests/mod/test_ast_analyzer.py
uv run pytest tests/mod/test_ast_analyzer.py -k "type_alias"
uv run pytest tests/mod/test_property.py --hypothesis-profile=thorough
```

The thorough Hypothesis run covered 500 generated examples successfully.
