### PR TITLE
fix: scope withRegistryAuth cache key per session

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3462,17 +3462,21 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 	_, err := container.Publish(ctx, testRef)
 	require.Error(t, err)
 
-	pushedRef, err := container.
-		WithRegistryAuth(
-			privateRegistryHost,
-			"john",
-			c.SetSecret("this-secret", "xFlejaPdjrt25Dvr"),
-		).
-		Publish(ctx, testRef)
-
-	require.NoError(t, err)
-	require.NotEqual(t, testRef, pushedRef)
-	require.Contains(t, pushedRef, "@sha256:")
+	for range 2 {
+		c := connect(ctx, t)
+		container := c.Container().From(alpineImage)
+		pushedRef, err := container.
+			WithRegistryAuth(
+				privateRegistryHost,
+				"john",
+				c.SetSecret("this-secret", "xFlejaPdjrt25Dvr"),
+			).
+			WithEnvVariable("CACHE", time.Now().String()).
+			Publish(ctx, testRef)
+		require.NoError(t, err)
+		require.NotEqual(t, testRef, pushedRef)
+		require.Contains(t, pushedRef, "@sha256:")
+	}
 }
 
 // Regression test for #11667: Directory/File access on private registry images

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -768,6 +768,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.Func("withRegistryAuth", s.withRegistryAuth).
+			WithInput(dagql.PerSessionInput).
 			Doc(`Attach credentials for future publishing to a registry. Use in combination with publish`).
 			Args(
 				dagql.Arg("address").Doc(`The image address that needs authentication. Same format as "docker push". Example: "registry.dagger.io/dagger:latest"`),


### PR DESCRIPTION
The withRegistryAuth function has a session-scoped side effect (adding credentials to the session's auth provider), but was registered without any cache scope. On a second call from a new session with the same arguments, dagql returned a global cache hit and skipped the function body — so credentials were never added to the new session's auth provider, causing Publish to fail.

Adding PerSessionInput ensures the cache key includes the session ID, so the function executes once per session and credentials are correctly registered every time.