### PR TITLE
core: persist container withNewFile lazy hits

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -4393,16 +4393,16 @@ func decodePersistedContainerLazy(
 			Owner:     persisted.Owner,
 		}
 		return nil
-	case "withFile":
+	case "withFile", "withNewFile":
 		var persisted persistedContainerWithFileLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
-			return fmt.Errorf("decode persisted container withFile lazy payload: %w", err)
+			return fmt.Errorf("decode persisted container %s lazy payload: %w", call.Field, err)
 		}
-		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container withFile parent")
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container "+call.Field+" parent")
 		if err != nil {
 			return err
 		}
-		source, err := loadPersistedObjectResultByResultID[*File](ctx, dag, persisted.SourceResultID, "container withFile source")
+		source, err := loadPersistedObjectResultByResultID[*File](ctx, dag, persisted.SourceResultID, "container "+call.Field+" source")
 		if err != nil {
 			return err
 		}

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -112,6 +112,38 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 		require.Greater(t, entryCount, 0)
 	})
 
+	t.Run("container withNewFile hit survives restart", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-container-with-new-file-state-" + identity.NewID()
+		const newFilePath = "/tmp/persisted-new-file.txt"
+		const newFileContents = "persisted withNewFile\n"
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		ctrID, err := engineClientA.
+			Container().
+			From(alpineImage).
+			WithNewFile(newFilePath, newFileContents).
+			ID(ctx)
+		require.NoError(t, err)
+
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		contents, err := engineClientB.
+			LoadContainerFromID(ctrID).
+			File(newFilePath).
+			Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, newFileContents, contents)
+	})
+
 	t.Run("function cache control survives restart", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-function-cache-state-" + identity.NewID()

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -2690,6 +2690,7 @@ type persistedFunction struct {
 	ReturnTypeResultID uint64              `json:"returnTypeResultID,omitempty"`
 	Deprecated         *string             `json:"deprecated,omitempty"`
 	SourceMapResultID  uint64              `json:"sourceMapResultID,omitempty"`
+	SourceModuleName   string              `json:"sourceModuleName,omitempty"`
 	CachePolicy        FunctionCachePolicy `json:"cachePolicy,omitempty"`
 	CacheTTLSeconds    *int64              `json:"cacheTTLSeconds,omitempty"`
 	IsCheck            bool                `json:"isCheck,omitempty"`
@@ -2866,6 +2867,7 @@ func encodePersistedFunction(cache dagql.PersistedObjectCache, fn *Function) (*p
 		Name:               fn.Name,
 		Description:        fn.Description,
 		Deprecated:         fn.Deprecated,
+		SourceModuleName:   fn.SourceModuleName,
 		CachePolicy:        fn.CachePolicy,
 		IsCheck:            fn.IsCheck,
 		IsGenerator:        fn.IsGenerator,
@@ -2913,6 +2915,7 @@ func decodePersistedFunction(ctx context.Context, dag *dagql.Server, fn *persist
 		Description:        fn.Description,
 		ReturnType:         returnType,
 		Deprecated:         fn.Deprecated,
+		SourceModuleName:   fn.SourceModuleName,
 		CachePolicy:        fn.CachePolicy,
 		IsCheck:            fn.IsCheck,
 		IsGenerator:        fn.IsGenerator,


### PR DESCRIPTION
## What changed

This fixes persisted container lazy hit reloads for `Container.withNewFile`.

`withNewFile` builds a `File` and stores the container using the same `ContainerWithFileLazy` persisted payload shape as `withFile`, but the persisted lazy decoder only accepted the `withFile` GraphQL field. After an engine restart, loading an unevaluated persisted `withNewFile` hit failed with `unsupported field "withNewFile"`.

The decoder now accepts both `withFile` and `withNewFile` for that payload shape, and the integration test covers the exact restart/reload path.

## Validation

```console
dagger --progress=plain call -m ./toolchains/engine-dev test --pkg=./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart/container_withNewFile_hit_survives_restart' --test-verbose
```
