### PR TITLE
fix dockerfile bind mounts for files

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -5581,6 +5581,7 @@ func dockerfileCompatMountSourcePathHasDirHint(sourcePath string) bool {
 	return strings.HasSuffix(sourcePath, "/") || strings.HasSuffix(sourcePath, "/.")
 }
 
+//nolint:dupl // symmetric with detachedFileAtSourcePath; sharing hides Directory vs File specifics
 func detachedDirectoryAtSourcePath(ctx context.Context, source dagql.ObjectResult[*Directory], sourcePath string) (*Directory, error) {
 	sourceDirPath, err := source.Self().Dir.GetOrEval(ctx, source.Result)
 	if err != nil {
@@ -5614,6 +5615,7 @@ func detachedDirectoryAtSourcePath(ctx context.Context, source dagql.ObjectResul
 	return dir, nil
 }
 
+//nolint:dupl // symmetric with detachedDirectoryAtSourcePath; sharing hides File vs Directory specifics
 func detachedFileAtSourcePath(ctx context.Context, source dagql.ObjectResult[*Directory], sourcePath string) (*File, error) {
 	sourceDirPath, err := source.Self().Dir.GetOrEval(ctx, source.Result)
 	if err != nil {

--- a/core/container.go
+++ b/core/container.go
@@ -334,6 +334,15 @@ type ContainerWithMountedFileLazy struct {
 	Readonly bool
 }
 
+type ContainerWithMountedPathDockerfileCompatLazy struct {
+	LazyState
+	Parent     dagql.ObjectResult[*Container]
+	Target     string
+	Source     dagql.ObjectResult[*Directory]
+	SourcePath string
+	Readonly   bool
+}
+
 type ContainerWithMountedCacheLazy struct {
 	LazyState
 	Parent dagql.ObjectResult[*Container]
@@ -707,6 +716,14 @@ type persistedContainerWithMountedFileLazy struct {
 	Target         string `json:"target"`
 	SourceResultID uint64 `json:"sourceResultID"`
 	Owner          string `json:"owner,omitempty"`
+	Readonly       bool   `json:"readonly,omitempty"`
+}
+
+type persistedContainerWithMountedPathDockerfileCompatLazy struct {
+	ParentResultID uint64 `json:"parentResultID"`
+	Target         string `json:"target"`
+	SourceResultID uint64 `json:"sourceResultID"`
+	SourcePath     string `json:"sourcePath,omitempty"`
 	Readonly       bool   `json:"readonly,omitempty"`
 }
 
@@ -3562,6 +3579,59 @@ func (lazy *ContainerWithMountedFileLazy) EncodePersisted(ctx context.Context, c
 	})
 }
 
+func (lazy *ContainerWithMountedPathDockerfileCompatLazy) Evaluate(ctx context.Context, container *Container) error {
+	return lazy.LazyState.Evaluate(ctx, "Container.withMountedPathDockerfileCompat", func(ctx context.Context) error {
+		cache, err := dagql.EngineCache(ctx)
+		if err != nil {
+			return err
+		}
+		if err := cache.Evaluate(ctx, lazy.Parent, lazy.Source); err != nil {
+			return err
+		}
+		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
+			return err
+		}
+		_, err = container.WithMountedPathDockerfileCompat(ctx, lazy.Target, lazy.Source, lazy.SourcePath, lazy.Readonly)
+		if err != nil {
+			return err
+		}
+		container.Lazy = nil
+		return nil
+	})
+}
+
+func (lazy *ContainerWithMountedPathDockerfileCompatLazy) AttachDependencies(ctx context.Context, attach func(dagql.AnyResult) (dagql.AnyResult, error)) ([]dagql.AnyResult, error) {
+	parent, err := attachContainerResult(attach, lazy.Parent, "attach container withMountedPathDockerfileCompat parent")
+	if err != nil {
+		return nil, err
+	}
+	source, err := attachDirectoryResult(attach, lazy.Source, "attach container withMountedPathDockerfileCompat source")
+	if err != nil {
+		return nil, err
+	}
+	lazy.Parent = parent
+	lazy.Source = source
+	return []dagql.AnyResult{parent, source}, nil
+}
+
+func (lazy *ContainerWithMountedPathDockerfileCompatLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
+	parentID, err := encodePersistedObjectRef(cache, lazy.Parent, "container withMountedPathDockerfileCompat parent")
+	if err != nil {
+		return nil, err
+	}
+	sourceID, err := encodePersistedObjectRef(cache, lazy.Source, "container withMountedPathDockerfileCompat source")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedContainerWithMountedPathDockerfileCompatLazy{
+		ParentResultID: parentID,
+		Target:         lazy.Target,
+		SourceResultID: sourceID,
+		SourcePath:     lazy.SourcePath,
+		Readonly:       lazy.Readonly,
+	})
+}
+
 func (lazy *ContainerWithMountedCacheLazy) Evaluate(ctx context.Context, container *Container) error {
 	return lazy.LazyState.Evaluate(ctx, "Container.withMountedCache", func(ctx context.Context) error {
 		if err := materializeContainerStateFromParent(ctx, container, lazy.Parent); err != nil {
@@ -4471,6 +4541,28 @@ func decodePersistedContainerLazy(
 			Source:    source,
 			Owner:     persisted.Owner,
 			Readonly:  persisted.Readonly,
+		}
+		return nil
+	case "__withMountedPathDockerfileCompat":
+		var persisted persistedContainerWithMountedPathDockerfileCompatLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return fmt.Errorf("decode persisted container withMountedPathDockerfileCompat lazy payload: %w", err)
+		}
+		parent, err := loadPersistedObjectResultByResultID[*Container](ctx, dag, persisted.ParentResultID, "container withMountedPathDockerfileCompat parent")
+		if err != nil {
+			return err
+		}
+		source, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.SourceResultID, "container withMountedPathDockerfileCompat source")
+		if err != nil {
+			return err
+		}
+		container.Lazy = &ContainerWithMountedPathDockerfileCompatLazy{
+			LazyState:  NewLazyState(),
+			Parent:     parent,
+			Target:     persisted.Target,
+			Source:     source,
+			SourcePath: persisted.SourcePath,
+			Readonly:   persisted.Readonly,
 		}
 		return nil
 	case "withMountedCache":
@@ -5386,6 +5478,173 @@ func (container *Container) WithMountedFile(
 	container.ImageRef = ""
 
 	return container, nil
+}
+
+// mutates container caller must have handled cloning or creating a new child.
+func (container *Container) WithMountedPathDockerfileCompat(
+	ctx context.Context,
+	target string,
+	source dagql.ObjectResult[*Directory],
+	sourcePath string,
+	readonly bool,
+) (*Container, error) {
+	target = absPath(container.Config.WorkingDir, target)
+	sourcePath = cleanDockerfileCompatMountSourcePath(sourcePath)
+
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := cache.Evaluate(ctx, source); err != nil {
+		return nil, err
+	}
+
+	if path.Clean(sourcePath) == "/" {
+		sourceDir, err := cloneDetachedDirectoryForContainerResult(ctx, source.Self())
+		if err != nil {
+			return nil, err
+		}
+		mountSource := new(LazyAccessor[*Directory, *Container])
+		mountSource.setValue(sourceDir)
+		container.Mounts = container.Mounts.With(ContainerMount{
+			DirectorySource: mountSource,
+			Target:          target,
+			Readonly:        readonly,
+		})
+		container.ImageRef = ""
+		return container, nil
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := query.Server.Server(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stat, err := source.Self().Stat(ctx, source, srv, sourcePath, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.FileType == FileTypeDirectory {
+		sourceDir, err := detachedDirectoryAtSourcePath(ctx, source, sourcePath)
+		if err != nil {
+			return nil, err
+		}
+		mountSource := new(LazyAccessor[*Directory, *Container])
+		mountSource.setValue(sourceDir)
+		container.Mounts = container.Mounts.With(ContainerMount{
+			DirectorySource: mountSource,
+			Target:          target,
+			Readonly:        readonly,
+		})
+		container.ImageRef = ""
+		return container, nil
+	}
+	if dockerfileCompatMountSourcePathHasDirHint(sourcePath) {
+		return nil, notADirectoryError{fmt.Errorf("path %s is a file, not a directory", sourcePath)}
+	}
+
+	sourceFile, err := detachedFileAtSourcePath(ctx, source, sourcePath)
+	if err != nil {
+		return nil, err
+	}
+	mountSource := new(LazyAccessor[*File, *Container])
+	mountSource.setValue(sourceFile)
+	container.Mounts = container.Mounts.With(ContainerMount{
+		FileSource: mountSource,
+		Target:     target,
+		Readonly:   readonly,
+	})
+	container.ImageRef = ""
+	return container, nil
+}
+
+func cleanDockerfileCompatMountSourcePath(sourcePath string) string {
+	if sourcePath == "" {
+		return "/"
+	}
+	trailingSlash := dockerfileCompatMountSourcePathHasDirHint(sourcePath)
+	sourcePath = path.Clean(sourcePath)
+	if !strings.HasPrefix(sourcePath, "/") {
+		sourcePath = "/" + sourcePath
+	}
+	if trailingSlash && !strings.HasSuffix(sourcePath, "/") {
+		sourcePath += "/"
+	}
+	return sourcePath
+}
+
+func dockerfileCompatMountSourcePathHasDirHint(sourcePath string) bool {
+	return strings.HasSuffix(sourcePath, "/") || strings.HasSuffix(sourcePath, "/.")
+}
+
+func detachedDirectoryAtSourcePath(ctx context.Context, source dagql.ObjectResult[*Directory], sourcePath string) (*Directory, error) {
+	sourceDirPath, err := source.Self().Dir.GetOrEval(ctx, source.Result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source directory path: %w", err)
+	}
+	sourceSnapshot, err := source.Self().Snapshot.GetOrEval(ctx, source.Result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source directory snapshot: %w", err)
+	}
+	if sourceSnapshot == nil {
+		return nil, fmt.Errorf("source directory snapshot is nil")
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reopened, err := query.SnapshotManager().GetBySnapshotID(ctx, sourceSnapshot.SnapshotID(), bkcache.NoUpdateLastUsed)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := &Directory{
+		Platform: source.Self().Platform,
+		Services: slices.Clone(source.Self().Services),
+		Dir:      new(LazyAccessor[string, *Directory]),
+		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
+	}
+	dir.Dir.setValue(path.Join(sourceDirPath, sourcePath))
+	dir.Snapshot.setValue(reopened)
+	return dir, nil
+}
+
+func detachedFileAtSourcePath(ctx context.Context, source dagql.ObjectResult[*Directory], sourcePath string) (*File, error) {
+	sourceDirPath, err := source.Self().Dir.GetOrEval(ctx, source.Result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source directory path: %w", err)
+	}
+	sourceSnapshot, err := source.Self().Snapshot.GetOrEval(ctx, source.Result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source directory snapshot: %w", err)
+	}
+	if sourceSnapshot == nil {
+		return nil, fmt.Errorf("source directory snapshot is nil")
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reopened, err := query.SnapshotManager().GetBySnapshotID(ctx, sourceSnapshot.SnapshotID(), bkcache.NoUpdateLastUsed)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &File{
+		Platform: source.Self().Platform,
+		Services: slices.Clone(source.Self().Services),
+		File:     new(LazyAccessor[string, *File]),
+		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *File]),
+	}
+	file.File.setValue(path.Join(sourceDirPath, sourcePath))
+	file.Snapshot.setValue(reopened)
+	return file, nil
 }
 
 // mutates container caller must have handled cloning or creating a new child.

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -562,6 +562,20 @@ CMD ["cat", "/copied.txt"]
 		require.Equal(t, "readonly-bind-data", strings.TrimSpace(copied))
 	})
 
+	t.Run("run-mount-bind-file", func(ctx context.Context, t *testctx.T) {
+		dir := c.Directory().
+			WithNewFile("pyproject.toml", "[project]\nname = \"bind-file\"\n").
+			WithNewFile("Dockerfile", fmt.Sprintf(`# syntax=docker/dockerfile:1.7
+FROM %s
+RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml sh -lc 'cat pyproject.toml > /copied.txt'
+CMD ["cat", "/copied.txt"]
+`, alpineImage))
+
+		out, err := dir.DockerBuild().WithExec(nil).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "[project]\nname = \"bind-file\"", strings.TrimSpace(out))
+	})
+
 	t.Run("run-mount-bind-non-sticky", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewFile("ctx.txt", "non-sticky-bind").

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -576,6 +576,33 @@ CMD ["cat", "/copied.txt"]
 		require.Equal(t, "[project]\nname = \"bind-file\"", strings.TrimSpace(out))
 	})
 
+	t.Run("run-mount-bind-file-metadata", func(ctx context.Context, t *testctx.T) {
+		dir := c.Container().
+			From(alpineImage).
+			WithWorkdir("/ctx").
+			WithExec([]string{"sh", "-lc", `
+set -eu
+printf 'exec-file\n' > exec-file
+chmod 0755 exec-file
+printf 'setuid-file\n' > setuid-file
+chmod 4755 setuid-file
+printf 'readonly-file\n' > readonly.txt
+`}).
+			Directory("/ctx").
+			WithNewFile("Dockerfile", fmt.Sprintf(`# syntax=docker/dockerfile:1.7
+FROM %s
+RUN --mount=type=bind,source=exec-file,target=/exec-file \
+    --mount=type=bind,source=setuid-file,target=/setuid-file \
+    --mount=type=bind,source=readonly.txt,target=/readonly.txt,readonly \
+    sh -lc '{ stat -c "%%a %%n" /exec-file /setuid-file; if sh -c "echo mutate > /readonly.txt" 2>/dev/null; then echo writable; else echo readonly; fi; } > /result.txt'
+CMD ["cat", "/result.txt"]
+`, alpineImage))
+
+		out, err := dir.DockerBuild().WithExec(nil).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "755 /exec-file\n4755 /setuid-file\nreadonly", strings.TrimSpace(out))
+	})
+
 	t.Run("run-mount-bind-non-sticky", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewFile("ctx.txt", "non-sticky-bind").

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -371,6 +371,15 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 			),
 
+		dagql.NodeFunc("__withMountedPathDockerfileCompat", s.withMountedPathDockerfileCompat).
+			Doc(`(Internal-only) Dockerfile-compat bind mount path.`).
+			Args(
+				dagql.Arg("path").Doc(`Location of the mounted path.`),
+				dagql.Arg("source").Doc(`Identifier of the directory containing the mounted path.`),
+				dagql.Arg("sourcePath").Doc(`Path within source to mount.`),
+				dagql.Arg("readOnly").Doc(`Mount the path read-only.`),
+			),
+
 		dagql.NodeFunc("withMountedTemp", s.withMountedTemp).
 			Doc(`Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.`).
 			Args(
@@ -2358,6 +2367,46 @@ func (s *containerSchema) withMountedFile(ctx context.Context, parent dagql.Obje
 		Target:     target,
 		Readonly:   false,
 		FileSource: new(core.LazyAccessor[*core.File, *core.Container]),
+	})
+	return ctr, nil
+}
+
+type containerWithMountedPathDockerfileCompatArgs struct {
+	Path       string
+	Source     core.DirectoryID
+	SourcePath string `internal:"true" default:"/"`
+	ReadOnly   bool   `default:"false"`
+}
+
+func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithMountedPathDockerfileCompatArgs) (*core.Container, error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server: %w", err)
+	}
+
+	dir, err := args.Source.Load(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	target := absPath(parent.Self().Config.WorkingDir, args.Path)
+	ctr.Lazy = &core.ContainerWithMountedPathDockerfileCompatLazy{
+		LazyState:  core.NewLazyState(),
+		Parent:     parent,
+		Target:     target,
+		Source:     dir,
+		SourcePath: args.SourcePath,
+		Readonly:   args.ReadOnly,
+	}
+	ctr.Mounts = ctr.Mounts.With(core.ContainerMount{
+		Target:          target,
+		Readonly:        args.ReadOnly,
+		DirectorySource: new(core.LazyAccessor[*core.Directory, *core.Container]),
 	})
 	return ctr, nil
 }

--- a/util/llbtodagger/exec.go
+++ b/util/llbtodagger/exec.go
@@ -121,13 +121,14 @@ func (c *converter) convertExec(exec *engineutil.ExecOp) (*call.ID, error) {
 
 		switch m.MountType {
 		case pb.MountType_BIND:
-			dirID, err := c.resolveExecMountInputDir(opDigest(exec.OpDAG), m, inputIDs)
+			dirID, err := c.resolveExecMountInputBaseDir(opDigest(exec.OpDAG), m, inputIDs)
 			if err != nil {
 				return nil, err
 			}
 			args := []*call.Argument{
 				argString("path", m.Dest),
 				argID("source", dirID),
+				argString("sourcePath", cleanPath(m.Selector)),
 			}
 			if m.Readonly {
 				args = append(args, argBool("readOnly", true))
@@ -135,7 +136,7 @@ func (c *converter) convertExec(exec *engineutil.ExecOp) (*call.ID, error) {
 			ctrID = appendCall(
 				ctrID,
 				containerType(),
-				"withMountedDirectory",
+				"__withMountedPathDockerfileCompat",
 				args...,
 			)
 			path := cleanPath(m.Dest)
@@ -371,19 +372,9 @@ func findMountByOutput(mounts []*pb.Mount, out pb.OutputIndex) (*pb.Mount, bool)
 }
 
 func (c *converter) resolveExecMountInputDir(opDgst digest.Digest, mount *pb.Mount, inputIDs []*call.ID) (*call.ID, error) {
-	var dirID *call.ID
-	if mount.Input == pb.Empty {
-		dirID = scratchDirectoryID()
-	} else {
-		idx := int(mount.Input)
-		if idx < 0 || idx >= len(inputIDs) {
-			return nil, unsupported(opDgst, "exec", fmt.Sprintf("mount input index %d out of range", mount.Input))
-		}
-		var err error
-		dirID, err = asDirectoryID(opDgst, "exec", inputIDs[idx])
-		if err != nil {
-			return nil, err
-		}
+	dirID, err := c.resolveExecMountInputBaseDir(opDgst, mount, inputIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	selector := cleanPath(mount.Selector)
@@ -391,4 +382,16 @@ func (c *converter) resolveExecMountInputDir(opDgst digest.Digest, mount *pb.Mou
 		return dirID, nil
 	}
 	return appendCall(dirID, directoryType(), "directory", argString("path", selector)), nil
+}
+
+func (c *converter) resolveExecMountInputBaseDir(opDgst digest.Digest, mount *pb.Mount, inputIDs []*call.ID) (*call.ID, error) {
+	if mount.Input == pb.Empty {
+		return scratchDirectoryID(), nil
+	}
+
+	idx := int(mount.Input)
+	if idx < 0 || idx >= len(inputIDs) {
+		return nil, unsupported(opDgst, "exec", fmt.Sprintf("mount input index %d out of range", mount.Input))
+	}
+	return asDirectoryID(opDgst, "exec", inputIDs[idx])
 }


### PR DESCRIPTION
## What changed

Fix Dockerfile RUN --mount=type=bind conversion when the bind source selector points at a regular file instead of a directory.

The LLB representation gives us a bind input plus a selector, but it does not statically identify whether that selector is a file or directory. The previous conversion eagerly resolved every non-root bind selector with Directory.directory(path: ...), then mounted it with withMountedDirectory. That worked for directory bind mounts, but a Dockerfile such as:

```dockerfile
RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml ...
```

failed during container state cloning with:

```text
path /pyproject.toml is a file, not a directory
```

## Fix

Add an internal Dockerfile-compat container mount path that preserves the LLB source directory and selector separately. During lazy evaluation, the core implementation stats the selected source path and materializes either a directory mount or a file mount.

This keeps the public withMountedDirectory and withMountedFile APIs unchanged while allowing Dockerfile bind mounts to match BuildKit behavior for both files and directories.

## Tests

Added coverage for binding pyproject.toml as a file in a Dockerfile RUN --mount.

Validated with:

```bash
dagger --progress=plain call engine-dev test --pkg ./core/integration --run=TestDockerfile/TestDockerBuild/run-mount-bind-file
```

```bash
dagger --progress=plain call engine-dev test --pkg ./core/integration --run=TestDockerfile/TestDockerBuild/run-mount-bind
```