### PR TITLE
Handle empty plaintext secret handles

### DIFF
--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -464,6 +464,18 @@ func (UserDefaultsSuite) TestConstructorOptional(ctx context.Context, t *testctx
 	}
 }
 
+func (UserDefaultsSuite) TestConstructorOptionalEmptySecret(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	out, err := nestedDaggerContainer(t, c, "go", "defaults").
+		WithEnvVariable("PASSWORD", "").
+		WithWorkdir("defaults").
+		WithNewFile(".env", "password=env://PASSWORD").
+		WithExec([]string{"dagger", "call", "password", "plaintext"}, nestedExec).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", out)
+}
+
 func trimDaggerFunctionUsageText(s string) string {
 	// Trim the output for readability
 	start := strings.Index(s, "ARGUMENTS")

--- a/core/secret.go
+++ b/core/secret.go
@@ -175,9 +175,6 @@ func SetSecretHandle(name string, accessor string) dagql.SessionResourceHandle {
 }
 
 func SecretHandleFromPlaintext(secretSalt []byte, plaintext []byte) dagql.SessionResourceHandle {
-	if len(plaintext) == 0 {
-		return ""
-	}
 	const (
 		timeCost = 10
 		memory   = 2 * 1024


### PR DESCRIPTION
## Summary

- derive provider-secret handles for zero-length plaintext instead of treating them as missing
- add an integration repro for an empty env-backed Secret used through constructor user defaults

## Root Cause

Provider-backed secrets without an explicit cache key derive their session resource handle from plaintext. Empty plaintext previously returned an empty handle, so user defaults like `password=env://PASSWORD` failed during object decoding when `PASSWORD` was set to an empty string.

## Validation

- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestUserDefaults/TestConstructorOptionalEmptySecret'`
