### PR TITLE
test: make fail-multi telemetry ordering deterministic

### DIFF
--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -103,26 +103,22 @@ func (*Viztest) FailMulti(ctx context.Context) (rerr error) {
 	defer telemetry.End(span, func() error { return rerr }) //nolint:staticcheck
 	// NB: theoretically this would be from a concurrency pool or something but
 	// we'll simulate it instead to reduce randomness
-	return errors.Join(
-		func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, "sub-thing 1")
-			defer telemetry.End(span, func() error { return rerr }) //nolint:staticcheck
-			_, err := dag.Container().
-				From("alpine").
-				WithExec([]string{"sh", "-c", "echo this is a failing effect; exit 1"}).
-				Sync(ctx)
-			return err
-		}(),
-		(func() (rerr error) {
-			ctx, span := Tracer().Start(ctx, "sub-thing 2")
-			defer telemetry.End(span, func() error { return rerr }) //nolint:staticcheck
-			_, err := dag.Container().
-				From("alpine").
-				WithExec([]string{"sh", "-c", "echo this is another failing effect; exit 1"}).
-				Sync(ctx)
-			return err
-		})(),
-	)
+
+	ctx1, span := Tracer().Start(ctx, "sub-thing 1")
+	_, err1 := dag.Container().
+		From("alpine").
+		WithExec([]string{"sh", "-c", "echo this is a failing effect; exit 1"}).
+		Sync(ctx1)
+	telemetry.End(span, func() error { return err1 }) //nolint:staticcheck
+
+	ctx2, span := Tracer().Start(ctx, "sub-thing 2")
+	_, err2 := dag.Container().
+		From("alpine").
+		WithExec([]string{"sh", "-c", "echo this is another failing effect; exit 1"}).
+		Sync(ctx2)
+	telemetry.End(span, func() error { return err2 }) //nolint:staticcheck
+
+	return errors.Join(err1, err2)
 }
 
 // +cache="session"


### PR DESCRIPTION
Rewrite the fail-multi viztest helper so the two failing child spans are created, executed, and ended sequentially instead of through nested function arguments passed to errors.Join.

The test is meant to verify how multiple failed child spans are rendered, not to depend on evaluation or span-end ordering. Making the two failing effects explicitly ordered keeps the golden output stable while preserving the same joined-error behavior.