### PR TITLE
core: improve cache pruning and engine test splits

### DIFF
--- a/.dagger/internal/dagger/engine-dev.gen.go
+++ b/.dagger/internal/dagger/engine-dev.gen.go
@@ -1002,8 +1002,8 @@ func (r *EngineDev) Tests(ctx context.Context) (string, error) { // engine-dev (
 	return response, q.Execute(ctx)
 }
 
-func (r *EngineDev) WithBuildkitConfig(key string, value string) *EngineDev { // engine-dev (../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withBuildkitConfig")
+func (r *EngineDev) WithEngineConfig(key string, value string) *EngineDev { // engine-dev (../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEngineConfig")
 	q = q.Arg("key", key)
 	q = q.Arg("value", value)
 

--- a/core/cache.go
+++ b/core/cache.go
@@ -23,9 +23,11 @@ type CacheVolume struct {
 	Sharing   CacheSharingMode
 	Owner     string
 
-	mu       sync.Mutex
-	snapshot bkcache.MutableRef
-	selector string
+	mu              sync.Mutex
+	snapshot        bkcache.MutableRef
+	snapshotID      string
+	selector        string
+	releaseSnapshot func(context.Context) error
 }
 
 func (*CacheVolume) Type() *ast.Type {
@@ -59,14 +61,19 @@ var _ dagql.OnReleaser = (*CacheVolume)(nil)
 
 func (cache *CacheVolume) OnRelease(ctx context.Context) error {
 	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	if cache.snapshot == nil {
-		return nil
-	}
-	err := cache.snapshot.Release(ctx)
+	snapshot := cache.snapshot
+	releaseSnapshot := cache.releaseSnapshot
 	cache.snapshot = nil
-	return err
+	cache.releaseSnapshot = nil
+	cache.mu.Unlock()
+
+	if releaseSnapshot != nil {
+		return releaseSnapshot(ctx)
+	}
+	if snapshot != nil {
+		return snapshot.Release(ctx)
+	}
+	return nil
 }
 
 func (cache *CacheVolume) getSnapshot() bkcache.MutableRef {
@@ -87,11 +94,26 @@ func (cache *CacheVolume) getSnapshotSelector() string {
 func (cache *CacheVolume) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
 	cache.mu.Lock()
 	snapshot := cache.snapshot
+	snapshotID := cache.snapshotID
 	cache.mu.Unlock()
-	if snapshot == nil || snapshot.SnapshotID() != identity {
+	if snapshot != nil {
+		if snapshot.SnapshotID() != identity {
+			return 0, false, nil
+		}
+		size, err := snapshot.Size(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+		return size, true, nil
+	}
+	if snapshotID == "" || snapshotID != identity {
 		return 0, false, nil
 	}
-	size, err := snapshot.Size(ctx)
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+	size, err := query.SnapshotManager().SnapshotSize(ctx, snapshotID)
 	if err != nil {
 		return 0, false, err
 	}
@@ -101,25 +123,154 @@ func (cache *CacheVolume) CacheUsageSize(ctx context.Context, identity string) (
 func (cache *CacheVolume) CacheUsageIdentities() []string {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
-	if cache.snapshot == nil {
+	if cache.snapshot != nil {
+		return []string{cache.snapshot.SnapshotID()}
+	}
+	if cache.snapshotID == "" {
 		return nil
 	}
-	return []string{cache.snapshot.SnapshotID()}
+	return []string{cache.snapshotID}
 }
 
 func (cache *CacheVolume) PersistedSnapshotRefLinks() []dagql.PersistedSnapshotRefLink {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if cache.snapshot == nil {
+	snapshotID := cache.snapshotID
+	if cache.snapshot != nil {
+		snapshotID = cache.snapshot.SnapshotID()
+	}
+	if snapshotID == "" {
 		return nil
 	}
 	return []dagql.PersistedSnapshotRefLink{
 		{
-			RefKey: cache.snapshot.SnapshotID(),
+			RefKey: snapshotID,
 			Role:   "snapshot",
 		},
 	}
+}
+
+type cacheVolumeStore struct {
+	mu      sync.Mutex
+	entries map[string]*cacheVolumeStoreEntry
+}
+
+type cacheVolumeStoreEntry struct {
+	ref  bkcache.MutableRef
+	refs int
+}
+
+type cacheVolumeStoreReleaser struct {
+	store      *cacheVolumeStore
+	snapshotID string
+	once       sync.Once
+	err        error
+}
+
+func (q *Query) cacheVolumes() *cacheVolumeStore {
+	q.cacheVolumeStoreMu.Lock()
+	defer q.cacheVolumeStoreMu.Unlock()
+
+	if q.cacheVolumeStore == nil {
+		q.cacheVolumeStore = &cacheVolumeStore{
+			entries: make(map[string]*cacheVolumeStoreEntry),
+		}
+	}
+	return q.cacheVolumeStore
+}
+
+func (s *cacheVolumeStore) acquire(
+	ctx context.Context,
+	snapshotID string,
+	open func(context.Context) (bkcache.MutableRef, error),
+) (bkcache.MutableRef, func(context.Context) error, error) {
+	if snapshotID == "" {
+		return nil, nil, fmt.Errorf("acquire cache volume snapshot: empty snapshot ID")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.entries == nil {
+		s.entries = make(map[string]*cacheVolumeStoreEntry)
+	}
+	if entry, ok := s.entries[snapshotID]; ok {
+		entry.refs++
+		return entry.ref, (&cacheVolumeStoreReleaser{store: s, snapshotID: snapshotID}).release, nil
+	}
+
+	ref, err := open(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ref == nil {
+		return nil, nil, fmt.Errorf("acquire cache volume snapshot %q: nil mutable ref", snapshotID)
+	}
+	if ref.SnapshotID() != snapshotID {
+		_ = ref.Release(context.WithoutCancel(ctx))
+		return nil, nil, fmt.Errorf("acquire cache volume snapshot %q: opened snapshot %q", snapshotID, ref.SnapshotID())
+	}
+
+	s.entries[snapshotID] = &cacheVolumeStoreEntry{
+		ref:  ref,
+		refs: 1,
+	}
+	return ref, (&cacheVolumeStoreReleaser{store: s, snapshotID: snapshotID}).release, nil
+}
+
+func (s *cacheVolumeStore) register(ctx context.Context, ref bkcache.MutableRef) (func(context.Context) error, error) {
+	if ref == nil {
+		return nil, fmt.Errorf("register cache volume snapshot: nil mutable ref")
+	}
+	snapshotID := ref.SnapshotID()
+	if snapshotID == "" {
+		_ = ref.Release(context.WithoutCancel(ctx))
+		return nil, fmt.Errorf("register cache volume snapshot: empty snapshot ID")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.entries == nil {
+		s.entries = make(map[string]*cacheVolumeStoreEntry)
+	}
+	if _, ok := s.entries[snapshotID]; ok {
+		_ = ref.Release(context.WithoutCancel(ctx))
+		return nil, fmt.Errorf("register cache volume snapshot %q: already registered", snapshotID)
+	}
+
+	s.entries[snapshotID] = &cacheVolumeStoreEntry{
+		ref:  ref,
+		refs: 1,
+	}
+	return (&cacheVolumeStoreReleaser{store: s, snapshotID: snapshotID}).release, nil
+}
+
+func (r *cacheVolumeStoreReleaser) release(ctx context.Context) error {
+	r.once.Do(func() {
+		r.err = r.store.release(ctx, r.snapshotID)
+	})
+	return r.err
+}
+
+func (s *cacheVolumeStore) release(ctx context.Context, snapshotID string) error {
+	s.mu.Lock()
+	entry, ok := s.entries[snapshotID]
+	if !ok {
+		s.mu.Unlock()
+		return nil
+	}
+	entry.refs--
+	if entry.refs > 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	delete(s.entries, snapshotID)
+	ref := entry.ref
+	s.mu.Unlock()
+
+	return ref.Release(ctx)
 }
 
 type persistedCacheVolumePayload struct {
@@ -150,10 +301,14 @@ func (cache *CacheVolume) EncodePersistedObject(ctx context.Context, persistedCa
 	if selector == "" {
 		selector = "/"
 	}
+	snapshotID := cache.snapshotID
 	var snapshotLinks []dagql.PersistedSnapshotRefLink
 	if cache.snapshot != nil {
+		snapshotID = cache.snapshot.SnapshotID()
+	}
+	if snapshotID != "" {
 		snapshotLinks = []dagql.PersistedSnapshotRefLink{{
-			RefKey: cache.snapshot.SnapshotID(),
+			RefKey: snapshotID,
 			Role:   "snapshot",
 		}}
 	}
@@ -200,6 +355,10 @@ func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server
 		persisted.Sharing,
 		persisted.Owner,
 	)
+	cache.selector = persisted.Selector
+	if cache.selector == "" {
+		cache.selector = "/"
+	}
 	if resultID == 0 {
 		return cache, nil
 	}
@@ -211,25 +370,7 @@ func (*CacheVolume) DecodePersistedObject(ctx context.Context, dag *dagql.Server
 		if link.Role != "snapshot" {
 			continue
 		}
-		query, err := persistedDecodeQuery(dag)
-		if err != nil {
-			return nil, err
-		}
-		ref, err := query.SnapshotManager().GetMutableBySnapshotID(
-			ctx,
-			link.RefKey,
-			bkcache.NoUpdateLastUsed,
-			bkcache.WithRecordType(bkclient.UsageRecordTypeCacheMount),
-			bkcache.WithDescription(fmt.Sprintf("cache volume %q", cache.Key)),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("reopen persisted cache volume snapshot %q: %w", link.RefKey, err)
-		}
-		cache.snapshot = ref
-		cache.selector = persisted.Selector
-		if cache.selector == "" {
-			cache.selector = "/"
-		}
+		cache.snapshotID = link.RefKey
 		break
 	}
 	return cache, nil
@@ -262,6 +403,30 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return err
+	}
+	if cache.snapshotID != "" {
+		ref, releaseSnapshot, err := query.cacheVolumes().acquire(ctx, cache.snapshotID, func(ctx context.Context) (bkcache.MutableRef, error) {
+			ref, err := query.SnapshotManager().GetMutableBySnapshotID(
+				ctx,
+				cache.snapshotID,
+				bkcache.NoUpdateLastUsed,
+				bkcache.WithRecordType(bkclient.UsageRecordTypeCacheMount),
+				bkcache.WithDescription(fmt.Sprintf("cache volume %q", cache.Key)),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("reopen persisted cache volume snapshot %q: %w", cache.snapshotID, err)
+			}
+			return ref, nil
+		})
+		if err != nil {
+			return err
+		}
+		cache.snapshot = ref
+		cache.releaseSnapshot = releaseSnapshot
+		if cache.selector == "" {
+			cache.selector = "/"
+		}
+		return nil
 	}
 
 	var source dagql.ObjectResult[*Directory]
@@ -337,8 +502,14 @@ func (cache *CacheVolume) InitializeSnapshot(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize cache volume snapshot: %w", err)
 	}
+	releaseSnapshot, err := query.cacheVolumes().register(ctx, newRef)
+	if err != nil {
+		return err
+	}
 
 	cache.snapshot = newRef
+	cache.snapshotID = newRef.SnapshotID()
+	cache.releaseSnapshot = releaseSnapshot
 	if sourceSelector == "" {
 		sourceSelector = "/"
 	}

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -77,6 +77,10 @@ func (m *cacheVolumeTestSnapshotManager) SnapshotSize(ctx context.Context, snaps
 	return size, nil
 }
 
+func (*cacheVolumeTestSnapshotManager) SnapshotRecordMetadata(context.Context, string) (bkcache.SnapshotRecordMetadata, bool, error) {
+	panic("unexpected SnapshotRecordMetadata call")
+}
+
 func (m *cacheVolumeTestSnapshotManager) New(_ context.Context, parent bkcache.ImmutableRef, _ ...bkcache.RefOption) (bkcache.MutableRef, error) {
 	m.newCalls = append(m.newCalls, parent)
 	if m.newResult == nil {

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -29,9 +31,17 @@ type cacheVolumeTestSnapshotManager struct {
 	immutableBySnapshotID map[string]bkcache.ImmutableRef
 	mutableBySnapshotID   map[string]bkcache.MutableRef
 	newResult             bkcache.MutableRef
+	snapshotSizes         map[string]int64
+	lockMutableSnapshotID bool
+	mutableSnapshotOpen   map[string]bool
+	loadedRows            bkcache.PersistentMetadataRows
+	attachCalls           []struct{ leaseID, snapshotID string }
+	removeCalls           []string
+	deleteStaleKeep       map[string]struct{}
 
 	getBySnapshotIDCalls        []string
 	getMutableBySnapshotIDCalls []string
+	snapshotSizeCalls           []string
 	newCalls                    []bkcache.ImmutableRef
 }
 
@@ -57,8 +67,14 @@ func (m *cacheVolumeTestSnapshotManager) GetBySnapshotID(ctx context.Context, sn
 	return ref, nil
 }
 
-func (*cacheVolumeTestSnapshotManager) SnapshotSize(context.Context, string) (int64, error) {
-	panic("unexpected SnapshotSize call")
+func (m *cacheVolumeTestSnapshotManager) SnapshotSize(ctx context.Context, snapshotID string) (int64, error) {
+	_ = ctx
+	m.snapshotSizeCalls = append(m.snapshotSizeCalls, snapshotID)
+	size, ok := m.snapshotSizes[snapshotID]
+	if !ok {
+		return 0, context.Canceled
+	}
+	return size, nil
 }
 
 func (m *cacheVolumeTestSnapshotManager) New(_ context.Context, parent bkcache.ImmutableRef, _ ...bkcache.RefOption) (bkcache.MutableRef, error) {
@@ -74,11 +90,35 @@ func (*cacheVolumeTestSnapshotManager) GetMutable(context.Context, string, ...bk
 }
 
 func (m *cacheVolumeTestSnapshotManager) GetMutableBySnapshotID(ctx context.Context, snapshotID string, _ ...bkcache.RefOption) (bkcache.MutableRef, error) {
-	_ = ctx
 	m.getMutableBySnapshotIDCalls = append(m.getMutableBySnapshotIDCalls, snapshotID)
 	ref, ok := m.mutableBySnapshotID[snapshotID]
 	if !ok {
 		return nil, context.Canceled
+	}
+	if m.lockMutableSnapshotID {
+		if m.mutableSnapshotOpen == nil {
+			m.mutableSnapshotOpen = map[string]bool{}
+		}
+		if m.mutableSnapshotOpen[snapshotID] {
+			return nil, errors.New("locked")
+		}
+		m.mutableSnapshotOpen[snapshotID] = true
+
+		size, err := ref.Size(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ref = &cacheVolumeTestMutableRef{
+			cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+				id:         ref.ID(),
+				snapshotID: ref.SnapshotID(),
+				size:       size,
+				release: func(context.Context) error {
+					m.mutableSnapshotOpen[snapshotID] = false
+					return nil
+				},
+			},
+		}
 	}
 	return ref, nil
 }
@@ -99,24 +139,37 @@ func (*cacheVolumeTestSnapshotManager) Diff(context.Context, bkcache.ImmutableRe
 	panic("unexpected Diff call")
 }
 
-func (*cacheVolumeTestSnapshotManager) AttachLease(context.Context, string, string) error {
-	panic("unexpected AttachLease call")
+func (m *cacheVolumeTestSnapshotManager) AttachLease(ctx context.Context, leaseID, snapshotID string) error {
+	_ = ctx
+	m.attachCalls = append(m.attachCalls, struct{ leaseID, snapshotID string }{
+		leaseID:    leaseID,
+		snapshotID: snapshotID,
+	})
+	return nil
 }
 
-func (*cacheVolumeTestSnapshotManager) RemoveLease(context.Context, string) error {
-	panic("unexpected RemoveLease call")
+func (m *cacheVolumeTestSnapshotManager) RemoveLease(ctx context.Context, leaseID string) error {
+	_ = ctx
+	m.removeCalls = append(m.removeCalls, leaseID)
+	return nil
 }
 
-func (*cacheVolumeTestSnapshotManager) LoadPersistentMetadata(bkcache.PersistentMetadataRows) error {
-	panic("unexpected LoadPersistentMetadata call")
+func (m *cacheVolumeTestSnapshotManager) LoadPersistentMetadata(rows bkcache.PersistentMetadataRows) error {
+	m.loadedRows = rows
+	return nil
 }
 
 func (*cacheVolumeTestSnapshotManager) PersistentMetadataRows() bkcache.PersistentMetadataRows {
 	return bkcache.PersistentMetadataRows{}
 }
 
-func (*cacheVolumeTestSnapshotManager) DeleteStaleDaggerOwnerLeases(context.Context, map[string]struct{}) error {
-	panic("unexpected DeleteStaleDaggerOwnerLeases call")
+func (m *cacheVolumeTestSnapshotManager) DeleteStaleDaggerOwnerLeases(ctx context.Context, keep map[string]struct{}) error {
+	_ = ctx
+	m.deleteStaleKeep = make(map[string]struct{}, len(keep))
+	for leaseID := range keep {
+		m.deleteStaleKeep[leaseID] = struct{}{}
+	}
+	return nil
 }
 
 func (*cacheVolumeTestSnapshotManager) Close() error {
@@ -127,6 +180,7 @@ type cacheVolumeTestImmutableRef struct {
 	id         string
 	snapshotID string
 	size       int64
+	release    func(context.Context) error
 }
 
 func (r *cacheVolumeTestImmutableRef) Mount(context.Context, bool) (bkcache.MountableRef, error) {
@@ -141,7 +195,10 @@ func (r *cacheVolumeTestImmutableRef) SnapshotID() string {
 	return r.snapshotID
 }
 
-func (*cacheVolumeTestImmutableRef) Release(context.Context) error {
+func (r *cacheVolumeTestImmutableRef) Release(ctx context.Context) error {
+	if r.release != nil {
+		return r.release(ctx)
+	}
 	return nil
 }
 
@@ -281,6 +338,32 @@ func TestCacheVolumeUsageSizeUsesLiveSnapshotID(t *testing.T) {
 	require.Equal(t, int64(42), size)
 }
 
+func TestCacheVolumeUsageSizeUsesPersistedSnapshotID(t *testing.T) {
+	t.Parallel()
+
+	manager := &cacheVolumeTestSnapshotManager{
+		snapshotSizes: map[string]int64{
+			"snapshot-123": 42,
+		},
+	}
+	query := &Query{
+		Server: &cacheVolumeTestQueryServer{
+			mockServer:   &mockServer{},
+			cacheManager: manager,
+		},
+	}
+	ctx := ContextWithQuery(context.Background(), query)
+
+	cache := NewCache("cache-key", "ns", dagql.Optional[DirectoryID]{}, CacheSharingModeShared, "")
+	cache.snapshotID = "snapshot-123"
+
+	size, ok, err := cache.CacheUsageSize(ctx, "snapshot-123")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(42), size)
+	require.Equal(t, []string{"snapshot-123"}, manager.snapshotSizeCalls)
+}
+
 func TestCacheVolumeEncodeDecodePersistsSourceID(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +425,125 @@ func TestCacheVolumeInitializeSnapshotCreatesMutableSnapshot(t *testing.T) {
 	require.Nil(t, manager.newCalls[0])
 	require.Equal(t, ref, cache.getSnapshot())
 	require.Equal(t, "/", cache.getSnapshotSelector())
+}
+
+func TestCacheVolumeDecodeDistinctPersistedResultsSharingSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+	const snapshotID = "cache-volume-snapshot"
+
+	cacheCall := func(field string) *dagql.ResultCall {
+		return &dagql.ResultCall{
+			Kind:  dagql.ResultCallKindField,
+			Type:  dagql.NewResultCallType((&CacheVolume{}).Type()),
+			Field: field,
+		}
+	}
+	cacheResult := func(t *testing.T, srv *dagql.Server, call *dagql.ResultCall, key string) dagql.ObjectResult[*CacheVolume] {
+		t.Helper()
+		cache := NewCache(key, "ns", dagql.Optional[DirectoryID]{}, CacheSharingModeLocked, "")
+		cache.snapshot = &cacheVolumeTestMutableRef{
+			cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+				id:         key + "-mutable",
+				snapshotID: snapshotID,
+			},
+		}
+		res, err := dagql.NewObjectResultForCall(cache, srv, call)
+		require.NoError(t, err)
+		return res
+	}
+	cacheServer := func(manager bkcache.SnapshotManager) (*dagql.Server, *Query) {
+		query := &Query{
+			Server: &cacheVolumeTestQueryServer{
+				mockServer:   &mockServer{},
+				cacheManager: manager,
+			},
+		}
+		srv := newCoreDagqlServerForTest(t, query)
+		srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*CacheVolume]{}))
+		return srv, query
+	}
+
+	callA := cacheCall("cache-volume-a")
+	callB := cacheCall("cache-volume-b")
+
+	cacheA, err := dagql.NewCache(ctx, dbPath, nil, nil)
+	require.NoError(t, err)
+	srvA, _ := cacheServer(nil)
+	ctxA := dagql.ContextWithCache(ctx, cacheA)
+
+	resA, err := cacheA.GetOrInitCall(ctxA, "session-a", srvA, &dagql.CallRequest{
+		ResultCall:    callA,
+		IsPersistable: true,
+	}, dagql.ValueFunc(cacheResult(t, srvA, callA, "cache-a")))
+	require.NoError(t, err)
+	resB, err := cacheA.GetOrInitCall(ctxA, "session-a", srvA, &dagql.CallRequest{
+		ResultCall:    callB,
+		IsPersistable: true,
+	}, dagql.ValueFunc(cacheResult(t, srvA, callB, "cache-b")))
+	require.NoError(t, err)
+
+	resultIDA, err := cacheA.PersistedResultID(resA)
+	require.NoError(t, err)
+	resultIDB, err := cacheA.PersistedResultID(resB)
+	require.NoError(t, err)
+	require.NotEqual(t, resultIDA, resultIDB)
+
+	require.NoError(t, cacheA.ReleaseSession(ctxA, "session-a"))
+	require.NoError(t, cacheA.Close(ctx))
+
+	managerB := &cacheVolumeTestSnapshotManager{
+		mutableBySnapshotID: map[string]bkcache.MutableRef{
+			snapshotID: &cacheVolumeTestMutableRef{
+				cacheVolumeTestImmutableRef: cacheVolumeTestImmutableRef{
+					id:         "cache-volume-mutable",
+					snapshotID: snapshotID,
+				},
+			},
+		},
+		lockMutableSnapshotID: true,
+	}
+	cacheB, err := dagql.NewCache(ctx, dbPath, managerB, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, cacheB.Close(context.Background()))
+	})
+	srvB, queryB := cacheServer(managerB)
+	ctxB := ContextWithQuery(dagql.ContextWithCache(ctx, cacheB), queryB)
+
+	loadedA, err := cacheB.GetOrInitCall(ctxB, "session-b", srvB, &dagql.CallRequest{
+		ResultCall:    callA,
+		IsPersistable: true,
+	}, func(context.Context) (dagql.AnyResult, error) {
+		return nil, errors.New("unexpected initializer for first persisted cache volume")
+	})
+	require.NoError(t, err)
+
+	loadedB, err := cacheB.GetOrInitCall(ctxB, "session-b", srvB, &dagql.CallRequest{
+		ResultCall:    callB,
+		IsPersistable: true,
+	}, func(context.Context) (dagql.AnyResult, error) {
+		return nil, errors.New("unexpected initializer for second persisted cache volume")
+	})
+	require.NoError(t, err)
+	require.Empty(t, managerB.getMutableBySnapshotIDCalls)
+
+	loadedCacheA, ok := loadedA.(dagql.ObjectResult[*CacheVolume])
+	require.True(t, ok)
+	loadedCacheB, ok := loadedB.(dagql.ObjectResult[*CacheVolume])
+	require.True(t, ok)
+
+	require.NoError(t, loadedCacheA.Self().InitializeSnapshot(ctxB))
+	require.NoError(t, loadedCacheB.Self().InitializeSnapshot(ctxB))
+	require.Equal(t, []string{snapshotID}, managerB.getMutableBySnapshotIDCalls)
+	require.True(t, managerB.mutableSnapshotOpen[snapshotID])
+
+	require.NoError(t, loadedCacheA.Self().OnRelease(ctxB))
+	require.True(t, managerB.mutableSnapshotOpen[snapshotID])
+	require.NoError(t, loadedCacheB.Self().OnRelease(ctxB))
+	require.False(t, managerB.mutableSnapshotOpen[snapshotID])
 }
 
 var _ bkcache.ImmutableRef = (*cacheVolumeTestImmutableRef)(nil)

--- a/core/engine.go
+++ b/core/engine.go
@@ -74,12 +74,14 @@ func (entrySet *EngineCacheEntrySet) Sync(ctx context.Context) error {
 }
 
 type EngineCacheEntry struct {
-	Description               string `field:"true" doc:"The description of the cache entry."`
-	DiskSpaceBytes            int    `field:"true" doc:"The disk space used by the cache entry."`
-	CreatedTimeUnixNano       int    `field:"true" doc:"The time the cache entry was created, in Unix nanoseconds."`
-	MostRecentUseTimeUnixNano int    `field:"true" doc:"The most recent time the cache entry was used, in Unix nanoseconds."`
-	ActivelyUsed              bool   `field:"true" doc:"Whether the cache entry is actively being used."`
-	RecordType                string `field:"true" doc:"The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount)."`
+	Description               string   `field:"true" doc:"The description of the cache entry."`
+	DiskSpaceBytes            int      `field:"true" doc:"The disk space used by the cache entry."`
+	CreatedTimeUnixNano       int      `field:"true" doc:"The time the cache entry was created, in Unix nanoseconds."`
+	MostRecentUseTimeUnixNano int      `field:"true" doc:"The most recent time the cache entry was used, in Unix nanoseconds."`
+	ActivelyUsed              bool     `field:"true" doc:"Whether the cache entry is actively being used."`
+	RecordType                string   `field:"true" doc:"The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount)."`
+	RecordTypes               []string `field:"true" doc:"The storage record types represented by this cache entry."`
+	DagqlCall                 string   `field:"true" doc:"The DagQL call that produced this cache entry."`
 }
 
 func (*EngineCacheEntry) Type() *ast.Type {

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -575,7 +575,7 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 		}
 
 		checkoutRef, err = cache.New(ctx, nil,
-			bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
+			bkcache.WithRecordType(bkclient.UsageRecordTypeGitCheckout),
 			bkcache.WithDescription(fmt.Sprintf("git checkout for %s (%s %s)", ref.repo.URL.Remote(), ref.Name, ref.SHA)))
 		if err != nil {
 			return err

--- a/core/git_remote_mirror.go
+++ b/core/git_remote_mirror.go
@@ -149,7 +149,13 @@ func (*RemoteGitMirror) DecodePersistedObject(ctx context.Context, dag *dagql.Se
 	if err != nil {
 		return nil, err
 	}
-	ref, err := query.SnapshotManager().GetMutableBySnapshotID(ctx, link.RefKey, bkcache.NoUpdateLastUsed)
+	ref, err := query.SnapshotManager().GetMutableBySnapshotID(
+		ctx,
+		link.RefKey,
+		bkcache.NoUpdateLastUsed,
+		bkcache.WithRecordType(bkclient.UsageRecordTypeGitCheckout),
+		bkcache.WithDescription(fmt.Sprintf("git bare repo for %s", mirror.RemoteURL)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("reopen persisted remote git mirror snapshot %q: %w", link.RefKey, err)
 	}
@@ -186,7 +192,7 @@ func (mirror *RemoteGitMirror) ensureSnapshotLocked(ctx context.Context, query *
 		ctx,
 		nil,
 		nil,
-		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
+		bkcache.WithRecordType(bkclient.UsageRecordTypeGitCheckout),
 		bkcache.WithDescription(fmt.Sprintf("git bare repo for %s", mirror.RemoteURL)),
 	)
 	if err != nil {

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -18,7 +18,7 @@ import (
 	"dagger.io/dagger"
 )
 
-func (EngineSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *testctx.T) {
+func (CachePersistenceSuite) TestDiskPersistenceAcrossRestart(ctx context.Context, t *testctx.T) {
 	const persistenceTestGCThresholdBytes = "1000000000000000"
 
 	engineWithPersistenceTestGC := func(ctx context.Context, t *testctx.T) func(*dagger.Container) *dagger.Container {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -30,9 +30,19 @@ import (
 )
 
 type EngineSuite struct{}
+type CachePersistenceSuite struct{}
+type LocalCacheSuite struct{}
 
 func TestEngine(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(EngineSuite{})
+}
+
+func TestCachePersistence(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(CachePersistenceSuite{})
+}
+
+func TestLocalCache(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(LocalCacheSuite{})
 }
 
 func devEngineContainerAsService(ctr *dagger.Container) *dagger.Service {

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
+	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -894,18 +895,44 @@ func (EngineSuite) TestLocalCachePruneReclaimsStoppedServiceSnapshots(ctx contex
 func (EngineSuite) TestLocalCacheEntryRecordType(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	// create some cache content so entries exist
-	_, err := c.Container().From(alpineImage).WithExec([]string{"echo", "hello"}).Sync(ctx)
+	_, err := c.Container().
+		From(alpineImage).
+		WithMountedCache("/cache", c.CacheVolume("record-type-"+identity.NewID())).
+		WithExec([]string{"sh", "-c", "echo cache mount > /cache/output.txt"}).
+		Sync(ctx)
 	require.NoError(t, err)
+
+	gitDaemon, repoURL := gitService(ctx, t, c, c.Directory().WithNewFile("README.md", "git source"))
+	gitContent, err := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
+		Branch("main").
+		Tree().
+		File("README.md").
+		Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "git source", gitContent)
 
 	ents, err := c.Engine().LocalCache().EntrySet().Entries(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, ents)
 
+	recordTypes := map[string]bool{}
 	for _, ent := range ents {
 		entVal := getCacheEntryVals(ctx, t, ent)
-		assert.NotEmpty(t, entVal.RecordType, "RecordType should be populated for entry %q", entVal.Description)
+		assert.NotEmpty(t, entVal.RecordType, "RecordType should be populated")
+
+		for _, recordType := range entVal.RecordTypes {
+			recordTypes[recordType] = true
+		}
+		if len(entVal.RecordTypes) == 1 {
+			require.Equal(t, entVal.RecordTypes[0], entVal.RecordType)
+		}
+
+		if entVal.RecordType == "exec.cachemount" || entVal.RecordType == "source.git.checkout" {
+			assert.NotEmpty(t, entVal.DagqlCall, "DagqlCall should be populated for entry %q", entVal.Description)
+		}
 	}
+	require.True(t, recordTypes["exec.cachemount"], "expected cache volume cache entry")
+	require.True(t, recordTypes["source.git.checkout"], "expected remote git cache entry")
 }
 
 func engineConfigWithEnabled(enabled bool) func(context.Context, *testctx.T, config.Config) config.Config {
@@ -968,6 +995,8 @@ type cacheEntryVals struct {
 	MostRecentUseTimeUnixNano int
 	ActivelyUsed              bool
 	RecordType                string
+	RecordTypes               []string
+	DagqlCall                 string
 }
 
 func getCacheEntryVals(ctx context.Context, t *testctx.T, ent dagger.EngineCacheEntry) *cacheEntryVals {
@@ -992,6 +1021,12 @@ func getCacheEntryVals(ctx context.Context, t *testctx.T, ent dagger.EngineCache
 	require.NoError(t, err)
 
 	vals.RecordType, err = ent.RecordType(ctx)
+	require.NoError(t, err)
+
+	vals.RecordTypes, err = ent.RecordTypes(ctx)
+	require.NoError(t, err)
+
+	vals.DagqlCall, err = ent.DagqlCall(ctx)
 	require.NoError(t, err)
 
 	return vals

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/dagger/testctx"
 )
 
-func (EngineSuite) TestLocalCacheGCDisabled(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCacheGCDisabled(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	f := false
 	engine := devEngineContainer(c, engineWithConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg config.Config) config.Config {
@@ -53,7 +53,7 @@ func (EngineSuite) TestLocalCacheGCDisabled(ctx context.Context, t *testctx.T) {
 	assert.Zero(t, rs)
 }
 
-func (EngineSuite) TestLocalCacheGCKeepBytesConfig(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCacheGCKeepBytesConfig(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	for _, tc := range []struct {
@@ -142,7 +142,7 @@ func (EngineSuite) TestLocalCacheGCKeepBytesConfig(ctx context.Context, t *testc
 	}
 }
 
-func (EngineSuite) TestLocalCacheGC(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCacheGC(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	for _, tc := range []struct {
@@ -376,7 +376,7 @@ func (EngineSuite) TestLocalCacheGC(ctx context.Context, t *testctx.T) {
 	}
 }
 
-func (EngineSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	setup := func(ctx context.Context, t *testctx.T) (endpoint string, c2 *dagger.Client, addCacheBlock func(*testctx.T, string, int), getUsedBytes func(*testctx.T) int) {
 		t.Helper()
@@ -586,7 +586,7 @@ func (EngineSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *tes
 	})
 }
 
-func (EngineSuite) TestLocalCachePruneRemoteGitSnapshot(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCachePruneRemoteGitSnapshot(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	engine := devEngineContainer(c, engineWithConfig(ctx, t, engineConfigWithEnabled(false)))
@@ -663,7 +663,7 @@ func (EngineSuite) TestLocalCachePruneRemoteGitSnapshot(ctx context.Context, t *
 	require.Equal(t, readmeBeforePrune, readmeAfterPrune)
 }
 
-func (EngineSuite) TestLocalCachePruneDoesNotBreakRunningNestedEngineService(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCachePruneDoesNotBreakRunningNestedEngineService(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	nestedEngine := devEngineContainer(c)
@@ -779,7 +779,7 @@ func (EngineSuite) TestLocalCachePruneDoesNotBreakRunningNestedEngineService(ctx
 	require.NoError(t, runNestedTmpProbe(ctx, finalClient, 99, 0))
 }
 
-func (EngineSuite) TestLocalCachePruneReclaimsStoppedServiceSnapshots(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCachePruneReclaimsStoppedServiceSnapshots(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	engine := devEngineContainer(c, engineWithConfig(ctx, t, engineConfigWithEnabled(false)))
@@ -892,7 +892,7 @@ func (EngineSuite) TestLocalCachePruneReclaimsStoppedServiceSnapshots(ctx contex
 	require.LessOrEqual(t, usedAfterPrune, serviceUsedBytes-servicePayloadSignalBytes, "stopped service snapshots should be released by explicit prune")
 }
 
-func (EngineSuite) TestLocalCacheEntryRecordType(ctx context.Context, t *testctx.T) {
+func (LocalCacheSuite) TestLocalCacheEntryRecordType(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	_, err := c.Container().

--- a/core/query.go
+++ b/core/query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/containerd/containerd/v2/core/content"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
@@ -32,6 +33,9 @@ type Query struct {
 	// constructor. Set by the `with` field on Query so that entrypoint
 	// proxy resolvers can forward them to the constructor.
 	ConstructorArgs map[string]dagql.Input
+
+	cacheVolumeStoreMu sync.Mutex
+	cacheVolumeStore   *cacheVolumeStore
 }
 
 var (

--- a/core/query.go
+++ b/core/query.go
@@ -242,15 +242,22 @@ func (*Query) TypeDescription() string {
 	return "The root of the DAG."
 }
 
-func (q Query) Clone() *Query {
-	cp := q
+func (q *Query) Clone() *Query {
+	cp := &Query{
+		Server: q.Server,
+	}
 	if q.ConstructorArgs != nil {
 		cp.ConstructorArgs = make(map[string]dagql.Input, len(q.ConstructorArgs))
 		for k, v := range q.ConstructorArgs {
 			cp.ConstructorArgs[k] = v
 		}
 	}
-	return &cp
+
+	q.cacheVolumeStoreMu.Lock()
+	cp.cacheVolumeStore = q.cacheVolumeStore
+	q.cacheVolumeStoreMu.Unlock()
+
+	return cp
 }
 
 func (q *Query) WithPipeline(name, desc string) *Query {

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -16,7 +16,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/dagger/dagger/engine/client/pathutil"
-	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/dagger/internal/buildkit/util/contentutil"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
@@ -285,6 +284,7 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 	drive := pathutil.GetDrive(absRootCopyPath)
 
 	var mirror *core.ClientFilesyncMirror
+	var releaseEphemeralMirror func(context.Context) error
 	if clientMetadata.ClientStableID != "" {
 		var persistedMirror dagql.ObjectResult[*core.ClientFilesyncMirror]
 		if err := srv.Select(ctx, srv.Root(), &persistedMirror, dagql.Selector{
@@ -298,13 +298,16 @@ func (s *hostSchema) directory(ctx context.Context, host dagql.ObjectResult[*cor
 		}
 		mirror = persistedMirror.Self()
 	} else {
-		mirror = &core.ClientFilesyncMirror{
-			Drive:       drive,
-			EphemeralID: identity.NewID(),
-		}
+		mirror = core.NewEphemeralClientFilesyncMirror(drive)
 		if err := mirror.EnsureCreated(ctx, query); err != nil {
 			return inst, fmt.Errorf("failed to create ephemeral client filesync mirror: %w", err)
 		}
+		releaseEphemeralMirror = mirror.OnRelease
+		defer func() {
+			if releaseErr := releaseEphemeralMirror(context.WithoutCancel(ctx)); releaseErr != nil {
+				err = errors.Join(err, fmt.Errorf("release ephemeral client filesync mirror: %w", releaseErr))
+			}
+		}()
 	}
 
 	ref, contentDgst, err := mirror.Snapshot(ctx, query, callerConn, absRootCopyPath, snapshotOpts)

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -50,6 +50,8 @@ type CacheUsageEntry struct {
 	ID                        string
 	Description               string
 	RecordType                string
+	RecordTypes               []string
+	DagqlCall                 string
 	SizeBytes                 int64
 	CreatedTimeUnixNano       int64
 	MostRecentUseTimeUnixNano int64
@@ -1399,6 +1401,7 @@ type sharedResult struct {
 	createdAtUnixNano        int64
 	lastUsedAtUnixNano       int64
 	cacheUsageSizeByIdentity map[string]int64
+	cacheUsageRecordTypeByID map[string]string
 	description              string
 	recordType               string
 
@@ -2297,6 +2300,16 @@ func (r Result[T]) WithContentDigest(ctx context.Context, contentDigest digest.D
 			}
 			return cp
 		}(),
+		cacheUsageRecordTypeByID: func() map[string]string {
+			if len(r.shared.cacheUsageRecordTypeByID) == 0 {
+				return nil
+			}
+			cp := make(map[string]string, len(r.shared.cacheUsageRecordTypeByID))
+			for id, recordType := range r.shared.cacheUsageRecordTypeByID {
+				cp[id] = recordType
+			}
+			return cp
+		}(),
 		description: r.shared.description,
 		recordType:  r.shared.recordType,
 	}
@@ -2378,6 +2391,16 @@ func (r Result[T]) WithSessionResourceHandle(ctx context.Context, handle Session
 			cp := make(map[string]int64, len(r.shared.cacheUsageSizeByIdentity))
 			for id, sz := range r.shared.cacheUsageSizeByIdentity {
 				cp[id] = sz
+			}
+			return cp
+		}(),
+		cacheUsageRecordTypeByID: func() map[string]string {
+			if len(r.shared.cacheUsageRecordTypeByID) == 0 {
+				return nil
+			}
+			cp := make(map[string]string, len(r.shared.cacheUsageRecordTypeByID))
+			for id, recordType := range r.shared.cacheUsageRecordTypeByID {
+				cp[id] = recordType
 			}
 			return cp
 		}(),
@@ -3000,10 +3023,9 @@ func (c *Cache) usageEntriesLocked(activeRoots map[sharedResultID]struct{}) []Ca
 		if lastUsedAt == 0 {
 			lastUsedAt = createdAt
 		}
-		recordType := res.recordType
-		if recordType == "" {
-			recordType = "dagql.unknown"
-		}
+		recordTypes := cacheUsageRecordTypesFromMap(res.cacheUsageRecordTypeByID)
+		recordType := cacheUsagePrimaryRecordType(recordTypes, res.recordType)
+		dagqlCall := c.cacheUsageDagqlCallLocked(res)
 		description := res.description
 		if description == "" {
 			description = fmt.Sprintf("dagql cache result %d", resID)
@@ -3018,6 +3040,8 @@ func (c *Cache) usageEntriesLocked(activeRoots map[sharedResultID]struct{}) []Ca
 			ID:                        fmt.Sprintf("dagql.result.%d", resID),
 			Description:               description,
 			RecordType:                recordType,
+			RecordTypes:               recordTypes,
+			DagqlCall:                 dagqlCall,
 			SizeBytes:                 sizeBytes,
 			CreatedTimeUnixNano:       createdAt,
 			MostRecentUseTimeUnixNano: lastUsedAt,
@@ -3038,6 +3062,81 @@ func (c *Cache) usageEntriesLocked(activeRoots map[sharedResultID]struct{}) []Ca
 	return entries
 }
 
+func (c *Cache) cacheUsageDagqlCallLocked(res *sharedResult) string {
+	if c == nil || res == nil {
+		return ""
+	}
+	frame := res.loadResultCall()
+	if frame == nil {
+		return ""
+	}
+
+	fieldName := ""
+	if identityField, err := resultCallIdentityField(frame); err == nil {
+		fieldName = identityField
+	}
+
+	receiverTypeName := ""
+	if frame.Receiver != nil {
+		if receiverRes := c.resultsByID[sharedResultID(frame.Receiver.ResultID)]; receiverRes != nil {
+			receiverFrame := receiverRes.loadResultCall()
+			switch {
+			case receiverFrame != nil && receiverFrame.Type != nil && receiverFrame.Type.NamedType != "":
+				receiverTypeName = receiverFrame.Type.NamedType
+			default:
+				receiverState := receiverRes.loadPayloadState()
+				receiverTypeName = sharedResultObjectTypeName(receiverRes, receiverState)
+			}
+		}
+	}
+
+	switch {
+	case receiverTypeName != "" && fieldName != "":
+		return receiverTypeName + "." + fieldName
+	case fieldName != "":
+		if frame.Kind == ResultCallKindField {
+			return "Query." + fieldName
+		}
+		return fieldName
+	default:
+		return ""
+	}
+}
+
+func cacheUsageRecordTypesFromMap(recordTypeByID map[string]string) []string {
+	if len(recordTypeByID) == 0 {
+		return nil
+	}
+	recordTypes := make([]string, 0, len(recordTypeByID))
+	seen := make(map[string]struct{}, len(recordTypeByID))
+	for _, recordType := range recordTypeByID {
+		if recordType == "" {
+			continue
+		}
+		if _, ok := seen[recordType]; ok {
+			continue
+		}
+		seen[recordType] = struct{}{}
+		recordTypes = append(recordTypes, recordType)
+	}
+	slices.Sort(recordTypes)
+	return recordTypes
+}
+
+func cacheUsagePrimaryRecordType(recordTypes []string, fallback string) string {
+	switch len(recordTypes) {
+	case 0:
+		if fallback != "" {
+			return fallback
+		}
+		return "dagql.unknown"
+	case 1:
+		return recordTypes[0]
+	default:
+		return "mixed"
+	}
+}
+
 type cacheUsageMeasurementInput struct {
 	resultID         sharedResultID
 	self             Typed
@@ -3047,13 +3146,18 @@ type cacheUsageMeasurementInput struct {
 	sizeMayChange    bool
 }
 
+type cacheUsageIdentityMeasurement struct {
+	sizeBytes  int64
+	recordType string
+}
+
 func (c *Cache) measureAllResultSizes(ctx context.Context) {
 	inputs := c.collectUsageMeasurementInputs()
 	if len(inputs) == 0 {
 		return
 	}
-	sizes := buildCacheUsageMeasurements(ctx, c.snapshotManager, inputs)
-	c.publishUsageMeasurements(sizes)
+	measurements := buildCacheUsageMeasurements(ctx, c.snapshotManager, inputs)
+	c.publishUsageMeasurements(measurements)
 }
 
 func (c *Cache) collectUsageMeasurementInputs() []cacheUsageMeasurementInput {
@@ -3098,7 +3202,7 @@ func (c *Cache) collectUsageMeasurementInputs() []cacheUsageMeasurementInput {
 	return inputs
 }
 
-func buildCacheUsageMeasurements(ctx context.Context, snapshotManager bkcache.SnapshotManager, inputs []cacheUsageMeasurementInput) map[sharedResultID]map[string]int64 {
+func buildCacheUsageMeasurements(ctx context.Context, snapshotManager bkcache.SnapshotManager, inputs []cacheUsageMeasurementInput) map[sharedResultID]map[string]cacheUsageIdentityMeasurement {
 	if len(inputs) == 0 {
 		return nil
 	}
@@ -3121,82 +3225,106 @@ func buildCacheUsageMeasurements(ctx context.Context, snapshotManager bkcache.Sn
 	}
 	slices.Sort(identities)
 
-	sizeByIdentity := make(map[string]int64, len(ownerByIdentity))
+	measurementByIdentity := make(map[string]cacheUsageIdentityMeasurement, len(ownerByIdentity))
 	for _, identity := range identities {
 		ownerID := ownerByIdentity[identity]
 		input := inputByResultID[ownerID]
-		if !input.sizeMayChange {
-			if sizeBytes, ok := input.existingSizeByID[identity]; ok {
-				sizeByIdentity[identity] = sizeBytes
-				continue
-			}
-		}
-
 		var (
 			sizeBytes int64
 			ok        bool
 			err       error
 		)
-		if input.self != nil {
-			sizeBytes, ok, err = cacheUsageSizeBytesFromSelf(ctx, input.self, identity)
-		} else if len(input.snapshotLinks) > 0 {
-			sizeBytes, ok, err = cacheUsageSizeBytesFromSnapshotLink(ctx, snapshotManager, identity)
+		if !input.sizeMayChange {
+			if existingSizeBytes, found := input.existingSizeByID[identity]; found {
+				sizeBytes = existingSizeBytes
+				ok = true
+			}
 		}
+
+		if !ok {
+			if input.self != nil {
+				sizeBytes, ok, err = cacheUsageSizeBytesFromSelf(ctx, input.self, identity)
+			} else if len(input.snapshotLinks) > 0 {
+				sizeBytes, ok, err = cacheUsageSizeBytesFromSnapshotLink(ctx, snapshotManager, identity)
+			}
+			if err != nil {
+				slog.Warn("failed to determine cache usage size",
+					"resultID", ownerID,
+					"usageIdentity", identity,
+					"err", err)
+				continue
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		recordType, _, err := cacheUsageRecordTypeFromSnapshotMetadata(ctx, snapshotManager, identity)
 		if err != nil {
-			slog.Warn("failed to determine cache usage size",
+			slog.Warn("failed to determine cache usage record type",
 				"resultID", ownerID,
 				"usageIdentity", identity,
 				"err", err)
-			continue
-		}
-		if !ok {
-			continue
 		}
 		if sizeBytes < 0 {
 			sizeBytes = 0
 		}
-		sizeByIdentity[identity] = sizeBytes
+		measurementByIdentity[identity] = cacheUsageIdentityMeasurement{
+			sizeBytes:  sizeBytes,
+			recordType: recordType,
+		}
 	}
 
-	published := make(map[sharedResultID]map[string]int64, len(inputs))
+	published := make(map[sharedResultID]map[string]cacheUsageIdentityMeasurement, len(inputs))
 	for _, input := range inputs {
-		resultSizes := make(map[string]int64)
+		resultMeasurements := make(map[string]cacheUsageIdentityMeasurement)
 		for _, identity := range input.identities {
 			if ownerByIdentity[identity] != input.resultID {
 				continue
 			}
-			sizeBytes, ok := sizeByIdentity[identity]
+			measurement, ok := measurementByIdentity[identity]
 			if !ok {
 				continue
 			}
-			resultSizes[identity] = sizeBytes
+			resultMeasurements[identity] = measurement
 		}
-		if len(resultSizes) == 0 {
+		if len(resultMeasurements) == 0 {
 			continue
 		}
-		published[input.resultID] = resultSizes
+		published[input.resultID] = resultMeasurements
 	}
 
 	return published
 }
 
-func (c *Cache) publishUsageMeasurements(sizes map[sharedResultID]map[string]int64) {
+func (c *Cache) publishUsageMeasurements(measurements map[sharedResultID]map[string]cacheUsageIdentityMeasurement) {
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
 	for resultID, res := range c.resultsByID {
 		if res == nil {
 			continue
 		}
-		resultSizes, ok := sizes[resultID]
+		resultMeasurements, ok := measurements[resultID]
 		if !ok {
 			res.cacheUsageSizeByIdentity = nil
+			res.cacheUsageRecordTypeByID = nil
 			continue
 		}
-		cp := make(map[string]int64, len(resultSizes))
-		for identity, sizeBytes := range resultSizes {
-			cp[identity] = sizeBytes
+		sizeByIdentity := make(map[string]int64, len(resultMeasurements))
+		recordTypeByIdentity := make(map[string]string, len(resultMeasurements))
+		for identity, measurement := range resultMeasurements {
+			sizeByIdentity[identity] = measurement.sizeBytes
+			if measurement.recordType != "" {
+				recordTypeByIdentity[identity] = measurement.recordType
+			}
 		}
-		res.cacheUsageSizeByIdentity = cp
+		res.cacheUsageSizeByIdentity = sizeByIdentity
+		res.cacheUsageRecordTypeByID = recordTypeByIdentity
+
+		recordTypes := cacheUsageRecordTypesFromMap(recordTypeByIdentity)
+		if len(recordTypes) > 0 {
+			res.recordType = cacheUsagePrimaryRecordType(recordTypes, "")
+		}
 	}
 }
 
@@ -4114,6 +4242,17 @@ func cacheUsageSizeBytesFromSnapshotLink(ctx context.Context, snapshotManager bk
 		return 0, false, err
 	}
 	return sizeBytes, true, nil
+}
+
+func cacheUsageRecordTypeFromSnapshotMetadata(ctx context.Context, snapshotManager bkcache.SnapshotManager, identity string) (string, bool, error) {
+	if snapshotManager == nil || identity == "" {
+		return "", false, nil
+	}
+	md, ok, err := snapshotManager.SnapshotRecordMetadata(ctx, identity)
+	if err != nil || !ok || md.RecordType == "" {
+		return "", ok, err
+	}
+	return string(md.RecordType), true, nil
 }
 
 func cacheUsageIdentitiesFromSelf(self Typed) []string {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -65,7 +65,7 @@ type CachePrunePolicy struct {
 	MinFreeSpace  int64
 	TargetSpace   int64
 
-	// CurrentFreeSpace is optional free-disk bytes at prune start used to
+	// CurrentFreeSpace is optional available-disk bytes at prune start used to
 	// evaluate MinFreeSpace. When unset, MinFreeSpace behaves as if free space
 	// were zero.
 	CurrentFreeSpace int64

--- a/dagql/cache_prune.go
+++ b/dagql/cache_prune.go
@@ -212,10 +212,8 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}) prun
 		if lastUsedAt == 0 {
 			lastUsedAt = createdAt
 		}
-		recordType := res.recordType
-		if recordType == "" {
-			recordType = "dagql.unknown"
-		}
+		recordTypes := cacheUsageRecordTypesFromMap(res.cacheUsageRecordTypeByID)
+		recordType := cacheUsagePrimaryRecordType(recordTypes, res.recordType)
 		description := res.description
 		if description == "" {
 			description = fmt.Sprintf("dagql cache result %d", resID)
@@ -229,37 +227,7 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}) prun
 		slices.Sort(deps)
 
 		callFrame := res.loadResultCall()
-		fieldName := ""
-		receiverTypeName := ""
-		callLabel := ""
-		if callFrame != nil {
-			frame := callFrame
-			if identityField, err := resultCallIdentityField(frame); err == nil {
-				fieldName = identityField
-			}
-			if frame.Receiver != nil {
-				if receiverRes := c.resultsByID[sharedResultID(frame.Receiver.ResultID)]; receiverRes != nil {
-					receiverFrame := receiverRes.loadResultCall()
-					switch {
-					case receiverFrame != nil && receiverFrame.Type != nil && receiverFrame.Type.NamedType != "":
-						receiverTypeName = receiverFrame.Type.NamedType
-					default:
-						receiverState := receiverRes.loadPayloadState()
-						receiverTypeName = sharedResultObjectTypeName(receiverRes, receiverState)
-					}
-				}
-			}
-			switch {
-			case receiverTypeName != "" && fieldName != "":
-				callLabel = receiverTypeName + "." + fieldName
-			case fieldName != "":
-				if frame.Kind == ResultCallKindField {
-					callLabel = "Query." + fieldName
-				} else {
-					callLabel = fieldName
-				}
-			}
-		}
+		callLabel := c.cacheUsageDagqlCallLocked(res)
 
 		edge, hasPersistedEdge := c.persistedEdgesByResult[resID]
 		snapshot.results[resID] = pruneSnapshotResult{
@@ -271,6 +239,8 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}) prun
 				ID:                        fmt.Sprintf("dagql.result.%d", resID),
 				Description:               description,
 				RecordType:                recordType,
+				RecordTypes:               recordTypes,
+				DagqlCall:                 callLabel,
 				SizeBytes:                 sizeBytes,
 				CreatedTimeUnixNano:       createdAt,
 				MostRecentUseTimeUnixNano: lastUsedAt,
@@ -654,35 +624,74 @@ func cachePrunePolicyMatchesEntry(policy CachePrunePolicy, entry CacheUsageEntry
 		return true
 	}
 	for _, filter := range policy.Filters {
-		key, value, ok := strings.Cut(filter, "==")
-		if !ok {
-			return false
-		}
-		key = strings.TrimSpace(strings.ToLower(key))
-		value = strings.TrimSpace(value)
-		switch key {
-		case "id":
-			if entry.ID != value {
-				return false
-			}
-		case "type", "recordtype":
-			if entry.RecordType != value {
-				return false
-			}
-		case "description":
-			if entry.Description != value {
-				return false
-			}
-		case "inuse":
-			want, err := strconv.ParseBool(value)
-			if err != nil || entry.ActivelyUsed != want {
-				return false
-			}
-		default:
+		if !cachePruneFilterMatchesEntry(filter, entry) {
 			return false
 		}
 	}
 	return true
+}
+
+func cachePruneFilterMatchesEntry(filter string, entry CacheUsageEntry) bool {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return false
+	}
+
+	if strings.Contains(filter, ",") {
+		clauses := strings.Split(filter, ",")
+		recordTypeFilter := true
+		recordTypeMatch := false
+		for _, clause := range clauses {
+			key, value, ok := strings.Cut(clause, "==")
+			if !ok {
+				recordTypeFilter = false
+				break
+			}
+			key = strings.TrimSpace(strings.ToLower(key))
+			if key != "type" && key != "recordtype" {
+				recordTypeFilter = false
+				break
+			}
+			if cacheUsageEntryRecordTypeMatches(entry, strings.TrimSpace(value)) {
+				recordTypeMatch = true
+			}
+		}
+		if recordTypeFilter {
+			return recordTypeMatch
+		}
+	}
+
+	key, value, ok := strings.Cut(filter, "==")
+	if !ok {
+		return false
+	}
+	key = strings.TrimSpace(strings.ToLower(key))
+	value = strings.TrimSpace(value)
+	switch key {
+	case "id":
+		return entry.ID == value
+	case "type", "recordtype":
+		return cacheUsageEntryRecordTypeMatches(entry, value)
+	case "description":
+		return entry.Description == value
+	case "inuse":
+		want, err := strconv.ParseBool(value)
+		return err == nil && entry.ActivelyUsed == want
+	default:
+		return false
+	}
+}
+
+func cacheUsageEntryRecordTypeMatches(entry CacheUsageEntry, value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, recordType := range entry.RecordTypes {
+		if recordType == value {
+			return true
+		}
+	}
+	return entry.RecordType == value
 }
 
 func max(a, b int64) int64 {

--- a/dagql/cache_prune_test.go
+++ b/dagql/cache_prune_test.go
@@ -1,0 +1,46 @@
+package dagql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachePrunePolicyMatchesLegacyRecordTypeListFilter(t *testing.T) {
+	policy := CachePrunePolicy{
+		Filters: []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
+	}
+
+	for _, recordType := range []string{"source.local", "exec.cachemount", "source.git.checkout"} {
+		require.True(t, cachePrunePolicyMatchesEntry(policy, CacheUsageEntry{
+			RecordTypes: []string{recordType},
+		}))
+	}
+
+	require.False(t, cachePrunePolicyMatchesEntry(policy, CacheUsageEntry{
+		RecordTypes: []string{"regular"},
+	}))
+	require.True(t, cachePrunePolicyMatchesEntry(policy, CacheUsageEntry{
+		RecordType:  "mixed",
+		RecordTypes: []string{"regular", "exec.cachemount"},
+	}))
+}
+
+func TestCachePrunePolicyMatchesExistingScalarFilters(t *testing.T) {
+	entry := CacheUsageEntry{
+		ID:           "entry-id",
+		Description:  "entry description",
+		RecordType:   "regular",
+		ActivelyUsed: true,
+	}
+
+	require.True(t, cachePrunePolicyMatchesEntry(CachePrunePolicy{Filters: []string{
+		"id==entry-id",
+		"description==entry description",
+		"recordtype==regular",
+		"inuse==true",
+	}}, entry))
+
+	require.False(t, cachePrunePolicyMatchesEntry(CachePrunePolicy{Filters: []string{"inuse==false"}}, entry))
+	require.False(t, cachePrunePolicyMatchesEntry(CachePrunePolicy{Filters: []string{"type==source.local"}}, entry))
+}

--- a/dagql/cache_snapshot_persistence_test.go
+++ b/dagql/cache_snapshot_persistence_test.go
@@ -58,6 +58,7 @@ type fakeSnapshotManager struct {
 	persistentRows      bkcache.PersistentMetadataRows
 	loadedRows          bkcache.PersistentMetadataRows
 	snapshotSizes       map[string]int64
+	snapshotMetadata    map[string]bkcache.SnapshotRecordMetadata
 	snapshotSizeCalls   []string
 	attachCalls         []struct{ LeaseID, SnapshotID string }
 	removeCalls         []string
@@ -88,6 +89,15 @@ func (m *fakeSnapshotManager) SnapshotSize(ctx context.Context, snapshotID strin
 	}
 	m.snapshotSizeCalls = append(m.snapshotSizeCalls, snapshotID)
 	return sizeBytes, nil
+}
+
+func (m *fakeSnapshotManager) SnapshotRecordMetadata(ctx context.Context, snapshotID string) (bkcache.SnapshotRecordMetadata, bool, error) {
+	_ = ctx
+	if m.snapshotMetadata == nil {
+		return bkcache.SnapshotRecordMetadata{}, false, nil
+	}
+	md, ok := m.snapshotMetadata[snapshotID]
+	return md, ok, nil
 }
 
 func (*fakeSnapshotManager) New(context.Context, bkcache.ImmutableRef, ...bkcache.RefOption) (bkcache.MutableRef, error) {

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -5327,6 +5327,24 @@ func TestCachePruneThresholdTargetSpace(t *testing.T) {
 	assert.Equal(t, cacheTestSharedResultEntryID(results[1]), report.Entries[1].ID)
 }
 
+func TestCachePruneMinFreeSpaceUsesCurrentFreeSpace(t *testing.T) {
+	t.Parallel()
+
+	target, triggered := pruneTargetBytes(CachePrunePolicy{
+		MinFreeSpace:     200,
+		CurrentFreeSpace: 150,
+	}, 50)
+	assert.Assert(t, triggered)
+	assert.Equal(t, int64(50), target)
+
+	target, triggered = pruneTargetBytes(CachePrunePolicy{
+		MinFreeSpace:     200,
+		CurrentFreeSpace: 250,
+	}, 50)
+	assert.Assert(t, !triggered)
+	assert.Equal(t, int64(0), target)
+}
+
 func TestCachePruneSessionOwnedEntriesAreNeverPruned(t *testing.T) {
 	t.Parallel()
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2308,6 +2308,9 @@ type EngineCacheEntry {
   """The time the cache entry was created, in Unix nanoseconds."""
   createdTimeUnixNano: Int!
 
+  """The DagQL call that produced this cache entry."""
+  dagqlCall: String!
+
   """The description of the cache entry."""
   description: String!
 
@@ -2324,6 +2327,9 @@ type EngineCacheEntry {
   The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).
   """
   recordType: String!
+
+  """The storage record types represented by this cache entry."""
+  recordTypes: [String!]!
 }
 
 """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -9196,6 +9196,10 @@
                         <td> The time the cache entry was created, in Unix nanoseconds. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="EngineCacheEntry-dagqlCall" href="#EngineCacheEntry-dagqlCall"><code>dagqlCall</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The DagQL call that produced this cache entry. </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="EngineCacheEntry-description" href="#EngineCacheEntry-description"><code>description</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The description of the cache entry. </td>
                       </tr>
@@ -9214,6 +9218,10 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="EngineCacheEntry-recordType" href="#EngineCacheEntry-recordType"><code>recordType</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount). </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="EngineCacheEntry-recordTypes" href="#EngineCacheEntry-recordTypes"><code>recordTypes</code></a> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span> </td>
+                        <td> The storage record types represented by this cache entry. </td>
                       </tr>
                     </tbody>
                   </table>

--- a/docs/static/reference/php/Dagger/EngineCacheEntry.html
+++ b/docs/static/reference/php/Dagger/EngineCacheEntry.html
@@ -80,31 +80,31 @@
         </div>
                 <div id="page-content">
     <div class="page-header">
-        <h1>EngineCacheEntry    
+        <h1>EngineCacheEntry
             </h1>
     </div>
 
-    
+
     <p>        class
     <strong>EngineCacheEntry</strong>        extends <a href="../Dagger/Client/AbstractObject.html"><abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a>        implements        <a href="../Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a>
 </p>
 
-        
-    
-        
+
+
+
 
             <div class="description">
             <p><p>An individual cache entry in a cache entry set</p></p>                    </div>
-            
-        
-    
+
+
+
             <h2>Properties</h2>
 
             <table class="table table-condensed">
                     <tr>
                 <td class="type" id="property_lastQuery">
-                                                                                
-                                                                                
+
+
                                     </td>
                 <td>$lastQuery</td>
                 <td class="last"></td>
@@ -113,17 +113,17 @@
             </tr>
             </table>
 
-    
+
             <h2>Methods</h2>
 
             <div class="container-fluid underlined">
                     <div class="row">
                 <div class="col-md-2 type">
-                    
+
                 </div>
                 <div class="col-md-8">
                     <a href="#method___construct">__construct</a>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method___construct">
@@ -135,7 +135,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_queryLeaf">queryLeaf</a>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
-        
+
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method_queryLeaf">
@@ -147,7 +147,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_activelyUsed">activelyUsed</a>()
-        
+
                                             <p><p>Whether the cache entry is actively being used.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -157,7 +157,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_createdTimeUnixNano">createdTimeUnixNano</a>()
-        
+
                                             <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -166,8 +166,18 @@
                     string
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_dagqlCall">dagqlCall</a>()
+
+                                            <p><p>The DagQL call that produced this cache entry.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
                     <a href="#method_description">description</a>()
-        
+
                                             <p><p>The description of the cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -177,7 +187,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_diskSpaceBytes">diskSpaceBytes</a>()
-        
+
                                             <p><p>The disk space used by the cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -187,7 +197,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_id">id</a>()
-        
+
                                             <p><p>A unique identifier for this EngineCacheEntry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -197,7 +207,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_mostRecentUseTimeUnixNano">mostRecentUseTimeUnixNano</a>()
-        
+
                                             <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -207,8 +217,18 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_recordType">recordType</a>()
-        
+
                                             <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    array
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_recordTypes">recordTypes</a>()
+
+                                            <p><p>The storage record types represented by this cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
             </div>
@@ -221,17 +241,17 @@
                     <h3 id="method___construct">
         <div class="location">in <a href="../Dagger/Client/AbstractObject.html#method___construct">
 <abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a> at line 13</div>
-        <code>                    
+        <code>
     <strong>__construct</strong>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -249,10 +269,10 @@
             </tr>
             </table>
 
-            
-            
-            
-            
+
+
+
+
                     </div>
     </div>
 
@@ -265,13 +285,13 @@
     <strong>queryLeaf</strong>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-                    
+
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -289,7 +309,7 @@
             </tr>
             </table>
 
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -299,9 +319,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -313,15 +333,15 @@
     <strong>activelyUsed</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>Whether the cache entry is actively being used.</p></p>                        
+                            <p><p>Whether the cache entry is actively being used.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -331,9 +351,9 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
@@ -345,15 +365,15 @@
     <strong>createdTimeUnixNano</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>                        
+                            <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -363,29 +383,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_description">
+                    <h3 id="method_dagqlCall">
         <div class="location">at line 37</div>
         <code>                    string
-    <strong>description</strong>()
+    <strong>dagqlCall</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The description of the cache entry.</p></p>                        
+                            <p><p>The DagQL call that produced this cache entry.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -395,29 +415,61 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_description">
+        <div class="location">at line 46</div>
+        <code>                    string
+    <strong>description</strong>()
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>The description of the cache entry.</p></p>
+        </div>
+        <div class="tags">
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_diskSpaceBytes">
-        <div class="location">at line 46</div>
+        <div class="location">at line 55</div>
         <code>                    int
     <strong>diskSpaceBytes</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The disk space used by the cache entry.</p></p>                        
+                            <p><p>The disk space used by the cache entry.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -427,29 +479,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 55</div>
+        <div class="location">at line 64</div>
         <code>                    <a href="../Dagger/Client/AbstractId.html"><abbr title="Dagger\Client\AbstractId">AbstractId</abbr></a>
     <strong>id</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>A unique identifier for this EngineCacheEntry.</p></p>                        
+                            <p><p>A unique identifier for this EngineCacheEntry.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -459,29 +511,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_mostRecentUseTimeUnixNano">
-        <div class="location">at line 64</div>
+        <div class="location">at line 73</div>
         <code>                    int
     <strong>mostRecentUseTimeUnixNano</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>                        
+                            <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -491,29 +543,29 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
                     </div>
     </div>
 
             </div>
                     <div class="method-item">
                     <h3 id="method_recordType">
-        <div class="location">at line 73</div>
+        <div class="location">at line 82</div>
         <code>                    string
     <strong>recordType</strong>()
         </code>
     </h3>
-    <div class="details">    
-    
-            
+    <div class="details">
+
+
 
         <div class="method-description">
-                            <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>                        
+                            <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>
         </div>
         <div class="tags">
-            
+
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -523,16 +575,48 @@
         </tr>
     </table>
 
-            
-            
-            
+
+
+
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_recordTypes">
+        <div class="location">at line 91</div>
+        <code>                    array
+    <strong>recordTypes</strong>()
+        </code>
+    </h3>
+    <div class="details">
+
+
+
+        <div class="method-description">
+                            <p><p>The storage record types represented by this cache entry.</p></p>
+        </div>
+        <div class="tags">
+
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>array</td>
+            <td></td>
+        </tr>
+    </table>
+
+
+
+
                     </div>
     </div>
 
             </div>
             </div>
 
-    
+
 </div><div id="footer">
         Generated by <a href="https://github.com/code-lts/doctum">Doctum, a API Documentation generator and fork of Sami</a>.</div></div>
     </div>

--- a/docs/static/reference/php/Dagger/EngineCacheEntry.html
+++ b/docs/static/reference/php/Dagger/EngineCacheEntry.html
@@ -80,31 +80,31 @@
         </div>
                 <div id="page-content">
     <div class="page-header">
-        <h1>EngineCacheEntry
+        <h1>EngineCacheEntry    
             </h1>
     </div>
 
-
+    
     <p>        class
     <strong>EngineCacheEntry</strong>        extends <a href="../Dagger/Client/AbstractObject.html"><abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a>        implements        <a href="../Dagger/Client/IdAble.html"><abbr title="Dagger\Client\IdAble">IdAble</abbr></a>
 </p>
 
-
-
-
+        
+    
+        
 
             <div class="description">
             <p><p>An individual cache entry in a cache entry set</p></p>                    </div>
-
-
-
+            
+        
+    
             <h2>Properties</h2>
 
             <table class="table table-condensed">
                     <tr>
                 <td class="type" id="property_lastQuery">
-
-
+                                                                                
+                                                                                
                                     </td>
                 <td>$lastQuery</td>
                 <td class="last"></td>
@@ -113,17 +113,17 @@
             </tr>
             </table>
 
-
+    
             <h2>Methods</h2>
 
             <div class="container-fluid underlined">
                     <div class="row">
                 <div class="col-md-2 type">
-
+                    
                 </div>
                 <div class="col-md-8">
                     <a href="#method___construct">__construct</a>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
-
+        
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method___construct">
@@ -135,7 +135,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_queryLeaf">queryLeaf</a>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
-
+        
                                             <p class="no-description">No description</p>
                                     </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractObject.html#method_queryLeaf">
@@ -147,7 +147,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_activelyUsed">activelyUsed</a>()
-
+        
                                             <p><p>Whether the cache entry is actively being used.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -157,7 +157,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_createdTimeUnixNano">createdTimeUnixNano</a>()
-
+        
                                             <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -167,7 +167,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_dagqlCall">dagqlCall</a>()
-
+        
                                             <p><p>The DagQL call that produced this cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -177,7 +177,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_description">description</a>()
-
+        
                                             <p><p>The description of the cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -187,7 +187,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_diskSpaceBytes">diskSpaceBytes</a>()
-
+        
                                             <p><p>The disk space used by the cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -197,7 +197,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_id">id</a>()
-
+        
                                             <p><p>A unique identifier for this EngineCacheEntry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -207,7 +207,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_mostRecentUseTimeUnixNano">mostRecentUseTimeUnixNano</a>()
-
+        
                                             <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -217,7 +217,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_recordType">recordType</a>()
-
+        
                                             <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -227,7 +227,7 @@
                 </div>
                 <div class="col-md-8">
                     <a href="#method_recordTypes">recordTypes</a>()
-
+        
                                             <p><p>The storage record types represented by this cache entry.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -241,17 +241,17 @@
                     <h3 id="method___construct">
         <div class="location">in <a href="../Dagger/Client/AbstractObject.html#method___construct">
 <abbr title="Dagger\Client\AbstractObject">AbstractObject</abbr></a> at line 13</div>
-        <code>
+        <code>                    
     <strong>__construct</strong>(<a href="../Dagger/Client/AbstractClient.html"><abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> $client, <abbr title="Dagger\GraphQl\QueryBuilderChain">QueryBuilderChain</abbr> $queryBuilderChain)
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-
+                    
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -269,10 +269,10 @@
             </tr>
             </table>
 
-
-
-
-
+            
+            
+            
+            
                     </div>
     </div>
 
@@ -285,13 +285,13 @@
     <strong>queryLeaf</strong>(<abbr title="GraphQL\QueryBuilder\QueryBuilder">QueryBuilder</abbr> $leafQueryBuilder, string $leafKey)
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
                             <p class="no-description">No description</p>
-
+                    
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -309,7 +309,7 @@
             </tr>
             </table>
 
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -319,9 +319,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -333,15 +333,15 @@
     <strong>activelyUsed</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>Whether the cache entry is actively being used.</p></p>
+                            <p><p>Whether the cache entry is actively being used.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -351,9 +351,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -365,15 +365,15 @@
     <strong>createdTimeUnixNano</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>
+                            <p><p>The time the cache entry was created, in Unix nanoseconds.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -383,9 +383,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -397,15 +397,15 @@
     <strong>dagqlCall</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The DagQL call that produced this cache entry.</p></p>
+                            <p><p>The DagQL call that produced this cache entry.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -415,9 +415,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -429,15 +429,15 @@
     <strong>description</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The description of the cache entry.</p></p>
+                            <p><p>The description of the cache entry.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -447,9 +447,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -461,15 +461,15 @@
     <strong>diskSpaceBytes</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The disk space used by the cache entry.</p></p>
+                            <p><p>The disk space used by the cache entry.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -479,9 +479,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -493,15 +493,15 @@
     <strong>id</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>A unique identifier for this EngineCacheEntry.</p></p>
+                            <p><p>A unique identifier for this EngineCacheEntry.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -511,9 +511,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -525,15 +525,15 @@
     <strong>mostRecentUseTimeUnixNano</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>
+                            <p><p>The most recent time the cache entry was used, in Unix nanoseconds.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -543,9 +543,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -557,15 +557,15 @@
     <strong>recordType</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>
+                            <p><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -575,9 +575,9 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
@@ -589,15 +589,15 @@
     <strong>recordTypes</strong>()
         </code>
     </h3>
-    <div class="details">
-
-
+    <div class="details">    
+    
+            
 
         <div class="method-description">
-                            <p><p>The storage record types represented by this cache entry.</p></p>
+                            <p><p>The storage record types represented by this cache entry.</p></p>                        
         </div>
         <div class="tags">
-
+            
                             <h4>Return Value</h4>
 
                     <table class="table table-condensed">
@@ -607,16 +607,16 @@
         </tr>
     </table>
 
-
-
-
+            
+            
+            
                     </div>
     </div>
 
             </div>
             </div>
 
-
+    
 </div><div id="footer">
         Generated by <a href="https://github.com/code-lts/doctum">Doctum, a API Documentation generator and fork of Sami</a>.</div></div>
     </div>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -423,7 +423,9 @@
                     <dd><p>Retrieves a directory at the given path.</p></dd><dt><a href="Dagger/Directory.html#method_dockerBuild">
 <abbr title="Dagger\Directory">Directory</abbr>::dockerBuild</a>() &mdash; <em>Method in class <a href="Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></em></dt>
                     <dd><p>Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.</p></dd><dt><a href="Dagger/DirectoryId.html"><abbr title="Dagger\DirectoryId">DirectoryId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
-                    <dd><p>The <code>DirectoryID</code> scalar type represents an identifier for an object of type Directory.</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_description">
+                    <dd><p>The <code>DirectoryID</code> scalar type represents an identifier for an object of type Directory.</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_dagqlCall">
+<abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr>::dagqlCall</a>() &mdash; <em>Method in class <a href="Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a></em></dt>
+                    <dd><p>The DagQL call that produced this cache entry.</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_description">
 <abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr>::description</a>() &mdash; <em>Method in class <a href="Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a></em></dt>
                     <dd><p>The description of the cache entry.</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_diskSpaceBytes">
 <abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr>::diskSpaceBytes</a>() &mdash; <em>Method in class <a href="Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a></em></dt>
@@ -1273,7 +1275,9 @@
 <abbr title="Dagger\EngineCache">EngineCache</abbr>::reservedSpace</a>() &mdash; <em>Method in class <a href="Dagger/EngineCache.html"><abbr title="Dagger\EngineCache">EngineCache</abbr></a></em></dt>
                     <dd><p>The minimum amount of disk space this policy is guaranteed to retain.</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_recordType">
 <abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr>::recordType</a>() &mdash; <em>Method in class <a href="Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a></em></dt>
-                    <dd><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></dd><dt><a href="Dagger/FunctionCall.html#method_returnError">
+                    <dd><p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p></dd><dt><a href="Dagger/EngineCacheEntry.html#method_recordTypes">
+<abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr>::recordTypes</a>() &mdash; <em>Method in class <a href="Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a></em></dt>
+                    <dd><p>The storage record types represented by this cache entry.</p></dd><dt><a href="Dagger/FunctionCall.html#method_returnError">
 <abbr title="Dagger\FunctionCall">FunctionCall</abbr>::returnError</a>() &mdash; <em>Method in class <a href="Dagger/FunctionCall.html"><abbr title="Dagger\FunctionCall">FunctionCall</abbr></a></em></dt>
                     <dd><p>Return an error from the function.</p></dd><dt><a href="Dagger/FunctionCall.html#method_returnValue">
 <abbr title="Dagger\FunctionCall">FunctionCall</abbr>::returnValue</a>() &mdash; <em>Method in class <a href="Dagger/FunctionCall.html"><abbr title="Dagger\FunctionCall">FunctionCall</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -3703,6 +3703,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::dagqlCall",
+			"p": "Dagger/EngineCacheEntry.html#method_dagqlCall",
+			"d": "<p>The DagQL call that produced this cache entry.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\EngineCacheEntry::description",
 			"p": "Dagger/EngineCacheEntry.html#method_description",
 			"d": "<p>The description of the cache entry.</p>"
@@ -3730,6 +3736,12 @@
 			"n": "Dagger\\EngineCacheEntry::recordType",
 			"p": "Dagger/EngineCacheEntry.html#method_recordType",
 			"d": "<p>The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\EngineCacheEntry::recordTypes",
+			"p": "Dagger/EngineCacheEntry.html#method_recordTypes",
+			"d": "<p>The storage record types represented by this cache entry.</p>"
 		},
 		{
 			"t": "M",

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -101,7 +101,7 @@ func resolveEngineLocalCachePrunePolicies(defaultPolicy []dagqlCachePrunePolicy,
 		}
 	}
 	for i := range prunePolicies {
-		prunePolicies[i].CurrentFreeSpace = dstat.Free
+		prunePolicies[i].CurrentFreeSpace = dstat.Available
 	}
 	return prunePolicies, nil
 }
@@ -196,7 +196,7 @@ func (srv *Server) gc() {
 	// static and must not be mutated in place.
 	prunePolicies := cloneDagqlCachePrunePolicies(srv.workerGCPolicies)
 	for i := range prunePolicies {
-		prunePolicies[i].CurrentFreeSpace = dstat.Free
+		prunePolicies[i].CurrentFreeSpace = dstat.Available
 	}
 
 	report, err := srv.engineCache.Prune(context.Background(), prunePolicies)

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/config"
+	bkclient "github.com/dagger/dagger/internal/buildkit/client"
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/disk"
@@ -70,6 +72,8 @@ func engineCacheEntrySetFromUsage(entries []dagql.CacheUsageEntry) *core.EngineC
 			MostRecentUseTimeUnixNano: int(entry.MostRecentUseTimeUnixNano),
 			ActivelyUsed:              entry.ActivelyUsed,
 			RecordType:                entry.RecordType,
+			RecordTypes:               entry.RecordTypes,
+			DagqlCall:                 entry.DagqlCall,
 		}
 		set.EntriesList = append(set.EntriesList, ent)
 		set.DiskSpaceBytes += int(entry.SizeBytes)
@@ -266,16 +270,36 @@ func defaultGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, dstat disk.Disk
 		space = DetectDefaultGCCap(dstat)
 	}
 
-	policies := convertBkPolicies(bkconfig.DefaultGCPolicy(bkconfig.GCConfig{
-		GCMinFreeSpace:  bkconfig.DiskSpace(space.MinFreeSpace),
-		GCReservedSpace: bkconfig.DiskSpace(space.ReservedSpace),
-		GCMaxUsedSpace:  bkconfig.DiskSpace(space.MaxUsedSpace),
-	}, dstat))
-	for i, policy := range policies {
-		policy.SweepSize = space.SweepSize
-		policies[i] = policy
+	defaultSpace := config.GCSpace{
+		ReservedSpace: space.ReservedSpace,
+		MaxUsedSpace:  space.MaxUsedSpace,
+		MinFreeSpace:  space.MinFreeSpace,
+		SweepSize:     space.SweepSize,
 	}
-	return policies
+
+	return []config.GCPolicy{
+		{
+			Filters: []string{fmt.Sprintf(
+				"type==%s,type==%s,type==%s",
+				bkclient.UsageRecordTypeLocalSource,
+				bkclient.UsageRecordTypeCacheMount,
+				bkclient.UsageRecordTypeGitCheckout,
+			)},
+			KeepDuration: config.Duration{Duration: 48 * time.Hour},
+			GCSpace: config.GCSpace{
+				MaxUsedSpace: config.DiskSpace{Bytes: 512 * 1e6},
+				SweepSize:    space.SweepSize,
+			},
+		},
+		{
+			KeepDuration: config.Duration{Duration: 60 * 24 * time.Hour},
+			GCSpace:      defaultSpace,
+		},
+		{
+			All:     true,
+			GCSpace: defaultSpace,
+		},
+	}
 }
 
 func DetectDefaultGCCap(dstat disk.DiskStat) config.GCSpace {

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -185,6 +185,39 @@ func TestGetDagqlGCPolicyFallsBackToBuildkitGCPolicy(t *testing.T) {
 	}, policies[0])
 }
 
+func TestGetDagqlGCPolicyDefaultPolicies(t *testing.T) {
+	cfg := config.Config{
+		GC: config.GCConfig{
+			GCSpace: config.GCSpace{
+				ReservedSpace: config.DiskSpace{Bytes: 100},
+				MaxUsedSpace:  config.DiskSpace{Bytes: 1000},
+				MinFreeSpace:  config.DiskSpace{Bytes: 200},
+			},
+		},
+	}
+
+	policies := getDagqlGCPolicy(cfg, bkconfig.GCConfig{}, t.TempDir())
+	require.Equal(t, []dagqlCachePrunePolicy{
+		{
+			Filters:      []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
+			KeepDuration: 48 * time.Hour,
+			MaxUsedSpace: 512 * 1e6,
+		},
+		{
+			KeepDuration:  60 * 24 * time.Hour,
+			ReservedSpace: 100,
+			MaxUsedSpace:  1000,
+			MinFreeSpace:  200,
+		},
+		{
+			All:           true,
+			ReservedSpace: 100,
+			MaxUsedSpace:  1000,
+			MinFreeSpace:  200,
+		},
+	}, policies)
+}
+
 func mustParseDiskSpace(t *testing.T, value string, dstat disk.DiskStat) int64 {
 	t.Helper()
 	var parsed bkconfig.DiskSpace

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -84,6 +84,31 @@ func TestResolveEngineLocalCachePrunePoliciesOverridesReservedAndMinFree(t *test
 	require.Equal(t, originalPolicy, defaultPolicy)
 }
 
+func TestResolveEngineLocalCachePrunePoliciesUsesAvailableSpaceForMinFree(t *testing.T) {
+	dstat := disk.DiskStat{
+		Total:     100 * 1e9,
+		Free:      25 * 1e9,
+		Available: 15 * 1e9,
+	}
+	defaultPolicy := []dagqlCachePrunePolicy{
+		{
+			All:           true,
+			ReservedSpace: 10 * 1e9,
+			MaxUsedSpace:  75 * 1e9,
+			MinFreeSpace:  20 * 1e9,
+		},
+	}
+
+	prunePolicies, err := resolveEngineLocalCachePrunePolicies(defaultPolicy, core.EngineCachePruneOptions{
+		UseDefaultPolicy: true,
+	}, dstat)
+	require.NoError(t, err)
+	require.Len(t, prunePolicies, 1)
+	require.Equal(t, dstat.Available, prunePolicies[0].CurrentFreeSpace)
+	require.Less(t, prunePolicies[0].CurrentFreeSpace, prunePolicies[0].MinFreeSpace)
+	require.GreaterOrEqual(t, dstat.Free, prunePolicies[0].MinFreeSpace)
+}
+
 func TestResolveEngineLocalCachePrunePoliciesInvalidSpaceValue(t *testing.T) {
 	dstat := disk.DiskStat{Total: 100 * 1e9}
 

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -729,7 +729,7 @@ func (srv *Server) GracefulStop(ctx context.Context) error {
 		} else {
 			prunePolicies := cloneDagqlCachePrunePolicies(srv.workerGCPolicies)
 			for i := range prunePolicies {
-				prunePolicies[i].CurrentFreeSpace = dstat.Free
+				prunePolicies[i].CurrentFreeSpace = dstat.Available
 			}
 			_, pruneErr := srv.engineCache.Prune(ctx, prunePolicies)
 			if pruneErr != nil {

--- a/engine/snapshots/manager.go
+++ b/engine/snapshots/manager.go
@@ -65,12 +65,18 @@ type Accessor interface {
 type SnapshotManager interface {
 	Accessor
 	SnapshotSize(ctx context.Context, snapshotID string) (int64, error)
+	SnapshotRecordMetadata(ctx context.Context, snapshotID string) (SnapshotRecordMetadata, bool, error)
 	AttachLease(ctx context.Context, leaseID, snapshotID string) error
 	RemoveLease(ctx context.Context, leaseID string) error
 	LoadPersistentMetadata(rows PersistentMetadataRows) error
 	PersistentMetadataRows() PersistentMetadataRows
 	DeleteStaleDaggerOwnerLeases(ctx context.Context, keep map[string]struct{}) error
 	Close() error
+}
+
+type SnapshotRecordMetadata struct {
+	RecordType  client.UsageRecordType
+	Description string
 }
 
 type snapshotManager struct {
@@ -201,6 +207,25 @@ func (cm *snapshotManager) SnapshotSize(ctx context.Context, snapshotID string) 
 	}
 
 	return usage.Size, nil
+}
+
+func (cm *snapshotManager) SnapshotRecordMetadata(ctx context.Context, snapshotID string) (SnapshotRecordMetadata, bool, error) {
+	_ = ctx
+	if snapshotID == "" {
+		return SnapshotRecordMetadata{}, false, errors.New("snapshot record metadata: empty snapshot ID")
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	md, ok := cm.getMetadata(snapshotID)
+	if !ok {
+		return SnapshotRecordMetadata{}, false, nil
+	}
+	return SnapshotRecordMetadata{
+		RecordType:  md.GetRecordType(),
+		Description: md.GetDescription(),
+	}, true, nil
 }
 
 // get requires manager lock to be taken

--- a/modules/dev/internal/dagger/engine-dev.gen.go
+++ b/modules/dev/internal/dagger/engine-dev.gen.go
@@ -1002,19 +1002,19 @@ func (r *EngineDev) Tests(ctx context.Context) (string, error) { // engine-dev (
 	return response, q.Execute(ctx)
 }
 
-func (r *EngineDev) WithBuildkitConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &EngineDev{
 		query: q,
 	}
 }
 
-func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *EngineDev) WithEngineConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &EngineDev{
 		query: q,

--- a/modules/metrics/internal/dagger/dagger-engine.gen.go
+++ b/modules/metrics/internal/dagger/dagger-engine.gen.go
@@ -1002,19 +1002,19 @@ func (r *DaggerEngine) Tests(ctx context.Context) (string, error) { // dagger-en
 	return response, q.Execute(ctx)
 }
 
-func (r *DaggerEngine) WithBuildkitConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &DaggerEngine{
 		query: q,
 	}
 }
 
-func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *DaggerEngine) WithEngineConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &DaggerEngine{
 		query: q,

--- a/sdk/elixir/lib/dagger/gen/engine_cache_entry.ex
+++ b/sdk/elixir/lib/dagger/gen/engine_cache_entry.ex
@@ -38,6 +38,17 @@ defmodule Dagger.EngineCacheEntry do
   end
 
   @doc """
+  The DagQL call that produced this cache entry.
+  """
+  @spec dagql_call(t()) :: {:ok, String.t()} | {:error, term()}
+  def dagql_call(%__MODULE__{} = engine_cache_entry) do
+    query_builder =
+      engine_cache_entry.query_builder |> QB.select("dagqlCall")
+
+    Client.execute(engine_cache_entry.client, query_builder)
+  end
+
+  @doc """
   The description of the cache entry.
   """
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
@@ -88,6 +99,17 @@ defmodule Dagger.EngineCacheEntry do
   def record_type(%__MODULE__{} = engine_cache_entry) do
     query_builder =
       engine_cache_entry.query_builder |> QB.select("recordType")
+
+    Client.execute(engine_cache_entry.client, query_builder)
+  end
+
+  @doc """
+  The storage record types represented by this cache entry.
+  """
+  @spec record_types(t()) :: {:ok, [String.t()]} | {:error, term()}
+  def record_types(%__MODULE__{} = engine_cache_entry) do
+    query_builder =
+      engine_cache_entry.query_builder |> QB.select("recordTypes")
 
     Client.execute(engine_cache_entry.client, query_builder)
   end

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5066,6 +5066,7 @@ type EngineCacheEntry struct {
 
 	activelyUsed              *bool
 	createdTimeUnixNano       *int
+	dagqlCall                 *string
 	description               *string
 	diskSpaceBytes            *int
 	id                        *EngineCacheEntryID
@@ -5100,6 +5101,19 @@ func (r *EngineCacheEntry) CreatedTimeUnixNano(ctx context.Context) (int, error)
 	q := r.query.Select("createdTimeUnixNano")
 
 	var response int
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The DagQL call that produced this cache entry.
+func (r *EngineCacheEntry) DagqlCall(ctx context.Context) (string, error) {
+	if r.dagqlCall != nil {
+		return *r.dagqlCall, nil
+	}
+	q := r.query.Select("dagqlCall")
+
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -5192,6 +5206,16 @@ func (r *EngineCacheEntry) RecordType(ctx context.Context) (string, error) {
 	q := r.query.Select("recordType")
 
 	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// The storage record types represented by this cache entry.
+func (r *EngineCacheEntry) RecordTypes(ctx context.Context) ([]string, error) {
+	q := r.query.Select("recordTypes")
+
+	var response []string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)

--- a/sdk/php/generated/EngineCacheEntry.php
+++ b/sdk/php/generated/EngineCacheEntry.php
@@ -32,6 +32,15 @@ class EngineCacheEntry extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The DagQL call that produced this cache entry.
+     */
+    public function dagqlCall(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('dagqlCall');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'dagqlCall');
+    }
+
+    /**
      * The description of the cache entry.
      */
     public function description(): string
@@ -74,5 +83,14 @@ class EngineCacheEntry extends Client\AbstractObject implements Client\IdAble
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('recordType');
         return (string)$this->queryLeaf($leafQueryBuilder, 'recordType');
+    }
+
+    /**
+     * The storage record types represented by this cache entry.
+     */
+    public function recordTypes(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('recordTypes');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'recordTypes');
     }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5295,6 +5295,27 @@ class EngineCacheEntry(Type):
         _ctx = self._select("createdTimeUnixNano", _args)
         return await _ctx.execute(int)
 
+    async def dagql_call(self) -> str:
+        """The DagQL call that produced this cache entry.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("dagqlCall", _args)
+        return await _ctx.execute(str)
+
     async def description(self) -> str:
         """The description of the cache entry.
 
@@ -5403,6 +5424,27 @@ class EngineCacheEntry(Type):
         _args: list[Arg] = []
         _ctx = self._select("recordType", _args)
         return await _ctx.execute(str)
+
+    async def record_types(self) -> list[str]:
+        """The storage record types represented by this cache entry.
+
+        Returns
+        -------
+        list[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("recordTypes", _args)
+        return await _ctx.execute(list[str])
 
 
 @typecheck

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7336,6 +7336,11 @@ impl EngineCacheEntry {
         let query = self.selection.select("createdTimeUnixNano");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The DagQL call that produced this cache entry.
+    pub async fn dagql_call(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("dagqlCall");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// The description of the cache entry.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
@@ -7359,6 +7364,11 @@ impl EngineCacheEntry {
     /// The type of the cache record (e.g. regular, internal, frontend, source.local, source.git.checkout, exec.cachemount).
     pub async fn record_type(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("recordType");
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// The storage record types represented by this cache entry.
+    pub async fn record_types(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("recordTypes");
         query.execute(self.graphql_client.clone()).await
     }
 }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -6333,6 +6333,7 @@ export class EngineCacheEntry extends BaseClient {
   private readonly _id?: EngineCacheEntryID = undefined
   private readonly _activelyUsed?: boolean = undefined
   private readonly _createdTimeUnixNano?: number = undefined
+  private readonly _dagqlCall?: string = undefined
   private readonly _description?: string = undefined
   private readonly _diskSpaceBytes?: number = undefined
   private readonly _mostRecentUseTimeUnixNano?: number = undefined
@@ -6346,6 +6347,7 @@ export class EngineCacheEntry extends BaseClient {
     _id?: EngineCacheEntryID,
     _activelyUsed?: boolean,
     _createdTimeUnixNano?: number,
+    _dagqlCall?: string,
     _description?: string,
     _diskSpaceBytes?: number,
     _mostRecentUseTimeUnixNano?: number,
@@ -6356,6 +6358,7 @@ export class EngineCacheEntry extends BaseClient {
     this._id = _id
     this._activelyUsed = _activelyUsed
     this._createdTimeUnixNano = _createdTimeUnixNano
+    this._dagqlCall = _dagqlCall
     this._description = _description
     this._diskSpaceBytes = _diskSpaceBytes
     this._mostRecentUseTimeUnixNano = _mostRecentUseTimeUnixNano
@@ -6403,6 +6406,21 @@ export class EngineCacheEntry extends BaseClient {
     const ctx = this._ctx.select("createdTimeUnixNano")
 
     const response: Awaited<number> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The DagQL call that produced this cache entry.
+   */
+  dagqlCall = async (): Promise<string> => {
+    if (this._dagqlCall) {
+      return this._dagqlCall
+    }
+
+    const ctx = this._ctx.select("dagqlCall")
+
+    const response: Awaited<string> = await ctx.execute()
 
     return response
   }
@@ -6463,6 +6481,17 @@ export class EngineCacheEntry extends BaseClient {
     const ctx = this._ctx.select("recordType")
 
     const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * The storage record types represented by this cache entry.
+   */
+  recordTypes = async (): Promise<string[]> => {
+    const ctx = this._ctx.select("recordTypes")
+
+    const response: Awaited<string[]> = await ctx.execute()
 
     return response
   }

--- a/toolchains/docs-dev/internal/dagger/engine-dev.gen.go
+++ b/toolchains/docs-dev/internal/dagger/engine-dev.gen.go
@@ -1002,19 +1002,19 @@ func (r *EngineDev) Tests(ctx context.Context) (string, error) { // engine-dev (
 	return response, q.Execute(ctx)
 }
 
-func (r *EngineDev) WithBuildkitConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &EngineDev{
 		query: q,
 	}
 }
 
-func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *EngineDev) WithEngineConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &EngineDev{
 		query: q,

--- a/toolchains/engine-dev/config.go
+++ b/toolchains/engine-dev/config.go
@@ -99,7 +99,7 @@ func generateConfig(logLevel string) (*dagger.File, error) {
 	return config, nil
 }
 
-func generateBKConfig(kvs []string) (*dagger.File, error) {
+func generateEngineTOML(kvs []string) (*dagger.File, error) {
 	opts := map[string]string{}
 	for _, kv := range kvs {
 		k, v, ok := strings.Cut(kv, "=")

--- a/toolchains/engine-dev/dagger.gen.go
+++ b/toolchains/engine-dev/dagger.gen.go
@@ -59,7 +59,7 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 func (r EngineDev) MarshalJSON() ([]byte, error) {
 	var concrete struct {
 		Source             *dagger.Directory
-		BuildkitConfig     []string
+		EngineConfig       []string
 		LogLevel           string
 		SubnetNumber       int
 		EBPFProgs          []string
@@ -67,7 +67,7 @@ func (r EngineDev) MarshalJSON() ([]byte, error) {
 		ClientDockerConfig *dagger.Secret
 	}
 	concrete.Source = r.Source
-	concrete.BuildkitConfig = r.BuildkitConfig
+	concrete.EngineConfig = r.EngineConfig
 	concrete.LogLevel = r.LogLevel
 	concrete.SubnetNumber = r.SubnetNumber
 	concrete.EBPFProgs = r.EBPFProgs
@@ -79,7 +79,7 @@ func (r EngineDev) MarshalJSON() ([]byte, error) {
 func (r *EngineDev) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
 		Source             *dagger.Directory
-		BuildkitConfig     []string
+		EngineConfig       []string
 		LogLevel           string
 		SubnetNumber       int
 		EBPFProgs          []string
@@ -91,7 +91,7 @@ func (r *EngineDev) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 	r.Source = concrete.Source
-	r.BuildkitConfig = concrete.BuildkitConfig
+	r.EngineConfig = concrete.EngineConfig
 	r.LogLevel = concrete.LogLevel
 	r.SubnetNumber = concrete.SubnetNumber
 	r.EBPFProgs = concrete.EBPFProgs
@@ -996,7 +996,21 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*EngineDev).Tests(&parent, ctx)
-		case "WithBuildkitConfig":
+		case "WithEBPFProgs":
+			var parent EngineDev
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var names []string
+			if inputArgs["names"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["names"]), &names)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg names", err))
+				}
+			}
+			return (*EngineDev).WithEBPFProgs(&parent, names), nil
+		case "WithEngineConfig":
 			var parent EngineDev
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
@@ -1016,21 +1030,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg value", err))
 				}
 			}
-			return (*EngineDev).WithBuildkitConfig(&parent, key, value), nil
-		case "WithEBPFProgs":
-			var parent EngineDev
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var names []string
-			if inputArgs["names"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["names"]), &names)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg names", err))
-				}
-			}
-			return (*EngineDev).WithEBPFProgs(&parent, names), nil
+			return (*EngineDev).WithEngineConfig(&parent, key, value), nil
 		case "WithLogLevel":
 			var parent EngineDev
 			err = json.Unmarshal(parentJSON, &parent)

--- a/toolchains/engine-dev/main.go
+++ b/toolchains/engine-dev/main.go
@@ -63,10 +63,10 @@ func New(
 type EngineDev struct {
 	Source *dagger.Directory
 
-	BuildkitConfig []string // +private
-	LogLevel       string   // +private
-	SubnetNumber   int      // +private
-	EBPFProgs      []string // +private
+	EngineConfig []string // +private
+	LogLevel     string   // +private
+	SubnetNumber int      // +private
+	EBPFProgs    []string // +private
 
 	Race               bool // +private
 	ClientDockerConfig *dagger.Secret
@@ -86,8 +86,8 @@ func (dev *EngineDev) WithEBPFProgs(names []string) *EngineDev {
 	return dev
 }
 
-func (dev *EngineDev) WithBuildkitConfig(key, value string) *EngineDev {
-	dev.BuildkitConfig = append(dev.BuildkitConfig, key+"="+value)
+func (dev *EngineDev) WithEngineConfig(key, value string) *EngineDev {
+	dev.EngineConfig = append(dev.EngineConfig, key+"="+value)
 	return dev
 }
 
@@ -156,7 +156,7 @@ func (dev *EngineDev) Container(
 	if err != nil {
 		return nil, err
 	}
-	bkcfg, err := generateBKConfig(dev.BuildkitConfig)
+	engineTOML, err := generateEngineTOML(dev.EngineConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (dev *EngineDev) Container(
 
 	ctr = ctr.
 		WithFile(engineJSONPath, cfg).
-		WithFile(engineTOMLPath, bkcfg).
+		WithFile(engineTOMLPath, engineTOML).
 		WithFile(engineEntrypointPath, entrypoint).
 		WithEntrypoint([]string{filepath.Base(engineEntrypointPath)})
 

--- a/toolchains/engine-dev/test.go
+++ b/toolchains/engine-dev/test.go
@@ -242,9 +242,9 @@ func (dev *EngineDev) test(
 func (dev *EngineDev) testContainer(ctx context.Context, ebpfProgs []string) (*dagger.Container, string, error) {
 	devEngine, err := dev.
 		WithEBPFProgs(ebpfProgs).
-		WithBuildkitConfig(`registry."registry:5000"`, `http = true`).
-		WithBuildkitConfig(`registry."privateregistry:5000"`, `http = true`).
-		WithBuildkitConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`).
+		WithEngineConfig(`registry."registry:5000"`, `http = true`).
+		WithEngineConfig(`registry."privateregistry:5000"`, `http = true`).
+		WithEngineConfig(`registry."docker.io"`, `mirrors = ["mirror.gcr.io"]`).
 		Container(
 			ctx,
 			"",    // platform

--- a/toolchains/php-sdk-dev/internal/dagger/dagger-engine.gen.go
+++ b/toolchains/php-sdk-dev/internal/dagger/dagger-engine.gen.go
@@ -1002,19 +1002,19 @@ func (r *DaggerEngine) Tests(ctx context.Context) (string, error) { // dagger-en
 	return response, q.Execute(ctx)
 }
 
-func (r *DaggerEngine) WithBuildkitConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &DaggerEngine{
 		query: q,
 	}
 }
 
-func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *DaggerEngine) WithEngineConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &DaggerEngine{
 		query: q,

--- a/toolchains/python-sdk-dev/internal/dagger/dagger-engine.gen.go
+++ b/toolchains/python-sdk-dev/internal/dagger/dagger-engine.gen.go
@@ -1002,19 +1002,19 @@ func (r *DaggerEngine) Tests(ctx context.Context) (string, error) { // dagger-en
 	return response, q.Execute(ctx)
 }
 
-func (r *DaggerEngine) WithBuildkitConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &DaggerEngine{
 		query: q,
 	}
 }
 
-func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *DaggerEngine) WithEngineConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &DaggerEngine{
 		query: q,

--- a/toolchains/release/internal/dagger/engine-dev.gen.go
+++ b/toolchains/release/internal/dagger/engine-dev.gen.go
@@ -1002,19 +1002,19 @@ func (r *EngineDev) Tests(ctx context.Context) (string, error) { // engine-dev (
 	return response, q.Execute(ctx)
 }
 
-func (r *EngineDev) WithBuildkitConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &EngineDev{
 		query: q,
 	}
 }
 
-func (r *EngineDev) WithEbpfprogs(names []string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *EngineDev) WithEngineConfig(key string, value string) *EngineDev { // engine-dev (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &EngineDev{
 		query: q,

--- a/toolchains/rust-sdk-dev/internal/dagger/dagger-engine.gen.go
+++ b/toolchains/rust-sdk-dev/internal/dagger/dagger-engine.gen.go
@@ -1002,19 +1002,19 @@ func (r *DaggerEngine) Tests(ctx context.Context) (string, error) { // dagger-en
 	return response, q.Execute(ctx)
 }
 
-func (r *DaggerEngine) WithBuildkitConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
-	q := r.query.Select("withBuildkitConfig")
-	q = q.Arg("key", key)
-	q = q.Arg("value", value)
+func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
+	q := r.query.Select("withEbpfprogs")
+	q = q.Arg("names", names)
 
 	return &DaggerEngine{
 		query: q,
 	}
 }
 
-func (r *DaggerEngine) WithEbpfprogs(names []string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:84:1)
-	q := r.query.Select("withEbpfprogs")
-	q = q.Arg("names", names)
+func (r *DaggerEngine) WithEngineConfig(key string, value string) *DaggerEngine { // dagger-engine (../../../../toolchains/engine-dev/main.go:89:1)
+	q := r.query.Select("withEngineConfig")
+	q = q.Arg("key", key)
+	q = q.Arg("value", value)
 
 	return &DaggerEngine{
 		query: q,

--- a/toolchains/test-split/main.dang
+++ b/toolchains/test-split/main.dang
@@ -14,6 +14,20 @@ type TestSplit {
     engineDev.test(race: race, run: run.join("|"), ebpfProgs: ebpfProgs, pkg: pkg)
   }
 
+  let testCliEngineSpecific(
+    run: [String!]!,
+    ebpfProgs: [String!],
+    pkg: String! = "./core/integration",
+    race: Boolean,
+  ): Void {
+    engineDev
+      .withEngineConfig("worker.oci", [
+        "minFreeSpace = \"30%\"",
+        "maxUsedSpace = \"50%\"",
+      ].join("\n"))
+      .test(race: race, run: run.join("|"), ebpfProgs: ebpfProgs, pkg: pkg)
+  }
+
   let testSkip(
     skip: [String!]!,
     ebpfProgs: [String!],
@@ -28,7 +42,7 @@ type TestSplit {
   """
   pub testBase: Void @check {
     testSkip(
-      skip: ["TestProvision", "TestTelemetry", "TestModule", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava", "TestContainer", "TestDockerfile", "TestLLM", "TestCLI", "TestEngine", "TestClientGenerator", "TestInterface", "TestCall", "TestShell", "TestDaggerCMD", "TestWorkspace"],
+      skip: ["TestProvision", "TestTelemetry", "TestModule", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava", "TestContainer", "TestDockerfile", "TestLLM", "TestCLI", "TestEngine", "TestCachePersistence", "TestLocalCache", "TestClientGenerator", "TestInterface", "TestCall", "TestShell", "TestDaggerCMD", "TestWorkspace"],
       pkg: "./...",
       race: true,
     )
@@ -59,7 +73,21 @@ type TestSplit {
   Test CLI Engine
   """
   pub testCliEngine: Void @check {
-    testSpecific(["TestCLI", "TestEngine"])
+    testCliEngineSpecific(["TestCLI", "TestEngine"])
+  }
+
+  """
+  Test cache persistence
+  """
+  pub testCachePersistence: Void @check {
+    testCliEngineSpecific(["TestCachePersistence"])
+  }
+
+  """
+  Test local cache
+  """
+  pub testLocalCache: Void @check {
+    testCliEngineSpecific(["TestLocalCache"])
   }
 
   """


### PR DESCRIPTION
## Summary

This PR collects a few related cache pruning and disk-pressure improvements for the engine and the engine-heavy integration checks.

## Commits

- `core: use available disk space for min-free pruning`
  - Fixes the min-free-space pruning decision to use filesystem available bytes instead of raw free bytes, so reserved blocks do not make the engine overestimate space users can actually consume.
  - Updates the cache and server GC plumbing/tests to carry available space through the pruning policy evaluation.

- `core: share persisted cache volume mutable refs`
  - Fixes persisted cache volume loading so repeated persisted decodes share the same mutable snapshot ref for a snapshot instead of reopening independent mutable refs.
  - Keeps cache volume persistence metadata-only on decode and centralizes mutable ref ownership/refcounting in the query.

- `core: expose storage record types for cache GC`
  - Adds storage record type accounting to engine cache entries so pruning policies can match source-local mirrors, git checkouts, cache mounts, and other record classes directly.
  - Updates default cache GC filtering around those record types and includes generated schema/SDK updates.

- `test: split heavy engine cache suites`
  - Splits cache persistence and local cache pruning integration tests out of the broad `TestEngine` group so the cli-engine split no longer runs all of those nested-engine-heavy tests together.
  - Adds engine-dev `WithEngineConfig` overrides for the cli-engine family of checks and tunes the middle dev engine to `minFreeSpace = "30%"` and `maxUsedSpace = "50%"` for lower disk pressure.

See each individual commit for more details on the problem, solution, and implementation.

## Validation

- `dagger --progress=plain generate -y`
- `git diff --check`
- Earlier cache changes in this branch were also validated with focused engine-dev integration/unit test runs for local cache pruning, disk persistence, server GC policy resolution, and dagql cache pruning policy behavior.
