### PR TITLE
Lock TypeScript SDK yarn cache

### DIFF
--- a/toolchains/typescript-sdk-dev/ts-sdk.dang
+++ b/toolchains/typescript-sdk-dev/ts-sdk.dang
@@ -199,7 +199,11 @@ type TypescriptSdkDev {
     container
       # ⚠️  Keep this in sync with the engine version defined in package.json
       .from("node:" + nodeVersion + "-alpine")
-      .withMountedCache("/usr/local/share/.cache/yarn", cacheVolume("yarn_cache:" + nodeVersion))
+      .withMountedCache(
+        path: "/usr/local/share/.cache/yarn",
+        cache: cacheVolume("yarn_cache:" + nodeVersion),
+        sharing: CacheSharingMode.LOCKED,
+      )
       .withWorkdir("/app")
       .withFile(sourcePath + "/package.json", source.file("package.json"))
       .withFile(sourcePath + "/yarn.lock", source.file("yarn.lock"))
@@ -212,7 +216,11 @@ type TypescriptSdkDev {
   pub nodejsBase(nodeVersion: String! = nodeVersionPrevLts): Container! {
     container
       .from("node:" + nodeVersion + "-alpine")
-      .withMountedCache("/usr/local/share/.cache/yarn", cacheVolume("yarn_cache:" + nodeVersion))
+      .withMountedCache(
+        path: "/usr/local/share/.cache/yarn",
+        cache: cacheVolume("yarn_cache:" + nodeVersion),
+        sharing: CacheSharingMode.LOCKED,
+      )
       .withWorkdir("/app")
   }
 


### PR DESCRIPTION
## Summary

Lock the TypeScript SDK Yarn cache volume so concurrent lint checks do not mutate Yarn v1 global cache at the same time.

## Root Cause

`ci:bootstrap` can run `typescript-sdk:lint-typescript` and `typescript-sdk:lint-docs-snippets` concurrently. Both construct the same Node dev container and run `yarn --cwd sdk/typescript install` against the same Yarn cache volume. With the default `SHARED` cache mode, those installs can overlap and leave partial Yarn v1 cache entries, producing ENOENT failures for files such as `.yarn-metadata.json`.

## Validation

- Reproduced the warm-cache/source-change failure locally with two overlapping Yarn installs.
- Verified the failed cache snapshot had a partial `npm-lodash-camelcase-4.3.0-integrity` entry.
- Ran the same warm-cache/source-change path five times with `CacheSharingMode.LOCKED`; all passed.
- Final clean-source verification passed: `./hack/with-dev ./bin/dagger --progress=plain call ci bootstrap --checks 'typescript-sdk:*lint*'`.