### PR TITLE
core: harden integration test scalar output parsing

### DIFF
--- a/core/integration/envfile_test.go
+++ b/core/integration/envfile_test.go
@@ -548,14 +548,22 @@ func (m *Dep) Bar(
 	callCmd := hostDaggerCommand(ctx, t, modDir, "call", "-s", "foo")
 	callOutput, err := callCmd.CombinedOutput()
 	require.NoError(t, err, string(callOutput))
-	// the CLI spams "user default: ..." messages despite -s, get the last line only
-	lastLine := callOutput
-	if idx := strings.LastIndex(string(callOutput), "\n"); idx != -1 {
-		lastLine = callOutput[idx+1:]
+	// the CLI spams "user default: ..." messages despite -s, so ignore them
+	// even if they are interleaved onto the same line as the scalar output.
+	var scalarOutput string
+	for _, line := range strings.Split(string(callOutput), "\n") {
+		if idx := strings.Index(line, "user default: "); idx != -1 {
+			line = line[:idx]
+		}
+		if line = strings.TrimSpace(line); line != "" {
+			scalarOutput = line
+		}
 	}
-	decodeOutput, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(lastLine)))
+	require.NotEmpty(t, scalarOutput, string(callOutput))
+
+	decodeOutput, err := base64.StdEncoding.DecodeString(scalarOutput)
 	require.NoError(t, err, string(callOutput))
-	require.Equal(t, "doodoo", string(decodeOutput))
+	require.Equal(t, "doodoo", string(decodeOutput), string(callOutput))
 }
 
 func (EnvFileSuite) TestUpdateVariableWithTheSameValue(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1431,7 +1431,7 @@ func (m *Test) Fn(ctx context.Context, sockPath string) (string, error) {
 
 		sockPath, cleanup := getHostSocket(t)
 		defer cleanup()
-		sockID, err := hostDaggerExec(ctx, t, idModDir, "call", "fn", "--sockPath", sockPath)
+		sockID, err := hostDaggerOutput(ctx, t, idModDir, "call", "fn", "--sockPath", sockPath)
 		require.NoError(t, err)
 
 		modDir := t.TempDir()

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -8264,6 +8264,19 @@ func hostDaggerExec(ctx context.Context, t testing.TB, workdir string, args ...s
 	return output, err
 }
 
+// runs a dagger cli command directly on the host and captures only stdout
+func hostDaggerOutput(ctx context.Context, t testing.TB, workdir string, args ...string) ([]byte, error) {
+	t.Helper()
+	var stderr bytes.Buffer
+	cmd := hostDaggerCommand(ctx, t, workdir, args...)
+	cmd.Stderr = io.MultiWriter(testutil.NewTWriter(t), &stderr)
+	output, err := cmd.Output()
+	if err != nil {
+		err = fmt.Errorf("stdout: %s\nstderr: %s: %w", string(output), stderr.String(), err)
+	}
+	return output, err
+}
+
 func cleanupExec(t testing.TB, cmd *exec.Cmd) {
 	t.Cleanup(func() {
 		if cmd.Process == nil {


### PR DESCRIPTION
## Summary
- harden `TestEnvFile/TestSecretFile` output parsing so combined stderr diagnostics cannot be decoded as scalar output
- add a stdout-only host Dagger helper and use it for socket ID scalar output passed between calls

## Details
The flaky env-file test captured combined CLI output and decoded the last raw line as base64. The CLI can still emit user-default diagnostics to stderr despite `-s`, and combined stdout/stderr can leave those diagnostics after a trailing newline or interleaved on the same line as the scalar payload. That made the test sometimes decode empty or contaminated data even when the function returned the expected secret plaintext.

The fix filters user-default diagnostics before decoding the scalar payload, and avoids combined output for another host scalar call by capturing stdout separately while still logging stderr and including it in command failure errors.

## Validation
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestEnvFile/TestSecretFile"` passed 10 fresh runs
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestCall/TestSocketArg/no implicit host access"`
- `git diff --check`