### PR TITLE
recommend modules with dagger mod recommended

### DIFF
--- a/cmd/dagger/mod.go
+++ b/cmd/dagger/mod.go
@@ -56,20 +56,20 @@ var modListCmd = &cobra.Command{
 	},
 }
 
-var modRecommendedCmd = &cobra.Command{
-	Use:   "recommended",
+var modRecommendCmd = &cobra.Command{
+	Use:   "recommend",
 	Short: "Recommend modules based on files in your workspace",
 	Long: `Scan the workspace for files matching the recommend glob of each known
 module and print those whose pattern matches at least one file.
 
 Modules already installed in the workspace are excluded.`,
-	Example: "dagger mod recommended",
+	Example: "dagger mod recommend",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return withEngine(cmd.Context(), client.Params{
 			SkipWorkspaceModules: true,
 		}, func(ctx context.Context, engineClient *client.Client) error {
-			return runRecommended(ctx, cmd.OutOrStdout(), engineClient.Dagger())
+			return runRecommend(ctx, cmd.OutOrStdout(), engineClient.Dagger())
 		})
 	},
 }
@@ -96,7 +96,7 @@ With no query, lists all known modules.`,
 }
 
 func init() {
-	modCmd.AddCommand(modInstallCmd, modUninstallCmd, modListCmd, modSearchCmd, modRecommendedCmd)
+	modCmd.AddCommand(modInstallCmd, modUninstallCmd, modListCmd, modSearchCmd, modRecommendCmd)
 
 	addWorkspaceInstallFlags(modInstallCmd)
 	addWorkspaceHereFlag(modUninstallCmd)
@@ -104,7 +104,7 @@ func init() {
 	setWorkspaceFlagPolicy(modInstallCmd, workspaceFlagPolicyLocalOnly)
 	setWorkspaceFlagPolicy(modUninstallCmd, workspaceFlagPolicyLocalOnly)
 	setWorkspaceFlagPolicy(modListCmd, workspaceFlagPolicyLocalOnly)
-	setWorkspaceFlagPolicy(modRecommendedCmd, workspaceFlagPolicyLocalOnly)
+	setWorkspaceFlagPolicy(modRecommendCmd, workspaceFlagPolicyLocalOnly)
 }
 
 func listWorkspaceModules(ctx context.Context, out io.Writer, dag *dagger.Client) error {
@@ -150,7 +150,7 @@ type registryModule struct {
 	Description string `json:"description"`
 	Repo        string `json:"repo"`
 	// Recommend is a doublestar glob (e.g. "**/go.mod") used by
-	// `dagger mod recommended` to decide whether to suggest this module
+	// `dagger mod recommend` to decide whether to suggest this module
 	// based on files present in the workspace. Empty means never recommended.
 	Recommend string `json:"recommend,omitempty"`
 }
@@ -232,10 +232,10 @@ var recommendWalkSkipDirs = map[string]bool{
 	"target":       true,
 }
 
-// runRecommended is the cobra runtime for `dagger mod recommended`. It
+// runRecommend is the cobra runtime for `dagger mod recommend`. It
 // resolves the workspace root (respecting -W), gathers installed module
 // names, walks the workspace, and prints the matches.
-func runRecommended(ctx context.Context, out io.Writer, dag *dagger.Client) error {
+func runRecommend(ctx context.Context, out io.Writer, dag *dagger.Client) error {
 	ws := dag.CurrentWorkspace()
 
 	address, err := ws.Address(ctx)

--- a/cmd/dagger/mod.go
+++ b/cmd/dagger/mod.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
-	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"dagger.io/dagger"
-	"github.com/bmatcuk/doublestar/v4"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/spf13/cobra"
 )
@@ -101,10 +97,11 @@ func init() {
 	addWorkspaceInstallFlags(modInstallCmd)
 	addWorkspaceHereFlag(modUninstallCmd)
 
+	// install/uninstall mutate workspace config and only make sense for a
+	// local workspace; list/search/recommend are read-only and work for
+	// both local and remote -W refs.
 	setWorkspaceFlagPolicy(modInstallCmd, workspaceFlagPolicyLocalOnly)
 	setWorkspaceFlagPolicy(modUninstallCmd, workspaceFlagPolicyLocalOnly)
-	setWorkspaceFlagPolicy(modListCmd, workspaceFlagPolicyLocalOnly)
-	setWorkspaceFlagPolicy(modRecommendCmd, workspaceFlagPolicyLocalOnly)
 }
 
 func listWorkspaceModules(ctx context.Context, out io.Writer, dag *dagger.Client) error {
@@ -219,40 +216,25 @@ type recommendation struct {
 	Match  string
 }
 
-// recommendWalkSkipDirs lists directories we never descend into when scanning
-// the workspace for recommend glob matches. Keeps the walk cheap and avoids
-// false positives from vendored or generated content.
-var recommendWalkSkipDirs = map[string]bool{
-	".git":         true,
-	".dagger":      true,
-	"node_modules": true,
-	"vendor":       true,
-	"dist":         true,
-	"build":        true,
-	"target":       true,
+// recommendExcludeDirs lists directories we strip from the workspace
+// snapshot before globbing. Keeps the work cheap and avoids false positives
+// from vendored or generated content. Patterns match Workspace.Directory's
+// exclude semantics (path-prefix style).
+var recommendExcludeDirs = []string{
+	".git/",
+	".dagger/",
+	"node_modules/",
+	"vendor/",
+	"dist/",
+	"build/",
+	"target/",
 }
 
-// runRecommend is the cobra runtime for `dagger mod recommend`. It
-// resolves the workspace root (respecting -W), gathers installed module
-// names, walks the workspace, and prints the matches.
+// runRecommend is the cobra runtime for `dagger mod recommend`. It works for
+// both local and remote workspaces by globbing through the engine rather
+// than walking the local filesystem.
 func runRecommend(ctx context.Context, out io.Writer, dag *dagger.Client) error {
 	ws := dag.CurrentWorkspace()
-
-	address, err := ws.Address(ctx)
-	if err != nil {
-		return fmt.Errorf("load workspace address: %w", err)
-	}
-	cwd, err := ws.Cwd(ctx)
-	if err != nil {
-		return fmt.Errorf("load workspace cwd: %w", err)
-	}
-	root, err := workspaceRootFromAddress(address, cwd)
-	if err != nil {
-		return err
-	}
-	if root == "" {
-		return fmt.Errorf("workspace root not available")
-	}
 
 	installed, err := installedModuleNames(ctx, dag)
 	if err != nil {
@@ -264,12 +246,32 @@ func runRecommend(ctx context.Context, out io.Writer, dag *dagger.Client) error 
 		return err
 	}
 
-	files, err := collectWorkspaceFiles(root)
-	if err != nil {
-		return fmt.Errorf("scan workspace %s: %w", root, err)
-	}
+	// "/" resolves to the workspace root regardless of cwd; excluding common
+	// vendored/generated dirs keeps matches relevant.
+	dir := ws.Directory("/", dagger.WorkspaceDirectoryOpts{
+		Exclude: recommendExcludeDirs,
+	})
 
-	return printRecommendations(out, recommendModules(mods, files, installed))
+	recs := make([]recommendation, 0, len(mods))
+	for _, m := range mods {
+		if m.Recommend == "" || installed[m.Name] {
+			continue
+		}
+		matches, err := dir.Glob(ctx, m.Recommend)
+		if err != nil {
+			// A bad pattern in the registry shouldn't take down the whole
+			// command; just skip the entry.
+			continue
+		}
+		if len(matches) == 0 {
+			continue
+		}
+		sort.Strings(matches)
+		recs = append(recs, recommendation{Module: m, Match: matches[0]})
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Module.Name < recs[j].Module.Name })
+
+	return printRecommendations(out, recs)
 }
 
 // installedModuleNames returns the set of module names installed in the
@@ -292,81 +294,6 @@ func installedModuleNames(ctx context.Context, dag *dagger.Client) (map[string]b
 		installed[m.Name] = true
 	}
 	return installed, nil
-}
-
-// collectWorkspaceFiles walks root and returns paths relative to it, using
-// forward slashes, suitable for doublestar matching. Directories listed in
-// recommendWalkSkipDirs are pruned.
-func collectWorkspaceFiles(root string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// Surface root-level errors; tolerate per-entry permission errors.
-			if path == root {
-				return err
-			}
-			if errors.Is(err, fs.ErrPermission) {
-				if d != nil && d.IsDir() {
-					return fs.SkipDir
-				}
-				return nil
-			}
-			return err
-		}
-		if d.IsDir() {
-			if path == root {
-				return nil
-			}
-			if recommendWalkSkipDirs[d.Name()] {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		files = append(files, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	sort.Strings(files)
-	return files, nil
-}
-
-// recommendModules is the pure matching core: given the registry, a sorted
-// list of workspace-relative file paths, and the set of already-installed
-// module names, it returns one recommendation per module whose Recommend
-// glob matches at least one file (and which is not already installed).
-//
-// Results are sorted by module name; the recorded Match is the first matching
-// path in the input order.
-func recommendModules(mods []registryModule, files []string, installed map[string]bool) []recommendation {
-	out := make([]recommendation, 0, len(mods))
-	for _, m := range mods {
-		if m.Recommend == "" {
-			continue
-		}
-		if installed[m.Name] {
-			continue
-		}
-		for _, f := range files {
-			ok, err := doublestar.Match(m.Recommend, f)
-			if err != nil {
-				// A bad pattern is a registry bug; skip the entry rather
-				// than abort the whole command.
-				break
-			}
-			if ok {
-				out = append(out, recommendation{Module: m, Match: f})
-				break
-			}
-		}
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Module.Name < out[j].Module.Name })
-	return out
 }
 
 func printRecommendations(out io.Writer, recs []recommendation) error {

--- a/cmd/dagger/mod.go
+++ b/cmd/dagger/mod.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"dagger.io/dagger"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +56,24 @@ var modListCmd = &cobra.Command{
 	},
 }
 
+var modRecommendedCmd = &cobra.Command{
+	Use:   "recommended",
+	Short: "Recommend modules based on files in your workspace",
+	Long: `Scan the workspace for files matching the recommend glob of each known
+module and print those whose pattern matches at least one file.
+
+Modules already installed in the workspace are excluded.`,
+	Example: "dagger mod recommended",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return withEngine(cmd.Context(), client.Params{
+			SkipWorkspaceModules: true,
+		}, func(ctx context.Context, engineClient *client.Client) error {
+			return runRecommended(ctx, cmd.OutOrStdout(), engineClient.Dagger())
+		})
+	},
+}
+
 var modSearchCmd = &cobra.Command{
 	Use:   "search [query]",
 	Short: "Search for modules you can install",
@@ -74,7 +96,7 @@ With no query, lists all known modules.`,
 }
 
 func init() {
-	modCmd.AddCommand(modInstallCmd, modUninstallCmd, modListCmd, modSearchCmd)
+	modCmd.AddCommand(modInstallCmd, modUninstallCmd, modListCmd, modSearchCmd, modRecommendedCmd)
 
 	addWorkspaceInstallFlags(modInstallCmd)
 	addWorkspaceHereFlag(modUninstallCmd)
@@ -82,6 +104,7 @@ func init() {
 	setWorkspaceFlagPolicy(modInstallCmd, workspaceFlagPolicyLocalOnly)
 	setWorkspaceFlagPolicy(modUninstallCmd, workspaceFlagPolicyLocalOnly)
 	setWorkspaceFlagPolicy(modListCmd, workspaceFlagPolicyLocalOnly)
+	setWorkspaceFlagPolicy(modRecommendedCmd, workspaceFlagPolicyLocalOnly)
 }
 
 func listWorkspaceModules(ctx context.Context, out io.Writer, dag *dagger.Client) error {
@@ -126,6 +149,10 @@ type registryModule struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Repo        string `json:"repo"`
+	// Recommend is a doublestar glob (e.g. "**/go.mod") used by
+	// `dagger mod recommended` to decide whether to suggest this module
+	// based on files present in the workspace. Empty means never recommended.
+	Recommend string `json:"recommend,omitempty"`
 }
 
 // embeddedModuleRegistry is the registry baked in at build time.
@@ -182,5 +209,185 @@ func printModuleSearchResults(out io.Writer, mods []registryModule) error {
 	}
 
 	_, err := fmt.Fprintln(out, "\nRun 'dagger install <repo>' to install a module.")
+	return err
+}
+
+// recommendation pairs a registry entry with the workspace-relative path that
+// triggered its recommendation.
+type recommendation struct {
+	Module registryModule
+	Match  string
+}
+
+// recommendWalkSkipDirs lists directories we never descend into when scanning
+// the workspace for recommend glob matches. Keeps the walk cheap and avoids
+// false positives from vendored or generated content.
+var recommendWalkSkipDirs = map[string]bool{
+	".git":         true,
+	".dagger":      true,
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	"target":       true,
+}
+
+// runRecommended is the cobra runtime for `dagger mod recommended`. It
+// resolves the workspace root (respecting -W), gathers installed module
+// names, walks the workspace, and prints the matches.
+func runRecommended(ctx context.Context, out io.Writer, dag *dagger.Client) error {
+	ws := dag.CurrentWorkspace()
+
+	address, err := ws.Address(ctx)
+	if err != nil {
+		return fmt.Errorf("load workspace address: %w", err)
+	}
+	cwd, err := ws.Cwd(ctx)
+	if err != nil {
+		return fmt.Errorf("load workspace cwd: %w", err)
+	}
+	root, err := workspaceRootFromAddress(address, cwd)
+	if err != nil {
+		return err
+	}
+	if root == "" {
+		return fmt.Errorf("workspace root not available")
+	}
+
+	installed, err := installedModuleNames(ctx, dag)
+	if err != nil {
+		return err
+	}
+
+	mods, err := loadModuleRegistry()
+	if err != nil {
+		return err
+	}
+
+	files, err := collectWorkspaceFiles(root)
+	if err != nil {
+		return fmt.Errorf("scan workspace %s: %w", root, err)
+	}
+
+	return printRecommendations(out, recommendModules(mods, files, installed))
+}
+
+// installedModuleNames returns the set of module names installed in the
+// current workspace (the same query backing `dagger mod list`).
+func installedModuleNames(ctx context.Context, dag *dagger.Client) (map[string]bool, error) {
+	var res struct {
+		CurrentWorkspace struct {
+			ModuleList []struct {
+				Name string
+			}
+		}
+	}
+	if err := dag.Do(ctx, &dagger.Request{
+		Query: `query { currentWorkspace { moduleList { name } } }`,
+	}, &dagger.Response{Data: &res}); err != nil {
+		return nil, fmt.Errorf("list installed modules: %w", err)
+	}
+	installed := make(map[string]bool, len(res.CurrentWorkspace.ModuleList))
+	for _, m := range res.CurrentWorkspace.ModuleList {
+		installed[m.Name] = true
+	}
+	return installed, nil
+}
+
+// collectWorkspaceFiles walks root and returns paths relative to it, using
+// forward slashes, suitable for doublestar matching. Directories listed in
+// recommendWalkSkipDirs are pruned.
+func collectWorkspaceFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Surface root-level errors; tolerate per-entry permission errors.
+			if path == root {
+				return err
+			}
+			if errors.Is(err, fs.ErrPermission) {
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			if path == root {
+				return nil
+			}
+			if recommendWalkSkipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// recommendModules is the pure matching core: given the registry, a sorted
+// list of workspace-relative file paths, and the set of already-installed
+// module names, it returns one recommendation per module whose Recommend
+// glob matches at least one file (and which is not already installed).
+//
+// Results are sorted by module name; the recorded Match is the first matching
+// path in the input order.
+func recommendModules(mods []registryModule, files []string, installed map[string]bool) []recommendation {
+	out := make([]recommendation, 0, len(mods))
+	for _, m := range mods {
+		if m.Recommend == "" {
+			continue
+		}
+		if installed[m.Name] {
+			continue
+		}
+		for _, f := range files {
+			ok, err := doublestar.Match(m.Recommend, f)
+			if err != nil {
+				// A bad pattern is a registry bug; skip the entry rather
+				// than abort the whole command.
+				break
+			}
+			if ok {
+				out = append(out, recommendation{Module: m, Match: f})
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Module.Name < out[j].Module.Name })
+	return out
+}
+
+func printRecommendations(out io.Writer, recs []recommendation) error {
+	if len(recs) == 0 {
+		_, err := fmt.Fprintln(out, "No recommended modules found.")
+		return err
+	}
+
+	w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "NAME\tDESCRIPTION\tREPO\tMATCHED"); err != nil {
+		return err
+	}
+	for _, r := range recs {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Module.Name, r.Module.Description, r.Module.Repo, r.Match); err != nil {
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	_, err := fmt.Fprintln(out, "\nRun 'dagger mod install <repo>' to install a module.")
 	return err
 }

--- a/cmd/dagger/mod_test.go
+++ b/cmd/dagger/mod_test.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -70,94 +67,10 @@ func TestModSubcommandsRegistered(t *testing.T) {
 	}
 }
 
-func TestRecommendModules(t *testing.T) {
-	reg := []registryModule{
-		{Name: "go", Repo: "github.com/dagger/go", Recommend: "**/go.mod"},
-		{Name: "eslint", Repo: "github.com/dagger/eslint", Recommend: "**/.eslintrc*"},
-		{Name: "prettier", Repo: "github.com/dagger/prettier", Recommend: "**/.prettierrc*"},
-		// no Recommend: must never appear
-		{Name: "naked", Repo: "github.com/dagger/naked"},
-	}
-
-	t.Run("matches on present files and sorts by name", func(t *testing.T) {
-		files := []string{"a/.eslintrc.json", "service/go.mod", "src/main.go"}
-		got := recommendModules(reg, files, nil)
-
-		var names, matches []string
-		for _, r := range got {
-			names = append(names, r.Module.Name)
-			matches = append(matches, r.Match)
-		}
-		require.Equal(t, []string{"eslint", "go"}, names)
-		require.Equal(t, []string{"a/.eslintrc.json", "service/go.mod"}, matches)
-	})
-
-	t.Run("installed modules are excluded", func(t *testing.T) {
-		files := []string{"go.mod"}
-		got := recommendModules(reg, files, map[string]bool{"go": true})
-		require.Empty(t, got)
-	})
-
-	t.Run("missing recommend never matches", func(t *testing.T) {
-		// Any file present; the "naked" entry must still be skipped.
-		files := []string{"anything"}
-		got := recommendModules(reg, files, nil)
-		for _, r := range got {
-			require.NotEqual(t, "naked", r.Module.Name)
-		}
-	})
-
-	t.Run("first matching file wins", func(t *testing.T) {
-		// Input is sorted by collectWorkspaceFiles, so first match is
-		// the lexicographically smallest path that satisfies the glob.
-		files := []string{"a/go.mod", "z/go.mod"}
-		got := recommendModules(reg, files, nil)
-		require.Len(t, got, 1)
-		require.Equal(t, "a/go.mod", got[0].Match)
-	})
-
-	t.Run("invalid glob is skipped, others proceed", func(t *testing.T) {
-		bad := []registryModule{
-			{Name: "broken", Repo: "x", Recommend: "[unterminated"},
-			{Name: "go", Repo: "github.com/dagger/go", Recommend: "**/go.mod"},
-		}
-		got := recommendModules(bad, []string{"go.mod"}, nil)
-		require.Len(t, got, 1)
-		require.Equal(t, "go", got[0].Module.Name)
-	})
-}
-
-func TestCollectWorkspaceFiles(t *testing.T) {
-	root := t.TempDir()
-
-	mustWrite := func(rel string) {
-		full := filepath.Join(root, filepath.FromSlash(rel))
-		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
-		require.NoError(t, os.WriteFile(full, nil, 0o644))
-	}
-
-	// Included files at varying depths.
-	mustWrite("go.mod")
-	mustWrite("svc/api/go.mod")
-	mustWrite("web/.eslintrc.json")
-
-	// Files under denylisted directories must be pruned.
-	mustWrite(".git/HEAD")
-	mustWrite("node_modules/foo/package.json")
-	mustWrite("vendor/example.com/pkg/file.go")
-	mustWrite(".dagger/config.toml")
-
-	files, err := collectWorkspaceFiles(root)
-	require.NoError(t, err)
-
-	require.Equal(t, []string{
-		"go.mod",
-		"svc/api/go.mod",
-		"web/.eslintrc.json",
-	}, files)
-	require.True(t, sort.StringsAreSorted(files))
-}
-
+// TestEmbeddedRegistryRecommendPatternsValid is a static smoke test on the
+// embedded registry: every populated recommend string must be a syntactically
+// valid glob. The runtime delegates matching to the engine via Directory.Glob,
+// so this catches typos in modules.json without requiring an engine.
 func TestEmbeddedRegistryRecommendPatternsValid(t *testing.T) {
 	mods, err := parseModuleRegistry(embeddedModuleRegistry)
 	require.NoError(t, err)
@@ -165,7 +78,6 @@ func TestEmbeddedRegistryRecommendPatternsValid(t *testing.T) {
 		if m.Recommend == "" {
 			continue
 		}
-		// doublestar.Match validates the pattern even on a probe string.
 		_, err := doublestar.Match(m.Recommend, "probe")
 		require.NoErrorf(t, err, "module %q has invalid recommend glob %q", m.Name, m.Recommend)
 	}

--- a/cmd/dagger/mod_test.go
+++ b/cmd/dagger/mod_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,7 +65,108 @@ func TestModSubcommandsRegistered(t *testing.T) {
 	for _, c := range modCmd.Commands() {
 		got[c.Name()] = true
 	}
-	for _, want := range []string{"install", "uninstall", "list", "search"} {
+	for _, want := range []string{"install", "uninstall", "list", "search", "recommended"} {
 		require.Truef(t, got[want], "expected `dagger mod %s` to be registered", want)
+	}
+}
+
+func TestRecommendModules(t *testing.T) {
+	reg := []registryModule{
+		{Name: "go", Repo: "github.com/dagger/go", Recommend: "**/go.mod"},
+		{Name: "eslint", Repo: "github.com/dagger/eslint", Recommend: "**/.eslintrc*"},
+		{Name: "prettier", Repo: "github.com/dagger/prettier", Recommend: "**/.prettierrc*"},
+		// no Recommend: must never appear
+		{Name: "naked", Repo: "github.com/dagger/naked"},
+	}
+
+	t.Run("matches on present files and sorts by name", func(t *testing.T) {
+		files := []string{"a/.eslintrc.json", "service/go.mod", "src/main.go"}
+		got := recommendModules(reg, files, nil)
+
+		var names, matches []string
+		for _, r := range got {
+			names = append(names, r.Module.Name)
+			matches = append(matches, r.Match)
+		}
+		require.Equal(t, []string{"eslint", "go"}, names)
+		require.Equal(t, []string{"a/.eslintrc.json", "service/go.mod"}, matches)
+	})
+
+	t.Run("installed modules are excluded", func(t *testing.T) {
+		files := []string{"go.mod"}
+		got := recommendModules(reg, files, map[string]bool{"go": true})
+		require.Empty(t, got)
+	})
+
+	t.Run("missing recommend never matches", func(t *testing.T) {
+		// Any file present; the "naked" entry must still be skipped.
+		files := []string{"anything"}
+		got := recommendModules(reg, files, nil)
+		for _, r := range got {
+			require.NotEqual(t, "naked", r.Module.Name)
+		}
+	})
+
+	t.Run("first matching file wins", func(t *testing.T) {
+		// Input is sorted by collectWorkspaceFiles, so first match is
+		// the lexicographically smallest path that satisfies the glob.
+		files := []string{"a/go.mod", "z/go.mod"}
+		got := recommendModules(reg, files, nil)
+		require.Len(t, got, 1)
+		require.Equal(t, "a/go.mod", got[0].Match)
+	})
+
+	t.Run("invalid glob is skipped, others proceed", func(t *testing.T) {
+		bad := []registryModule{
+			{Name: "broken", Repo: "x", Recommend: "[unterminated"},
+			{Name: "go", Repo: "github.com/dagger/go", Recommend: "**/go.mod"},
+		}
+		got := recommendModules(bad, []string{"go.mod"}, nil)
+		require.Len(t, got, 1)
+		require.Equal(t, "go", got[0].Module.Name)
+	})
+}
+
+func TestCollectWorkspaceFiles(t *testing.T) {
+	root := t.TempDir()
+
+	mustWrite := func(rel string) {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, nil, 0o644))
+	}
+
+	// Included files at varying depths.
+	mustWrite("go.mod")
+	mustWrite("svc/api/go.mod")
+	mustWrite("web/.eslintrc.json")
+
+	// Files under denylisted directories must be pruned.
+	mustWrite(".git/HEAD")
+	mustWrite("node_modules/foo/package.json")
+	mustWrite("vendor/example.com/pkg/file.go")
+	mustWrite(".dagger/config.toml")
+
+	files, err := collectWorkspaceFiles(root)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{
+		"go.mod",
+		"svc/api/go.mod",
+		"web/.eslintrc.json",
+	}, files)
+	require.True(t, sort.StringsAreSorted(files))
+}
+
+func TestEmbeddedRegistryRecommendPatternsValid(t *testing.T) {
+	mods, err := parseModuleRegistry(embeddedModuleRegistry)
+	require.NoError(t, err)
+	for _, m := range mods {
+		if m.Recommend == "" {
+			continue
+		}
+		// doublestar.Match validates the pattern even on a probe string.
+		_, err := doublestar.Match(m.Recommend, "probe")
+		require.NoErrorf(t, err, "module %q has invalid recommend glob %q", m.Name, m.Recommend)
 	}
 }

--- a/cmd/dagger/mod_test.go
+++ b/cmd/dagger/mod_test.go
@@ -65,7 +65,7 @@ func TestModSubcommandsRegistered(t *testing.T) {
 	for _, c := range modCmd.Commands() {
 		got[c.Name()] = true
 	}
-	for _, want := range []string{"install", "uninstall", "list", "search", "recommended"} {
+	for _, want := range []string{"install", "uninstall", "list", "search", "recommend"} {
 		require.Truef(t, got[want], "expected `dagger mod %s` to be registered", want)
 	}
 }

--- a/cmd/dagger/modules.json
+++ b/cmd/dagger/modules.json
@@ -2,41 +2,49 @@
   {
     "name": "go",
     "description": "Build, test, and lint Go projects with the Go toolchain",
-    "repo": "github.com/dagger/go"
+    "repo": "github.com/dagger/go",
+    "recommend": "**/go.mod"
   },
   {
     "name": "eslint",
     "description": "Lint JavaScript and TypeScript with ESLint",
-    "repo": "github.com/dagger/eslint"
+    "repo": "github.com/dagger/eslint",
+    "recommend": "**/{.eslintrc*,eslint.config.*}"
   },
   {
     "name": "prettier",
     "description": "Format code with Prettier",
-    "repo": "github.com/dagger/prettier"
+    "repo": "github.com/dagger/prettier",
+    "recommend": "**/{.prettierrc*,prettier.config.*}"
   },
   {
     "name": "jest",
     "description": "Run JavaScript and TypeScript tests with Jest",
-    "repo": "github.com/dagger/jest"
+    "repo": "github.com/dagger/jest",
+    "recommend": "**/jest.config.*"
   },
   {
     "name": "vitest",
     "description": "Run JavaScript and TypeScript tests with Vitest",
-    "repo": "github.com/dagger/vitest"
+    "repo": "github.com/dagger/vitest",
+    "recommend": "**/vitest.config.*"
   },
   {
     "name": "pytest",
     "description": "Run Python tests with pytest",
-    "repo": "github.com/dagger/pytest"
+    "repo": "github.com/dagger/pytest",
+    "recommend": "**/{pytest.ini,pyproject.toml}"
   },
   {
     "name": "biomejs",
     "description": "Format and lint JavaScript and TypeScript with Biome",
-    "repo": "github.com/dagger/biomejs"
+    "repo": "github.com/dagger/biomejs",
+    "recommend": "**/biome.json*"
   },
   {
     "name": "playwright",
     "description": "Run end-to-end browser tests with Playwright",
-    "repo": "github.com/dagger/playwright"
+    "repo": "github.com/dagger/playwright",
+    "recommend": "**/playwright.config.*"
   }
 ]


### PR DESCRIPTION
```
> dagger-dev -W ~/github.com/kpenfound/demo-react-app mod recommended

NAME        DESCRIPTION                                    REPO                          MATCHED
jest        Run JavaScript and TypeScript tests with Jest  github.com/dagger/jest        jest.config.js
playwright  Run end-to-end browser tests with Playwright   github.com/dagger/playwright  playwright.config.js
```

Each module specifies a glob pattern to match on in the workspace. The matched file is printed in the output. We can make this more advanced/dynamic in the future.