### PR TITLE
dagql: infer + automate interface implementations

### DIFF
--- a/core/schema/coreinterfaces.go
+++ b/core/schema/coreinterfaces.go
@@ -2,10 +2,9 @@ package schema
 
 import "github.com/dagger/dagger/dagql"
 
-// installCoreInterfaces registers Dagger-specific interfaces that core types
-// auto-implement based on structural conformance. These are installed as
-// auto-interfaces so that any object with the matching fields automatically
-// declares conformance.
+// installCoreInterfaces registers Dagger-specific interfaces. Like all dagql
+// interfaces, these are matched structurally: any object whose fields line up
+// automatically declares conformance, with no explicit implements declaration.
 //
 // Unlike Node (which lives in dagql and is pure GraphQL infrastructure),
 // these interfaces encode Dagger-specific semantics.
@@ -26,7 +25,7 @@ func installCoreInterfaces(srv *dagql.Server) {
 			Type: dagql.AnyID{},
 		},
 	})
-	srv.AddAutoInterface(syncer)
+	srv.InstallInterface(syncer)
 
 	exportable := dagql.NewInterface("Exportable", dagql.FormatDescription(
 		`An object that can be exported to the host.`,
@@ -47,5 +46,5 @@ func installCoreInterfaces(srv *dagql.Server) {
 			),
 		},
 	})
-	srv.AddAutoInterface(exportable)
+	srv.InstallInterface(exportable)
 }

--- a/core/schema_build.go
+++ b/core/schema_build.go
@@ -110,151 +110,29 @@ func buildSchema(
 
 	InstallCoreSchemaLoaders(dag)
 
-	objects, ifaces, err := installModules(ctx, dag, mods, coreMod)
-	if err != nil {
+	if err := installModules(ctx, dag, mods, coreMod); err != nil {
 		return nil, err
 	}
-
-	if err := registerInterfaceImpls(dag, objects, ifaces); err != nil {
-		return nil, err
-	}
-
-	registerInterfaceToInterfaceImpls(dag, objects, ifaces)
 
 	return dag, nil
 }
 
-// installModules installs each module into the server and collects object/interface type defs.
+// installModules installs each module into the server.
 func installModules(
 	ctx context.Context,
 	dag *dagql.Server,
 	mods []modInstall,
 	coreMod coreSchemaForker,
-) ([]*ModuleObjectType, []*InterfaceType, error) {
-	var objects []*ModuleObjectType
-	var ifaces []*InterfaceType
+) error {
 	for _, mod := range mods {
 		if _, ok := mod.mod.(coreSchemaForker); ok && coreMod != nil {
 			continue
 		}
 		if err := mod.mod.Install(ctx, dag, mod.opts); err != nil {
-			return nil, nil, fmt.Errorf("failed to get schema for module %q: %w", mod.mod.Name(), err)
-		}
-
-		userMod, ok := mod.mod.(*userMod)
-		if !ok {
-			continue
-		}
-		defs, err := mod.mod.TypeDefs(ctx, dag)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get type defs for module %q: %w", mod.mod.Name(), err)
-		}
-		for _, def := range defs {
-			switch def.Self().Kind {
-			case TypeDefKindObject:
-				objects = append(objects, &ModuleObjectType{
-					typeDef: def.Self().AsObject.Value.Self(),
-					mod:     userMod.res,
-				})
-			case TypeDefKindInterface:
-				ifaces = append(ifaces, &InterfaceType{
-					typeDef: def.Self().AsInterface.Value.Self(),
-					mod:     userMod.res,
-				})
-			}
-		}
-	}
-	return objects, ifaces, nil
-}
-
-// makeImplementsChecker returns a function that checks whether a type implements an interface,
-// considering both object-implements-interface and interface-satisfies-interface relationships.
-func makeImplementsChecker(
-	dag *dagql.Server,
-	objects []*ModuleObjectType,
-	ifaces []*InterfaceType,
-) func(typeName, ifaceName string) bool {
-	return func(typeName, ifaceName string) bool {
-		// Check if typeName (an object) implements ifaceName (an interface).
-		for _, ot := range objects {
-			if ot.typeDef.Name == typeName {
-				for _, it := range ifaces {
-					if it.typeDef.Name == ifaceName {
-						return ot.typeDef.IsSubtypeOf(it.typeDef)
-					}
-				}
-			}
-		}
-		// Check if typeName is an interface that structurally satisfies ifaceName.
-		// This handles cases like ImplLocalOtherIface satisfying TestOtherIface.
-		typeIface, typeOK := dag.InterfaceType(typeName)
-		targetIface, targetOK := dag.InterfaceType(ifaceName)
-		if typeOK && targetOK {
-			return targetIface.SatisfiedByInterface(typeIface, dag.View)
-		}
-		return false
-	}
-}
-
-// registerInterfaceImpls registers object types as implementations of interfaces they satisfy.
-func registerInterfaceImpls(
-	dag *dagql.Server,
-	objects []*ModuleObjectType,
-	ifaces []*InterfaceType,
-) error {
-	checker := makeImplementsChecker(dag, objects, ifaces)
-	for _, objType := range objects {
-		class, found := dag.ObjectType(objType.typeDef.Name)
-		if !found {
-			return fmt.Errorf("failed to find object %q in schema", objType.typeDef.Name)
-		}
-		for _, ifaceType := range ifaces {
-			dagqlIface, ok := dag.InterfaceType(ifaceType.typeDef.Name)
-			if !ok {
-				continue
-			}
-			impl, ok := class.(dagql.InterfaceImplementor)
-			if !ok {
-				continue
-			}
-			if dagqlIface.Satisfies(class, dag.View, checker) {
-				impl.ImplementInterfaceUnchecked(dagqlIface)
-			}
+			return fmt.Errorf("failed to get schema for module %q: %w", mod.mod.Name(), err)
 		}
 	}
 	return nil
-}
-
-// registerInterfaceToInterfaceImpls registers interface-implements-interface
-// relationships via duck typing.
-func registerInterfaceToInterfaceImpls(
-	dag *dagql.Server,
-	objects []*ModuleObjectType,
-	ifaces []*InterfaceType,
-) {
-	checker := makeImplementsChecker(dag, objects, ifaces)
-	for _, ifaceTypeA := range ifaces {
-		dagqlIfaceA, okA := dag.InterfaceType(ifaceTypeA.typeDef.Name)
-		if !okA {
-			continue
-		}
-		for _, ifaceTypeB := range ifaces {
-			if ifaceTypeA.typeDef.Name == ifaceTypeB.typeDef.Name {
-				continue
-			}
-			dagqlIfaceB, okB := dag.InterfaceType(ifaceTypeB.typeDef.Name)
-			if !okB {
-				continue
-			}
-			// Avoid circular references: don't declare A implements B if B already implements A.
-			if _, alreadyReverse := dagqlIfaceB.Interfaces()[dagqlIfaceA.TypeName()]; alreadyReverse {
-				continue
-			}
-			if dagqlIfaceB.SatisfiedByInterface(dagqlIfaceA, dag.View, checker) {
-				dagqlIfaceA.ImplementInterface(dagqlIfaceB)
-			}
-		}
-	}
 }
 
 func schemaJSONFileFromServer(ctx context.Context, dag *dagql.Server, hiddenTypes []string) (dagql.Result[*File], error) {

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -3529,14 +3529,12 @@ func TestInterfaces(t *testing.T) {
 		})
 		srv.InstallInterface(spatial)
 
-		// Point should satisfy Spatial (it has x and y fields)
+		// Point should satisfy Spatial (it has x and y fields) and the
+		// relationship should be inferred retroactively when Spatial is installed.
 		pointType, ok := srv.ObjectType("Point")
 		assert.Assert(t, ok, "Point type not found")
 		assert.Assert(t, spatial.Satisfies(pointType, ""), "Point should satisfy Spatial")
-
-		// Declare that Point implements Spatial
-		pointClass := pointType.(dagql.Class[*points.Point])
-		pointClass.Implements(spatial)
+		assert.Assert(t, spatial.HasImplementor("Point"), "Point should auto-implement Spatial")
 
 		// Verify the interface shows up in introspection
 		gql := newTestClient(srv)
@@ -3583,6 +3581,77 @@ func TestInterfaces(t *testing.T) {
 			}
 		}
 		assert.Assert(t, foundSpatial, "Point should declare Spatial interface")
+	})
+
+	t.Run("recursive covariant return types are inferred", func(t *testing.T) {
+		srv := newExternalDagqlServerForTest(t, Query{})
+		introspection.Install[Query](srv)
+
+		selfer := dagql.NewInterface("Selfer", "Something that returns itself.")
+		selfer.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "id",
+				Type: dagql.AnyID{},
+			},
+		})
+		selfer.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "self",
+				Type: selfer.Typed(),
+			},
+		})
+		srv.InstallInterface(selfer)
+
+		points.Install[Query](srv)
+
+		gql := newTestClient(srv)
+		var res struct {
+			Type struct {
+				Interfaces []struct{ Name string }
+			} `json:"__type"`
+		}
+		req(t, gql, `{ __type(name: "Point") { interfaces { name } } }`, &res)
+		var names []string
+		for _, iface := range res.Type.Interfaces {
+			names = append(names, iface.Name)
+		}
+		assert.Assert(t, slices.Contains(names, "Selfer"), "Point interfaces should include Selfer, got: %v", names)
+		assert.Assert(t, selfer.HasImplementor("Point"), "Point.self returning Point should satisfy Selfer.self returning Selfer")
+	})
+
+	t.Run("interface-to-interface relationships are inferred", func(t *testing.T) {
+		srv := newExternalDagqlServerForTest(t, Query{})
+
+		hasX := dagql.NewInterface("HasX", "Something with an X coordinate.")
+		hasX.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "x",
+				Type: dagql.Int(0),
+			},
+		})
+		srv.InstallInterface(hasX)
+
+		spatial := dagql.NewInterface("Spatial", "Something with spatial coordinates.")
+		spatial.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "x",
+				Type: dagql.Int(0),
+			},
+		})
+		spatial.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "y",
+				Type: dagql.Int(0),
+			},
+		})
+		srv.InstallInterface(spatial)
+
+		// Reading the type back through the server triggers lazy reconciliation.
+		spatialType, ok := srv.InterfaceType("Spatial")
+		assert.Assert(t, ok, "Spatial type not found")
+		_, ok = spatialType.Interfaces()["HasX"]
+		assert.Assert(t, ok, "Spatial should auto-implement HasX")
+		assert.Assert(t, hasX.HasImplementor("Spatial"), "HasX should list Spatial as an implementor")
 	})
 
 	t.Run("object must have every field required by the interface", func(t *testing.T) {
@@ -3906,11 +3975,11 @@ func TestInterfaces(t *testing.T) {
 		assert.Assert(t, foundPoint, "Node interface should include Point in possibleTypes")
 	})
 
-	t.Run("AddAutoInterface and AutoImplementInterfaces", func(t *testing.T) {
+	t.Run("fields added after install are inferred", func(t *testing.T) {
 		srv := newExternalDagqlServerForTest(t, Query{})
 		introspection.Install[Query](srv)
 
-		// Register a custom auto-interface with a "sync" field.
+		// Register a custom interface with a "sync" field.
 		syncable := dagql.NewInterface("Syncable", "Can be synced.")
 		syncable.AddField(dagql.InterfaceFieldSpec{
 			FieldSpec: dagql.FieldSpec{
@@ -3924,7 +3993,7 @@ func TestInterfaces(t *testing.T) {
 				Type: dagql.AnyID{},
 			},
 		})
-		srv.AddAutoInterface(syncable)
+		srv.InstallInterface(syncable)
 
 		gql := newTestClient(srv)
 
@@ -3958,7 +4027,7 @@ func TestInterfaces(t *testing.T) {
 		}
 
 		// Line with sync added via Fields[T].Install SHOULD implement it
-		// (AutoImplementInterfaces is called at the end of Install).
+		// (Fields.Install flags inference stale once the sync field is added).
 		dagql.Fields[*points.Line]{
 			dagql.Func("sync", func(ctx context.Context, self *points.Line, _ struct{}) (dagql.ID[*points.Line], error) {
 				return dagql.ID[*points.Line]{}, nil

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -1323,9 +1323,12 @@ func (fields Fields[T]) Install(server *Server) {
 	}
 	class.Install(fields...)
 
-	// Re-check auto-interfaces now that all fields (including sync, etc.)
-	// have been installed. InstallObject only sees the id field.
-	server.AutoImplementInterfaces(class)
+	// Flag interface inference stale now that every field is installed. At
+	// InstallObject time only the id field was present, so fields like sync
+	// weren't yet visible to the structural checks. (Done here, after
+	// class.Install releases the field lock, to preserve installLock -> fieldsL
+	// ordering.)
+	server.markInterfacesDirty()
 }
 
 type GenericDynamicInputFunc func(

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -33,15 +33,14 @@ import (
 // Server represents a GraphQL server whose schema is dynamically modified at
 // runtime.
 type Server struct {
-	root           AnyObjectResult
-	telemetry      AroundFunc
-	objects        map[string]ObjectType
-	interfaces     map[string]*Interface
-	autoInterfaces []*Interface // core interfaces auto-implemented by qualifying types
-	scalars        map[string]ScalarType
-	scalarFilters  map[string]ViewFilter
-	typeDefs       map[string]TypeDef
-	directives     map[string]DirectiveSpec
+	root          AnyObjectResult
+	telemetry     AroundFunc
+	objects       map[string]ObjectType
+	interfaces    map[string]*Interface
+	scalars       map[string]ScalarType
+	scalarFilters map[string]ViewFilter
+	typeDefs      map[string]TypeDef
+	directives    map[string]DirectiveSpec
 
 	schemas       map[call.View]*ast.Schema
 	schemaDigests map[call.View]digest.Digest
@@ -50,6 +49,13 @@ type Server struct {
 
 	installLock  *sync.RWMutex
 	installHooks []InstallHook
+
+	// interfacesDirty is set when an install changes the set of objects or
+	// interfaces, and cleared when interface implementations are reconciled.
+	// Reconciliation is deferred until the type system is next read (see
+	// reconcileInterfaceImplsIfDirty) so a burst of installs reconciles once,
+	// against the complete schema, rather than once per install.
+	interfacesDirty bool
 
 	// View is the default view that is applied to queries on this server.
 	//
@@ -149,9 +155,7 @@ func NewServer[T Typed](_ context.Context, root T) (*Server, error) {
 	srv.root = rootRes
 
 	// Install core interfaces before any objects so that InstallObject
-	// can auto-implement them for qualifying classes.
-	//
-	// autoInterfaces are checked in order for every installed object/interface.
+	// can infer implementations for qualifying classes.
 	nodeIface := NewInterface("Node", "An object with a globally unique ID.")
 	nodeIface.AddField(InterfaceFieldSpec{
 		FieldSpec: FieldSpec{
@@ -160,7 +164,6 @@ func NewServer[T Typed](_ context.Context, root T) (*Server, error) {
 		},
 	})
 	srv.interfaces[nodeIface.TypeName()] = nodeIface
-	srv.autoInterfaces = []*Interface{nodeIface}
 
 	srv.InstallObject(rootClass)
 	for _, scalar := range coreScalars {
@@ -243,7 +246,6 @@ func (s *Server) Fork(_ context.Context, root Typed) (*Server, error) {
 	for name, iface := range s.interfaces {
 		out.interfaces[name] = iface
 	}
-	out.autoInterfaces = append(out.autoInterfaces, s.autoInterfaces...)
 	for name, scalar := range s.scalars {
 		out.scalars[name] = scalar
 	}
@@ -284,6 +286,10 @@ func (s *Server) Fork(_ context.Context, root Typed) (*Server, error) {
 		return nil, fmt.Errorf("new forked root: %w", err)
 	}
 	out.root = rootObj
+
+	// Forked object types are fresh instances, so reconcile their interface
+	// implementations on first read rather than assuming the fork carried them.
+	out.interfacesDirty = true
 
 	return out, nil
 }
@@ -537,15 +543,7 @@ func (s *Server) InstallObject(class ObjectType, directives ...*ast.Directive) O
 	s.invalidateSchemaCache()
 
 	s.objects[class.TypeName()] = class
-
-	// Auto-implement core interfaces for qualifying classes.
-	if impl, ok := class.(InterfaceImplementor); ok {
-		for _, iface := range s.autoInterfaces {
-			if iface.Satisfies(class, "") {
-				impl.ImplementInterface(iface)
-			}
-		}
-	}
+	s.interfacesDirty = true
 	s.installLock.Unlock()
 
 	for _, hook := range s.installHooks {
@@ -555,24 +553,18 @@ func (s *Server) InstallObject(class ObjectType, directives ...*ast.Directive) O
 	return class
 }
 
-// AutoImplementInterfaces re-checks whether the given object type satisfies
-// any auto-interfaces that it didn't qualify for at InstallObject time. This
-// is needed because fields like "sync" are installed after InstallObject.
-func (s *Server) AutoImplementInterfaces(class ObjectType) {
-	impl, ok := class.(InterfaceImplementor)
-	if !ok {
-		return
-	}
+// markInterfacesDirty flags interface inference as stale, so it re-runs on the
+// next read of the type system (see reconcileInterfaceImplsIfDirty). Install
+// flows that add fields to a class after InstallObject -- e.g. a sync field
+// added via Fields.Install -- call this so the completed class is re-checked;
+// InstallObject's own flag may already have been consumed by an intervening
+// read (such as an install hook). It must not be called while holding a class's
+// field lock: it takes installLock, and reconciliation takes installLock before
+// reading field specs.
+func (s *Server) markInterfacesDirty() {
 	s.installLock.Lock()
 	defer s.installLock.Unlock()
-	for _, iface := range s.autoInterfaces {
-		if iface.HasImplementor(class.TypeName()) {
-			continue
-		}
-		if iface.Satisfies(class, "") {
-			impl.ImplementInterface(iface)
-		}
-	}
+	s.interfacesDirty = true
 }
 
 // InstallInterface installs the given Interface type into the schema.
@@ -598,60 +590,239 @@ func (s *Server) installInterfaceLocked(iface *Interface) *Interface {
 		return existing
 	}
 	s.interfaces[iface.TypeName()] = iface
-
-	// Auto-implement core interfaces for qualifying interfaces.
-	for _, autoIface := range s.autoInterfaces {
-		if autoIface.TypeName() == iface.TypeName() {
-			continue
-		}
-		if autoIface.SatisfiedByInterface(iface, "") {
-			iface.ImplementInterface(autoIface)
-		}
-	}
-
+	s.interfacesDirty = true
 	s.invalidateSchemaCache()
 	return iface
 }
 
-// AddAutoInterface registers an interface for automatic implementation.
-// Any subsequently installed object or interface that structurally satisfies
-// it will automatically declare conformance. Already-installed objects are
-// NOT retroactively checked — call this before installing objects, or use
-// AutoImplementInterfaces to re-check specific types.
-func (s *Server) AddAutoInterface(iface *Interface) {
-	s.installLock.Lock()
-	iface = s.installInterfaceLocked(iface)
-	newlyAdded := true
-	for _, existing := range s.autoInterfaces {
-		if existing.TypeName() == iface.TypeName() {
-			newlyAdded = false
-			break
-		}
-	}
-	if newlyAdded {
-		s.autoInterfaces = append(s.autoInterfaces, iface)
+// interfaceRelationSet records "type implements interface" pairs, keyed by type
+// name then interface name.
+type interfaceRelationSet map[string]map[string]struct{}
 
-		// Resolve interface-implements-interface among all auto-interfaces.
-		for _, other := range s.autoInterfaces {
-			if other.TypeName() == iface.TypeName() {
+func (rels interfaceRelationSet) add(typeName, ifaceName string) {
+	if rels[typeName] == nil {
+		rels[typeName] = map[string]struct{}{}
+	}
+	rels[typeName][ifaceName] = struct{}{}
+}
+
+func (rels interfaceRelationSet) has(typeName, ifaceName string) bool {
+	if rels[typeName] == nil {
+		return false
+	}
+	_, ok := rels[typeName][ifaceName]
+	return ok
+}
+
+func (rels interfaceRelationSet) del(typeName, ifaceName string) bool {
+	if rels[typeName] == nil {
+		return false
+	}
+	if _, ok := rels[typeName][ifaceName]; !ok {
+		return false
+	}
+	delete(rels[typeName], ifaceName)
+	return true
+}
+
+// reconcileInterfaceImplsIfDirty reconciles interface implementations if an
+// install has invalidated them since the last reconcile, then clears the flag.
+// Read paths into the type system (SchemaForView, ObjectType, InterfaceType)
+// call this so reconciliation happens once, lazily, against the fully-installed
+// schema -- recovering the cost of the single post-pass this replaced while
+// keeping InstallInterface retroactive. The common case (not dirty) only takes
+// the read lock, so it stays cheap on the hot query-resolution path.
+func (s *Server) reconcileInterfaceImplsIfDirty() {
+	s.installLock.RLock()
+	dirty := s.interfacesDirty
+	s.installLock.RUnlock()
+	if !dirty {
+		return
+	}
+
+	s.installLock.Lock()
+	defer s.installLock.Unlock()
+	if s.interfacesDirty {
+		s.interfacesDirty = false
+		s.reconcileInterfaceImplsLocked(s.View)
+	}
+}
+
+// reconcileInterfaceImplsLocked recomputes which objects and interfaces
+// structurally implement each installed interface and records the results on
+// the types themselves. It considers every installed object and interface, so
+// an interface is matched against types installed both before and after it;
+// this is what makes InstallInterface retroactive.
+//
+// The caller must hold s.installLock.
+func (s *Server) reconcileInterfaceImplsLocked(view call.View) {
+	if len(s.interfaces) == 0 {
+		return
+	}
+
+	rels := interfaceRelationSet{}
+	permanent := interfaceRelationSet{}
+
+	// Seed every (object, interface) and (interface, interface) pair as a
+	// candidate, then whittle the set down in the loop below. Assuming all
+	// pairs hold and only removing the disproven ones computes a greatest
+	// fixed point, which is what lets mutually recursive, covariant
+	// relationships resolve: e.g. `Obj.self: Obj` satisfies `Iface.self: Iface`
+	// only if Obj implements Iface, which is the very pair we're proving.
+	sortutil.RangeSorted(s.objects, func(objName string, obj ObjectType) {
+		if _, ok := obj.(InterfaceImplementor); !ok {
+			return
+		}
+		sortutil.RangeSorted(s.interfaces, func(ifaceName string, _ *Interface) {
+			rels.add(objName, ifaceName)
+		})
+	})
+	sortutil.RangeSorted(s.interfaces, func(typeName string, _ *Interface) {
+		sortutil.RangeSorted(s.interfaces, func(ifaceName string, _ *Interface) {
+			if typeName != ifaceName {
+				rels.add(typeName, ifaceName)
+			}
+		})
+	})
+
+	// Relationships that were declared explicitly (or inferred by an earlier
+	// pass) are facts, not candidates: keep them in permanent so the loop
+	// never disproves them, and add them to rels so they count as evidence
+	// when checking other pairs.
+	sortutil.RangeSorted(s.objects, func(objName string, obj ObjectType) {
+		withInterfaces, ok := obj.(objectTypeWithInterfaces)
+		if !ok {
+			return
+		}
+		for _, iface := range withInterfaces.Interfaces() {
+			if iface == nil {
 				continue
 			}
-			if other.SatisfiedByInterface(iface, "") {
-				iface.ImplementInterface(other)
+			if _, ok := s.interfaces[iface.TypeName()]; !ok {
+				continue
 			}
+			rels.add(objName, iface.TypeName())
+			permanent.add(objName, iface.TypeName())
 		}
-	}
-	s.installLock.Unlock()
+	})
+	sortutil.RangeSorted(s.interfaces, func(typeName string, iface *Interface) {
+		for ifaceName := range iface.Interfaces() {
+			if _, ok := s.interfaces[ifaceName]; !ok {
+				continue
+			}
+			rels.add(typeName, ifaceName)
+			permanent.add(typeName, ifaceName)
+		}
+	})
 
-	if newlyAdded {
-		for _, hook := range s.installHooks {
-			hook.InstallInterface(iface)
+	// Drop any candidate pair whose fields don't structurally line up, using
+	// the shrinking rels set as the oracle for nested type comparisons.
+	// Removing one pair can invalidate another, so iterate until stable.
+	changed := true
+	for changed {
+		changed = false
+		checker := func(typeName, ifaceName string) bool {
+			return rels.has(typeName, ifaceName)
+		}
+
+		sortutil.RangeSorted(s.objects, func(objName string, obj ObjectType) {
+			sortutil.RangeSorted(s.interfaces, func(ifaceName string, iface *Interface) {
+				if !rels.has(objName, ifaceName) || permanent.has(objName, ifaceName) {
+					return
+				}
+				if !iface.Satisfies(obj, view, checker) {
+					changed = rels.del(objName, ifaceName) || changed
+				}
+			})
+		})
+
+		sortutil.RangeSorted(s.interfaces, func(typeName string, typ *Interface) {
+			sortutil.RangeSorted(s.interfaces, func(ifaceName string, iface *Interface) {
+				if typeName == ifaceName || !rels.has(typeName, ifaceName) || permanent.has(typeName, ifaceName) {
+					return
+				}
+				if !iface.SatisfiedByInterface(typ, view, checker) {
+					changed = rels.del(typeName, ifaceName) || changed
+				}
+			})
+		})
+	}
+
+	// The surviving pairs are the proven relationships; record them on the
+	// types, skipping any already declared.
+	sortutil.RangeSorted(s.objects, func(objName string, obj ObjectType) {
+		impl, ok := obj.(InterfaceImplementor)
+		if !ok {
+			return
+		}
+		sortutil.RangeSorted(s.interfaces, func(ifaceName string, iface *Interface) {
+			if !rels.has(objName, ifaceName) || objectTypeHasInterface(obj, ifaceName) {
+				return
+			}
+			impl.ImplementInterfaceUnchecked(iface)
+		})
+	})
+
+	sortutil.RangeSorted(s.interfaces, func(typeName string, typ *Interface) {
+		sortutil.RangeSorted(s.interfaces, func(ifaceName string, iface *Interface) {
+			if typeName == ifaceName || !rels.has(typeName, ifaceName) {
+				return
+			}
+			if _, ok := typ.Interfaces()[ifaceName]; ok {
+				return
+			}
+			if interfaceImplementsTransitive(iface, typeName, nil) {
+				return
+			}
+			typ.ImplementInterface(iface)
+			s.invalidateSchemaCache()
+		})
+	})
+}
+
+// objectTypeHasInterface reports whether obj already declares the named
+// interface.
+func objectTypeHasInterface(obj ObjectType, ifaceName string) bool {
+	withInterfaces, ok := obj.(objectTypeWithInterfaces)
+	if !ok {
+		return false
+	}
+	for _, iface := range withInterfaces.Interfaces() {
+		if iface != nil && iface.TypeName() == ifaceName {
+			return true
 		}
 	}
+	return false
+}
+
+// interfaceImplementsTransitive reports whether iface implements target either
+// directly or through another interface it implements. It guards against
+// re-declaring an existing (possibly indirect) relationship and against cycles.
+func interfaceImplementsTransitive(iface *Interface, target string, seen map[string]struct{}) bool {
+	if iface == nil {
+		return false
+	}
+	if iface.TypeName() == target {
+		return true
+	}
+	if seen == nil {
+		seen = map[string]struct{}{}
+	}
+	if _, ok := seen[iface.TypeName()]; ok {
+		return false
+	}
+	seen[iface.TypeName()] = struct{}{}
+	for _, implemented := range iface.Interfaces() {
+		if interfaceImplementsTransitive(implemented, target, seen) {
+			return true
+		}
+	}
+	return false
 }
 
 // InterfaceType returns the Interface with the given name, if it exists.
 func (s *Server) InterfaceType(name string) (*Interface, bool) {
+	s.reconcileInterfaceImplsIfDirty()
 	s.installLock.RLock()
 	defer s.installLock.RUnlock()
 	t, ok := s.interfaces[name]
@@ -697,6 +868,7 @@ func (s *Server) InstallTypeDef(def TypeDef) {
 
 // ObjectType returns the ObjectType with the given name, if it exists.
 func (s *Server) ObjectType(name string) (ObjectType, bool) {
+	s.reconcileInterfaceImplsIfDirty()
 	s.installLock.RLock()
 	defer s.installLock.RUnlock()
 	t, ok := s.objects[name]
@@ -743,6 +915,7 @@ func (s *Server) Schema() *ast.Schema {
 }
 
 func (s *Server) SchemaForView(view call.View) *ast.Schema {
+	s.reconcileInterfaceImplsIfDirty()
 	s.installLock.RLock()
 	defer s.installLock.RUnlock()
 	s.schemaLock.Lock()


### PR DESCRIPTION
Noticed `dagql` had an `AddAutoInterface` API which went against my mental model of what `dagql`-native interfaces should mean. Turns out actual auto-implementing logic was split between `core` and `dagql` with duplicate effort between native GraphQL and Dagger's `TypeDef` schema. This refactor consolidates it all into `dagql` which now treats all interface implementing as "automatic" rather than only the core interfaces.

LLM-written below:

---

**TL;DR:** Interface "X implements Y" inference now lives in dagql and runs once, lazily, the next time the schema is read — so `InstallInterface` works retroactively and every interface participates, at the same cost as the old one-shot post-pass in core.

---

Structural interface inference — deciding which objects and interfaces implement which interfaces by matching fields — used to run in core's schema build as a single post-pass, after every module was installed. dagql itself only auto-implemented a fixed set of "auto-interfaces" that had to be registered *before* any objects, so an interface installed later was never matched against the types it described.

This moves inference into dagql, where every installed interface is reconciled against every installed object and interface. `InstallInterface` becomes retroactive, every interface participates (not just a privileged few registered up front), and the duplicated logic in core — along with the now-redundant `AddAutoInterface` entry point — is deleted.

## Summary

- Add `reconcileInterfaceImplsLocked` to `dagql.Server`. It seeds all object×interface and interface×interface candidate pairs, prunes the ones it can't structurally prove, and records the survivors on the types.
- Compute a **greatest fixed point** instead of a single pass: assume every pair holds, then remove disproven ones until stable. This resolves mutually recursive, covariant relationships — e.g. `Obj.self: Obj` satisfying `Iface.self: Iface` — which the old single-pass checker could not handle.
- **Reconcile lazily, once.** An install only flags relationships dirty; the actual reconcile runs the next time the type system is read (`SchemaForView`, `ObjectType`, `InterfaceType`), so a burst of installs reconciles a single time against the complete schema. The dirty check is a cheap read-locked bool, kept off the hot query-resolution path.
- Drop `registerInterfaceImpls`, `registerInterfaceToInterfaceImpls`, and `makeImplementsChecker` from `core/schema_build.go`; `installModules` no longer collects and returns type defs.
- Remove `AddAutoInterface`; core interfaces (`Syncer`, `Exportable`) and all callers now use `InstallInterface`.

## Performance

Equivalent to the old one-shot post-pass: **O(N·M + M²)** structural checks (N objects, M interfaces), run once per schema settle rather than once per install. The earlier eager-per-install version of this PR was O(N²·M); deferring the work behind a dirty flag recovers the original cost while keeping retroactivity and the greatest-fixed-point correctness. Reconciliation re-runs only when a later install flags the schema dirty again.

## Test plan

- [ ] `dagger --progress=dots call go test --pkgs=./dagql` — covers retroactive inference, recursive covariant return types, and interface→interface inference (passing locally, incl. `-race`)
- [ ] `dagger --progress=dots call go test --pkgs=./core --run '^\$'`
- [ ] `dagger --progress=dots call test-split test-interface`

🤖 Generated with [Claude Code](https://claude.com/claude-code)