### PR TITLE
chore: upgrade github action to v0.21.0

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.20.8"
+    default: "v0.21.0"
     required: false
 
   dev-engine:


### PR DESCRIPTION
To fix runs like https://github.com/dagger/dagger/actions/runs/26523068102/job/78119237796

This was missing from https://github.com/dagger/dagger/pull/13224 because it was bumping from v0.20.6 but #13113 had manually bumped it to v0.20.8.