### PR TITLE
chore: improve release workflows for prereleases and idempotency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,10 @@ jobs:
   # TODO: move this into Publish above
   dagger-io-bump-dagger:
     needs: publish
-    if: github.ref_name != 'main'
+    if: |
+      github.repository == 'dagger/dagger' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       # Configure credentials to clone dagger modules
@@ -120,6 +123,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: macos-15-intel
     steps:
@@ -207,6 +211,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -261,6 +266,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-24.04-arm
     steps:
@@ -308,6 +314,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -362,6 +369,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-24.04-arm
     steps:
@@ -409,6 +417,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -472,6 +481,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
+      !contains(github.ref_name, '-') &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -33,3 +33,6 @@ builds:
 
 checksum:
   name_template: "checksums.txt"
+
+release:
+  replace_existing_artifacts: true

--- a/modules/git-releaser/main.go
+++ b/modules/git-releaser/main.go
@@ -134,6 +134,26 @@ func (gitrel *GitReleaser) Release(
 		WithDirectory(".", sourceRepo.Ref(sourceTag).Tree(dagger.GitRefTreeOpts{Depth: -1})).
 		WithExec(filterRepoArgs)
 	if !dryRun {
+		localCommit, err := result.
+			WithExec([]string{"git", "rev-parse", sourceTag + "^{}"}).
+			Stdout(ctx)
+		if err != nil {
+			return err
+		}
+		localCommit = strings.TrimSpace(localCommit)
+
+		remoteCommit, exists, err := gitrel.remoteRefCommit(ctx, result, destRemote, destTag)
+		if err != nil {
+			return err
+		}
+		if exists && remoteCommit == localCommit {
+			fmt.Printf("found existing git ref %s at %s; skipping push to %s\n", destTag, remoteCommit, destRemote)
+			return nil
+		}
+		if exists && destTag != "main" {
+			return fmt.Errorf("remote git ref %s already exists at %s, expected %s", destTag, remoteCommit, localCommit)
+		}
+
 		result = result.WithExec([]string{
 			"git",
 			"push",
@@ -179,4 +199,39 @@ func (gitrel *GitReleaser) Release(
 
 	_, err := result.Sync(ctx)
 	return err
+}
+
+func (gitrel *GitReleaser) remoteRefCommit(
+	ctx context.Context,
+	ctr *dagger.Container,
+	remote string,
+	ref string,
+) (string, bool, error) {
+	fetch := ctr.WithExec(
+		[]string{"git", "fetch", "--no-tags", remote, ref},
+		dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny},
+	)
+
+	code, err := fetch.ExitCode(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if code != 0 {
+		stderr, err := fetch.Stderr(ctx)
+		if err != nil {
+			return "", false, err
+		}
+		if strings.Contains(stderr, "couldn't find remote ref") {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to fetch remote ref %s from %s: %s", ref, remote, strings.TrimSpace(stderr))
+	}
+
+	commit, err := fetch.
+		WithExec([]string{"git", "rev-parse", "FETCH_HEAD^{}"}).
+		Stdout(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	return strings.TrimSpace(commit), true, nil
 }

--- a/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
@@ -6,17 +6,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"dagger.io/dagger/querybuilder"
+	"github.com/dagger/querybuilder"
 )
-
-// The `PythonSdkDevDocsID` scalar type represents an identifier for an object of type PythonSdkDevDocs.
-type PythonSDKDevDocsID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
-
-// The `PythonSdkDevID` scalar type represents an identifier for an object of type PythonSdkDev.
-type PythonSDKDevID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
-
-// The `PythonSdkDevTestForPythonVersionID` scalar type represents an identifier for an object of type PythonSdkDevTestForPythonVersion.
-type PythonSDKDevTestForPythonVersionID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 
 // Retrieve the binding value, as type PythonSdkDev
 func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
@@ -121,7 +112,7 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	query *querybuilder.Selection
 
-	id            *PythonSDKDevID
+	id            *ID
 	release       *Void
 	releaseDryRun *Void
 	sourcePath    *string
@@ -228,13 +219,13 @@ func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // py
 }
 
 // A unique identifier for this PythonSdkDev.
-func (r *PythonSDKDev) ID(ctx context.Context) (PythonSDKDevID, error) {
+func (r *PythonSDKDev) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -247,7 +238,7 @@ func (r *PythonSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDev) XXX_GraphQLIDType() string {
-	return "PythonSDKDevID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -272,7 +263,7 @@ func (r *PythonSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevFromID(PythonSDKDevID(id))
+	*r = PythonSDKDev{query: selectNode(dag.query, id, "PythonSdkDev")}
 	return nil
 }
 
@@ -546,10 +537,18 @@ func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../t
 	}
 }
 
+// AsNode returns this PythonSDKDev as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDev) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 type PythonSDKDevDocs struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
 	query *querybuilder.Selection
 
-	id *PythonSDKDevDocsID
+	id *ID
 }
 
 func (r *PythonSDKDevDocs) WithGraphQLQuery(q *querybuilder.Selection) *PythonSDKDevDocs {
@@ -568,13 +567,13 @@ func (r *PythonSDKDevDocs) Build() *Directory { // python-sdk-dev (../../../../t
 }
 
 // A unique identifier for this PythonSdkDevDocs.
-func (r *PythonSDKDevDocs) ID(ctx context.Context) (PythonSDKDevDocsID, error) {
+func (r *PythonSDKDevDocs) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevDocsID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -587,7 +586,7 @@ func (r *PythonSDKDevDocs) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevDocs) XXX_GraphQLIDType() string {
-	return "PythonSDKDevDocsID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -612,7 +611,7 @@ func (r *PythonSDKDevDocs) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevDocsFromID(PythonSDKDevDocsID(id))
+	*r = PythonSDKDevDocs{query: selectNode(dag.query, id, "PythonSdkDevDocs")}
 	return nil
 }
 
@@ -641,10 +640,18 @@ func (r *PythonSDKDevDocs) Preview(opts ...PythonSDKDevDocsPreviewOpts) *Service
 	}
 }
 
+// AsNode returns this PythonSDKDevDocs as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDevDocs) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 type PythonSDKDevTestForPythonVersion struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 	query *querybuilder.Selection
 
-	id   *PythonSDKDevTestForPythonVersionID
+	id   *ID
 	run  *Void
 	slow *Void
 	unit *Void
@@ -657,13 +664,13 @@ func (r *PythonSDKDevTestForPythonVersion) WithGraphQLQuery(q *querybuilder.Sele
 }
 
 // A unique identifier for this PythonSdkDevTestForPythonVersion.
-func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (PythonSDKDevTestForPythonVersionID, error) {
+func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevTestForPythonVersionID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -676,7 +683,7 @@ func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLIDType() string {
-	return "PythonSDKDevTestForPythonVersionID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -701,7 +708,7 @@ func (r *PythonSDKDevTestForPythonVersion) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevTestForPythonVersionFromID(PythonSDKDevTestForPythonVersionID(id))
+	*r = PythonSDKDevTestForPythonVersion{query: selectNode(dag.query, id, "PythonSdkDevTestForPythonVersion")}
 	return nil
 }
 
@@ -736,33 +743,11 @@ func (r *PythonSDKDevTestForPythonVersion) Unit(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
-// Load a PythonSdkDevDocs from its ID.
-func (r *Query) LoadPythonSDKDevDocsFromID(id PythonSDKDevDocsID) *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
-	q := r.query.Select("loadPythonSdkDevDocsFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDevDocs{
-		query: q,
-	}
-}
-
-// Load a PythonSdkDev from its ID.
-func (r *Query) LoadPythonSDKDevFromID(id PythonSDKDevID) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
-	q := r.query.Select("loadPythonSdkDevFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDev{
-		query: q,
-	}
-}
-
-// Load a PythonSdkDevTestForPythonVersion from its ID.
-func (r *Query) LoadPythonSDKDevTestForPythonVersionFromID(id PythonSDKDevTestForPythonVersionID) *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
-	q := r.query.Select("loadPythonSdkDevTestForPythonVersionFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDevTestForPythonVersion{
-		query: q,
+// AsNode returns this PythonSDKDevTestForPythonVersion as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDevTestForPythonVersion) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
 	}
 }
 

--- a/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
@@ -6,11 +6,20 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dagger/querybuilder"
+	"dagger.io/dagger/querybuilder"
 )
 
+// The `PythonSdkDevDocsID` scalar type represents an identifier for an object of type PythonSdkDevDocs.
+type PythonSDKDevDocsID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
+
+// The `PythonSdkDevID` scalar type represents an identifier for an object of type PythonSdkDev.
+type PythonSDKDevID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+
+// The `PythonSdkDevTestForPythonVersionID` scalar type represents an identifier for an object of type PythonSdkDevTestForPythonVersion.
+type PythonSDKDevTestForPythonVersionID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
+
 // Retrieve the binding value, as type PythonSdkDev
-func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	q := r.query.Select("asPythonSdkDev")
 
 	return &PythonSDKDev{
@@ -61,7 +70,7 @@ func (r *Env) WithPythonSDKDevDocsOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type PythonSdkDev in the environment
-func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPythonSdkDevInput")
 	q = q.Arg("name", name)
@@ -74,7 +83,7 @@ func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, descriptio
 }
 
 // Declare a desired PythonSdkDev output to be assigned in the environment
-func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	q := r.query.Select("withPythonSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -109,10 +118,10 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 }
 
 // A toolchain to develop the Dagger Python SDK
-type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	query *querybuilder.Selection
 
-	id            *ID
+	id            *PythonSDKDevID
 	release       *Void
 	releaseDryRun *Void
 	sourcePath    *string
@@ -140,11 +149,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:283:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:313:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:280:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +168,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:268:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:298:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +178,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:175:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -178,7 +187,7 @@ func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../
 }
 
 // Python container to develop Python SDK
-func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:17:2)
+func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
 	q := r.query.Select("devContainer")
 
 	return &Container{
@@ -187,7 +196,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:321:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:351:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +209,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:104:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:101:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -219,13 +228,13 @@ func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // py
 }
 
 // A unique identifier for this PythonSdkDev.
-func (r *PythonSDKDev) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDev) ID(ctx context.Context) (PythonSDKDevID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -238,7 +247,7 @@ func (r *PythonSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDev) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -263,7 +272,7 @@ func (r *PythonSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDev{query: selectNode(dag.query, id, "PythonSdkDev")}
+	*r = *dag.LoadPythonSDKDevFromID(PythonSDKDevID(id))
 	return nil
 }
 
@@ -272,11 +281,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:92:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:89:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +301,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:81:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:75:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +324,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:333:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:363:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:357:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +350,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:300:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:330:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:292:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:322:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +379,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:134:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +388,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:142:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +397,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:150:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +406,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:158:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +415,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:166:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,15 +425,15 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:240:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:242:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:243:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:245:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:232:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:233:1)
 	if r.release != nil {
 		return nil
 	}
@@ -449,7 +458,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:221:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -458,7 +467,7 @@ func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-
 	return q.Execute(ctx)
 }
 
-func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
+func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:20:2)
 	if r.sourcePath != nil {
 		return *r.sourcePath, nil
 	}
@@ -471,7 +480,7 @@ func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // pyth
 }
 
 // Supported Python versions
-func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:21:2)
+func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:22:2)
 	q := r.query.Select("supportedVersions")
 
 	var response []string
@@ -487,11 +496,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:345:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:340:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -509,7 +518,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:116:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -519,7 +528,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:125:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -529,7 +538,7 @@ func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // pytho
 	}
 }
 
-func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
+func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
 	q := r.query.Select("workspace")
 
 	return &Directory{
@@ -537,18 +546,10 @@ func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../t
 	}
 }
 
-// AsNode returns this PythonSDKDev as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDev) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
-	}
-}
-
 type PythonSDKDevDocs struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
 	query *querybuilder.Selection
 
-	id *ID
+	id *PythonSDKDevDocsID
 }
 
 func (r *PythonSDKDevDocs) WithGraphQLQuery(q *querybuilder.Selection) *PythonSDKDevDocs {
@@ -567,13 +568,13 @@ func (r *PythonSDKDevDocs) Build() *Directory { // python-sdk-dev (../../../../t
 }
 
 // A unique identifier for this PythonSdkDevDocs.
-func (r *PythonSDKDevDocs) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDevDocs) ID(ctx context.Context) (PythonSDKDevDocsID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevDocsID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -586,7 +587,7 @@ func (r *PythonSDKDevDocs) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevDocs) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevDocsID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -611,7 +612,7 @@ func (r *PythonSDKDevDocs) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDevDocs{query: selectNode(dag.query, id, "PythonSdkDevDocs")}
+	*r = *dag.LoadPythonSDKDevDocsFromID(PythonSDKDevDocsID(id))
 	return nil
 }
 
@@ -640,18 +641,10 @@ func (r *PythonSDKDevDocs) Preview(opts ...PythonSDKDevDocsPreviewOpts) *Service
 	}
 }
 
-// AsNode returns this PythonSDKDevDocs as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDevDocs) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
-	}
-}
-
 type PythonSDKDevTestForPythonVersion struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 	query *querybuilder.Selection
 
-	id   *ID
+	id   *PythonSDKDevTestForPythonVersionID
 	run  *Void
 	slow *Void
 	unit *Void
@@ -664,13 +657,13 @@ func (r *PythonSDKDevTestForPythonVersion) WithGraphQLQuery(q *querybuilder.Sele
 }
 
 // A unique identifier for this PythonSdkDevTestForPythonVersion.
-func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (PythonSDKDevTestForPythonVersionID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevTestForPythonVersionID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -683,7 +676,7 @@ func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevTestForPythonVersionID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -708,7 +701,7 @@ func (r *PythonSDKDevTestForPythonVersion) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDevTestForPythonVersion{query: selectNode(dag.query, id, "PythonSdkDevTestForPythonVersion")}
+	*r = *dag.LoadPythonSDKDevTestForPythonVersionFromID(PythonSDKDevTestForPythonVersionID(id))
 	return nil
 }
 
@@ -743,11 +736,33 @@ func (r *PythonSDKDevTestForPythonVersion) Unit(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
-// AsNode returns this PythonSDKDevTestForPythonVersion as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDevTestForPythonVersion) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
+// Load a PythonSdkDevDocs from its ID.
+func (r *Query) LoadPythonSDKDevDocsFromID(id PythonSDKDevDocsID) *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
+	q := r.query.Select("loadPythonSdkDevDocsFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDevDocs{
+		query: q,
+	}
+}
+
+// Load a PythonSdkDev from its ID.
+func (r *Query) LoadPythonSDKDevFromID(id PythonSDKDevID) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+	q := r.query.Select("loadPythonSdkDevFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDev{
+		query: q,
+	}
+}
+
+// Load a PythonSdkDevTestForPythonVersion from its ID.
+func (r *Query) LoadPythonSDKDevTestForPythonVersionFromID(id PythonSDKDevTestForPythonVersionID) *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
+	q := r.query.Select("loadPythonSdkDevTestForPythonVersionFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDevTestForPythonVersion{
+		query: q,
 	}
 }
 
@@ -756,14 +771,14 @@ type PythonSDKDevOpts struct {
 	//
 	// A workspace containing the SDK source code and other relevant files
 	//
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:45:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:46:2)
 
 	// Default: "sdk/python"
-	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
+	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:49:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
-func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:24:1)
+func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:25:1)
 	q := r.query.Select("pythonSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument

--- a/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
@@ -6,11 +6,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"dagger.io/dagger/querybuilder"
+	"github.com/dagger/querybuilder"
 )
-
-// The `RustSdkDevID` scalar type represents an identifier for an object of type RustSdkDev.
-type RustSDKDevID string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 
 // Retrieve the binding value, as type RustSdkDev
 func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
@@ -41,16 +38,6 @@ func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // ru
 	q = q.Arg("description", description)
 
 	return &Env{
-		query: q,
-	}
-}
-
-// Load a RustSdkDev from its ID.
-func (r *Query) LoadRustSDKDevFromID(id RustSDKDevID) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
-	q := r.query.Select("loadRustSdkDevFromID")
-	q = q.Arg("id", id)
-
-	return &RustSDKDev{
 		query: q,
 	}
 }
@@ -94,7 +81,7 @@ type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/ma
 
 	cargoCheck    *Void
 	cargoFmt      *Void
-	id            *RustSDKDevID
+	id            *ID
 	release       *Void
 	releaseDryRun *Void
 	test          *Void
@@ -195,13 +182,13 @@ func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container
 }
 
 // A unique identifier for this RustSdkDev.
-func (r *RustSDKDev) ID(ctx context.Context) (RustSDKDevID, error) {
+func (r *RustSDKDev) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response RustSDKDevID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -214,7 +201,7 @@ func (r *RustSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *RustSDKDev) XXX_GraphQLIDType() string {
-	return "RustSDKDevID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -239,7 +226,7 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadRustSDKDevFromID(RustSDKDevID(id))
+	*r = RustSDKDev{query: selectNode(dag.query, id, "RustSdkDev")}
 	return nil
 }
 
@@ -306,5 +293,13 @@ func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../
 
 	return &RustSDKDev{
 		query: q,
+	}
+}
+
+// AsNode returns this RustSDKDev as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *RustSDKDev) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
 	}
 }

--- a/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dagger/querybuilder"
+	"dagger.io/dagger/querybuilder"
 )
 
+// The `RustSdkDevID` scalar type represents an identifier for an object of type RustSdkDev.
+type RustSDKDevID string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+
 // Retrieve the binding value, as type RustSdkDev
-func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	q := r.query.Select("asRustSdkDev")
 
 	return &RustSDKDev{
@@ -19,7 +22,7 @@ func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../tool
 }
 
 // Create or update a binding of type RustSdkDev in the environment
-func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withRustSdkDevInput")
 	q = q.Arg("name", name)
@@ -32,7 +35,7 @@ func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description st
 }
 
 // Declare a desired RustSdkDev output to be assigned in the environment
-func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	q := r.query.Select("withRustSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,22 +45,32 @@ func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // ru
 	}
 }
 
+// Load a RustSdkDev from its ID.
+func (r *Query) LoadRustSDKDevFromID(id RustSDKDevID) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+	q := r.query.Select("loadRustSdkDevFromID")
+	q = q.Arg("id", id)
+
+	return &RustSDKDev{
+		query: q,
+	}
+}
+
 // RustSDKDevOpts contains options for Query.RustSDKDev
 type RustSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:40:2)
+	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:41:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/rust"
-	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:43:2)
+	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:44:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
-func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:38:1)
+func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:39:1)
 	q := r.query.Select("rustSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -76,12 +89,12 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 }
 
 // Develop the Dagger Rust SDK (experimental)
-type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	query *querybuilder.Selection
 
 	cargoCheck    *Void
 	cargoFmt      *Void
-	id            *ID
+	id            *RustSDKDevID
 	release       *Void
 	releaseDryRun *Void
 	test          *Void
@@ -102,7 +115,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:150:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:151:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -110,7 +123,7 @@ func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolc
 	}
 }
 
-func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:35:2)
+func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:36:2)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -119,7 +132,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:277:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:305:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +142,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:129:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:130:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +152,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:119:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +161,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:154:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:155:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +175,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:73:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:74:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:69:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:70:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -182,13 +195,13 @@ func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container
 }
 
 // A unique identifier for this RustSdkDev.
-func (r *RustSDKDev) ID(ctx context.Context) (ID, error) {
+func (r *RustSDKDev) ID(ctx context.Context) (RustSDKDevID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response RustSDKDevID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -201,7 +214,7 @@ func (r *RustSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *RustSDKDev) XXX_GraphQLIDType() string {
-	return "ID"
+	return "RustSDKDevID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -226,12 +239,12 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = RustSDKDev{query: selectNode(dag.query, id, "RustSdkDev")}
+	*r = *dag.LoadRustSDKDevFromID(RustSDKDevID(id))
 	return nil
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:246:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:247:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -250,11 +263,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:183:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:184:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:178:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:179:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -270,7 +283,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:113:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:114:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -279,7 +292,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:139:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:140:1)
 	if r.test != nil {
 		return nil
 	}
@@ -288,18 +301,10 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:158:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:159:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{
 		query: q,
-	}
-}
-
-// AsNode returns this RustSDKDev as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *RustSDKDev) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
 	}
 }

--- a/toolchains/cli-dev/publish.go
+++ b/toolchains/cli-dev/publish.go
@@ -170,6 +170,7 @@ func (cli *CliDev) PublishMetadata(
 			Stdin: strings.TrimPrefix(version, "v"),
 		}
 		if semver.Prerelease(version) == "" {
+			// update version pointers
 			ctr = ctr.
 				WithExec([]string{"aws", "s3", "cp", "-", s3Path(awsBucket, "dagger/latest_version")}, cpOpts).
 				WithExec([]string{"aws", "s3", "cp", "-", s3Path(awsBucket, "dagger/versions/latest")}, cpOpts).

--- a/toolchains/docs-dev/internal/dagger/dagger-cli.gen.go
+++ b/toolchains/docs-dev/internal/dagger/dagger-cli.gen.go
@@ -235,7 +235,7 @@ func (r *DaggerCli) Reference(opts ...DaggerCliReferenceOpts) *File { // dagger-
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:200:1)
+func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:201:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -18,9 +18,7 @@ type ElixirSdkDev {
 
   pub devContainer: Container! {
     daggerEngine
-      .installClient(
-        withBase(source),
-      )
+      .installClient(withBase(source))
   }
 
   """
@@ -126,26 +124,32 @@ type ElixirSdkDev {
     let version = versionFromTag(tag)
     let ctr = devContainer
 
-    # Update version in mix.exs if this is a valid semver
-    if (isSemver(version)) {
-      let mixFile = "/sdk/elixir/mix.exs"
-      let mixExs = workspace.file(sourcePath + "/mix.exs")
-      let newMixExs = mixExs.withReplaced(
-        "@version \"0.0.0\"",
-        "@version \"" + version.trimPrefix("v") + "\"",
-      )
-      ctr = ctr.withFile(mixFile, newMixExs)
-    }
+    if (dryRun == false and isSemver(version) and hexVersionExists(
+      version.trimPrefix("v"),
+    )) {
+      print("found existing Elixir SDK package dagger " + version.trimPrefix("v") + "; skipping publish")
+    } else {
+      # Update version in mix.exs if this is a valid semver
+      if (isSemver(version)) {
+        let mixFile = "/sdk/elixir/mix.exs"
+        let mixExs = workspace.file(sourcePath + "/mix.exs")
+        let newMixExs = mixExs.withReplaced(
+          "@version \"0.0.0\"",
+          "@version \"" + version.trimPrefix("v") + "\"",
+        )
+        ctr = ctr.withFile(mixFile, newMixExs)
+      }
 
-    # Publish or dry-run
-    let mix = ["mix", "hex.publish", "--yes"]
-    if (dryRun) {
-      mix += ["--dry-run"]
-      ctr = ctr.withEnvVariable("HEX_API_KEY", "")
-    } else if (hexApiKey != null) {
-      ctr = ctr.withSecretVariable("HEX_API_KEY", hexApiKey)
+      # Publish or dry-run
+      let mix = ["mix", "hex.publish", "--yes"]
+      if (dryRun) {
+        mix += ["--dry-run"]
+        ctr = ctr.withEnvVariable("HEX_API_KEY", "")
+      } else if (hexApiKey != null) {
+        ctr = ctr.withSecretVariable("HEX_API_KEY", hexApiKey)
+      }
+      ctr.withExec(mix).sync
     }
-    ctr.withExec(mix).sync
     null
   }
 
@@ -206,6 +210,15 @@ type ElixirSdkDev {
       .from("alpine:3")
       .withFile("/bin/is-semver", binary)
       .withExec(["is-semver", version], expect: ReturnType.ANY)
+      .exitCode
+    exitCode == 0
+  }
+
+  let hexVersionExists(version: String!): Boolean! {
+    let exitCode = container
+      .from(baseImage)
+      .withExec(["mix", "local.hex", "--force"])
+      .withExec(["mix", "hex.info", "dagger", version], expect: ReturnType.ANY)
       .exitCode
     exitCode == 0
   }

--- a/toolchains/engine-dev/internal/dagger/dagger-cli.gen.go
+++ b/toolchains/engine-dev/internal/dagger/dagger-cli.gen.go
@@ -235,7 +235,7 @@ func (r *DaggerCli) Reference(opts ...DaggerCliReferenceOpts) *File { // dagger-
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:200:1)
+func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:201:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/python-sdk-dev/main.go
+++ b/toolchains/python-sdk-dev/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
 	"runtime"
 	"strings"
 
@@ -251,8 +252,20 @@ func (t PythonSdkDev) Release(
 		ctr = t.Build("0.0.0") // no default arg in Go, without self call just replicate the default value
 	} else {
 		var url string
+		var indexURL string
 		if pypiRepo == "test" {
 			url = "https://test.pypi.org/legacy/"
+			indexURL = fmt.Sprintf("https://test.pypi.org/pypi/dagger-io/%s/json", strings.TrimPrefix(version, "v"))
+		} else {
+			indexURL = fmt.Sprintf("https://pypi.org/pypi/dagger-io/%s/json", strings.TrimPrefix(version, "v"))
+		}
+		exists, err := packageVersionExists(indexURL)
+		if err != nil {
+			return err
+		}
+		if exists {
+			fmt.Printf("found existing Python SDK package dagger-io %s; skipping publish\n", strings.TrimPrefix(version, "v"))
+			return nil
 		}
 		ctr = t.Publish(pypiToken, strings.TrimPrefix(version, "v"), url)
 	}
@@ -262,6 +275,23 @@ func (t PythonSdkDev) Release(
 	}
 
 	return nil
+}
+
+func packageVersionExists(url string) (bool, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected package lookup status %s from %s", resp.Status, url)
+	}
 }
 
 // Bump the Python SDK's Engine dependency

--- a/toolchains/release/internal/dagger/cli-dev.gen.go
+++ b/toolchains/release/internal/dagger/cli-dev.gen.go
@@ -235,7 +235,7 @@ func (r *CliDev) Reference(opts ...CliDevReferenceOpts) *File { // cli-dev (../.
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *CliDev) ReleaseDryRun(ctx context.Context) error { // cli-dev (../../../../toolchains/cli-dev/publish.go:200:1)
+func (r *CliDev) ReleaseDryRun(ctx context.Context) error { // cli-dev (../../../../toolchains/cli-dev/publish.go:201:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/release/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/python-sdk-dev.gen.go
@@ -6,17 +6,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"dagger.io/dagger/querybuilder"
+	"github.com/dagger/querybuilder"
 )
-
-// The `PythonSdkDevDocsID` scalar type represents an identifier for an object of type PythonSdkDevDocs.
-type PythonSDKDevDocsID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
-
-// The `PythonSdkDevID` scalar type represents an identifier for an object of type PythonSdkDev.
-type PythonSDKDevID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
-
-// The `PythonSdkDevTestForPythonVersionID` scalar type represents an identifier for an object of type PythonSdkDevTestForPythonVersion.
-type PythonSDKDevTestForPythonVersionID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 
 // Retrieve the binding value, as type PythonSdkDev
 func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
@@ -121,7 +112,7 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	query *querybuilder.Selection
 
-	id            *PythonSDKDevID
+	id            *ID
 	release       *Void
 	releaseDryRun *Void
 	sourcePath    *string
@@ -228,13 +219,13 @@ func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // py
 }
 
 // A unique identifier for this PythonSdkDev.
-func (r *PythonSDKDev) ID(ctx context.Context) (PythonSDKDevID, error) {
+func (r *PythonSDKDev) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -247,7 +238,7 @@ func (r *PythonSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDev) XXX_GraphQLIDType() string {
-	return "PythonSDKDevID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -272,7 +263,7 @@ func (r *PythonSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevFromID(PythonSDKDevID(id))
+	*r = PythonSDKDev{query: selectNode(dag.query, id, "PythonSdkDev")}
 	return nil
 }
 
@@ -546,10 +537,18 @@ func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../t
 	}
 }
 
+// AsNode returns this PythonSDKDev as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDev) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 type PythonSDKDevDocs struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
 	query *querybuilder.Selection
 
-	id *PythonSDKDevDocsID
+	id *ID
 }
 
 func (r *PythonSDKDevDocs) WithGraphQLQuery(q *querybuilder.Selection) *PythonSDKDevDocs {
@@ -568,13 +567,13 @@ func (r *PythonSDKDevDocs) Build() *Directory { // python-sdk-dev (../../../../t
 }
 
 // A unique identifier for this PythonSdkDevDocs.
-func (r *PythonSDKDevDocs) ID(ctx context.Context) (PythonSDKDevDocsID, error) {
+func (r *PythonSDKDevDocs) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevDocsID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -587,7 +586,7 @@ func (r *PythonSDKDevDocs) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevDocs) XXX_GraphQLIDType() string {
-	return "PythonSDKDevDocsID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -612,7 +611,7 @@ func (r *PythonSDKDevDocs) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevDocsFromID(PythonSDKDevDocsID(id))
+	*r = PythonSDKDevDocs{query: selectNode(dag.query, id, "PythonSdkDevDocs")}
 	return nil
 }
 
@@ -641,10 +640,18 @@ func (r *PythonSDKDevDocs) Preview(opts ...PythonSDKDevDocsPreviewOpts) *Service
 	}
 }
 
+// AsNode returns this PythonSDKDevDocs as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDevDocs) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
 type PythonSDKDevTestForPythonVersion struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 	query *querybuilder.Selection
 
-	id   *PythonSDKDevTestForPythonVersionID
+	id   *ID
 	run  *Void
 	slow *Void
 	unit *Void
@@ -657,13 +664,13 @@ func (r *PythonSDKDevTestForPythonVersion) WithGraphQLQuery(q *querybuilder.Sele
 }
 
 // A unique identifier for this PythonSdkDevTestForPythonVersion.
-func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (PythonSDKDevTestForPythonVersionID, error) {
+func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response PythonSDKDevTestForPythonVersionID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -676,7 +683,7 @@ func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLIDType() string {
-	return "PythonSDKDevTestForPythonVersionID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -701,7 +708,7 @@ func (r *PythonSDKDevTestForPythonVersion) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadPythonSDKDevTestForPythonVersionFromID(PythonSDKDevTestForPythonVersionID(id))
+	*r = PythonSDKDevTestForPythonVersion{query: selectNode(dag.query, id, "PythonSdkDevTestForPythonVersion")}
 	return nil
 }
 
@@ -736,33 +743,11 @@ func (r *PythonSDKDevTestForPythonVersion) Unit(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
-// Load a PythonSdkDevDocs from its ID.
-func (r *Query) LoadPythonSDKDevDocsFromID(id PythonSDKDevDocsID) *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
-	q := r.query.Select("loadPythonSdkDevDocsFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDevDocs{
-		query: q,
-	}
-}
-
-// Load a PythonSdkDev from its ID.
-func (r *Query) LoadPythonSDKDevFromID(id PythonSDKDevID) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
-	q := r.query.Select("loadPythonSdkDevFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDev{
-		query: q,
-	}
-}
-
-// Load a PythonSdkDevTestForPythonVersion from its ID.
-func (r *Query) LoadPythonSDKDevTestForPythonVersionFromID(id PythonSDKDevTestForPythonVersionID) *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
-	q := r.query.Select("loadPythonSdkDevTestForPythonVersionFromID")
-	q = q.Arg("id", id)
-
-	return &PythonSDKDevTestForPythonVersion{
-		query: q,
+// AsNode returns this PythonSDKDevTestForPythonVersion as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *PythonSDKDevTestForPythonVersion) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
 	}
 }
 

--- a/toolchains/release/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/python-sdk-dev.gen.go
@@ -6,11 +6,20 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dagger/querybuilder"
+	"dagger.io/dagger/querybuilder"
 )
 
+// The `PythonSdkDevDocsID` scalar type represents an identifier for an object of type PythonSdkDevDocs.
+type PythonSDKDevDocsID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
+
+// The `PythonSdkDevID` scalar type represents an identifier for an object of type PythonSdkDev.
+type PythonSDKDevID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+
+// The `PythonSdkDevTestForPythonVersionID` scalar type represents an identifier for an object of type PythonSdkDevTestForPythonVersion.
+type PythonSDKDevTestForPythonVersionID string // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
+
 // Retrieve the binding value, as type PythonSdkDev
-func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	q := r.query.Select("asPythonSdkDev")
 
 	return &PythonSDKDev{
@@ -61,7 +70,7 @@ func (r *Env) WithPythonSDKDevDocsOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type PythonSdkDev in the environment
-func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPythonSdkDevInput")
 	q = q.Arg("name", name)
@@ -74,7 +83,7 @@ func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, descriptio
 }
 
 // Declare a desired PythonSdkDev output to be assigned in the environment
-func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	q := r.query.Select("withPythonSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -109,10 +118,10 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 }
 
 // A toolchain to develop the Dagger Python SDK
-type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
+type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
 	query *querybuilder.Selection
 
-	id            *ID
+	id            *PythonSDKDevID
 	release       *Void
 	releaseDryRun *Void
 	sourcePath    *string
@@ -140,11 +149,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:283:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:313:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:280:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +168,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:268:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:298:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +178,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:175:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -178,7 +187,7 @@ func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../
 }
 
 // Python container to develop Python SDK
-func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:17:2)
+func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
 	q := r.query.Select("devContainer")
 
 	return &Container{
@@ -187,7 +196,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:321:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:351:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +209,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:104:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:101:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -219,13 +228,13 @@ func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // py
 }
 
 // A unique identifier for this PythonSdkDev.
-func (r *PythonSDKDev) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDev) ID(ctx context.Context) (PythonSDKDevID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -238,7 +247,7 @@ func (r *PythonSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDev) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -263,7 +272,7 @@ func (r *PythonSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDev{query: selectNode(dag.query, id, "PythonSdkDev")}
+	*r = *dag.LoadPythonSDKDevFromID(PythonSDKDevID(id))
 	return nil
 }
 
@@ -272,11 +281,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:92:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:89:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +301,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:81:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:75:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +324,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:333:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:363:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:357:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +350,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:300:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:330:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:292:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:322:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +379,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:134:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +388,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:142:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +397,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:150:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +406,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:158:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +415,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:166:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,15 +425,15 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:240:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:242:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:243:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:245:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:232:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:233:1)
 	if r.release != nil {
 		return nil
 	}
@@ -449,7 +458,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:221:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -458,7 +467,7 @@ func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-
 	return q.Execute(ctx)
 }
 
-func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
+func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:20:2)
 	if r.sourcePath != nil {
 		return *r.sourcePath, nil
 	}
@@ -471,7 +480,7 @@ func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // pyth
 }
 
 // Supported Python versions
-func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:21:2)
+func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:22:2)
 	q := r.query.Select("supportedVersions")
 
 	var response []string
@@ -487,11 +496,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:345:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:340:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -509,7 +518,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:116:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -519,7 +528,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:125:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -529,7 +538,7 @@ func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // pytho
 	}
 }
 
-func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
+func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
 	q := r.query.Select("workspace")
 
 	return &Directory{
@@ -537,18 +546,10 @@ func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../t
 	}
 }
 
-// AsNode returns this PythonSDKDev as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDev) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
-	}
-}
-
 type PythonSDKDevDocs struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
 	query *querybuilder.Selection
 
-	id *ID
+	id *PythonSDKDevDocsID
 }
 
 func (r *PythonSDKDevDocs) WithGraphQLQuery(q *querybuilder.Selection) *PythonSDKDevDocs {
@@ -567,13 +568,13 @@ func (r *PythonSDKDevDocs) Build() *Directory { // python-sdk-dev (../../../../t
 }
 
 // A unique identifier for this PythonSdkDevDocs.
-func (r *PythonSDKDevDocs) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDevDocs) ID(ctx context.Context) (PythonSDKDevDocsID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevDocsID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -586,7 +587,7 @@ func (r *PythonSDKDevDocs) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevDocs) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevDocsID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -611,7 +612,7 @@ func (r *PythonSDKDevDocs) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDevDocs{query: selectNode(dag.query, id, "PythonSdkDevDocs")}
+	*r = *dag.LoadPythonSDKDevDocsFromID(PythonSDKDevDocsID(id))
 	return nil
 }
 
@@ -640,18 +641,10 @@ func (r *PythonSDKDevDocs) Preview(opts ...PythonSDKDevDocsPreviewOpts) *Service
 	}
 }
 
-// AsNode returns this PythonSDKDevDocs as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDevDocs) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
-	}
-}
-
 type PythonSDKDevTestForPythonVersion struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
 	query *querybuilder.Selection
 
-	id   *ID
+	id   *PythonSDKDevTestForPythonVersionID
 	run  *Void
 	slow *Void
 	unit *Void
@@ -664,13 +657,13 @@ func (r *PythonSDKDevTestForPythonVersion) WithGraphQLQuery(q *querybuilder.Sele
 }
 
 // A unique identifier for this PythonSdkDevTestForPythonVersion.
-func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (ID, error) {
+func (r *PythonSDKDevTestForPythonVersion) ID(ctx context.Context) (PythonSDKDevTestForPythonVersionID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response PythonSDKDevTestForPythonVersionID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -683,7 +676,7 @@ func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *PythonSDKDevTestForPythonVersion) XXX_GraphQLIDType() string {
-	return "ID"
+	return "PythonSDKDevTestForPythonVersionID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -708,7 +701,7 @@ func (r *PythonSDKDevTestForPythonVersion) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = PythonSDKDevTestForPythonVersion{query: selectNode(dag.query, id, "PythonSdkDevTestForPythonVersion")}
+	*r = *dag.LoadPythonSDKDevTestForPythonVersionFromID(PythonSDKDevTestForPythonVersionID(id))
 	return nil
 }
 
@@ -743,11 +736,33 @@ func (r *PythonSDKDevTestForPythonVersion) Unit(ctx context.Context) error { // 
 	return q.Execute(ctx)
 }
 
-// AsNode returns this PythonSDKDevTestForPythonVersion as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *PythonSDKDevTestForPythonVersion) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
+// Load a PythonSdkDevDocs from its ID.
+func (r *Query) LoadPythonSDKDevDocsFromID(id PythonSDKDevDocsID) *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/docs.go:9:6)
+	q := r.query.Select("loadPythonSdkDevDocsFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDevDocs{
+		query: q,
+	}
+}
+
+// Load a PythonSdkDev from its ID.
+func (r *Query) LoadPythonSDKDevFromID(id PythonSDKDevID) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+	q := r.query.Select("loadPythonSdkDevFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDev{
+		query: q,
+	}
+}
+
+// Load a PythonSdkDevTestForPythonVersion from its ID.
+func (r *Query) LoadPythonSDKDevTestForPythonVersionFromID(id PythonSDKDevTestForPythonVersionID) *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/test.go:9:6)
+	q := r.query.Select("loadPythonSdkDevTestForPythonVersionFromID")
+	q = q.Arg("id", id)
+
+	return &PythonSDKDevTestForPythonVersion{
+		query: q,
 	}
 }
 
@@ -756,14 +771,14 @@ type PythonSDKDevOpts struct {
 	//
 	// A workspace containing the SDK source code and other relevant files
 	//
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:45:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:46:2)
 
 	// Default: "sdk/python"
-	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
+	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:49:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
-func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:24:1)
+func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:25:1)
 	q := r.query.Select("pythonSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument

--- a/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
@@ -6,11 +6,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"dagger.io/dagger/querybuilder"
+	"github.com/dagger/querybuilder"
 )
-
-// The `RustSdkDevID` scalar type represents an identifier for an object of type RustSdkDev.
-type RustSDKDevID string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 
 // Retrieve the binding value, as type RustSdkDev
 func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
@@ -41,16 +38,6 @@ func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // ru
 	q = q.Arg("description", description)
 
 	return &Env{
-		query: q,
-	}
-}
-
-// Load a RustSdkDev from its ID.
-func (r *Query) LoadRustSDKDevFromID(id RustSDKDevID) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
-	q := r.query.Select("loadRustSdkDevFromID")
-	q = q.Arg("id", id)
-
-	return &RustSDKDev{
 		query: q,
 	}
 }
@@ -94,7 +81,7 @@ type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/ma
 
 	cargoCheck    *Void
 	cargoFmt      *Void
-	id            *RustSDKDevID
+	id            *ID
 	release       *Void
 	releaseDryRun *Void
 	test          *Void
@@ -195,13 +182,13 @@ func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container
 }
 
 // A unique identifier for this RustSdkDev.
-func (r *RustSDKDev) ID(ctx context.Context) (RustSDKDevID, error) {
+func (r *RustSDKDev) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response RustSDKDevID
+	var response ID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -214,7 +201,7 @@ func (r *RustSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *RustSDKDev) XXX_GraphQLIDType() string {
-	return "RustSDKDevID"
+	return "ID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -239,7 +226,7 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = *dag.LoadRustSDKDevFromID(RustSDKDevID(id))
+	*r = RustSDKDev{query: selectNode(dag.query, id, "RustSdkDev")}
 	return nil
 }
 
@@ -306,5 +293,13 @@ func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../
 
 	return &RustSDKDev{
 		query: q,
+	}
+}
+
+// AsNode returns this RustSDKDev as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *RustSDKDev) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
 	}
 }

--- a/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dagger/querybuilder"
+	"dagger.io/dagger/querybuilder"
 )
 
+// The `RustSdkDevID` scalar type represents an identifier for an object of type RustSdkDev.
+type RustSDKDevID string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+
 // Retrieve the binding value, as type RustSdkDev
-func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	q := r.query.Select("asRustSdkDev")
 
 	return &RustSDKDev{
@@ -19,7 +22,7 @@ func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../tool
 }
 
 // Create or update a binding of type RustSdkDev in the environment
-func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withRustSdkDevInput")
 	q = q.Arg("name", name)
@@ -32,7 +35,7 @@ func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description st
 }
 
 // Declare a desired RustSdkDev output to be assigned in the environment
-func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	q := r.query.Select("withRustSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -42,22 +45,32 @@ func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // ru
 	}
 }
 
+// Load a RustSdkDev from its ID.
+func (r *Query) LoadRustSDKDevFromID(id RustSDKDevID) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+	q := r.query.Select("loadRustSdkDevFromID")
+	q = q.Arg("id", id)
+
+	return &RustSDKDev{
+		query: q,
+	}
+}
+
 // RustSDKDevOpts contains options for Query.RustSDKDev
 type RustSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:40:2)
+	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:41:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/rust"
-	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:43:2)
+	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:44:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
-func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:38:1)
+func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:39:1)
 	q := r.query.Select("rustSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -76,12 +89,12 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 }
 
 // Develop the Dagger Rust SDK (experimental)
-type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
+type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
 	query *querybuilder.Selection
 
 	cargoCheck    *Void
 	cargoFmt      *Void
-	id            *ID
+	id            *RustSDKDevID
 	release       *Void
 	releaseDryRun *Void
 	test          *Void
@@ -102,7 +115,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:150:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:151:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -110,7 +123,7 @@ func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolc
 	}
 }
 
-func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:35:2)
+func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:36:2)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -119,7 +132,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:277:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:305:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +142,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:129:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:130:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +152,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:119:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +161,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:154:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:155:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +175,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:73:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:74:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:69:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:70:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -182,13 +195,13 @@ func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container
 }
 
 // A unique identifier for this RustSdkDev.
-func (r *RustSDKDev) ID(ctx context.Context) (ID, error) {
+func (r *RustSDKDev) ID(ctx context.Context) (RustSDKDevID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
 	q := r.query.Select("id")
 
-	var response ID
+	var response RustSDKDevID
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -201,7 +214,7 @@ func (r *RustSDKDev) XXX_GraphQLType() string {
 
 // XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
 func (r *RustSDKDev) XXX_GraphQLIDType() string {
-	return "ID"
+	return "RustSDKDevID"
 }
 
 // XXX_GraphQLID is an internal function. It returns the underlying type ID
@@ -226,12 +239,12 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = RustSDKDev{query: selectNode(dag.query, id, "RustSdkDev")}
+	*r = *dag.LoadRustSDKDevFromID(RustSDKDevID(id))
 	return nil
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:246:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:247:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -250,11 +263,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:183:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:184:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:178:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:179:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -270,7 +283,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:113:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:114:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -279,7 +292,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:139:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:140:1)
 	if r.test != nil {
 		return nil
 	}
@@ -288,18 +301,10 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:158:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:159:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{
 		query: q,
-	}
-}
-
-// AsNode returns this RustSDKDev as a Node.
-// This is a local type conversion — no GraphQL call.
-func (r *RustSDKDev) AsNode() Node {
-	return &NodeClient{
-		query: r.query,
 	}
 }

--- a/toolchains/release/main.go
+++ b/toolchains/release/main.go
@@ -136,6 +136,8 @@ func (r *Release) Publish( //nolint:gocyclo
 	if semver.IsValid(tag) {
 		version = tag
 	}
+	isStableRelease := semver.IsValid(version) && semver.Prerelease(version) == ""
+	isPrerelease := semver.IsValid(version) && semver.Prerelease(version) != ""
 
 	report := ReleaseReport{
 		Date:    time.Now().UTC().Format(time.RFC822),
@@ -151,7 +153,7 @@ func (r *Release) Publish( //nolint:gocyclo
 	}
 
 	tags := []string{tag, commit}
-	if semver.IsValid(version) && semver.Prerelease(version) == "" {
+	if isStableRelease {
 		// this is a public release
 		tags = append(tags, "latest")
 	}
@@ -200,7 +202,6 @@ func (r *Release) Publish( //nolint:gocyclo
 		return &report, nil
 	}
 
-	isPrerelease := semver.IsValid(version) && semver.Prerelease(version) != ""
 	if isPrerelease {
 		// early-exit if this is a pre-release
 		return &report, nil

--- a/toolchains/release/main.go
+++ b/toolchains/release/main.go
@@ -173,7 +173,7 @@ func (r *Release) Publish( //nolint:gocyclo
 		Tag:  tag,
 	}
 	if !dryRun {
-		_, err := dag.CliDev().
+		_, err = dag.CliDev().
 			Publish(tag, goreleaserKey, githubOrgName, dagger.CliDevPublishOpts{
 				GithubToken:        githubToken,
 				AwsAccessKeyID:     awsAccessKeyID,

--- a/toolchains/release/util.go
+++ b/toolchains/release/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -55,6 +56,15 @@ func (r Release) githubRelease(
 		return nil
 	}
 
+	exists, err := r.githubReleaseExists(ctx, repository, dest, src, token)
+	if err != nil {
+		return err
+	}
+	if exists {
+		fmt.Printf("found existing GitHub release %s; skipping\n", dest)
+		return nil
+	}
+
 	gh := dag.Gh(dagger.GhOpts{
 		Repo:  githubRepo,
 		Token: token,
@@ -69,6 +79,90 @@ func (r Release) githubRelease(
 			Latest:    dagger.GhLatestFalse,
 		},
 	)
+}
+
+func (r Release) githubReleaseExists(
+	ctx context.Context,
+	repository string,
+	tag string,
+	expectedCommit string,
+	token *dagger.Secret,
+) (bool, error) {
+	githubRepo, err := githubRepo(repository)
+	if err != nil {
+		return false, err
+	}
+
+	gh := dag.Gh(dagger.GhOpts{
+		Repo:  githubRepo,
+		Token: token,
+	})
+	releaseExists := true
+	if _, err = gh.Exec([]string{"release", "view", tag, "--json", "tagName"}).Sync(ctx); err != nil {
+		if !isGitHubNotFound(err) {
+			return false, err
+		}
+		releaseExists = false
+	}
+
+	if err := r.verifyGitHubReleaseTag(ctx, githubRepo, tag, expectedCommit, token); err != nil {
+		return false, err
+	}
+	return releaseExists, nil
+}
+
+func (r Release) verifyGitHubReleaseTag(
+	ctx context.Context,
+	githubRepo string,
+	tag string,
+	expectedCommit string,
+	token *dagger.Secret,
+) error {
+	gh := dag.Gh(dagger.GhOpts{
+		Repo:  githubRepo,
+		Token: token,
+	})
+
+	out, err := gh.Exec([]string{
+		"api",
+		fmt.Sprintf("repos/%s/git/ref/tags/%s", githubRepo, tag),
+		"--jq",
+		`.object.type + " " + .object.sha`,
+	}).Stdout(ctx)
+	if err != nil {
+		if isGitHubNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	fields := strings.Fields(out)
+	if len(fields) != 2 {
+		return fmt.Errorf("unexpected GitHub tag response for %s: %q", tag, strings.TrimSpace(out))
+	}
+
+	kind, sha := fields[0], fields[1]
+	if kind != "commit" {
+		return fmt.Errorf("GitHub tag %s points to a %s object %s, expected commit %s", tag, kind, sha, expectedCommit)
+	}
+
+	if sha != expectedCommit {
+		return fmt.Errorf("GitHub tag %s resolves to %s; expected %s", tag, sha, expectedCommit)
+	}
+
+	return nil
+}
+
+func isGitHubNotFound(err error) bool {
+	var execErr *dagger.ExecError
+	if errors.As(err, &execErr) {
+		stderr := strings.ToLower(execErr.Stderr + "\n" + execErr.Stdout)
+		if strings.Contains(stderr, "release not found") || strings.Contains(stderr, "not found") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func githubRepo(repo string) (string, error) {

--- a/toolchains/rust-sdk-dev/main.go
+++ b/toolchains/rust-sdk-dev/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -257,12 +258,39 @@ func (t *RustSdkDev) Release(
 		return fmt.Errorf("invalid version %q", version)
 	}
 
+	exists, err := crateVersionExists(rustSdkCrate, versionFlag)
+	if err != nil {
+		return err
+	}
+	if exists {
+		fmt.Printf("found existing Rust SDK crate %s %s; skipping publish\n", rustSdkCrate, versionFlag)
+		return nil
+	}
+
 	_, err = t.releaseContainer(versionFlag).
 		WithSecretVariable("CARGO_REGISTRY_TOKEN", cargoRegistryToken).
 		WithExec([]string{"cargo", "publish", "-p", rustSdkCrate, "-v", "--all-features"}).
 		Sync(ctx)
 
 	return err
+}
+
+func crateVersionExists(crate string, version string) (bool, error) {
+	url := fmt.Sprintf("https://crates.io/api/v1/crates/%s/%s", crate, version)
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected crate lookup status %s from %s", resp.Status, url)
+	}
 }
 
 func (t *RustSdkDev) releaseContainer(

--- a/toolchains/typescript-sdk-dev/ts-sdk.dang
+++ b/toolchains/typescript-sdk-dev/ts-sdk.dang
@@ -153,29 +153,40 @@ type TypescriptSdkDev {
     } else {
       "prepatch"
     }
-    let build = nodejsDevContainer
-      .withWorkdir(sourcePath)
-      .withExec(["npm", "run", "build"])
-      .withExec(["npm", "version", versionFlag])
-    # Check that dist/ exists in the build
-    build.directory("dist").entries
-    let publishArgs = ["npm", "publish", "--access", "public"]
-    if (dryRun == true) {
-      publishArgs += ["--dry-run"]
-      # TODO(vito): in dang, if exprs have to have same return type on all
-      # branches, which gets awkward here
-      null
-    } else if (npmToken != null) {
-      let npmrc = [
-        "//registry.npmjs.org/:_authToken=" + npmToken.plaintext,
-        "registry=https://registry.npmjs.org/",
-        "always-auth=true",
-      ].join("\n")
-      build = build.withMountedSecret(".npmrc", setSecret("npmrc", npmrc))
-      null
+    if (dryRun == false and isSemver(version) and npmVersionExists(versionFlag)) {
+      print("found existing TypeScript SDK package @dagger.io/dagger " + versionFlag + "; skipping publish")
+    } else {
+      let build = nodejsDevContainer
+        .withWorkdir(sourcePath)
+        .withExec(["npm", "run", "build"])
+        .withExec(["npm", "version", versionFlag])
+      # Check that dist/ exists in the build
+      build.directory("dist").entries
+      let publishArgs = ["npm", "publish", "--access", "public"]
+      if (dryRun == true) {
+        publishArgs += ["--dry-run"]
+        # TODO(vito): in dang, if exprs have to have same return type on all
+        # branches, which gets awkward here
+        null
+      } else if (npmToken != null) {
+        let npmrc = [
+          "//registry.npmjs.org/:_authToken=" + npmToken.plaintext,
+          "registry=https://registry.npmjs.org/",
+          "always-auth=true",
+        ].join("\n")
+        build = build.withMountedSecret(".npmrc", setSecret("npmrc", npmrc))
+        null
+      }
+      build.withExec(publishArgs).sync
     }
-    build.withExec(publishArgs).sync
     null
+  }
+
+  let npmVersionExists(version: String!): Boolean! {
+    let exitCode = nodejsBase
+      .withExec(["npm", "view", "@dagger.io/dagger@" + version, "version"], expect: ReturnType.ANY)
+      .exitCode
+    exitCode == 0
   }
 
   pub isSemver(version: String!): Boolean! {


### PR DESCRIPTION
[release: limit prerelease side effects](https://github.com/dagger/dagger/commit/971ca1ee863e342c50ff504c443af333e7efda0e)

When running a prerelease:
1. Do not trigger bump PR on dagger.io.
2. Do not trigger test SDK workflows
3. Do not publish install.sh

In addition, this commit refactors toolchains/release a bit.

[release: make publish reruns idempotent](https://github.com/dagger/dagger/commit/bd2ba2ed87a4c35a2cfa6da50a8a4d69b3aa4a55)

Skip publishing when release artifacts already exist, so rerunning a failed or
partial release does not fail on duplicate outputs.

Check for existing GitHub releases before rerunning CLI publishing or creating
component releases. Check SDK destinations before publishing: filtered Go/PHP
mirror refs, PyPI, npm, Hex, and crates.io.

Example of run we could not re-run because of lack of idempotency: https://github.com/dagger/dagger/actions/runs/26462104827