### PR TITLE
sdk/python: exclude broken yarl release

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "anyio>=3.6.2",
     "cattrs>=25.1.0",
     "gql[httpx]>=4.0",
+    # Avoid a broken release with only cp310 wheels.
+    "yarl!=1.24.1",
     "httpcore>=1.0.8",
     "beartype>=0.22.0",
     "platformdirs>=2.6.2",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -372,6 +372,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "rich" },
     { name = "typing-extensions" },
+    { name = "yarl" },
 ]
 
 [package.dev-dependencies]
@@ -405,6 +406,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=2.6.2" },
     { name = "rich", specifier = ">=10.11.0" },
     { name = "typing-extensions", specifier = ">=4.13.0" },
+    { name = "yarl", specifier = "!=1.24.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
We've been seeing issues with yarl 1.24.1:
https://dagger.cloud/dagger/traces/033d4d3ec42819ba3e721733671f69d8?listen=aeec109729c3c6ad&listen=ff30275ebbf1b697&test=TestPython/TestVersion/.python-version_takes_precedence&viewMode=tests#aeec109729c3c6ad:L131

This commit is a stopgap