### PR TITLE
Testing reused cache mounts in CI

### DIFF
--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -61,7 +61,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 )
 
-// cache-mount-ci-perturbation: cycle-1-20260522T021116Z
+// cache-mount-ci-perturbation: cycle-2-20260522T031433Z
 type Server struct {
 	controlapi.UnimplementedControlServer
 	engineName string

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -61,6 +61,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 )
 
+// cache-mount-ci-perturbation: cycle-1-20260522T021116Z
 type Server struct {
 	controlapi.UnimplementedControlServer
 	engineName string


### PR DESCRIPTION
## Summary

This is a no-diff draft PR for validating reused cache mounts in CI.

The branch contains only an empty commit so it can produce PR CI runs. After creation, this PR number will be specified as the one that gets selective enablement of cache mount in our infra, letting us observe and debug re-use of persisted cache state across engine runs.

## Testing

Not run locally; this PR is intended to exercise CI.