### PR TITLE
cli: use release artifacts for x-release tags

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/mod/semver"
 	"golang.org/x/term"
 	"mvdan.cc/sh/v3/interp"
 
@@ -394,13 +395,21 @@ func disableFlagsInUseLine(cmd *cobra.Command) {
 
 func execXRelease(ctx context.Context) error {
 	ref := strings.TrimSpace(xRelease)
-	commit, resolved, err := resolveXReleaseRef(ctx, ref)
-	if err != nil {
-		return fmt.Errorf("resolve experimental release %q: %w", ref, err)
+	downloadRef, engineRef, release := xReleaseReleaseRef(ref)
+	resolved := false
+	if !release {
+		commit, wasResolved, err := resolveXReleaseRef(ctx, ref)
+		if err != nil {
+			return fmt.Errorf("resolve experimental release %q: %w", ref, err)
+		}
+		downloadRef = commit
+		engineRef = commit
+		resolved = wasResolved
 	}
 
 	downloader := engineconn.CLIDownloader{
-		Ref:       commit,
+		Ref:       downloadRef,
+		Release:   release,
 		LogOutput: stderr,
 	}
 	binPath, err := downloader.Download(ctx)
@@ -409,15 +418,17 @@ func execXRelease(ctx context.Context) error {
 	}
 
 	msg := fmt.Sprintf("running build from %s", ref)
-	if resolved {
-		msg += fmt.Sprintf("; resolved to %s; pin with %s=%s or --x-release=%s", commit, daggerXReleaseEnv, commit, commit)
+	if release {
+		msg += fmt.Sprintf("; using release %s", engineRef)
+	} else if resolved {
+		msg += fmt.Sprintf("; resolved to %s; pin with %s=%s or --x-release=%s", downloadRef, daggerXReleaseEnv, downloadRef, downloadRef)
 	}
 	fmt.Fprintln(stderr, xReleaseLogLine(msg))
 
 	if shouldCleanupOldEngines() {
 		_ = drivers.CleanupOldEngines(ctx, []string{
 			engineVersion(engine.Tag),
-			engineVersion(commit),
+			engineVersion(engineRef),
 		})
 	}
 
@@ -428,6 +439,14 @@ func execXRelease(ctx context.Context) error {
 		return fmt.Errorf("exec experimental release CLI: %w", err)
 	}
 	return nil
+}
+
+func xReleaseReleaseRef(ref string) (downloadRef string, engineRef string, ok bool) {
+	maybeTag := strings.TrimPrefix(ref, "v")
+	if !semver.IsValid("v" + maybeTag) {
+		return "", "", false
+	}
+	return maybeTag, "v" + maybeTag, true
 }
 
 func resolveXReleaseRef(ctx context.Context, ref string) (string, bool, error) {
@@ -486,7 +505,8 @@ func xReleaseProcessEnv(environ []string) []string {
 	hasLeaveOldEngine := false
 	for _, kv := range environ {
 		key, _, _ := strings.Cut(kv, "=")
-		if key == daggerXReleaseEnv {
+		switch key {
+		case daggerXReleaseEnv, RunnerHostEnv, RunnerImageLoaderEnv:
 			continue
 		}
 		if key == "DAGGER_LEAVE_OLD_ENGINE" {

--- a/cmd/dagger/xrelease_test.go
+++ b/cmd/dagger/xrelease_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestXReleaseReleaseRef(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		ref         string
+		downloadRef string
+		engineRef   string
+		ok          bool
+	}{
+		{
+			name:        "release with v",
+			ref:         "v0.20.8",
+			downloadRef: "0.20.8",
+			engineRef:   "v0.20.8",
+			ok:          true,
+		},
+		{
+			name:        "release without v",
+			ref:         "0.20.8",
+			downloadRef: "0.20.8",
+			engineRef:   "v0.20.8",
+			ok:          true,
+		},
+		{
+			name:        "prerelease",
+			ref:         "v0.21.0-beta.1",
+			downloadRef: "0.21.0-beta.1",
+			engineRef:   "v0.21.0-beta.1",
+			ok:          true,
+		},
+		{
+			name: "main",
+			ref:  "main",
+		},
+		{
+			name: "sha",
+			ref:  "74bff7d10fd78dd6935c60c4514558598f216451",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			downloadRef, engineRef, ok := xReleaseReleaseRef(tc.ref)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.downloadRef, downloadRef)
+			require.Equal(t, tc.engineRef, engineRef)
+		})
+	}
+}
+
+func TestXReleaseProcessEnvClearsRunnerOverrides(t *testing.T) {
+	env := xReleaseProcessEnv([]string{
+		daggerXReleaseEnv + "=v0.20.8",
+		RunnerHostEnv + "=docker-container://dagger-engine.dev",
+		RunnerImageLoaderEnv + "=docker",
+		"KEEP=1",
+	})
+
+	require.Equal(t, []string{
+		"KEEP=1",
+		"DAGGER_LEAVE_OLD_ENGINE=1",
+	}, env)
+}


### PR DESCRIPTION
### Problem

`dagger --x-release` downloads another CLI and re-execs into it before running the requested command.

Before this change, x-release resolved release tags through the GitHub commit API and then treated the resulting SHA as a main-build artifact ref:

`dl.dagger.io/dagger/main/<sha>/dagger_<sha>_...`

That is the right namespace for successful main publishes, but it is the wrong namespace for tagged releases.

The concrete bug was `v0.20.7` and `v0.20.8`. They are real releases from the 0.20 release branch. Their CLI artifacts are published in the release namespace:

`dl.dagger.io/dagger/releases/<version>/dagger_v<version>_...`

The matching `main/<sha>` artifacts do not exist for those tags. So `--x-release v0.20.8` resolved the tag to a commit, requested the wrong URL under `main/<sha>`, and failed with 403.

`v0.20.6` made the failure mode harder to read. That tagged commit did have a main artifact, so the download succeeded, but it downloaded the dev build for that commit rather than the release build. The command then printed a dev pseudo-version and used a commit-tagged engine image instead of the released `v0.20.6` CLI and engine.

There was also a related re-exec environment issue: local development runner overrides such as `_EXPERIMENTAL_DAGGER_RUNNER_HOST` could be inherited by the downloaded CLI. That made `dagger version` and later engine connections mix the selected x-release CLI with the outer process runner configuration.

### Solution

Classify semver x-release refs before resolving through GitHub.

* semver refs, with or without a leading `v`, use the existing release download path and checksum validation.
* non-release refs keep the existing behavior: full SHAs are used directly, and other refs are resolved through GitHub before downloading from the main artifact namespace.

Also strip the x-release activation env and local runner override env vars before re-execing into the downloaded CLI:

* `DAGGER_X_RELEASE`
* `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
* `_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE`

This lets the child CLI compute its runner defaults from its own linked engine tag, keeping `dagger version` and engine startup aligned with the selected x-release build.

Tests cover release ref normalization and the x-release environment rewrite.