### PR TITLE
sdk/java: vendor the SDK as real source for dagger develop

### DIFF
--- a/.changes/unreleased/Changed-20260528-174946.yaml
+++ b/.changes/unreleased/Changed-20260528-174946.yaml
@@ -1,0 +1,7 @@
+kind: Changed
+body: |
+  Java SDK: `dagger develop` now vendors the SDK as real, buildable source under `sdk/`, so a module builds with a single `mvn package` and standard Maven tooling works, removing the per-module version dance and the broken `target/` exports. Existing modules are migrated to the new layout automatically the next time they are loaded.
+time: 2026-05-28T17:49:46.983832+02:00
+custom:
+    Author: eunomie
+    PR: "13252"

--- a/core/integration/module_java_test.go
+++ b/core/integration/module_java_test.go
@@ -87,6 +87,21 @@ func (JavaSuite) TestInit(_ context.Context, t *testctx.T) {
 	})
 }
 
+func (JavaSuite) TestDevelopExportsEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// `dagger develop` must export the generated entrypoint
+	// (io.dagger.gen.entrypoint.Entrypoint) as real source under src/generated/java,
+	// alongside the vendored SDK sources, so the user and their IDE can see and
+	// build it with a plain `mvn package`.
+	modGen := javaModule(t, c, "fields").
+		With(daggerExec("develop"))
+
+	entries, err := modGen.Directory(".").Glob(ctx, "src/generated/java/io/dagger/gen/entrypoint/Entrypoint.java")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "expected io.dagger.gen.entrypoint.Entrypoint to be exported under src/generated/java by dagger develop")
+}
+
 func (JavaSuite) TestFields(_ context.Context, t *testctx.T) {
 	t.Run("can set and retrieve field using custom function", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/integration/testdata/modules/java/construct/.gitattributes
+++ b/core/integration/testdata/modules/java/construct/.gitattributes
@@ -1,1 +1,1 @@
-/target/generated-sources/** linguist-generated
+/sdk/src/** linguist-generated

--- a/core/integration/testdata/modules/java/construct/.gitattributes
+++ b/core/integration/testdata/modules/java/construct/.gitattributes
@@ -1,1 +1,2 @@
 /sdk/src/** linguist-generated
+/src/generated/** linguist-generated

--- a/core/integration/testdata/modules/java/construct/.gitignore
+++ b/core/integration/testdata/modules/java/construct/.gitignore
@@ -1,1 +1,2 @@
+/sdk/src
 /target

--- a/core/integration/testdata/modules/java/construct/.gitignore
+++ b/core/integration/testdata/modules/java/construct/.gitignore
@@ -1,2 +1,3 @@
 /sdk/src
+/src/generated
 /target

--- a/core/integration/testdata/modules/java/construct/pom.xml
+++ b/core/integration/testdata/modules/java/construct/pom.xml
@@ -12,6 +12,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        Controls whether the Dagger annotation processor runs to (re)generate
+        io.dagger.gen.entrypoint.Entrypoint. A plain `mvn package` leaves it at
+        "none" and just compiles the already-generated source under
+        src/generated/java. `dagger develop` / the engine pass -Ddagger.proc=full
+        to regenerate it from the current module code.
+        -->
+        <dagger.proc>none</dagger.proc>
     </properties>
 
     <!--
@@ -203,10 +211,13 @@
         <plugins>
             <plugin>
                 <!--
-                Register the vendored Dagger Java SDK sources as compilation roots:
+                Register the vendored Dagger Java SDK sources and the generated
+                entrypoint as compilation roots:
                   - sdk/src/main/java       the hand-written SDK library
                   - sdk/src/processor/java  the annotation processor (generates the entrypoint)
                   - sdk/src/generated/java  the client bindings generated from the engine schema
+                  - src/generated/java      io.dagger.gen.entrypoint.Entrypoint, generated
+                                            from the module code (see maven-compiler-plugin)
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -222,6 +233,7 @@
                                 <source>sdk/src/main/java</source>
                                 <source>sdk/src/processor/java</source>
                                 <source>sdk/src/generated/java</source>
+                                <source>src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -231,11 +243,21 @@
                 <!--
                 The module is built in two compilation passes from a single `mvn package`:
                   1. default-compile compiles the vendored SDK and annotation processor
-                     (everything but the user module) without annotation processing.
-                  2. compile-module compiles the user module (io.dagger.modules.*); the
-                     annotation processor compiled in pass 1 is then discovered on the
-                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
-                This avoids depending on pre-built/published Dagger SDK artifacts.
+                     plus the client bindings (everything but the user module and the
+                     generated entrypoint), without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*) and the
+                     entrypoint (io.dagger.gen.*) together.
+
+                Whether the entrypoint is (re)generated depends on the dagger.proc
+                property, so the very same pom serves two purposes:
+                  - dagger.proc=none (default, a plain `mvn package`): the processor does
+                    not run; the entrypoint already present as vendored source under
+                    src/generated/java is just compiled.
+                  - dagger.proc=full (passed by `dagger develop` / the engine): the
+                    processor runs in pass 2 and (re)generates the entrypoint. `dagger
+                    develop` vendors the result under src/generated/java.
+                This keeps the entrypoint as real, vendored source and avoids depending
+                on pre-built/published Dagger SDK artifacts.
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -249,6 +271,7 @@
                             <proc>none</proc>
                             <excludes>
                                 <exclude>io/dagger/modules/**</exclude>
+                                <exclude>io/dagger/gen/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -259,8 +282,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <proc>${dagger.proc}</proc>
                             <includes>
                                 <include>io/dagger/modules/**</include>
+                                <include>io/dagger/gen/**</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/core/integration/testdata/modules/java/construct/pom.xml
+++ b/core/integration/testdata/modules/java/construct/pom.xml
@@ -12,26 +12,134 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dagger.module.deps>0.16.3-construct-module</dagger.module.deps>
     </properties>
 
+    <!--
+    The Dagger Java SDK is vendored as source under sdk/ by `dagger develop`.
+    The whole sdk/ directory is generated (see .gitattributes / .gitignore) and
+    rebuilt by Dagger; do not edit it by hand. You can add your own dependencies
+    below.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.61.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Dagger Java SDK runtime dependencies -->
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-sdk</artifactId>
-            <version>${dagger.module.deps}</version>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>${dagger.module.deps}</version>
-            <scope>provided</scope>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>4.5.26</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kothar</groupId>
+            <artifactId>xdg-java</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ongres</groupId>
+            <artifactId>fluent-process</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
+        <!-- Needed only to compile the vendored annotation processor sources -->
+        <dependency>
+            <groupId>com.palantir.javapoet</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Runtime-only dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
             <scope>runtime</scope>
-            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>
@@ -40,19 +148,29 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.125.Final</version>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.2</version>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Service descriptor that registers the Dagger annotation processor -->
+            <resource>
+                <directory>sdk/src/processor/resources</directory>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -62,27 +180,6 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
-                </plugin>
-                <plugin>
-                    <!--
-                    This plugin configuration is required by Dagger to generate the module.
-                    Please do not remove or modify it.
-                    -->
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
-                    <configuration>
-                        <verbose>false</verbose>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>io.dagger</groupId>
-                                <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>${dagger.module.deps}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <annotationProcessors>
-                            <annotationProcessor>io.dagger.annotation.processor.DaggerModuleAnnotationProcessor</annotationProcessor>
-                        </annotationProcessors>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -100,38 +197,31 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <!--
-                This plugin configuration helps VS Code editor (and others) to find
-                the generated code created by `dagger init` and `dagger develop` and
-                helps for code completion.
+                Register the vendored Dagger Java SDK sources as compilation roots:
+                  - sdk/src/main/java       the hand-written SDK library
+                  - sdk/src/processor/java  the annotation processor (generates the entrypoint)
+                  - sdk/src/generated/java  the client bindings generated from the engine schema
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>add-generated-sources</id>
+                        <id>add-dagger-sdk-sources</id>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/dagger-io</source>
-                                <source>${project.build.directory}/generated-sources/dagger-module</source>
-                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                                <source>sdk/src/main/java</source>
+                                <source>sdk/src/processor/java</source>
+                                <source>sdk/src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -139,7 +229,46 @@
             </plugin>
             <plugin>
                 <!--
-                This plugin configuration is required by Dagger to generate the module.
+                The module is built in two compilation passes from a single `mvn package`:
+                  1. default-compile compiles the vendored SDK and annotation processor
+                     (everything but the user module) without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*); the
+                     annotation processor compiled in pass 1 is then discovered on the
+                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
+                This avoids depending on pre-built/published Dagger SDK artifacts.
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <excludes>
+                                <exclude>io/dagger/modules/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/dagger/modules/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to package the module.
                 Please do not remove or modify it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/integration/testdata/modules/java/defaults/.gitattributes
+++ b/core/integration/testdata/modules/java/defaults/.gitattributes
@@ -1,1 +1,1 @@
-/target/generated-sources/** linguist-generated
+/sdk/src/** linguist-generated

--- a/core/integration/testdata/modules/java/defaults/.gitattributes
+++ b/core/integration/testdata/modules/java/defaults/.gitattributes
@@ -1,1 +1,2 @@
 /sdk/src/** linguist-generated
+/src/generated/** linguist-generated

--- a/core/integration/testdata/modules/java/defaults/.gitignore
+++ b/core/integration/testdata/modules/java/defaults/.gitignore
@@ -1,1 +1,2 @@
+/sdk/src
 /target

--- a/core/integration/testdata/modules/java/defaults/.gitignore
+++ b/core/integration/testdata/modules/java/defaults/.gitignore
@@ -1,2 +1,3 @@
 /sdk/src
+/src/generated
 /target

--- a/core/integration/testdata/modules/java/defaults/pom.xml
+++ b/core/integration/testdata/modules/java/defaults/pom.xml
@@ -12,6 +12,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        Controls whether the Dagger annotation processor runs to (re)generate
+        io.dagger.gen.entrypoint.Entrypoint. A plain `mvn package` leaves it at
+        "none" and just compiles the already-generated source under
+        src/generated/java. `dagger develop` / the engine pass -Ddagger.proc=full
+        to regenerate it from the current module code.
+        -->
+        <dagger.proc>none</dagger.proc>
     </properties>
 
     <!--
@@ -203,10 +211,13 @@
         <plugins>
             <plugin>
                 <!--
-                Register the vendored Dagger Java SDK sources as compilation roots:
+                Register the vendored Dagger Java SDK sources and the generated
+                entrypoint as compilation roots:
                   - sdk/src/main/java       the hand-written SDK library
                   - sdk/src/processor/java  the annotation processor (generates the entrypoint)
                   - sdk/src/generated/java  the client bindings generated from the engine schema
+                  - src/generated/java      io.dagger.gen.entrypoint.Entrypoint, generated
+                                            from the module code (see maven-compiler-plugin)
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -222,6 +233,7 @@
                                 <source>sdk/src/main/java</source>
                                 <source>sdk/src/processor/java</source>
                                 <source>sdk/src/generated/java</source>
+                                <source>src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -231,11 +243,21 @@
                 <!--
                 The module is built in two compilation passes from a single `mvn package`:
                   1. default-compile compiles the vendored SDK and annotation processor
-                     (everything but the user module) without annotation processing.
-                  2. compile-module compiles the user module (io.dagger.modules.*); the
-                     annotation processor compiled in pass 1 is then discovered on the
-                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
-                This avoids depending on pre-built/published Dagger SDK artifacts.
+                     plus the client bindings (everything but the user module and the
+                     generated entrypoint), without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*) and the
+                     entrypoint (io.dagger.gen.*) together.
+
+                Whether the entrypoint is (re)generated depends on the dagger.proc
+                property, so the very same pom serves two purposes:
+                  - dagger.proc=none (default, a plain `mvn package`): the processor does
+                    not run; the entrypoint already present as vendored source under
+                    src/generated/java is just compiled.
+                  - dagger.proc=full (passed by `dagger develop` / the engine): the
+                    processor runs in pass 2 and (re)generates the entrypoint. `dagger
+                    develop` vendors the result under src/generated/java.
+                This keeps the entrypoint as real, vendored source and avoids depending
+                on pre-built/published Dagger SDK artifacts.
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -249,6 +271,7 @@
                             <proc>none</proc>
                             <excludes>
                                 <exclude>io/dagger/modules/**</exclude>
+                                <exclude>io/dagger/gen/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -259,8 +282,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <proc>${dagger.proc}</proc>
                             <includes>
                                 <include>io/dagger/modules/**</include>
+                                <include>io/dagger/gen/**</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/core/integration/testdata/modules/java/defaults/pom.xml
+++ b/core/integration/testdata/modules/java/defaults/pom.xml
@@ -12,26 +12,134 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dagger.module.deps>0.16.3-defaults-module</dagger.module.deps>
     </properties>
 
+    <!--
+    The Dagger Java SDK is vendored as source under sdk/ by `dagger develop`.
+    The whole sdk/ directory is generated (see .gitattributes / .gitignore) and
+    rebuilt by Dagger; do not edit it by hand. You can add your own dependencies
+    below.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.61.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Dagger Java SDK runtime dependencies -->
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-sdk</artifactId>
-            <version>${dagger.module.deps}</version>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>${dagger.module.deps}</version>
-            <scope>provided</scope>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>4.5.26</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kothar</groupId>
+            <artifactId>xdg-java</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ongres</groupId>
+            <artifactId>fluent-process</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
+        <!-- Needed only to compile the vendored annotation processor sources -->
+        <dependency>
+            <groupId>com.palantir.javapoet</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Runtime-only dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
             <scope>runtime</scope>
-            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>
@@ -40,19 +148,29 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.125.Final</version>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.2</version>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Service descriptor that registers the Dagger annotation processor -->
+            <resource>
+                <directory>sdk/src/processor/resources</directory>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -62,27 +180,6 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
-                </plugin>
-                <plugin>
-                    <!--
-                    This plugin configuration is required by Dagger to generate the module.
-                    Please do not remove or modify it.
-                    -->
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
-                    <configuration>
-                        <verbose>false</verbose>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>io.dagger</groupId>
-                                <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>${dagger.module.deps}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <annotationProcessors>
-                            <annotationProcessor>io.dagger.annotation.processor.DaggerModuleAnnotationProcessor</annotationProcessor>
-                        </annotationProcessors>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -100,38 +197,31 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <!--
-                This plugin configuration helps VS Code editor (and others) to find
-                the generated code created by `dagger init` and `dagger develop` and
-                helps for code completion.
+                Register the vendored Dagger Java SDK sources as compilation roots:
+                  - sdk/src/main/java       the hand-written SDK library
+                  - sdk/src/processor/java  the annotation processor (generates the entrypoint)
+                  - sdk/src/generated/java  the client bindings generated from the engine schema
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>add-generated-sources</id>
+                        <id>add-dagger-sdk-sources</id>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/dagger-io</source>
-                                <source>${project.build.directory}/generated-sources/dagger-module</source>
-                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                                <source>sdk/src/main/java</source>
+                                <source>sdk/src/processor/java</source>
+                                <source>sdk/src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -139,7 +229,46 @@
             </plugin>
             <plugin>
                 <!--
-                This plugin configuration is required by Dagger to generate the module.
+                The module is built in two compilation passes from a single `mvn package`:
+                  1. default-compile compiles the vendored SDK and annotation processor
+                     (everything but the user module) without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*); the
+                     annotation processor compiled in pass 1 is then discovered on the
+                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
+                This avoids depending on pre-built/published Dagger SDK artifacts.
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <excludes>
+                                <exclude>io/dagger/modules/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/dagger/modules/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to package the module.
                 Please do not remove or modify it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/integration/testdata/modules/java/enums/.gitattributes
+++ b/core/integration/testdata/modules/java/enums/.gitattributes
@@ -1,1 +1,1 @@
-/target/generated-sources/** linguist-generated
+/sdk/src/** linguist-generated

--- a/core/integration/testdata/modules/java/enums/.gitattributes
+++ b/core/integration/testdata/modules/java/enums/.gitattributes
@@ -1,1 +1,2 @@
 /sdk/src/** linguist-generated
+/src/generated/** linguist-generated

--- a/core/integration/testdata/modules/java/enums/.gitignore
+++ b/core/integration/testdata/modules/java/enums/.gitignore
@@ -1,1 +1,2 @@
+/sdk/src
 /target

--- a/core/integration/testdata/modules/java/enums/.gitignore
+++ b/core/integration/testdata/modules/java/enums/.gitignore
@@ -1,2 +1,3 @@
 /sdk/src
+/src/generated
 /target

--- a/core/integration/testdata/modules/java/enums/pom.xml
+++ b/core/integration/testdata/modules/java/enums/pom.xml
@@ -4,34 +4,142 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.dagger.modules.construct</groupId>
-    <artifactId>construct</artifactId>
+    <groupId>io.dagger.modules.enums</groupId>
+    <artifactId>enums</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <name>construct</name>
+    <name>enums</name>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dagger.module.deps>0.16.3-construct-module</dagger.module.deps>
     </properties>
 
+    <!--
+    The Dagger Java SDK is vendored as source under sdk/ by `dagger develop`.
+    The whole sdk/ directory is generated (see .gitattributes / .gitignore) and
+    rebuilt by Dagger; do not edit it by hand. You can add your own dependencies
+    below.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.61.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Dagger Java SDK runtime dependencies -->
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-sdk</artifactId>
-            <version>${dagger.module.deps}</version>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>${dagger.module.deps}</version>
-            <scope>provided</scope>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>4.5.26</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kothar</groupId>
+            <artifactId>xdg-java</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ongres</groupId>
+            <artifactId>fluent-process</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
+        <!-- Needed only to compile the vendored annotation processor sources -->
+        <dependency>
+            <groupId>com.palantir.javapoet</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Runtime-only dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
             <scope>runtime</scope>
-            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>
@@ -40,19 +148,29 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.125.Final</version>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.2</version>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Service descriptor that registers the Dagger annotation processor -->
+            <resource>
+                <directory>sdk/src/processor/resources</directory>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -62,27 +180,6 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
-                </plugin>
-                <plugin>
-                    <!--
-                    This plugin configuration is required by Dagger to generate the module.
-                    Please do not remove or modify it.
-                    -->
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
-                    <configuration>
-                        <verbose>false</verbose>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>io.dagger</groupId>
-                                <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>${dagger.module.deps}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <annotationProcessors>
-                            <annotationProcessor>io.dagger.annotation.processor.DaggerModuleAnnotationProcessor</annotationProcessor>
-                        </annotationProcessors>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -100,38 +197,31 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <!--
-                This plugin configuration helps VS Code editor (and others) to find
-                the generated code created by `dagger init` and `dagger develop` and
-                helps for code completion.
+                Register the vendored Dagger Java SDK sources as compilation roots:
+                  - sdk/src/main/java       the hand-written SDK library
+                  - sdk/src/processor/java  the annotation processor (generates the entrypoint)
+                  - sdk/src/generated/java  the client bindings generated from the engine schema
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>add-generated-sources</id>
+                        <id>add-dagger-sdk-sources</id>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/dagger-io</source>
-                                <source>${project.build.directory}/generated-sources/dagger-module</source>
-                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                                <source>sdk/src/main/java</source>
+                                <source>sdk/src/processor/java</source>
+                                <source>sdk/src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -139,7 +229,46 @@
             </plugin>
             <plugin>
                 <!--
-                This plugin configuration is required by Dagger to generate the module.
+                The module is built in two compilation passes from a single `mvn package`:
+                  1. default-compile compiles the vendored SDK and annotation processor
+                     (everything but the user module) without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*); the
+                     annotation processor compiled in pass 1 is then discovered on the
+                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
+                This avoids depending on pre-built/published Dagger SDK artifacts.
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <excludes>
+                                <exclude>io/dagger/modules/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/dagger/modules/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to package the module.
                 Please do not remove or modify it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/integration/testdata/modules/java/enums/pom.xml
+++ b/core/integration/testdata/modules/java/enums/pom.xml
@@ -12,6 +12,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        Controls whether the Dagger annotation processor runs to (re)generate
+        io.dagger.gen.entrypoint.Entrypoint. A plain `mvn package` leaves it at
+        "none" and just compiles the already-generated source under
+        src/generated/java. `dagger develop` / the engine pass -Ddagger.proc=full
+        to regenerate it from the current module code.
+        -->
+        <dagger.proc>none</dagger.proc>
     </properties>
 
     <!--
@@ -203,10 +211,13 @@
         <plugins>
             <plugin>
                 <!--
-                Register the vendored Dagger Java SDK sources as compilation roots:
+                Register the vendored Dagger Java SDK sources and the generated
+                entrypoint as compilation roots:
                   - sdk/src/main/java       the hand-written SDK library
                   - sdk/src/processor/java  the annotation processor (generates the entrypoint)
                   - sdk/src/generated/java  the client bindings generated from the engine schema
+                  - src/generated/java      io.dagger.gen.entrypoint.Entrypoint, generated
+                                            from the module code (see maven-compiler-plugin)
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -222,6 +233,7 @@
                                 <source>sdk/src/main/java</source>
                                 <source>sdk/src/processor/java</source>
                                 <source>sdk/src/generated/java</source>
+                                <source>src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -231,11 +243,21 @@
                 <!--
                 The module is built in two compilation passes from a single `mvn package`:
                   1. default-compile compiles the vendored SDK and annotation processor
-                     (everything but the user module) without annotation processing.
-                  2. compile-module compiles the user module (io.dagger.modules.*); the
-                     annotation processor compiled in pass 1 is then discovered on the
-                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
-                This avoids depending on pre-built/published Dagger SDK artifacts.
+                     plus the client bindings (everything but the user module and the
+                     generated entrypoint), without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*) and the
+                     entrypoint (io.dagger.gen.*) together.
+
+                Whether the entrypoint is (re)generated depends on the dagger.proc
+                property, so the very same pom serves two purposes:
+                  - dagger.proc=none (default, a plain `mvn package`): the processor does
+                    not run; the entrypoint already present as vendored source under
+                    src/generated/java is just compiled.
+                  - dagger.proc=full (passed by `dagger develop` / the engine): the
+                    processor runs in pass 2 and (re)generates the entrypoint. `dagger
+                    develop` vendors the result under src/generated/java.
+                This keeps the entrypoint as real, vendored source and avoids depending
+                on pre-built/published Dagger SDK artifacts.
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -249,6 +271,7 @@
                             <proc>none</proc>
                             <excludes>
                                 <exclude>io/dagger/modules/**</exclude>
+                                <exclude>io/dagger/gen/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -259,8 +282,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <proc>${dagger.proc}</proc>
                             <includes>
                                 <include>io/dagger/modules/**</include>
+                                <include>io/dagger/gen/**</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/core/integration/testdata/modules/java/fields/.gitattributes
+++ b/core/integration/testdata/modules/java/fields/.gitattributes
@@ -1,1 +1,1 @@
-/target/generated-sources/** linguist-generated
+/sdk/src/** linguist-generated

--- a/core/integration/testdata/modules/java/fields/.gitattributes
+++ b/core/integration/testdata/modules/java/fields/.gitattributes
@@ -1,1 +1,2 @@
 /sdk/src/** linguist-generated
+/src/generated/** linguist-generated

--- a/core/integration/testdata/modules/java/fields/.gitignore
+++ b/core/integration/testdata/modules/java/fields/.gitignore
@@ -1,1 +1,2 @@
+/sdk/src
 /target

--- a/core/integration/testdata/modules/java/fields/.gitignore
+++ b/core/integration/testdata/modules/java/fields/.gitignore
@@ -1,2 +1,3 @@
 /sdk/src
+/src/generated
 /target

--- a/core/integration/testdata/modules/java/fields/pom.xml
+++ b/core/integration/testdata/modules/java/fields/pom.xml
@@ -12,6 +12,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        Controls whether the Dagger annotation processor runs to (re)generate
+        io.dagger.gen.entrypoint.Entrypoint. A plain `mvn package` leaves it at
+        "none" and just compiles the already-generated source under
+        src/generated/java. `dagger develop` / the engine pass -Ddagger.proc=full
+        to regenerate it from the current module code.
+        -->
+        <dagger.proc>none</dagger.proc>
     </properties>
 
     <!--
@@ -203,10 +211,13 @@
         <plugins>
             <plugin>
                 <!--
-                Register the vendored Dagger Java SDK sources as compilation roots:
+                Register the vendored Dagger Java SDK sources and the generated
+                entrypoint as compilation roots:
                   - sdk/src/main/java       the hand-written SDK library
                   - sdk/src/processor/java  the annotation processor (generates the entrypoint)
                   - sdk/src/generated/java  the client bindings generated from the engine schema
+                  - src/generated/java      io.dagger.gen.entrypoint.Entrypoint, generated
+                                            from the module code (see maven-compiler-plugin)
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -222,6 +233,7 @@
                                 <source>sdk/src/main/java</source>
                                 <source>sdk/src/processor/java</source>
                                 <source>sdk/src/generated/java</source>
+                                <source>src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -231,11 +243,21 @@
                 <!--
                 The module is built in two compilation passes from a single `mvn package`:
                   1. default-compile compiles the vendored SDK and annotation processor
-                     (everything but the user module) without annotation processing.
-                  2. compile-module compiles the user module (io.dagger.modules.*); the
-                     annotation processor compiled in pass 1 is then discovered on the
-                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
-                This avoids depending on pre-built/published Dagger SDK artifacts.
+                     plus the client bindings (everything but the user module and the
+                     generated entrypoint), without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*) and the
+                     entrypoint (io.dagger.gen.*) together.
+
+                Whether the entrypoint is (re)generated depends on the dagger.proc
+                property, so the very same pom serves two purposes:
+                  - dagger.proc=none (default, a plain `mvn package`): the processor does
+                    not run; the entrypoint already present as vendored source under
+                    src/generated/java is just compiled.
+                  - dagger.proc=full (passed by `dagger develop` / the engine): the
+                    processor runs in pass 2 and (re)generates the entrypoint. `dagger
+                    develop` vendors the result under src/generated/java.
+                This keeps the entrypoint as real, vendored source and avoids depending
+                on pre-built/published Dagger SDK artifacts.
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -249,6 +271,7 @@
                             <proc>none</proc>
                             <excludes>
                                 <exclude>io/dagger/modules/**</exclude>
+                                <exclude>io/dagger/gen/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -259,8 +282,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <proc>${dagger.proc}</proc>
                             <includes>
                                 <include>io/dagger/modules/**</include>
+                                <include>io/dagger/gen/**</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/core/integration/testdata/modules/java/fields/pom.xml
+++ b/core/integration/testdata/modules/java/fields/pom.xml
@@ -12,30 +12,165 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dagger.module.deps>0.16.3-fields-module</dagger.module.deps>
     </properties>
 
+    <!--
+    The Dagger Java SDK is vendored as source under sdk/ by `dagger develop`.
+    The whole sdk/ directory is generated (see .gitattributes / .gitignore) and
+    rebuilt by Dagger; do not edit it by hand. You can add your own dependencies
+    below.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.61.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Dagger Java SDK runtime dependencies -->
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-sdk</artifactId>
-            <version>${dagger.module.deps}</version>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>${dagger.module.deps}</version>
-            <scope>provided</scope>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>4.5.26</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kothar</groupId>
+            <artifactId>xdg-java</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ongres</groupId>
+            <artifactId>fluent-process</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
+        <!-- Needed only to compile the vendored annotation processor sources -->
+        <dependency>
+            <groupId>com.palantir.javapoet</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Runtime-only dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
             <scope>runtime</scope>
-            <version>2.0.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>3.0.4</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.125.Final</version>
         </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Service descriptor that registers the Dagger annotation processor -->
+            <resource>
+                <directory>sdk/src/processor/resources</directory>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -45,27 +180,6 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
-                </plugin>
-                <plugin>
-                    <!--
-                    This plugin configuration is required by Dagger to generate the module.
-                    Please do not remove or modify it.
-                    -->
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
-                    <configuration>
-                        <verbose>false</verbose>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>io.dagger</groupId>
-                                <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>${dagger.module.deps}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <annotationProcessors>
-                            <annotationProcessor>io.dagger.annotation.processor.DaggerModuleAnnotationProcessor</annotationProcessor>
-                        </annotationProcessors>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -83,38 +197,31 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <!--
-                This plugin configuration helps VS Code editor (and others) to find
-                the generated code created by `dagger init` and `dagger develop` and
-                helps for code completion.
+                Register the vendored Dagger Java SDK sources as compilation roots:
+                  - sdk/src/main/java       the hand-written SDK library
+                  - sdk/src/processor/java  the annotation processor (generates the entrypoint)
+                  - sdk/src/generated/java  the client bindings generated from the engine schema
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>add-generated-sources</id>
+                        <id>add-dagger-sdk-sources</id>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/dagger-io</source>
-                                <source>${project.build.directory}/generated-sources/dagger-module</source>
-                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                                <source>sdk/src/main/java</source>
+                                <source>sdk/src/processor/java</source>
+                                <source>sdk/src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -122,7 +229,46 @@
             </plugin>
             <plugin>
                 <!--
-                This plugin configuration is required by Dagger to generate the module.
+                The module is built in two compilation passes from a single `mvn package`:
+                  1. default-compile compiles the vendored SDK and annotation processor
+                     (everything but the user module) without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*); the
+                     annotation processor compiled in pass 1 is then discovered on the
+                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
+                This avoids depending on pre-built/published Dagger SDK artifacts.
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <excludes>
+                                <exclude>io/dagger/modules/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/dagger/modules/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to package the module.
                 Please do not remove or modify it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -20,8 +19,14 @@ const (
 	ModSourceDirPath = "/src"
 	ModDirPath       = "/opt/module"
 	GenPath          = "/dagger-io"
+	// VendorDir is the directory, relative to the module root, where the Java
+	// SDK is vendored as real, buildable source by `dagger develop`.
+	VendorDir = "sdk"
 
 	javaSdkModuleNameEnv = "_DAGGER_JAVA_SDK_MODULE_NAME"
+
+	processorServiceFile = "META-INF/services/javax.annotation.processing.Processor"
+	processorClassName   = "io.dagger.annotation.processor.DaggerModuleAnnotationProcessor"
 )
 
 type JavaSdk struct {
@@ -79,120 +84,142 @@ func (m *JavaSdk) Codegen(
 	if err := m.setModuleConfig(ctx, modSource); err != nil {
 		return nil, err
 	}
-	mvnCtr, err := m.codegenBase(ctx, modSource, introspectionJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	generatedCode, err := m.generateCode(ctx, mvnCtr, introspectionJSON)
+	ctr, err := m.moduleContainer(ctx, modSource, introspectionJSON)
 	if err != nil {
 		return nil, err
 	}
 
 	return dag.
-		GeneratedCode(dag.Directory().WithDirectory("/", generatedCode)).
+		GeneratedCode(dag.Directory().WithDirectory("/", ctr.Directory(ModSourceDirPath))).
 		WithVCSGeneratedPaths([]string{
-			"target/generated-sources/**",
+			filepath.Join(VendorDir, "src", "**"),
 		}).
 		WithVCSIgnoredPaths([]string{
+			filepath.Join(VendorDir, "src"),
 			"target",
 		}), nil
 }
 
-// codegenBase takes the user module code, add the generated SDK dependencies
-// if the user module code is empty, creates a default module content based on the template from the SDK
-// The generated container will *not* contain the SDK source code, but only the packages built from the SDK
-func (m *JavaSdk) codegenBase(
+// moduleContainer returns a maven container with the user module sources, the
+// vendored Java SDK sources (the hand-written library, the annotation processor
+// and the client bindings generated from the engine schema) and a pom.xml.
+//
+// Everything needed to build the module is present as real source, so a single
+// `mvn package` is enough: there is no need to build or install the SDK as
+// separate Maven artifacts first.
+func (m *JavaSdk) moduleContainer(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
 	introspectionJSON *dagger.File,
 ) (*dagger.Container, error) {
-	ctr, err := m.buildJavaDependencies(ctx, introspectionJSON)
+	vendoredSDK, err := m.vendoredSDK(ctx, introspectionJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := m.mvnContainer(ctx)
 	if err != nil {
 		return nil, err
 	}
 	ctr = ctr.
+		WithMountedCache("/root/.m2", dag.CacheVolume("sdk-java-maven-m2"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.CacheSharingModeLocked}).
 		// Copy the user module directory under /src
 		WithDirectory(ModSourceDirPath, modSource.ContextDirectory()).
 		// Set the working directory to the one containing the sources to build, not just the module root
 		WithWorkdir(m.moduleConfig.modulePath())
+
 	// Add a default template if there's no existing user code
 	ctr, err = m.addTemplate(ctx, ctr)
 	if err != nil {
 		return nil, err
 	}
-	// Ensure the version in the pom.xml is the same as the introspection file
-	// This is updating the pom.xml whatever it's coming from the template or the user module
-	version, err := m.getDaggerVersionForModule(ctx, introspectionJSON)
-	if err != nil {
-		return nil, err
-	}
+
+	// Vendor the SDK as real source next to the user module, replacing any
+	// stale content from a previous `dagger develop`. Only the generated
+	// sdk/src subtree is managed by Dagger, so we leave the rest of sdk/
+	// untouched (e.g. a locally referenced SDK checkout at sdk/java).
+	vendorPath := filepath.Join(m.moduleConfig.modulePath(), VendorDir)
 	ctr = ctr.
-		// set the version of the Dagger dependencies to the version of the introspection file
-		WithExec(m.mavenCommand(
-			"mvn",
-			"versions:set-property",
-			"-DgenerateBackupPoms=false",
-			"-Dproperty=dagger.module.deps",
-			fmt.Sprintf("-DnewVersion=%s", version),
-		))
+		WithoutDirectory(filepath.Join(vendorPath, "src")).
+		WithDirectory(vendorPath, vendoredSDK)
+
 	return ctr, nil
 }
 
-// buildJavaDependencies builds and install the needed dependencies
-// used to build, package and run the user module.
-// Everything will be done under ModSourceDirPath/dagger-io (m.moduleConfig.genPath()).
-func (m *JavaSdk) buildJavaDependencies(
+// vendoredSDK returns the Java SDK as buildable source, laid out under a single
+// directory so it can be dropped next to the user module:
+//
+//	sdk/src/main/java          the hand-written SDK library
+//	sdk/src/processor/java     the annotation processor that generates the entrypoint
+//	sdk/src/generated/java     the client bindings generated from the engine schema
+//	sdk/src/processor/resources the annotation processor service descriptor
+//
+// The only thing that needs to be built ahead of time is the codegen Maven
+// plugin, which turns the introspection schema into the client bindings.
+func (m *JavaSdk) vendoredSDK(
 	ctx context.Context,
 	introspectionJSON *dagger.File,
-) (*dagger.Container, error) {
-	// We need maven to build the dependencies
+) (*dagger.Directory, error) {
 	ctr, err := m.mvnContainer(ctx)
 	if err != nil {
 		return nil, err
 	}
-	version, err := m.getDaggerVersionForModule(ctx, introspectionJSON)
-	if err != nil {
-		return nil, err
-	}
-	return ctr.
+	built := ctr.
 		// Cache maven dependencies
 		WithMountedCache("/root/.m2", dag.CacheVolume("sdk-java-maven-m2"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.CacheSharingModeLocked}).
-		// Mount the introspection JSON file used to generate the SDK
+		// Mount the introspection JSON file used to generate the client bindings
 		WithMountedFile("/schema.json", introspectionJSON).
-		// Copy the SDK source directory, so all the files needed to build the dependencies
+		// Copy the SDK source directory, with all the files needed to generate the bindings
 		WithDirectory(GenPath, m.SDKSourceDir).
 		WithWorkdir(GenPath).
-		// Set the version of the dependencies we are building to the version of the introspection file
+		// Build and install the codegen Maven plugin. It is a build-time only tool
+		// (it converts the introspection schema into Java client bindings) and is
+		// the same regardless of the module, so it benefits from the shared m2 cache.
 		WithExec(m.mavenCommand(
 			"mvn",
-			"versions:set",
-			"-DgenerateBackupPoms=false",
-			"-DprocessDependencies=false",
-			"-DprocessPlugins=false",
-			fmt.Sprintf("-DnewVersion=%s", version),
-		)).
-		// Build and install the java modules one by one
-		// - dagger-codegen-maven-plugin: this plugin will be used to generate the SDK code, from the introspection file,
-		//   this means including the ability to call other projects (not part of the main dagger SDK)
-		//   - this plugin is only used to build the SDK, the user module doesn't need it
-		// - dagger-java-annotation-processor: this will read dagger specific annotations (@Module, @Object, @Function)
-		//   and generate the entrypoint to register the module and invoke the functions
-		//   - this processor will be used by the user module to generate the entrypoint, so it's referenced in the user module pom.xml
-		// - dagger-java-sdk: the actual SDK, where the generated code will be written
-		//   - the user module code only depends on this, it includes all the required types
-		WithExec(m.mavenCommand(
-			"mvn",
-			"--projects", "dagger-codegen-maven-plugin,dagger-java-annotation-processor,dagger-java-sdk", "--also-make",
+			"--projects", "dagger-codegen-maven-plugin", "--also-make",
 			"clean", "install",
-			// avoid tests
 			"-DskipTests",
-			// specify the introspection json file
+			"-Dfmt.skip=true",
+		)).
+		// Generate the client bindings from the introspection schema.
+		WithExec(m.mavenCommand(
+			"mvn",
+			"--projects", "dagger-java-sdk",
+			"generate-sources",
 			"-Ddaggerengine.schema=/schema.json",
-		)), nil
+			"-Dfmt.skip=true",
+		))
+
+	return dag.Directory().
+		WithDirectory(
+			filepath.Join("src", "main", "java"),
+			built.Directory(filepath.Join(GenPath, "dagger-java-sdk", "src", "main", "java"))).
+		WithDirectory(
+			filepath.Join("src", "processor", "java"),
+			built.Directory(filepath.Join(GenPath, "dagger-java-annotation-processor", "src", "main", "java"))).
+		WithDirectory(
+			filepath.Join("src", "generated", "java"),
+			built.Directory(filepath.Join(GenPath, "dagger-java-sdk", "target", "generated-sources", "dagger"))).
+		WithNewFile(
+			filepath.Join("src", "processor", "resources", processorServiceFile),
+			processorClassName+"\n"), nil
 }
 
-// addTemplate creates all the necessary files to start a new Java module
+// legacyPom reports whether an existing pom.xml predates the vendored-source
+// layout: such poms depend on the (never published) io.dagger SDK artifacts via
+// the dagger.module.deps version dance and cannot be built by the current SDK.
+func legacyPom(content string) bool {
+	return strings.Contains(content, "dagger.module.deps") ||
+		strings.Contains(content, "dagger-java-sdk")
+}
+
+// addTemplate creates all the necessary files to start a new Java module.
+//
+// For a brand new module (no pom.xml) it lays down the full starter template.
+// For an existing module whose pom.xml predates the vendored-source layout it
+// regenerates only the pom.xml so the module keeps building, leaving the user
+// sources untouched. An up-to-date pom.xml is left as-is.
 func (m *JavaSdk) addTemplate(
 	ctx context.Context,
 	ctr *dagger.Container,
@@ -202,9 +229,13 @@ func (m *JavaSdk) addTemplate(
 	kebabName := strcase.ToKebab(name)
 	camelName := strcase.ToCamel(name)
 
-	// Check if there's a pom.xml inside the module path. If a file exist, no need to add the templates
-	if _, err := ctr.File(filepath.Join(m.moduleConfig.modulePath(), "pom.xml")).Name(ctx); err == nil {
-		return ctr, nil
+	pomExists := false
+	if content, err := ctr.File(filepath.Join(m.moduleConfig.modulePath(), "pom.xml")).Contents(ctx); err == nil {
+		pomExists = true
+		if !legacyPom(content) {
+			// pom.xml already uses the vendored-source layout, keep it as-is
+			return ctr, nil
+		}
 	}
 
 	absPath := func(rel ...string) string {
@@ -224,6 +255,15 @@ func (m *JavaSdk) addTemplate(
 		return ctr, fmt.Errorf("could not add template: %w", err)
 	}
 
+	// Always (re)generate the pom.xml so it uses the vendored-source layout
+	ctr = ctr.WithNewFile(absPath("pom.xml"), pomXML)
+
+	// Only lay down the starter sources for a brand new module; for an existing
+	// module we just migrated the pom.xml and must keep the user's own sources.
+	if pomExists {
+		return ctr, nil
+	}
+
 	changes = append(changes, repl{"DaggerModule", camelName})
 	daggerModuleJava, err := m.replace(ctx, templateDir,
 		filepath.Join("src", "main", "java", "io", "dagger", "modules", "daggermodule", "DaggerModule.java"),
@@ -240,57 +280,10 @@ func (m *JavaSdk) addTemplate(
 
 	// And copy them to the container, renamed to match the dagger module name
 	ctr = ctr.
-		WithNewFile(absPath("pom.xml"), pomXML).
 		WithNewFile(absPath("src", "main", "java", "io", "dagger", "modules", pkgName, fmt.Sprintf("%s.java", camelName)), daggerModuleJava).
 		WithNewFile(absPath("src", "main", "java", "io", "dagger", "modules", pkgName, "package-info.java"), packageInfoJava)
 
 	return ctr, nil
-}
-
-// generateCode builds and returns the generated source code and java classes
-func (m *JavaSdk) generateCode(
-	ctx context.Context,
-	ctr *dagger.Container,
-	introspectionJSON *dagger.File,
-) (*dagger.Directory, error) {
-	// generate the java sdk dependencies
-	javaDeps, err := m.buildJavaDependencies(ctx, introspectionJSON)
-	if err != nil {
-		return nil, err
-	}
-	// generate the entrypoint class based on the user module
-	entrypoint := ctr.
-		// set the module name as an environment variable so we ensure constructor is only on main object
-		WithEnvVariable(javaSdkModuleNameEnv, m.moduleConfig.name).
-		// generate the entrypoint
-		WithExec(m.mavenCommand(
-			"mvn",
-			"clean",
-			"compile",
-		))
-	return dag.
-		Directory().
-		// copy all user files
-		WithDirectory(
-			m.moduleConfig.modulePath(),
-			ctr.Directory(m.moduleConfig.modulePath())).
-		// copy the generated entrypoint under target/generated-sources/annotations
-		WithDirectory(
-			filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "entrypoint"),
-			entrypoint.Directory(filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "annotations"))).
-		// copy the sdk source code under target/generated-sources/dagger-io
-		// this is not really generated-sources, this is the sdk. But we don't want it as the user source code
-		// and we don't want to install it on the user machine. That way the java classes are made available
-		// to a build system or an IDE without to interfere with the user source code
-		WithDirectory(
-			filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "dagger-io"),
-			javaDeps.Directory(filepath.Join(GenPath, "dagger-java-sdk", "src", "main", "java"))).
-		// copy the generated SDK files to target/generated-sources/dagger-module
-		// those are all the types generated from the introspection
-		WithDirectory(
-			filepath.Join(m.moduleConfig.modulePath(), "target", "generated-sources", "dagger-module"),
-			javaDeps.Directory(filepath.Join(GenPath, "dagger-java-sdk", "target", "generated-sources", "dagger"))).
-		Directory(ModSourceDirPath), nil
 }
 
 func (m *JavaSdk) ModuleRuntime(
@@ -302,8 +295,8 @@ func (m *JavaSdk) ModuleRuntime(
 		return nil, err
 	}
 
-	// Get a container with the user module sources and the SDK packages built and installed
-	mvnCtr, err := m.codegenBase(ctx, modSource, introspectionJSON)
+	// Get a container with the user module sources and the vendored SDK sources
+	mvnCtr, err := m.moduleContainer(ctx, modSource, introspectionJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -411,26 +404,6 @@ func (m *JavaSdk) setModuleConfig(ctx context.Context, modSource *dagger.ModuleS
 	}
 
 	return nil
-}
-
-func (m *JavaSdk) getDaggerVersionForModule(ctx context.Context, introspectionJSON *dagger.File) (string, error) {
-	content, err := introspectionJSON.Contents(ctx)
-	if err != nil {
-		return "", err
-	}
-	var introspectJSON IntrospectJSON
-	if err = json.Unmarshal([]byte(content), &introspectJSON); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf(
-		"%s-%s-module",
-		strings.TrimPrefix(introspectJSON.SchemaVersion, "v"),
-		m.moduleConfig.name,
-	), nil
-}
-
-type IntrospectJSON struct {
-	SchemaVersion string `json:"__schemaVersion"`
 }
 
 type repl struct {

--- a/sdk/java/runtime/main.go
+++ b/sdk/java/runtime/main.go
@@ -22,6 +22,22 @@ const (
 	// VendorDir is the directory, relative to the module root, where the Java
 	// SDK is vendored as real, buildable source by `dagger develop`.
 	VendorDir = "sdk"
+	// GeneratedSrcDir is the directory, relative to the module root, where
+	// `dagger develop` vendors the generated entrypoint
+	// (io.dagger.gen.entrypoint.Entrypoint) as real, buildable source. Its java/
+	// subdirectory is a regular compilation root (see template/pom.xml), so a
+	// plain `mvn package` compiles it without re-running the processor. It is
+	// generated and git-ignored, like the vendored sdk/src tree.
+	GeneratedSrcDir = "src/generated"
+
+	// annotationsDir is where the Maven compiler plugin writes annotation-processed
+	// sources (the entrypoint) during an engine build (proc=full). The engine
+	// relocates it to GeneratedSrcDir/java for export.
+	annotationsDir = "target/generated-sources/annotations"
+
+	// procFull enables the Dagger annotation processor (entrypoint generation)
+	// for an engine-driven build; a plain `mvn package` defaults to "none".
+	procFull = "-Ddagger.proc=full"
 
 	javaSdkModuleNameEnv = "_DAGGER_JAVA_SDK_MODULE_NAME"
 
@@ -89,15 +105,48 @@ func (m *JavaSdk) Codegen(
 		return nil, err
 	}
 
+	// Generate the entrypoint (io.dagger.gen.entrypoint.Entrypoint) as real source
+	// under src/generated/java by running the vendored annotation processor over
+	// the user module, and export it alongside the vendored SDK sources. A plain
+	// `mvn package` then compiles it without re-running the processor.
+	entrypoint, err := m.generateEntrypoint(ctx, ctr)
+	if err != nil {
+		return nil, err
+	}
+
+	genDir := dag.Directory().
+		WithDirectory("/", ctr.Directory(ModSourceDirPath)).
+		WithDirectory(filepath.Join(m.moduleConfig.subPath, GeneratedSrcDir, "java"), entrypoint)
+
 	return dag.
-		GeneratedCode(dag.Directory().WithDirectory("/", ctr.Directory(ModSourceDirPath))).
+		GeneratedCode(genDir).
 		WithVCSGeneratedPaths([]string{
 			filepath.Join(VendorDir, "src", "**"),
+			filepath.Join(GeneratedSrcDir, "**"),
 		}).
 		WithVCSIgnoredPaths([]string{
 			filepath.Join(VendorDir, "src"),
+			GeneratedSrcDir,
 			"target",
 		}), nil
+}
+
+// generateEntrypoint compiles the user module with the Dagger annotation
+// processor enabled (proc=full) so it generates io.dagger.gen.entrypoint.Entrypoint,
+// and returns the generated-sources directory (the entrypoint) as real, buildable
+// source for the caller to vendor under src/generated/java.
+//
+// This mirrors the two-pass build performed when packaging the jar, but stops
+// after `compile` so we only pay for source generation, not packaging.
+func (m *JavaSdk) generateEntrypoint(
+	ctx context.Context,
+	ctr *dagger.Container,
+) (*dagger.Directory, error) {
+	compiled := ctr.
+		// set the module name as an environment variable so we ensure constructor is only on main object
+		WithEnvVariable(javaSdkModuleNameEnv, m.moduleConfig.name).
+		WithExec(m.mavenCommand("mvn", "clean", "compile", procFull))
+	return compiled.Directory(filepath.Join(m.moduleConfig.modulePath(), annotationsDir)), nil
 }
 
 // moduleContainer returns a maven container with the user module sources, the
@@ -141,7 +190,10 @@ func (m *JavaSdk) moduleContainer(
 	vendorPath := filepath.Join(m.moduleConfig.modulePath(), VendorDir)
 	ctr = ctr.
 		WithoutDirectory(filepath.Join(vendorPath, "src")).
-		WithDirectory(vendorPath, vendoredSDK)
+		WithDirectory(vendorPath, vendoredSDK).
+		// Drop any entrypoint left over from a previous `dagger develop`; an
+		// engine-driven build regenerates it (proc=full) from the current code.
+		WithoutDirectory(filepath.Join(m.moduleConfig.modulePath(), GeneratedSrcDir))
 
 	return ctr, nil
 }
@@ -327,12 +379,14 @@ func (m *JavaSdk) buildJar(
 		ctr.
 			// set the module name as an environment variable so we ensure constructor is only on main object
 			WithEnvVariable(javaSdkModuleNameEnv, m.moduleConfig.name).
-			// build the final jar
+			// build the final jar, (re)generating the entrypoint from the current
+			// module code (proc=full) in the same pass
 			WithExec(m.mavenCommand(
 				"mvn",
 				"clean",
 				"package",
 				"-DskipTests",
+				procFull,
 			)))
 }
 

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -12,6 +12,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        Controls whether the Dagger annotation processor runs to (re)generate
+        io.dagger.gen.entrypoint.Entrypoint. A plain `mvn package` leaves it at
+        "none" and just compiles the already-generated source under
+        src/generated/java. `dagger develop` / the engine pass -Ddagger.proc=full
+        to regenerate it from the current module code.
+        -->
+        <dagger.proc>none</dagger.proc>
     </properties>
 
     <!--
@@ -203,10 +211,13 @@
         <plugins>
             <plugin>
                 <!--
-                Register the vendored Dagger Java SDK sources as compilation roots:
+                Register the vendored Dagger Java SDK sources and the generated
+                entrypoint as compilation roots:
                   - sdk/src/main/java       the hand-written SDK library
                   - sdk/src/processor/java  the annotation processor (generates the entrypoint)
                   - sdk/src/generated/java  the client bindings generated from the engine schema
+                  - src/generated/java      io.dagger.gen.entrypoint.Entrypoint, generated
+                                            from the module code (see maven-compiler-plugin)
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -222,6 +233,7 @@
                                 <source>sdk/src/main/java</source>
                                 <source>sdk/src/processor/java</source>
                                 <source>sdk/src/generated/java</source>
+                                <source>src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -231,11 +243,21 @@
                 <!--
                 The module is built in two compilation passes from a single `mvn package`:
                   1. default-compile compiles the vendored SDK and annotation processor
-                     (everything but the user module) without annotation processing.
-                  2. compile-module compiles the user module (io.dagger.modules.*); the
-                     annotation processor compiled in pass 1 is then discovered on the
-                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
-                This avoids depending on pre-built/published Dagger SDK artifacts.
+                     plus the client bindings (everything but the user module and the
+                     generated entrypoint), without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*) and the
+                     entrypoint (io.dagger.gen.*) together.
+
+                Whether the entrypoint is (re)generated depends on the dagger.proc
+                property, so the very same pom serves two purposes:
+                  - dagger.proc=none (default, a plain `mvn package`): the processor does
+                    not run; the entrypoint already present as vendored source under
+                    src/generated/java is just compiled.
+                  - dagger.proc=full (passed by `dagger develop` / the engine): the
+                    processor runs in pass 2 and (re)generates the entrypoint. `dagger
+                    develop` vendors the result under src/generated/java.
+                This keeps the entrypoint as real, vendored source and avoids depending
+                on pre-built/published Dagger SDK artifacts.
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -249,6 +271,7 @@
                             <proc>none</proc>
                             <excludes>
                                 <exclude>io/dagger/modules/**</exclude>
+                                <exclude>io/dagger/gen/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -259,8 +282,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <proc>${dagger.proc}</proc>
                             <includes>
                                 <include>io/dagger/modules/**</include>
+                                <include>io/dagger/gen/**</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/sdk/java/runtime/template/pom.xml
+++ b/sdk/java/runtime/template/pom.xml
@@ -12,26 +12,134 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dagger.module.deps>0.21.4-template-module</dagger.module.deps>
     </properties>
 
+    <!--
+    The Dagger Java SDK is vendored as source under sdk/ by `dagger develop`.
+    The whole sdk/ directory is generated (see .gitattributes / .gitignore) and
+    rebuilt by Dagger; do not edit it by hand. You can add your own dependencies
+    below.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.61.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Dagger Java SDK runtime dependencies -->
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-sdk</artifactId>
-            <version>${dagger.module.deps}</version>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dagger</groupId>
-            <artifactId>dagger-java-annotation-processor</artifactId>
-            <version>${dagger.module.deps}</version>
-            <scope>provided</scope>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>4.5.26</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kothar</groupId>
+            <artifactId>xdg-java</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ongres</groupId>
+            <artifactId>fluent-process</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
+        <!-- Needed only to compile the vendored annotation processor sources -->
+        <dependency>
+            <groupId>com.palantir.javapoet</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Runtime-only dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
             <scope>runtime</scope>
-            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>
@@ -40,19 +148,29 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.125.Final</version>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.2</version>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- Service descriptor that registers the Dagger annotation processor -->
+            <resource>
+                <directory>sdk/src/processor/resources</directory>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -62,27 +180,6 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
-                </plugin>
-                <plugin>
-                    <!--
-                    This plugin configuration is required by Dagger to generate the module.
-                    Please do not remove or modify it.
-                    -->
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
-                    <configuration>
-                        <verbose>false</verbose>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>io.dagger</groupId>
-                                <artifactId>dagger-java-annotation-processor</artifactId>
-                                <version>${dagger.module.deps}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                        <annotationProcessors>
-                            <annotationProcessor>io.dagger.annotation.processor.DaggerModuleAnnotationProcessor</annotationProcessor>
-                        </annotationProcessors>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -100,38 +197,31 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
             <plugin>
                 <!--
-                This plugin configuration helps VS Code editor (and others) to find
-                the generated code created by `dagger init` and `dagger develop` and
-                helps for code completion.
+                Register the vendored Dagger Java SDK sources as compilation roots:
+                  - sdk/src/main/java       the hand-written SDK library
+                  - sdk/src/processor/java  the annotation processor (generates the entrypoint)
+                  - sdk/src/generated/java  the client bindings generated from the engine schema
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>add-generated-sources</id>
+                        <id>add-dagger-sdk-sources</id>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${project.build.directory}/generated-sources/dagger-io</source>
-                                <source>${project.build.directory}/generated-sources/dagger-module</source>
-                                <source>${project.build.directory}/generated-sources/entrypoint</source>
+                                <source>sdk/src/main/java</source>
+                                <source>sdk/src/processor/java</source>
+                                <source>sdk/src/generated/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -139,7 +229,46 @@
             </plugin>
             <plugin>
                 <!--
-                This plugin configuration is required by Dagger to generate the module.
+                The module is built in two compilation passes from a single `mvn package`:
+                  1. default-compile compiles the vendored SDK and annotation processor
+                     (everything but the user module) without annotation processing.
+                  2. compile-module compiles the user module (io.dagger.modules.*); the
+                     annotation processor compiled in pass 1 is then discovered on the
+                     classpath and generates io.dagger.gen.entrypoint.Entrypoint.
+                This avoids depending on pre-built/published Dagger SDK artifacts.
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <excludes>
+                                <exclude>io/dagger/modules/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/dagger/modules/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin configuration is required by Dagger to package the module.
                 Please do not remove or modify it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

`dagger develop` on a Java module used to:

- install the Java SDK and annotation processor into the local Maven repo
  under a per-module *magic* version (`<schema>-<module>-module`), and
- export non-buildable copies of the SDK and generated client bindings
  under `target/`.

The generated `pom.xml` therefore referenced `io.dagger` artifacts that
don't exist anywhere (`io.dagger:dagger-java-sdk`,
`io.dagger:dagger-java-annotation-processor`), so standard Maven tooling
(IDEs, plain `mvn`) could not build the user sources — the exported code was
"for show" only.

This PR realigns the host-exported sources with what is actually used to
build the module: the SDK is **vendored as real, buildable source** under
`sdk/`, and the module builds with a single `mvn package` and no version
dance.

### New layout (under the module, all generated + git-ignored)

```
sdk/src/main/java        the hand-written SDK library
sdk/src/processor/java   the annotation processor (generates the entrypoint)
sdk/src/generated/java   the client bindings generated from the engine schema
```

The module `pom.xml` now:

- declares the regular third-party dependencies (smallrye-graphql, vertx,
  opentelemetry, jakarta.json, …) resolvable from Maven Central,
- registers the vendored source roots via `build-helper`,
- compiles in two passes from a single `mvn package`: the SDK + annotation
  processor are compiled first, then the user module
  (`io.dagger.modules.*`) is compiled so the processor is discovered on the
  classpath and generates `io.dagger.gen.entrypoint.Entrypoint`,
- contains no `io.dagger` dependencies and no `dagger.module.deps` version
  property.

The only thing still built ahead of time is the codegen Maven plugin (a
build-time-only tool that turns the introspection schema into the client
bindings); it is the same for every module and benefits from the shared m2
cache.

### Notes / design choices

- The annotation processor must be a compiled artifact to process the user
  module, so it is vendored under `sdk/src/processor/java` and compiled in
  the first pass. `io.dagger.gen.entrypoint.Entrypoint` is generated by Maven
  into `target/generated-sources/annotations` during the build (standard
  annotation-processing output, IDE-discoverable), so it always reflects the
  current module code.
- The exported `sdk/` tree is fully Dagger-managed: it is rebuilt on every
  `dagger develop` / module load and is marked `linguist-generated` +
  git-ignored.

## Test plan

Validated end-to-end against a dev engine built from this branch
(`dagger call engine-dev test --pkg ./core/integration --run=TestJava/...`):

- [x] `TestJava/TestDefaultValue`
- [x] `TestJava/TestFields`
- [x] `TestJava/TestOptionalValue`
- [x] `TestJava/TestDefaultPath`
- [x] `TestJava/TestIgnore`
- [x] `TestJava/TestConstructor`
- [x] `TestJava/TestEnum`
- [ ] CI green