### PR TITLE
core: pin Vault image in TTL secret provider test

### DIFF
--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -328,11 +328,13 @@ func (SecretProvider) TestVaultOIDCEndToEnd(ctx context.Context, t *testctx.T) {
 }
 
 func (SecretProvider) TestVaultTTL(ctx context.Context, t *testctx.T) {
+	const vaultImage = "hashicorp/vault:1.18"
+
 	baseContainer := func(c *dagger.Client, vault *dagger.Service) *dagger.Container {
 		return c.Container().
 			From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-			WithFile("/bin/vault", c.Container().From("hashicorp/vault").File("/bin/vault")).
+			WithFile("/bin/vault", c.Container().From(vaultImage).File("/bin/vault")).
 			WithEnvVariable("VAULT_ADDR", "http://vault:8200").
 			WithEnvVariable("VAULT_TOKEN", "vault-root-token").
 			WithServiceBinding("vault", vault)
@@ -358,7 +360,7 @@ type Foo struct{}
 // to expire. It then gets its plaintext value again.
 // After that it returns both the values as string, which our tescase then verifies.
 func (m *Foo) VerifySecret(ctx context.Context, vault *dagger.Service, secret *dagger.Secret, tc string) (string, error) {
-	_, err := dag.Container().From("hashicorp/vault").
+	_, err := dag.Container().From("`+vaultImage+`").
 		WithEnvVariable("VAULT_ADDR", "http://vault:8200").
 		WithEnvVariable("VAULT_TOKEN", "vault-root-token").
 		WithServiceBinding("vault", vault).
@@ -374,7 +376,7 @@ func (m *Foo) VerifySecret(ctx context.Context, vault *dagger.Service, secret *d
 	}
 
 	// simulate an update in secret while the pipeline is running
-	_, err = dag.Container().From("hashicorp/vault").
+	_, err = dag.Container().From("`+vaultImage+`").
 		WithEnvVariable("VAULT_ADDR", "http://vault:8200").
 		WithEnvVariable("VAULT_TOKEN", "vault-root-token").
 		WithServiceBinding("vault", vault).
@@ -420,7 +422,7 @@ func (m *Foo) VerifySecret(ctx context.Context, vault *dagger.Service, secret *d
 			c := connect(ctx, t)
 
 			vault, err := c.Container().
-				From("hashicorp/vault").
+				From(vaultImage).
 				WithEnvVariable("VAULT_DEV_ROOT_TOKEN_ID", "vault-root-token").
 				WithEnvVariable("VAULT_LOG_LEVEL", "debug").
 				WithDockerHealthcheck([]string{"vault", "status", "-address=http://127.0.0.1:8200"}, dagger.ContainerWithDockerHealthcheckOpts{


### PR DESCRIPTION
## Summary
- pin `TestSecretProvider/TestVaultTTL` to `hashicorp/vault:1.18`
- reuse that pinned image for the Vault service, copied CLI binary, and nested module Vault clients

## Details
`TestSecretProvider/TestVaultTTL` was pulling the untagged `hashicorp/vault` image in several places. That tag now resolves to Vault 2.0.1, created on 2026-05-19. In this environment, the new image fails before any Dagger-specific secret-provider behavior is exercised:

```text
sh: vault: Operation not permitted
exit code: 126
```

This reproduces outside Dagger with a plain Docker run of the latest image. The latest image defaults to the `vault` user and ships `/bin/vault` with `cap_ipc_lock=ep`; executing the binary fails with the same `Operation not permitted` error. The existing `hashicorp/vault:1.18` image used by neighboring Vault provider tests still runs successfully.

Pinning the TTL test removes that external moving target and keeps the test focused on Vault secret TTL behavior.

## Validation
- `git pull --rebase upstream main`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestSecretProvider/TestVaultTTL"`
- `git diff --check`