### PR TITLE
core: fill in more persistence codecs for object types

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -102,11 +102,49 @@ type DiffStat struct {
 	RemovedLines int          `field:"true" doc:"Number of removed lines for this path."`
 }
 
+var _ dagql.PersistedObject = (*DiffStat)(nil)
+var _ dagql.PersistedObjectDecoder = (*DiffStat)(nil)
+
 func (*DiffStat) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "DiffStat",
 		NonNull:   true,
 	}
+}
+
+type persistedDiffStat struct {
+	Path         string       `json:"path"`
+	OldPath      *string      `json:"oldPath,omitempty"`
+	Kind         DiffStatKind `json:"kind"`
+	AddedLines   int          `json:"addedLines"`
+	RemovedLines int          `json:"removedLines"`
+}
+
+func (s *DiffStat) EncodePersistedObject(context.Context, dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	if s == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted diff stat: nil diff stat")
+	}
+	return encodePersistedObjectPayload(persistedDiffStat{
+		Path:         s.Path,
+		OldPath:      s.OldPath,
+		Kind:         s.Kind,
+		AddedLines:   s.AddedLines,
+		RemovedLines: s.RemovedLines,
+	})
+}
+
+func (*DiffStat) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	var persisted persistedDiffStat
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted diff stat payload: %w", err)
+	}
+	return &DiffStat{
+		Path:         persisted.Path,
+		OldPath:      persisted.OldPath,
+		Kind:         persisted.Kind,
+		AddedLines:   persisted.AddedLines,
+		RemovedLines: persisted.RemovedLines,
+	}, nil
 }
 
 // ComputePaths computes the added, modified, and removed paths using git diff.

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -232,6 +232,124 @@ head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
 		require.Equal(t, newFileContents, contents)
 	})
 
+	t.Run("directory search result list survives restart", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-directory-search-result-state-" + identity.NewID()
+		const pattern = `^\s*//\s*workspace:include\s+\S+\s*$`
+
+		runSearch := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) []string {
+			t.Helper()
+
+			results, err := engineClient.
+				Directory().
+				WithNewFile("one.go", "package main\n// workspace:include ./one\n").
+				WithNewFile("two.go", "package main\n// workspace:include ./two\n").
+				Search(ctx, pattern, dagger.DirectorySearchOpts{
+					Paths: []string{"one.go", "two.go"},
+				})
+			require.NoError(t, err)
+			require.Len(t, results, 2)
+
+			matches := make([]string, 0, len(results))
+			for _, result := range results {
+				filePath, err := result.FilePath(ctx)
+				require.NoError(t, err)
+
+				matchedLines, err := result.MatchedLines(ctx)
+				require.NoError(t, err)
+
+				submatches, err := result.Submatches(ctx)
+				require.NoError(t, err)
+				require.NotEmpty(t, submatches)
+				submatchText, err := submatches[0].Text(ctx)
+				require.NoError(t, err)
+				require.Contains(t, submatchText, "workspace:include")
+
+				matches = append(matches, filePath+":"+strings.TrimSpace(matchedLines))
+			}
+			require.ElementsMatch(t, []string{
+				"one.go:// workspace:include ./one",
+				"two.go:// workspace:include ./two",
+			}, matches)
+
+			return matches
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		matchesA := runSearch(ctx, t, engineClientA)
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		matchesB := runSearch(ctx, t, engineClientB)
+		require.ElementsMatch(t, matchesA, matchesB)
+	})
+
+	t.Run("changeset diff stat list survives restart", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-changeset-diff-stat-state-" + identity.NewID()
+
+		runDiffStats := func(ctx context.Context, t *testctx.T, engineClient *dagger.Client) []string {
+			t.Helper()
+
+			before := engineClient.
+				Directory().
+				WithNewFile("same.txt", "same\n").
+				WithNewFile("changed.txt", "old\n").
+				WithNewFile("removed.txt", "gone\n")
+			after := engineClient.
+				Directory().
+				WithNewFile("same.txt", "same\n").
+				WithNewFile("changed.txt", "new\n").
+				WithNewFile("added.txt", "new\n")
+
+			stats, err := after.Changes(before).DiffStats(ctx)
+			require.NoError(t, err)
+			require.Len(t, stats, 3)
+
+			got := make([]string, 0, len(stats))
+			for _, stat := range stats {
+				path, err := stat.Path(ctx)
+				require.NoError(t, err)
+				kind, err := stat.Kind(ctx)
+				require.NoError(t, err)
+				added, err := stat.AddedLines(ctx)
+				require.NoError(t, err)
+				removed, err := stat.RemovedLines(ctx)
+				require.NoError(t, err)
+				got = append(got, fmt.Sprintf("%s:%s:%d:%d", path, kind, added, removed))
+			}
+			require.ElementsMatch(t, []string{
+				"added.txt:ADDED:1:0",
+				"changed.txt:MODIFIED:1:1",
+				"removed.txt:REMOVED:0:1",
+			}, got)
+
+			return got
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		statsA := runDiffStats(ctx, t, engineClientA)
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		statsB := runDiffStats(ctx, t, engineClientB)
+		require.ElementsMatch(t, statsA, statsB)
+	})
+
 	t.Run("service-bound graph does not break disk persistence", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-service-binding-state-" + identity.NewID()

--- a/core/search.go
+++ b/core/search.go
@@ -26,11 +26,71 @@ type SearchResult struct {
 	Submatches     []*SearchSubmatch `field:"true" doc:"Sub-match positions and content within the matched lines."`
 }
 
+var _ dagql.PersistedObject = (*SearchResult)(nil)
+var _ dagql.PersistedObjectDecoder = (*SearchResult)(nil)
+
 func (*SearchResult) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "SearchResult",
 		NonNull:   true,
 	}
+}
+
+type persistedSearchResult struct {
+	FilePath       string                     `json:"filePath"`
+	LineNumber     int                        `json:"lineNumber"`
+	AbsoluteOffset int                        `json:"absoluteOffset"`
+	MatchedLines   string                     `json:"matchedLines"`
+	Submatches     []*persistedSearchSubmatch `json:"submatches,omitempty"`
+}
+
+func (r *SearchResult) EncodePersistedObject(context.Context, dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	if r == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted search result: nil search result")
+	}
+	payload := persistedSearchResult{
+		FilePath:       r.FilePath,
+		LineNumber:     r.LineNumber,
+		AbsoluteOffset: r.AbsoluteOffset,
+		MatchedLines:   r.MatchedLines,
+		Submatches:     make([]*persistedSearchSubmatch, 0, len(r.Submatches)),
+	}
+	for _, submatch := range r.Submatches {
+		if submatch == nil {
+			continue
+		}
+		payload.Submatches = append(payload.Submatches, &persistedSearchSubmatch{
+			Text:  submatch.Text,
+			Start: submatch.Start,
+			End:   submatch.End,
+		})
+	}
+	return encodePersistedObjectPayload(payload)
+}
+
+func (*SearchResult) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	var persisted persistedSearchResult
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted search result payload: %w", err)
+	}
+	result := &SearchResult{
+		FilePath:       persisted.FilePath,
+		LineNumber:     persisted.LineNumber,
+		AbsoluteOffset: persisted.AbsoluteOffset,
+		MatchedLines:   persisted.MatchedLines,
+		Submatches:     make([]*SearchSubmatch, 0, len(persisted.Submatches)),
+	}
+	for _, submatch := range persisted.Submatches {
+		if submatch == nil {
+			continue
+		}
+		result.Submatches = append(result.Submatches, &SearchSubmatch{
+			Text:  submatch.Text,
+			Start: submatch.Start,
+			End:   submatch.End,
+		})
+	}
+	return result, nil
 }
 
 type SearchSubmatch struct {
@@ -39,11 +99,43 @@ type SearchSubmatch struct {
 	End   int    `field:"true" doc:"The match's end offset within the matched lines."`
 }
 
+var _ dagql.PersistedObject = (*SearchSubmatch)(nil)
+var _ dagql.PersistedObjectDecoder = (*SearchSubmatch)(nil)
+
 func (*SearchSubmatch) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "SearchSubmatch",
 		NonNull:   true,
 	}
+}
+
+type persistedSearchSubmatch struct {
+	Text  string `json:"text"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+}
+
+func (m *SearchSubmatch) EncodePersistedObject(context.Context, dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	if m == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted search submatch: nil search submatch")
+	}
+	return encodePersistedObjectPayload(persistedSearchSubmatch{
+		Text:  m.Text,
+		Start: m.Start,
+		End:   m.End,
+	})
+}
+
+func (*SearchSubmatch) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	var persisted persistedSearchSubmatch
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted search submatch payload: %w", err)
+	}
+	return &SearchSubmatch{
+		Text:  persisted.Text,
+		Start: persisted.Start,
+		End:   persisted.End,
+	}, nil
 }
 
 type SearchOpts struct {

--- a/dagql/cache_persistence_self.go
+++ b/dagql/cache_persistence_self.go
@@ -180,6 +180,13 @@ func encodePersistedResultEnvelope(ctx context.Context, cache PersistedObjectCac
 		}, nil
 	}
 
+	if _, ok := res.Unwrap().(Input); !ok {
+		if _, ok := res.Unwrap().(ScalarType); !ok {
+			if _, ok := res.Unwrap().(Derefable); !ok {
+				return PersistedResultEncoding{}, fmt.Errorf("encode scalar_json payload: type %q does not implement persisted object encoding or scalar input encoding", res.Type().Name())
+			}
+		}
+	}
 	scalarJSON, err := json.Marshal(res.Unwrap())
 	if err != nil {
 		return PersistedResultEncoding{}, fmt.Errorf("encode scalar_json payload: %w", err)

--- a/dagql/cache_persistence_self_test.go
+++ b/dagql/cache_persistence_self_test.go
@@ -24,6 +24,10 @@ type persistCodecObj struct {
 	Name string
 }
 
+type persistCodecNonPersistedObj struct {
+	Name string
+}
+
 type persistedPersistCodecObj struct {
 	Name string `json:"name"`
 }
@@ -31,6 +35,13 @@ type persistedPersistCodecObj struct {
 func (*persistCodecObj) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "PersistCodecObj",
+		NonNull:   true,
+	}
+}
+
+func (*persistCodecNonPersistedObj) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "PersistCodecNonPersistedObj",
 		NonNull:   true,
 	}
 }
@@ -253,4 +264,65 @@ func TestPersistedSelfCodecNestedListRoundTrip(t *testing.T) {
 	list, ok := decoded.Unwrap().(Enumerable)
 	assert.Assert(t, ok)
 	assert.Check(t, is.Equal(list.Len(), 2))
+}
+
+func TestPersistedSelfCodecRawObjectArrayRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := setupPersistCodecTest(t)
+	srv := CurrentDagqlServer(ctx)
+	assert.Assert(t, srv != nil)
+
+	arrVal := Array[*persistCodecObj]{
+		{Name: "a"},
+		{Name: "b"},
+	}
+	original, err := NewResultForCall(arrVal, &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(arrVal.Type()),
+		Field: "persist-raw-object-array",
+	})
+	assert.NilError(t, err)
+
+	encoding, err := DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
+	assert.NilError(t, err)
+	env := encoding.Envelope
+	assert.Check(t, is.Equal(env.Kind, persistedResultKindList))
+	assert.Check(t, is.Equal(len(env.Items), 2))
+	assert.Check(t, is.Equal(env.Items[0].Kind, persistedResultKindObject))
+	assert.Check(t, is.Equal(env.Items[1].Kind, persistedResultKindObject))
+
+	decoded, err := DefaultPersistedSelfCodec.DecodeResult(ctx, srv, 0, original.cacheSharedResult().resultCall.clone(), env)
+	assert.NilError(t, err)
+
+	list, ok := decoded.Unwrap().(Enumerable)
+	assert.Assert(t, ok)
+	assert.Check(t, is.Equal(list.Len(), 2))
+
+	first, err := list.NthValue(1, nil)
+	assert.NilError(t, err)
+	firstObj, ok := first.(ObjectResult[*persistCodecObj])
+	assert.Assert(t, ok)
+	assert.Check(t, is.Equal(firstObj.Self().Name, "a"))
+
+	second, err := list.NthValue(2, nil)
+	assert.NilError(t, err)
+	secondObj, ok := second.(ObjectResult[*persistCodecObj])
+	assert.Assert(t, ok)
+	assert.Check(t, is.Equal(secondObj.Self().Name, "b"))
+}
+
+func TestPersistedSelfCodecRejectsNonPersistedObjectLikeScalar(t *testing.T) {
+	t.Parallel()
+	ctx := setupPersistCodecTest(t)
+
+	obj := &persistCodecNonPersistedObj{Name: "x"}
+	original, err := NewResultForCall(obj, &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(obj.Type()),
+		Field: "persist-non-persisted-object",
+	})
+	assert.NilError(t, err)
+
+	_, err = DefaultPersistedSelfCodec.EncodeResult(ctx, nil, original)
+	assert.ErrorContains(t, err, `type "PersistCodecNonPersistedObj" does not implement persisted object encoding or scalar input encoding`)
 }


### PR DESCRIPTION
## Summary

- Persist `SearchResult`, `SearchSubmatch`, and `DiffStat` values so cache-persisted list results round-trip after engine restart.
- Reject object-like values without explicit persisted-object encoding instead of silently storing them as `scalar_json`.
- Add dagql codec tests and disk-persistence integration coverage for `Directory.search`, search submatches, and `Changeset.diffStats`.

## Validation

- `dagger --progress=plain call go test --pkgs ./dagql --run 'TestPersistedSelfCodec(RawObjectArrayRoundTrip|RejectsNonPersistedObjectLikeScalar|NestedListRoundTrip|ObjectIDRoundTrip|ScalarRoundTrip)'`\n- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart/(directory_search_result_list_survives_restart|changeset_diff_stat_list_survives_restart)'`\n- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart'`