### PR TITLE
fix: scrub plaintext Secret user defaults

### DIFF
--- a/core/integration/user_defaults_test.go
+++ b/core/integration/user_defaults_test.go
@@ -476,6 +476,33 @@ func (UserDefaultsSuite) TestConstructorOptionalEmptySecret(ctx context.Context,
 	require.Equal(t, "", out)
 }
 
+func (UserDefaultsSuite) TestConstructorPlaintextSecretDefault(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ctr := daggerCliBase(t, c).
+		With(withModInit("go", `package main
+
+import "dagger/test/internal/dagger"
+
+func New(
+	password *dagger.Secret,
+	somekey string,
+) *Test {
+	return &Test{}
+}
+
+type Test struct{}
+`)).
+		WithNewFile(".env", "password=topsecret\nsomekey=somevalue\n")
+
+	out, err := ctr.
+		WithExec([]string{"dagger", "call", "--help"}, nestedExec).
+		Stderr(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, out, "topsecret")
+	require.Contains(t, out, `user default: test(password=*****)`)
+	require.Contains(t, out, `user default: test(somekey="somevalue")`)
+}
+
 func trimDaggerFunctionUsageText(s string) string {
 	// Trim the output for readability
 	start := strings.Index(s, "ARGUMENTS")

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -236,7 +236,7 @@ func (fn *ModuleFunction) mergeUserDefaultsTypeDefs(ctx context.Context) error {
 		if fn.metadata.Name != "" {
 			uiFnName += "." + fn.metadata.Name
 		}
-		console(ctx, "user default: %s(%s=%q)", uiFnName, argName, argDefault.UserInput)
+		console(ctx, "user default: %s(%s=%s)", uiFnName, argName, argDefault.DisplayInput())
 		currentArgRes, ok := updatedMetadata.LookupArg(argName)
 		if !ok {
 			return fmt.Errorf("find function arg %q on %s", argName, uiFnName)
@@ -387,6 +387,23 @@ func (fn *ModuleFunction) newUserDefault(arg *FunctionArg, userInput string) *Us
 
 type UserDefault struct {
 	UserDefaultPrimitive
+}
+
+func (ud *UserDefault) DisplayInput() string {
+	if ud.IsPlaintextSecret() {
+		return "*****"
+	}
+	return fmt.Sprintf("%q", ud.UserInput)
+}
+
+func (ud *UserDefault) IsPlaintextSecret() bool {
+	typeDef := ud.Arg.TypeDef.Self()
+	return typeDef != nil &&
+		typeDef.Kind == TypeDefKindObject &&
+		typeDef.AsObject.Valid &&
+		typeDef.AsObject.Value.Self() != nil &&
+		typeDef.AsObject.Value.Self().Name == "Secret" &&
+		!strings.Contains(ud.UserInput, "://")
 }
 
 func (ud *UserDefault) IsObject() bool {


### PR DESCRIPTION
Treat schemeless .env values for Secret user defaults as plaintext secrets instead of address-style secret provider URIs.

This routes those values through setSecret so they resolve as Dagger Secrets without exposing the raw value in the user default console output. URI-style values such as env:// and op:// keep the existing provider behavior.

Adds regression coverage for a plaintext Secret default to ensure the displayed default is scrubbed while the secret still resolves correctly.