### PR TITLE
ci: investigate intermittent disk full failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ Dagger makes your software delivery *programmable*, *local-first*, *repeatable* 
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md).
+
+<!-- CI-only disk pressure investigation marker. -->

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Dagger makes your software delivery *programmable*, *local-first*, *repeatable* 
 See [CONTRIBUTING.md](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md).
 
 <!-- CI-only disk pressure investigation marker. -->
+<!-- CI-only rerun after Namespace outer-engine rollout. -->

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -54,7 +54,8 @@ import (
 	telemetry "github.com/dagger/otel-go"
 )
 
-const gracefulStopTimeout = 5 * time.Minute // need to sync disks, which could be expensive
+// Engine shutdown may need to sync disks, which can be expensive.
+const gracefulStopTimeout = 5 * time.Minute
 const ebpfProgramEnvPrefix = "DAGGER_EBPF_PROG_"
 
 type ebpfProgram struct {

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -54,7 +54,7 @@ import (
 	telemetry "github.com/dagger/otel-go"
 )
 
-// Engine shutdown may need to sync disks, which can be expensive.
+// Engine shutdown may need to sync disks and cache metadata, which can be expensive.
 const gracefulStopTimeout = 5 * time.Minute
 const ebpfProgramEnvPrefix = "DAGGER_EBPF_PROG_"
 


### PR DESCRIPTION
## Summary

Draft PR for CI-only testing. The diff is intentionally inert; it exists only to trigger CI so we can investigate intermittent disk-full failures on Namespace-backed outer engines.

The suspected failure mode is not caused by this README marker. We are trying to observe jobs where the outer engine restarts from previously used disk state, then collect failing traces, Namespace instance details, outer-engine logs, pruning logs, and engine metrics around disk usage.

## Validation

No local validation needed; this PR is only for CI observation.
