### PR TITLE
core: restore persisted cache volume mount sharing

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -199,7 +199,13 @@ func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server
 		if err != nil {
 			return nil, err
 		}
-		ref, err := query.SnapshotManager().GetMutableBySnapshotID(ctx, link.RefKey, bkcache.NoUpdateLastUsed)
+		ref, err := query.SnapshotManager().GetMutableBySnapshotID(
+			ctx,
+			link.RefKey,
+			bkcache.NoUpdateLastUsed,
+			bkcache.WithRecordType(bkclient.UsageRecordTypeCacheMount),
+			bkcache.WithDescription(fmt.Sprintf("cache volume %q", cache.Key)),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("reopen persisted cache volume snapshot %q: %w", link.RefKey, err)
 		}

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"dagger.io/dagger"
 )
@@ -678,5 +680,65 @@ printf 'layered\n' > /work/layered.txt
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, cacheValue+"\n", outB)
+	})
+
+	t.Run("source-backed cache volume supports concurrent mounts after restart", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-source-cache-volume-state-" + identity.NewID()
+		cacheKey := "phase7-source-cache-volume-data-" + identity.NewID()
+
+		cacheSource := func(client *dagger.Client) *dagger.Directory {
+			return client.
+				Container().
+				From(alpineImage).
+				WithNewFile("/cache-source/seed.txt", "seed\n").
+				Directory("/cache-source")
+		}
+
+		mountSourceCache := func(client *dagger.Client) *dagger.Container {
+			return client.
+				Container().
+				From(alpineImage).
+				WithMountedCache(
+					"/mnt/cache",
+					client.CacheVolume(cacheKey),
+					dagger.ContainerWithMountedCacheOpts{Source: cacheSource(client)},
+				)
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		outA, err := mountSourceCache(engineClientA).
+			WithExec([]string{"sh", "-ec", "cat /mnt/cache/seed.txt; echo initialized >> /mnt/cache/log.txt"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "seed\n", outA)
+
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		var eg errgroup.Group
+		for i := range 8 {
+			eg.Go(func() error {
+				out, err := mountSourceCache(engineClientB).
+					WithEnvVariable("WORKER", fmt.Sprint(i)).
+					WithExec([]string{"sh", "-ec", "cat /mnt/cache/seed.txt; sleep 2; echo \"$WORKER\" >> /mnt/cache/log.txt"}).
+					Stdout(ctx)
+				if err != nil {
+					return fmt.Errorf("worker %d: %w", i, err)
+				}
+				if out != "seed\n" {
+					return fmt.Errorf("worker %d: expected seed output, got %q", i, out)
+				}
+				return nil
+			})
+		}
+		require.NoError(t, eg.Wait())
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds a focused integration repro for a persisted source-backed cache volume mount failure, then fixes the persisted cache volume decode path.

After a persisted engine restart, `CacheVolume` reopened its mutable snapshot by snapshot ID without restoring the `exec.cachemount` record type that fresh cache-volume initialization sets. That record type is required for mutable cache mounts to use the existing shareable mount wrapper. Without it, concurrent execs mounting the same source-backed cache volume can receive the raw writable overlay mount and the kernel can reject duplicate mounts of the same `upperdir`/`workdir` with `EINVAL`.

The fix restores the cache-mount record type, and the cache volume description, when reopening a persisted cache volume snapshot.

## Validation

```bash
dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart/source-backed'
```

Trace: https://dagger.cloud/dagger/traces/67387e04acb721c34dd112d81737b16b
