### PR TITLE
fix(core): apply COPY --chown ownership to newly-created parent dirs

### DIFF
--- a/.changes/unreleased/Fixed-20260528-180000.yaml
+++ b/.changes/unreleased/Fixed-20260528-180000.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  `dockerBuild` now applies `COPY --chown` ownership to parent directories it newly creates.
+
+  Previously, WORKDIR and COPY destination parent directories were created as `root:root` even when `USER <nonroot>` was active and `COPY --chown=<user>:<group>` was specified, causing a subsequent non-root `RUN` to fail with `EACCES` writing into its own WORKDIR (e.g. `npm i` -> `mkdir node_modules: permission denied`). This regressed in v0.21.0 with the DagQL solver migration; plain `docker build` and Dagger <= v0.20.8 were unaffected.
+time: 2026-05-28T18:00:00.000000000+05:30
+custom:
+    Author: rajdeepsignzy
+    PR: "13248"

--- a/core/directory.go
+++ b/core/directory.go
@@ -2299,6 +2299,40 @@ func copyDirectorySourceToScratch(
 	return ref, nil
 }
 
+// mkdirAllChown is like os.MkdirAll but, when ownership is non-nil, applies it
+// to every directory level that this call newly creates. Pre-existing parents
+// are left untouched, matching Docker/BuildKit COPY --chown semantics (only the
+// directories materialised by the COPY get the requested owner). Without this,
+// os.MkdirAll creates parents as root:root (the engine process uid), so a later
+// non-root RUN (e.g. USER node; RUN npm i) cannot write into its own WORKDIR.
+func mkdirAllChown(dir string, perm os.FileMode, ownership *Ownership) error {
+	// Walk up to the first existing ancestor, recording the dirs we must create.
+	var toCreate []string
+	for p := dir; ; p = filepath.Dir(p) {
+		if _, err := os.Stat(p); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		toCreate = append(toCreate, p)
+		if parent := filepath.Dir(p); parent == p {
+			break // reached filesystem root
+		}
+	}
+	if err := os.MkdirAll(dir, perm); err != nil {
+		return err
+	}
+	if ownership == nil {
+		return nil
+	}
+	for _, p := range toCreate {
+		if err := os.Chown(p, ownership.UID, ownership.GID); err != nil {
+			return fmt.Errorf("failed to set chown %s: %w", p, err)
+		}
+	}
+	return nil
+}
+
 //nolint:gocyclo
 func (dir *Directory) WithDirectoryDockerfileCompat(
 	ctx context.Context,
@@ -2393,7 +2427,7 @@ func (dir *Directory) WithDirectoryDockerfileCompat(
 				return err
 			}
 			if srcRef == nil {
-				if err := os.MkdirAll(resolvedCopyDest, 0o755); err != nil {
+				if err := mkdirAllChown(resolvedCopyDest, 0o755, ownership); err != nil {
 					return err
 				}
 				if permissions != nil {
@@ -2509,7 +2543,7 @@ func (dir *Directory) WithDirectoryDockerfileCompat(
 					if strings.HasSuffix(copyDestPath, "/") {
 						destDirPath = resolvedDestPath
 					}
-					if err := os.MkdirAll(destDirPath, 0o755); err != nil {
+					if err := mkdirAllChown(destDirPath, 0o755, ownership); err != nil {
 						return err
 					}
 				} else {


### PR DESCRIPTION
## What

Fixes #13247.

`dockerBuild`'s `WithDirectoryDockerfileCompat` created COPY-destination and WORKDIR parent directories via `os.MkdirAll`, which leaves them owned by `root:root` (the engine process uid) — even when `USER <nonroot>` is active and `COPY --chown=<user>:<group>` is specified. A subsequent non-root `RUN` then fails with `EACCES` writing into its own WORKDIR (e.g. `npm i` → `mkdir node_modules: permission denied`), surfacing as `failed to clone built container state: exit code: 243`.

## Why

Regressed in **v0.21.0** (clean on v0.20.7 / v0.20.8) alongside the DagQL solver migration. Plain `docker build` is unaffected. This diverges from Docker/BuildKit `COPY --chown` semantics, where directories materialised by the COPY receive the requested owner (cf. moby/moby#42819, docker/buildx#1855).

## How

Add a `mkdirAllChown(dir, perm, ownership)` helper that chowns each directory level the call **newly creates** — leaving pre-existing parents untouched (Docker semantics) — and use it at both `os.MkdirAll` sites in `WithDirectoryDockerfileCompat` (the `createDestPath` COPY branch and the empty-WORKDIR `srcRef == nil` branch).

## Reproduction

```dockerfile
FROM node:18
USER node
WORKDIR /home/node/app
COPY --chown=node:node package.json .
RUN ls -land /home/node/app && touch /home/node/app/probe
```
Before: `/home/node/app` owned `root:root`, `touch` → Permission denied, exit 1.
After: `/home/node/app` owned `node:node`, builds clean (matches v0.20.8 + `docker build`).

## Notes / open items

- Compiles clean (`GOOS=linux go build ./core/`), `gofmt` clean.
- I have **not** yet added a `core/integration` test, a `changie` release note, or run `dagger checks *:lint` / `dagger generate` — those need the dagger-in-dagger dev harness. Per CONTRIBUTING.md I'm raising this PR alongside the issue to confirm the **approach + fix location** in the new DagQL solver path first; happy to add the test + changie note + generated files once a maintainer confirms this is the right place to fix.
