### PR TITLE
dagql: redact sensitive args in ResultCall telemetry protobuf

### DIFF
--- a/dagql/result_call_frame.go
+++ b/dagql/result_call_frame.go
@@ -490,6 +490,16 @@ func resultCallArgPB(c *Cache, arg *ResultCallArg) (*callpbv1.Argument, error) {
 	if arg == nil {
 		return nil, nil
 	}
+	// Redact sensitive args from the telemetry/call protobuf, mirroring
+	// redactedArgForID on the call.ID path. Without this, sensitive values such
+	// as setSecret(plaintext:) are emitted verbatim to telemetry and rendered
+	// in the CLI progress output.
+	if arg.IsSensitive {
+		return &callpbv1.Argument{
+			Name:  arg.Name,
+			Value: &callpbv1.Literal{Value: &callpbv1.Literal_String_{String_: "***"}},
+		}, nil
+	}
 	lit, err := resultCallLiteralPB(c, arg.Value)
 	if err != nil {
 		return nil, err

--- a/dagql/result_call_frame_test.go
+++ b/dagql/result_call_frame_test.go
@@ -455,3 +455,73 @@ func TestResultCallRefResultIDFallbackStillWorks(t *testing.T) {
 
 	cacheTestReleaseSession(t, cacheIface, ctx)
 }
+
+// TestResultCallArgPBRedactsSensitive ensures the telemetry/call protobuf
+// encoder redacts args flagged sensitive (e.g. setSecret(plaintext:)), mirroring
+// redactedArgForID on the call.ID path. Regression test for sensitive secret
+// plaintext leaking verbatim into CLI --progress output.
+func TestResultCallArgPBRedactsSensitive(t *testing.T) {
+	t.Parallel()
+
+	c := &Cache{}
+
+	sensitive := &ResultCallArg{
+		Name:        "plaintext",
+		IsSensitive: true,
+		Value:       &ResultCallLiteral{Kind: ResultCallLiteralKindString, StringValue: "super-secret"},
+	}
+	pbArg, err := resultCallArgPB(c, sensitive)
+	require.NoError(t, err)
+	require.Equal(t, "plaintext", pbArg.Name)
+	require.Equal(t, "***", pbArg.Value.GetString_())
+	require.NotContains(t, pbArg.Value.GetString_(), "super-secret")
+
+	public := &ResultCallArg{
+		Name:  "name",
+		Value: &ResultCallLiteral{Kind: ResultCallLiteralKindString, StringValue: "toast"},
+	}
+	pbArg, err = resultCallArgPB(c, public)
+	require.NoError(t, err)
+	require.Equal(t, "toast", pbArg.Value.GetString_())
+
+	pbArg, err = resultCallArgPB(c, nil)
+	require.NoError(t, err)
+	require.Nil(t, pbArg)
+}
+
+// TestResultCallPBRedactsSensitiveArg exercises the full ResultCall.callPB
+// encoder (the path core/telemetry.go uses for the DagCall span attr) with a
+// setSecret-shaped frame: the non-sensitive arg passes through while the
+// sensitive plaintext is redacted.
+func TestResultCallPBRedactsSensitiveArg(t *testing.T) {
+	t.Parallel()
+
+	c := &Cache{}
+	frame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(String("").Type()),
+		Field: "setSecret",
+		Args: []*ResultCallArg{
+			{
+				Name:  "name",
+				Value: &ResultCallLiteral{Kind: ResultCallLiteralKindString, StringValue: "toast"},
+			},
+			{
+				Name:        "plaintext",
+				IsSensitive: true,
+				Value:       &ResultCallLiteral{Kind: ResultCallLiteralKindString, StringValue: "super-secret"},
+			},
+		},
+	}
+
+	pb, err := frame.callPB(c)
+	require.NoError(t, err)
+	require.Len(t, pb.Args, 2)
+
+	byName := make(map[string]string, len(pb.Args))
+	for _, a := range pb.Args {
+		byName[a.Name] = a.Value.GetString_()
+	}
+	require.Equal(t, "toast", byName["name"])
+	require.Equal(t, "***", byName["plaintext"])
+}


### PR DESCRIPTION
ResultCall.callPB / resultCallArgPB encodes the call protobuf used for the
DagCall telemetry span attribute (core/telemetry.go). It emitted arg values
verbatim and ignored ResultCallArg.IsSensitive, so sensitive arguments such
as setSecret(plaintext:) were sent to telemetry and rendered unredacted in
the CLI --progress output (e.g. as the embedded source: of withMountedSecret).

This regressed in #11856 ("migrate all caching to dagql"): the old call.ID
path redacts sensitive args via redactedArgForID, but the new ResultCall->pb
encoder introduced there did not carry that redaction over. Bisected to
aa719a10d (v0.20.8 is unaffected; current main and forks are affected).

Redact sensitive args to "***" in resultCallArgPB, mirroring redactedArgForID.
The request frame already carries IsSensitive=true correctly (schema
.Sensitive() and the sensitive:"true" struct tag both propagate via
resultCallArgFromInput); the encoder was dropping it.

Adds TestResultCallArgPBRedactsSensitive and TestResultCallPBRedactsSensitiveArg
(pass with the fix, fail without).

Fixes: #13183 

Co-Authored-By: Claude Code<noreply@anthropic.com>
Signed-off-by: Geoff Wilson <geoff@gr-oss.io>