### PR TITLE
fix(engine): refresh registry auth per resolver operation

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3479,6 +3479,196 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (ContainerSuite) TestWithRegistryAuthAfterAnonymousBearerPull(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const (
+		registryPassword = "xFlejaPdjrt25Dvr"
+		registryConfig   = `version: 0.1
+log:
+  level: debug
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+auth:
+  silly:
+    realm: http://tokenauth:5001/token
+    service: registry:5000
+`
+		tokenAuthServer = `package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	username = "john"
+	password = "` + registryPassword + `"
+)
+
+func main() {
+	if err := os.MkdirAll("/logs", 0o755); err != nil {
+		log.Fatal(err)
+	}
+	f, err := os.OpenFile("/logs/token.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	log.SetOutput(f)
+
+	http.HandleFunc("/token", token)
+	log.Fatal(http.ListenAndServe(":5001", nil))
+}
+
+func token(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	scopes := append([]string{}, r.URL.Query()["scope"]...)
+	scopes = append(scopes, r.PostForm["scope"]...)
+	scope := strings.Join(scopes, " ")
+
+	gotUser, gotPassword, presentedCredentials := credentials(r)
+	authenticated := gotUser == username && gotPassword == password
+
+	log.Printf("method=%s scope=%q user=%q presentedCredentials=%t authenticated=%t", r.Method, scope, gotUser, presentedCredentials, authenticated)
+
+	if presentedCredentials && !authenticated {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		return
+	}
+	if !authenticated && strings.Contains(scope, "private") {
+		http.Error(w, "private scope requires credentials", http.StatusUnauthorized)
+		return
+	}
+
+	token := "anonymous-token"
+	if authenticated {
+		token = "authenticated-token"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"token":        token,
+		"access_token": token,
+		"expires_in":   3600,
+		"issued_at":    time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func credentials(r *http.Request) (string, string, bool) {
+	if user, pass, ok := r.BasicAuth(); ok {
+		return user, pass, true
+	}
+	if r.Method == http.MethodPost {
+		if r.Form.Get("grant_type") == "password" {
+			return r.Form.Get("username"), r.Form.Get("password"), true
+		}
+		if refreshToken := r.Form.Get("refresh_token"); refreshToken != "" {
+			return "", refreshToken, true
+		}
+	}
+	return "", "", false
+}
+`
+	)
+
+	tokenLogs := c.CacheVolume("bearer-token-auth-logs-" + identity.NewID())
+	tokenAuthSvc := c.Container().
+		From("golang:1.26-alpine").
+		WithNewFile("/src/main.go", tokenAuthServer).
+		WithMountedCache("/logs", tokenLogs).
+		WithEnvVariable("GOCACHE", "/tmp/go-cache").
+		WithExposedPort(5001, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+		WithDefaultArgs([]string{"go", "run", "/src/main.go"}).
+		AsService()
+
+	registryLogs := c.CacheVolume("bearer-registry-logs-" + identity.NewID())
+	registrySvc := c.Container().
+		From("registry:3").
+		WithNewFile("/etc/distribution/config.yml", registryConfig).
+		WithMountedCache("/cache/logs", registryLogs).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+		WithDefaultArgs([]string{"sh", "-c", "registry serve /etc/distribution/config.yml | tee /cache/logs/registry.log"}).
+		AsService()
+
+	devEngine := devEngineContainer(c,
+		func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithServiceBinding("registry", registrySvc).
+				WithServiceBinding("tokenauth", tokenAuthSvc)
+		},
+		engineWithBkConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg bkconfig.Config) bkconfig.Config {
+			cfg.Registries = map[string]resolverconfig.RegistryConfig{
+				"registry:5000": {PlainHTTP: ptr(true)},
+			}
+			return cfg
+		}),
+	)
+
+	engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(devEngine)).Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engineSvc.Stop(ctx) })
+
+	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+	require.NoError(t, err)
+
+	emptyDockerConfig := t.TempDir()
+	connectNested := func() *dagger.Client {
+		return connect(ctx, t,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithEnvironmentVariable("DOCKER_CONFIG", emptyDockerConfig),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+	}
+
+	publicRef := "registry:5000/public:" + identity.NewID()
+	seedClient := connectNested()
+	_, err = seedClient.Container().
+		From(alpineImage).
+		WithNewFile("/public.txt", "public").
+		WithRegistryAuth("registry:5000", "john", seedClient.SetSecret("seed-registry-password", registryPassword)).
+		Publish(ctx, publicRef)
+	require.NoError(t, err)
+
+	reproClient := connectNested()
+	out, err := reproClient.Container().
+		From(publicRef).
+		WithExec([]string{"cat", "/public.txt"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "public", strings.TrimSpace(out))
+
+	privateRef := "registry:5000/private:" + identity.NewID()
+	_, err = reproClient.Container().
+		From(alpineImage).
+		WithNewFile("/private.txt", "private").
+		WithRegistryAuth("registry:5000", "john", reproClient.SetSecret("repro-registry-password", registryPassword)).
+		Publish(ctx, privateRef)
+	if err != nil {
+		tokenLog, logErr := c.Container().
+			From(alpineImage).
+			WithMountedCache("/logs", tokenLogs).
+			WithExec([]string{"sh", "-c", "cat /logs/token.log 2>/dev/null || true"}).
+			Stdout(ctx)
+		if logErr != nil {
+			t.Logf("failed to read token auth log: %v", logErr)
+		} else {
+			t.Logf("token auth log:\n%s", tokenLog)
+		}
+	}
+	require.NoError(t, err)
+}
+
 // Regression test for #11667: Directory/File access on private registry images
 // requires auth credentials to be passed through when fetching uncached blobs.
 func (ContainerSuite) TestWithRegistryAuthFileAndDirectoryAccess(ctx context.Context, t *testctx.T) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -777,6 +777,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.Func("withoutRegistryAuth", s.withoutRegistryAuth).
+			WithInput(dagql.PerSessionInput).
 			Doc(`Retrieves this container without the registry authentication of a given address.`).
 			Args(
 				dagql.Arg("address").Doc(`Registry's address to remove the authentication from.`,

--- a/engine/server/resolver/resolver.go
+++ b/engine/server/resolver/resolver.go
@@ -724,40 +724,84 @@ func (s *sessionAuthSource) Credentials(ctx context.Context, host string) (Crede
 }
 
 func (r *Resolver) registryHosts() docker.RegistryHosts {
+	authorizers := newRegistryHostAuthorizerCache()
 	return func(domain string) ([]docker.RegistryHost, error) {
-		r.mu.Lock()
-		cached, ok := r.hostCache[domain]
-		r.mu.Unlock()
-		if ok {
-			return cloneRegistryHosts(cached), nil
+		hosts, err := r.registryHostConfigs(domain)
+		if err != nil {
+			return nil, err
 		}
+		return r.withRegistryHostAuthorizers(hosts, authorizers), nil
+	}
+}
 
-		var hosts []docker.RegistryHost
-		var err error
-		if r.hosts != nil {
-			hosts, err = r.hosts(domain)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if len(hosts) == 0 {
-			hosts, err = docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost))(domain)
-			if err != nil {
-				return nil, err
-			}
-		}
+func (r *Resolver) registryHostConfigs(domain string) ([]docker.RegistryHost, error) {
+	r.mu.Lock()
+	cached, ok := r.hostCache[domain]
+	r.mu.Unlock()
+	if ok {
+		return cloneRegistryHosts(cached), nil
+	}
 
-		sessionHosts := make([]docker.RegistryHost, len(hosts))
-		closeFns := make([]func() error, 0, len(hosts))
-		for i, host := range hosts {
-			host := host
-			if host.Header != nil {
-				host.Header = host.Header.Clone()
-			}
-			if host.Client == nil {
-				host.Client = http.DefaultClient
-			}
-			host.Authorizer = docker.NewDockerAuthorizer(
+	var hosts []docker.RegistryHost
+	var err error
+	if r.hosts != nil {
+		hosts, err = r.hosts(domain)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(hosts) == 0 {
+		hosts, err = docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost))(domain)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sessionHosts := make([]docker.RegistryHost, len(hosts))
+	closeFns := make([]func() error, 0, len(hosts))
+	for i, host := range hosts {
+		host := host
+		if host.Header != nil {
+			host.Header = host.Header.Clone()
+		}
+		if host.Client == nil {
+			host.Client = http.DefaultClient
+		}
+		host.Authorizer = nil
+		sessionHosts[i] = host
+		if host.Client != nil {
+			closeFns = append(closeFns, func() error {
+				host.Client.CloseIdleConnections()
+				return nil
+			})
+		}
+	}
+
+	r.mu.Lock()
+	r.hostCache[domain] = cloneRegistryHosts(sessionHosts)
+	r.closers = append(r.closers, closeFns...)
+	r.mu.Unlock()
+
+	return cloneRegistryHosts(sessionHosts), nil
+}
+
+type registryHostAuthorizerCache struct {
+	mu         sync.Mutex
+	authorizer map[string]docker.Authorizer
+}
+
+func newRegistryHostAuthorizerCache() *registryHostAuthorizerCache {
+	return &registryHostAuthorizerCache{
+		authorizer: map[string]docker.Authorizer{},
+	}
+}
+
+func (r *Resolver) withRegistryHostAuthorizers(hosts []docker.RegistryHost, authorizers *registryHostAuthorizerCache) []docker.RegistryHost {
+	out := cloneRegistryHosts(hosts)
+	for i := range out {
+		host := out[i]
+		out[i].Authorizer = authorizers.get(host, func() docker.Authorizer {
+			return docker.NewDockerAuthorizer(
 				docker.WithAuthClient(host.Client),
 				docker.WithAuthHeader(host.Header),
 				docker.WithAuthCreds(func(host string) (string, string, error) {
@@ -765,22 +809,39 @@ func (r *Resolver) registryHosts() docker.RegistryHosts {
 					return username, secret, err
 				}),
 			)
-			sessionHosts[i] = host
-			if host.Client != nil {
-				closeFns = append(closeFns, func() error {
-					host.Client.CloseIdleConnections()
-					return nil
-				})
-			}
-		}
-
-		r.mu.Lock()
-		r.hostCache[domain] = cloneRegistryHosts(sessionHosts)
-		r.closers = append(r.closers, closeFns...)
-		r.mu.Unlock()
-
-		return cloneRegistryHosts(sessionHosts), nil
+		})
 	}
+	return out
+}
+
+func (c *registryHostAuthorizerCache) get(host docker.RegistryHost, create func() docker.Authorizer) docker.Authorizer {
+	key := registryHostAuthorizerKey(host)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if authorizer, ok := c.authorizer[key]; ok {
+		return authorizer
+	}
+	authorizer := create()
+	c.authorizer[key] = authorizer
+	return authorizer
+}
+
+func registryHostAuthorizerKey(host docker.RegistryHost) string {
+	var headerParts []string
+	for key, values := range host.Header {
+		values := slices.Clone(values)
+		slices.Sort(values)
+		headerParts = append(headerParts, key+"="+strings.Join(values, "\x00"))
+	}
+	slices.Sort(headerParts)
+	return strings.Join([]string{
+		host.Scheme,
+		host.Host,
+		host.Path,
+		strings.Join(headerParts, "\x01"),
+	}, "\x00")
 }
 
 func (r *Resolver) lookupCredentials(host string) (string, string, error) {
@@ -898,27 +959,26 @@ func hydratePulledDescriptor(desc ocispecs.Descriptor) ocispecs.Descriptor {
 }
 
 func (r *Resolver) pushRegistryHosts(insecure bool) docker.RegistryHosts {
-	base := r.registryHosts()
-	if !insecure {
-		return base
-	}
+	authorizers := newRegistryHostAuthorizerCache()
 	return func(domain string) ([]docker.RegistryHost, error) {
-		hosts, err := base(domain)
+		hosts, err := r.registryHostConfigs(domain)
 		if err != nil {
 			return nil, err
 		}
-		for i := range hosts {
-			hosts[i].Scheme = "http"
-			if hosts[i].Client != nil {
-				hosts[i].Client = &http.Client{
-					Transport:     hosts[i].Client.Transport,
-					CheckRedirect: hosts[i].Client.CheckRedirect,
-					Jar:           hosts[i].Client.Jar,
-					Timeout:       hosts[i].Client.Timeout,
+		if insecure {
+			for i := range hosts {
+				hosts[i].Scheme = "http"
+				if hosts[i].Client != nil {
+					hosts[i].Client = &http.Client{
+						Transport:     hosts[i].Client.Transport,
+						CheckRedirect: hosts[i].Client.CheckRedirect,
+						Jar:           hosts[i].Client.Jar,
+						Timeout:       hosts[i].Client.Timeout,
+					}
 				}
 			}
 		}
-		return hosts, nil
+		return r.withRegistryHostAuthorizers(hosts, authorizers), nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- cache registry host configs without attached containerd Docker authorizers
- attach fresh operation-scoped authorizers for pull and push registry host callbacks
- mark `withoutRegistryAuth` as per-session input, matching `withRegistryAuth`
- add an integration regression for anonymous Bearer pull followed by authenticated publish to the same registry

## Root Cause

`Resolver.hostCache` stored `docker.RegistryHost` values after attaching `docker.NewDockerAuthorizer`. Those authorizers are stateful: after an anonymous Bearer pull, the cached authorizer can keep using the anonymous token flow even when the same Dagger client session later calls `withRegistryAuth` before publishing to that registry.

That makes an authenticated publish fail with an anonymous token request for the private push scope. This showed up with GHCR in CI after the outer engine moved to v0.21.0, and it reproduced locally with a registry that allows anonymous access to a public repo but requires credentials for a private repo.

## Fix

The resolver now caches only the stable registry host configuration: scheme, host, path, client, headers, and capabilities. Pull and push registry host callbacks clone those configs and attach operation-scoped authorizers. This preserves the useful host config reuse while letting each resolver operation observe the current Dagger auth provider state.

The `withoutRegistryAuth` schema function also gets `dagql.PerSessionInput` because it mutates session-local registry auth state, just like `withRegistryAuth`.

## Validation

- `git diff --check`
- `go test ./engine/server/resolver ./auth -count=1`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestContainer/TestWithRegistryAuthAfterAnonymousBearerPull"` passed after rebasing onto current `upstream/main`; log: `/tmp/reg-auth-bearer-test-post-rebase.log`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestContainer"` was run; the new regression passed there too, but the suite failed in `TestSystemCACerts/wolfi_basic` and `TestWithMountedDirectoryCaching`, which look unrelated to this registry auth change; log: `/tmp/reg-auth-testcontainer.log`
