### PR TITLE
Revert "Set pinned as default lock mode (#13245)"

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -349,7 +349,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs)")
-	flags.StringVar(&lockMode, "lock", "", "Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.")
+	flags.StringVar(&lockMode, "lock", "", "Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")

--- a/core/schema/lockfile_test.go
+++ b/core/schema/lockfile_test.go
@@ -144,13 +144,13 @@ func TestResolveLookupFromLock(t *testing.T) {
 func TestCurrentLookupLockMode(t *testing.T) {
 	t.Parallel()
 
-	t.Run("defaults to pinned", func(t *testing.T) {
+	t.Run("defaults to disabled", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{})
 		mode, err := currentLookupLockMode(ctx)
 		require.NoError(t, err)
-		require.Equal(t, workspace.LockModePinned, mode)
+		require.Equal(t, workspace.LockModeDisabled, mode)
 	})
 
 	t.Run("uses explicit mode", func(t *testing.T) {

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -22,8 +22,12 @@ const (
 	LockModePinned   LockMode = "pinned"
 	LockModeFrozen   LockMode = "frozen"
 
+	// Backward-compatible aliases for the previous experimental names.
+	LockModeAuto   = LockModePinned
+	LockModeStrict = LockModeFrozen
+
 	// DefaultLockMode is used when no mode is explicitly set.
-	DefaultLockMode = LockModePinned
+	DefaultLockMode = LockModeDisabled
 )
 
 // LockPolicy controls update intent for a lock entry.
@@ -206,6 +210,15 @@ func moduleResolveInputs(source string) []any {
 
 // ParseLockMode validates an explicitly configured lock mode.
 func ParseLockMode(mode string) (LockMode, error) {
+	switch mode {
+	case "update":
+		return LockModeLive, nil
+	case "auto":
+		return LockModePinned, nil
+	case "strict":
+		return LockModeFrozen, nil
+	}
+
 	lockMode := LockMode(mode)
 	if !isValidLockMode(lockMode) {
 		return "", fmt.Errorf("invalid lock mode %q", mode)

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -162,6 +162,24 @@ func TestParseLockMode(t *testing.T) {
 		require.Equal(t, LockModeFrozen, mode)
 	})
 
+	t.Run("legacy update alias", func(t *testing.T) {
+		mode, err := ParseLockMode("update")
+		require.NoError(t, err)
+		require.Equal(t, LockModeLive, mode)
+	})
+
+	t.Run("legacy auto alias", func(t *testing.T) {
+		mode, err := ParseLockMode("auto")
+		require.NoError(t, err)
+		require.Equal(t, LockModePinned, mode)
+	})
+
+	t.Run("legacy strict alias", func(t *testing.T) {
+		mode, err := ParseLockMode("strict")
+		require.NoError(t, err)
+		require.Equal(t, LockModeFrozen, mode)
+	})
+
 	t.Run("invalid", func(t *testing.T) {
 		_, err := ParseLockMode("weird")
 		require.Error(t, err)
@@ -172,5 +190,5 @@ func TestParseLockMode(t *testing.T) {
 func TestResolveLockMode(t *testing.T) {
 	mode, err := ResolveLockMode("")
 	require.NoError(t, err)
-	require.Equal(t, LockModePinned, mode)
+	require.Equal(t, DefaultLockMode, mode)
 }

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -22,7 +22,7 @@ dagger [options] [subcommand | file...]
       --eager-runtime                load module runtime eagerly
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -m, --mod string                   Module reference to load, either a local path or a remote git repo (defaults to current directory)
       --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
   -E, --no-exit                      Leave the TUI running after completion
@@ -80,7 +80,7 @@ dagger call [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -129,7 +129,7 @@ dagger config -m github.com/dagger/hello-dagger
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -165,7 +165,7 @@ dagger core [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -229,7 +229,7 @@ dagger develop [options]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -274,7 +274,7 @@ dagger functions [options] [function]...
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -340,7 +340,7 @@ dagger init --sdk=go
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -389,7 +389,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -414,7 +414,7 @@ Manage workspace lockfiles
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -450,7 +450,7 @@ dagger lock update
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -479,7 +479,7 @@ dagger login [options] [org]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -508,7 +508,7 @@ dagger logout
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -576,7 +576,7 @@ EOF
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -638,7 +638,7 @@ dagger run python main.py
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -663,7 +663,7 @@ Manage toolchains
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -716,7 +716,7 @@ dagger toolchain install github.com/dagger/dagger/toolchains/go
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -763,7 +763,7 @@ dagger toolchain list
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -811,7 +811,7 @@ dagger toolchain uninstall mytoolchain
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -859,7 +859,7 @@ dagger toolchain update
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -907,7 +907,7 @@ dagger uninstall hello
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -960,7 +960,7 @@ dagger update [options] [<DEPENDENCY>...]
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -995,7 +995,7 @@ dagger version
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to pinned.
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
   -E, --no-exit                      Leave the TUI running after completion
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)

--- a/docs/current_docs/reference/cli/lockfiles.mdx
+++ b/docs/current_docs/reference/cli/lockfiles.mdx
@@ -19,8 +19,6 @@ Lock mode is set for a run, typically with `--lock`.
 dagger --lock=pinned call ...
 ```
 
-When `--lock` is not set, Dagger uses `pinned`.
-
 Available modes:
 
 | Mode | Meaning |

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -133,7 +133,7 @@ type Params struct {
 	SkipWorkspaceModules bool
 
 	// LockMode controls lockfile behavior for lookup resolution.
-	// Valid values: "disabled", "live", "pinned", "frozen".
+	// Valid values: "disabled", "strict", "auto", "update".
 	LockMode string
 
 	// Workspace explicitly declares workspace binding for this client.

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -126,7 +126,8 @@ type ClientMetadata struct {
 	SkipWorkspaceModules bool `json:"skip_workspace_modules,omitempty"`
 
 	// LockMode controls lockfile behavior for lookup resolution.
-	// Valid values: "disabled", "live", "pinned", "frozen".
+	// Valid values: "live", "pinned", "frozen", "update".
+	// Legacy aliases "disabled", "auto", and "strict" are also accepted.
 	LockMode string `json:"lock_mode,omitempty"`
 
 	// Workspace explicitly declares the workspace binding for this client.


### PR DESCRIPTION
## Summary

Reverts `da5a7161c5` so the default lock lookup mode returns to `disabled` for now.

After the default changed to `pinned`, some tests started consistently failing. One concrete reproducer is `TestContainer/TestWithMountedDirectoryCaching`: the first session writes `.dagger/lock` into the test workdir, so the second `Host().Directory(".")` snapshot sees changed content and the cached exec is invalidated.

This backs the change out while we reassess the lockfile behavior and its interaction with host directory snapshots.

## Validation

- `go test ./core/workspace ./core/schema -run 'Test(ParseLockMode|ResolveLockMode|CurrentLookupLockMode|ResolveLookupFromLock)' -count=1`\n- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestContainer/TestWithMountedDirectoryCaching'`