### PR TITLE
dagql: size cache usage without query context

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -114,7 +114,7 @@ func (cache *CacheVolume) getSnapshotSelector() string {
 	return cache.selector
 }
 
-func (cache *CacheVolume) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (cache *CacheVolume) CacheUsageSize(ctx context.Context, sizeProvider dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	cache.mu.Lock()
 	snapshot := cache.snapshot
 	snapshotID := cache.snapshotID
@@ -132,11 +132,10 @@ func (cache *CacheVolume) CacheUsageSize(ctx context.Context, identity string) (
 	if snapshotID == "" || snapshotID != identity {
 		return 0, false, nil
 	}
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return 0, false, err
+	if sizeProvider == nil {
+		return 0, false, nil
 	}
-	size, err := query.SnapshotManager().SnapshotSize(ctx, snapshotID)
+	size, err := sizeProvider.SnapshotSize(ctx, snapshotID)
 	if err != nil {
 		return 0, false, err
 	}

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -365,7 +365,7 @@ func TestCacheVolumeUsageSizeUsesLiveSnapshotID(t *testing.T) {
 	cache := NewCache("cache-key", "ns", dagql.Null[dagql.ObjectResult[*Directory]](), CacheSharingModeShared, "")
 	cache.snapshot = &cacheVolumeTestMutableRef{cacheVolumeTestImmutableRef: *ref}
 
-	size, ok, err := cache.CacheUsageSize(context.Background(), "snapshot-123")
+	size, ok, err := cache.CacheUsageSize(context.Background(), nil, "snapshot-123")
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, int64(42), size)
@@ -379,21 +379,33 @@ func TestCacheVolumeUsageSizeUsesPersistedSnapshotID(t *testing.T) {
 			"snapshot-123": 42,
 		},
 	}
-	query := &Query{
-		Server: &cacheVolumeTestQueryServer{
-			mockServer:   &mockServer{},
-			cacheManager: manager,
-		},
-	}
-	ctx := ContextWithQuery(context.Background(), query)
-
 	cache := NewCache("cache-key", "ns", dagql.Null[dagql.ObjectResult[*Directory]](), CacheSharingModeShared, "")
 	cache.snapshotID = "snapshot-123"
 
-	size, ok, err := cache.CacheUsageSize(ctx, "snapshot-123")
+	size, ok, err := cache.CacheUsageSize(context.Background(), manager, "snapshot-123")
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, int64(42), size)
+	require.Equal(t, []string{"snapshot-123"}, manager.snapshotSizeCalls)
+}
+
+func TestHTTPStateUsageSizeUsesPersistedSnapshotID(t *testing.T) {
+	t.Parallel()
+
+	manager := &cacheVolumeTestSnapshotManager{
+		snapshotSizes: map[string]int64{
+			"snapshot-123": 42,
+		},
+	}
+	state := &HTTPState{
+		snapshotID: "snapshot-123",
+	}
+
+	size, ok, err := state.CacheUsageSize(context.Background(), manager, "snapshot-123")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(42), size)
+	require.Empty(t, manager.getBySnapshotIDCalls)
 	require.Equal(t, []string{"snapshot-123"}, manager.snapshotSizeCalls)
 }
 

--- a/core/client_filesync_mirror.go
+++ b/core/client_filesync_mirror.go
@@ -79,7 +79,7 @@ func (m *ClientFilesyncMirror) CacheUsageIdentities() []string {
 	return []string{m.snapshot.SnapshotID()}
 }
 
-func (m *ClientFilesyncMirror) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (m *ClientFilesyncMirror) CacheUsageSize(ctx context.Context, _ dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if m == nil {
 		return 0, false, nil
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -1217,7 +1217,7 @@ func (container *Container) CacheUsageIdentities() []string {
 }
 
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
-func (container *Container) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (container *Container) CacheUsageSize(ctx context.Context, sizeProvider dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if container == nil || identity == "" {
 		return 0, false, nil
 	}
@@ -1280,18 +1280,10 @@ func (container *Container) CacheUsageSize(ctx context.Context, identity string)
 		return 0, false, nil
 	}
 
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return 0, false, err
+	if sizeProvider == nil {
+		return 0, false, nil
 	}
-	ref, err := query.SnapshotManager().GetBySnapshotID(ctx, identity, bkcache.NoUpdateLastUsed)
-	if err != nil {
-		return 0, false, err
-	}
-	defer func() {
-		_ = ref.Release(context.WithoutCancel(ctx))
-	}()
-	size, err := ref.Size(ctx)
+	size, err := sizeProvider.SnapshotSize(ctx, identity)
 	if err != nil {
 		return 0, false, err
 	}

--- a/core/directory.go
+++ b/core/directory.go
@@ -142,7 +142,7 @@ func (dir *Directory) LazyEvalFunc() dagql.LazyEvalFunc {
 	}
 }
 
-func (dir *Directory) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (dir *Directory) CacheUsageSize(ctx context.Context, _ dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if dir == nil {
 		return 0, false, nil
 	}

--- a/core/file.go
+++ b/core/file.go
@@ -137,7 +137,7 @@ func ParseFileOwner(owner string) (*Ownership, error) {
 	return ParseDirectoryOwner(owner)
 }
 
-func (file *File) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (file *File) CacheUsageSize(ctx context.Context, _ dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if file == nil {
 		return 0, false, nil
 	}

--- a/core/git_remote_mirror.go
+++ b/core/git_remote_mirror.go
@@ -84,7 +84,7 @@ func (mirror *RemoteGitMirror) CacheUsageIdentities() []string {
 	return []string{mirror.snapshot.SnapshotID()}
 }
 
-func (mirror *RemoteGitMirror) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (mirror *RemoteGitMirror) CacheUsageSize(ctx context.Context, _ dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if mirror == nil {
 		return 0, false, nil
 	}

--- a/core/http.go
+++ b/core/http.go
@@ -126,7 +126,7 @@ func (state *HTTPState) CacheUsageIdentities() []string {
 	return []string{state.snapshotID}
 }
 
-func (state *HTTPState) CacheUsageSize(ctx context.Context, identity string) (int64, bool, error) {
+func (state *HTTPState) CacheUsageSize(ctx context.Context, sizeProvider dagql.CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if state == nil {
 		return 0, false, nil
 	}
@@ -150,18 +150,10 @@ func (state *HTTPState) CacheUsageSize(ctx context.Context, identity string) (in
 	if snapshotID == "" {
 		return 0, false, nil
 	}
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return 0, false, err
+	if sizeProvider == nil {
+		return 0, false, nil
 	}
-	ref, err := query.SnapshotManager().GetBySnapshotID(ctx, snapshotID, bkcache.NoUpdateLastUsed)
-	if err != nil {
-		return 0, false, err
-	}
-	defer func() {
-		_ = ref.Release(context.WithoutCancel(ctx))
-	}()
-	size, err := ref.Size(ctx)
+	size, err := sizeProvider.SnapshotSize(ctx, snapshotID)
 	if err != nil {
 		return 0, false, err
 	}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -1327,10 +1327,15 @@ func spanContextKey(ctx trace.SpanContext) string {
 	return ctx.TraceID().String() + "/" + ctx.SpanID().String()
 }
 
+// CacheUsageSizeProvider resolves concrete snapshot sizes for cache usage accounting.
+type CacheUsageSizeProvider interface {
+	SnapshotSize(context.Context, string) (int64, error)
+}
+
 type cacheUsageSizer interface {
 	// CacheUsageSize returns the concrete size of the cached payload when known.
 	// ok=false means "size is currently unknown/not available".
-	CacheUsageSize(context.Context, string) (sizeBytes int64, ok bool, err error)
+	CacheUsageSize(context.Context, CacheUsageSizeProvider, string) (sizeBytes int64, ok bool, err error)
 }
 
 type hasCacheUsageIdentity interface {
@@ -3336,7 +3341,7 @@ func buildCacheUsageMeasurements(ctx context.Context, snapshotManager bkcache.Sn
 
 		if !ok {
 			if input.self != nil {
-				sizeBytes, ok, err = cacheUsageSizeBytesFromSelf(ctx, input.self, identity)
+				sizeBytes, ok, err = cacheUsageSizeBytesFromSelf(ctx, snapshotManager, input.self, identity)
 			} else if len(input.snapshotLinks) > 0 {
 				sizeBytes, ok, err = cacheUsageSizeBytesFromSnapshotLink(ctx, snapshotManager, identity)
 			}
@@ -4319,7 +4324,7 @@ func mergeSharedResultExpiryUnix(existingExpiresAtUnix, candidateExpiresAtUnix i
 	}
 }
 
-func cacheUsageSizeBytesFromSelf(ctx context.Context, self Typed, identity string) (int64, bool, error) {
+func cacheUsageSizeBytesFromSelf(ctx context.Context, sizeProvider CacheUsageSizeProvider, self Typed, identity string) (int64, bool, error) {
 	if self == nil {
 		return 0, false, nil
 	}
@@ -4327,14 +4332,14 @@ func cacheUsageSizeBytesFromSelf(ctx context.Context, self Typed, identity strin
 	if !ok {
 		return 0, false, nil
 	}
-	return sizer.CacheUsageSize(ctx, identity)
+	return sizer.CacheUsageSize(ctx, sizeProvider, identity)
 }
 
-func cacheUsageSizeBytesFromSnapshotLink(ctx context.Context, snapshotManager bkcache.SnapshotManager, identity string) (int64, bool, error) {
-	if snapshotManager == nil || identity == "" {
+func cacheUsageSizeBytesFromSnapshotLink(ctx context.Context, sizeProvider CacheUsageSizeProvider, identity string) (int64, bool, error) {
+	if sizeProvider == nil || identity == "" {
 		return 0, false, nil
 	}
-	sizeBytes, err := snapshotManager.SnapshotSize(ctx, identity)
+	sizeBytes, err := sizeProvider.SnapshotSize(ctx, identity)
 	if err != nil {
 		return 0, false, err
 	}

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -131,7 +131,7 @@ type cacheTestSizedInt struct {
 	sizeMayChange        bool
 }
 
-func (v cacheTestSizedInt) CacheUsageSize(_ context.Context, identity string) (int64, bool, error) {
+func (v cacheTestSizedInt) CacheUsageSize(_ context.Context, _ CacheUsageSizeProvider, identity string) (int64, bool, error) {
 	if v.sizeCalls != nil {
 		v.sizeCalls.Add(1)
 	}


### PR DESCRIPTION
## Summary

This fixes DagQL cache usage sizing in background and shutdown prune paths that do not run under a request-scoped `core.Query`.

The cache now passes an explicit snapshot size provider into cache usage sizing hooks. `CacheVolume`, `HTTPState`, and `Container` use that provider when they only have a persisted snapshot ID, so they no longer reach through `core.CurrentQuery(ctx)` while pruning. Live refs still size themselves directly, and objects that only account live refs ignore the provider.

## Problem

Automatic pruning can run from background GC and engine shutdown contexts. Those contexts may not contain a `core.Query`, but some `CacheUsageSize` implementations used `CurrentQuery(ctx)` to reopen or size persisted snapshots. That could produce `no query in context` usage accounting warnings and miss accounting for those retained snapshots.

## Validation

- `GOCACHE=/tmp/codex-go-build GOTOOLCHAIN=go1.26.3 go test ./dagql -run 'TestCache'`
- `GOCACHE=/tmp/codex-go-build GOTOOLCHAIN=go1.26.3 go test ./core -run 'TestCacheVolumeUsageSize|TestHTTPStateUsageSize'`