### PR TITLE
fix(sdk/python): resolve absolute self-imports in AST analyzer

### DIFF
--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -297,11 +297,12 @@ class ModuleParser:
         # type-aliases can't bleed into each other's resolution paths.
         self._module_type_aliases: dict[Path, dict[str, ast.expr]] = {}
 
-        # Per-file map of names brought in by relative imports to the parsed
-        # file they came from. Populated in ``_collect_relative_imports``
-        # and consumed by ``_expand_alias`` (cross-file alias resolution)
-        # and ``_eval_constant`` (cross-file constant resolution).
-        self._relative_import_origins: dict[Path, dict[str, Path]] = {}
+        # Per-file map of names brought in by a relative import or an
+        # absolute self-package import to the parsed file they came from.
+        # Populated in ``_collect_cross_file_imports`` and consumed by
+        # ``_expand_alias`` (cross-file alias resolution) and
+        # ``_eval_constant`` (cross-file constant resolution).
+        self._cross_file_import_origins: dict[Path, dict[str, Path]] = {}
 
         # File currently being extracted. Set by ``_extract_declarations`` so
         # ``_eval_constant`` can scope name lookups to the containing file.
@@ -344,9 +345,10 @@ class ModuleParser:
         # Phase 2.5: Collect module-level constants for default resolution
         self._collect_module_constants()
 
-        # Phase 2.6: Map relative-import names to the file that defines them
-        # (so cross-file aliases and constants can be resolved).
-        self._collect_relative_imports()
+        # Phase 2.6: Map relative- and absolute-self-import names to the
+        # file that defines them (so cross-file aliases and constants can
+        # be resolved).
+        self._collect_cross_file_imports()
 
         # Record per-file origin of the unqualified ``field`` name.
         self._track_field_origins()
@@ -596,14 +598,39 @@ class ModuleParser:
                 constants[item.target.id] = item.value
         self._class_constants[key] = constants
 
-    def _collect_relative_imports(self) -> None:
-        """Map relative-import names to the parsed file they were defined in.
+    def _detect_package_root(self) -> tuple[Path, str] | None:
+        """Locate the analyzed module's package root directory and name.
 
-        For ``from .types import Source`` in ``pkg/main.py``, record
-        ``(pkg/main.py, "Source") -> pkg/types.py`` provided ``pkg/types.py``
-        is also in the parsed file set. ``_expand_alias`` consults this map
-        to follow aliases across files; ``_eval_constant`` can do the same
-        for constants.
+        The root is the parent of the shallowest ``__init__.py`` among the
+        parsed files; its directory name is what the module imports itself
+        by (``from <pkg>.helpers import X``). Returns ``None`` for a
+        single-file module or when no ``__init__.py`` was parsed — neither
+        can carry an absolute self-import.
+        """
+        init_files = [
+            file_path.resolve()
+            for file_path in self._asts
+            if file_path.name == "__init__.py"
+        ]
+        if not init_files:
+            return None
+        shallowest = min(init_files, key=lambda p: len(p.parts))
+        root = shallowest.parent
+        return root, root.name
+
+    def _collect_cross_file_imports(self) -> None:
+        """Map imported names to the parsed file they were defined in.
+
+        Two import shapes both bind a name from a sibling file of the same
+        module, and both are recorded here:
+
+        * relative imports — ``from .types import Source`` in
+          ``pkg/main.py`` records ``(pkg/main.py, "Source") -> pkg/types.py``;
+        * absolute self-imports — ``from pkg.types import Source`` records
+          the same, when ``pkg`` is the module's own package name.
+
+        ``_expand_alias`` consults this map to follow aliases across files;
+        ``_eval_constant`` does the same for constants.
 
         The mapping is best-effort — when the target file isn't in the
         parsed set (third-party package, dynamic ``__path__``, etc.), the
@@ -616,16 +643,22 @@ class ModuleParser:
         path_index: dict[Path, Path] = {
             resolved: original for original, resolved in resolved_paths.items()
         }
+        package_root = self._detect_package_root()
 
         for file_path, tree in self._asts.items():
-            mapping = self._relative_import_origins.setdefault(file_path, {})
+            mapping = self._cross_file_import_origins.setdefault(file_path, {})
             current_resolved = resolved_paths[file_path]
             for node in ast.iter_child_nodes(tree):
-                if not isinstance(node, ast.ImportFrom) or node.level <= 0:
+                if not isinstance(node, ast.ImportFrom):
                     continue
-                target = self._resolve_relative_import_target(
-                    current_resolved, node.level, node.module, path_index
-                )
+                if node.level > 0:
+                    target = self._resolve_relative_import_target(
+                        current_resolved, node.level, node.module, path_index
+                    )
+                else:
+                    target = self._resolve_absolute_import_target(
+                        node.module, package_root, path_index
+                    )
                 if target is None:
                     continue
                 for alias in node.names:
@@ -661,6 +694,37 @@ class ModuleParser:
         # Bare ``from . import x`` — no module to resolve to a file.
         return None
 
+    @staticmethod
+    def _resolve_absolute_import_target(
+        module: str | None,
+        package_root: tuple[Path, str] | None,
+        path_index: dict[Path, Path],
+    ) -> Path | None:
+        """Return the parsed-file path for an absolute self-package import.
+
+        ``from <pkg>.sub.mod import X`` resolves to ``<root>/sub/mod.py``
+        (or its ``__init__.py``) when ``<pkg>`` is the analyzed module's
+        own package name. Anything whose first component isn't that name —
+        third-party packages, the stdlib — returns ``None`` and keeps its
+        existing stub behavior. A bare ``from <pkg> import x`` (no
+        submodule) also returns ``None``: like ``from . import x`` it has
+        no dotted module to pin to a file.
+        """
+        if module is None or package_root is None:
+            return None
+        root, package_name = package_root
+        head, _, submodule = module.partition(".")
+        if head != package_name or not submodule:
+            return None
+        target_dir = root
+        for part in submodule.split("."):
+            target_dir = target_dir / part
+        for cand in (target_dir.with_suffix(".py"), target_dir / "__init__.py"):
+            resolved = cand.resolve() if cand.exists() else cand
+            if resolved in path_index:
+                return path_index[resolved]
+        return None
+
     def _looks_like_type_expr(self, node: ast.expr) -> bool:
         """Return True when ``node`` looks like a type expression.
 
@@ -684,8 +748,9 @@ class ModuleParser:
         type-position ``Name`` that resolves to a known alias with the alias's
         right-hand side. Chained aliases (``B = A``, ``A = dagger.Directory``)
         collapse to their final form, and cross-file aliases imported via
-        ``from .types import Source`` are followed by switching the active file
-        context while expanding the foreign alias body.
+        ``from .types import Source`` (or the absolute ``from pkg.types
+        import Source``) are followed by switching the active file context
+        while expanding the foreign alias body.
 
         The traversal deliberately stops at value positions inside annotations,
         especially ``Annotated`` metadata arguments, so ``Name("Alias")`` keeps
@@ -712,7 +777,7 @@ class ModuleParser:
         cloned = copy.deepcopy(annotation)
         expander = _AliasExpander(
             aliases_by_file=self._module_type_aliases,
-            origins_by_file=self._relative_import_origins,
+            origins_by_file=self._cross_file_import_origins,
             current_file=file_path,
         )
         return expander.visit(cloned)
@@ -2026,7 +2091,8 @@ class ModuleParser:
             #   1. Class body — closest scope when evaluating a default
             #      inside a method.
             #   2. Current file's module-level constants.
-            #   3. Any file that bound this name via a relative import.
+            #   3. Any file that bound this name via a relative or
+            #      absolute self-package import.
             current = self._current_file
             if current is not None and self._current_class_name is not None:
                 class_constants = self._class_constants.get(
@@ -2038,7 +2104,7 @@ class ModuleParser:
                 file_constants = self._module_constants.get(current, {})
                 if node.id in file_constants:
                     return self._eval_constant(file_constants[node.id])
-                origin = self._relative_import_origins.get(current, {}).get(node.id)
+                origin = self._cross_file_import_origins.get(current, {}).get(node.id)
                 if origin is not None:
                     origin_constants = self._module_constants.get(origin, {})
                     if node.id in origin_constants:

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -704,18 +704,21 @@ class ModuleParser:
 
         ``from <pkg>.sub.mod import X`` resolves to ``<root>/sub/mod.py``
         (or its ``__init__.py``) when ``<pkg>`` is the analyzed module's
-        own package name. Anything whose first component isn't that name —
-        third-party packages, the stdlib — returns ``None`` and keeps its
-        existing stub behavior. A bare ``from <pkg> import x`` (no
-        submodule) also returns ``None``: like ``from . import x`` it has
-        no dotted module to pin to a file.
+        own package name. A package-root import (``from <pkg> import X``)
+        resolves to ``<root>/__init__.py``. Anything whose first component
+        isn't that name — third-party packages, the stdlib — returns
+        ``None`` and keeps its existing stub behavior.
         """
         if module is None or package_root is None:
             return None
         root, package_name = package_root
         head, _, submodule = module.partition(".")
-        if head != package_name or not submodule:
+        if head != package_name:
             return None
+        if not submodule:
+            cand = root / "__init__.py"
+            resolved = cand.resolve() if cand.exists() else cand
+            return path_index.get(resolved)
         target_dir = root
         for part in submodule.split("."):
             target_dir = target_dir / part

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -135,7 +135,7 @@ class _AliasExpander(ast.NodeTransformer):
     def __init__(
         self,
         aliases_by_file: dict[Path, dict[str, ast.expr]],
-        origins_by_file: dict[Path, dict[str, Path]],
+        origins_by_file: dict[Path, dict[str, tuple[Path, str]]],
         current_file: Path,
     ):
         super().__init__()
@@ -196,8 +196,8 @@ class _AliasExpander(ast.NodeTransformer):
         if target is None:
             return original
 
-        origin, value = target
-        key = (origin, name)
+        origin, origin_name, value = target
+        key = (origin, origin_name)
         if key in self.seen:
             return original
 
@@ -211,18 +211,29 @@ class _AliasExpander(ast.NodeTransformer):
             self.current_file = saved_file
             self.seen.discard(key)
 
-    def _alias_target(self, name: str) -> tuple[Path, ast.expr] | None:
+    def _alias_target(self, name: str) -> tuple[Path, str, ast.expr] | None:
         local_aliases = self.aliases_by_file.get(self.current_file, {})
         if name in local_aliases:
-            return self.current_file, local_aliases[name]
+            return self.current_file, name, local_aliases[name]
 
-        origin = self.origins_by_file.get(self.current_file, {}).get(name)
-        if origin is not None:
-            origin_aliases = self.aliases_by_file.get(origin, {})
-            if name in origin_aliases:
-                return origin, origin_aliases[name]
-
-        return None
+        # Follow import chain, handling re-exports through __init__.py
+        current_file = self.current_file
+        current_name = name
+        visited: set[tuple[Path, str]] = set()
+        while True:
+            key = (current_file, current_name)
+            if key in visited:
+                return None
+            visited.add(key)
+            entry = self.origins_by_file.get(current_file, {}).get(current_name)
+            if entry is None:
+                return None
+            origin_file, origin_name = entry
+            origin_aliases = self.aliases_by_file.get(origin_file, {})
+            if origin_name in origin_aliases:
+                return origin_file, origin_name, origin_aliases[origin_name]
+            current_file = origin_file
+            current_name = origin_name
 
     def visit_Constant(self, node: ast.Constant) -> ast.expr:
         # String forward references — re-parse the string, recursively
@@ -298,11 +309,12 @@ class ModuleParser:
         self._module_type_aliases: dict[Path, dict[str, ast.expr]] = {}
 
         # Per-file map of names brought in by a relative import or an
-        # absolute self-package import to the parsed file they came from.
+        # absolute self-package import to the parsed file and original name
+        # they came from.
         # Populated in ``_collect_cross_file_imports`` and consumed by
         # ``_expand_alias`` (cross-file alias resolution) and
         # ``_eval_constant`` (cross-file constant resolution).
-        self._cross_file_import_origins: dict[Path, dict[str, Path]] = {}
+        self._cross_file_import_origins: dict[Path, dict[str, tuple[Path, str]]] = {}
 
         # File currently being extracted. Set by ``_extract_declarations`` so
         # ``_eval_constant`` can scope name lookups to the containing file.
@@ -625,9 +637,11 @@ class ModuleParser:
         module, and both are recorded here:
 
         * relative imports — ``from .types import Source`` in
-          ``pkg/main.py`` records ``(pkg/main.py, "Source") -> pkg/types.py``;
-        * absolute self-imports — ``from pkg.types import Source`` records
-          the same, when ``pkg`` is the module's own package name.
+          ``pkg/main.py`` records
+          ``(pkg/main.py, "Source") -> (pkg/types.py, "Source")``;
+        * absolute self-imports — ``from pkg.types import Source as Src``
+          records ``(pkg/main.py, "Src") -> (pkg/types.py, "Source")``,
+          when ``pkg`` is the module's own package name.
 
         ``_expand_alias`` consults this map to follow aliases across files;
         ``_eval_constant`` does the same for constants.
@@ -665,7 +679,38 @@ class ModuleParser:
                     if alias.name == "*":
                         continue
                     bound = alias.asname or alias.name
-                    mapping[bound] = target
+                    mapping[bound] = (target, alias.name)
+
+    def _resolve_cross_file_import_origin(
+        self, file_path: Path, name: str
+    ) -> tuple[Path, str] | None:
+        """Return the final parsed-file/name origin for an imported name.
+
+        ``_collect_cross_file_imports`` stores one import edge at a time:
+        local bound name -> (origin file, original exported name). This
+        helper follows those edges so package-root re-exports like
+        ``main.py: from pkg import Count`` plus
+        ``pkg/__init__.py: from .params import Count`` resolve to
+        ``(params.py, "Count")``.
+        """
+        current_file = file_path
+        current_name = name
+        seen: set[tuple[Path, str]] = set()
+
+        while True:
+            key = (current_file, current_name)
+            if key in seen:
+                return None
+            seen.add(key)
+
+            origin = self._cross_file_import_origins.get(current_file, {}).get(
+                current_name
+            )
+            if origin is None:
+                if current_file == file_path and current_name == name:
+                    return None
+                return current_file, current_name
+            current_file, current_name = origin
 
     @staticmethod
     def _resolve_relative_import_target(
@@ -2107,17 +2152,18 @@ class ModuleParser:
                 file_constants = self._module_constants.get(current, {})
                 if node.id in file_constants:
                     return self._eval_constant(file_constants[node.id])
-                origin = self._cross_file_import_origins.get(current, {}).get(node.id)
+                origin = self._resolve_cross_file_import_origin(current, node.id)
                 if origin is not None:
-                    origin_constants = self._module_constants.get(origin, {})
-                    if node.id in origin_constants:
+                    origin_file, origin_name = origin
+                    origin_constants = self._module_constants.get(origin_file, {})
+                    if origin_name in origin_constants:
                         # Switch the current-file scope so any nested name
                         # references inside the constant resolve against the
                         # foreign file's own constants.
                         previous = self._current_file
-                        self._current_file = origin
+                        self._current_file = origin_file
                         try:
-                            return self._eval_constant(origin_constants[node.id])
+                            return self._eval_constant(origin_constants[origin_name])
                         finally:
                             self._current_file = previous
             logger.warning(

--- a/sdk/python/tests/mod/_runtime_introspect.py
+++ b/sdk/python/tests/mod/_runtime_introspect.py
@@ -143,16 +143,29 @@ def runtime_introspect_package(
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding="utf-8")
 
+        # A caller-supplied ``package_name`` is the corpus module's real
+        # name, which can collide with a package already imported in this
+        # test session — a module literally named ``tests`` shadows the
+        # SDK's own ``tests`` package. ``importlib.import_module`` would
+        # then return the cached package instead of our materialised copy.
+        # Evict any colliding entries first and restore them afterwards.
+        shadowed = {
+            name: sys.modules.pop(name)
+            for name in list(sys.modules)
+            if name == package_name or name.startswith(package_name + ".")
+        }
         sys.path.insert(0, str(tmp_root))
         try:
             package = importlib.import_module(package_name)
             return _build_package_metadata(package, main_object_name)
         finally:
             # Drop every cached module under our package so a follow-up
-            # call starts clean even if it reuses a name.
+            # call starts clean even if it reuses a name, then restore any
+            # pre-existing package we shadowed.
             for mod_name in list(sys.modules):
                 if mod_name == package_name or mod_name.startswith(package_name + "."):
                     sys.modules.pop(mod_name, None)
+            sys.modules.update(shadowed)
             with contextlib.suppress(ValueError):
                 sys.path.remove(str(tmp_root))
     finally:

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1894,6 +1894,44 @@ def test_ast_cross_file_type_alias_with_default_path(tmp_path):
     assert param.default_path == "."
 
 
+def test_ast_absolute_self_import_type_alias(tmp_path):
+    """Alias imported via an absolute self-package import resolves cross-file.
+
+    Real modules commonly import their own siblings absolutely
+    (``from my_pkg.params import Count``) rather than relatively. The
+    analyzer must recognise the leading component as its own package name
+    and follow the import to the parsed sibling file, just as it does for
+    ``from .params import Count``.
+    """
+    pkg = tmp_path / "my_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "params.py").write_text(
+        "from typing import Annotated, TypeAlias\n"
+        "from dagger import Doc\n"
+        'Count: TypeAlias = Annotated[int, Doc("how many")]\n',
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from my_pkg.params import Count\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo:\n"
+        "    @dagger.function\n"
+        "    def run(self, n: Count) -> str: ...\n",
+        encoding="utf-8",
+    )
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "params.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "int"
+    assert param.doc == "how many"
+
+
 # -- Annotated metadata recursion -------------------------------------------
 
 

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1932,6 +1932,39 @@ def test_ast_absolute_self_import_type_alias(tmp_path):
     assert param.doc == "how many"
 
 
+def test_ast_absolute_self_import_aliased_original_name(tmp_path):
+    """``from my_pkg.params import Count as C`` looks up ``Count`` in params."""
+    pkg = tmp_path / "my_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "params.py").write_text(
+        "from typing import Annotated, TypeAlias\n"
+        "from dagger import Doc\n"
+        'Count: TypeAlias = Annotated[int, Doc("how many")]\n'
+        "DEFAULT_COUNT = 7\n",
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from my_pkg.params import Count as C, DEFAULT_COUNT as D\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo:\n"
+        "    @dagger.function\n"
+        "    def run(self, n: C = D) -> str: ...\n",
+        encoding="utf-8",
+    )
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "params.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "int"
+    assert param.doc == "how many"
+    assert param.default_value == 7
+
+
 def test_ast_absolute_package_root_self_import_metadata(tmp_path):
     """``from my_pkg import X`` resolves aliases and constants from ``__init__``."""
     pkg = tmp_path / "my_pkg"
@@ -1955,6 +1988,42 @@ def test_ast_absolute_package_root_self_import_metadata(tmp_path):
     )
     metadata = analyze_module(
         source_files=[pkg / "__init__.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "int"
+    assert param.doc == "how many"
+    assert param.default_value == 7
+
+
+def test_ast_absolute_package_root_self_import_reexport_metadata(tmp_path):
+    """``from my_pkg import X`` follows re-exports from ``__init__``."""
+    pkg = tmp_path / "my_pkg"
+    pkg.mkdir()
+    (pkg / "params.py").write_text(
+        "from typing import Annotated, TypeAlias\n"
+        "from dagger import Doc\n"
+        'Count: TypeAlias = Annotated[int, Doc("how many")]\n'
+        "DEFAULT_COUNT = 7\n",
+        encoding="utf-8",
+    )
+    (pkg / "__init__.py").write_text(
+        "from .params import Count as PublicCount, DEFAULT_COUNT as PUBLIC_DEFAULT\n",
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from my_pkg import PublicCount as C, PUBLIC_DEFAULT as D\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo:\n"
+        "    @dagger.function\n"
+        "    def run(self, n: C = D) -> str: ...\n",
+        encoding="utf-8",
+    )
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "params.py", pkg / "main.py"],
         main_object_name="Foo",
     )
     param = metadata.objects["Foo"].functions[0].parameters[0]

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -1932,6 +1932,38 @@ def test_ast_absolute_self_import_type_alias(tmp_path):
     assert param.doc == "how many"
 
 
+def test_ast_absolute_package_root_self_import_metadata(tmp_path):
+    """``from my_pkg import X`` resolves aliases and constants from ``__init__``."""
+    pkg = tmp_path / "my_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        "from typing import Annotated, TypeAlias\n"
+        "from dagger import Doc\n"
+        'Count: TypeAlias = Annotated[int, Doc("how many")]\n'
+        "DEFAULT_COUNT = 7\n",
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from my_pkg import Count, DEFAULT_COUNT\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo:\n"
+        "    @dagger.function\n"
+        "    def run(self, n: Count = DEFAULT_COUNT) -> str: ...\n",
+        encoding="utf-8",
+    )
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.resolved_type.kind == "primitive"
+    assert param.resolved_type.name == "int"
+    assert param.doc == "how many"
+    assert param.default_value == 7
+
+
 # -- Annotated metadata recursion -------------------------------------------
 
 

--- a/sdk/python/tests/mod/test_daggerverse_corpus.py
+++ b/sdk/python/tests/mod/test_daggerverse_corpus.py
@@ -1,16 +1,17 @@
 """Differential test against real Daggerverse Python modules.
 
-Pulls the modules from `https://github.com/telchak/daggerverse`, walks
-every top-level module that declares ``sdk: python``, and runs the AST
-analyzer + runtime introspector on each. This is the "what users
-actually write" half of the confidence story — if a single module
-differs between the two paths, the test fails with the module name and
-the path of the divergent member.
+Pulls the modules from a daggerverse repo (``telchak/daggerverse`` by
+default), walks every top-level module that declares ``sdk: python``,
+and runs the AST analyzer + runtime introspector on each. This is the
+"what users actually write" half of the confidence story — if a single
+module differs between the two paths, the test fails with the module
+name and the path of the divergent member.
 
 The corpus is cloned once per session (network required). Set
-``DAGGERVERSE_CORPUS_REF`` to pin to a specific commit/branch; default
-is the repo's current ``main`` branch. Skip the whole file by setting
-``SKIP_DAGGERVERSE_CORPUS=1`` (useful for offline development).
+``DAGGERVERSE_CORPUS_URL`` to point at a different daggerverse repo and
+``DAGGERVERSE_CORPUS_REF`` to pin to a specific commit/branch; the ref
+defaults to the repo's current ``main`` branch. Skip the whole file by
+setting ``SKIP_DAGGERVERSE_CORPUS=1`` (useful for offline development).
 """
 
 from __future__ import annotations
@@ -31,7 +32,9 @@ from dagger.mod._analyzer.analyze import analyze_module
 from ._differential import assert_metadata_equivalent
 from ._runtime_introspect import runtime_introspect_package
 
-CORPUS_URL = "https://github.com/telchak/daggerverse.git"
+CORPUS_URL = os.environ.get(
+    "DAGGERVERSE_CORPUS_URL", "https://github.com/telchak/daggerverse.git"
+)
 CORPUS_REF = os.environ.get("DAGGERVERSE_CORPUS_REF", "main")
 
 
@@ -119,26 +122,30 @@ def _module_id(module_dir: Path) -> str:
     return module_dir.name
 
 
-def _read_module_files(module_dir: Path) -> dict[str, str]:
+def _read_module_files(module_dir: Path) -> tuple[str, dict[str, str]]:
     """Collect ``.py`` files under ``src/<package>/`` keyed by relative path.
 
     Daggerverse modules live in ``<module>/src/<package_name>/``. We treat
-    that subdirectory as the package root the runtime will import.
+    that subdirectory as the package root the runtime will import, and
+    return ``(package_name, files)`` — the package name matters because
+    modules commonly import their own siblings absolutely
+    (``from my_pkg.helpers import X``), which only resolves when the
+    package is materialised under its real name.
     """
     src_root = module_dir / "src"
     if not src_root.is_dir():
-        return {}
+        return "", {}
     # Daggerverse always has exactly one package directory inside src/.
     package_dirs = [p for p in sorted(src_root.iterdir()) if p.is_dir()]
     if not package_dirs:
-        return {}
+        return "", {}
     package_dir = package_dirs[0]
 
     files: dict[str, str] = {}
     for py_file in sorted(package_dir.rglob("*.py")):
         rel = py_file.relative_to(package_dir).as_posix()
         files[rel] = py_file.read_text(encoding="utf-8")
-    return files
+    return package_dir.name, files
 
 
 def _main_object_name(module_dir: Path) -> str:
@@ -153,13 +160,19 @@ def _main_object_name(module_dir: Path) -> str:
 
 
 def _materialise_for_ast(
-    module_dir: Path, files: dict[str, str], tmp_path: Path
+    package_name: str, files: dict[str, str], dest: Path
 ) -> list[Path]:
-    """Write the module files under ``tmp_path`` for the AST analyzer.
+    """Write the module files under ``dest/<package_name>/`` for the analyzer.
+
+    The package directory is named after the real Python package — not the
+    daggerverse module directory, which may contain hyphens — so the AST
+    analyzer sees the same layout ``dagger develop`` would. That match
+    matters for absolute self-imports (``from <package_name>.x import Y``),
+    which only resolve when the package root carries its real name.
 
     The AST analyzer takes a list of file paths, not a string dict.
     """
-    pkg_root = tmp_path / module_dir.name
+    pkg_root = dest / package_name
     pkg_root.mkdir(parents=True, exist_ok=True)
     written: list[Path] = []
     for rel, content in files.items():
@@ -207,23 +220,29 @@ def test_daggerverse_module_diff(
 
     failures: list[tuple[str, str]] = []
     for module_dir in modules:
-        files = _read_module_files(module_dir)
+        package_name, files = _read_module_files(module_dir)
         if not files:
             failures.append((module_dir.name, "no .py files under src/<pkg>/"))
             continue
         main = _main_object_name(module_dir)
 
         # AST side — uses the real file paths for accurate location info.
-        ast_paths = _materialise_for_ast(module_dir, files, tmp_path / module_dir.name)
+        ast_paths = _materialise_for_ast(
+            package_name, files, tmp_path / module_dir.name
+        )
         try:
             ast_md = analyze_module(source_files=ast_paths, main_object_name=main)
         except Exception as exc:  # noqa: BLE001 — surface any analyzer crash
             failures.append((module_dir.name, f"AST analyze raised: {exc!r}"))
             continue
 
-        # Runtime side — imports the package via importlib.
+        # Runtime side — imports the package via importlib. The package
+        # must be materialised under its real name so the module's own
+        # absolute self-imports (``from <pkg>.x import Y``) resolve.
         try:
-            runtime_md = runtime_introspect_package(files, main)
+            runtime_md = runtime_introspect_package(
+                files, main, package_name=package_name
+            )
         except Exception as exc:  # noqa: BLE001 — surface any import crash
             failures.append((module_dir.name, f"runtime import raised: {exc!r}"))
             continue


### PR DESCRIPTION
## What this fixes

The Python SDK's static module analyzer derives a module's API from its source code, without importing it. When a module is split across files, it only followed **relative** imports (`from .params import Foo`) to find names defined in sibling files.

Modules that import their own siblings **absolutely** (`from my_pkg.params import Foo`) — a common style — left those names unresolved. A type alias imported that way collapsed to an unresolved custom type instead of its real underlying type, so any function parameter or field typed through such an alias ended up with the **wrong type in the generated API**.

This PR teaches the analyzer to recognise a module's own package name and resolve those absolute imports to the parsed sibling file, reusing the cross-file resolution already in place for relative imports.

## Commits

1. **`fix(sdk/python): resolve absolute self-package imports in AST analyzer`** — the analyzer fix plus a regression test. The cross-file origin map is renamed from `_relative_import_origins` to `_cross_file_import_origins` since it now covers both import styles.
2. **`test(sdk/python): run the daggerverse corpus under real package names`** — the daggerverse corpus differential test now lays modules out under their real package name (matching how `dagger develop` loads a module) so absolute self-imports resolve; the runtime introspector handles package-name collisions; `DAGGERVERSE_CORPUS_URL` makes the corpus repo configurable.

## Test plan

- [x] New unit test `test_ast_absolute_self_import_type_alias` — fails before the fix, passes after.
- [x] Daggerverse corpus vs `typesafe-ai/daggerverse`: 2/3 modules diverged → 0.
- [x] Daggerverse corpus vs `telchak/daggerverse` (default): still green.
- [x] Full `tests/mod/` suite: 298 passed, 1 xfailed.

## Related

Complementary to #13162: that PR improves the alias *expander* (how an alias is expanded); this one fixes import *resolution* (whether a cross-file alias is found at all). Different root cause; a minor rebase is needed if both land.