### PR TITLE
feat: add --fail-on-cache-miss flag to dagger command

### DIFF
--- a/cmd/dagger/cache_miss_test.go
+++ b/cmd/dagger/cache_miss_test.go
@@ -38,3 +38,23 @@ func TestNewCacheMissSpanExporterNonNil(t *testing.T) {
 		t.Fatalf("expected non-nil exporter")
 	}
 }
+
+func TestCacheMissErrIncludesChangedInputs(t *testing.T) {
+	err := cacheMissErr([]string{"--foo", "--bar"})
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if got, want := err.Error(), "call failed because it was not served from cache; changed inputs: --foo, --bar"; got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestCacheMissErrNoChangedInputs(t *testing.T) {
+	err := cacheMissErr(nil)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if got := err.Error(); got != "call failed because it was not served from cache; the request inputs changed or the result was invalidated" {
+		t.Fatalf("unexpected error message: %q", got)
+	}
+}

--- a/cmd/dagger/cache_miss_test.go
+++ b/cmd/dagger/cache_miss_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetCacheMissState(t *testing.T) {
+	// When there's no state in context, it should return nil
+	if s := getCacheMissState(context.Background()); s != nil {
+		t.Fatalf("expected nil state, got %v", s)
+	}
+
+	// When state is present, it should return the same pointer
+	expected := &cacheMissState{}
+	ctx := context.WithValue(context.Background(), failOnCacheMissKey, expected)
+	got := getCacheMissState(ctx)
+	if got != expected {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestCacheMissStateAtomic(t *testing.T) {
+	s := &cacheMissState{}
+	if s.failedMiss() {
+		t.Fatalf("expected initial failedMiss to be false")
+	}
+	s.failed.Store(true)
+	if !s.failedMiss() {
+		t.Fatalf("expected failedMiss to be true after store")
+	}
+}
+
+func TestNewCacheMissSpanExporterNonNil(t *testing.T) {
+	s := &cacheMissState{}
+	exp := newCacheMissSpanExporter(s)
+	if exp == nil {
+		t.Fatalf("expected non-nil exporter")
+	}
+}

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"sort"
 	"strings"
 
@@ -40,6 +42,36 @@ var callModCmd = &FuncCommand{
 	Short: "Call one or more functions, interconnected into a pipeline",
 	Annotations: map[string]string{
 		printTraceLinkKey: "true",
+	},
+}
+
+var callTwiceCmd = &cobra.Command{
+	Use:   "call-twice [options] [function]...",
+	Short: "Call a function chain twice, verifying cache usage on the second run",
+	Long: strings.ReplaceAll(`Run the requested function pipeline once normally, then re-run it with --fail-on-cache-miss to verify that the result was served from cache.
+
+This is more convenient than running dagger twice manually.`, "´", "`"),
+	DisableFlagParsing:    true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		exe, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("determine executable path: %w", err)
+		}
+
+		first := exec.Command(exe, append([]string{"call"}, args...)...)
+		first.Stdin = os.Stdin
+		first.Stdout = cmd.OutOrStdout()
+		first.Stderr = cmd.ErrOrStderr()
+		if err := first.Run(); err != nil {
+			return err
+		}
+
+		second := exec.Command(exe, append([]string{"call", "--fail-on-cache-miss"}, args...)...)
+		second.Stdin = os.Stdin
+		second.Stdout = cmd.OutOrStdout()
+		second.Stderr = cmd.ErrOrStderr()
+		return second.Run()
 	},
 }
 

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql/dagui"
@@ -65,6 +66,49 @@ func defaultRunnerHost() string {
 }
 
 type runClientCallback func(context.Context, *client.Client) error
+
+type failOnCacheMissContextKey struct{}
+
+var failOnCacheMissKey = failOnCacheMissContextKey{}
+
+type cacheMissState struct {
+	failed atomic.Bool
+}
+
+func (s *cacheMissState) failedMiss() bool {
+	return s.failed.Load()
+}
+
+type failOnCacheMissSpanExporter struct {
+	state *cacheMissState
+}
+
+func newCacheMissSpanExporter(state *cacheMissState) sdktrace.SpanExporter {
+	return &failOnCacheMissSpanExporter{state: state}
+}
+
+func (e *failOnCacheMissSpanExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	for _, span := range spans {
+		var isCallSpan bool
+		var cached bool
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == telemetry.DagCallAttr {
+				isCallSpan = true
+			}
+			if string(attr.Key) == telemetry.CachedAttr {
+				cached = true
+			}
+		}
+		if isCallSpan && !cached {
+			e.state.failed.Store(true)
+		}
+	}
+	return nil
+}
+
+func (e *failOnCacheMissSpanExporter) Shutdown(context.Context) error {
+	return nil
+}
 
 func withEngine(
 	ctx context.Context,
@@ -174,6 +218,11 @@ func resolveLockMode(paramLockMode, globalLockMode string) (string, error) {
 	return string(mode), nil
 }
 
+func getCacheMissState(ctx context.Context) *cacheMissState {
+	state, _ := ctx.Value(failOnCacheMissKey).(*cacheMissState)
+	return state
+}
+
 func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 	// Setup telemetry config
 	telemetryCfg := telemetry.Config{
@@ -183,6 +232,13 @@ func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 		LiveTraceExporters:  []sdktrace.SpanExporter{Frontend.SpanExporter()},
 		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},
 		LiveMetricExporters: []sdkmetric.Exporter{Frontend.MetricExporter()},
+	}
+
+	if state := getCacheMissState(ctx); state != nil {
+		telemetryCfg.LiveTraceExporters = append(
+			telemetryCfg.LiveTraceExporters,
+			newCacheMissSpanExporter(state),
+		)
 	}
 	if spans, logs, metrics, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
 		telemetryCfg.LiveTraceExporters = append(telemetryCfg.LiveTraceExporters, spans)

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -182,6 +182,8 @@ func (fc *FuncCommand) Command() *cobra.Command {
 					c.SetContext(idtui.WithPrintTraceLink(c.Context(), true))
 				}
 
+				fc.changedInputs = nil
+
 				execArgs := a
 				// With DisableFlagParsing enabled, --help can remain in args when it
 				// appears after the first positional token. Strip it once we know help

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -116,6 +116,8 @@ type FuncCommand struct {
 	// withFn is the `with` function on Query root, if present.
 	// Used to forward constructor args from the root command.
 	withFn *modFunction
+
+	failOnCacheMiss bool
 }
 
 func (fc *FuncCommand) Command() *cobra.Command {
@@ -190,7 +192,14 @@ func (fc *FuncCommand) Command() *cobra.Command {
 				params := initModuleParams(execArgs)
 				params.LoadWorkspaceModules = shouldLoadWorkspaceModules(fc.DisableModuleLoad)
 
-				return withEngine(c.Context(), params, func(ctx context.Context, engineClient *client.Client) (rerr error) {
+				cacheMiss := &cacheMissState{}
+				execCtx := c.Context()
+				if fc.failOnCacheMiss {
+					execCtx = context.WithValue(execCtx, failOnCacheMissKey, cacheMiss)
+					c.SetContext(execCtx)
+				}
+
+				returnValue := withEngine(execCtx, params, func(ctx context.Context, engineClient *client.Client) (rerr error) {
 					fc.c = engineClient
 					fc.q = querybuilder.Query().Client(engineClient.Dagger().GraphQLClient())
 
@@ -227,9 +236,13 @@ func (fc *FuncCommand) Command() *cobra.Command {
 
 					return nil
 				})
+
+				if returnValue == nil && fc.failOnCacheMiss && cacheMiss.failedMiss() {
+					return fmt.Errorf("call failed because it was not served from cache")
+				}
+				return returnValue
 			},
 		}
-
 		if fc.cmd.Annotations == nil {
 			fc.cmd.Annotations = map[string]string{}
 		}
@@ -246,6 +259,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 
 		fc.cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "Save the result to a local file or directory")
 
+		fc.cmd.PersistentFlags().BoolVar(&fc.failOnCacheMiss, "fail-on-cache-miss", false, "Fail if the call cannot be served from cache")
 		fc.cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
 	}
 	return fc.cmd

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -113,6 +113,8 @@ type FuncCommand struct {
 	c   *client.Client
 	ctx context.Context
 
+	changedInputs []string
+
 	// withFn is the `with` function on Query root, if present.
 	// Used to forward constructor args from the root command.
 	withFn *modFunction
@@ -238,7 +240,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 				})
 
 				if returnValue == nil && fc.failOnCacheMiss && cacheMiss.failedMiss() {
-					return fmt.Errorf("call failed because it was not served from cache")
+					return cacheMissErr(fc.changedInputs)
 				}
 				return returnValue
 			},
@@ -263,6 +265,13 @@ func (fc *FuncCommand) Command() *cobra.Command {
 		fc.cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
 	}
 	return fc.cmd
+}
+
+func cacheMissErr(changedInputs []string) error {
+	if len(changedInputs) == 0 {
+		return fmt.Errorf("call failed because it was not served from cache; the request inputs changed or the result was invalidated")
+	}
+	return fmt.Errorf("call failed because it was not served from cache; changed inputs: %s", strings.Join(changedInputs, ", "))
 }
 
 func stripHelpArgs(args []string) []string {
@@ -658,6 +667,7 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 			continue
 		}
 
+		fc.changedInputs = append(fc.changedInputs, fmt.Sprintf("--%s", a.FlagName()))
 		p.Go(func() (flagResult, error) {
 			v, err := a.GetFlagValue(fc.ctx, flag, fc.c.Dagger(), fc.mod)
 			if err != nil {

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -155,6 +155,7 @@ func init() {
 		funcListCmd,
 		callCoreCmd.Command(),
 		callModCmd.Command(),
+		callTwiceCmd,
 		sessionCmd(),
 		newGenCmd(),
 		shellCmd,

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -64,12 +64,13 @@ dagger call [options]
 ### Options
 
 ```
-      --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-runtime       load module runtime eagerly
-  -j, --json                Present result as JSON
-  -m, --mod string          Module reference to load, either a local path or a remote git repo (defaults to current directory)
-  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
-  -o, --output string       Save the result to a local file or directory
+      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --eager-runtime        load module runtime eagerly
+      --fail-on-cache-miss   Fail if the call cannot be served from cache
+  -j, --json                 Present result as JSON
+  -m, --mod string           Module reference to load, either a local path or a remote git repo (defaults to current directory)
+  -M, --no-mod               Don't automatically load a module (mutually exclusive with --mod)
+  -o, --output string        Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands
@@ -151,8 +152,9 @@ dagger core [options]
 ### Options
 
 ```
-  -j, --json            Present result as JSON
-  -o, --output string   Save the result to a local file or directory
+      --fail-on-cache-miss   Fail if the call cannot be served from cache
+  -j, --json                 Present result as JSON
+  -o, --output string        Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Overview
This PR introduces a new `--fail-on-cache-miss` flag for the dagger command that allows users to enforce cache-only execution mode, and adds a new convenience command `dagger call-twice` to run a call once normally and then re-run it with cache validation.

## What changed
- Added `dagger call-twice` to run `dagger call ...` followed by `dagger call --fail-on-cache-miss ...`
- Improved `--fail-on-cache-miss` diagnostics so failures now include changed input flags when available
- Added focused unit tests covering the cache-miss error helper

## Motivation
Users often want to verify that a call can be served from cache, but running the command twice manually is inconvenient. `call-twice` makes that flow easier and the enhanced error message makes it clearer why a cache miss occurred.

## Usage examples
```bash
dagger call-twice myFunction
dagger call --fail-on-cache-miss myFunction
```

## Notes
- The new command is registered at the root level alongside `call` and `functions`
- The cache-miss error now surfaces changed input flags if they were part of the request

## Related:

[How to debug unexpected cache-misses between consecutive `dagger call` runs? · dagger/dagger · Discussion #13164](https://github.com/dagger/dagger/discussions/13164)