### PR TITLE
core: account lazy imported snapshot usage

### DIFF
--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -57,6 +57,10 @@ func (m *cacheVolumeTestSnapshotManager) GetBySnapshotID(ctx context.Context, sn
 	return ref, nil
 }
 
+func (*cacheVolumeTestSnapshotManager) SnapshotSize(context.Context, string) (int64, error) {
+	panic("unexpected SnapshotSize call")
+}
+
 func (m *cacheVolumeTestSnapshotManager) New(_ context.Context, parent bkcache.ImmutableRef, _ ...bkcache.RefOption) (bkcache.MutableRef, error) {
 	m.newCalls = append(m.newCalls, parent)
 	if m.newResult == nil {

--- a/core/container.go
+++ b/core/container.go
@@ -671,6 +671,10 @@ type persistedContainerWithRootFSLazy struct {
 	SourceResultID uint64 `json:"sourceResultID"`
 }
 
+type persistedContainerRootFSLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+}
+
 type persistedContainerWithDirectoryLazy struct {
 	ParentResultID uint64     `json:"parentResultID"`
 	Path           string     `json:"path"`
@@ -679,12 +683,22 @@ type persistedContainerWithDirectoryLazy struct {
 	Owner          string     `json:"owner,omitempty"`
 }
 
+type persistedContainerDirectoryLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+	Path           string `json:"path"`
+}
+
 type persistedContainerWithFileLazy struct {
 	ParentResultID uint64 `json:"parentResultID"`
 	Path           string `json:"path"`
 	SourceResultID uint64 `json:"sourceResultID"`
 	Permissions    *int   `json:"permissions,omitempty"`
 	Owner          string `json:"owner,omitempty"`
+}
+
+type persistedContainerFileLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+	Path           string `json:"path"`
 }
 
 type persistedContainerWithMountedDirectoryLazy struct {
@@ -2982,8 +2996,12 @@ func (lazy *ContainerRootFSLazy) AttachDependencies(ctx context.Context, attach 
 	return []dagql.AnyResult{parent}, nil
 }
 
-func (*ContainerRootFSLazy) EncodePersisted(context.Context, dagql.PersistedObjectCache) (json.RawMessage, error) {
-	return nil, fmt.Errorf("encode persisted container rootfs lazy: unsupported top-level form")
+func (lazy *ContainerRootFSLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container rootfs parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerRootFSLazy{ParentResultID: parentID})
 }
 
 func (lazy *ContainerWithRootFSLazy) Evaluate(ctx context.Context, container *Container) error {
@@ -3181,8 +3199,15 @@ func (lazy *ContainerDirectoryLazy) AttachDependencies(ctx context.Context, atta
 	return []dagql.AnyResult{parent}, nil
 }
 
-func (*ContainerDirectoryLazy) EncodePersisted(context.Context, dagql.PersistedObjectCache) (json.RawMessage, error) {
-	return nil, fmt.Errorf("encode persisted container directory lazy: unsupported top-level form")
+func (lazy *ContainerDirectoryLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container directory parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerDirectoryLazy{
+		ParentResultID: parentID,
+		Path:           lazy.Path,
+	})
 }
 
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
@@ -3330,8 +3355,15 @@ func (lazy *ContainerFileLazy) AttachDependencies(ctx context.Context, attach fu
 	return []dagql.AnyResult{parent}, nil
 }
 
-func (*ContainerFileLazy) EncodePersisted(context.Context, dagql.PersistedObjectCache) (json.RawMessage, error) {
-	return nil, fmt.Errorf("encode persisted container file lazy: unsupported top-level form")
+func (lazy *ContainerFileLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container file parent")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerFileLazy{
+		ParentResultID: parentID,
+		Path:           lazy.Path,
+	})
 }
 
 func containerWithDirectoryOpFromLazy(lazy *ContainerWithDirectoryLazy) containerWithDirectoryOp {

--- a/core/container.go
+++ b/core/container.go
@@ -1380,7 +1380,7 @@ func decodePersistedContainerDirectoryValue(ctx context.Context, dag *dagql.Serv
 	case persistedContainerValueFormPending:
 		return decodedContainerDirectoryValue{Dir: nil, Kind: wrapped.Form}, nil
 	case persistedContainerValueFormMaterialized:
-		dir, err := decodePersistedDirectoryWithSnapshotRole(ctx, dag, resultID, nil, wrapped.Value, role)
+		dir, err := decodePersistedDirectoryWithSnapshotRole(ctx, dag, resultID, wrapped.Value, role)
 		if err != nil {
 			return decodedContainerDirectoryValue{}, err
 		}
@@ -1404,7 +1404,7 @@ func decodePersistedContainerFileValue(ctx context.Context, dag *dagql.Server, r
 	case persistedContainerValueFormPending:
 		return decodedContainerFileValue{File: nil, Kind: wrapped.Form}, nil
 	case persistedContainerValueFormMaterialized:
-		file, err := decodePersistedFileWithSnapshotRole(ctx, dag, resultID, nil, wrapped.Value, role)
+		file, err := decodePersistedFileWithSnapshotRole(ctx, dag, resultID, wrapped.Value, role)
 		if err != nil {
 			return decodedContainerFileValue{}, err
 		}

--- a/core/container_emulator.go
+++ b/core/container_emulator.go
@@ -45,7 +45,7 @@ type staticEmulatorMount struct {
 }
 
 func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
-	tmpdir, err := os.MkdirTemp("", "buildkit-qemu-emulator")
+	tmpdir, err := os.MkdirTemp("", "dagger-qemu-emulator")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,7 +56,7 @@ func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
 		}
 	}()
 
-	if err := copy.Copy(context.TODO(), filepath.Dir(m.path), filepath.Base(m.path), tmpdir, engineutil.BuildkitQemuEmulatorMountPoint, func(ci *copy.CopyInfo) {
+	if err := copy.Copy(context.TODO(), filepath.Dir(m.path), filepath.Base(m.path), tmpdir, engineutil.DaggerQemuEmulatorMountPoint, func(ci *copy.CopyInfo) {
 		m := 0555
 		ci.Mode = &m
 	}); err != nil {
@@ -66,7 +66,7 @@ func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
 	ret = true
 	return []mount.Mount{{
 			Type:    "bind",
-			Source:  filepath.Join(tmpdir, engineutil.BuildkitQemuEmulatorMountPoint),
+			Source:  filepath.Join(tmpdir, engineutil.DaggerQemuEmulatorMountPoint),
 			Options: []string{"ro", "bind"},
 		}}, func() error {
 			return os.RemoveAll(tmpdir)

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -967,7 +967,7 @@ type execSecretMountInstance struct {
 }
 
 func (secret *execSecretMountInstance) Mount() ([]ctrdmount.Mount, func() error, error) {
-	dir, err := os.MkdirTemp("", "buildkit-secrets")
+	dir, err := os.MkdirTemp("", "dagger-secrets")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
@@ -1995,11 +1995,11 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			return err
 		}
 		if emu != nil {
-			metaSpec.Args = append([]string{engineutil.BuildkitQemuEmulatorMountPoint}, metaSpec.Args...)
+			metaSpec.Args = append([]string{engineutil.DaggerQemuEmulatorMountPoint}, metaSpec.Args...)
 			execMounts = append(execMounts, executor.Mount{
 				Readonly: true,
 				Src:      emu,
-				Dest:     engineutil.BuildkitQemuEmulatorMountPoint,
+				Dest:     engineutil.DaggerQemuEmulatorMountPoint,
 			})
 		}
 

--- a/core/directory.go
+++ b/core/directory.go
@@ -281,7 +281,7 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 }
 
 //nolint:dupl // symmetric with decodePersistedFileWithSnapshotRole in file.go; sharing hides type specifics
-func decodePersistedDirectoryWithSnapshotRole(ctx context.Context, dag *dagql.Server, resultID uint64, call *dagql.ResultCall, payload json.RawMessage, snapshotRole string) (*Directory, error) {
+func decodePersistedDirectoryWithSnapshotRole(ctx context.Context, dag *dagql.Server, resultID uint64, payload json.RawMessage, snapshotRole string) (*Directory, error) {
 	var persisted persistedDirectoryPayload
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return nil, fmt.Errorf("decode persisted directory payload: %w", err)
@@ -323,8 +323,8 @@ func decodePersistedDirectoryWithSnapshotRole(ctx context.Context, dag *dagql.Se
 	}
 }
 
-func (*Directory) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, call *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
-	return decodePersistedDirectoryWithSnapshotRole(ctx, dag, resultID, call, payload, "snapshot")
+func (*Directory) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	return decodePersistedDirectoryWithSnapshotRole(ctx, dag, resultID, payload, "snapshot")
 }
 
 func loadCanonicalScratchDirectory(ctx context.Context) (string, bkcache.ImmutableRef, error) {

--- a/core/directory.go
+++ b/core/directory.go
@@ -195,11 +195,30 @@ const (
 	persistedDirectoryFormLazy     = "lazy"
 )
 
+const (
+	persistedDirectoryLazyKindContainerRootFS               = "container.rootfs"
+	persistedDirectoryLazyKindContainerDirectory            = "container.directory"
+	persistedDirectoryLazyKindWithDirectory                 = "directory.withDirectory"
+	persistedDirectoryLazyKindWithDirectoryDockerfileCompat = "directory.__withDirectoryDockerfileCompat"
+	persistedDirectoryLazyKindWithPatchFile                 = "directory.withPatchFile"
+	persistedDirectoryLazyKindWithNewFile                   = "directory.withNewFile"
+	persistedDirectoryLazyKindWithFile                      = "directory.withFile"
+	persistedDirectoryLazyKindWithTimestamps                = "directory.withTimestamps"
+	persistedDirectoryLazyKindWithNewDirectory              = "directory.withNewDirectory"
+	persistedDirectoryLazyKindSubdirectory                  = "directory.directory"
+	persistedDirectoryLazyKindDiff                          = "directory.diff"
+	persistedDirectoryLazyKindWithChanges                   = "directory.withChanges"
+	persistedDirectoryLazyKindWithout                       = "directory.without"
+	persistedDirectoryLazyKindWithSymlink                   = "directory.withSymlink"
+	persistedDirectoryLazyKindChown                         = "directory.chown"
+)
+
 type persistedDirectoryPayload struct {
 	Form     string                    `json:"form"`
 	Dir      string                    `json:"dir,omitempty"`
 	Platform Platform                  `json:"platform"`
 	Services []persistedServiceBinding `json:"services,omitempty"`
+	LazyKind string                    `json:"lazyKind,omitempty"`
 	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
@@ -240,10 +259,11 @@ func (dir *Directory) EncodePersistedObject(ctx context.Context, cache dagql.Per
 	}
 	if dir.Lazy != nil {
 		payload.Form = persistedDirectoryFormLazy
-		lazyJSON, err := dir.Lazy.EncodePersisted(ctx, cache)
+		lazyKind, lazyJSON, err := encodePersistedDirectoryLazy(ctx, cache, dir.Lazy)
 		if err != nil {
 			return dagql.PersistedObjectEncoding{}, err
 		}
+		payload.LazyKind = lazyKind
 		payload.LazyJSON = lazyJSON
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
@@ -289,10 +309,10 @@ func decodePersistedDirectoryWithSnapshotRole(ctx context.Context, dag *dagql.Se
 		dir.Snapshot.setValue(snapshot)
 		return dir, nil
 	case persistedDirectoryFormLazy:
-		if call == nil {
-			return nil, fmt.Errorf("decode persisted directory payload: missing call for lazy form")
+		if persisted.LazyKind == "" {
+			return nil, fmt.Errorf("decode persisted directory payload: missing lazy kind")
 		}
-		lazy, err := decodePersistedDirectoryLazy(ctx, dag, call, persisted.LazyJSON)
+		lazy, err := decodePersistedDirectoryLazy(ctx, dag, persisted.LazyKind, persisted.LazyJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -580,10 +600,82 @@ func attachFileResult(attach func(dagql.AnyResult) (dagql.AnyResult, error), res
 	return typed, nil
 }
 
+func encodePersistedDirectoryLazy(ctx context.Context, cache dagql.PersistedObjectCache, lazy Lazy[*Directory]) (string, json.RawMessage, error) {
+	switch lazy := lazy.(type) {
+	case *ContainerRootFSLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindContainerRootFS, payload, err
+	case *ContainerDirectoryLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindContainerDirectory, payload, err
+	case *DirectoryWithDirectoryLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithDirectory, payload, err
+	case *DirectoryWithDirectoryDockerfileCompatLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithDirectoryDockerfileCompat, payload, err
+	case *DirectoryWithPatchFileLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithPatchFile, payload, err
+	case *DirectoryWithNewFileLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithNewFile, payload, err
+	case *DirectoryWithFileLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithFile, payload, err
+	case *DirectoryWithTimestampsLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithTimestamps, payload, err
+	case *DirectoryWithNewDirectoryLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithNewDirectory, payload, err
+	case *DirectorySubdirectoryLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindSubdirectory, payload, err
+	case *DirectoryDiffLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindDiff, payload, err
+	case *DirectoryWithChangesLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithChanges, payload, err
+	case *DirectoryWithoutLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithout, payload, err
+	case *DirectoryWithSymlinkLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindWithSymlink, payload, err
+	case *DirectoryChownLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindChown, payload, err
+	default:
+		return "", nil, fmt.Errorf("encode persisted directory lazy: unsupported lazy type %T", lazy)
+	}
+}
+
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
-func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *dagql.ResultCall, payload json.RawMessage) (Lazy[*Directory], error) {
-	switch call.Field {
-	case "withDirectory":
+func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, lazyKind string, payload json.RawMessage) (Lazy[*Directory], error) {
+	switch lazyKind {
+	case persistedDirectoryLazyKindContainerRootFS:
+		var persisted persistedContainerRootFSLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return nil, fmt.Errorf("decode persisted container rootfs lazy: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container rootfs parent")
+		if err != nil {
+			return nil, err
+		}
+		return &ContainerRootFSLazy{LazyState: NewLazyState(), Parent: parent}, nil
+	case persistedDirectoryLazyKindContainerDirectory:
+		var persisted persistedContainerDirectoryLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return nil, fmt.Errorf("decode persisted container directory lazy: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container directory parent")
+		if err != nil {
+			return nil, err
+		}
+		return &ContainerDirectoryLazy{LazyState: NewLazyState(), Parent: parent, Path: persisted.Path}, nil
+	case persistedDirectoryLazyKindWithDirectory:
 		var persisted persistedDirectoryWithDirectoryLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withDirectory lazy: %w", err)
@@ -605,7 +697,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			Owner:       persisted.Owner,
 			Permissions: persisted.Permissions,
 		}, nil
-	case "__withDirectoryDockerfileCompat":
+	case persistedDirectoryLazyKindWithDirectoryDockerfileCompat:
 		var persisted persistedDirectoryWithDirectoryDockerfileCompatLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory __withDirectoryDockerfileCompat lazy: %w", err)
@@ -635,21 +727,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			AllowEmptyWildcard:               persisted.AllowEmptyWildcard,
 			AlwaysReplaceExistingDestPaths:   persisted.AlwaysReplaceExistingDestPaths,
 		}, nil
-	case "withPatch":
-		var persisted persistedDirectoryWithPatchFileLazy
-		if err := json.Unmarshal(payload, &persisted); err != nil {
-			return nil, fmt.Errorf("decode persisted directory withPatch lazy: %w", err)
-		}
-		parent, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.ParentResultID, "directory withPatch parent")
-		if err != nil {
-			return nil, err
-		}
-		patch, err := loadPersistedObjectResultByResultID[*File](ctx, dag, persisted.PatchResultID, "directory withPatch patch")
-		if err != nil {
-			return nil, err
-		}
-		return &DirectoryWithPatchFileLazy{LazyState: NewLazyState(), Parent: parent, Patch: patch}, nil
-	case "withPatchFile":
+	case persistedDirectoryLazyKindWithPatchFile:
 		var persisted persistedDirectoryWithPatchFileLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withPatchFile lazy: %w", err)
@@ -663,7 +741,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithPatchFileLazy{LazyState: NewLazyState(), Parent: parent, Patch: patch}, nil
-	case "withNewFile":
+	case persistedDirectoryLazyKindWithNewFile:
 		var persisted persistedDirectoryWithNewFileLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withNewFile lazy: %w", err)
@@ -680,7 +758,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			Permissions: persisted.Permissions,
 			Ownership:   persisted.Ownership,
 		}, nil
-	case "withFile":
+	case persistedDirectoryLazyKindWithFile:
 		var persisted persistedDirectoryWithFileLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withFile lazy: %w", err)
@@ -703,7 +781,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			DoNotCreateDestPath:              persisted.DoNotCreateDestPath,
 			AttemptUnpackDockerCompatibility: persisted.AttemptUnpackDockerCompatibility,
 		}, nil
-	case "withTimestamps":
+	case persistedDirectoryLazyKindWithTimestamps:
 		var persisted persistedDirectoryWithTimestampsLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withTimestamps lazy: %w", err)
@@ -713,7 +791,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithTimestampsLazy{LazyState: NewLazyState(), Parent: parent, Timestamp: persisted.Timestamp}, nil
-	case "withNewDirectory":
+	case persistedDirectoryLazyKindWithNewDirectory:
 		var persisted persistedDirectoryWithNewDirectoryLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withNewDirectory lazy: %w", err)
@@ -723,7 +801,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithNewDirectoryLazy{LazyState: NewLazyState(), Parent: parent, Dest: persisted.Dest, Permissions: persisted.Permissions}, nil
-	case "directory":
+	case persistedDirectoryLazyKindSubdirectory:
 		var persisted persistedDirectorySubdirectoryLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory directory lazy: %w", err)
@@ -733,7 +811,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectorySubdirectoryLazy{LazyState: NewLazyState(), Parent: parent, Subdir: persisted.Subdir}, nil
-	case "diff":
+	case persistedDirectoryLazyKindDiff:
 		var persisted persistedDirectoryDiffLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory diff lazy: %w", err)
@@ -747,7 +825,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryDiffLazy{LazyState: NewLazyState(), Parent: parent, Other: other}, nil
-	case "withChanges":
+	case persistedDirectoryLazyKindWithChanges:
 		var persisted persistedDirectoryWithChangesLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withChanges lazy: %w", err)
@@ -761,7 +839,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithChangesLazy{LazyState: NewLazyState(), Parent: parent, Changes: changes}, nil
-	case "withoutDirectory", "withoutFile", "withoutFiles":
+	case persistedDirectoryLazyKindWithout:
 		var persisted persistedDirectoryWithoutLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory without lazy: %w", err)
@@ -771,7 +849,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithoutLazy{LazyState: NewLazyState(), Parent: parent, Paths: persisted.Paths}, nil
-	case "withSymlink":
+	case persistedDirectoryLazyKindWithSymlink:
 		var persisted persistedDirectoryWithSymlinkLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory withSymlink lazy: %w", err)
@@ -781,7 +859,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 			return nil, err
 		}
 		return &DirectoryWithSymlinkLazy{LazyState: NewLazyState(), Parent: parent, Target: persisted.Target, LinkName: persisted.LinkName}, nil
-	case "chown":
+	case persistedDirectoryLazyKindChown:
 		var persisted persistedDirectoryChownLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted directory chown lazy: %w", err)
@@ -792,7 +870,7 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, call *
 		}
 		return &DirectoryChownLazy{LazyState: NewLazyState(), Parent: parent, ChownPath: persisted.ChownPath, Owner: persisted.Owner}, nil
 	default:
-		return nil, fmt.Errorf("decode persisted directory lazy payload: unsupported field %q", call.Field)
+		return nil, fmt.Errorf("decode persisted directory lazy payload: unsupported lazy kind %q", lazyKind)
 	}
 }
 

--- a/core/file.go
+++ b/core/file.go
@@ -261,7 +261,7 @@ func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.Persist
 }
 
 //nolint:dupl // symmetric with decodePersistedDirectoryWithSnapshotRole in directory.go; sharing hides type specifics
-func decodePersistedFileWithSnapshotRole(ctx context.Context, dag *dagql.Server, resultID uint64, call *dagql.ResultCall, payload json.RawMessage, snapshotRole string) (*File, error) {
+func decodePersistedFileWithSnapshotRole(ctx context.Context, dag *dagql.Server, resultID uint64, payload json.RawMessage, snapshotRole string) (*File, error) {
 	var persisted persistedFilePayload
 	if err := json.Unmarshal(payload, &persisted); err != nil {
 		return nil, fmt.Errorf("decode persisted file payload: %w", err)
@@ -303,8 +303,8 @@ func decodePersistedFileWithSnapshotRole(ctx context.Context, dag *dagql.Server,
 	}
 }
 
-func (*File) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, call *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
-	return decodePersistedFileWithSnapshotRole(ctx, dag, resultID, call, payload, "snapshot")
+func (*File) DecodePersistedObject(ctx context.Context, dag *dagql.Server, resultID uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	return decodePersistedFileWithSnapshotRole(ctx, dag, resultID, payload, "snapshot")
 }
 
 type FileWithReplacedLazy struct {

--- a/core/file.go
+++ b/core/file.go
@@ -190,11 +190,21 @@ const (
 	persistedFileFormLazy     = "lazy"
 )
 
+const (
+	persistedFileLazyKindDirectoryFile  = "directory.file"
+	persistedFileLazyKindContainerFile  = "container.file"
+	persistedFileLazyKindWithName       = "file.withName"
+	persistedFileLazyKindWithReplaced   = "file.withReplaced"
+	persistedFileLazyKindWithTimestamps = "file.withTimestamps"
+	persistedFileLazyKindChown          = "file.chown"
+)
+
 type persistedFilePayload struct {
 	Form     string                    `json:"form"`
 	File     string                    `json:"file,omitempty"`
 	Platform Platform                  `json:"platform"`
 	Services []persistedServiceBinding `json:"services,omitempty"`
+	LazyKind string                    `json:"lazyKind,omitempty"`
 	LazyJSON json.RawMessage           `json:"lazyJSON,omitempty"`
 }
 
@@ -235,10 +245,11 @@ func (file *File) EncodePersistedObject(ctx context.Context, cache dagql.Persist
 	}
 	if file.Lazy != nil {
 		payload.Form = persistedFileFormLazy
-		lazyJSON, err := file.Lazy.EncodePersisted(ctx, cache)
+		lazyKind, lazyJSON, err := encodePersistedFileLazy(ctx, cache, file.Lazy)
 		if err != nil {
 			return dagql.PersistedObjectEncoding{}, err
 		}
+		payload.LazyKind = lazyKind
 		payload.LazyJSON = lazyJSON
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
@@ -278,10 +289,10 @@ func decodePersistedFileWithSnapshotRole(ctx context.Context, dag *dagql.Server,
 		file.Snapshot.setValue(snapshot)
 		return file, nil
 	case persistedFileFormLazy:
-		if call == nil {
-			return nil, fmt.Errorf("decode persisted file payload: missing call for lazy form")
+		if persisted.LazyKind == "" {
+			return nil, fmt.Errorf("decode persisted file payload: missing lazy kind")
 		}
-		lazy, err := decodePersistedFileLazy(ctx, dag, call, persisted.LazyJSON)
+		lazy, err := decodePersistedFileLazy(ctx, dag, persisted.LazyKind, persisted.LazyJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -357,9 +368,34 @@ type persistedFileSubfileLazy struct {
 	Path           string `json:"path"`
 }
 
-func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql.ResultCall, payload json.RawMessage) (Lazy[*File], error) {
-	switch call.Field {
-	case "file":
+func encodePersistedFileLazy(ctx context.Context, cache dagql.PersistedObjectCache, lazy Lazy[*File]) (string, json.RawMessage, error) {
+	switch lazy := lazy.(type) {
+	case *FileSubfileLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindDirectoryFile, payload, err
+	case *ContainerFileLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindContainerFile, payload, err
+	case *FileWithNameLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindWithName, payload, err
+	case *FileWithReplacedLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindWithReplaced, payload, err
+	case *FileWithTimestampsLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindWithTimestamps, payload, err
+	case *FileChownLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedFileLazyKindChown, payload, err
+	default:
+		return "", nil, fmt.Errorf("encode persisted file lazy: unsupported lazy type %T", lazy)
+	}
+}
+
+func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, lazyKind string, payload json.RawMessage) (Lazy[*File], error) {
+	switch lazyKind {
+	case persistedFileLazyKindDirectoryFile:
 		var persisted persistedFileSubfileLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted file subfile lazy: %w", err)
@@ -369,7 +405,17 @@ func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql
 			return nil, err
 		}
 		return &FileSubfileLazy{LazyState: NewLazyState(), Parent: parent, Path: persisted.Path}, nil
-	case "withName":
+	case persistedFileLazyKindContainerFile:
+		var persisted persistedContainerFileLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return nil, fmt.Errorf("decode persisted container file lazy: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container file parent")
+		if err != nil {
+			return nil, err
+		}
+		return &ContainerFileLazy{LazyState: NewLazyState(), Parent: parent, Path: persisted.Path}, nil
+	case persistedFileLazyKindWithName:
 		var persisted persistedFileWithNameLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted file withName lazy: %w", err)
@@ -379,7 +425,7 @@ func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql
 			return nil, err
 		}
 		return &FileWithNameLazy{LazyState: NewLazyState(), Parent: parent, Filename: persisted.Filename}, nil
-	case "withReplaced":
+	case persistedFileLazyKindWithReplaced:
 		var persisted persistedFileWithReplacedLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted file withReplaced lazy: %w", err)
@@ -396,7 +442,7 @@ func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql
 			FirstFrom:   persisted.FirstFrom,
 			All:         persisted.All,
 		}, nil
-	case "withTimestamps":
+	case persistedFileLazyKindWithTimestamps:
 		var persisted persistedFileWithTimestampsLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted file withTimestamps lazy: %w", err)
@@ -406,7 +452,7 @@ func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql
 			return nil, err
 		}
 		return &FileWithTimestampsLazy{LazyState: NewLazyState(), Parent: parent, Timestamp: persisted.Timestamp}, nil
-	case "chown":
+	case persistedFileLazyKindChown:
 		var persisted persistedFileChownLazy
 		if err := json.Unmarshal(payload, &persisted); err != nil {
 			return nil, fmt.Errorf("decode persisted file chown lazy: %w", err)
@@ -417,7 +463,7 @@ func decodePersistedFileLazy(ctx context.Context, dag *dagql.Server, call *dagql
 		}
 		return &FileChownLazy{LazyState: NewLazyState(), Parent: parent, Owner: persisted.Owner}, nil
 	default:
-		return nil, fmt.Errorf("decode persisted file lazy payload: unsupported field %q", call.Field)
+		return nil, fmt.Errorf("decode persisted file lazy payload: unsupported lazy kind %q", lazyKind)
 	}
 }
 

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -127,6 +127,73 @@ func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *test
 		require.Greater(t, entryCount, 0)
 	})
 
+	t.Run("lazy imported snapshot links count toward local cache usage and max-used prune", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-lazy-import-cache-usage-state-" + identity.NewID()
+
+		runWorkload := func(ctx context.Context, t *testctx.T, client *dagger.Client) string {
+			t.Helper()
+			out, err := client.
+				Container().
+				From(alpineImage).
+				WithExec([]string{
+					"sh",
+					"-ec",
+					`token="$(dd if=/dev/urandom bs=32 count=1 status=none | base64)"
+dd if=/dev/urandom of=/bigfile bs=1M count=64 status=none
+printf "%s" "$token"`,
+				}).
+				Stdout(ctx)
+			require.NoError(t, err)
+			return out
+		}
+
+		localCacheDiskBytes := func(ctx context.Context, t *testctx.T, client *dagger.Client) int {
+			t.Helper()
+			used, err := client.Engine().LocalCache().EntrySet().DiskSpaceBytes(ctx)
+			require.NoError(t, err)
+			return used
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		outA := runWorkload(ctx, t, engineClientA)
+		usedA := localCacheDiskBytes(ctx, t, engineClientA)
+		require.Greater(t, usedA, 32*1024*1024)
+
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		usedB := localCacheDiskBytes(ctx, t, engineClientB)
+		require.Greater(t, usedB, 32*1024*1024)
+
+		stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB)
+		upstreamSvcB = nil
+		engineSvcB = nil
+		engineClientB = nil
+
+		upstreamSvcC, engineSvcC, engineClientC := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcC, engineSvcC, engineClientC) })
+
+		err := engineClientC.Engine().LocalCache().Prune(ctx, dagger.EngineCachePruneOpts{
+			UseDefaultPolicy: false,
+			MaxUsedSpace:     "1",
+			ReservedSpace:    "0",
+			MinFreeSpace:     "0",
+			TargetSpace:      "1",
+		})
+		require.NoError(t, err)
+
+		outC := runWorkload(ctx, t, engineClientC)
+		require.NotEqual(t, outA, outC, "max-used prune should evict lazy imported snapshot-backed results before they are cache-hit")
+	})
+
 	t.Run("unclean shutdown discards local cache state and recovers", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-unclean-reset-state-" + identity.NewID()

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -299,6 +299,55 @@ head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
 		require.Equal(t, newFileContents, contents)
 	})
 
+	t.Run("container selector lazy dependencies survive restart", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-container-selector-lazy-state-" + identity.NewID()
+		const fileContents = "selector lazy persisted\n"
+
+		buildRetainedGraph := func(engineClient *dagger.Client) *dagger.Directory {
+			source := engineClient.
+				Directory().
+				WithNewFile("file.txt", fileContents)
+			ctr := engineClient.
+				Container().
+				WithDirectory("/work", source)
+
+			return engineClient.
+				Directory().
+				WithDirectory("rootfs", ctr.Rootfs()).
+				WithDirectory("selected-dir", ctr.Directory("/work")).
+				WithFile("selected-file.txt", ctr.File("/work/file.txt"))
+		}
+
+		upstreamSvcA, engineSvcA, engineClientA := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA) })
+
+		dirID, err := buildRetainedGraph(engineClientA).ID(ctx)
+		require.NoError(t, err)
+
+		stopEngine(ctx, t, upstreamSvcA, engineSvcA, engineClientA)
+		upstreamSvcA = nil
+		engineSvcA = nil
+		engineClientA = nil
+
+		upstreamSvcB, engineSvcB, engineClientB := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB) })
+
+		loaded := engineClientB.LoadDirectoryFromID(dirID)
+
+		selectedFile, err := loaded.File("selected-file.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fileContents, selectedFile)
+
+		selectedDirFile, err := loaded.File("selected-dir/file.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fileContents, selectedDirFile)
+
+		rootfsFile, err := loaded.File("rootfs/work/file.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fileContents, rootfsFile)
+	})
+
 	t.Run("directory search result list survives restart", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		stateKey := "phase7-directory-search-result-state-" + identity.NewID()

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -10,6 +10,7 @@ import (
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/engine/config"
@@ -661,6 +662,207 @@ func (EngineSuite) TestLocalCachePruneRemoteGitSnapshot(ctx context.Context, t *
 	require.Equal(t, readmeBeforePrune, readmeAfterPrune)
 }
 
+func (EngineSuite) TestLocalCachePruneDoesNotBreakRunningNestedEngineService(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	nestedEngine := devEngineContainer(c)
+	upstreamSvc := devEngineContainerAsService(nestedEngine)
+	t.Cleanup(func() {
+		_, _ = upstreamSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+	})
+
+	engineSvc, err := c.Host().Tunnel(upstreamSvc).Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = engineSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+	})
+
+	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+	require.NoError(t, err)
+
+	runNestedTmpProbe := func(ctx context.Context, client *dagger.Client, worker, iter int) error {
+		_, err := client.
+			Container().
+			From(alpineImage).
+			WithEnvVariable("PRUNE_PROBE", fmt.Sprintf("%d-%d", worker, iter)).
+			WithExec([]string{
+				"sh", "-ec",
+				`tmp="$(mktemp /tmp/dagger-prune-repro.XXXXXX)"; echo ok > "$tmp"; test "$(cat "$tmp")" = ok; rm "$tmp"`,
+			}).
+			Sync(ctx)
+		return err
+	}
+
+	newNestedClient := func(ctx context.Context) (*dagger.Client, error) {
+		return dagger.Connect(
+			ctx,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+	}
+
+	warmClient, err := newNestedClient(ctx)
+	require.NoError(t, err)
+	require.NoError(t, runNestedTmpProbe(ctx, warmClient, 0, 0))
+	require.NoError(t, warmClient.Close())
+
+	probeCtx, cancelProbes := context.WithCancel(ctx)
+	t.Cleanup(cancelProbes)
+	g, probeCtx := errgroup.WithContext(probeCtx)
+	for worker := range 2 {
+		worker := worker
+		g.Go(func() error {
+			nestedClient, err := newNestedClient(probeCtx)
+			if err != nil {
+				return err
+			}
+			defer nestedClient.Close()
+
+			for iter := 0; ; iter++ {
+				if probeCtx.Err() != nil {
+					return nil
+				}
+				if err := runNestedTmpProbe(probeCtx, nestedClient, worker, iter); err != nil {
+					if probeCtx.Err() != nil {
+						return nil
+					}
+					return fmt.Errorf("nested engine tmp probe failed worker=%d iter=%d: %w", worker, iter, err)
+				}
+				select {
+				case <-probeCtx.Done():
+					return nil
+				case <-time.After(100 * time.Millisecond):
+				}
+			}
+		})
+	}
+
+	seedOuterPrunableCache := func(iter int) {
+		t.Helper()
+
+		seedClient, err := dagger.Connect(ctx, dagger.WithLogOutput(testutil.NewTWriter(t)))
+		require.NoError(t, err)
+		defer seedClient.Close()
+
+		_, err = seedClient.
+			Container().
+			From(alpineImage).
+			WithEnvVariable("OUTER_PRUNE_SEED", fmt.Sprint(iter)).
+			WithExec([]string{
+				"sh", "-ec",
+				"dd if=/dev/urandom of=/bigfile bs=1M count=64 status=none",
+			}).
+			Sync(ctx)
+		require.NoError(t, err)
+	}
+
+	for i := range 3 {
+		seedOuterPrunableCache(i)
+
+		err := c.Engine().LocalCache().Prune(ctx, dagger.EngineCachePruneOpts{
+			UseDefaultPolicy: false,
+			MaxUsedSpace:     "1",
+			ReservedSpace:    "0",
+			MinFreeSpace:     "0",
+			TargetSpace:      "1",
+		})
+		require.NoError(t, err)
+	}
+
+	cancelProbes()
+	require.NoError(t, g.Wait())
+
+	finalClient, err := newNestedClient(ctx)
+	require.NoError(t, err)
+	defer finalClient.Close()
+	require.NoError(t, runNestedTmpProbe(ctx, finalClient, 99, 0))
+}
+
+func (EngineSuite) TestLocalCachePruneReclaimsStoppedServiceSnapshots(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	pruneAll := func() {
+		t.Helper()
+
+		err := c.Engine().LocalCache().Prune(ctx, dagger.EngineCachePruneOpts{
+			UseDefaultPolicy: false,
+			MaxUsedSpace:     "1",
+			ReservedSpace:    "0",
+			MinFreeSpace:     "0",
+			TargetSpace:      "1",
+		})
+		require.NoError(t, err)
+	}
+
+	pruneAll()
+	baselineAvailable := getEngineAvailableBytes(ctx, t, c)
+
+	seedClient, err := dagger.Connect(ctx, dagger.WithLogOutput(testutil.NewTWriter(t)))
+	require.NoError(t, err)
+	seedClientClosed := false
+	t.Cleanup(func() {
+		if !seedClientClosed {
+			_ = seedClient.Close()
+		}
+	})
+
+	svc := seedClient.
+		Container().
+		From(alpineImage).
+		WithExec([]string{
+			"sh", "-ec",
+			"dd if=/dev/zero of=/service-payload bs=1M count=256 status=none",
+		}).
+		WithDefaultArgs([]string{"sh", "-ec", "while true; do echo -n ok | nc -l -p 8080; done"}).
+		WithExposedPort(8080).
+		AsService()
+
+	runningSvc, err := svc.Start(ctx)
+	require.NoError(t, err)
+	serviceRunning := true
+	t.Cleanup(func() {
+		if serviceRunning {
+			_, _ = runningSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+		}
+	})
+
+	out, err := seedClient.
+		Container().
+		From(alpineImage).
+		WithServiceBinding("svc", runningSvc).
+		WithExec([]string{"nc", "svc", "8080"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ok", out)
+
+	serviceAvailable := getEngineAvailableBytes(ctx, t, c)
+	const servicePayloadSignalBytes = 128 * 1024 * 1024
+	require.Less(t, serviceAvailable, baselineAvailable-servicePayloadSignalBytes, "service payload should consume enough engine disk space to make pruning observable")
+
+	_, err = runningSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true})
+	require.NoError(t, err)
+	serviceRunning = false
+
+	require.NoError(t, seedClient.Close())
+	seedClientClosed = true
+
+	var availableAfterPrune int
+	for i := range 10 {
+		pruneAll()
+
+		availableAfterPrune = getEngineAvailableBytes(ctx, t, c)
+		if availableAfterPrune >= serviceAvailable+servicePayloadSignalBytes {
+			return
+		}
+
+		t.Logf("engine available bytes %d did not increase enough from %d after stopped service prune, retrying", availableAfterPrune, serviceAvailable)
+		if i < 9 {
+			time.Sleep(1 * time.Second)
+		}
+	}
+	require.GreaterOrEqual(t, availableAfterPrune, serviceAvailable+servicePayloadSignalBytes, "stopped service snapshots should be released by explicit prune")
+}
+
 func (EngineSuite) TestLocalCacheEntryRecordType(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -729,6 +931,27 @@ func getEngineBytesFromSpec(ctx context.Context, t *testctx.T, c *dagger.Client,
 	keepBytes, err := strconv.Atoi(amount)
 	require.NoError(t, err)
 	return keepBytes
+}
+
+func getEngineAvailableBytes(ctx context.Context, t *testctx.T, c *dagger.Client) int {
+	t.Helper()
+
+	dfOut, err := c.
+		Container().
+		From(alpineImage).
+		WithEnvVariable("DF_BUST", fmt.Sprint(time.Now().UnixNano())).
+		WithExec([]string{"df", "-B", "1", "/"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	dfLines := strings.Split(strings.TrimSpace(dfOut), "\n")
+	require.Len(t, dfLines, 2)
+	dfFields := strings.Fields(dfLines[1])
+	require.Len(t, dfFields, 6)
+
+	availableBytes, err := strconv.Atoi(dfFields[3])
+	require.NoError(t, err)
+	return availableBytes
 }
 
 type cacheEntryVals struct {

--- a/core/service.go
+++ b/core/service.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	ctdleases "github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/mount"
 	containerdfs "github.com/containerd/continuity/fs"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
@@ -647,6 +648,18 @@ func (svc *Service) startContainer(
 	cache := query.SnapshotManager()
 
 	svcID := identity.NewID()
+	serviceResourceLeaseID := "dagger-service-" + svcID
+	_, err = query.LeaseManager().Create(ctx,
+		ctdleases.WithID(serviceResourceLeaseID),
+		ctdleases.WithLabel("dagger.io/lease.type", "service"),
+		ctdleases.WithLabel("dagger.io/service.id", svcID),
+		ctdleases.WithLabel("dagger.io/service.digest", dig.String()),
+	)
+	if err != nil {
+		return fmt.Errorf("create service resource lease: %w", err)
+	}
+	running.setResourceLease(cache, serviceResourceLeaseID)
+	ctx = ctdleases.WithLease(ctx, serviceResourceLeaseID)
 
 	releaseLockedCaches, err := lockMountedCaches(ctx, ctr.Mounts)
 	if err != nil {
@@ -670,6 +683,27 @@ func (svc *Service) startContainer(
 	cleanup.Add("release output refs", func() error {
 		return p.releaseOutputRefs(context.WithoutCancel(ctx))
 	})
+	protectedSnapshots := make(map[string]struct{})
+	for _, state := range p.States {
+		for _, ref := range []bkcache.Ref{
+			state.SourceRef,
+			state.ActiveRef,
+			state.OutputMutable,
+			state.OutputImmutable,
+		} {
+			if ref == nil {
+				continue
+			}
+			snapshotID := ref.SnapshotID()
+			if _, ok := protectedSnapshots[snapshotID]; ok {
+				continue
+			}
+			protectedSnapshots[snapshotID] = struct{}{}
+			if err := running.ProtectRef(ctx, ref); err != nil {
+				return fmt.Errorf("protect service mount snapshot %s: %w", snapshotID, err)
+			}
+		}
+	}
 
 	meta := svc.ExecMeta
 	if meta == nil {
@@ -1504,7 +1538,9 @@ func (svc *Service) runAndSnapshotChanges(
 		return res, false, fmt.Errorf("failed to remount mutable copy: %w", err)
 	}
 
-	running.TrackRef(abandonedRef)
+	if err := running.TrackRef(ctx, abandonedRef); err != nil {
+		return res, false, fmt.Errorf("track mcp remount ref: %w", err)
+	}
 	abandonedRef = nil
 
 	srv, err := CurrentDagqlServer(ctx)

--- a/core/services.go
+++ b/core/services.go
@@ -88,8 +88,10 @@ type RunningService struct {
 	// The runc container ID, if any
 	ContainerID string
 
-	refsMu sync.Mutex
-	refs   []bkcache.Ref
+	refsMu                sync.Mutex
+	refs                  []bkcache.Ref
+	resourceSnapshotCache bkcache.SnapshotManager
+	resourceLeaseID       string
 
 	workspaceMu sync.Mutex
 
@@ -757,24 +759,59 @@ func (svc *RunningService) waitDependencyExitPropagationUnsuppressed(ctx context
 	}
 }
 
-func (svc *RunningService) TrackRef(ref bkcache.Ref) {
+func (svc *RunningService) setResourceLease(snapshotManager bkcache.SnapshotManager, leaseID string) {
+	svc.refsMu.Lock()
+	defer svc.refsMu.Unlock()
+	svc.resourceSnapshotCache = snapshotManager
+	svc.resourceLeaseID = leaseID
+}
+
+func (svc *RunningService) ProtectRef(ctx context.Context, ref bkcache.Ref) error {
 	if ref == nil {
-		return
+		return nil
+	}
+
+	svc.refsMu.Lock()
+	snapshotManager := svc.resourceSnapshotCache
+	leaseID := svc.resourceLeaseID
+	svc.refsMu.Unlock()
+
+	if snapshotManager == nil || leaseID == "" {
+		return fmt.Errorf("service resource lease not initialized")
+	}
+
+	return snapshotManager.AttachLease(context.WithoutCancel(ctx), leaseID, ref.SnapshotID())
+}
+
+func (svc *RunningService) TrackRef(ctx context.Context, ref bkcache.Ref) error {
+	if ref == nil {
+		return nil
+	}
+	if err := svc.ProtectRef(ctx, ref); err != nil {
+		return err
 	}
 	svc.refsMu.Lock()
 	defer svc.refsMu.Unlock()
 	svc.refs = append(svc.refs, ref)
+	return nil
 }
 
 func (svc *RunningService) ReleaseTrackedRefs(ctx context.Context) error {
 	svc.refsMu.Lock()
 	refs := svc.refs
 	svc.refs = nil
+	snapshotManager := svc.resourceSnapshotCache
+	svc.resourceSnapshotCache = nil
+	leaseID := svc.resourceLeaseID
+	svc.resourceLeaseID = ""
 	svc.refsMu.Unlock()
 
 	var errs error
 	for _, ref := range refs {
 		errs = stderrors.Join(errs, ref.Release(context.WithoutCancel(ctx)))
+	}
+	if snapshotManager != nil && leaseID != "" {
+		errs = stderrors.Join(errs, snapshotManager.RemoveLease(context.WithoutCancel(ctx), leaseID))
 	}
 	return errs
 }

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -83,7 +83,7 @@ type persistedEdge struct {
 	unpruneable       bool
 }
 
-const cachePersistenceSchemaVersion = "15"
+const cachePersistenceSchemaVersion = "16"
 
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrPersistStateNotReady = errors.New("persist state not ready")

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3041,6 +3041,7 @@ func (c *Cache) usageEntriesLocked(activeRoots map[sharedResultID]struct{}) []Ca
 type cacheUsageMeasurementInput struct {
 	resultID         sharedResultID
 	self             Typed
+	snapshotLinks    []PersistedSnapshotRefLink
 	identities       []string
 	existingSizeByID map[string]int64
 	sizeMayChange    bool
@@ -3051,7 +3052,7 @@ func (c *Cache) measureAllResultSizes(ctx context.Context) {
 	if len(inputs) == 0 {
 		return
 	}
-	sizes := buildCacheUsageMeasurements(ctx, inputs)
+	sizes := buildCacheUsageMeasurements(ctx, c.snapshotManager, inputs)
 	c.publishUsageMeasurements(sizes)
 }
 
@@ -3064,26 +3065,40 @@ func (c *Cache) collectUsageMeasurementInputs() []cacheUsageMeasurementInput {
 			continue
 		}
 		state := res.loadPayloadState()
-		if !state.hasValue || state.self == nil {
+		var (
+			self          Typed
+			snapshotLinks []PersistedSnapshotRefLink
+			identities    []string
+			sizeMayChange bool
+		)
+		if state.hasValue && state.self != nil {
+			self = state.self
+			identities = cacheUsageIdentitiesFromSelf(state.self)
+			sizeMayChange = cacheUsageSizeMayChangeFromSelf(state.self)
+		} else {
+			snapshotLinks = slices.Clone(state.snapshotOwnerLinks)
+			identities = cacheUsageIdentitiesFromSnapshotLinks(snapshotLinks)
+		}
+		if len(identities) == 0 {
 			continue
 		}
-		identities := cacheUsageIdentitiesFromSelf(state.self)
 		existing := make(map[string]int64, len(res.cacheUsageSizeByIdentity))
 		for identity, sizeBytes := range res.cacheUsageSizeByIdentity {
 			existing[identity] = sizeBytes
 		}
 		inputs = append(inputs, cacheUsageMeasurementInput{
 			resultID:         resID,
-			self:             state.self,
+			self:             self,
+			snapshotLinks:    snapshotLinks,
 			identities:       identities,
 			existingSizeByID: existing,
-			sizeMayChange:    cacheUsageSizeMayChangeFromSelf(state.self),
+			sizeMayChange:    sizeMayChange,
 		})
 	}
 	return inputs
 }
 
-func buildCacheUsageMeasurements(ctx context.Context, inputs []cacheUsageMeasurementInput) map[sharedResultID]map[string]int64 {
+func buildCacheUsageMeasurements(ctx context.Context, snapshotManager bkcache.SnapshotManager, inputs []cacheUsageMeasurementInput) map[sharedResultID]map[string]int64 {
 	if len(inputs) == 0 {
 		return nil
 	}
@@ -3117,7 +3132,16 @@ func buildCacheUsageMeasurements(ctx context.Context, inputs []cacheUsageMeasure
 			}
 		}
 
-		sizeBytes, ok, err := cacheUsageSizeBytesFromSelf(ctx, input.self, identity)
+		var (
+			sizeBytes int64
+			ok        bool
+			err       error
+		)
+		if input.self != nil {
+			sizeBytes, ok, err = cacheUsageSizeBytesFromSelf(ctx, input.self, identity)
+		} else if len(input.snapshotLinks) > 0 {
+			sizeBytes, ok, err = cacheUsageSizeBytesFromSnapshotLink(ctx, snapshotManager, identity)
+		}
 		if err != nil {
 			slog.Warn("failed to determine cache usage size",
 				"resultID", ownerID,
@@ -4081,6 +4105,17 @@ func cacheUsageSizeBytesFromSelf(ctx context.Context, self Typed, identity strin
 	return sizer.CacheUsageSize(ctx, identity)
 }
 
+func cacheUsageSizeBytesFromSnapshotLink(ctx context.Context, snapshotManager bkcache.SnapshotManager, identity string) (int64, bool, error) {
+	if snapshotManager == nil || identity == "" {
+		return 0, false, nil
+	}
+	sizeBytes, err := snapshotManager.SnapshotSize(ctx, identity)
+	if err != nil {
+		return 0, false, err
+	}
+	return sizeBytes, true, nil
+}
+
 func cacheUsageIdentitiesFromSelf(self Typed) []string {
 	if self == nil {
 		return nil
@@ -4094,12 +4129,33 @@ func cacheUsageIdentitiesFromSelf(self Typed) []string {
 	return slices.Compact(ids)
 }
 
-func cacheUsageIdentities(res *sharedResult) []string {
-	state := res.loadPayloadState()
-	if res == nil || !state.hasValue || state.self == nil {
+func cacheUsageIdentitiesFromSnapshotLinks(links []PersistedSnapshotRefLink) []string {
+	if len(links) == 0 {
 		return nil
 	}
-	return cacheUsageIdentitiesFromSelf(state.self)
+	ids := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.RefKey == "" {
+			continue
+		}
+		ids = append(ids, link.RefKey)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	slices.Sort(ids)
+	return slices.Compact(ids)
+}
+
+func cacheUsageIdentities(res *sharedResult) []string {
+	if res == nil {
+		return nil
+	}
+	state := res.loadPayloadState()
+	if state.hasValue && state.self != nil {
+		return cacheUsageIdentitiesFromSelf(state.self)
+	}
+	return cacheUsageIdentitiesFromSnapshotLinks(state.snapshotOwnerLinks)
 }
 
 func cacheUsageSizeMayChangeFromSelf(self Typed) bool {

--- a/dagql/cache_snapshot_persistence_test.go
+++ b/dagql/cache_snapshot_persistence_test.go
@@ -3,6 +3,7 @@ package dagql
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -56,6 +57,8 @@ func (v *persistSnapshotValue) PersistedSnapshotRefLinks() []PersistedSnapshotRe
 type fakeSnapshotManager struct {
 	persistentRows      bkcache.PersistentMetadataRows
 	loadedRows          bkcache.PersistentMetadataRows
+	snapshotSizes       map[string]int64
+	snapshotSizeCalls   []string
 	attachCalls         []struct{ LeaseID, SnapshotID string }
 	removeCalls         []string
 	deleteStaleKeep     map[string]struct{}
@@ -72,6 +75,19 @@ func (*fakeSnapshotManager) Get(context.Context, string, ...bkcache.RefOption) (
 
 func (*fakeSnapshotManager) GetBySnapshotID(context.Context, string, ...bkcache.RefOption) (bkcache.ImmutableRef, error) {
 	panic("unexpected GetBySnapshotID call")
+}
+
+func (m *fakeSnapshotManager) SnapshotSize(ctx context.Context, snapshotID string) (int64, error) {
+	_ = ctx
+	if m.snapshotSizes == nil {
+		panic("unexpected SnapshotSize call")
+	}
+	sizeBytes, ok := m.snapshotSizes[snapshotID]
+	if !ok {
+		return 0, fmt.Errorf("snapshot %q not found", snapshotID)
+	}
+	m.snapshotSizeCalls = append(m.snapshotSizeCalls, snapshotID)
+	return sizeBytes, nil
 }
 
 func (*fakeSnapshotManager) New(context.Context, bkcache.ImmutableRef, ...bkcache.RefOption) (bkcache.MutableRef, error) {
@@ -257,6 +273,84 @@ func TestCachePersistenceImportHydratesSnapshotMetadataAndSyncsOwnerLeases(t *te
 	assert.Assert(t, snapshotManagerB.deleteStaleCallSeen)
 	_, keepFound := snapshotManagerB.deleteStaleKeep[resultSnapshotLeaseID(resultID, "snapshot")]
 	assert.Assert(t, keepFound)
+}
+
+func importedSnapshotLinkUsageTestCache(t *testing.T, ctx context.Context, snapshotID string, sizeBytes int64) (*Cache, *fakeSnapshotManager) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+	cacheA, err := NewCache(ctx, dbPath, &fakeSnapshotManager{}, nil)
+	assert.NilError(t, err)
+	cA := cacheA
+
+	key := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&persistSnapshotValue{}).Type()),
+		Field: "persist-snapshot-owner",
+	}
+
+	_, err = cA.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+		ResultCall:    key,
+		IsPersistable: true,
+	}, func(context.Context) (AnyResult, error) {
+		return cacheTestPlainResult(&persistSnapshotValue{
+			Name:       "x",
+			SnapshotID: snapshotID,
+		}), nil
+	})
+	assert.NilError(t, err)
+
+	cacheTestReleaseSession(t, cA, ctx)
+	assert.NilError(t, cA.persistCurrentState(ctx))
+	assert.NilError(t, cA.Close(context.Background()))
+
+	snapshotManagerB := &fakeSnapshotManager{
+		snapshotSizes: map[string]int64{
+			snapshotID: sizeBytes,
+		},
+	}
+	cacheB, err := NewCache(ctx, dbPath, snapshotManagerB, nil)
+	assert.NilError(t, err)
+	return cacheB, snapshotManagerB
+}
+
+func TestCachePersistenceImportedSnapshotLinksContributeUsageBeforeDecode(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	cacheB, snapshotManagerB := importedSnapshotLinkUsageTestCache(t, ctx, "snapshot-a", 1234)
+	defer func() {
+		assert.NilError(t, cacheB.Close(context.Background()))
+	}()
+
+	entries := cacheB.UsageEntriesAll(ctx)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, int64(1234), entries[0].SizeBytes)
+	assert.DeepEqual(t, snapshotManagerB.snapshotSizeCalls, []string{"snapshot-a"})
+}
+
+func TestCachePruneThresholdUsesImportedSnapshotLinkUsage(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	cacheB, snapshotManagerB := importedSnapshotLinkUsageTestCache(t, ctx, "snapshot-a", 1234)
+	defer func() {
+		assert.NilError(t, cacheB.Close(context.Background()))
+	}()
+
+	report, err := cacheB.Prune(ctx, []CachePrunePolicy{{
+		All:          true,
+		MaxUsedSpace: 100,
+		TargetSpace:  1,
+	}})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(report.Entries))
+	assert.Equal(t, int64(1234), report.Entries[0].SizeBytes)
+	assert.Equal(t, int64(1234), report.ReclaimedBytes)
+	assert.DeepEqual(t, snapshotManagerB.snapshotSizeCalls, []string{"snapshot-a"})
+
+	entries := cacheB.UsageEntriesAll(ctx)
+	assert.Equal(t, 0, len(entries))
 }
 
 func TestCachePersistenceWorkerUsesEncodedSnapshotLinks(t *testing.T) {

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -70,7 +70,7 @@ const (
 	DaggerSessionTokenEnv = "DAGGER_SESSION_TOKEN"
 	DaggerEngineNumCPUEnv = "DAGGER_ENGINE_NUM_CPU"
 
-	BuildkitQemuEmulatorMountPoint = "/dev/.buildkit_qemu_emulator"
+	DaggerQemuEmulatorMountPoint = "/dev/.dagger_qemu_emulator"
 
 	cgroupSampleInterval     = 5 * time.Second
 	finalCgroupSampleTimeout = 5 * time.Second
@@ -480,11 +480,11 @@ func (c *Client) setupRootfs(ctx context.Context, state *execState) error {
 		case mnt.Destination == MetaMountDestPath:
 			metaMount = &mnt
 
-		case mnt.Destination == BuildkitQemuEmulatorMountPoint,
+		case mnt.Destination == DaggerQemuEmulatorMountPoint,
 			strings.HasPrefix(mnt.Destination, "/dev/pipes/"):
 			// Keep specific sub-mounts of /dev in the OCI spec so that runc processes
 			// them after the /dev tmpfs mount. The qemu emulator is at
-			// /dev/.buildkit_qemu_emulator and /dev/pipes/ is used by heredoc processing.
+			// /dev/.dagger_qemu_emulator and /dev/pipes/ is used by heredoc processing.
 			filteredMounts = append(filteredMounts, mnt)
 
 		case containerfs.IsSpecialMountType(mnt.Type):

--- a/engine/snapshots/fsdiff/overlay_linux.go
+++ b/engine/snapshots/fsdiff/overlay_linux.go
@@ -96,7 +96,7 @@ func GetOverlayLayers(m mount.Mount) ([]string, error) {
 }
 
 func WriteUpperdir(ctx context.Context, w io.Writer, upperdir string, lower []mount.Mount) error {
-	emptyLower, err := os.MkdirTemp("", "buildkit")
+	emptyLower, err := os.MkdirTemp("", "dagger")
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temp dir")
 	}

--- a/engine/snapshots/manager.go
+++ b/engine/snapshots/manager.go
@@ -64,6 +64,7 @@ type Accessor interface {
 
 type SnapshotManager interface {
 	Accessor
+	SnapshotSize(ctx context.Context, snapshotID string) (int64, error)
 	AttachLease(ctx context.Context, leaseID, snapshotID string) error
 	RemoveLease(ctx context.Context, leaseID string) error
 	LoadPersistentMetadata(rows PersistentMetadataRows) error
@@ -150,6 +151,56 @@ func (cm *snapshotManager) GetBySnapshotID(ctx context.Context, snapshotID strin
 		return nil, err
 	}
 	return cm.get(ctx, snapshotID, opts...)
+}
+
+func (cm *snapshotManager) SnapshotSize(ctx context.Context, snapshotID string) (int64, error) {
+	if snapshotID == "" {
+		return 0, errors.New("snapshot size: empty snapshot ID")
+	}
+
+	usage, err := cm.Snapshotter.Usage(ctx, snapshotID)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return 0, errors.Wrap(errNotFound, snapshotID)
+		}
+		return 0, errors.Wrapf(err, "failed to get usage for %s", snapshotID)
+	}
+
+	cm.mu.Lock()
+	contentDigests := make([]digest.Digest, 0, len(cm.snapshotContentDigests[snapshotID]))
+	for dgst := range cm.snapshotContentDigests[snapshotID] {
+		contentDigests = append(contentDigests, dgst)
+	}
+	cm.mu.Unlock()
+
+	if cm.ContentStore == nil {
+		return usage.Size, nil
+	}
+
+	added := make(map[digest.Digest]struct{}, len(contentDigests))
+	for _, dgst := range contentDigests {
+		if dgst == "" {
+			continue
+		}
+		if _, ok := added[dgst]; !ok {
+			if info, err := cm.ContentStore.Info(ctx, dgst); err == nil {
+				usage.Size += info.Size
+				added[dgst] = struct{}{}
+			}
+		}
+		walkBlobVariantsOnly(ctx, cm.ContentStore, dgst, func(desc ocispecs.Descriptor) bool {
+			if _, ok := added[desc.Digest]; ok {
+				return true
+			}
+			if info, err := cm.ContentStore.Info(ctx, desc.Digest); err == nil {
+				usage.Size += info.Size
+				added[desc.Digest] = struct{}{}
+			}
+			return true
+		}, nil)
+	}
+
+	return usage.Size, nil
 }
 
 // get requires manager lock to be taken

--- a/engine/snapshots/refs.go
+++ b/engine/snapshots/refs.go
@@ -993,7 +993,7 @@ func (sm *sharableMountable) Mount() (_ []mount.Mount, _ func() error, retErr er
 			// Don't need temporary mount wrapper for non-overlayfs mounts
 			return mounts, release, nil
 		}
-		dir, err := os.MkdirTemp(sm.mountPoolRoot, "buildkit")
+		dir, err := os.MkdirTemp(sm.mountPoolRoot, "dagger")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/skills/cache-expert/references/lazy_evaluation.md
+++ b/skills/cache-expert/references/lazy_evaluation.md
@@ -451,21 +451,25 @@ For `Container`, the persisted payload distinguishes:
 
 Nested directory/file values inside containers are also encoded explicitly.
 
-Each lazy type that supports persistence implements `EncodePersisted`, and the corresponding object decoder reconstructs the right lazy type by inspecting the authoritative `call.Field`.
+Each lazy type that supports persistence implements `EncodePersisted`, and the corresponding object decoder reconstructs the right lazy type from an explicit persisted lazy kind.
 
 So persistence does not serialize "a function pointer." It serializes an explicit, typed lazy recipe plus references to the attached dependency results it needs.
 
-## Not Every Lazy Shape Is a Standalone Top-Level Persisted Form
+## Selector Lazies as Standalone Persisted Forms
 
-One important nuance is that some selector-style container lazies are not supported as standalone top-level persisted forms.
+Selector-style container lazies are supported as standalone top-level persisted forms.
 
-For example:
+The persisted directory/file payload carries a `lazyKind` alongside the lazy recipe JSON. This is necessary because some field names are ambiguous across parent types. For example, `file` can mean `Directory.file` or `Container.file`; decoding from the retained call field alone is not enough to know which lazy recipe to reconstruct.
 
-- `ContainerRootFSLazy.EncodePersisted` returns unsupported
-- `ContainerDirectoryLazy.EncodePersisted` returns unsupported
-- `ContainerFileLazy.EncodePersisted` returns unsupported
+The supported selector lazy kinds are:
 
-That is a real current limitation of the implementation, not a general property of the lazy model.
+- `container.rootfs`
+- `container.directory`
+- `container.file`
+
+These recipes store the parent container result ID, plus the selected path for `container.directory` and `container.file`. They do not evaluate the container or materialize snapshots during shutdown persistence.
+
+Directory and File decoders require `lazyKind` for lazy forms. This is a hard persistence schema cut: older persisted lazy payloads without `lazyKind` are not decoded.
 
 ## Performance and Correctness Notes
 


### PR DESCRIPTION
## Summary

Restarted engines can import persisted dagql object results lazily because object payload decode needs a dagql server context. Before this change, those lazy imported results retained snapshot-owner links and leases, but local-cache usage accounting ignored them until a later cache hit materialized the object value.

This makes lazy imported snapshot-owner links participate in local-cache usage and max-used prune before payload decode. The snapshot manager now exposes direct snapshot size lookup, including persisted content blobs, without rehydrating refs as immutable or mutable state.

## Tests

- `git diff --check`
- `dagger --progress=plain call go test --pkgs ./dagql --pkgs ./core`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart/lazy imported snapshot links count toward local cache usage and max-used prune'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestEngine/TestDiskPersistenceAcrossRestart'`
