### PR TITLE
fix(sdk/python): AST analyzer scalar/inherited defaults + differential oracle fidelity

### DIFF
--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -1865,13 +1865,38 @@ class ModuleParser:
             location=location,
         )
 
-    def _parse_parameters(  # noqa: C901, PLR0915 — parameter dispatch
+    def _parse_parameters(
         self,
         node: ast.FunctionDef | ast.AsyncFunctionDef,
         file_path: Path,
         skip_first: bool = True,  # Skip 'self' or 'cls'
     ) -> list[ParameterMetadata]:
         """Parse function parameters."""
+        assert self._resolver is not None
+
+        # Default expressions (and ``Annotated`` metadata like ``Doc(NAME)``)
+        # must be evaluated in the scope of the file where this function is
+        # *defined*, which is ``file_path``. For a method inherited from a
+        # base class in another file, that differs from the child class's
+        # file that the visitor is currently positioned on — without this,
+        # ``_eval_constant`` would look up the base method's default constants
+        # in the child's namespace and miss the ones the child doesn't import.
+        # For non-inherited functions ``file_path`` already equals
+        # ``_current_file``, so this is a no-op.
+        previous_file = self._current_file
+        self._current_file = file_path
+        try:
+            return self._parse_parameters_in_scope(node, file_path, skip_first)
+        finally:
+            self._current_file = previous_file
+
+    def _parse_parameters_in_scope(  # noqa: C901, PLR0915 — parameter dispatch
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        file_path: Path,
+        skip_first: bool,
+    ) -> list[ParameterMetadata]:
+        """Parse parameters with ``_current_file`` already scoped to the def."""
         assert self._resolver is not None
 
         parameters: list[ParameterMetadata] = []

--- a/sdk/python/src/dagger/mod/_analyzer/parser.py
+++ b/sdk/python/src/dagger/mod/_analyzer/parser.py
@@ -25,7 +25,7 @@ from dagger.mod._analyzer.metadata import (
     ResolvedType,
 )
 from dagger.mod._analyzer.namespace import StubNamespace
-from dagger.mod._analyzer.resolver import TypeResolver
+from dagger.mod._analyzer.resolver import DAGGER_SCALAR_TYPES, TypeResolver
 from dagger.mod._analyzer.visitors.annotations import (
     extract_annotated_metadata,
     get_annotation_string,
@@ -2189,6 +2189,26 @@ class ModuleParser:
             val = self._eval_constant(node.operand)
             if isinstance(val, (int, float)):
                 return -val
+        if isinstance(node, ast.Call):
+            # Dagger scalar types subclass ``str`` (``Scalar(str)``), so a
+            # constructor call wrapping a single literal — written inline as
+            # ``dagger.Platform("linux/amd64")`` or behind a ``Final``
+            # constant — evaluates to that literal at runtime. Unwrap it so
+            # the recorded default matches; other calls (factories,
+            # ``os.environ.get(...)``) stay unevaluable and fall through.
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                callee = func.attr
+            elif isinstance(func, ast.Name):
+                callee = func.id
+            else:
+                callee = None
+            if (
+                callee in DAGGER_SCALAR_TYPES
+                and len(node.args) == 1
+                and not node.keywords
+            ):
+                return self._eval_constant(node.args[0])
 
         # Can't evaluate. Warn so the user sees that the default they wrote
         # didn't survive static analysis — without a warning, the parameter

--- a/sdk/python/tests/mod/_runtime_introspect.py
+++ b/sdk/python/tests/mod/_runtime_introspect.py
@@ -389,9 +389,7 @@ def _build_function_metadata(owner: type, func: Any, meta: Any) -> FunctionMetad
             )
 
         has_default = param.default is not inspect.Parameter.empty
-        default_value = (
-            _default_as_engine_value(param.default) if has_default else None
-        )
+        default_value = _default_as_engine_value(param.default) if has_default else None
         api_name = alt_name or _normalize_name(param_name)
 
         parameters.append(
@@ -431,17 +429,34 @@ def _build_function_metadata(owner: type, func: Any, meta: Any) -> FunctionMetad
     )
 
 
+def _enum_member_value(member: enum_module.Enum) -> str:
+    """Render an enum member's value the way the AST analyzer (and engine) do.
+
+    A Dagger enum member value must be a scalar the schema can carry. The
+    AST analyzer records the literal for simple scalar values and falls
+    back to the member *name* for anything it can't express as a constant
+    (``DEPLOY = SomeNamedTuple(...)``) — see ``_extract_enum_member_value``
+    in the parser. The runtime path *is* the AST path now, so the oracle
+    must mirror that: keep ``str(value)`` for the literal kinds an
+    ``ast.Constant`` can hold (str/bytes/int/float/complex/bool/None), and
+    use the member name otherwise. Without this, an object-valued enum
+    surfaces its ``repr`` here while the analyzer (correctly) uses the name.
+    """
+    value = member.value
+    if value is None or isinstance(value, (str, bytes, int, float, complex)):
+        return str(value)
+    return member.name
+
+
 def _build_enum_metadata(cls: type) -> EnumTypeMetadata:
-    members: list[EnumMemberMetadata] = []
-    for member in cls.__members__.values():
-        value = member.value
-        members.append(
-            EnumMemberMetadata(
-                name=member.name,
-                value=str(value),
-                doc=inspect.getdoc(member) if hasattr(member, "__doc__") else None,
-            )
+    members = [
+        EnumMemberMetadata(
+            name=member.name,
+            value=_enum_member_value(member),
+            doc=inspect.getdoc(member) if hasattr(member, "__doc__") else None,
         )
+        for member in cls.__members__.values()
+    ]
     return EnumTypeMetadata(
         name=cls.__name__,
         doc=inspect.getdoc(cls),

--- a/sdk/python/tests/mod/_runtime_introspect.py
+++ b/sdk/python/tests/mod/_runtime_introspect.py
@@ -74,6 +74,35 @@ _DAGGER_SCALAR_TYPES = {
 _PRIMITIVES = {str: "str", int: "int", float: "float", bool: "bool", bytes: "bytes"}
 
 
+def _default_as_engine_value(value: Any) -> Any:
+    """Render a captured Python default the way the engine receives it.
+
+    Dagger serialises every enum member by its *name*, including primitive
+    (``StrEnum`` / ``IntEnum``) enums: ``@dagger.enum_type`` registers a
+    per-class name hook that overrides the str/int subclass behaviour (see
+    ``configure_converter_enum`` use in ``dagger.mod._module``). The AST
+    analyzer records the member name too, so a default captured here as a
+    live enum member (``<SCM.GITLAB: 'gitlab'>``) must be normalised to its
+    name (``"GITLAB"``) before diffing — otherwise a ``StrEnum`` member,
+    which compares equal to its value, spuriously differs from the
+    analyzer's ``"GITLAB"``.
+
+    Recurse through the containers the analyzer's ``_eval_constant`` also
+    produces (list / tuple / dict) so nested enum defaults match too. The
+    ``enum.Enum`` check must come first: primitive enum members are also
+    ``str``/``int`` instances.
+    """
+    if isinstance(value, enum_module.Enum):
+        return value.name
+    if isinstance(value, list):
+        return [_default_as_engine_value(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_default_as_engine_value(v) for v in value)
+    if isinstance(value, dict):
+        return {k: _default_as_engine_value(v) for k, v in value.items()}
+    return value
+
+
 def runtime_introspect(source: str, main_object_name: str) -> ModuleMetadata:
     """Import ``source`` as a fresh module and produce ModuleMetadata.
 
@@ -266,7 +295,7 @@ def _build_object_metadata(cls: type) -> ObjectTypeMetadata:  # noqa: C901
                 field.default_factory is not dataclasses.MISSING
             )
             if field.default is not dataclasses.MISSING:
-                default_value = field.default
+                default_value = _default_as_engine_value(field.default)
             elif field.default_factory is not dataclasses.MISSING:
                 # ``dagger.field(default=list)`` is rewritten to
                 # ``default_factory=list`` by the dagger decorator.
@@ -274,7 +303,7 @@ def _build_object_metadata(cls: type) -> ObjectTypeMetadata:  # noqa: C901
                 # value (``[]`` / ``{}`` / …), matching the AST analyzer's
                 # name_map which special-cases ``list``/``dict``.
                 try:
-                    default_value = field.default_factory()
+                    default_value = _default_as_engine_value(field.default_factory())
                 except Exception:  # noqa: BLE001 — user factory may raise
                     default_value = None
             else:
@@ -360,7 +389,9 @@ def _build_function_metadata(owner: type, func: Any, meta: Any) -> FunctionMetad
             )
 
         has_default = param.default is not inspect.Parameter.empty
-        default_value = param.default if has_default else None
+        default_value = (
+            _default_as_engine_value(param.default) if has_default else None
+        )
         api_name = alt_name or _normalize_name(param_name)
 
         parameters.append(

--- a/sdk/python/tests/mod/_runtime_introspect.py
+++ b/sdk/python/tests/mod/_runtime_introspect.py
@@ -22,6 +22,7 @@ import inspect
 import sys
 import tempfile
 import typing
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, get_args, get_origin
 
@@ -201,19 +202,41 @@ def runtime_introspect_package(
         shutil.rmtree(tmp_root, ignore_errors=True)
 
 
+def _iter_submodule_names(package: Any) -> Iterator[str]:
+    """Yield dotted names for every ``.py`` module under ``package``.
+
+    ``pkgutil.walk_packages`` only descends into *regular* packages (those
+    with an ``__init__.py``); it silently skips PEP 420 namespace-package
+    directories. Real modules split code across such directories (shiryu's
+    ``utils/`` has no ``__init__.py``), so walking the filesystem under each
+    ``__path__`` root catches both kinds and matches the AST analyzer, which
+    is handed every file explicitly. Without this the oracle under-reports
+    whole subtrees, which can also mask genuine analyzer divergences there.
+    """
+    for root in package.__path__:
+        root_path = Path(root)
+        for py_file in sorted(root_path.rglob("*.py")):
+            rel_parts = py_file.relative_to(root_path).with_suffix("").parts
+            if "__pycache__" in rel_parts:
+                continue
+            if rel_parts and rel_parts[-1] == "__init__":
+                rel_parts = rel_parts[:-1]
+            if not rel_parts:
+                continue  # the package's own __init__, already ingested
+            yield package.__name__ + "." + ".".join(rel_parts)
+
+
 def _build_package_metadata(  # noqa: C901 — submodule walking dispatch
     package: Any, main_object_name: str
 ) -> ModuleMetadata:
     """Walk a package's submodules and merge their decorated classes.
 
-    Submodules are discovered via ``pkgutil.walk_packages`` rather than
-    importing everything from the ``__init__`` namespace — that way we
+    Submodules are discovered by walking the package's source tree rather
+    than importing everything from the ``__init__`` namespace — that way we
     pick up classes a user split across files even if the ``__init__``
     didn't re-export them (the AST analyzer also walks files directly,
     so this matches its discovery model).
     """
-    import pkgutil
-
     objects: dict[str, ObjectTypeMetadata] = {}
     enums: dict[str, EnumTypeMetadata] = {}
 
@@ -237,11 +260,9 @@ def _build_package_metadata(  # noqa: C901 — submodule walking dispatch
 
     _ingest(package)
     if hasattr(package, "__path__"):
-        for info in pkgutil.walk_packages(
-            package.__path__, prefix=package.__name__ + "."
-        ):
+        for name in _iter_submodule_names(package):
             try:
-                submodule = importlib.import_module(info.name)
+                submodule = importlib.import_module(name)
             except Exception:  # noqa: BLE001 — third-party submodules may fail
                 continue
             _ingest(submodule)

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -2621,6 +2621,47 @@ class Foo:
     assert param.default_value == "x"
 
 
+def test_ast_inherited_function_default_resolves_in_base_file(tmp_path):
+    """An inherited method's constant default resolves in the base's file.
+
+    The default ``GREETING_DEFAULT`` is a module-level constant in
+    ``base.py``. The child class in ``main.py`` inherits ``greet`` but
+    does *not* import the constant. The analyzer must evaluate the
+    default in the file where the method is defined (``base.py``), not
+    in the child's file — otherwise the name is unresolvable and falls
+    back to the literal string ``"GREETING_DEFAULT"``.
+    """
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "base.py").write_text(
+        "import dagger\n"
+        '\nGREETING_DEFAULT = "hello-from-base"\n'
+        "\n"
+        "class Base:\n"
+        "    @dagger.function\n"
+        "    def greet(self, msg: str = GREETING_DEFAULT) -> str:\n"
+        "        return msg\n",
+        encoding="utf-8",
+    )
+    (pkg / "main.py").write_text(
+        "import dagger\n"
+        "from .base import Base\n"
+        "\n"
+        "@dagger.object_type\n"
+        "class Foo(Base):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    metadata = analyze_module(
+        source_files=[pkg / "__init__.py", pkg / "base.py", pkg / "main.py"],
+        main_object_name="Foo",
+    )
+    fn = metadata.objects["Foo"].functions[0]
+    assert fn.python_name == "greet"
+    assert fn.parameters[0].default_value == "hello-from-base"
+
+
 def test_ast_class_level_constant_does_not_leak():
     """A class constant on Foo must not resolve inside Bar's defaults."""
     metadata = _analyze(

--- a/sdk/python/tests/mod/test_ast_analyzer.py
+++ b/sdk/python/tests/mod/test_ast_analyzer.py
@@ -2404,6 +2404,62 @@ class Foo:
     assert any("could not be evaluated statically" in m for m in msgs), msgs
 
 
+def test_ast_scalar_constructor_default_inline():
+    """``platform: dagger.Platform = dagger.Platform("linux/amd64")`` → "linux/amd64".
+
+    Dagger scalar types subclass ``str`` (``Scalar(str)``), so calling the
+    constructor with a string literal yields that literal at runtime. The
+    analyzer must unwrap it instead of recording ``None``.
+    """
+    metadata = _analyze("""
+import dagger
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self, platform: dagger.Platform = dagger.Platform("linux/amd64")) -> str:
+        return platform
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.has_default is True
+    assert param.default_value == "linux/amd64"
+
+
+def test_ast_scalar_constructor_default_via_constant():
+    """A ``Final`` constant whose value is a scalar constructor call resolves."""
+    metadata = _analyze("""
+import dagger
+from typing import Final
+
+PLATFORM_DEFAULT: Final = dagger.Platform("linux/amd64")
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self, platform: dagger.Platform = PLATFORM_DEFAULT) -> str:
+        return platform
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.has_default is True
+    assert param.default_value == "linux/amd64"
+
+
+def test_ast_scalar_constructor_default_bare_name():
+    """The unqualified ``Platform("...")`` form resolves too."""
+    metadata = _analyze("""
+import dagger
+from dagger import Platform
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def hello(self, platform: Platform = Platform("linux/arm64")) -> str:
+        return platform
+""")
+    param = metadata.objects["Foo"].functions[0].parameters[0]
+    assert param.default_value == "linux/arm64"
+
+
 def test_ast_subscript_default_warns(caplog):
     """``def f(name = D["k"])`` warns; default is None."""
     import logging

--- a/sdk/python/tests/mod/test_differential.py
+++ b/sdk/python/tests/mod/test_differential.py
@@ -442,6 +442,51 @@ class Foo:
     assert_metadata_equivalent(ast_md, runtime_md)
 
 
+def test_diff_enum_member_default_uses_member_name():
+    """An enum-member default matches between AST and runtime.
+
+    Dagger serialises enum defaults by member *name* — even for primitive
+    (``StrEnum`` / ``IntEnum``) enums, where ``@dagger.enum_type`` registers
+    a per-class name hook so the str/int subclass value isn't used. The AST
+    analyzer records the member name; the runtime introspector must do the
+    same rather than retaining the live member (a ``StrEnum`` member equals
+    its value, so an unnormalised ``<SCM.GITLAB: 'gitlab'>`` would differ
+    from the analyzer's ``"GITLAB"``).
+    """
+    # ``str, Enum`` rather than ``StrEnum`` so the runtime oracle (which
+    # *executes* this source) imports cleanly on Python 3.10, where
+    # ``enum.StrEnum`` doesn't exist yet. Both are primitive str-backed
+    # enums and exercise the same name-vs-value serialisation path.
+    source = """
+import dagger
+from enum import Enum
+from typing import Annotated
+
+@dagger.enum_type
+class SCM(str, Enum):
+    GITHUB = "github"
+    GITLAB = "gitlab"
+
+SCMList = Annotated[list[SCM], dagger.Doc("scms")]
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def run(self, scm: SCM = SCM.GITLAB, scms: SCMList = [SCM.GITLAB]) -> str:
+        return scm
+"""
+    ast_md, runtime_md = _both(source)
+    # The scalar default is the member name, and the list default is a list
+    # of member names — identical on both sides.
+    params = {
+        p.python_name: p.default_value
+        for p in ast_md.objects["Foo"].functions[0].parameters
+    }
+    assert params["scm"] == "GITLAB"
+    assert params["scms"] == ["GITLAB"]
+    assert_metadata_equivalent(ast_md, runtime_md)
+
+
 # ---------------------------------------------------------------------------
 # Decorator metadata: name override, doc, deprecated.
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/mod/test_differential.py
+++ b/sdk/python/tests/mod/test_differential.py
@@ -487,6 +487,44 @@ class Foo:
     assert_metadata_equivalent(ast_md, runtime_md)
 
 
+def test_diff_enum_with_object_member_values_uses_name():
+    """An enum whose members hold non-scalar objects renders by member name.
+
+    A Dagger enum member value must be a scalar the schema can carry. The
+    AST analyzer (the production registration path) records the literal for
+    simple scalar values and falls back to the member *name* for values it
+    can't express as a constant — here ``NamedTuple`` instances. The runtime
+    oracle must mirror that instead of stringifying the live object's repr.
+    """
+    source = """
+import dagger
+from enum import Enum
+from typing import NamedTuple
+
+class Props(NamedTuple):
+    name: str
+    rank: int
+
+@dagger.enum_type
+class WorkflowId(Enum):
+    \"\"\"workflow ids\"\"\"
+    DEPLOY = Props("deploy", 1)
+    QUALITY = Props("quality", 2)
+
+@dagger.object_type
+class Foo:
+    @dagger.function
+    def run(self) -> str:
+        return WorkflowId.DEPLOY.name
+"""
+    ast_md, runtime_md = _both(source)
+    assert {m.name: m.value for m in ast_md.enums["WorkflowId"].members} == {
+        "DEPLOY": "DEPLOY",
+        "QUALITY": "QUALITY",
+    }
+    assert_metadata_equivalent(ast_md, runtime_md)
+
+
 # ---------------------------------------------------------------------------
 # Decorator metadata: name override, doc, deprecated.
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/mod/test_differential.py
+++ b/sdk/python/tests/mod/test_differential.py
@@ -525,6 +525,40 @@ class Foo:
     assert_metadata_equivalent(ast_md, runtime_md)
 
 
+def test_diff_namespace_package_submodule_is_discovered(tmp_path):
+    """A class in a PEP 420 namespace subpackage (no ``__init__.py``) is found.
+
+    ``pkgutil.walk_packages`` skips namespace-package directories, so the
+    oracle used to miss everything under them while the AST analyzer — handed
+    every file explicitly — saw it (a class "only in AST"). The oracle now
+    walks the source tree so its discovery matches.
+    """
+    files = {
+        "__init__.py": "",
+        # ``helpers/`` deliberately has no __init__.py → namespace package.
+        "helpers/extra.py": (
+            "import dagger\n"
+            "\n"
+            "@dagger.object_type\n"
+            "class Widget:\n"
+            '    name: str = dagger.field(default="w")\n'
+        ),
+        "main.py": (
+            "import dagger\n"
+            "from .helpers.extra import Widget\n"
+            "\n"
+            "@dagger.object_type\n"
+            "class Foo:\n"
+            "    @dagger.function\n"
+            "    def widget(self) -> Widget: ...\n"
+        ),
+    }
+    ast_md, runtime_md = _both_pkg(files, "Foo", tmp_path=tmp_path)
+    # Pre-fix the oracle missed the namespace-package class entirely.
+    assert "Widget" in runtime_md.objects
+    assert_metadata_equivalent(ast_md, runtime_md)
+
+
 # ---------------------------------------------------------------------------
 # Decorator metadata: name override, doc, deprecated.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes found by running the daggerverse corpus differential (`test_daggerverse_corpus.py`) against a real, heavily-metaprogrammed Python module. The changes fall into **two distinct kinds** — worth calling out because they have very different risk profiles:

### 1. Analyzer fixes — real production bugs

These change what the AST analyzer (the production registration path) actually emits to the engine:

- **`fix(sdk/python): resolve scalar-type constructor defaults`** — a default written as a dagger scalar constructor (`dagger.Platform("linux/amd64")`), inline or behind a `Final` constant, was an `ast.Call` the evaluator had no case for, so it was recorded as `None`. Now unwrapped to the literal, matching runtime.
- **`fix(sdk/python): scope inherited method defaults to their defining file`** — an inherited method's default constants were resolved in the *child* class's file scope instead of the base file where the method is defined, so constants the child didn't re-import fell back to a literal name string. Now scoped to the function's own file.

### 2. Oracle fixes — test-fidelity only, no production change

In these cases the analyzer was **already correct**; the differential's runtime *oracle* (test-only `_runtime_introspect.py`, never on the production path) was misrepresenting the engine-visible value and crying "divergence" wrongly. These don't change any user-facing behavior — they keep the differential trustworthy (an unfaithful oracle can also *mask* real analyzer bugs):

- **enum-default fidelity** — record enum-member defaults by member *name*, as dagger serialises them (incl. primitive `StrEnum`/`IntEnum` via the per-class name hook).
- **enum object-value fidelity** — render non-scalar enum member values by name, mirroring the analyzer (which can't express a `NamedTuple` value as a constant).
- **namespace-package discovery** — walk the package source tree so PEP 420 namespace packages (no `__init__.py`) are discovered, instead of `pkgutil.walk_packages` which silently skips them.

## The distinction in one line

**Analyzer fix** = the production engine output was wrong. **Oracle fix** = the output was right, but the test's reference computation was wrong.

## Test plan

- `uv run pytest tests/mod/` → 310 passed, 1 xfailed.
- Each fix has a targeted regression test.

## Out of scope

Remaining corpus divergences are fundamental static-analysis limits (the analyzer can't execute code): methods added by runtime decorators, enums built dynamically from the filesystem, and `enum.auto()` values (already warned).
