### PR TITLE
core: persist dagql cache graphs and reset dirty worker state

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -131,32 +131,48 @@ type persistedCacheVolumePayload struct {
 	Selector  string           `json:"selector,omitempty"`
 }
 
-func (cache *CacheVolume) EncodePersistedObject(ctx context.Context, persistedCache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (cache *CacheVolume) EncodePersistedObject(ctx context.Context, persistedCache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = persistedCache
 	if cache == nil {
-		return nil, fmt.Errorf("encode persisted cache volume: nil cache volume")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted cache volume: nil cache volume")
 	}
 	sourceID := ""
 	if cache.Source.Valid {
 		encoded, err := cache.Source.Value.Encode()
 		if err != nil {
-			return nil, fmt.Errorf("encode persisted cache volume source: %w", err)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted cache volume source: %w", err)
 		}
 		sourceID = encoded
 	}
+	cache.mu.Lock()
+	selector := cache.selector
+	if selector == "" {
+		selector = "/"
+	}
+	var snapshotLinks []dagql.PersistedSnapshotRefLink
+	if cache.snapshot != nil {
+		snapshotLinks = []dagql.PersistedSnapshotRefLink{{
+			RefKey: cache.snapshot.SnapshotID(),
+			Role:   "snapshot",
+		}}
+	}
+	cache.mu.Unlock()
 	payload, err := json.Marshal(persistedCacheVolumePayload{
 		Key:       cache.Key,
 		Namespace: cache.Namespace,
 		SourceID:  sourceID,
 		Sharing:   cache.Sharing,
 		Owner:     cache.Owner,
-		Selector:  cache.getSnapshotSelector(),
+		Selector:  selector,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted cache volume payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted cache volume payload: %w", err)
 	}
-	return payload, nil
+	return dagql.PersistedObjectEncoding{
+		JSON:          payload,
+		SnapshotLinks: snapshotLinks,
+	}, nil
 }
 
 func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -298,10 +298,10 @@ func TestCacheVolumeEncodeDecodePersistsSourceID(t *testing.T) {
 	require.NoError(t, err)
 
 	var raw persistedCacheVolumePayload
-	require.NoError(t, json.Unmarshal(payload, &raw))
+	require.NoError(t, json.Unmarshal(payload.JSON, &raw))
 	require.NotEmpty(t, raw.SourceID)
 
-	decodedAny, err := (&CacheVolume{}).DecodePersistedObject(context.Background(), nil, 0, nil, payload)
+	decodedAny, err := (&CacheVolume{}).DecodePersistedObject(context.Background(), nil, 0, nil, payload.JSON)
 	require.NoError(t, err)
 	decoded := decodedAny.(*CacheVolume)
 	require.True(t, decoded.Source.Valid)

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -240,6 +240,11 @@ type changesetJSONEnvelope struct {
 	AfterID  dagql.ID[*Directory] `json:"afterId"`
 }
 
+type persistedChangesetPayload struct {
+	BeforeResultID uint64 `json:"beforeResultID,omitempty"`
+	AfterResultID  uint64 `json:"afterResultID,omitempty"`
+}
+
 // MarshalJSON implements custom JSON marshaling that stores directory IDs
 func (ch *Changeset) MarshalJSON() ([]byte, error) {
 	beforeID, err := ch.Before.ID()
@@ -285,6 +290,52 @@ func (ch *Changeset) ResolveRefs(ctx context.Context, srv *dagql.Server) error {
 	return nil
 }
 
+func (ch *Changeset) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	_ = ctx
+	if ch == nil {
+		return nil, fmt.Errorf("encode persisted changeset: nil changeset")
+	}
+	beforeID, err := encodePersistedObjectRef(cache, ch.Before, "changeset before")
+	if err != nil {
+		return nil, err
+	}
+	afterID, err := encodePersistedObjectRef(cache, ch.After, "changeset after")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(persistedChangesetPayload{
+		BeforeResultID: beforeID,
+		AfterResultID:  afterID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal persisted changeset payload: %w", err)
+	}
+	return payload, nil
+}
+
+func (*Changeset) DecodePersistedObject(
+	ctx context.Context,
+	dag *dagql.Server,
+	_ uint64,
+	_ *dagql.ResultCall,
+	payload json.RawMessage,
+) (dagql.Typed, error) {
+	var persisted persistedChangesetPayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted changeset payload: %w", err)
+	}
+
+	before, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.BeforeResultID, "changeset before")
+	if err != nil {
+		return nil, err
+	}
+	after, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.AfterResultID, "changeset after")
+	if err != nil {
+		return nil, err
+	}
+	return NewChangeset(ctx, before, after)
+}
+
 // changesetPathSets enables O(1) path lookups during conflict detection.
 type changesetPathSets struct {
 	added    map[string]struct{}
@@ -322,6 +373,8 @@ func (*Changeset) TypeDescription() string {
 }
 
 var _ Syncable = (*Changeset)(nil)
+var _ dagql.PersistedObject = (*Changeset)(nil)
+var _ dagql.PersistedObjectDecoder = (*Changeset)(nil)
 var _ dagql.HasDependencyResults = (*Changeset)(nil)
 
 func (ch *Changeset) Evaluate(context.Context) error {

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -290,27 +290,27 @@ func (ch *Changeset) ResolveRefs(ctx context.Context, srv *dagql.Server) error {
 	return nil
 }
 
-func (ch *Changeset) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (ch *Changeset) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if ch == nil {
-		return nil, fmt.Errorf("encode persisted changeset: nil changeset")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted changeset: nil changeset")
 	}
 	beforeID, err := encodePersistedObjectRef(cache, ch.Before, "changeset before")
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	afterID, err := encodePersistedObjectRef(cache, ch.After, "changeset after")
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	payload, err := json.Marshal(persistedChangesetPayload{
 		BeforeResultID: beforeID,
 		AfterResultID:  afterID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted changeset payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted changeset payload: %w", err)
 	}
-	return payload, nil
+	return encodePersistedObjectRawJSON(payload), nil
 }
 
 func (*Changeset) DecodePersistedObject(

--- a/core/checks.go
+++ b/core/checks.go
@@ -184,7 +184,7 @@ func (c *Check) Description() string {
 }
 
 func (c *Check) OriginalModule() *Module {
-	return c.Node.OriginalModule
+	return c.Node.OriginalModule.Self()
 }
 
 func (*Check) Type() *ast.Type {

--- a/core/client_filesync_mirror.go
+++ b/core/client_filesync_mirror.go
@@ -101,19 +101,35 @@ type persistedClientFilesyncMirrorPayload struct {
 	Drive          string `json:"drive,omitempty"`
 }
 
-func (m *ClientFilesyncMirror) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (m *ClientFilesyncMirror) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if m == nil {
-		return nil, fmt.Errorf("encode persisted client filesync mirror: nil mirror")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted client filesync mirror: nil mirror")
 	}
 	if m.StableClientID == "" {
-		return nil, fmt.Errorf("encode persisted client filesync mirror: stable client id is empty")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted client filesync mirror: stable client id is empty")
 	}
-	return json.Marshal(persistedClientFilesyncMirrorPayload{
+	m.mu.Lock()
+	var links []dagql.PersistedSnapshotRefLink
+	if m.snapshot != nil {
+		links = []dagql.PersistedSnapshotRefLink{{
+			RefKey: m.snapshot.SnapshotID(),
+			Role:   "snapshot",
+		}}
+	}
+	m.mu.Unlock()
+	payload, err := json.Marshal(persistedClientFilesyncMirrorPayload{
 		StableClientID: m.StableClientID,
 		Drive:          m.Drive,
 	})
+	if err != nil {
+		return dagql.PersistedObjectEncoding{}, err
+	}
+	return dagql.PersistedObjectEncoding{
+		JSON:          payload,
+		SnapshotLinks: links,
+	}, nil
 }
 
 func (*ClientFilesyncMirror) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/container.go
+++ b/core/container.go
@@ -1291,40 +1291,65 @@ func (container *Container) CacheUsageSize(ctx context.Context, identity string)
 	return size, true, nil
 }
 
-func encodePersistedContainerDirectoryValue(ctx context.Context, cache dagql.PersistedObjectCache, dir *Directory) (json.RawMessage, error) {
+func remapContainerSnapshotLinks(links []dagql.PersistedSnapshotRefLink, role string) []dagql.PersistedSnapshotRefLink {
+	if len(links) == 0 {
+		return nil
+	}
+	remapped := make([]dagql.PersistedSnapshotRefLink, 0, len(links))
+	for _, link := range links {
+		if link.Role != "snapshot" {
+			continue
+		}
+		remapped = append(remapped, dagql.PersistedSnapshotRefLink{
+			RefKey: link.RefKey,
+			Role:   role,
+		})
+	}
+	return remapped
+}
+
+func encodePersistedContainerDirectoryValue(ctx context.Context, cache dagql.PersistedObjectCache, dir *Directory, role string) (json.RawMessage, []dagql.PersistedSnapshotRefLink, error) {
 	if dir == nil {
 		encoded, err := json.Marshal(persistedContainerDirectoryValue{Form: persistedContainerValueFormPending})
 		if err != nil {
-			return nil, fmt.Errorf("marshal pending container directory value: %w", err)
+			return nil, nil, fmt.Errorf("marshal pending container directory value: %w", err)
 		}
-		return encoded, nil
+		return encoded, nil, nil
 	}
-	value, err := dir.EncodePersistedObject(ctx, cache)
+	encoding, err := dir.EncodePersistedObject(ctx, cache)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return json.Marshal(persistedContainerDirectoryValue{
+	encoded, err := json.Marshal(persistedContainerDirectoryValue{
 		Form:  persistedContainerValueFormMaterialized,
-		Value: value,
+		Value: encoding.JSON,
 	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return encoded, remapContainerSnapshotLinks(encoding.SnapshotLinks, role), nil
 }
 
-func encodePersistedContainerFileValue(ctx context.Context, cache dagql.PersistedObjectCache, file *File) (json.RawMessage, error) {
+func encodePersistedContainerFileValue(ctx context.Context, cache dagql.PersistedObjectCache, file *File, role string) (json.RawMessage, []dagql.PersistedSnapshotRefLink, error) {
 	if file == nil {
 		encoded, err := json.Marshal(persistedContainerFileValue{Form: persistedContainerValueFormPending})
 		if err != nil {
-			return nil, fmt.Errorf("marshal pending container file value: %w", err)
+			return nil, nil, fmt.Errorf("marshal pending container file value: %w", err)
 		}
-		return encoded, nil
+		return encoded, nil, nil
 	}
-	value, err := file.EncodePersistedObject(ctx, cache)
+	encoding, err := file.EncodePersistedObject(ctx, cache)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return json.Marshal(persistedContainerFileValue{
+	encoded, err := json.Marshal(persistedContainerFileValue{
 		Form:  persistedContainerValueFormMaterialized,
-		Value: value,
+		Value: encoding.JSON,
 	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return encoded, remapContainerSnapshotLinks(encoding.SnapshotLinks, role), nil
 }
 
 func decodePersistedContainerDirectoryValue(ctx context.Context, dag *dagql.Server, resultID uint64, role string, payload json.RawMessage) (decodedContainerDirectoryValue, error) {
@@ -1375,15 +1400,16 @@ func decodePersistedContainerFileValue(ctx context.Context, dag *dagql.Server, r
 	}
 }
 
-func (container *Container) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (container *Container) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if container == nil {
-		return nil, fmt.Errorf("encode persisted container: nil container")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted container: nil container")
 	}
 	services, err := encodePersistedServiceBindings(cache, "container", container.Services)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 
+	var snapshotLinks []dagql.PersistedSnapshotRefLink
 	payload := persistedContainerPayload{
 		Form:               persistedContainerFormReady,
 		Config:             container.Config,
@@ -1403,23 +1429,32 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 	if container.Lazy != nil {
 		lazyJSON, err := container.Lazy.EncodePersisted(ctx, cache)
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.Form = persistedContainerFormLazy
 		payload.LazyJSON = lazyJSON
 	}
+	if container.MetaSnapshot != nil {
+		if snapshot, ok := container.MetaSnapshot.Peek(); ok && snapshot != nil {
+			snapshotLinks = append(snapshotLinks, dagql.PersistedSnapshotRefLink{
+				RefKey: snapshot.SnapshotID(),
+				Role:   "meta",
+			})
+		}
+	}
 	if container.FS != nil {
 		fsValue, ok := container.FS.Peek()
 		if ok && fsValue != nil {
-			encoded, err := encodePersistedContainerDirectoryValue(ctx, cache, fsValue)
+			encoded, links, err := encodePersistedContainerDirectoryValue(ctx, cache, fsValue, "fs")
 			if err != nil {
-				return nil, err
+				return dagql.PersistedObjectEncoding{}, err
 			}
 			payload.FS = encoded
+			snapshotLinks = append(snapshotLinks, links...)
 		}
 	}
 
-	for _, mnt := range container.Mounts {
+	for i, mnt := range container.Mounts {
 		encoded := persistedContainerMountPayload{
 			Target:   mnt.Target,
 			Readonly: mnt.Readonly,
@@ -1428,40 +1463,42 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 		case mnt.DirectorySource != nil:
 			encoded.Kind = persistedContainerMountKindDirectory
 			if dir, ok := mnt.DirectorySource.Peek(); ok && dir != nil {
-				val, err := encodePersistedContainerDirectoryValue(ctx, cache, dir)
+				val, links, err := encodePersistedContainerDirectoryValue(ctx, cache, dir, fmt.Sprintf("mount_dir:%d", i))
 				if err != nil {
-					return nil, err
+					return dagql.PersistedObjectEncoding{}, err
 				}
 				encoded.Value = val
+				snapshotLinks = append(snapshotLinks, links...)
 			}
 		case mnt.FileSource != nil:
 			encoded.Kind = persistedContainerMountKindFile
 			if file, ok := mnt.FileSource.Peek(); ok && file != nil {
-				val, err := encodePersistedContainerFileValue(ctx, cache, file)
+				val, links, err := encodePersistedContainerFileValue(ctx, cache, file, fmt.Sprintf("mount_file:%d", i))
 				if err != nil {
-					return nil, err
+					return dagql.PersistedObjectEncoding{}, err
 				}
 				encoded.Value = val
+				snapshotLinks = append(snapshotLinks, links...)
 			}
 		case mnt.CacheSource != nil:
 			encoded.Kind = persistedContainerMountKindCache
 			id, err := encodePersistedObjectRef(cache, mnt.CacheSource.Volume, fmt.Sprintf("cache mount %q", mnt.Target))
 			if err != nil {
-				return nil, err
+				return dagql.PersistedObjectEncoding{}, err
 			}
 			encoded.CacheSourceResultID = id
 		case mnt.TmpfsSource != nil:
 			encoded.Kind = persistedContainerMountKindTmpfs
 			encoded.TmpfsSize = mnt.TmpfsSource.Size
 		default:
-			return nil, fmt.Errorf("encode persisted container mount %q: unsupported mount source", mnt.Target)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted container mount %q: unsupported mount source", mnt.Target)
 		}
 		payload.Mounts = append(payload.Mounts, encoded)
 	}
 	for _, secret := range container.Secrets {
 		secretID, err := encodePersistedObjectRef(cache, secret.Secret, "container secret")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.Secrets = append(payload.Secrets, persistedContainerSecretPayload{
 			SecretResultID: secretID,
@@ -1474,7 +1511,7 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 	for _, socket := range container.Sockets {
 		sourceID, err := encodePersistedObjectRef(cache, socket.Source, "container socket")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.Sockets = append(payload.Sockets, persistedContainerSocketPayload{
 			SourceResultID: sourceID,
@@ -1485,9 +1522,12 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 
 	enc, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted container payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted container payload: %w", err)
 	}
-	return enc, nil
+	return dagql.PersistedObjectEncoding{
+		JSON:          enc,
+		SnapshotLinks: snapshotLinks,
+	}, nil
 }
 
 func (*Container) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, call *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/container.go
+++ b/core/container.go
@@ -507,6 +507,7 @@ type persistedContainerPayload struct {
 	Annotations        []containerutil.ContainerAnnotation `json:"annotations,omitempty"`
 	ImageRef           string                              `json:"imageRef,omitempty"`
 	Ports              []Port                              `json:"ports,omitempty"`
+	Services           []persistedServiceBinding           `json:"services,omitempty"`
 	DefaultTerminalCmd DefaultTerminalCmdOpts              `json:"defaultTerminalCmd"`
 	SystemEnvNames     []string                            `json:"systemEnvNames,omitempty"`
 	DefaultArgs        bool                                `json:"defaultArgs,omitempty"`
@@ -1378,10 +1379,9 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 	if container == nil {
 		return nil, fmt.Errorf("encode persisted container: nil container")
 	}
-	// FIXME: remove this restriction immediately after the first cut by adding
-	// explicit structural persistence for services.
-	if len(container.Services) > 0 {
-		return nil, fmt.Errorf("encode persisted container: services are not yet supported")
+	services, err := encodePersistedServiceBindings(cache, "container", container.Services)
+	if err != nil {
+		return nil, err
 	}
 
 	payload := persistedContainerPayload{
@@ -1395,6 +1395,7 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 		Annotations:        slices.Clone(container.Annotations),
 		ImageRef:           container.ImageRef,
 		Ports:              slices.Clone(container.Ports),
+		Services:           services,
 		DefaultTerminalCmd: container.DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(container.SystemEnvNames),
 		DefaultArgs:        container.DefaultArgs,
@@ -1584,6 +1585,10 @@ func (*Container) DecodePersistedObject(ctx context.Context, dag *dagql.Server, 
 			Owner:         persistedSocket.Owner,
 		})
 	}
+	services, err := decodePersistedServiceBindings(ctx, dag, "container", persisted.Services)
+	if err != nil {
+		return nil, err
+	}
 
 	metaAccessor := new(LazyAccessor[bkcache.ImmutableRef, *Container])
 	links, err := loadPersistedSnapshotLinksByResultID(ctx, dag, resultID, "container")
@@ -1614,6 +1619,7 @@ func (*Container) DecodePersistedObject(ctx context.Context, dag *dagql.Server, 
 		Sockets:            sockets,
 		ImageRef:           persisted.ImageRef,
 		Ports:              slices.Clone(persisted.Ports),
+		Services:           services,
 		DefaultTerminalCmd: persisted.DefaultTerminalCmd,
 		SystemEnvNames:     slices.Clone(persisted.SystemEnvNames),
 		DefaultArgs:        persisted.DefaultArgs,

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -525,7 +525,7 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 		if err != nil {
 			return nil, fmt.Errorf("encode cache lock key for mount %d: %w", i, err)
 		}
-		lockSet["cache-volume:"+string(payload)] = struct{}{}
+		lockSet["cache-volume:"+string(payload.JSON)] = struct{}{}
 	}
 	if len(lockSet) == 0 {
 		return func() {}, nil

--- a/core/directory.go
+++ b/core/directory.go
@@ -196,11 +196,11 @@ const (
 )
 
 type persistedDirectoryPayload struct {
-	Form     string          `json:"form"`
-	Dir      string          `json:"dir,omitempty"`
-	Platform Platform        `json:"platform"`
-	Services ServiceBindings `json:"services,omitempty"`
-	LazyJSON json.RawMessage `json:"lazyJSON,omitempty"`
+	Form     string                    `json:"form"`
+	Dir      string                    `json:"dir,omitempty"`
+	Platform Platform                  `json:"platform"`
+	Services []persistedServiceBinding `json:"services,omitempty"`
+	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
 func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
@@ -213,10 +213,14 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 			dirPath = peekedDir
 		}
 	}
+	services, err := encodePersistedServiceBindings(cache, "directory", dir.Services)
+	if err != nil {
+		return nil, err
+	}
 	payload := persistedDirectoryPayload{
 		Dir:      dirPath,
 		Platform: dir.Platform,
-		Services: slices.Clone(dir.Services),
+		Services: services,
 	}
 	if dir.Snapshot != nil {
 		if snapshot, ok := dir.Snapshot.Peek(); ok && snapshot != nil {
@@ -256,10 +260,14 @@ func decodePersistedDirectoryWithSnapshotRole(ctx context.Context, dag *dagql.Se
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return nil, fmt.Errorf("decode persisted directory payload: %w", err)
 	}
+	services, err := decodePersistedServiceBindings(ctx, dag, "directory", persisted.Services)
+	if err != nil {
+		return nil, err
+	}
 
 	dir := &Directory{
 		Platform: persisted.Platform,
-		Services: slices.Clone(persisted.Services),
+		Services: services,
 		Dir:      new(LazyAccessor[string, *Directory]),
 		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
 	}

--- a/core/directory.go
+++ b/core/directory.go
@@ -203,9 +203,9 @@ type persistedDirectoryPayload struct {
 	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
-func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if dir == nil {
-		return nil, fmt.Errorf("encode persisted directory: nil directory")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted directory: nil directory")
 	}
 	dirPath := ""
 	if dir.Dir != nil {
@@ -215,7 +215,7 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 	}
 	services, err := encodePersistedServiceBindings(cache, "directory", dir.Services)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	payload := persistedDirectoryPayload{
 		Dir:      dirPath,
@@ -227,23 +227,29 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 			payload.Form = persistedDirectoryFormSnapshot
 			payloadJSON, err := json.Marshal(payload)
 			if err != nil {
-				return nil, fmt.Errorf("marshal persisted directory payload: %w", err)
+				return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted directory payload: %w", err)
 			}
-			return payloadJSON, nil
+			return dagql.PersistedObjectEncoding{
+				JSON: payloadJSON,
+				SnapshotLinks: []dagql.PersistedSnapshotRefLink{{
+					RefKey: snapshot.SnapshotID(),
+					Role:   "snapshot",
+				}},
+			}, nil
 		}
 	}
 	if dir.Lazy != nil {
 		payload.Form = persistedDirectoryFormLazy
 		lazyJSON, err := dir.Lazy.EncodePersisted(ctx, cache)
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.LazyJSON = lazyJSON
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			return nil, fmt.Errorf("marshal persisted directory payload: %w", err)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted directory payload: %w", err)
 		}
-		return payloadJSON, nil
+		return encodePersistedObjectRawJSON(payloadJSON), nil
 	}
 	slog.Error(
 		"encode persisted directory: neither snapshot nor lazy op is available",
@@ -251,7 +257,7 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 		"platform", dir.Platform,
 		"services", len(dir.Services),
 	)
-	return nil, fmt.Errorf("%w: encode persisted directory: missing snapshot and lazy op", dagql.ErrPersistStateNotReady)
+	return dagql.PersistedObjectEncoding{}, fmt.Errorf("%w: encode persisted directory: missing snapshot and lazy op", dagql.ErrPersistStateNotReady)
 }
 
 //nolint:dupl // symmetric with decodePersistedFileWithSnapshotRole in file.go; sharing hides type specifics

--- a/core/file.go
+++ b/core/file.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -192,11 +191,11 @@ const (
 )
 
 type persistedFilePayload struct {
-	Form     string          `json:"form"`
-	File     string          `json:"file,omitempty"`
-	Platform Platform        `json:"platform"`
-	Services ServiceBindings `json:"services,omitempty"`
-	LazyJSON json.RawMessage `json:"lazyJSON,omitempty"`
+	Form     string                    `json:"form"`
+	File     string                    `json:"file,omitempty"`
+	Platform Platform                  `json:"platform"`
+	Services []persistedServiceBinding `json:"services,omitempty"`
+	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
 func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
@@ -209,10 +208,14 @@ func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.Persist
 			filePath = peekedPath
 		}
 	}
+	services, err := encodePersistedServiceBindings(cache, "file", file.Services)
+	if err != nil {
+		return nil, err
+	}
 	payload := persistedFilePayload{
 		File:     filePath,
 		Platform: file.Platform,
-		Services: slices.Clone(file.Services),
+		Services: services,
 	}
 	if file.Snapshot != nil {
 		if snapshot, ok := file.Snapshot.Peek(); ok && snapshot != nil {
@@ -246,10 +249,14 @@ func decodePersistedFileWithSnapshotRole(ctx context.Context, dag *dagql.Server,
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return nil, fmt.Errorf("decode persisted file payload: %w", err)
 	}
+	services, err := decodePersistedServiceBindings(ctx, dag, "file", persisted.Services)
+	if err != nil {
+		return nil, err
+	}
 
 	file := &File{
 		Platform: persisted.Platform,
-		Services: slices.Clone(persisted.Services),
+		Services: services,
 		File:     new(LazyAccessor[string, *File]),
 		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *File]),
 	}

--- a/core/file.go
+++ b/core/file.go
@@ -198,9 +198,9 @@ type persistedFilePayload struct {
 	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
-func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if file == nil {
-		return nil, fmt.Errorf("encode persisted file: nil file")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted file: nil file")
 	}
 	filePath := ""
 	if file.File != nil {
@@ -210,7 +210,7 @@ func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.Persist
 	}
 	services, err := encodePersistedServiceBindings(cache, "file", file.Services)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	payload := persistedFilePayload{
 		File:     filePath,
@@ -222,25 +222,31 @@ func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.Persist
 			payload.Form = persistedFileFormSnapshot
 			payloadJSON, err := json.Marshal(payload)
 			if err != nil {
-				return nil, fmt.Errorf("marshal persisted file payload: %w", err)
+				return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted file payload: %w", err)
 			}
-			return payloadJSON, nil
+			return dagql.PersistedObjectEncoding{
+				JSON: payloadJSON,
+				SnapshotLinks: []dagql.PersistedSnapshotRefLink{{
+					RefKey: snapshot.SnapshotID(),
+					Role:   "snapshot",
+				}},
+			}, nil
 		}
 	}
 	if file.Lazy != nil {
 		payload.Form = persistedFileFormLazy
 		lazyJSON, err := file.Lazy.EncodePersisted(ctx, cache)
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.LazyJSON = lazyJSON
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			return nil, fmt.Errorf("marshal persisted file payload: %w", err)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted file payload: %w", err)
 		}
-		return payloadJSON, nil
+		return encodePersistedObjectRawJSON(payloadJSON), nil
 	}
-	return nil, fmt.Errorf("%w: encode persisted file: missing snapshot and lazy op", dagql.ErrPersistStateNotReady)
+	return dagql.PersistedObjectEncoding{}, fmt.Errorf("%w: encode persisted file: missing snapshot and lazy op", dagql.ErrPersistStateNotReady)
 }
 
 //nolint:dupl // symmetric with decodePersistedDirectoryWithSnapshotRole in directory.go; sharing hides type specifics

--- a/core/generators.go
+++ b/core/generators.go
@@ -253,21 +253,21 @@ func decodePersistedGeneratorPayload(
 	return g, nil
 }
 
-func (g *Generator) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (g *Generator) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	tree := newPersistedModTreeEncoder(cache)
 	generatorPayload, err := encodePersistedGeneratorPayload(cache, tree, g)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	payload, err := json.Marshal(persistedGeneratorObjectPayload{
 		Tree:      tree.tree,
 		Generator: generatorPayload,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted generator payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted generator payload: %w", err)
 	}
-	return payload, nil
+	return encodePersistedObjectRawJSON(payload), nil
 }
 
 func (*Generator) DecodePersistedObject(
@@ -316,21 +316,21 @@ func (g *Generator) AttachDependencyResults(
 	return owned, nil
 }
 
-func (gg *GeneratorGroup) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (gg *GeneratorGroup) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if gg == nil {
-		return nil, fmt.Errorf("encode persisted generator group: nil generator group")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted generator group: nil generator group")
 	}
 	tree := newPersistedModTreeEncoder(cache)
 	nodeID, err := tree.Add(gg.Node)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	generatorPayloads := make([]persistedGeneratorPayload, 0, len(gg.Generators))
 	for _, generator := range gg.Generators {
 		generatorPayload, err := encodePersistedGeneratorPayload(cache, tree, generator)
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		generatorPayloads = append(generatorPayloads, generatorPayload)
 	}
@@ -340,9 +340,9 @@ func (gg *GeneratorGroup) EncodePersistedObject(ctx context.Context, cache dagql
 		Generators: generatorPayloads,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted generator group payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted generator group payload: %w", err)
 	}
-	return payload, nil
+	return encodePersistedObjectRawJSON(payload), nil
 }
 
 func (*GeneratorGroup) DecodePersistedObject(

--- a/core/generators.go
+++ b/core/generators.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/dagger/dagger/dagql"
@@ -13,7 +14,7 @@ import (
 type Generator struct {
 	Node      *ModTreeNode `json:"node"`
 	Completed bool         `field:"true" doc:"Whether the generator complete"`
-	Changes   *Changeset   `json:"changes"`
+	Changes   dagql.ObjectResult[*Changeset]
 }
 
 func (*Generator) Type() *ast.Type {
@@ -36,7 +37,7 @@ func (g *Generator) Name() string {
 }
 
 func (g *Generator) OriginalModule() *Module {
-	return g.Node.OriginalModule
+	return g.Node.OriginalModule.Self()
 }
 
 func (g *Generator) Clone() *Generator {
@@ -54,19 +55,51 @@ func (g *Generator) Run(ctx context.Context) (*Generator, error) {
 	return g, nil
 }
 
-func (g *Generator) RequireChanges(field string) (*Changeset, error) {
+func (g *Generator) RequireChangesResult(field string) (dagql.ObjectResult[*Changeset], error) {
 	if !g.Completed {
-		return nil, fmt.Errorf("generator %q must be run before querying %s", g.Name(), field)
+		return dagql.ObjectResult[*Changeset]{}, fmt.Errorf("generator %q must be run before querying %s", g.Name(), field)
 	}
-	if g.Changes == nil {
-		return nil, fmt.Errorf("generator %q did not produce a changeset result", g.Name())
+	if g.Changes.Self() == nil {
+		return dagql.ObjectResult[*Changeset]{}, fmt.Errorf("generator %q did not produce a changeset result", g.Name())
 	}
 	return g.Changes, nil
+}
+
+func (g *Generator) RequireChanges(field string) (*Changeset, error) {
+	changes, err := g.RequireChangesResult(field)
+	if err != nil {
+		return nil, err
+	}
+	return changes.Self(), nil
 }
 
 type GeneratorGroup struct {
 	Node       *ModTreeNode `json:"node"`
 	Generators []*Generator `json:"generators"`
+}
+
+var _ dagql.PersistedObject = (*Generator)(nil)
+var _ dagql.PersistedObjectDecoder = (*Generator)(nil)
+var _ dagql.HasDependencyResults = (*Generator)(nil)
+var _ dagql.PersistedObject = (*GeneratorGroup)(nil)
+var _ dagql.PersistedObjectDecoder = (*GeneratorGroup)(nil)
+var _ dagql.HasDependencyResults = (*GeneratorGroup)(nil)
+
+type persistedGeneratorPayload struct {
+	NodeID          int    `json:"nodeID,omitempty"`
+	Completed       bool   `json:"completed,omitempty"`
+	ChangesResultID uint64 `json:"changesResultID,omitempty"`
+}
+
+type persistedGeneratorObjectPayload struct {
+	Tree      persistedModTree          `json:"tree"`
+	Generator persistedGeneratorPayload `json:"generator"`
+}
+
+type persistedGeneratorGroupPayload struct {
+	Tree       persistedModTree            `json:"tree"`
+	NodeID     int                         `json:"nodeID,omitempty"`
+	Generators []persistedGeneratorPayload `json:"generators,omitempty"`
 }
 
 func NewGeneratorGroup(ctx context.Context, mod dagql.ObjectResult[*Module], include []string) (*GeneratorGroup, error) {
@@ -110,7 +143,7 @@ func (gg *GeneratorGroup) Run(ctx context.Context) (*GeneratorGroup, error) {
 	for _, generator := range gg.Generators {
 		// Reset output fields, in case we're re-running
 		generator.Completed = false
-		generator.Changes = nil
+		generator.Changes = dagql.ObjectResult[*Changeset]{}
 		jobs = jobs.WithJob(generator.Name(), func(ctx context.Context) error {
 			cs, err := generator.Node.RunGenerator(ctx, nil, nil)
 			generator.Completed = true
@@ -165,4 +198,209 @@ func (gg *GeneratorGroup) Clone() *GeneratorGroup {
 		c.Generators[i] = gg.Generators[i].Clone()
 	}
 	return &c
+}
+
+func encodePersistedGeneratorPayload(
+	cache dagql.PersistedObjectCache,
+	tree *persistedModTreeEncoder,
+	g *Generator,
+) (persistedGeneratorPayload, error) {
+	if g == nil {
+		return persistedGeneratorPayload{}, fmt.Errorf("encode persisted generator: nil generator")
+	}
+	nodeID, err := tree.Add(g.Node)
+	if err != nil {
+		return persistedGeneratorPayload{}, err
+	}
+	payload := persistedGeneratorPayload{
+		NodeID:    nodeID,
+		Completed: g.Completed,
+	}
+	if g.Completed && g.Changes.Self() != nil {
+		changesID, err := encodePersistedObjectRef(cache, g.Changes, "generator changes")
+		if err != nil {
+			return persistedGeneratorPayload{}, err
+		}
+		payload.ChangesResultID = changesID
+	}
+	return payload, nil
+}
+
+func decodePersistedGeneratorPayload(
+	ctx context.Context,
+	dag *dagql.Server,
+	nodes map[int]*ModTreeNode,
+	payload persistedGeneratorPayload,
+) (*Generator, error) {
+	if payload.NodeID == 0 {
+		return nil, fmt.Errorf("decode persisted generator: missing node ID")
+	}
+	node, ok := nodes[payload.NodeID]
+	if !ok {
+		return nil, fmt.Errorf("decode persisted generator: unknown node ID %d", payload.NodeID)
+	}
+	g := &Generator{
+		Node:      node,
+		Completed: payload.Completed,
+	}
+	if payload.ChangesResultID != 0 {
+		changes, err := loadPersistedObjectResultByResultID[*Changeset](ctx, dag, payload.ChangesResultID, "generator changes")
+		if err != nil {
+			return nil, err
+		}
+		g.Changes = changes
+	}
+	return g, nil
+}
+
+func (g *Generator) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	_ = ctx
+	tree := newPersistedModTreeEncoder(cache)
+	generatorPayload, err := encodePersistedGeneratorPayload(cache, tree, g)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(persistedGeneratorObjectPayload{
+		Tree:      tree.tree,
+		Generator: generatorPayload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal persisted generator payload: %w", err)
+	}
+	return payload, nil
+}
+
+func (*Generator) DecodePersistedObject(
+	ctx context.Context,
+	dag *dagql.Server,
+	_ uint64,
+	_ *dagql.ResultCall,
+	payload json.RawMessage,
+) (dagql.Typed, error) {
+	var persisted persistedGeneratorObjectPayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted generator payload: %w", err)
+	}
+	nodes, err := decodePersistedModTree(ctx, dag, persisted.Tree)
+	if err != nil {
+		return nil, err
+	}
+	return decodePersistedGeneratorPayload(ctx, dag, nodes, persisted.Generator)
+}
+
+func (g *Generator) AttachDependencyResults(
+	ctx context.Context,
+	_ dagql.AnyResult,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	_ = ctx
+	if g == nil {
+		return nil, nil
+	}
+	owned, err := attachModTreeNodeDependencyResults(g.Node, attach)
+	if err != nil {
+		return nil, err
+	}
+	if g.Changes.Self() != nil {
+		attached, err := attach(g.Changes)
+		if err != nil {
+			return nil, fmt.Errorf("attach generator changes: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Changeset])
+		if !ok {
+			return nil, fmt.Errorf("attach generator changes: unexpected result %T", attached)
+		}
+		g.Changes = typed
+		owned = append(owned, typed)
+	}
+	return owned, nil
+}
+
+func (gg *GeneratorGroup) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	_ = ctx
+	if gg == nil {
+		return nil, fmt.Errorf("encode persisted generator group: nil generator group")
+	}
+	tree := newPersistedModTreeEncoder(cache)
+	nodeID, err := tree.Add(gg.Node)
+	if err != nil {
+		return nil, err
+	}
+	generatorPayloads := make([]persistedGeneratorPayload, 0, len(gg.Generators))
+	for _, generator := range gg.Generators {
+		generatorPayload, err := encodePersistedGeneratorPayload(cache, tree, generator)
+		if err != nil {
+			return nil, err
+		}
+		generatorPayloads = append(generatorPayloads, generatorPayload)
+	}
+	payload, err := json.Marshal(persistedGeneratorGroupPayload{
+		Tree:       tree.tree,
+		NodeID:     nodeID,
+		Generators: generatorPayloads,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal persisted generator group payload: %w", err)
+	}
+	return payload, nil
+}
+
+func (*GeneratorGroup) DecodePersistedObject(
+	ctx context.Context,
+	dag *dagql.Server,
+	_ uint64,
+	_ *dagql.ResultCall,
+	payload json.RawMessage,
+) (dagql.Typed, error) {
+	var persisted persistedGeneratorGroupPayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted generator group payload: %w", err)
+	}
+	nodes, err := decodePersistedModTree(ctx, dag, persisted.Tree)
+	if err != nil {
+		return nil, err
+	}
+	var node *ModTreeNode
+	if persisted.NodeID != 0 {
+		var ok bool
+		node, ok = nodes[persisted.NodeID]
+		if !ok {
+			return nil, fmt.Errorf("decode persisted generator group: unknown node ID %d", persisted.NodeID)
+		}
+	}
+	generators := make([]*Generator, 0, len(persisted.Generators))
+	for _, generatorPayload := range persisted.Generators {
+		generator, err := decodePersistedGeneratorPayload(ctx, dag, nodes, generatorPayload)
+		if err != nil {
+			return nil, err
+		}
+		generators = append(generators, generator)
+	}
+	return &GeneratorGroup{
+		Node:       node,
+		Generators: generators,
+	}, nil
+}
+
+func (gg *GeneratorGroup) AttachDependencyResults(
+	ctx context.Context,
+	_ dagql.AnyResult,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	_ = ctx
+	if gg == nil {
+		return nil, nil
+	}
+	owned, err := attachModTreeNodeDependencyResults(gg.Node, attach)
+	if err != nil {
+		return nil, err
+	}
+	for _, generator := range gg.Generators {
+		generatorDeps, err := generator.AttachDependencyResults(ctx, nil, attach)
+		if err != nil {
+			return nil, err
+		}
+		owned = append(owned, generatorDeps...)
+	}
+	return owned, nil
 }

--- a/core/git.go
+++ b/core/git.go
@@ -250,13 +250,13 @@ type persistedRemoteGitRepositoryPayload struct {
 	Platform      Platform `json:"platform"`
 }
 
-func (repo *GitRepository) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (repo *GitRepository) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if repo == nil {
-		return nil, fmt.Errorf("encode persisted git repository: nil repository")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted git repository: nil repository")
 	}
 	remoteJSON, err := json.Marshal(repo.Remote)
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted git repository remote: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted git repository remote: %w", err)
 	}
 	payload := persistedGitRepositoryPayload{
 		DiscardGitDir: repo.DiscardGitDir,
@@ -266,7 +266,7 @@ func (repo *GitRepository) EncodePersistedObject(ctx context.Context, cache dagq
 	case *LocalGitRepository:
 		dirID, err := encodePersistedObjectRef(cache, backend.Directory, "git repository directory")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.Form = persistedGitRepositoryFormLocal
 		payload.Local = &persistedLocalGitRepositoryPayload{
@@ -274,7 +274,7 @@ func (repo *GitRepository) EncodePersistedObject(ctx context.Context, cache dagq
 		}
 	case *RemoteGitRepository:
 		if backend.URL == nil {
-			return nil, fmt.Errorf("encode persisted git repository: remote backend missing URL")
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted git repository: remote backend missing URL")
 		}
 		payload.Form = persistedGitRepositoryFormRemote
 		payload.Remote = &persistedRemoteGitRepositoryPayload{
@@ -284,13 +284,13 @@ func (repo *GitRepository) EncodePersistedObject(ctx context.Context, cache dagq
 			Platform:      backend.Platform,
 		}
 	default:
-		return nil, fmt.Errorf("encode persisted git repository: unsupported backend %T", repo.Backend)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted git repository: unsupported backend %T", repo.Backend)
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted git repository payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted git repository payload: %w", err)
 	}
-	return payloadJSON, nil
+	return encodePersistedObjectRawJSON(payloadJSON), nil
 }
 
 func (*GitRepository) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -357,17 +357,17 @@ type persistedGitRefPayload struct {
 	SHA          string `json:"sha"`
 }
 
-func (ref *GitRef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (ref *GitRef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if ref == nil {
-		return nil, fmt.Errorf("encode persisted git ref: nil ref")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted git ref: nil ref")
 	}
 	if ref.Ref == nil {
-		return nil, fmt.Errorf("encode persisted git ref: missing ref")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted git ref: missing ref")
 	}
 	repoID, err := encodePersistedObjectRef(cache, ref.Repo, "git ref repo")
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
 	payloadJSON, err := json.Marshal(persistedGitRefPayload{
 		RepoResultID: repoID,
@@ -375,9 +375,9 @@ func (ref *GitRef) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 		SHA:          ref.Ref.SHA,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted git ref payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted git ref payload: %w", err)
 	}
-	return payloadJSON, nil
+	return encodePersistedObjectRawJSON(payloadJSON), nil
 }
 
 func (*GitRef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/git_remote_mirror.go
+++ b/core/git_remote_mirror.go
@@ -105,15 +105,31 @@ type persistedRemoteGitMirrorPayload struct {
 	RemoteURL string `json:"remoteURL"`
 }
 
-func (mirror *RemoteGitMirror) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (mirror *RemoteGitMirror) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if mirror == nil {
-		return nil, fmt.Errorf("encode persisted remote git mirror: nil mirror")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted remote git mirror: nil mirror")
 	}
-	return json.Marshal(persistedRemoteGitMirrorPayload{
+	mirror.mu.Lock()
+	var links []dagql.PersistedSnapshotRefLink
+	if mirror.snapshot != nil {
+		links = []dagql.PersistedSnapshotRefLink{{
+			RefKey: mirror.snapshot.SnapshotID(),
+			Role:   "bare_repo",
+		}}
+	}
+	mirror.mu.Unlock()
+	payload, err := json.Marshal(persistedRemoteGitMirrorPayload{
 		RemoteURL: mirror.RemoteURL,
 	})
+	if err != nil {
+		return dagql.PersistedObjectEncoding{}, err
+	}
+	return dagql.PersistedObjectEncoding{
+		JSON:          payload,
+		SnapshotLinks: links,
+	}, nil
 }
 
 func (*RemoteGitMirror) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/host.go
+++ b/core/host.go
@@ -24,8 +24,8 @@ func (*Host) TypeDescription() string {
 	return "Information about the host environment."
 }
 
-func (*Host) EncodePersistedObject(context.Context, dagql.PersistedObjectCache) (json.RawMessage, error) {
-	return json.RawMessage(`{}`), nil
+func (*Host) EncodePersistedObject(context.Context, dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	return dagql.PersistedObjectEncoding{JSON: json.RawMessage(`{}`)}, nil
 }
 
 func (*Host) DecodePersistedObject(context.Context, *dagql.Server, uint64, *dagql.ResultCall, json.RawMessage) (dagql.Typed, error) {

--- a/core/http.go
+++ b/core/http.go
@@ -168,18 +168,38 @@ func (state *HTTPState) CacheUsageSize(ctx context.Context, identity string) (in
 	return size, true, nil
 }
 
-func (state *HTTPState) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (state *HTTPState) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if state == nil {
-		return nil, fmt.Errorf("encode persisted http state: nil state")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted http state: nil state")
 	}
-	return json.Marshal(persistedHTTPStatePayload{
+	state.mu.Lock()
+	snapshotID := state.snapshotID
+	if snapshotID == "" && state.snapshot != nil {
+		snapshotID = state.snapshot.SnapshotID()
+	}
+	state.mu.Unlock()
+	var links []dagql.PersistedSnapshotRefLink
+	if snapshotID != "" {
+		links = []dagql.PersistedSnapshotRefLink{{
+			RefKey: snapshotID,
+			Role:   "snapshot",
+		}}
+	}
+	payload, err := json.Marshal(persistedHTTPStatePayload{
 		URL:           state.URL,
 		ETag:          state.ETag,
 		LastModified:  state.LastModified,
 		ContentDigest: state.ContentDigest.String(),
 	})
+	if err != nil {
+		return dagql.PersistedObjectEncoding{}, err
+	}
+	return dagql.PersistedObjectEncoding{
+		JSON:          payload,
+		SnapshotLinks: links,
+	}, nil
 }
 
 func (*HTTPState) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -265,13 +265,18 @@ head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
 		runGeneratorGroup := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) {
 			t.Helper()
 
-			empty, err := engineClient.
+			run := engineClient.
 				CurrentWorkspace().
 				Generators(dagger.WorkspaceGeneratorsOpts{Include: []string{"generate-files"}}).
-				Run().
-				IsEmpty(ctx)
+				Run()
+
+			empty, err := run.IsEmpty(ctx)
 			require.NoError(t, err)
 			require.False(t, empty)
+
+			changesEmpty, err := run.Changes().IsEmpty(ctx)
+			require.NoError(t, err)
+			require.False(t, changesEmpty)
 		}
 
 		upstreamSvcA, engineSvcA, engineClientA := startEngineWithClientOpts(c, ctx, t, stateKey, clientOpts, engineWithPersistenceTestGC(ctx, t))

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -127,6 +127,79 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 		require.Greater(t, entryCount, 0)
 	})
 
+	t.Run("unclean shutdown discards local cache state and recovers", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-unclean-reset-state-" + identity.NewID()
+		const sentinelPath = "/state/worker/reset-sentinel"
+		randomScript := `
+set -eu
+mkdir -p /work
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+`
+
+		runRandom := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) string {
+			t.Helper()
+
+			randomContents, err := engineClient.
+				Container().
+				From(alpineImage).
+				WithExec([]string{"sh", "-ec", randomScript}).
+				Directory("/work").
+				File("random.txt").
+				Contents(ctx)
+			require.NoError(t, err)
+			random := strings.TrimSpace(randomContents)
+			require.NotEmpty(t, random)
+			return random
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		randomA := runRandom(ctx, t, engineClientA)
+
+		_, err := upstreamSvcA.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+		require.NoError(t, err)
+		upstreamSvcA = nil
+		_, err = engineSvcA.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+		require.NoError(t, err)
+		engineSvcA = nil
+		engineClientA = nil
+
+		_, err = c.
+			Container().
+			From(alpineImage).
+			WithMountedCache("/state", c.CacheVolume(stateKey)).
+			WithExec([]string{"sh", "-ec", "test -d /state/worker && touch " + sentinelPath}).
+			Sync(ctx)
+		require.NoError(t, err)
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		randomB := runRandom(ctx, t, engineClientB)
+		require.NotEqual(t, randomA, randomB, "cache state from before the unclean shutdown should be discarded")
+
+		stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB)
+		upstreamSvcB = nil
+		engineSvcB = nil
+		engineClientB = nil
+
+		_, err = c.
+			Container().
+			From(alpineImage).
+			WithMountedCache("/state", c.CacheVolume(stateKey)).
+			WithExec([]string{"sh", "-ec", "test ! -e " + sentinelPath}).
+			Sync(ctx)
+		require.NoError(t, err)
+
+		upstreamSvcC, engineSvcC, engineClientC := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcC, engineSvcC, engineClientC) })
+
+		randomC := runRandom(ctx, t, engineClientC)
+		require.Equal(t, randomB, randomC, "cache state produced after reset should survive a later clean restart")
+	})
+
 	t.Run("container withNewFile hit survives restart", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-container-with-new-file-state-" + identity.NewID()

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -162,65 +162,67 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 	t.Run("service-bound graph does not break disk persistence", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-service-binding-state-" + identity.NewID()
-		serviceScript := "#!/bin/sh\nwhile true; do printf 'ok\\n' | nc -l -p 8080; done\n"
-		randomScript := `
+		serviceScript := "#!/bin/sh\nwhile true; do cat /work/service-random.txt | nc -l -p 8080; done\n"
+		serviceSetupScript := `
 set -eu
 mkdir -p /work
-head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/service-random.txt
 `
 		serviceRunScript := `
 set -eu
 mkdir -p /work
 nc sidecar 8080 > /work/service.txt
-head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/client-random.txt
 `
 
-		runRandom := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) string {
-			t.Helper()
-
-			randomContents, err := engineClient.
-				Container().
-				From(alpineImage).
-				WithExec([]string{"sh", "-ec", randomScript}).
-				Directory("/work").
-				File("random.txt").
-				Contents(ctx)
-			require.NoError(t, err)
-			return strings.TrimSpace(randomContents)
+		type serviceBoundOutput struct {
+			serviceRandom string
+			clientRandom  string
 		}
 
-		runServiceBound := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) {
+		runServiceBound := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client, clientBust string) serviceBoundOutput {
 			t.Helper()
 
 			service := engineClient.
 				Container().
 				From(alpineImage).
+				WithExec([]string{"sh", "-ec", serviceSetupScript}).
 				WithNewFile("/bin/app", serviceScript, dagger.ContainerWithNewFileOpts{Permissions: 0o755}).
 				WithExposedPort(8080).
 				WithDefaultArgs([]string{"/bin/app"}).
 				AsService()
 
-			workDir := engineClient.
+			clientCtr := engineClient.
 				Container().
 				From(alpineImage).
-				WithServiceBinding("sidecar", service).
+				WithServiceBinding("sidecar", service)
+			if clientBust != "" {
+				clientCtr = clientCtr.WithEnvVariable("CLIENT_BUST", clientBust)
+			}
+			workDir := clientCtr.
 				WithExec([]string{"sh", "-ec", serviceRunScript}).
 				Directory("/work")
 
 			serviceContents, err := workDir.File("service.txt").Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "ok\n", serviceContents)
+			serviceRandom := strings.TrimSpace(serviceContents)
+			require.NotEmpty(t, serviceRandom)
 
-			randomContents, err := workDir.File("random.txt").Contents(ctx)
+			clientContents, err := workDir.File("client-random.txt").Contents(ctx)
 			require.NoError(t, err)
-			require.NotEmpty(t, strings.TrimSpace(randomContents))
+			clientRandom := strings.TrimSpace(clientContents)
+			require.NotEmpty(t, clientRandom)
+
+			return serviceBoundOutput{
+				serviceRandom: serviceRandom,
+				clientRandom:  clientRandom,
+			}
 		}
 
 		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
 		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
 
-		randomA := runRandom(ctx, t, engineClientA)
-		runServiceBound(ctx, t, engineClientA)
+		outA := runServiceBound(ctx, t, engineClientA, "")
 		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
 		upstreamSvcA = nil
 		engineSvcA = nil
@@ -229,8 +231,13 @@ head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
 		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
 		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
 
-		randomB := runRandom(ctx, t, engineClientB)
-		require.Equal(t, randomA, randomB, "unrelated withExec output should survive engine restart after a service-bound graph")
+		outB := runServiceBound(ctx, t, engineClientB, "")
+		require.Equal(t, outA.serviceRandom, outB.serviceRandom, "service container output should survive engine restart")
+		require.Equal(t, outA.clientRandom, outB.clientRandom, "service-bound client output should survive engine restart")
+
+		outC := runServiceBound(ctx, t, engineClientB, identity.NewID())
+		require.Equal(t, outA.serviceRandom, outC.serviceRandom, "service container output should still be cached when only the client container is invalidated")
+		require.NotEqual(t, outA.clientRandom, outC.clientRandom, "client container output should be recomputed after invalidation")
 	})
 
 	t.Run("generator group graph does not break disk persistence", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -36,11 +36,12 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 		)
 	}
 
-	startEngine := func(
+	startEngineWithClientOpts := func(
 		client *dagger.Client,
 		ctx context.Context,
 		t *testctx.T,
 		stateKey string,
+		clientOpts []dagger.ClientOpt,
 		opts ...func(*dagger.Container) *dagger.Container,
 	) (*dagger.Service, *dagger.Service, *dagger.Client) {
 		t.Helper()
@@ -53,13 +54,25 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 		endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
 		require.NoError(t, err)
 
-		engineClient, err := dagger.Connect(
-			ctx,
+		connectOpts := []dagger.ClientOpt{
 			dagger.WithRunnerHost(endpoint),
 			dagger.WithLogOutput(testutil.NewTWriter(t)),
-		)
+		}
+		connectOpts = append(connectOpts, clientOpts...)
+		engineClient, err := dagger.Connect(ctx, connectOpts...)
 		require.NoError(t, err)
 		return upstreamSvc, engineSvc, engineClient
+	}
+
+	startEngine := func(
+		client *dagger.Client,
+		ctx context.Context,
+		t *testctx.T,
+		stateKey string,
+		opts ...func(*dagger.Container) *dagger.Container,
+	) (*dagger.Service, *dagger.Service, *dagger.Client) {
+		t.Helper()
+		return startEngineWithClientOpts(client, ctx, t, stateKey, nil, opts...)
 	}
 
 	stopEngine := func(
@@ -144,6 +157,138 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 			Contents(ctx)
 		require.NoError(t, err)
 		require.Equal(t, newFileContents, contents)
+	})
+
+	t.Run("service-bound graph does not break disk persistence", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-service-binding-state-" + identity.NewID()
+		serviceScript := "#!/bin/sh\nwhile true; do printf 'ok\\n' | nc -l -p 8080; done\n"
+		randomScript := `
+set -eu
+mkdir -p /work
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+`
+		serviceRunScript := `
+set -eu
+mkdir -p /work
+nc sidecar 8080 > /work/service.txt
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+`
+
+		runRandom := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) string {
+			t.Helper()
+
+			randomContents, err := engineClient.
+				Container().
+				From(alpineImage).
+				WithExec([]string{"sh", "-ec", randomScript}).
+				Directory("/work").
+				File("random.txt").
+				Contents(ctx)
+			require.NoError(t, err)
+			return strings.TrimSpace(randomContents)
+		}
+
+		runServiceBound := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) {
+			t.Helper()
+
+			service := engineClient.
+				Container().
+				From(alpineImage).
+				WithNewFile("/bin/app", serviceScript, dagger.ContainerWithNewFileOpts{Permissions: 0o755}).
+				WithExposedPort(8080).
+				WithDefaultArgs([]string{"/bin/app"}).
+				AsService()
+
+			workDir := engineClient.
+				Container().
+				From(alpineImage).
+				WithServiceBinding("sidecar", service).
+				WithExec([]string{"sh", "-ec", serviceRunScript}).
+				Directory("/work")
+
+			serviceContents, err := workDir.File("service.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "ok\n", serviceContents)
+
+			randomContents, err := workDir.File("random.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, strings.TrimSpace(randomContents))
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		randomA := runRandom(ctx, t, engineClientA)
+		runServiceBound(ctx, t, engineClientA)
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		randomB := runRandom(ctx, t, engineClientB)
+		require.Equal(t, randomA, randomB, "unrelated withExec output should survive engine restart after a service-bound graph")
+	})
+
+	t.Run("generator group graph does not break disk persistence", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-generator-group-state-" + identity.NewID()
+		generatorWorkdir, err := filepath.Abs("testdata/generators/hello-with-generators")
+		require.NoError(t, err)
+		clientOpts := []dagger.ClientOpt{
+			dagger.WithWorkdir(generatorWorkdir),
+			dagger.WithLoadWorkspaceModules(),
+		}
+		randomScript := `
+set -eu
+mkdir -p /work
+head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
+`
+
+		runRandom := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) string {
+			t.Helper()
+
+			randomContents, err := engineClient.
+				Container().
+				From(alpineImage).
+				WithExec([]string{"sh", "-ec", randomScript}).
+				Directory("/work").
+				File("random.txt").
+				Contents(ctx)
+			require.NoError(t, err)
+			return strings.TrimSpace(randomContents)
+		}
+
+		runGeneratorGroup := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) {
+			t.Helper()
+
+			empty, err := engineClient.
+				CurrentWorkspace().
+				Generators(dagger.WorkspaceGeneratorsOpts{Include: []string{"generate-files"}}).
+				Run().
+				IsEmpty(ctx)
+			require.NoError(t, err)
+			require.False(t, empty)
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngineWithClientOpts(c, ctx, t, stateKey, clientOpts, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		randomA := runRandom(ctx, t, engineClientA)
+		runGeneratorGroup(ctx, t, engineClientA)
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngineWithClientOpts(c, ctx, t, stateKey, clientOpts, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		randomB := runRandom(ctx, t, engineClientB)
+		require.Equal(t, randomA, randomB, "unrelated withExec output should survive engine restart after a generator group graph")
 	})
 
 	t.Run("function cache control survives restart", func(ctx context.Context, t *testctx.T) {

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -27,10 +27,10 @@ type ModTreeNode struct {
 	Description string
 	DagqlServer *dagql.Server
 	// This module is the same across all ModTreeNode, this is the root module.
-	Module *Module
+	Module dagql.ObjectResult[*Module]
 	// This original module is the one in which the node has been defined.
-	OriginalModule *Module
-	Type           *TypeDef
+	OriginalModule dagql.ObjectResult[*Module]
+	Type           dagql.ObjectResult[*TypeDef]
 	IsCheck        bool
 	IsGenerator    bool
 	IsUp           bool
@@ -48,7 +48,7 @@ func (node *ModTreeNode) Path() ModTreePath {
 
 func NewModTree(ctx context.Context, mod dagql.ObjectResult[*Module]) (*ModTreeNode, error) {
 	main := mod.Self()
-	mainObj, ok := main.MainObject()
+	mainType, ok := main.mainObjectTypeDefResult()
 	if !ok {
 		return nil, fmt.Errorf("%q: no main object", main.Name())
 	}
@@ -56,19 +56,12 @@ func NewModTree(ctx context.Context, mod dagql.ObjectResult[*Module]) (*ModTreeN
 	if err != nil {
 		return nil, err
 	}
-	mainObjRes, err := dagql.NewObjectResultForCurrentCall(ctx, srv, mainObj)
-	if err != nil {
-		return nil, fmt.Errorf("wrap main object typedef %q: %w", mainObj.Name, err)
-	}
 	return &ModTreeNode{
 		DagqlServer:    srv,
-		Module:         main,
-		OriginalModule: main,
-		Type: (&TypeDef{
-			Kind:     TypeDefKindObject,
-			AsObject: dagql.NonNull(mainObjRes),
-		}).syncName(),
-		Description: main.Description,
+		Module:         mod,
+		OriginalModule: mod,
+		Type:           mainType,
+		Description:    main.Description,
 	}, nil
 }
 
@@ -176,14 +169,14 @@ func (node *ModTreeNode) runAsCheck(
 }
 
 func (node *ModTreeNode) runGeneratorAsCheckLocally(ctx context.Context) error {
-	cs, err := node.runGeneratorLocally(ctx)
+	changes, err := node.runGeneratorLocally(ctx)
 	if err != nil {
 		return err
 	}
-	if cs == nil {
+	if changes.Self() == nil {
 		return nil
 	}
-	empty, err := cs.IsEmpty(ctx)
+	empty, err := changes.Self().IsEmpty(ctx)
 	if err != nil {
 		return err
 	}
@@ -478,8 +471,8 @@ func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span
 	return &runUpStartResult{ReadySpan: readySpan}, nil
 }
 
-func (node *ModTreeNode) RunGenerator(ctx context.Context, include, exclude []string) (*Changeset, error) {
-	var cs *Changeset
+func (node *ModTreeNode) RunGenerator(ctx context.Context, include, exclude []string) (dagql.ObjectResult[*Changeset], error) {
+	var changes dagql.ObjectResult[*Changeset]
 	err := node.Run(ctx,
 		func(n *ModTreeNode) bool { return n.IsGenerator },
 		func(ctx context.Context, n *ModTreeNode, _ *engine.ClientMetadata) (rerr error) {
@@ -492,27 +485,31 @@ func (node *ModTreeNode) RunGenerator(ctx context.Context, include, exclude []st
 				),
 			)
 			defer telemetry.EndWithCause(span, &rerr)
-			changes, err := n.runGeneratorLocally(ctx)
-			cs = changes
+			localChanges, err := n.runGeneratorLocally(ctx)
+			changes = localChanges
 			return err
 		},
 		include, exclude)
-	return cs, err
+	return changes, err
 }
 
-func (node *ModTreeNode) runGeneratorLocally(ctx context.Context) (*Changeset, error) {
+func (node *ModTreeNode) runGeneratorLocally(ctx context.Context) (dagql.ObjectResult[*Changeset], error) {
 	var changes dagql.ObjectResult[*Changeset]
 	if err := node.DagqlValue(ctx, &changes); err != nil {
-		return nil, err
+		return dagql.ObjectResult[*Changeset]{}, err
 	}
-	return changes.Self(), nil
+	return changes, nil
 }
 
 // buildScaleOutModuleQuery builds a query to load a module for scale-out execution.
 // It handles all module source kinds (Local, Git, Dir) and returns a query
 // positioned at the "asModule" selection, ready for check/generator-specific queries.
 func (node *ModTreeNode) buildScaleOutModuleQuery(query *querybuilder.Selection) (*querybuilder.Selection, error) {
-	modSrc := node.Module.Source.Value.Self()
+	mod := node.Module.Self()
+	if mod == nil {
+		return nil, fmt.Errorf("build scale-out module query: missing module")
+	}
+	modSrc := mod.Source.Value.Self()
 	switch modSrc.Kind {
 	case ModuleSourceKindLocal:
 		query = query.Select("moduleSource").
@@ -574,7 +571,7 @@ func dagqlServerForModule(ctx context.Context, mod dagql.ObjectResult[*Module]) 
 // The address of the dagger module that is the root of the tree
 // If the node is a "file", the root address is the URL of the filesystem root
 func (node *ModTreeNode) RootAddress() string {
-	mod := node.Module
+	mod := node.Module.Self()
 	if mod == nil {
 		return ""
 	}
@@ -599,8 +596,12 @@ func (node *ModTreeNode) DagqlValue(ctx context.Context, dest any) error {
 	// A node is also treated as root if its parent is a synthetic naming-only
 	// node (e.g. injected by workspace checks reparenting, which sets
 	// Parent to an empty ModTreeNode with nil Module).
-	if node.Parent == nil || node.Parent.Module == nil {
-		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{Field: gqlFieldName(node.Module.Name())})
+	if node.Parent == nil || node.Parent.Module.Self() == nil {
+		mod := node.Module.Self()
+		if mod == nil {
+			return fmt.Errorf("%q: get value: missing module", node.PathString())
+		}
+		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{Field: gqlFieldName(mod.Name())})
 	}
 	// 2. Is parent an object?
 	if parentObjType := node.Parent.ObjectType(); parentObjType != nil {
@@ -837,7 +838,7 @@ func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
 				DagqlServer:    node.DagqlServer,
 				Module:         node.Module,
 				OriginalModule: node.OriginalModule,
-				Type:           fn.ReturnType.Self(),
+				Type:           fn.ReturnType,
 				IsCheck:        fn.IsCheck,
 				IsGenerator:    fn.IsGenerator,
 				IsUp:           fn.IsUp,
@@ -847,25 +848,18 @@ func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
 			if returnsObject := fn.ReturnType.Self().AsObject.Valid; returnsObject &&
 				// avoid cycles (X.withFoo: X)
 				returnType != nodeType {
-				if subObj, ok := node.OriginalModule.ObjectByName(fn.ReturnType.Self().ToType().Name()); ok {
-					subObjRes, err := dagql.NewObjectResultForCurrentCall(ctx, node.DagqlServer, subObj)
-					if err != nil {
-						return nil, fmt.Errorf("wrap child object typedef %q: %w", subObj.Name, err)
-					}
+				if subType, ok := node.OriginalModule.Self().objectTypeDefResultByName(fn.ReturnType.Self().ToType().Name()); ok {
 					children = append(children, &ModTreeNode{
 						Parent:         node,
 						Name:           fn.Name,
 						DagqlServer:    node.DagqlServer,
 						Module:         node.Module,
 						OriginalModule: node.OriginalModule,
-						Type: (&TypeDef{
-							Kind:     TypeDefKindObject,
-							AsObject: dagql.NonNull(subObjRes),
-						}).syncName(),
-						IsCheck:     false,
-						IsGenerator: false,
-						IsUp:        false,
-						Description: subObj.Description,
+						Type:           subType,
+						IsCheck:        false,
+						IsGenerator:    false,
+						IsUp:           false,
+						Description:    subType.Self().AsObject.Value.Self().Description,
 					})
 				}
 			}
@@ -878,7 +872,7 @@ func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
 				DagqlServer:    node.DagqlServer,
 				Module:         node.Module,
 				OriginalModule: node.OriginalModule,
-				Type:           field.TypeDef.Self(),
+				Type:           field.TypeDef,
 				IsCheck:        false,
 				IsGenerator:    false,
 				IsUp:           false,
@@ -915,5 +909,234 @@ func (node *ModTreeNode) Child(ctx context.Context, name string) (*ModTreeNode, 
 }
 
 func (node *ModTreeNode) ObjectType() *ObjectTypeDef {
-	return node.Type.AsObject.Value.Self()
+	if node == nil || node.Type.Self() == nil {
+		return nil
+	}
+	typeDef := node.Type.Self()
+	if !typeDef.AsObject.Valid {
+		return nil
+	}
+	return typeDef.AsObject.Value.Self()
+}
+
+type persistedModTree struct {
+	Nodes []persistedModTreeNode `json:"nodes,omitempty"`
+}
+
+type persistedModTreeNode struct {
+	ID                     int    `json:"id"`
+	ParentID               int    `json:"parentID,omitempty"`
+	Name                   string `json:"name,omitempty"`
+	Description            string `json:"description,omitempty"`
+	ModuleResultID         uint64 `json:"moduleResultID,omitempty"`
+	OriginalModuleResultID uint64 `json:"originalModuleResultID,omitempty"`
+	TypeResultID           uint64 `json:"typeResultID,omitempty"`
+	IsCheck                bool   `json:"isCheck,omitempty"`
+	IsGenerator            bool   `json:"isGenerator,omitempty"`
+	IsUp                   bool   `json:"isUp,omitempty"`
+}
+
+type persistedModTreeEncoder struct {
+	cache    dagql.PersistedObjectCache
+	ids      map[*ModTreeNode]int
+	visiting map[*ModTreeNode]bool
+	tree     persistedModTree
+}
+
+func newPersistedModTreeEncoder(cache dagql.PersistedObjectCache) *persistedModTreeEncoder {
+	return &persistedModTreeEncoder{
+		cache:    cache,
+		ids:      map[*ModTreeNode]int{},
+		visiting: map[*ModTreeNode]bool{},
+	}
+}
+
+func (enc *persistedModTreeEncoder) Add(node *ModTreeNode) (int, error) {
+	if node == nil {
+		return 0, nil
+	}
+	if id, ok := enc.ids[node]; ok {
+		return id, nil
+	}
+	if enc.visiting[node] {
+		return 0, fmt.Errorf("encode persisted mod tree node %q: parent cycle", node.Name)
+	}
+	enc.visiting[node] = true
+	defer delete(enc.visiting, node)
+
+	parentID, err := enc.Add(node.Parent)
+	if err != nil {
+		return 0, err
+	}
+
+	id := len(enc.tree.Nodes) + 1
+	enc.ids[node] = id
+	persisted := persistedModTreeNode{
+		ID:          id,
+		ParentID:    parentID,
+		Name:        node.Name,
+		Description: node.Description,
+		IsCheck:     node.IsCheck,
+		IsGenerator: node.IsGenerator,
+		IsUp:        node.IsUp,
+	}
+	if node.Module.Self() != nil {
+		moduleID, err := encodePersistedObjectRef(enc.cache, node.Module, "mod tree module")
+		if err != nil {
+			return 0, err
+		}
+		persisted.ModuleResultID = moduleID
+	}
+	if node.OriginalModule.Self() != nil {
+		originalModuleID, err := encodePersistedObjectRef(enc.cache, node.OriginalModule, "mod tree original module")
+		if err != nil {
+			return 0, err
+		}
+		persisted.OriginalModuleResultID = originalModuleID
+	}
+	if node.Type.Self() != nil {
+		typeID, err := encodePersistedObjectRef(enc.cache, node.Type, "mod tree typedef")
+		if err != nil {
+			return 0, err
+		}
+		persisted.TypeResultID = typeID
+	}
+	enc.tree.Nodes = append(enc.tree.Nodes, persisted)
+	return id, nil
+}
+
+func decodePersistedModTree(ctx context.Context, dag *dagql.Server, tree persistedModTree) (map[int]*ModTreeNode, error) {
+	nodes := make(map[int]*ModTreeNode, len(tree.Nodes))
+	serverByModuleID := map[uint64]*dagql.Server{}
+
+	for _, persisted := range tree.Nodes {
+		if persisted.ID == 0 {
+			return nil, fmt.Errorf("decode persisted mod tree: zero node ID")
+		}
+		if _, exists := nodes[persisted.ID]; exists {
+			return nil, fmt.Errorf("decode persisted mod tree: duplicate node ID %d", persisted.ID)
+		}
+
+		node := &ModTreeNode{
+			Name:        persisted.Name,
+			Description: persisted.Description,
+			IsCheck:     persisted.IsCheck,
+			IsGenerator: persisted.IsGenerator,
+			IsUp:        persisted.IsUp,
+		}
+		if persisted.ModuleResultID != 0 {
+			module, err := loadPersistedObjectResultByResultID[*Module](ctx, dag, persisted.ModuleResultID, "mod tree module")
+			if err != nil {
+				return nil, err
+			}
+			node.Module = module
+			if srv, ok := serverByModuleID[persisted.ModuleResultID]; ok {
+				node.DagqlServer = srv
+			} else {
+				srv, err := dagqlServerForModule(ctx, module)
+				if err != nil {
+					return nil, fmt.Errorf("decode persisted mod tree server for module %d: %w", persisted.ModuleResultID, err)
+				}
+				serverByModuleID[persisted.ModuleResultID] = srv
+				node.DagqlServer = srv
+			}
+		}
+		if persisted.OriginalModuleResultID != 0 {
+			originalModule, err := loadPersistedObjectResultByResultID[*Module](ctx, dag, persisted.OriginalModuleResultID, "mod tree original module")
+			if err != nil {
+				return nil, err
+			}
+			node.OriginalModule = originalModule
+		}
+		if persisted.TypeResultID != 0 {
+			typeDef, err := loadPersistedObjectResultByResultID[*TypeDef](ctx, dag, persisted.TypeResultID, "mod tree typedef")
+			if err != nil {
+				return nil, err
+			}
+			node.Type = typeDef
+		}
+		nodes[persisted.ID] = node
+	}
+
+	for _, persisted := range tree.Nodes {
+		if persisted.ParentID == 0 {
+			continue
+		}
+		parent, ok := nodes[persisted.ParentID]
+		if !ok {
+			return nil, fmt.Errorf("decode persisted mod tree node %d: unknown parent %d", persisted.ID, persisted.ParentID)
+		}
+		nodes[persisted.ID].Parent = parent
+	}
+
+	return nodes, nil
+}
+
+func attachModTreeNodeDependencyResults(
+	node *ModTreeNode,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	return attachModTreeNodeDependencyResultsWithSeen(node, attach, map[*ModTreeNode]struct{}{})
+}
+
+func attachModTreeNodeDependencyResultsWithSeen(
+	node *ModTreeNode,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+	seen map[*ModTreeNode]struct{},
+) ([]dagql.AnyResult, error) {
+	if node == nil {
+		return nil, nil
+	}
+	if _, ok := seen[node]; ok {
+		return nil, nil
+	}
+	seen[node] = struct{}{}
+
+	var owned []dagql.AnyResult
+	if node.Parent != nil {
+		parentDeps, err := attachModTreeNodeDependencyResultsWithSeen(node.Parent, attach, seen)
+		if err != nil {
+			return nil, err
+		}
+		owned = append(owned, parentDeps...)
+	}
+
+	if node.Module.Self() != nil {
+		attached, err := attach(node.Module)
+		if err != nil {
+			return nil, fmt.Errorf("attach mod tree module: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Module])
+		if !ok {
+			return nil, fmt.Errorf("attach mod tree module: unexpected result %T", attached)
+		}
+		node.Module = typed
+		owned = append(owned, typed)
+	}
+	if node.OriginalModule.Self() != nil {
+		attached, err := attach(node.OriginalModule)
+		if err != nil {
+			return nil, fmt.Errorf("attach mod tree original module: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Module])
+		if !ok {
+			return nil, fmt.Errorf("attach mod tree original module: unexpected result %T", attached)
+		}
+		node.OriginalModule = typed
+		owned = append(owned, typed)
+	}
+	if node.Type.Self() != nil {
+		attached, err := attach(node.Type)
+		if err != nil {
+			return nil, fmt.Errorf("attach mod tree typedef: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*TypeDef])
+		if !ok {
+			return nil, fmt.Errorf("attach mod tree typedef: unexpected result %T", attached)
+		}
+		node.Type = typed
+		owned = append(owned, typed)
+	}
+
+	return owned, nil
 }

--- a/core/module.go
+++ b/core/module.go
@@ -877,26 +877,26 @@ type persistedModulePayload struct {
 	AsModuleVariantDigest         string         `json:"asModuleVariantDigest,omitempty"`
 }
 
-func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	var persisted persistedModulePayload
 	if mod.Source.Valid {
 		sourceID, err := encodePersistedObjectRef(cache, mod.Source.Value, "module source")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.SourceResultID = sourceID
 	}
 	if mod.ContextSource.Valid {
 		contextSourceID, err := encodePersistedObjectRef(cache, mod.ContextSource.Value, "module context source")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.ContextSourceResultID = contextSourceID
 	}
 	if mod.Runtime.Valid {
 		runtimeID, err := encodePersistedObjectRef(cache, mod.Runtime.Value, "module runtime")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.RuntimeResultID = runtimeID
 	}
@@ -911,7 +911,7 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 			}
 			depResultID, err := encodePersistedObjectRef(cache, depInst, fmt.Sprintf("module dependency %q", dep.Name()))
 			if err != nil {
-				return nil, err
+				return dagql.PersistedObjectEncoding{}, err
 			}
 			if mod.IncludeSelfInDeps && depInst.Self() == mod {
 				continue
@@ -928,7 +928,7 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 	for _, def := range mod.ObjectDefs {
 		defID, err := encodePersistedObjectRef(cache, def, "module object typedef")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.ObjectDefResultIDs = append(persisted.ObjectDefResultIDs, defID)
 	}
@@ -936,7 +936,7 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 	for _, def := range mod.InterfaceDefs {
 		defID, err := encodePersistedObjectRef(cache, def, "module interface typedef")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.InterfaceDefResultIDs = append(persisted.InterfaceDefResultIDs, defID)
 	}
@@ -944,7 +944,7 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 	for _, def := range mod.EnumDefs {
 		defID, err := encodePersistedObjectRef(cache, def, "module enum typedef")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		persisted.EnumDefResultIDs = append(persisted.EnumDefResultIDs, defID)
 	}
@@ -956,9 +956,9 @@ func (mod *Module) EncodePersistedObject(ctx context.Context, cache dagql.Persis
 
 	jsonBytes, err := json.Marshal(persisted)
 	if err != nil {
-		return nil, fmt.Errorf("encode persisted module payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted module payload: %w", err)
 	}
-	return jsonBytes, nil
+	return encodePersistedObjectRawJSON(jsonBytes), nil
 }
 
 func (*Module) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -616,9 +616,9 @@ func (sdk persistedModuleSourceLazyClientGenerator) GenerateClient(
 	return clientSDK.GenerateClient(ctx, modSource, schemaJSONFile, outputDir)
 }
 
-func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if src == nil {
-		return nil, fmt.Errorf("encode persisted module source: nil module source")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted module source: nil module source")
 	}
 	payload := persistedModuleSourcePayload{
 		ConfigExists:                  src.ConfigExists,
@@ -646,7 +646,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 	}
 	if src.SDK != nil {
 		if src.SDKImpl == nil {
-			return nil, fmt.Errorf("encode persisted module source: sdk config is set but sdk impl is not initialized")
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted module source: sdk config is set but sdk impl is not initialized")
 		}
 		_, hasRuntime := src.SDKImpl.AsRuntime()
 		_, hasModuleTypes := src.SDKImpl.AsModuleTypes()
@@ -662,7 +662,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 	if src.ContextDirectory.Self() != nil {
 		contextDirID, err := encodePersistedObjectRef(cache, src.ContextDirectory, "module source context directory")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.ContextDirectoryResultID = contextDirID
 	}
@@ -673,14 +673,14 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		}
 		depID, err := encodePersistedObjectRef(cache, dep, "module source dependency")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.DependencyResultIDs = append(payload.DependencyResultIDs, depID)
 	}
 	if src.Blueprint.Self() != nil {
 		blueprintID, err := encodePersistedObjectRef(cache, src.Blueprint, "module source blueprint")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.BlueprintResultID = blueprintID
 	}
@@ -691,14 +691,14 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		}
 		toolchainID, err := encodePersistedObjectRef(cache, toolchain, "module source toolchain")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.ToolchainResultIDs = append(payload.ToolchainResultIDs, toolchainID)
 	}
 	if src.ToolchainContextSource.Valid && src.ToolchainContextSource.Value.Self() != nil {
 		toolchainContextSourceID, err := encodePersistedObjectRef(cache, src.ToolchainContextSource.Value, "module source toolchain context source")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.ToolchainContextSourceResultID = toolchainContextSourceID
 	}
@@ -716,7 +716,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		if src.Git.UnfilteredContextDir.Self() != nil {
 			unfilteredID, err := encodePersistedObjectRef(cache, src.Git.UnfilteredContextDir, "module source git unfiltered context dir")
 			if err != nil {
-				return nil, err
+				return dagql.PersistedObjectEncoding{}, err
 			}
 			payload.GitUnfilteredContextDirResultID = unfilteredID
 		}
@@ -728,12 +728,12 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		if src.DirSrc.OriginalContextDir.Self() != nil {
 			originalContextDirID, err := encodePersistedObjectRef(cache, src.DirSrc.OriginalContextDir, "module source dir original context dir")
 			if err != nil {
-				return nil, err
+				return dagql.PersistedObjectEncoding{}, err
 			}
 			payload.DirSrc.OriginalContextDirResultID = originalContextDirID
 		}
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/object.go
+++ b/core/object.go
@@ -670,9 +670,9 @@ func persistedModuleObjectValueHasCallID(val persistedModuleObjectValue) bool {
 	return false
 }
 
-func (obj *ModuleObject) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (obj *ModuleObject) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	if obj == nil || len(obj.Fields) == 0 {
-		return json.Marshal(persistedModuleObjectPayload{})
+		return encodePersistedObjectPayload(persistedModuleObjectPayload{})
 	}
 	payload := persistedModuleObjectPayload{
 		Fields: make(map[string]persistedModuleObjectValue, len(obj.Fields)),
@@ -682,14 +682,14 @@ func (obj *ModuleObject) EncodePersistedObject(ctx context.Context, cache dagql.
 	for _, name := range fieldNames {
 		encoded, err := encodePersistedModuleObjectValue(cache, obj.Fields[name])
 		if err != nil {
-			return nil, fmt.Errorf("encode persisted module object field %q: %w", name, err)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted module object field %q: %w", name, err)
 		}
 		if _, ok := obj.TypeDef.FieldByOriginalName(name); ok && persistedModuleObjectValueHasCallID(encoded) {
-			return nil, fmt.Errorf("encode persisted module object field %q: unexpected raw call ID in semantic field", name)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted module object field %q: unexpected raw call ID in semantic field", name)
 		}
 		payload.Fields[name] = encoded
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (obj *ModuleObject) DecodePersistedObject(

--- a/core/object_test.go
+++ b/core/object_test.go
@@ -259,7 +259,7 @@ func TestModulePersistedTypeDefsRoundTripPreservesNullableValidity(t *testing.T)
 	payload, err := mod.EncodePersistedObject(ctx, sc)
 	assert.NilError(t, err)
 
-	decodedTyped, err := (&Module{}).DecodePersistedObject(ctx, dag, 0, nil, payload)
+	decodedTyped, err := (&Module{}).DecodePersistedObject(ctx, dag, 0, nil, payload.JSON)
 	assert.NilError(t, err)
 	decoded, ok := decodedTyped.(*Module)
 	assert.Assert(t, ok)
@@ -515,10 +515,10 @@ func TestModuleObjectPersistedResultRefsRoundTrip(t *testing.T) {
 	assert.NilError(t, err)
 
 	var persisted persistedModuleObjectPayload
-	assert.NilError(t, json.Unmarshal(payload, &persisted))
+	assert.NilError(t, json.Unmarshal(payload.JSON, &persisted))
 	assert.Equal(t, persistedModuleObjectValueKindResultRef, persisted.Fields["child"].Kind)
 
-	decodedTyped, err := obj.DecodePersistedObject(ctx, dag, 0, nil, payload)
+	decodedTyped, err := obj.DecodePersistedObject(ctx, dag, 0, nil, payload.JSON)
 	assert.NilError(t, err)
 	decoded, ok := decodedTyped.(*ModuleObject)
 	assert.Assert(t, ok)
@@ -575,7 +575,7 @@ func TestModuleObjectEncodeAllowsRawCallIDInPrivateField(t *testing.T) {
 	assert.NilError(t, err)
 
 	var persisted persistedModuleObjectPayload
-	assert.NilError(t, json.Unmarshal(payload, &persisted))
+	assert.NilError(t, json.Unmarshal(payload.JSON, &persisted))
 	assert.Equal(t, persistedModuleObjectValueKindCallID, persisted.Fields["private"].Kind)
 }
 

--- a/core/persisted_object.go
+++ b/core/persisted_object.go
@@ -2,12 +2,25 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 )
+
+func encodePersistedObjectPayload(payload any) (dagql.PersistedObjectEncoding, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return dagql.PersistedObjectEncoding{}, err
+	}
+	return dagql.PersistedObjectEncoding{JSON: raw}, nil
+}
+
+func encodePersistedObjectRawJSON(raw json.RawMessage) dagql.PersistedObjectEncoding {
+	return dagql.PersistedObjectEncoding{JSON: raw}
+}
 
 func persistedDecodeQuery(dag *dagql.Server) (*Query, error) {
 	if dag == nil {

--- a/core/schema/generators.go
+++ b/core/schema/generators.go
@@ -99,8 +99,9 @@ func (s generatorsSchema) originalModule(_ context.Context, parent *core.Generat
 	return parent.OriginalModule(), nil
 }
 
-func (s generatorsSchema) changes(ctx context.Context, parent dagql.ObjectResult[*core.Generator], args struct{}) (*core.Changeset, error) {
-	return parent.Self().RequireChanges("changes")
+func (s generatorsSchema) changes(ctx context.Context, parent dagql.ObjectResult[*core.Generator], args struct{}) (dagql.ObjectResult[*core.Changeset], error) {
+	_ = ctx
+	return parent.Self().RequireChangesResult("changes")
 }
 
 func (s generatorsSchema) runSingleGenerator(ctx context.Context, parent *core.Generator, args struct{}) (*core.Generator, error) {

--- a/core/secret.go
+++ b/core/secret.go
@@ -52,13 +52,13 @@ type persistedSecretPayload struct {
 	Name   string                      `json:"name,omitempty"`
 }
 
-func (secret *Secret) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (secret *Secret) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	payload := persistedSecretPayload{}
 	if secret != nil {
 		payload.Handle = secret.Handle
 		payload.Name = secret.NameVal
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*Secret) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, call *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/service.go
+++ b/core/service.go
@@ -112,10 +112,10 @@ type persistedServiceBinding struct {
 	Aliases         AliasSet `json:"aliases,omitempty"`
 }
 
-func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if svc == nil {
-		return nil, fmt.Errorf("encode persisted service: nil service")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted service: nil service")
 	}
 	payload := persistedServicePayload{
 		CustomHostname:                svc.CustomHostname,
@@ -132,24 +132,24 @@ func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.Persi
 	if svc.Container.Self() != nil {
 		payload.ContainerResultID, err = encodePersistedObjectRef(cache, svc.Container, "service container")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 	}
 	if svc.ModuleContext.Self() != nil {
 		payload.ModuleContextResultID, err = encodePersistedObjectRef(cache, svc.ModuleContext, "service module context")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 	}
 	if svc.TunnelUpstream.Self() != nil {
 		payload.TunnelUpstreamResultID, err = encodePersistedObjectRef(cache, svc.TunnelUpstream, "service tunnel upstream")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 	}
 	for i, sock := range svc.HostSockets {
 		if sock == nil {
-			return nil, fmt.Errorf("encode persisted service host socket %d: nil socket", i)
+			return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted service host socket %d: nil socket", i)
 		}
 		payload.HostSockets = append(payload.HostSockets, persistedServiceHostSocket{
 			Kind:           sock.Kind,
@@ -161,9 +161,9 @@ func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.Persi
 	}
 	enc, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted service payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted service payload: %w", err)
 	}
-	return enc, nil
+	return encodePersistedObjectRawJSON(enc), nil
 }
 
 func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/service.go
+++ b/core/service.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -56,8 +57,6 @@ type Service struct {
 	NoInit                        bool
 	ExecMD                        *engineutil.ExecutionMetadata
 	ModuleContext                 dagql.ObjectResult[*Module]
-	FunctionCall                  *FunctionCall
-	EnvContext                    dagql.ObjectResult[*Env]
 	ExecMeta                      *executor.Meta
 
 	// TunnelUpstream is the service that this service is tunnelling to.
@@ -78,6 +77,215 @@ func (*Service) Type() *ast.Type {
 
 func (*Service) TypeDescription() string {
 	return "A content-addressed service providing TCP connectivity."
+}
+
+var _ dagql.PersistedObject = (*Service)(nil)
+var _ dagql.PersistedObjectDecoder = (*Service)(nil)
+var _ dagql.HasDependencyResults = (*Service)(nil)
+
+type persistedServicePayload struct {
+	CustomHostname                string                        `json:"customHostname,omitempty"`
+	ContainerResultID             uint64                        `json:"containerResultID,omitempty"`
+	Args                          []string                      `json:"args,omitempty"`
+	ExperimentalPrivilegedNesting bool                          `json:"experimentalPrivilegedNesting,omitempty"`
+	InsecureRootCapabilities      bool                          `json:"insecureRootCapabilities,omitempty"`
+	NoInit                        bool                          `json:"noInit,omitempty"`
+	ExecMD                        *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
+	ModuleContextResultID         uint64                        `json:"moduleContextResultID,omitempty"`
+	ExecMeta                      *executor.Meta                `json:"execMeta,omitempty"`
+	TunnelUpstreamResultID        uint64                        `json:"tunnelUpstreamResultID,omitempty"`
+	TunnelPorts                   []PortForward                 `json:"tunnelPorts,omitempty"`
+	HostSockets                   []persistedServiceHostSocket  `json:"hostSockets,omitempty"`
+}
+
+type persistedServiceHostSocket struct {
+	Kind           SocketKind                  `json:"kind,omitempty"`
+	Handle         dagql.SessionResourceHandle `json:"handle,omitempty"`
+	URLVal         string                      `json:"urlVal,omitempty"`
+	PortForwardVal PortForward                 `json:"portForwardVal,omitempty"`
+	SourceClientID string                      `json:"sourceClientID,omitempty"`
+}
+
+type persistedServiceBinding struct {
+	ServiceResultID uint64   `json:"serviceResultID"`
+	Hostname        string   `json:"hostname"`
+	Aliases         AliasSet `json:"aliases,omitempty"`
+}
+
+func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	_ = ctx
+	if svc == nil {
+		return nil, fmt.Errorf("encode persisted service: nil service")
+	}
+	payload := persistedServicePayload{
+		CustomHostname:                svc.CustomHostname,
+		Args:                          slices.Clone(svc.Args),
+		ExperimentalPrivilegedNesting: svc.ExperimentalPrivilegedNesting,
+		InsecureRootCapabilities:      svc.InsecureRootCapabilities,
+		NoInit:                        svc.NoInit,
+		ExecMD:                        svc.ExecMD,
+		ExecMeta:                      svc.ExecMeta,
+		TunnelPorts:                   slices.Clone(svc.TunnelPorts),
+		HostSockets:                   make([]persistedServiceHostSocket, 0, len(svc.HostSockets)),
+	}
+	var err error
+	if svc.Container.Self() != nil {
+		payload.ContainerResultID, err = encodePersistedObjectRef(cache, svc.Container, "service container")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if svc.ModuleContext.Self() != nil {
+		payload.ModuleContextResultID, err = encodePersistedObjectRef(cache, svc.ModuleContext, "service module context")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if svc.TunnelUpstream.Self() != nil {
+		payload.TunnelUpstreamResultID, err = encodePersistedObjectRef(cache, svc.TunnelUpstream, "service tunnel upstream")
+		if err != nil {
+			return nil, err
+		}
+	}
+	for i, sock := range svc.HostSockets {
+		if sock == nil {
+			return nil, fmt.Errorf("encode persisted service host socket %d: nil socket", i)
+		}
+		payload.HostSockets = append(payload.HostSockets, persistedServiceHostSocket{
+			Kind:           sock.Kind,
+			Handle:         sock.Handle,
+			URLVal:         sock.URLVal,
+			PortForwardVal: sock.PortForwardVal,
+			SourceClientID: sock.SourceClientID,
+		})
+	}
+	enc, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal persisted service payload: %w", err)
+	}
+	return enc, nil
+}
+
+func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	var persisted persistedServicePayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted service payload: %w", err)
+	}
+	container, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ContainerResultID, "service container")
+	if err != nil {
+		return nil, err
+	}
+	moduleContext, err := loadPersistedObjectResultByResultID[*Module](ctx, dag, persisted.ModuleContextResultID, "service module context")
+	if err != nil {
+		return nil, err
+	}
+	tunnelUpstream, err := loadPersistedObjectResultByResultID[*Service](ctx, dag, persisted.TunnelUpstreamResultID, "service tunnel upstream")
+	if err != nil {
+		return nil, err
+	}
+	hostSockets := make([]*Socket, 0, len(persisted.HostSockets))
+	for _, sock := range persisted.HostSockets {
+		hostSockets = append(hostSockets, &Socket{
+			Kind:           sock.Kind,
+			Handle:         sock.Handle,
+			URLVal:         sock.URLVal,
+			PortForwardVal: sock.PortForwardVal,
+			SourceClientID: sock.SourceClientID,
+		})
+	}
+	return &Service{
+		CustomHostname:                persisted.CustomHostname,
+		Container:                     container,
+		Args:                          slices.Clone(persisted.Args),
+		ExperimentalPrivilegedNesting: persisted.ExperimentalPrivilegedNesting,
+		InsecureRootCapabilities:      persisted.InsecureRootCapabilities,
+		NoInit:                        persisted.NoInit,
+		ExecMD:                        persisted.ExecMD,
+		ModuleContext:                 moduleContext,
+		ExecMeta:                      persisted.ExecMeta,
+		TunnelUpstream:                tunnelUpstream,
+		TunnelPorts:                   slices.Clone(persisted.TunnelPorts),
+		HostSockets:                   hostSockets,
+	}, nil
+}
+
+func (svc *Service) AttachDependencyResults(
+	ctx context.Context,
+	_ dagql.AnyResult,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	_ = ctx
+	if svc == nil {
+		return nil, nil
+	}
+	var owned []dagql.AnyResult
+	if svc.Container.Self() != nil {
+		container, err := attachContainerResult(attach, svc.Container, "attach service container")
+		if err != nil {
+			return nil, err
+		}
+		svc.Container = container
+		owned = append(owned, container)
+	}
+	if svc.ModuleContext.Self() != nil {
+		attached, err := attach(svc.ModuleContext)
+		if err != nil {
+			return nil, fmt.Errorf("attach service module context: %w", err)
+		}
+		moduleContext, ok := attached.(dagql.ObjectResult[*Module])
+		if !ok {
+			return nil, fmt.Errorf("attach service module context: expected %T, got %T", svc.ModuleContext, attached)
+		}
+		svc.ModuleContext = moduleContext
+		owned = append(owned, moduleContext)
+	}
+	if svc.TunnelUpstream.Self() != nil {
+		upstream, err := attachServiceResult(attach, svc.TunnelUpstream, "attach service tunnel upstream")
+		if err != nil {
+			return nil, err
+		}
+		svc.TunnelUpstream = upstream
+		owned = append(owned, upstream)
+	}
+	return owned, nil
+}
+
+func encodePersistedServiceBindings(cache dagql.PersistedObjectCache, owner string, bindings ServiceBindings) ([]persistedServiceBinding, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	persisted := make([]persistedServiceBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		serviceID, err := encodePersistedObjectRef(cache, binding.Service, fmt.Sprintf("%s service %q", owner, binding.Hostname))
+		if err != nil {
+			return nil, err
+		}
+		persisted = append(persisted, persistedServiceBinding{
+			ServiceResultID: serviceID,
+			Hostname:        binding.Hostname,
+			Aliases:         slices.Clone(binding.Aliases),
+		})
+	}
+	return persisted, nil
+}
+
+func decodePersistedServiceBindings(ctx context.Context, dag *dagql.Server, owner string, persisted []persistedServiceBinding) (ServiceBindings, error) {
+	if len(persisted) == 0 {
+		return nil, nil
+	}
+	bindings := make(ServiceBindings, 0, len(persisted))
+	for _, binding := range persisted {
+		service, err := loadPersistedObjectResultByResultID[*Service](ctx, dag, binding.ServiceResultID, fmt.Sprintf("%s service %q", owner, binding.Hostname))
+		if err != nil {
+			return nil, err
+		}
+		bindings = append(bindings, ServiceBinding{
+			Service:  service,
+			Hostname: binding.Hostname,
+			Aliases:  slices.Clone(binding.Aliases),
+		})
+	}
+	return bindings, nil
 }
 
 // Clone returns a deep copy of the container suitable for modifying in a
@@ -609,8 +817,8 @@ func (svc *Service) startContainer(
 			clientMetadata.ClientID,
 			nestedClientMetadata,
 			svc.ModuleContext,
-			svc.FunctionCall,
-			svc.EnvContext,
+			nil,
+			dagql.ObjectResult[*Env]{},
 		)
 		runErr <- err
 	}()

--- a/core/socket.go
+++ b/core/socket.go
@@ -64,7 +64,7 @@ type persistedSocketPayload struct {
 	PortForward PortForward                 `json:"portForward,omitempty"`
 }
 
-func (socket *Socket) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (socket *Socket) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	payload := persistedSocketPayload{}
 	if socket != nil {
 		payload.Kind = socket.Kind
@@ -73,7 +73,7 @@ func (socket *Socket) EncodePersistedObject(ctx context.Context, cache dagql.Per
 			payload.PortForward = socket.PortForwardVal
 		}
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*Socket) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, call *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -83,16 +83,16 @@ func (*Function) TypeDescription() string {
 	)
 }
 
-func (fn *Function) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (fn *Function) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if fn == nil {
-		return nil, fmt.Errorf("encode persisted function: nil function")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted function: nil function")
 	}
 	payload, err := encodePersistedFunction(cache, fn)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*Function) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -637,16 +637,16 @@ func (*FunctionArg) TypeDescription() string {
 		an argument passed at function call time.`)
 }
 
-func (arg *FunctionArg) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (arg *FunctionArg) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if arg == nil {
-		return nil, fmt.Errorf("encode persisted function arg: nil function arg")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted function arg: nil function arg")
 	}
 	payload, err := encodePersistedFunctionArg(cache, arg)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*FunctionArg) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -901,16 +901,16 @@ func (*TypeDef) TypeDescription() string {
 	return "A definition of a parameter or return type in a Module."
 }
 
-func (typeDef *TypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (typeDef *TypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if typeDef == nil {
-		return nil, fmt.Errorf("encode persisted type def: nil type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted type def: nil type def")
 	}
 	payload, err := encodePersistedTypeDef(cache, typeDef)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*TypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1269,16 +1269,16 @@ func (*ObjectTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*ObjectTypeDef)(nil)
 
-func (obj *ObjectTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (obj *ObjectTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if obj == nil {
-		return nil, fmt.Errorf("encode persisted object type def: nil object type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted object type def: nil object type def")
 	}
 	payload, err := encodePersistedObjectTypeDef(cache, obj)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*ObjectTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1550,16 +1550,16 @@ func (*FieldTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*FieldTypeDef)(nil)
 
-func (field *FieldTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (field *FieldTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if field == nil {
-		return nil, fmt.Errorf("encode persisted field type def: nil field type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted field type def: nil field type def")
 	}
 	payload, err := encodePersistedFieldTypeDef(cache, field)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*FieldTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1667,16 +1667,16 @@ func (*InterfaceTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*InterfaceTypeDef)(nil)
 
-func (iface *InterfaceTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (iface *InterfaceTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if iface == nil {
-		return nil, fmt.Errorf("encode persisted interface type def: nil interface type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted interface type def: nil interface type def")
 	}
 	payload, err := encodePersistedInterfaceTypeDef(cache, iface)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*InterfaceTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1832,13 +1832,13 @@ func (typeDef *ScalarTypeDef) TypeDescription() string {
 	return "A definition of a custom scalar defined in a Module."
 }
 
-func (typeDef *ScalarTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (typeDef *ScalarTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if typeDef == nil {
-		return nil, fmt.Errorf("encode persisted scalar type def: nil scalar type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted scalar type def: nil scalar type def")
 	}
-	return json.Marshal(encodePersistedScalarTypeDef(typeDef))
+	return encodePersistedObjectPayload(encodePersistedScalarTypeDef(typeDef))
 }
 
 func (*ScalarTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1872,16 +1872,16 @@ func (*ListTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*ListTypeDef)(nil)
 
-func (typeDef *ListTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (typeDef *ListTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if typeDef == nil {
-		return nil, fmt.Errorf("encode persisted list type def: nil list type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted list type def: nil list type def")
 	}
 	payload, err := encodePersistedListTypeDef(cache, typeDef)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*ListTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -1944,16 +1944,16 @@ module accept input objects via their id rather than graphql input types.`
 
 var _ dagql.HasDependencyResults = (*InputTypeDef)(nil)
 
-func (typeDef *InputTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (typeDef *InputTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if typeDef == nil {
-		return nil, fmt.Errorf("encode persisted input type def: nil input type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted input type def: nil input type def")
 	}
 	payload, err := encodePersistedInputTypeDef(cache, typeDef)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*InputTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -2049,16 +2049,16 @@ func (*EnumTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*EnumTypeDef)(nil)
 
-func (enum *EnumTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (enum *EnumTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if enum == nil {
-		return nil, fmt.Errorf("encode persisted enum type def: nil enum type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted enum type def: nil enum type def")
 	}
 	payload, err := encodePersistedEnumTypeDef(cache, enum)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*EnumTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -2227,16 +2227,16 @@ func (*EnumMemberTypeDef) TypeDescription() string {
 
 var _ dagql.HasDependencyResults = (*EnumMemberTypeDef)(nil)
 
-func (enumValue *EnumMemberTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (enumValue *EnumMemberTypeDef) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if enumValue == nil {
-		return nil, fmt.Errorf("encode persisted enum member type def: nil enum member type def")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted enum member type def: nil enum member type def")
 	}
 	payload, err := encodePersistedEnumMemberTypeDef(cache, enumValue)
 	if err != nil {
-		return nil, err
+		return dagql.PersistedObjectEncoding{}, err
 	}
-	return json.Marshal(payload)
+	return encodePersistedObjectPayload(payload)
 }
 
 func (*EnumMemberTypeDef) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -2452,13 +2452,13 @@ func (*FunctionCall) TypeDescription() string {
 	return "An active function call."
 }
 
-func (fnCall *FunctionCall) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (fnCall *FunctionCall) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if fnCall == nil {
-		return nil, fmt.Errorf("encode persisted function call: nil function call")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted function call: nil function call")
 	}
-	return json.Marshal(persistedFunctionCall(*fnCall))
+	return encodePersistedObjectPayload(persistedFunctionCall(*fnCall))
 }
 
 func (*FunctionCall) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -2539,13 +2539,13 @@ func (*FunctionCallArgValue) TypeDescription() string {
 	return "A value passed as a named argument to a function call."
 }
 
-func (arg *FunctionCallArgValue) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (arg *FunctionCallArgValue) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if arg == nil {
-		return nil, fmt.Errorf("encode persisted function call arg value: nil function call arg value")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted function call arg value: nil function call arg value")
 	}
-	return json.Marshal(persistedFunctionCallArgValue(*arg))
+	return encodePersistedObjectPayload(persistedFunctionCallArgValue(*arg))
 }
 
 func (*FunctionCallArgValue) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
@@ -2581,13 +2581,13 @@ func (*SourceMap) TypeDescription() string {
 	return "Source location information."
 }
 
-func (sourceMap *SourceMap) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (sourceMap *SourceMap) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
 	if sourceMap == nil {
-		return nil, fmt.Errorf("encode persisted source map: nil source map")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted source map: nil source map")
 	}
-	return json.Marshal(encodePersistedSourceMap(sourceMap))
+	return encodePersistedObjectPayload(encodePersistedSourceMap(sourceMap))
 }
 
 func (*SourceMap) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {

--- a/core/up.go
+++ b/core/up.go
@@ -209,7 +209,7 @@ func (u *Up) Description() string {
 }
 
 func (u *Up) OriginalModule() *Module {
-	return u.Node.OriginalModule
+	return u.Node.OriginalModule.Self()
 }
 
 func (*Up) Type() *ast.Type {

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -1,6 +1,10 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+
 	"github.com/dagger/dagger/dagql"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -61,6 +65,106 @@ func (*Workspace) Type() *ast.Type {
 
 func (*Workspace) TypeDescription() string {
 	return "A Dagger workspace detected from the current working directory."
+}
+
+var _ dagql.PersistedObject = (*Workspace)(nil)
+var _ dagql.PersistedObjectDecoder = (*Workspace)(nil)
+var _ dagql.HasDependencyResults = (*Workspace)(nil)
+
+type persistedWorkspacePayload struct {
+	RootfsResultID uint64 `json:"rootfsResultID,omitempty"`
+	Path           string `json:"path,omitempty"`
+	Address        string `json:"address,omitempty"`
+	Initialized    bool   `json:"initialized,omitempty"`
+	ConfigPath     string `json:"configPath,omitempty"`
+	HasConfig      bool   `json:"hasConfig,omitempty"`
+	ClientID       string `json:"clientID,omitempty"`
+	HostPath       string `json:"hostPath,omitempty"`
+}
+
+func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	_ = ctx
+	if ws == nil {
+		return nil, fmt.Errorf("encode persisted workspace: nil workspace")
+	}
+
+	payload := persistedWorkspacePayload{
+		Path:        ws.Path,
+		Address:     ws.Address,
+		Initialized: ws.Initialized,
+		ConfigPath:  ws.ConfigPath,
+		HasConfig:   ws.HasConfig,
+		ClientID:    ws.ClientID,
+		HostPath:    ws.hostPath,
+	}
+	if ws.rootfs.Self() != nil {
+		rootfsID, err := encodePersistedObjectRef(cache, ws.rootfs, "workspace rootfs")
+		if err != nil {
+			return nil, err
+		}
+		payload.RootfsResultID = rootfsID
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal persisted workspace payload: %w", err)
+	}
+	return payloadBytes, nil
+}
+
+func (*Workspace) DecodePersistedObject(
+	ctx context.Context,
+	dag *dagql.Server,
+	_ uint64,
+	_ *dagql.ResultCall,
+	payload json.RawMessage,
+) (dagql.Typed, error) {
+	var persisted persistedWorkspacePayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted workspace payload: %w", err)
+	}
+
+	var rootfs dagql.ObjectResult[*Directory]
+	if persisted.RootfsResultID != 0 {
+		var err error
+		rootfs, err = loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.RootfsResultID, "workspace rootfs")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Workspace{
+		rootfs:      rootfs,
+		Path:        persisted.Path,
+		Address:     persisted.Address,
+		Initialized: persisted.Initialized,
+		ConfigPath:  persisted.ConfigPath,
+		HasConfig:   persisted.HasConfig,
+		ClientID:    persisted.ClientID,
+		hostPath:    persisted.HostPath,
+	}, nil
+}
+
+func (ws *Workspace) AttachDependencyResults(
+	ctx context.Context,
+	_ dagql.AnyResult,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	_ = ctx
+	if ws == nil || ws.rootfs.Self() == nil {
+		return nil, nil
+	}
+
+	attached, err := attach(ws.rootfs)
+	if err != nil {
+		return nil, fmt.Errorf("attach workspace rootfs: %w", err)
+	}
+	typed, ok := attached.(dagql.ObjectResult[*Directory])
+	if !ok {
+		return nil, fmt.Errorf("attach workspace rootfs: unexpected result %T", attached)
+	}
+	ws.rootfs = typed
+	return []dagql.AnyResult{typed}, nil
 }
 
 func (ws *Workspace) Clone() *Workspace {

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -82,10 +82,10 @@ type persistedWorkspacePayload struct {
 	HostPath       string `json:"hostPath,omitempty"`
 }
 
-func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
 	_ = ctx
 	if ws == nil {
-		return nil, fmt.Errorf("encode persisted workspace: nil workspace")
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted workspace: nil workspace")
 	}
 
 	payload := persistedWorkspacePayload{
@@ -100,16 +100,16 @@ func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.Pers
 	if ws.rootfs.Self() != nil {
 		rootfsID, err := encodePersistedObjectRef(cache, ws.rootfs, "workspace rootfs")
 		if err != nil {
-			return nil, err
+			return dagql.PersistedObjectEncoding{}, err
 		}
 		payload.RootfsResultID = rootfsID
 	}
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal persisted workspace payload: %w", err)
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted workspace payload: %w", err)
 	}
-	return payloadBytes, nil
+	return encodePersistedObjectRawJSON(payloadBytes), nil
 }
 
 func (*Workspace) DecodePersistedObject(

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -83,7 +83,7 @@ type persistedEdge struct {
 	unpruneable       bool
 }
 
-const cachePersistenceSchemaVersion = "14"
+const cachePersistenceSchemaVersion = "15"
 
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrPersistStateNotReady = errors.New("persist state not ready")

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -83,7 +83,7 @@ type persistedEdge struct {
 	unpruneable       bool
 }
 
-const cachePersistenceSchemaVersion = "13"
+const cachePersistenceSchemaVersion = "14"
 
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrPersistStateNotReady = errors.New("persist state not ready")

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -88,6 +88,15 @@ const cachePersistenceSchemaVersion = "15"
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrPersistStateNotReady = errors.New("persist state not ready")
 
+type CachePersistenceResetReason string
+
+const (
+	CachePersistenceResetNone            CachePersistenceResetReason = ""
+	CachePersistenceResetSchemaMismatch  CachePersistenceResetReason = "schema_mismatch"
+	CachePersistenceResetUncleanShutdown CachePersistenceResetReason = "unclean_shutdown"
+	CachePersistenceResetImportFailure   CachePersistenceResetReason = "import_failure"
+)
+
 func NewCache(
 	ctx context.Context,
 	dbPath string,
@@ -119,6 +128,7 @@ func NewCache(
 		return nil, fmt.Errorf("read schema_version metadata: %w", err)
 	}
 	if found && schemaVersionVal != cachePersistenceSchemaVersion {
+		c.persistenceResetReason = CachePersistenceResetSchemaMismatch
 		c.tracePersistStoreWipedSchemaMismatch(ctx, cachePersistenceSchemaVersion, schemaVersionVal)
 		slog.Warn("dagql persistence store schema version mismatch; wiping and cold-starting", "expected", cachePersistenceSchemaVersion, "actual", schemaVersionVal)
 		if closeErr := closeCacheDBs(db, c.pdb); closeErr != nil {
@@ -144,6 +154,7 @@ func NewCache(
 		return nil, fmt.Errorf("read clean_shutdown metadata: %w", err)
 	}
 	if found && cleanShutdownVal != "1" {
+		c.persistenceResetReason = CachePersistenceResetUncleanShutdown
 		c.tracePersistStoreWipedUncleanShutdown(ctx, cleanShutdownVal)
 		slog.Warn("dagql persistence store marked unclean; wiping and cold-starting", "cleanShutdown", cleanShutdownVal)
 		if closeErr := closeCacheDBs(db, c.pdb); closeErr != nil {
@@ -161,6 +172,7 @@ func NewCache(
 		c.pdb = persistDB
 	}
 	if err := c.importPersistedState(ctx); err != nil {
+		c.persistenceResetReason = CachePersistenceResetImportFailure
 		c.tracePersistStoreWipedImportFailure(ctx, err)
 		slog.Warn("dagql persistence import failed; wiping and cold-starting", "err", err)
 		if closeErr := closeCacheDBs(db, c.pdb); closeErr != nil {
@@ -1108,6 +1120,10 @@ func closeCacheDBs(db *sql.DB, persistDB *persistdb.Queries) error {
 	return err
 }
 
+func RemoveCachePersistenceStore(dbPath string) error {
+	return wipeSQLiteFiles(dbPath)
+}
+
 func wipeSQLiteFiles(dbPath string) error {
 	removeIfExists := func(path string) error {
 		err := os.Remove(path)
@@ -1135,6 +1151,8 @@ type Cache struct {
 	sessionMu sync.Mutex
 	// egraphMu protects all e-graph state and indexes.
 	egraphMu sync.RWMutex
+
+	persistenceResetReason CachePersistenceResetReason
 
 	// calls that are in progress, keyed by a combination of the call key and the concurrency key
 	// two calls with the same call+concurrency key will be "single-flighted" (only one will actually run)
@@ -2895,6 +2913,30 @@ func (c *Cache) Close(ctx context.Context) error {
 		slog.Info("completed dagql cache close successfully")
 	})
 	return c.closeErr
+}
+
+func (c *Cache) CloseDiscardingPersistence() error {
+	c.closeOnce.Do(func() {
+		slog.Info(
+			"discarding dagql cache without persistence",
+			"hasSQLDB", c.sqlDB != nil,
+			"hasPersistDB", c.pdb != nil,
+		)
+		if closeErr := closeCacheDBs(c.sqlDB, c.pdb); closeErr != nil {
+			slog.Error("failed to close discarded dagql persistence databases", "err", closeErr)
+			c.closeErr = errors.Join(c.closeErr, closeErr)
+		}
+		c.sqlDB = nil
+		c.pdb = nil
+	})
+	return c.closeErr
+}
+
+func (c *Cache) PersistenceResetReason() CachePersistenceResetReason {
+	if c == nil {
+		return CachePersistenceResetNone
+	}
+	return c.persistenceResetReason
 }
 
 func (c *Cache) Size() int {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -918,14 +918,10 @@ func desiredSnapshotLinksForResult(res *sharedResult) []PersistedSnapshotRefLink
 		return snapshotOwnerLinksFromTyped(state.self)
 	}
 
-	res.payloadMu.RLock()
-	defer res.payloadMu.RUnlock()
-	if len(res.snapshotOwnerLinks) == 0 {
+	if len(state.snapshotOwnerLinks) == 0 {
 		return nil
 	}
-	links := make([]PersistedSnapshotRefLink, len(res.snapshotOwnerLinks))
-	copy(links, res.snapshotOwnerLinks)
-	return links
+	return slices.Clone(state.snapshotOwnerLinks)
 }
 
 func (c *Cache) resultSnapshotLeaseCleanup(res *sharedResult) OnReleaseFunc {
@@ -938,9 +934,7 @@ func (c *Cache) resultSnapshotLeaseCleanup(res *sharedResult) OnReleaseFunc {
 			return nil
 		}
 
-		res.payloadMu.RLock()
-		links := append([]PersistedSnapshotRefLink(nil), res.snapshotOwnerLinks...)
-		res.payloadMu.RUnlock()
+		links := res.loadSnapshotOwnerLinks()
 
 		seen := make(map[snapshotOwnerKey]struct{}, len(links))
 		var rerr error
@@ -966,9 +960,7 @@ func (c *Cache) syncResultSnapshotLeases(ctx context.Context, res *sharedResult)
 
 	links := desiredSnapshotLinksForResult(res)
 
-	res.payloadMu.RLock()
-	oldLinks := append([]PersistedSnapshotRefLink(nil), res.snapshotOwnerLinks...)
-	res.payloadMu.RUnlock()
+	oldLinks := res.loadSnapshotOwnerLinks()
 
 	oldByKey := make(map[snapshotOwnerKey]PersistedSnapshotRefLink, len(oldLinks))
 	newByKey := make(map[snapshotOwnerKey]PersistedSnapshotRefLink, len(links))
@@ -1015,12 +1007,11 @@ func (c *Cache) syncResultSnapshotLeases(ctx context.Context, res *sharedResult)
 		}
 	}
 
-	res.payloadMu.Lock()
-	res.snapshotOwnerLinks = make([]PersistedSnapshotRefLink, 0, len(newByKey))
+	newLinks := make([]PersistedSnapshotRefLink, 0, len(newByKey))
 	for _, link := range newByKey {
-		res.snapshotOwnerLinks = append(res.snapshotOwnerLinks, link)
+		newLinks = append(newLinks, link)
 	}
-	res.payloadMu.Unlock()
+	res.storeSnapshotOwnerLinks(newLinks)
 
 	return nil
 }
@@ -1373,9 +1364,10 @@ type sharedResult struct {
 	sessionResourceHandle    SessionResourceHandle
 	requiredSessionResources *set.TreeSet[SessionResourceHandle]
 	// snapshotOwnerLinks are the exact direct snapshot-owner links currently
-	// attached for this result. They are the single source of truth for owner
-	// lease cleanup, debug output, and persistence export. They are not
-	// child-result deps.
+	// attached for this result. They are the source of truth for owner lease
+	// cleanup and debug output. Persistence export for newly encoded objects
+	// derives links from the same object encode pass that produced the payload.
+	// They are not child-result deps.
 	snapshotOwnerLinks []PersistedSnapshotRefLink
 
 	// expiresAtUnix is the in-memory TTL deadline for cache-hit eligibility.
@@ -1418,6 +1410,7 @@ type sharedResultPayloadState struct {
 	isObject           bool
 	hasValue           bool
 	persistedEnvelope  *PersistedResultEnvelope
+	snapshotOwnerLinks []PersistedSnapshotRefLink
 	createdAtUnixNano  int64
 	lastUsedAtUnixNano int64
 }
@@ -1451,11 +1444,31 @@ func (res *sharedResult) loadPayloadState() sharedResultPayloadState {
 		isObject:           res.isObject,
 		hasValue:           res.hasValue,
 		persistedEnvelope:  res.persistedEnvelope,
+		snapshotOwnerLinks: slices.Clone(res.snapshotOwnerLinks),
 		createdAtUnixNano:  res.createdAtUnixNano,
 		lastUsedAtUnixNano: res.lastUsedAtUnixNano,
 	}
 	res.payloadMu.RUnlock()
 	return state
+}
+
+func (res *sharedResult) loadSnapshotOwnerLinks() []PersistedSnapshotRefLink {
+	if res == nil {
+		return nil
+	}
+	res.payloadMu.RLock()
+	links := slices.Clone(res.snapshotOwnerLinks)
+	res.payloadMu.RUnlock()
+	return links
+}
+
+func (res *sharedResult) storeSnapshotOwnerLinks(links []PersistedSnapshotRefLink) {
+	if res == nil {
+		return
+	}
+	res.payloadMu.Lock()
+	res.snapshotOwnerLinks = slices.Clone(links)
+	res.payloadMu.Unlock()
 }
 
 func resultIsObject(val AnyResult, resolver TypeResolver) (bool, error) {
@@ -2253,7 +2266,7 @@ func (r Result[T]) WithContentDigest(ctx context.Context, contentDigest digest.D
 			return r.shared.requiredSessionResources.Copy()
 		}(),
 		persistedEnvelope:  state.persistedEnvelope,
-		snapshotOwnerLinks: slices.Clone(r.shared.snapshotOwnerLinks),
+		snapshotOwnerLinks: state.snapshotOwnerLinks,
 		createdAtUnixNano:  state.createdAtUnixNano,
 		lastUsedAtUnixNano: state.lastUsedAtUnixNano,
 		cacheUsageSizeByIdentity: func() map[string]int64 {
@@ -2337,7 +2350,7 @@ func (r Result[T]) WithSessionResourceHandle(ctx context.Context, handle Session
 		sessionResourceHandle:    handle,
 		requiredSessionResources: reqs,
 		persistedEnvelope:        state.persistedEnvelope,
-		snapshotOwnerLinks:       slices.Clone(r.shared.snapshotOwnerLinks),
+		snapshotOwnerLinks:       state.snapshotOwnerLinks,
 		createdAtUnixNano:        state.createdAtUnixNano,
 		lastUsedAtUnixNano:       state.lastUsedAtUnixNano,
 		cacheUsageSizeByIdentity: func() map[string]int64 {

--- a/dagql/cache_debug.go
+++ b/dagql/cache_debug.go
@@ -936,7 +936,7 @@ func (c *Cache) DebugEGraphSnapshot() *EGraphDebugSnapshot {
 			outputEqIDs = append(outputEqIDs, uint64(outputEqID))
 		}
 		slices.Sort(outputEqIDs)
-		links := append([]PersistedSnapshotRefLink(nil), res.snapshotOwnerLinks...)
+		links := res.loadSnapshotOwnerLinks()
 		slices.SortFunc(links, func(a, b PersistedSnapshotRefLink) int {
 			switch {
 			case a.RefKey < b.RefKey:
@@ -1194,7 +1194,7 @@ func (c *Cache) WriteDebugCacheSnapshot(w io.Writer) error {
 			}
 			slices.Sort(outputEqIDs)
 
-			links := append([]PersistedSnapshotRefLink(nil), res.snapshotOwnerLinks...)
+			links := res.loadSnapshotOwnerLinks()
 			slices.SortFunc(links, func(a, b PersistedSnapshotRefLink) int {
 				switch {
 				case a.RefKey < b.RefKey:

--- a/dagql/cache_persistence_contracts.go
+++ b/dagql/cache_persistence_contracts.go
@@ -36,6 +36,7 @@ type persistResultSnapshot struct {
 	hasValue              bool
 	sessionResourceHandle SessionResourceHandle
 	persistedEnvelope     *PersistedResultEnvelope
+	snapshotOwnerLinks    []PersistedSnapshotRefLink
 	row                   persistdb.MirrorResult
 	resultDeps            []persistdb.MirrorResultDep
 	resultSnapshotLinks   []persistdb.MirrorResultSnapshotLink

--- a/dagql/cache_persistence_contracts.go
+++ b/dagql/cache_persistence_contracts.go
@@ -32,6 +32,7 @@ type persistResultSnapshot struct {
 	resultID              sharedResultID
 	frame                 *ResultCall
 	self                  Typed
+	isObject              bool
 	hasValue              bool
 	sessionResourceHandle SessionResourceHandle
 	persistedEnvelope     *PersistedResultEnvelope

--- a/dagql/cache_persistence_import.go
+++ b/dagql/cache_persistence_import.go
@@ -348,10 +348,12 @@ func (c *Cache) importPersistedState(ctx context.Context) error {
 			if res == nil {
 				return fmt.Errorf("import result_snapshot_link: missing result %d", row.ResultID)
 			}
+			res.payloadMu.Lock()
 			res.snapshotOwnerLinks = append(res.snapshotOwnerLinks, PersistedSnapshotRefLink{
 				RefKey: row.RefKey,
 				Role:   row.Role,
 			})
+			res.payloadMu.Unlock()
 			c.traceImportResultSnapshotLinkLoaded(ctx, importRunID, resultID, row.RefKey, row.Role)
 		}
 

--- a/dagql/cache_persistence_import_test.go
+++ b/dagql/cache_persistence_import_test.go
@@ -170,6 +170,7 @@ func TestCachePersistenceImportRoundTripAcrossRestart(t *testing.T) {
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetNone, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()
@@ -215,6 +216,7 @@ func TestCachePersistenceImportRoundTripObjectResult(t *testing.T) {
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetNone, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()
@@ -271,6 +273,7 @@ func TestCachePersistenceImportedObjectHitWithoutServerErrors(t *testing.T) {
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetNone, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()
@@ -368,6 +371,7 @@ func TestCachePersistenceImportedObjectLoadSerializesPersistedDecode(t *testing.
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetNone, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()
@@ -464,6 +468,7 @@ func TestCachePersistenceUncleanMarkerWipesStore(t *testing.T) {
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetUncleanShutdown, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()
@@ -478,6 +483,73 @@ func TestCachePersistenceUncleanMarkerWipesStore(t *testing.T) {
 	assert.Assert(t, !resB.HitCache())
 	assert.Equal(t, 8, cacheTestUnwrapInt(t, resB))
 	cacheTestReleaseSession(t, cB, ctx)
+}
+
+func TestCachePersistenceSchemaMismatchWipesStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+
+	cacheA, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	cA := cacheA
+
+	key := cacheTestIntCall("persist-import-schema-mismatch-wipe")
+	_, err = cA.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+		ResultCall:    key,
+		IsPersistable: true,
+	}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(key, 70), nil
+	})
+	assert.NilError(t, err)
+	cacheTestReleaseSession(t, cA, ctx)
+	assert.NilError(t, cA.persistCurrentState(ctx))
+	assert.NilError(t, cA.Close(context.Background()))
+
+	db, q, err := prepareCacheDBs(ctx, dbPath)
+	assert.NilError(t, err)
+	assert.NilError(t, q.UpsertMeta(ctx, persistdb.MetaKeySchemaVersion, "old-schema"))
+	assert.NilError(t, q.UpsertMeta(ctx, persistdb.MetaKeyCleanShutdown, "1"))
+	assert.NilError(t, closeCacheDBs(db, q))
+
+	cacheB, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	cB := cacheB
+	assert.Equal(t, CachePersistenceResetSchemaMismatch, cB.PersistenceResetReason())
+	defer func() {
+		assert.NilError(t, cB.Close(context.Background()))
+	}()
+
+	resB, err := cB.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+		ResultCall:    key,
+		IsPersistable: true,
+	}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(key, 71), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !resB.HitCache())
+	assert.Equal(t, 71, cacheTestUnwrapInt(t, resB))
+	cacheTestReleaseSession(t, cB, ctx)
+}
+
+func TestCacheCloseDiscardingPersistenceDoesNotMarkClean(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+
+	cacheA, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	assert.NilError(t, cacheA.CloseDiscardingPersistence())
+
+	db, q, err := prepareCacheDBs(ctx, dbPath)
+	assert.NilError(t, err)
+	cleanShutdownVal, found, err := q.SelectMetaValue(ctx, persistdb.MetaKeyCleanShutdown)
+	assert.NilError(t, err)
+	assert.Assert(t, found)
+	assert.Equal(t, "0", cleanShutdownVal)
+	assert.NilError(t, closeCacheDBs(db, q))
 }
 
 func TestCachePersistenceImportFailureWipesStore(t *testing.T) {
@@ -512,6 +584,7 @@ func TestCachePersistenceImportFailureWipesStore(t *testing.T) {
 	cacheB, err := NewCache(ctx, dbPath, nil, nil)
 	assert.NilError(t, err)
 	cB := cacheB
+	assert.Equal(t, CachePersistenceResetImportFailure, cB.PersistenceResetReason())
 	defer func() {
 		assert.NilError(t, cB.Close(context.Background()))
 	}()

--- a/dagql/cache_persistence_import_test.go
+++ b/dagql/cache_persistence_import_test.go
@@ -43,10 +43,14 @@ func (*persistConcurrentDecodeObj) Type() *ast.Type {
 	}
 }
 
-func (obj *persistConcurrentDecodeObj) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (json.RawMessage, error) {
+func (obj *persistConcurrentDecodeObj) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
-	return json.Marshal(persistedPersistConcurrentDecodeObj{Name: obj.Name})
+	payload, err := json.Marshal(persistedPersistConcurrentDecodeObj{Name: obj.Name})
+	if err != nil {
+		return PersistedObjectEncoding{}, err
+	}
+	return PersistedObjectEncoding{JSON: payload}, nil
 }
 
 func (*persistConcurrentDecodeObj) DecodePersistedObject(ctx context.Context, dag *Server, resultID uint64, _ *ResultCall, payload json.RawMessage) (Typed, error) {

--- a/dagql/cache_persistence_resolver.go
+++ b/dagql/cache_persistence_resolver.go
@@ -23,10 +23,7 @@ func (c *Cache) PersistedSnapshotLinksByResultID(ctx context.Context, resultID u
 		return nil, err
 	}
 
-	c.egraphMu.RLock()
-	links := append([]PersistedSnapshotRefLink(nil), res.snapshotOwnerLinks...)
-	c.egraphMu.RUnlock()
-	return links, nil
+	return res.loadSnapshotOwnerLinks(), nil
 }
 
 func (c *Cache) PersistedResultID(res AnyResult) (uint64, error) {

--- a/dagql/cache_persistence_self.go
+++ b/dagql/cache_persistence_self.go
@@ -38,11 +38,16 @@ type PersistedObjectCache interface {
 	PersistedResultID(AnyResult) (uint64, error)
 }
 
+type PersistedObjectEncoding struct {
+	JSON          json.RawMessage
+	SnapshotLinks []PersistedSnapshotRefLink
+}
+
 // PersistedObject is implemented by object self payloads that can be encoded
 // directly for import-time cache persistence.
 type PersistedObject interface {
 	Typed
-	EncodePersistedObject(context.Context, PersistedObjectCache) (json.RawMessage, error)
+	EncodePersistedObject(context.Context, PersistedObjectCache) (PersistedObjectEncoding, error)
 }
 
 // PersistedObjectDecoder is implemented by zero-value object types that know
@@ -56,7 +61,7 @@ type PersistedObjectDecoder interface {
 // PersistedSelfCodec is the shared interface used to encode/decode result self
 // payloads for disk persistence.
 type PersistedSelfCodec interface {
-	EncodeResult(context.Context, PersistedObjectCache, AnyResult) (PersistedResultEnvelope, error)
+	EncodeResult(context.Context, PersistedObjectCache, AnyResult) (PersistedResultEncoding, error)
 	DecodeResult(context.Context, *Server, uint64, *ResultCall, PersistedResultEnvelope) (AnyResult, error)
 }
 
@@ -64,7 +69,12 @@ type defaultPersistedSelfCodec struct{}
 
 var DefaultPersistedSelfCodec PersistedSelfCodec = defaultPersistedSelfCodec{}
 
-func (defaultPersistedSelfCodec) EncodeResult(ctx context.Context, cache PersistedObjectCache, res AnyResult) (PersistedResultEnvelope, error) {
+type PersistedResultEncoding struct {
+	Envelope      PersistedResultEnvelope
+	SnapshotLinks []PersistedSnapshotRefLink
+}
+
+func (defaultPersistedSelfCodec) EncodeResult(ctx context.Context, cache PersistedObjectCache, res AnyResult) (PersistedResultEncoding, error) {
 	return encodePersistedResultEnvelope(ctx, cache, res)
 }
 
@@ -72,11 +82,13 @@ func (defaultPersistedSelfCodec) DecodeResult(ctx context.Context, dag *Server, 
 	return decodePersistedResultEnvelope(ctx, dag, resultID, call, env)
 }
 
-func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCache, res AnyResult) (PersistedResultEnvelope, error) {
+func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCache, res AnyResult) (PersistedResultEncoding, error) {
 	if res == nil {
-		return PersistedResultEnvelope{
-			Version: 2,
-			Kind:    persistedResultKindNull,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version: 2,
+				Kind:    persistedResultKindNull,
+			},
 		}, nil
 	}
 	var resultID uint64
@@ -101,76 +113,86 @@ func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCac
 	if isObject {
 		encoder, ok := res.Unwrap().(PersistedObject)
 		if !ok {
-			return PersistedResultEnvelope{}, fmt.Errorf("encode persisted object payload: type %q does not implement persisted object encoding", res.Type().Name())
+			return PersistedResultEncoding{}, fmt.Errorf("encode persisted object payload: type %q does not implement persisted object encoding", res.Type().Name())
 		}
-		objectJSON, err := encoder.EncodePersistedObject(ctx, cache)
+		objectEncoding, err := encoder.EncodePersistedObject(ctx, cache)
 		if err != nil {
-			return PersistedResultEnvelope{}, fmt.Errorf("encode persisted object payload: %w", err)
+			return PersistedResultEncoding{}, fmt.Errorf("encode persisted object payload: %w", err)
 		}
-		return PersistedResultEnvelope{
-			Version:               2,
-			Kind:                  persistedResultKindObject,
-			TypeName:              res.Type().Name(),
-			ResultID:              resultID,
-			SessionResourceHandle: sessionResourceHandle,
-			ObjectJSON:            objectJSON,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version:               2,
+				Kind:                  persistedResultKindObject,
+				TypeName:              res.Type().Name(),
+				ResultID:              resultID,
+				SessionResourceHandle: sessionResourceHandle,
+				ObjectJSON:            objectEncoding.JSON,
+			},
+			SnapshotLinks: objectEncoding.SnapshotLinks,
 		}, nil
 	}
 	if encoder, ok := res.Unwrap().(PersistedObject); ok {
-		objectJSON, err := encoder.EncodePersistedObject(ctx, cache)
+		objectEncoding, err := encoder.EncodePersistedObject(ctx, cache)
 		if err != nil {
-			return PersistedResultEnvelope{}, fmt.Errorf("encode persisted object payload: %w", err)
+			return PersistedResultEncoding{}, fmt.Errorf("encode persisted object payload: %w", err)
 		}
-		return PersistedResultEnvelope{
-			Version:               2,
-			Kind:                  persistedResultKindObject,
-			TypeName:              res.Type().Name(),
-			ResultID:              resultID,
-			SessionResourceHandle: sessionResourceHandle,
-			ObjectJSON:            objectJSON,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version:               2,
+				Kind:                  persistedResultKindObject,
+				TypeName:              res.Type().Name(),
+				ResultID:              resultID,
+				SessionResourceHandle: sessionResourceHandle,
+				ObjectJSON:            objectEncoding.JSON,
+			},
+			SnapshotLinks: objectEncoding.SnapshotLinks,
 		}, nil
 	}
 
 	if enumerable, ok := res.Unwrap().(Enumerable); ok {
 		shared := res.cacheSharedResult()
 		if shared == nil || shared.loadResultCall() == nil {
-			return PersistedResultEnvelope{}, fmt.Errorf("encode persisted list: missing authoritative call")
+			return PersistedResultEncoding{}, fmt.Errorf("encode persisted list: missing authoritative call")
 		}
 		parentCall := shared.loadResultCall()
 		itemEnvs := make([]PersistedResultEnvelope, 0, enumerable.Len())
 		for i := 1; i <= enumerable.Len(); i++ {
 			item, err := enumerable.NthValue(i, parentCall)
 			if err != nil {
-				return PersistedResultEnvelope{}, fmt.Errorf("encode persisted list item %d: %w", i, err)
+				return PersistedResultEncoding{}, fmt.Errorf("encode persisted list item %d: %w", i, err)
 			}
-			itemEnv, err := encodePersistedResultEnvelope(ctx, cache, item)
+			itemEncoding, err := encodePersistedResultEnvelope(ctx, cache, item)
 			if err != nil {
-				return PersistedResultEnvelope{}, fmt.Errorf("encode persisted list item %d envelope: %w", i, err)
+				return PersistedResultEncoding{}, fmt.Errorf("encode persisted list item %d envelope: %w", i, err)
 			}
-			itemEnvs = append(itemEnvs, itemEnv)
+			itemEnvs = append(itemEnvs, itemEncoding.Envelope)
 		}
-		return PersistedResultEnvelope{
-			Version:               2,
-			Kind:                  persistedResultKindList,
-			TypeName:              res.Type().Name(),
-			ResultID:              resultID,
-			SessionResourceHandle: sessionResourceHandle,
-			ElemTypeName:          enumerable.Element().Type().Name(),
-			Items:                 itemEnvs,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version:               2,
+				Kind:                  persistedResultKindList,
+				TypeName:              res.Type().Name(),
+				ResultID:              resultID,
+				SessionResourceHandle: sessionResourceHandle,
+				ElemTypeName:          enumerable.Element().Type().Name(),
+				Items:                 itemEnvs,
+			},
 		}, nil
 	}
 
 	scalarJSON, err := json.Marshal(res.Unwrap())
 	if err != nil {
-		return PersistedResultEnvelope{}, fmt.Errorf("encode scalar_json payload: %w", err)
+		return PersistedResultEncoding{}, fmt.Errorf("encode scalar_json payload: %w", err)
 	}
-	return PersistedResultEnvelope{
-		Version:               2,
-		Kind:                  persistedResultKindScalar,
-		TypeName:              res.Type().Name(),
-		ResultID:              resultID,
-		SessionResourceHandle: sessionResourceHandle,
-		ScalarJSON:            scalarJSON,
+	return PersistedResultEncoding{
+		Envelope: PersistedResultEnvelope{
+			Version:               2,
+			Kind:                  persistedResultKindScalar,
+			TypeName:              res.Type().Name(),
+			ResultID:              resultID,
+			SessionResourceHandle: sessionResourceHandle,
+			ScalarJSON:            scalarJSON,
+		},
 	}, nil
 }
 

--- a/dagql/cache_persistence_self.go
+++ b/dagql/cache_persistence_self.go
@@ -90,7 +90,15 @@ func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCac
 		sessionResourceHandle = shared.sessionResourceHandle
 	}
 
+	isObject := false
 	if _, ok := res.(AnyObjectResult); ok {
+		isObject = true
+	}
+	if shared := res.cacheSharedResult(); shared != nil && shared.isObject {
+		isObject = true
+	}
+
+	if isObject {
 		encoder, ok := res.Unwrap().(PersistedObject)
 		if !ok {
 			return PersistedResultEnvelope{}, fmt.Errorf("encode persisted object payload: type %q does not implement persisted object encoding", res.Type().Name())

--- a/dagql/cache_persistence_self_test.go
+++ b/dagql/cache_persistence_self_test.go
@@ -126,6 +126,28 @@ func TestPersistedSelfCodecObjectIDRoundTrip(t *testing.T) {
 	assert.Check(t, is.Equal(decodedRecipeEnc, originalRecipeEnc))
 }
 
+func TestPersistedSelfCodecUsesSharedObjectClassification(t *testing.T) {
+	t.Parallel()
+	ctx := setupPersistCodecTest(t)
+
+	call := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&persistCodecObj{}).Type()),
+		Field: "obj",
+	}
+	shared := &sharedResult{
+		self:     &persistCodecObj{Name: "x"},
+		isObject: true,
+		hasValue: true,
+	}
+	shared.storeResultCall(call)
+
+	env, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, Result[Typed]{shared: shared})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(env.Kind, persistedResultKindObject))
+	assert.Check(t, is.Equal(string(env.ObjectJSON), `{"name":"x"}`))
+}
+
 func TestObjectCacheHitPreservesObjectResultShape(t *testing.T) {
 	t.Parallel()
 

--- a/dagql/cache_persistence_self_test.go
+++ b/dagql/cache_persistence_self_test.go
@@ -35,10 +35,14 @@ func (*persistCodecObj) Type() *ast.Type {
 	}
 }
 
-func (obj *persistCodecObj) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (json.RawMessage, error) {
+func (obj *persistCodecObj) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
-	return json.Marshal(persistedPersistCodecObj{Name: obj.Name})
+	payload, err := json.Marshal(persistedPersistCodecObj{Name: obj.Name})
+	if err != nil {
+		return PersistedObjectEncoding{}, err
+	}
+	return PersistedObjectEncoding{JSON: payload}, nil
 }
 
 func (*persistCodecObj) DecodePersistedObject(ctx context.Context, dag *Server, _ uint64, _ *ResultCall, payload json.RawMessage) (Typed, error) {
@@ -86,8 +90,9 @@ func TestPersistedSelfCodecScalarRoundTrip(t *testing.T) {
 	original, err := NewResultForCall(String("hello"), originalCall)
 	assert.NilError(t, err)
 
-	env, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
+	encoding, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
 	assert.NilError(t, err)
+	env := encoding.Envelope
 	assert.Check(t, is.Equal(env.Kind, persistedResultKindScalar))
 
 	decoded, err := DefaultPersistedSelfCodec.DecodeResult(ctx, CurrentDagqlServer(ctx), 0, original.cacheSharedResult().resultCall.clone(), env)
@@ -111,8 +116,9 @@ func TestPersistedSelfCodecObjectIDRoundTrip(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, original != nil)
 
-	env, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
+	encoding, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
 	assert.NilError(t, err)
+	env := encoding.Envelope
 	assert.Check(t, is.Equal(env.Kind, persistedResultKindObject))
 	assert.Check(t, is.Equal(string(env.ObjectJSON), `{"name":"x"}`))
 
@@ -142,8 +148,9 @@ func TestPersistedSelfCodecUsesSharedObjectClassification(t *testing.T) {
 	}
 	shared.storeResultCall(call)
 
-	env, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, Result[Typed]{shared: shared})
+	encoding, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, Result[Typed]{shared: shared})
 	assert.NilError(t, err)
+	env := encoding.Envelope
 	assert.Check(t, is.Equal(env.Kind, persistedResultKindObject))
 	assert.Check(t, is.Equal(string(env.ObjectJSON), `{"name":"x"}`))
 }
@@ -228,8 +235,9 @@ func TestPersistedSelfCodecNestedListRoundTrip(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	env, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, outer)
+	encoding, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, outer)
 	assert.NilError(t, err)
+	env := encoding.Envelope
 	assert.Check(t, is.Equal(env.Kind, persistedResultKindList))
 	assert.Check(t, is.Equal(len(env.Items), 2))
 

--- a/dagql/cache_persistence_worker.go
+++ b/dagql/cache_persistence_worker.go
@@ -108,30 +108,6 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			})
 		}
 
-		links := append([]PersistedSnapshotRefLink(nil), c.snapshotOwnerLinksForResultLocked(res)...)
-		slices.SortFunc(links, func(a, b PersistedSnapshotRefLink) int {
-			switch {
-			case a.RefKey < b.RefKey:
-				return -1
-			case a.RefKey > b.RefKey:
-				return 1
-			case a.Role < b.Role:
-				return -1
-			case a.Role > b.Role:
-				return 1
-			default:
-				return 0
-			}
-		})
-		resultSnapshotLinks := make([]persistdb.MirrorResultSnapshotLink, 0, len(links))
-		for _, link := range links {
-			resultSnapshotLinks = append(resultSnapshotLinks, persistdb.MirrorResultSnapshotLink{
-				ResultID: int64(resultID),
-				RefKey:   link.RefKey,
-				Role:     link.Role,
-			})
-		}
-
 		outputEqClasses := c.outputEqClassesForResultLocked(resultID)
 		outputEqIDs := make([]eqClassID, 0, len(outputEqClasses))
 		for outputEqID := range outputEqClasses {
@@ -155,6 +131,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			hasValue:              payload.hasValue,
 			sessionResourceHandle: res.sessionResourceHandle,
 			persistedEnvelope:     payload.persistedEnvelope,
+			snapshotOwnerLinks:    payload.snapshotOwnerLinks,
 			row: persistdb.MirrorResult{
 				ID:                 int64(resultID),
 				ExpiresAtUnix:      res.expiresAtUnix,
@@ -163,8 +140,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 				RecordType:         res.recordType,
 				Description:        res.description,
 			},
-			resultDeps:          resultDeps,
-			resultSnapshotLinks: resultSnapshotLinks,
+			resultDeps: resultDeps,
 		})
 	}
 
@@ -262,7 +238,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			}
 		}
 
-		env, err := c.persistResultEnvelope(ctx, resultSnapshot)
+		encoding, err := c.persistResultEnvelope(ctx, resultSnapshot)
 		switch {
 		case errors.Is(err, ErrPersistStateNotReady):
 			return persistStateSnapshot{}, err
@@ -270,7 +246,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			return persistStateSnapshot{}, fmt.Errorf("persist result %d envelope: %w", resultSnapshot.resultID, err)
 		}
 
-		payload, err := json.Marshal(env)
+		payload, err := json.Marshal(encoding.Envelope)
 		if err != nil {
 			return persistStateSnapshot{}, fmt.Errorf("persist result %d payload JSON: %w", resultSnapshot.resultID, err)
 		}
@@ -282,6 +258,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			resultSnapshot.row.CallFrameJSON = string(callFrameJSON)
 		}
 		resultSnapshot.row.SelfPayload = payload
+		resultSnapshot.resultSnapshotLinks = resultSnapshotLinkRows(resultSnapshot.resultID, encoding.SnapshotLinks)
 	}
 	return snapshot, nil
 }
@@ -382,27 +359,64 @@ func (c *Cache) applyPersistStateSnapshot(ctx context.Context, snapshot persistS
 	return nil
 }
 
-func (c *Cache) persistResultEnvelope(ctx context.Context, snapshot *persistResultSnapshot) (PersistedResultEnvelope, error) {
+func resultSnapshotLinkRows(resultID sharedResultID, links []PersistedSnapshotRefLink) []persistdb.MirrorResultSnapshotLink {
+	if len(links) == 0 {
+		return nil
+	}
+	links = slices.Clone(links)
+	slices.SortFunc(links, func(a, b PersistedSnapshotRefLink) int {
+		switch {
+		case a.RefKey < b.RefKey:
+			return -1
+		case a.RefKey > b.RefKey:
+			return 1
+		case a.Role < b.Role:
+			return -1
+		case a.Role > b.Role:
+			return 1
+		default:
+			return 0
+		}
+	})
+	rows := make([]persistdb.MirrorResultSnapshotLink, 0, len(links))
+	for _, link := range links {
+		rows = append(rows, persistdb.MirrorResultSnapshotLink{
+			ResultID: int64(resultID),
+			RefKey:   link.RefKey,
+			Role:     link.Role,
+		})
+	}
+	return rows
+}
+
+func (c *Cache) persistResultEnvelope(ctx context.Context, snapshot *persistResultSnapshot) (PersistedResultEncoding, error) {
 	if snapshot != nil && snapshot.persistedEnvelope != nil {
-		return *snapshot.persistedEnvelope, nil
+		return PersistedResultEncoding{
+			Envelope:      *snapshot.persistedEnvelope,
+			SnapshotLinks: snapshot.snapshotOwnerLinks,
+		}, nil
 	}
 	if snapshot == nil || !snapshot.hasValue {
-		return PersistedResultEnvelope{
-			Version: 1,
-			Kind:    persistedResultKindNull,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version: 1,
+				Kind:    persistedResultKindNull,
+			},
 		}, nil
 	}
 	if snapshot.self == nil {
-		return PersistedResultEnvelope{
-			Version:               2,
-			Kind:                  persistedResultKindNull,
-			ResultID:              uint64(snapshot.resultID),
-			SessionResourceHandle: snapshot.sessionResourceHandle,
+		return PersistedResultEncoding{
+			Envelope: PersistedResultEnvelope{
+				Version:               2,
+				Kind:                  persistedResultKindNull,
+				ResultID:              uint64(snapshot.resultID),
+				SessionResourceHandle: snapshot.sessionResourceHandle,
+			},
 		}, nil
 	}
 	if snapshot.frame == nil {
 		if snapshot.self == nil || snapshot.self.Type() == nil || snapshot.self.Type().Name() != "Query" {
-			return PersistedResultEnvelope{}, fmt.Errorf("result has no call frame and no persisted envelope")
+			return PersistedResultEncoding{}, fmt.Errorf("result has no call frame and no persisted envelope")
 		}
 		shared := &sharedResult{
 			self:                  snapshot.self,
@@ -450,16 +464,7 @@ func (c *Cache) persistResultEnvelope(ctx context.Context, snapshot *persistResu
 			"sessionResourceHandle", snapshot.sessionResourceHandle,
 			"err", err,
 		)
-		return PersistedResultEnvelope{}, err
+		return PersistedResultEncoding{}, err
 	}
 	return env, nil
-}
-
-func (c *Cache) snapshotOwnerLinksForResultLocked(res *sharedResult) []PersistedSnapshotRefLink {
-	if res == nil || len(res.snapshotOwnerLinks) == 0 {
-		return nil
-	}
-	links := make([]PersistedSnapshotRefLink, len(res.snapshotOwnerLinks))
-	copy(links, res.snapshotOwnerLinks)
-	return links
 }

--- a/dagql/cache_persistence_worker.go
+++ b/dagql/cache_persistence_worker.go
@@ -151,6 +151,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 			resultID:              resultID,
 			frame:                 res.loadResultCall().clone(),
 			self:                  payload.self,
+			isObject:              payload.isObject,
 			hasValue:              payload.hasValue,
 			sessionResourceHandle: res.sessionResourceHandle,
 			persistedEnvelope:     payload.persistedEnvelope,
@@ -405,6 +406,7 @@ func (c *Cache) persistResultEnvelope(ctx context.Context, snapshot *persistResu
 		}
 		shared := &sharedResult{
 			self:                  snapshot.self,
+			isObject:              snapshot.isObject,
 			hasValue:              snapshot.hasValue,
 			id:                    snapshot.resultID,
 			sessionResourceHandle: snapshot.sessionResourceHandle,
@@ -413,6 +415,7 @@ func (c *Cache) persistResultEnvelope(ctx context.Context, snapshot *persistResu
 	}
 	shared := &sharedResult{
 		self:                  snapshot.self,
+		isObject:              snapshot.isObject,
 		hasValue:              snapshot.hasValue,
 		id:                    snapshot.resultID,
 		sessionResourceHandle: snapshot.sessionResourceHandle,

--- a/dagql/cache_snapshot_persistence_test.go
+++ b/dagql/cache_snapshot_persistence_test.go
@@ -26,14 +26,21 @@ func (*persistSnapshotValue) Type() *ast.Type {
 	}
 }
 
-func (v *persistSnapshotValue) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (json.RawMessage, error) {
+func (v *persistSnapshotValue) EncodePersistedObject(ctx context.Context, cache PersistedObjectCache) (PersistedObjectEncoding, error) {
 	_ = ctx
 	_ = cache
-	return json.Marshal(struct {
+	payload, err := json.Marshal(struct {
 		Name string `json:"name"`
 	}{
 		Name: v.Name,
 	})
+	if err != nil {
+		return PersistedObjectEncoding{}, err
+	}
+	return PersistedObjectEncoding{
+		JSON:          payload,
+		SnapshotLinks: v.PersistedSnapshotRefLinks(),
+	}, nil
 }
 
 func (v *persistSnapshotValue) PersistedSnapshotRefLinks() []PersistedSnapshotRefLink {
@@ -250,6 +257,53 @@ func TestCachePersistenceImportHydratesSnapshotMetadataAndSyncsOwnerLeases(t *te
 	assert.Assert(t, snapshotManagerB.deleteStaleCallSeen)
 	_, keepFound := snapshotManagerB.deleteStaleKeep[resultSnapshotLeaseID(resultID, "snapshot")]
 	assert.Assert(t, keepFound)
+}
+
+func TestCachePersistenceWorkerUsesEncodedSnapshotLinks(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+	cacheIface, err := NewCache(ctx, dbPath, &fakeSnapshotManager{}, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	defer func() {
+		assert.NilError(t, c.Close(context.Background()))
+	}()
+
+	key := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&persistSnapshotValue{}).Type()),
+		Field: "persist-snapshot-owner",
+	}
+
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+		ResultCall:    key,
+		IsPersistable: true,
+	}, func(context.Context) (AnyResult, error) {
+		return cacheTestPlainResult(&persistSnapshotValue{
+			Name:       "x",
+			SnapshotID: "snapshot-before",
+		}), nil
+	})
+	assert.NilError(t, err)
+	resultID := res.cacheSharedResult().id
+	assert.DeepEqual(t, res.cacheSharedResult().loadSnapshotOwnerLinks(), []PersistedSnapshotRefLink{{
+		RefKey: "snapshot-before",
+		Role:   "snapshot",
+	}})
+
+	self := res.Unwrap().(*persistSnapshotValue)
+	self.SnapshotID = "snapshot-after"
+
+	assert.NilError(t, c.persistCurrentState(ctx))
+	rows, err := c.pdb.ListMirrorResultSnapshotLinks(ctx)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, rows, []persistdb.MirrorResultSnapshotLink{{
+		ResultID: int64(resultID),
+		RefKey:   "snapshot-after",
+		Role:     "snapshot",
+	}})
 }
 
 var _ bkcache.SnapshotManager = (*fakeSnapshotManager)(nil)

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -172,7 +172,6 @@ type NewServerOpts struct {
 	BuildkitConfig *bkconfig.Config
 }
 
-//nolint:gocyclo
 func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	cfg := opts.Config
 	bkcfg := opts.BuildkitConfig

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -158,6 +158,14 @@ type Server struct {
 
 var configureBboltDefaultsOnce sync.Once
 
+type localCacheStateResetReason string
+
+const (
+	localCacheStateResetNone             localCacheStateResetReason = ""
+	localCacheStateResetBoltDBInitFailed localCacheStateResetReason = "boltdb_init_failed"
+	localCacheStateResetDagqlOpenFailed  localCacheStateResetReason = "dagql_open_failed"
+)
+
 type NewServerOpts struct {
 	Name           string
 	Config         *config.Config
@@ -220,62 +228,9 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 
 	srv.executorRootDir = filepath.Join(srv.workerRootDir, "executor")
 
-	//
-	// setup various buildkit/containerd entities and DBs
-	//
-
-	if err := srv.mkdirBaseDirs(); err != nil {
+	if err := srv.initLocalCacheState(ctx, *cfg, ociCfg); err != nil {
 		return nil, err
 	}
-
-	if err := srv.initBoltDBs(); err != nil {
-		// It's possible for DBs to get corrupted because we run them w/ Sync: false (for performance)
-		// Reset all our state, but set corruptDBReset so it can be reported via metrics
-		srv.corruptDBReset = true
-		slog.Error("failed to initialize boltdbs, resetting all local cache state", "error", err)
-
-		// need to rm paths individually since srv.rootDir is often a mount (and thus rm'ing it gives
-		// a "device busy" error)
-		rootEnts, err := os.ReadDir(srv.rootDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read root dir entries for boltdb reset: %w", err)
-		}
-		for _, ent := range rootEnts {
-			p := filepath.Join(srv.rootDir, ent.Name())
-			if err := os.RemoveAll(p); err != nil {
-				return nil, fmt.Errorf("failed to remove dir after boltdb init failure: %w", err)
-			}
-		}
-
-		// try again
-		if err := srv.mkdirBaseDirs(); err != nil {
-			return nil, err
-		}
-		if err := srv.initBoltDBs(); err != nil {
-			return nil, fmt.Errorf("failed to initialize boltdbs after reset: %w", err)
-		}
-	}
-
-	srv.snapshotter, srv.snapshotterName, err = newSnapshotter(srv.snapshotterRootDir, ociCfg, srv.snapshotterMDStore)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create snapshotter: %w", err)
-	}
-
-	srv.localContentStore, err = localcontentstore.NewStore(srv.contentStoreRootDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create content store: %w", err)
-	}
-
-	srv.containerdMetaDB = ctdmetadata.NewDB(srv.containerdMetaBoltDB, srv.localContentStore, map[string]ctdsnapshot.Snapshotter{
-		srv.snapshotterName: srv.snapshotter,
-	})
-	if err := srv.containerdMetaDB.Init(context.TODO()); err != nil {
-		return nil, fmt.Errorf("failed to init metadata db: %w", err)
-	}
-
-	srv.leaseManager = bkcache.NewLeaseManager(ctdmetadata.NewLeaseManager(srv.containerdMetaDB), "dagger")
-
-	srv.contentStore = containerdsnapshot.NewContentStore(srv.containerdMetaDB.ContentStore(), "dagger")
 
 	//
 	// clean up old hosts/resolv.conf file. ignore errors
@@ -398,23 +353,6 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		"dagger",
 	)
 
-	workerGCPolicies := getDagqlGCPolicy(*cfg, ociCfg.GCConfig, srv.rootDir)
-
-	srv.workerCache, err = bkcache.NewSnapshotManager(bkcache.SnapshotManagerOpt{
-		Snapshotter:   workerSnapshotter,
-		ContentStore:  srv.contentStore,
-		LeaseManager:  srv.leaseManager,
-		Applier:       winlayers.NewFileSystemApplierWithWindows(srv.contentStore, apply.NewFileSystemApplier(srv.contentStore)),
-		Differ:        winlayers.NewWalkingDiffWithWindows(srv.contentStore, walking.NewWalkingDiff(srv.contentStore)),
-		MountPoolRoot: srv.buildkitMountPoolDir,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create snapshot manager: %w", err)
-	}
-
-	srv.workerGCPolicies = cloneDagqlCachePrunePolicies(workerGCPolicies)
-	srv.workerDefaultGCPolicy = getDefaultDagqlGCPolicy(*cfg, ociCfg.GCConfig, srv.rootDir)
-
 	archutil.WarnIfUnsupported(srv.enabledPlatforms)
 
 	hostMntNS, err := os.OpenFile("/proc/self/ns/mnt", os.O_RDONLY, 0)
@@ -477,32 +415,6 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		time.AfterFunc(time.Second, srv.throttledGC)
 	}()
 
-	//
-	// setup dagql caching
-	//
-	dagqlCacheDBPath := filepath.Join(srv.rootDir, "dagql-cache.db")
-	snapshotGC := func(ctx context.Context) error {
-		stats, err := srv.containerdMetaDB.GarbageCollect(ctx)
-		if err != nil {
-			return err
-		}
-		slog.Debug("containerd garbage collect after dagql prune", "stats", stats)
-		return nil
-	}
-	srv.engineCache, err = dagql.NewCache(ctx, dagqlCacheDBPath, srv.workerCache, snapshotGC)
-	if err != nil {
-		// Attempt to handle a corrupt db (which is possible since we currently run w/ synchronous=OFF) by removing any existing
-		// db and trying again.
-		slog.Error("failed to create dagql cache, attempting to recover by removing existing cache db", "error", err)
-		if err := os.Remove(dagqlCacheDBPath); err != nil && !os.IsNotExist(err) {
-			slog.Error("failed to remove existing dagql cache db", "error", err)
-		}
-		srv.engineCache, err = dagql.NewCache(ctx, dagqlCacheDBPath, srv.workerCache, snapshotGC)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create dagql cache after removing existing db: %w", err)
-		}
-	}
-
 	// garbage collect client DBs
 	go srv.gcClientDBs()
 
@@ -525,6 +437,155 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	}
 
 	return srv, nil
+}
+
+func (srv *Server) initLocalCacheState(ctx context.Context, cfg config.Config, ociCfg bkconfig.OCIConfig) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		resetReason, err := srv.initLocalCacheStateOnce(ctx, cfg, ociCfg)
+		if resetReason == localCacheStateResetNone {
+			return err
+		}
+		if attempt == 1 {
+			if err != nil {
+				return fmt.Errorf("local cache state still invalid after reset (%s): %w", resetReason, err)
+			}
+			return fmt.Errorf("local cache state still invalid after reset (%s)", resetReason)
+		}
+
+		if resetReason == localCacheStateResetBoltDBInitFailed {
+			srv.corruptDBReset = true
+		}
+		slog.Warn("local cache state invalid; resetting worker and dagql persistence state", "reason", resetReason, "error", err)
+		if closeErr := srv.closeLocalCacheStateForReset(); closeErr != nil {
+			return fmt.Errorf("close local cache state before reset: %w", closeErr)
+		}
+		if err := srv.removeLocalCacheStateOnDisk(); err != nil {
+			return fmt.Errorf("remove local cache state after %s: %w", resetReason, err)
+		}
+	}
+	return fmt.Errorf("local cache state reset retry exhausted")
+}
+
+func (srv *Server) initLocalCacheStateOnce(ctx context.Context, cfg config.Config, ociCfg bkconfig.OCIConfig) (localCacheStateResetReason, error) {
+	if err := srv.mkdirBaseDirs(); err != nil {
+		return localCacheStateResetNone, err
+	}
+
+	if err := srv.initBoltDBs(); err != nil {
+		return localCacheStateResetBoltDBInitFailed, fmt.Errorf("failed to initialize boltdbs: %w", err)
+	}
+
+	var err error
+	srv.snapshotter, srv.snapshotterName, err = newSnapshotter(srv.snapshotterRootDir, ociCfg, srv.snapshotterMDStore)
+	if err != nil {
+		return localCacheStateResetNone, fmt.Errorf("failed to create snapshotter: %w", err)
+	}
+
+	srv.localContentStore, err = localcontentstore.NewStore(srv.contentStoreRootDir)
+	if err != nil {
+		return localCacheStateResetNone, fmt.Errorf("failed to create content store: %w", err)
+	}
+
+	srv.containerdMetaDB = ctdmetadata.NewDB(srv.containerdMetaBoltDB, srv.localContentStore, map[string]ctdsnapshot.Snapshotter{
+		srv.snapshotterName: srv.snapshotter,
+	})
+	if err := srv.containerdMetaDB.Init(context.TODO()); err != nil {
+		return localCacheStateResetNone, fmt.Errorf("failed to init metadata db: %w", err)
+	}
+
+	srv.leaseManager = bkcache.NewLeaseManager(ctdmetadata.NewLeaseManager(srv.containerdMetaDB), "dagger")
+	srv.contentStore = containerdsnapshot.NewContentStore(srv.containerdMetaDB.ContentStore(), "dagger")
+
+	workerSnapshotter := containerdsnapshot.NewSnapshotter(
+		srv.snapshotterName,
+		srv.containerdMetaDB.Snapshotter(srv.snapshotterName),
+		"dagger",
+	)
+
+	workerGCPolicies := getDagqlGCPolicy(cfg, ociCfg.GCConfig, srv.rootDir)
+	srv.workerCache, err = bkcache.NewSnapshotManager(bkcache.SnapshotManagerOpt{
+		Snapshotter:   workerSnapshotter,
+		ContentStore:  srv.contentStore,
+		LeaseManager:  srv.leaseManager,
+		Applier:       winlayers.NewFileSystemApplierWithWindows(srv.contentStore, apply.NewFileSystemApplier(srv.contentStore)),
+		Differ:        winlayers.NewWalkingDiffWithWindows(srv.contentStore, walking.NewWalkingDiff(srv.contentStore)),
+		MountPoolRoot: srv.buildkitMountPoolDir,
+	})
+	if err != nil {
+		return localCacheStateResetNone, fmt.Errorf("failed to create snapshot manager: %w", err)
+	}
+	srv.workerGCPolicies = cloneDagqlCachePrunePolicies(workerGCPolicies)
+	srv.workerDefaultGCPolicy = getDefaultDagqlGCPolicy(cfg, ociCfg.GCConfig, srv.rootDir)
+
+	dagqlCacheDBPath := filepath.Join(srv.rootDir, "dagql-cache.db")
+	snapshotGC := func(ctx context.Context) error {
+		stats, err := srv.containerdMetaDB.GarbageCollect(ctx)
+		if err != nil {
+			return err
+		}
+		slog.Debug("containerd garbage collect after dagql prune", "stats", stats)
+		return nil
+	}
+	srv.engineCache, err = dagql.NewCache(ctx, dagqlCacheDBPath, srv.workerCache, snapshotGC)
+	if err != nil {
+		return localCacheStateResetDagqlOpenFailed, fmt.Errorf("failed to create dagql cache: %w", err)
+	}
+	if resetReason := srv.engineCache.PersistenceResetReason(); resetReason != dagql.CachePersistenceResetNone {
+		return localCacheStateResetReason("dagql_" + string(resetReason)), nil
+	}
+
+	return localCacheStateResetNone, nil
+}
+
+func (srv *Server) closeLocalCacheStateForReset() error {
+	var err error
+	if srv.engineCache != nil {
+		err = errors.Join(err, srv.engineCache.CloseDiscardingPersistence())
+		srv.engineCache = nil
+	}
+	if srv.workerCache != nil {
+		err = errors.Join(err, srv.workerCache.Close())
+		srv.workerCache = nil
+	}
+
+	snapshotterClosedMDStore := false
+	if srv.snapshotter != nil {
+		if closeErr := srv.snapshotter.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		} else if srv.snapshotterName == "overlayfs" {
+			snapshotterClosedMDStore = true
+		}
+		srv.snapshotter = nil
+	}
+	if srv.snapshotterMDStore != nil {
+		if !snapshotterClosedMDStore {
+			err = errors.Join(err, srv.snapshotterMDStore.Close())
+		}
+		srv.snapshotterMDStore = nil
+	}
+	if srv.containerdMetaBoltDB != nil {
+		err = errors.Join(err, srv.containerdMetaBoltDB.Close())
+		srv.containerdMetaBoltDB = nil
+	}
+
+	srv.snapshotterName = ""
+	srv.localContentStore = nil
+	srv.containerdMetaDB = nil
+	srv.leaseManager = nil
+	srv.contentStore = nil
+	srv.workerGCPolicies = nil
+	srv.workerDefaultGCPolicy = nil
+	return err
+}
+
+func (srv *Server) removeLocalCacheStateOnDisk() error {
+	if err := os.RemoveAll(srv.workerRootDir); err != nil {
+		return fmt.Errorf("remove worker state: %w", err)
+	}
+	if err := dagql.RemoveCachePersistenceStore(filepath.Join(srv.rootDir, "dagql-cache.db")); err != nil {
+		return fmt.Errorf("remove dagql persistence state: %w", err)
+	}
+	return nil
 }
 
 func (srv *Server) mkdirBaseDirs() (err error) {
@@ -571,6 +632,7 @@ func (srv *Server) initBoltDBs() (err error) {
 	defer func() {
 		if err != nil {
 			err = errors.Join(err, srv.snapshotterMDStore.Close())
+			srv.snapshotterMDStore = nil
 		}
 	}()
 
@@ -587,6 +649,7 @@ func (srv *Server) initBoltDBs() (err error) {
 	defer func() {
 		if err != nil {
 			err = errors.Join(err, srv.containerdMetaBoltDB.Close())
+			srv.containerdMetaBoltDB = nil
 		}
 	}()
 

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -463,7 +463,7 @@ func (srv *Server) initLocalCacheState(ctx context.Context, cfg config.Config, o
 			return fmt.Errorf("remove local cache state after %s: %w", resetReason, err)
 		}
 	}
-	return fmt.Errorf("local cache state reset retry exhausted")
+	return errors.New("local cache state reset retry exhausted")
 }
 
 func (srv *Server) initLocalCacheStateOnce(ctx context.Context, cfg config.Config, ociCfg bkconfig.OCIConfig) (localCacheStateResetReason, error) {

--- a/engine/server/snapshotter.go
+++ b/engine/server/snapshotter.go
@@ -1,21 +1,29 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/v2/core/mount"
 	ctdsnapshot "github.com/containerd/containerd/v2/core/snapshots"
+	snproxy "github.com/containerd/containerd/v2/core/snapshots/proxy"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/containerd/v2/plugins/snapshots/native"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
+	fuseoverlayfs "github.com/containerd/fuse-overlayfs-snapshotter/v2"
 	"github.com/dagger/dagger/engine/slog"
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func newSnapshotter(
@@ -30,15 +38,39 @@ func newSnapshotter(
 		address = cfg.ProxySnapshotterPath
 	)
 	if address != "" {
-		return nil, "", errors.New("proxy snapshotter is not supported")
+		if _, err := os.Stat(address); os.IsNotExist(err) {
+			return nil, "", fmt.Errorf("snapshotter doesn't exist on %q (Do not include 'unix://' prefix): %w", address, err)
+		}
+		backoffConfig := backoff.DefaultConfig
+		backoffConfig.MaxDelay = 3 * time.Second
+		connParams := grpc.ConnectParams{
+			Backoff: backoffConfig,
+		}
+		gopts := []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithConnectParams(connParams),
+			grpc.WithContextDialer(dialer.ContextDialer),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+		}
+		conn, err := grpc.NewClient(dialer.DialAddress(address), gopts...)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to dial %q: %w", address, err)
+		}
+		return snproxy.NewSnapshotter(snapshotsapi.NewSnapshotsClient(conn), name), name, nil
 	}
 
 	if name == "" {
 		if err := overlayutils.Supported(rootDir); err == nil {
 			name = "overlayfs"
 		} else {
-			logrus.Debugf("auto snapshotter: overlayfs is not available for %s, falling back to native: %v", rootDir, err)
-			name = "native"
+			logrus.Debugf("auto snapshotter: overlayfs is not available for %s, trying fuse-overlayfs: %v", rootDir, err)
+			if err2 := fuseoverlayfs.Supported(rootDir); err2 == nil {
+				name = "fuse-overlayfs"
+			} else {
+				logrus.Debugf("auto snapshotter: fuse-overlayfs is not available for %s, falling back to native: %v", rootDir, err2)
+				name = "native"
+			}
 		}
 		logrus.Infof("auto snapshotter: using %s", name)
 	}
@@ -57,6 +89,9 @@ func newSnapshotter(
 			opts = append(opts, overlay.WithMountOptions([]string{"volatile"}))
 		}
 		sn, snErr = overlay.NewSnapshotter(rootDir, opts...)
+	case "fuse-overlayfs":
+		// no Opt (AsynchronousRemove is untested for fuse-overlayfs)
+		sn, snErr = fuseoverlayfs.NewSnapshotter(rootDir)
 	default:
 		return nil, "", fmt.Errorf("unknown snapshotter %q", name)
 	}

--- a/engine/server/snapshotter.go
+++ b/engine/server/snapshotter.go
@@ -5,25 +5,16 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
-	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/v2/core/mount"
 	ctdsnapshot "github.com/containerd/containerd/v2/core/snapshots"
-	snproxy "github.com/containerd/containerd/v2/core/snapshots/proxy"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
-	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/containerd/v2/plugins/snapshots/native"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
-	fuseoverlayfs "github.com/containerd/fuse-overlayfs-snapshotter/v2"
 	"github.com/dagger/dagger/engine/slog"
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func newSnapshotter(
@@ -38,39 +29,15 @@ func newSnapshotter(
 		address = cfg.ProxySnapshotterPath
 	)
 	if address != "" {
-		if _, err := os.Stat(address); os.IsNotExist(err) {
-			return nil, "", fmt.Errorf("snapshotter doesn't exist on %q (Do not include 'unix://' prefix): %w", address, err)
-		}
-		backoffConfig := backoff.DefaultConfig
-		backoffConfig.MaxDelay = 3 * time.Second
-		connParams := grpc.ConnectParams{
-			Backoff: backoffConfig,
-		}
-		gopts := []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithConnectParams(connParams),
-			grpc.WithContextDialer(dialer.ContextDialer),
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
-		}
-		conn, err := grpc.NewClient(dialer.DialAddress(address), gopts...)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to dial %q: %w", address, err)
-		}
-		return snproxy.NewSnapshotter(snapshotsapi.NewSnapshotsClient(conn), name), name, nil
+		return nil, "", fmt.Errorf("proxy snapshotter is not supported")
 	}
 
 	if name == "" {
 		if err := overlayutils.Supported(rootDir); err == nil {
 			name = "overlayfs"
 		} else {
-			logrus.Debugf("auto snapshotter: overlayfs is not available for %s, trying fuse-overlayfs: %v", rootDir, err)
-			if err2 := fuseoverlayfs.Supported(rootDir); err2 == nil {
-				name = "fuse-overlayfs"
-			} else {
-				logrus.Debugf("auto snapshotter: fuse-overlayfs is not available for %s, falling back to native: %v", rootDir, err2)
-				name = "native"
-			}
+			logrus.Debugf("auto snapshotter: overlayfs is not available for %s, falling back to native: %v", rootDir, err)
+			name = "native"
 		}
 		logrus.Infof("auto snapshotter: using %s", name)
 	}
@@ -89,9 +56,6 @@ func newSnapshotter(
 			opts = append(opts, overlay.WithMountOptions([]string{"volatile"}))
 		}
 		sn, snErr = overlay.NewSnapshotter(rootDir, opts...)
-	case "fuse-overlayfs":
-		// no Opt (AsynchronousRemove is untested for fuse-overlayfs)
-		sn, snErr = fuseoverlayfs.NewSnapshotter(rootDir)
 	default:
 		return nil, "", fmt.Errorf("unknown snapshotter %q", name)
 	}

--- a/engine/server/snapshotter.go
+++ b/engine/server/snapshotter.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ func newSnapshotter(
 		address = cfg.ProxySnapshotterPath
 	)
 	if address != "" {
-		return nil, "", fmt.Errorf("proxy snapshotter is not supported")
+		return nil, "", errors.New("proxy snapshotter is not supported")
 	}
 
 	if name == "" {

--- a/engine/snapshots/blobs.go
+++ b/engine/snapshots/blobs.go
@@ -183,7 +183,7 @@ func (cm *snapshotManager) ensureExportBlob(
 			switch cm.Snapshotter.Name() {
 			case "overlayfs", "stargz":
 				logWarnOnErr = true
-			case "native":
+			case "fuse-overlayfs", "native":
 				enableOverlay = false
 			}
 		}

--- a/engine/snapshots/blobs.go
+++ b/engine/snapshots/blobs.go
@@ -183,7 +183,7 @@ func (cm *snapshotManager) ensureExportBlob(
 			switch cm.Snapshotter.Name() {
 			case "overlayfs", "stargz":
 				logWarnOnErr = true
-			case "fuse-overlayfs", "native":
+			case "native":
 				enableOverlay = false
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0
+	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/go-runc v1.1.0
 	github.com/containerd/log v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0
-	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/go-runc v1.1.0
 	github.com/containerd/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
-github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2 h1:rSFmw6hC+boVBL0o4x3epk07VkipsDvMDNNXND3oWkU=
-github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2/go.mod h1:JgmYll6DAr92UfJ/FVuOH5qa0Z1qzppLl0Q7eDHjbRU=
 github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7Hnis=
 github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
+github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2 h1:rSFmw6hC+boVBL0o4x3epk07VkipsDvMDNNXND3oWkU=
+github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.2/go.mod h1:JgmYll6DAr92UfJ/FVuOH5qa0Z1qzppLl0Q7eDHjbRU=
 github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7Hnis=
 github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=

--- a/skills/cache-expert/SKILL.md
+++ b/skills/cache-expert/SKILL.md
@@ -15,7 +15,9 @@ This enables caching: since inputs are immutable and operations are deterministi
 
 DAGs of operations can be serialized as IDs, which have associated digests that serve as the operations' cache keys.
 
-For test-running and debugging workflow, see `references/debugging.md`.
+The reference docs in `references/` are up to date and should be treated as current guidance for understanding the cache, persistence, pruning, lazy evaluation, session resources, filesync, typedefs, and e-graph behavior. The code remains the final source of truth, but the reference docs are expected to match the current implementation.
+
+Always read the relevant reference docs for the cache area being debugged. For broad cache investigations, read all of them. `references/debugging.md` has critical instructions on running tests, replaying CI traces, and debugging generally.
 
 ## Scripts
 

--- a/skills/cache-expert/references/cache_persistence.md
+++ b/skills/cache-expert/references/cache_persistence.md
@@ -72,7 +72,7 @@ wipe it and cold-start.
 If no DB path is configured, the cache is just in-memory and persistence is
 effectively disabled.
 
-If a DB path is configured, startup does this:
+If a DB path is configured, dagql startup does this:
 
 1. open the SQLite DB
 2. ensure the schema exists
@@ -88,6 +88,15 @@ If a DB path is configured, startup does this:
 That `clean_shutdown=0` write at startup is important: it means the store is
 considered dirty until a later successful graceful close explicitly marks it
 clean.
+
+At the engine level, the dagql persisted graph is the source of truth for
+restartable local cache state. If dagql startup discards persistence, or if the
+dagql cache cannot be opened at all, `engine/server.NewServer` also discards
+the local worker/containerd state before retrying startup. That reset removes
+the worker state directory and dagql SQLite files, then recreates the
+containerd metadata DB, content store, snapshotter, snapshot manager, and dagql
+cache from empty state. Root-level non-cache state such as the engine secret
+salt is preserved.
 
 ## 2. Runtime
 
@@ -147,8 +156,11 @@ If any of these happen:
 - schema mismatch
 - `clean_shutdown != 1`
 - import failure
+- dagql persistence open failure
 
-the persistence DB is wiped and the engine starts from an empty cache.
+the persistence DB is wiped. During full engine startup, the corresponding
+worker/containerd state is wiped too, because those snapshots and content are
+only meaningful if the dagql graph that owns them is trusted.
 
 ### On Shutdown
 


### PR DESCRIPTION
## Summary

This PR fixes the dagql cache persistence shutdown/restart failures we have been reproducing while the engine writes retained cache state to disk, plus the dirty-restart cleanup path needed when persistence cannot be trusted.

It fixes four related persistence/recovery issues:

- Generator-group retained graphs now persist structurally. Generator/mod-tree/changeset/workspace state is represented through persisted dagql object results, and the broken generator scale-out changeset path is removed.
- Service-bound retained graphs now persist structurally. `Service` is a persisted object, and container/directory/file service bindings encode explicit persisted service object refs instead of raw binding state.
- A rare shutdown/restart persisted-hit decode failure is fixed. We reproduced `missing persisted directory snapshot link role "fs"` manually with `go:check-tidy` on a persistent dev engine, interrupted by SIGTERM during cache persistence. The root cause was that object payload JSON and `result_snapshot_links` rows were written from different sources, so a container could persist a materialized rootfs payload without the matching `fs` link row. The fix makes newly encoded persisted payloads return their direct snapshot links from the same encode pass, and the persistence worker writes link rows from that encoding.
- Dirty/invalid persistence reset now resets local worker state as well as dagql persistence. If startup sees an unclean shutdown, schema mismatch, or import failure, the server discards stale worker/containerd state before reinitializing. That prevents orphaned snapshots/content from leaking disk after the dagql store is wiped, and the engine then cold-starts from an empty cache and can persist cleanly again. Existing proxy and fuse-overlayfs snapshotter startup paths are preserved; the dirty reset removes Dagger's local worker state, while proxy snapshotter backing storage remains external as before.

There is not an end-to-end automated integration repro for the SIGTERM timing case yet. There is focused dagql unit coverage for the core mismatch: the encoded payload's snapshot link wins even if the older live owner-link state is stale.

There is integration coverage for dirty-restart cleanup/recovery: SIGKILL the engine, restart, verify pre-kill cache state was discarded, run fresh work successfully, then cleanly restart again.

See the individual commits for the detailed root cause and implementation notes.

## Validation

- `git diff --check`
- `$(go env GOROOT)/bin/go test ./dagql`
- `$(go env GOROOT)/bin/go test ./core`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestModule/(TestCodegenOptionals|TestConstructor|TestNamespacing|TestStartServices|TestModuleSchemaVersion|TestModulePreFilteringDirectory|TestFunctionCacheControlReturnedContainer)$'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='Test(Cache/(TestVolume|TestCacheIdSameAcrossSession|TestCacheVolumePassedAcrossModules)|File/(TestFileCachingContents|TestDigest)|HTTP/(TestHTTP|TestHTTPUsedInCache))$'`
- `dagger --progress=plain check go:lint`
- `dagger --progress=plain check go:check-tidy`
- Manual persistent dev-engine repro, `go:check-tidy` interrupted by SIGTERM at 15s, restart, rerun: passed; captured DB had 21/21 materialized `Container.fs` rows with `fs` snapshot links.
- Manual persistent dev-engine repro, SIGTERM at 8s: passed; captured DB had 21/21 materialized `Container.fs` rows with `fs` snapshot links.
- Manual persistent dev-engine repro, SIGTERM at 25s: passed; captured DB had 43/43 materialized `Container.fs` rows with `fs` snapshot links.

The full `TestModule` suite was also attempted. It failed only on `TestPrivateGitRepoArgCaching` because this local environment did not have the private GitLab credentials; a focused module subset excluding that credentialed path passed.

