### PR TITLE
core: global cache for 1Password secrets

### DIFF
--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,9 +123,113 @@ func (SecretProvider) TestCmd(ctx context.Context, t *testctx.T) {
 	requireErrOut(t, err, "failed to run secret command")
 }
 
-// TODO: implement - but ideally without being dependent on an external service
-// func (SecretProvider) TestOnePassword(ctx context.Context, t *testctx.T) {
-// }
+func (SecretProvider) TestOnePasswordCache(ctx context.Context, t *testctx.T) {
+	fakeOp := `#!/bin/sh
+set -eu
+if [ "$1" != "read" ] || [ "$2" != "-n" ]; then
+	echo "unexpected op invocation: $*" >&2
+	exit 1
+fi
+case "$3" in
+	*ttl=*)
+		echo "ttl query leaked to op ref: $3" >&2
+		exit 1
+		;;
+esac
+count_dir=/tmp/op-counts/$3
+mkdir -p "$count_dir"
+count_file=$count_dir/count
+count=0
+if [ -f "$count_file" ]; then
+	count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+printf 'secret%s' "$count"
+`
+
+	baseContainer := func(c *dagger.Client) *dagger.Container {
+		return c.Container().
+			From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithNewFile("/usr/local/bin/op", fakeOp, dagger.ContainerWithNewFileOpts{Permissions: 0o755}).
+			WithEnvVariable("OP_SERVICE_ACCOUNT_TOKEN", "")
+	}
+
+	verifySecretFromOnePassword := func(ctx context.Context, base *dagger.Container, secretURL string) (string, error) {
+		return base.
+			WithWorkdir("/work").
+			With(daggerExec("init", "--sdk=go", "--name=foo", "--source=.")).
+			WithNewFile("main.go", `package main
+
+import (
+	"context"
+	"dagger/foo/internal/dagger"
+	"fmt"
+	"time"
+)
+
+type Foo struct{}
+
+func (m *Foo) VerifySecret(ctx context.Context, secret *dagger.Secret) (string, error) {
+	original, err := secret.Plaintext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	time.Sleep(3 * time.Second)
+
+	updated, err := secret.Plaintext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("original: %s\nupdated: %s", original, updated), nil
+}
+`).
+			With(daggerCall("-vvv", "verify-secret", fmt.Sprintf("--secret=%s", secretURL))).Stdout(ctx)
+	}
+
+	testcases := []struct {
+		name         string
+		secret       string
+		shouldUpdate bool
+	}{
+		{
+			name:   "without-ttl",
+			secret: "op://vault/without-ttl/field",
+		},
+		{
+			name:         "with-ttl",
+			secret:       "op://vault/with-ttl/field?ttl=2s",
+			shouldUpdate: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+
+			base := baseContainer(c).
+				WithEnvVariable("CACHE_BUSTER", tc.name)
+
+			output, err := verifySecretFromOnePassword(ctx, base, tc.secret)
+			require.NoError(t, err)
+
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			require.Len(t, lines, 2)
+			original := strings.TrimPrefix(lines[0], "original: ")
+			updated := strings.TrimPrefix(lines[1], "updated: ")
+			require.NotEmpty(t, original)
+			require.NotEmpty(t, updated)
+			if tc.shouldUpdate {
+				require.NotEqual(t, original, updated)
+			} else {
+				require.Equal(t, original, updated)
+			}
+		})
+	}
+}
 
 func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)

--- a/engine/client/secretprovider/op.go
+++ b/engine/client/secretprovider/op.go
@@ -3,16 +3,77 @@ package secretprovider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/1password/onepassword-sdk-go"
 	"github.com/dagger/dagger/engine"
 )
 
-func opProvider(ctx context.Context, key string) ([]byte, error) {
-	key = "op://" + key
+type opCacheEntry struct {
+	expiresAt time.Time
+	data      []byte
+}
 
+var (
+	opCacheMu sync.Mutex
+	opCache   = make(map[string]opCacheEntry)
+)
+
+func opProvider(ctx context.Context, key string) ([]byte, error) {
+	cacheKey, ttl, err := parseOpCacheKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	opCacheMu.Lock()
+	defer opCacheMu.Unlock()
+
+	if existing, ok := opCache[cacheKey]; ok && !opCacheExpired(existing) {
+		return append([]byte(nil), existing.data...), nil
+	}
+
+	plaintext, err := resolveOp(ctx, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	entry := opCacheEntry{data: append([]byte(nil), plaintext...)}
+	if ttl > 0 {
+		entry.expiresAt = time.Now().Add(ttl)
+	}
+	opCache[cacheKey] = entry
+	return append([]byte(nil), plaintext...), nil
+}
+
+func parseOpCacheKey(key string) (string, time.Duration, error) {
+	parsed, err := url.Parse("op://" + key)
+	if err != nil {
+		return "", 0, err
+	}
+
+	var ttl time.Duration
+	query := parsed.Query()
+	if ttlStr := query.Get("ttl"); ttlStr != "" {
+		ttl, err = time.ParseDuration(ttlStr)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid ttl %q provided for secret %q: %w", ttlStr, parsed.Redacted(), err)
+		}
+		query.Del("ttl")
+		parsed.RawQuery = query.Encode()
+	}
+
+	return strings.TrimPrefix(parsed.String(), "op://"), ttl, nil
+}
+
+func opCacheExpired(entry opCacheEntry) bool {
+	return !entry.expiresAt.IsZero() && !entry.expiresAt.After(time.Now())
+}
+
+func resolveOp(ctx context.Context, key string) ([]byte, error) {
 	// Attempt to use the `OP_SERVICE_ACCOUNT_TOKEN`
 	if os.Getenv("OP_SERVICE_ACCOUNT_TOKEN") != "" {
 		return opSDKProvider(ctx, key)


### PR DESCRIPTION
## Summary
Users with `op://` defaults were seeing repeated outgoing 1Password calls for the same secret during a single function run, especially when a secret was mounted/read multiple times. This was causing their pipelines to fail due to rate limits.

~~`SetSecret` already stores plaintext on the concrete secret resource for the session. This PR applies the same model to provider-backed secrets: resolve the provider once for a concrete secret binding, memoize the plaintext in memory, and reuse it for later mounts/reads.~~

More context in the discussion below. Instead of modifying existing `SetSecret` plumbing, we went with creating a global cache for 1Password just like we do for Vault. Makes the overall change scoped to 1Password.

## Testing
- Added focused cmd:// integration coverage for repeated secret use.