### PR TITLE
version: derive dev versions from git workspace state

### DIFF
--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:52:6)
+type VersionID string // version (../../../../version/main.go:40:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -61,14 +61,6 @@ type VersionOpts struct {
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
-	//
-	// A directory containing all the inputs of the artifact to be versioned.
-	// An input is any file that changes the artifact if it changes.
-	// This directory is used to compute a digest. If any input changes, the digest changes.
-	// - To avoid false positives, only include actual inputs
-	// - To avoid false negatives, include *all* inputs
-	//
-	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -82,10 +74,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `inputs` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Inputs) {
-			q = q.Arg("inputs", opts[i].Inputs)
-		}
 	}
 
 	return &Version{
@@ -93,7 +81,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:52:6)
+type Version struct { // version (../../../../version/main.go:40:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -110,7 +98,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -122,7 +110,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -184,7 +172,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -197,7 +185,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -210,7 +198,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:57:6)
+type VersionID string // version (../../../../version/main.go:52:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -62,17 +62,13 @@ type VersionOpts struct {
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
 	//
-	// A git repository containing the source code of the artifact to be versioned.
-	//
-	Git *GitRepository // version (../../../../version/main.go:31:2)
-	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
 	// This directory is used to compute a digest. If any input changes, the digest changes.
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:41:2)
+	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -86,10 +82,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `git` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Git) {
-			q = q.Arg("git", opts[i].Git)
-		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
@@ -101,7 +93,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:52:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -118,7 +110,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +122,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -192,7 +184,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -205,7 +197,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -218,7 +210,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:40:6)
+type VersionID string // version (../../../../version/main.go:55:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:55:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -60,14 +60,17 @@ type VersionOpts struct {
 	//
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:27:2)
+	GitParent *Directory // version (../../../../version/main.go:38:2)
 }
 
-// Shared logic for managing Dagger versions
+// New builds the Version helper from the contextual git metadata Dagger can
+// currently provide.
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
+// Today that metadata arrives as a Directory filtered down to .git. That works
+// for ordinary clones where .git is a directory, but not for linked worktrees
+// where .git is a pointer file. In that case Git remains nil and the public
+// methods use their documented best-effort fallback behavior.
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:31:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -81,7 +84,11 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:40:6)
+// Version contains the local git repository used for version decisions.
+//
+// Git is private because callers should not depend on how the module currently
+// obtains workspace git state. The intended replacement is core Workspace.git().
+type Version struct { // version (../../../../version/main.go:55:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -98,7 +105,11 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
+// CurrentTag returns the semver tag currently pointing at HEAD.
+//
+// An empty string means HEAD is not a semver-tagged release commit, or local git
+// metadata is unavailable.
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:206:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -110,7 +121,11 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
+// Dirty reports whether the workspace has uncommitted git changes.
+//
+// When local git is unavailable, the module treats the checkout as dirty. That
+// keeps all no-git/worktree fallback versions out of the release-version shape.
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:189:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -171,8 +186,17 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
+// ImageTag returns the tag used by CLI auto-downloads for engine images.
+//
+// This is still the legacy image-tag policy: release commits use the current
+// semver tag, and untagged commits use a merge-base commit with main when one
+// can be found. The longer-term plan is to remove this separate image tag path
+// and use Version everywhere.
+//
+// FIXME: Remove ImageTag after engine/CLI build callers use Version for image
+// tagging too. Keeping a separate merge-base-based tag policy makes version
+// behavior harder to reason about and is not part of the Workspace.git facade.
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:158:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -184,8 +208,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
+// NextPatchVersion returns the next patch version after the latest stable semver tag.
+//
+// With workspace git available, tags come from the local repository. Without it,
+// this explicitly uses the upstream Dagger repository as a temporary fallback so
+// direct calls continue to work from linked worktrees.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:215:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -197,8 +225,17 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 	return response, q.Execute(ctx)
 }
 
-// Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
+// Version generates the release or dev version string for the current checkout.
+//
+// Release commits return their semver tag. Clean untagged commits use the next
+// patch version, the HEAD commit timestamp, and the HEAD commit SHA. Dirty
+// checkouts use the next patch version, wall-clock time, and a digest of the
+// uncommitted patch.
+//
+// If local git metadata cannot be loaded, this falls back to a digestless dirty
+// dev version. That fallback exists for linked worktrees until Workspace.git()
+// can provide worktree-aware git state.
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -58,9 +58,13 @@ func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../
 // VersionOpts contains options for Query.Version
 type VersionOpts struct {
 	//
+	// A directory containing the git metadata for the artifact to be versioned.
+	//
+	GitParent *Directory // version (../../../../version/main.go:27:2)
+	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	Git *GitRepository // version (../../../../version/main.go:31:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -68,31 +72,27 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
-	//
-	// File containing the next release version (e.g. .changes/.next)
-	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	Inputs *Directory // version (../../../../version/main.go:41:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
+		// `git` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Git) {
+			q = q.Arg("git", opts[i].Git)
+		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
-		}
-		// `nextVersionFile` optional argument
-		if !querybuilder.IsZeroValue(opts[i].NextVersionFile) {
-			q = q.Arg("nextVersionFile", opts[i].NextVersionFile)
 		}
 	}
 
@@ -104,12 +104,12 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
-	currentTag         *string
-	dirty              *bool
-	id                 *VersionID
-	imageTag           *string
-	nextReleaseVersion *string
-	version            *string
+	currentTag       *string
+	dirty            *bool
+	id               *VersionID
+	imageTag         *string
+	nextPatchVersion *string
+	version          *string
 }
 
 func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -140,14 +140,6 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
-}
-
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
-	q := r.query.Select("gitDir")
-
-	return &Directory{
-		query: q,
-	}
 }
 
 // A unique identifier for this Version.
@@ -200,7 +192,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -212,12 +204,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
-	if r.nextReleaseVersion != nil {
-		return *r.nextReleaseVersion, nil
+// NextPatchVersion returns the next patch version after the latest stable semver git tag.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+	if r.nextPatchVersion != nil {
+		return *r.nextPatchVersion, nil
 	}
-	q := r.query.Select("nextReleaseVersion")
+	q := r.query.Select("nextPatchVersion")
 
 	var response string
 
@@ -226,7 +218,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:52:6)
+type VersionID string // version (../../../../version/main.go:40:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -61,14 +61,6 @@ type VersionOpts struct {
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
-	//
-	// A directory containing all the inputs of the artifact to be versioned.
-	// An input is any file that changes the artifact if it changes.
-	// This directory is used to compute a digest. If any input changes, the digest changes.
-	// - To avoid false positives, only include actual inputs
-	// - To avoid false negatives, include *all* inputs
-	//
-	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -82,10 +74,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `inputs` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Inputs) {
-			q = q.Arg("inputs", opts[i].Inputs)
-		}
 	}
 
 	return &Version{
@@ -93,7 +81,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:52:6)
+type Version struct { // version (../../../../version/main.go:40:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -110,7 +98,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -122,7 +110,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -184,7 +172,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -197,7 +185,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -210,7 +198,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:57:6)
+type VersionID string // version (../../../../version/main.go:52:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -62,17 +62,13 @@ type VersionOpts struct {
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
 	//
-	// A git repository containing the source code of the artifact to be versioned.
-	//
-	Git *GitRepository // version (../../../../version/main.go:31:2)
-	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
 	// This directory is used to compute a digest. If any input changes, the digest changes.
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:41:2)
+	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -86,10 +82,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `git` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Git) {
-			q = q.Arg("git", opts[i].Git)
-		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
@@ -101,7 +93,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:52:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -118,7 +110,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +122,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -192,7 +184,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -205,7 +197,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -218,7 +210,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:40:6)
+type VersionID string // version (../../../../version/main.go:55:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:55:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -60,14 +60,17 @@ type VersionOpts struct {
 	//
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:27:2)
+	GitParent *Directory // version (../../../../version/main.go:38:2)
 }
 
-// Shared logic for managing Dagger versions
+// New builds the Version helper from the contextual git metadata Dagger can
+// currently provide.
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
+// Today that metadata arrives as a Directory filtered down to .git. That works
+// for ordinary clones where .git is a directory, but not for linked worktrees
+// where .git is a pointer file. In that case Git remains nil and the public
+// methods use their documented best-effort fallback behavior.
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:31:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -81,7 +84,11 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:40:6)
+// Version contains the local git repository used for version decisions.
+//
+// Git is private because callers should not depend on how the module currently
+// obtains workspace git state. The intended replacement is core Workspace.git().
+type Version struct { // version (../../../../version/main.go:55:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -98,7 +105,11 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
+// CurrentTag returns the semver tag currently pointing at HEAD.
+//
+// An empty string means HEAD is not a semver-tagged release commit, or local git
+// metadata is unavailable.
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:206:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -110,7 +121,11 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
+// Dirty reports whether the workspace has uncommitted git changes.
+//
+// When local git is unavailable, the module treats the checkout as dirty. That
+// keeps all no-git/worktree fallback versions out of the release-version shape.
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:189:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -171,8 +186,17 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
+// ImageTag returns the tag used by CLI auto-downloads for engine images.
+//
+// This is still the legacy image-tag policy: release commits use the current
+// semver tag, and untagged commits use a merge-base commit with main when one
+// can be found. The longer-term plan is to remove this separate image tag path
+// and use Version everywhere.
+//
+// FIXME: Remove ImageTag after engine/CLI build callers use Version for image
+// tagging too. Keeping a separate merge-base-based tag policy makes version
+// behavior harder to reason about and is not part of the Workspace.git facade.
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:158:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -184,8 +208,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
+// NextPatchVersion returns the next patch version after the latest stable semver tag.
+//
+// With workspace git available, tags come from the local repository. Without it,
+// this explicitly uses the upstream Dagger repository as a temporary fallback so
+// direct calls continue to work from linked worktrees.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:215:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -197,8 +225,17 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 	return response, q.Execute(ctx)
 }
 
-// Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
+// Version generates the release or dev version string for the current checkout.
+//
+// Release commits return their semver tag. Clean untagged commits use the next
+// patch version, the HEAD commit timestamp, and the HEAD commit SHA. Dirty
+// checkouts use the next patch version, wall-clock time, and a digest of the
+// uncommitted patch.
+//
+// If local git metadata cannot be loaded, this falls back to a digestless dirty
+// dev version. That fallback exists for linked worktrees until Workspace.git()
+// can provide worktree-aware git state.
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -58,9 +58,13 @@ func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../
 // VersionOpts contains options for Query.Version
 type VersionOpts struct {
 	//
+	// A directory containing the git metadata for the artifact to be versioned.
+	//
+	GitParent *Directory // version (../../../../version/main.go:27:2)
+	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	Git *GitRepository // version (../../../../version/main.go:31:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -68,31 +72,27 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
-	//
-	// File containing the next release version (e.g. .changes/.next)
-	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	Inputs *Directory // version (../../../../version/main.go:41:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
+		// `git` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Git) {
+			q = q.Arg("git", opts[i].Git)
+		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
-		}
-		// `nextVersionFile` optional argument
-		if !querybuilder.IsZeroValue(opts[i].NextVersionFile) {
-			q = q.Arg("nextVersionFile", opts[i].NextVersionFile)
 		}
 	}
 
@@ -104,12 +104,12 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
-	currentTag         *string
-	dirty              *bool
-	id                 *VersionID
-	imageTag           *string
-	nextReleaseVersion *string
-	version            *string
+	currentTag       *string
+	dirty            *bool
+	id               *VersionID
+	imageTag         *string
+	nextPatchVersion *string
+	version          *string
 }
 
 func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -140,14 +140,6 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
-}
-
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
-	q := r.query.Select("gitDir")
-
-	return &Directory{
-		query: q,
-	}
 }
 
 // A unique identifier for this Version.
@@ -200,7 +192,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -212,12 +204,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
-	if r.nextReleaseVersion != nil {
-		return *r.nextReleaseVersion, nil
+// NextPatchVersion returns the next patch version after the latest stable semver git tag.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+	if r.nextPatchVersion != nil {
+		return *r.nextPatchVersion, nil
 	}
-	q := r.query.Select("nextReleaseVersion")
+	q := r.query.Select("nextPatchVersion")
 
 	var response string
 
@@ -226,7 +218,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:52:6)
+type VersionID string // version (../../../../version/main.go:40:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -61,14 +61,6 @@ type VersionOpts struct {
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
-	//
-	// A directory containing all the inputs of the artifact to be versioned.
-	// An input is any file that changes the artifact if it changes.
-	// This directory is used to compute a digest. If any input changes, the digest changes.
-	// - To avoid false positives, only include actual inputs
-	// - To avoid false negatives, include *all* inputs
-	//
-	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -82,10 +74,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `inputs` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Inputs) {
-			q = q.Arg("inputs", opts[i].Inputs)
-		}
 	}
 
 	return &Version{
@@ -93,7 +81,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:52:6)
+type Version struct { // version (../../../../version/main.go:40:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -110,7 +98,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -122,7 +110,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -184,7 +172,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -197,7 +185,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -210,7 +198,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:57:6)
+type VersionID string // version (../../../../version/main.go:52:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:52:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:57:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:52:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -62,17 +62,13 @@ type VersionOpts struct {
 	//
 	GitParent *Directory // version (../../../../version/main.go:27:2)
 	//
-	// A git repository containing the source code of the artifact to be versioned.
-	//
-	Git *GitRepository // version (../../../../version/main.go:31:2)
-	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
 	// This directory is used to compute a digest. If any input changes, the digest changes.
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:41:2)
+	Inputs *Directory // version (../../../../version/main.go:37:2)
 }
 
 // Shared logic for managing Dagger versions
@@ -86,10 +82,6 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
-		// `git` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Git) {
-			q = q.Arg("git", opts[i].Git)
-		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
@@ -101,7 +93,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:52:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -118,7 +110,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:182:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +122,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:161:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -192,7 +184,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:135:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -205,7 +197,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -218,7 +210,7 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:61:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `VersionID` scalar type represents an identifier for an object of type Version.
-type VersionID string // version (../../../../version/main.go:40:6)
+type VersionID string // version (../../../../version/main.go:55:6)
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:40:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -22,7 +22,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:55:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:40:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -46,7 +46,7 @@ func (r *Env) WithVersionOutput(name string, description string) *Env { // versi
 }
 
 // Load a Version from its ID.
-func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:40:6)
+func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../../version/main.go:55:6)
 	q := r.query.Select("loadVersionFromID")
 	q = q.Arg("id", id)
 
@@ -60,14 +60,17 @@ type VersionOpts struct {
 	//
 	// A directory containing the git metadata for the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:27:2)
+	GitParent *Directory // version (../../../../version/main.go:38:2)
 }
 
-// Shared logic for managing Dagger versions
+// New builds the Version helper from the contextual git metadata Dagger can
+// currently provide.
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
+// Today that metadata arrives as a Directory filtered down to .git. That works
+// for ordinary clones where .git is a directory, but not for linked worktrees
+// where .git is a pointer file. In that case Git remains nil and the public
+// methods use their documented best-effort fallback behavior.
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:31:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -81,7 +84,11 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:40:6)
+// Version contains the local git repository used for version decisions.
+//
+// Git is private because callers should not depend on how the module currently
+// obtains workspace git state. The intended replacement is core Workspace.git().
+type Version struct { // version (../../../../version/main.go:55:6)
 	query *querybuilder.Selection
 
 	currentTag       *string
@@ -98,7 +105,11 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
+// CurrentTag returns the semver tag currently pointing at HEAD.
+//
+// An empty string means HEAD is not a semver-tagged release commit, or local git
+// metadata is unavailable.
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:206:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -110,7 +121,11 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:139:1)
+// Dirty reports whether the workspace has uncommitted git changes.
+//
+// When local git is unavailable, the module treats the checkout as dirty. That
+// keeps all no-git/worktree fallback versions out of the release-version shape.
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:189:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -171,8 +186,17 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:113:1)
+// ImageTag returns the tag used by CLI auto-downloads for engine images.
+//
+// This is still the legacy image-tag policy: release commits use the current
+// semver tag, and untagged commits use a merge-base commit with main when one
+// can be found. The longer-term plan is to remove this separate image tag path
+// and use Version everywhere.
+//
+// FIXME: Remove ImageTag after engine/CLI build callers use Version for image
+// tagging too. Keeping a separate merge-base-based tag policy makes version
+// behavior harder to reason about and is not part of the Workspace.git facade.
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:158:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -184,8 +208,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextPatchVersion returns the next patch version after the latest stable semver git tag.
-func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:173:1)
+// NextPatchVersion returns the next patch version after the latest stable semver tag.
+//
+// With workspace git available, tags come from the local repository. Without it,
+// this explicitly uses the upstream Dagger repository as a temporary fallback so
+// direct calls continue to work from linked worktrees.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:215:1)
 	if r.nextPatchVersion != nil {
 		return *r.nextPatchVersion, nil
 	}
@@ -197,8 +225,17 @@ func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // ver
 	return response, q.Execute(ctx)
 }
 
-// Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:46:1)
+// Version generates the release or dev version string for the current checkout.
+//
+// Release commits return their semver tag. Clean untagged commits use the next
+// patch version, the HEAD commit timestamp, and the HEAD commit SHA. Dirty
+// checkouts use the next patch version, wall-clock time, and a digest of the
+// uncommitted patch.
+//
+// If local git metadata cannot be loaded, this falls back to a digestless dirty
+// dev version. That fallback exists for linked worktrees until Workspace.git()
+// can provide worktree-aware git state.
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -58,9 +58,13 @@ func (r *Query) LoadVersionFromID(id VersionID) *Version { // version (../../../
 // VersionOpts contains options for Query.Version
 type VersionOpts struct {
 	//
+	// A directory containing the git metadata for the artifact to be versioned.
+	//
+	GitParent *Directory // version (../../../../version/main.go:27:2)
+	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	Git *GitRepository // version (../../../../version/main.go:31:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -68,31 +72,27 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
-	//
-	// File containing the next release version (e.g. .changes/.next)
-	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	Inputs *Directory // version (../../../../version/main.go:41:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:20:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
 		if !querybuilder.IsZeroValue(opts[i].GitParent) {
 			q = q.Arg("gitParent", opts[i].GitParent)
 		}
+		// `git` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Git) {
+			q = q.Arg("git", opts[i].Git)
+		}
 		// `inputs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Inputs) {
 			q = q.Arg("inputs", opts[i].Inputs)
-		}
-		// `nextVersionFile` optional argument
-		if !querybuilder.IsZeroValue(opts[i].NextVersionFile) {
-			q = q.Arg("nextVersionFile", opts[i].NextVersionFile)
 		}
 	}
 
@@ -104,12 +104,12 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
-	currentTag         *string
-	dirty              *bool
-	id                 *VersionID
-	imageTag           *string
-	nextReleaseVersion *string
-	version            *string
+	currentTag       *string
+	dirty            *bool
+	id               *VersionID
+	imageTag         *string
+	nextPatchVersion *string
+	version          *string
 }
 
 func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
@@ -118,7 +118,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:187:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -130,7 +130,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:166:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -140,14 +140,6 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
-}
-
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
-	q := r.query.Select("gitDir")
-
-	return &Directory{
-		query: q,
-	}
 }
 
 // A unique identifier for this Version.
@@ -200,7 +192,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:140:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -212,12 +204,12 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 	return response, q.Execute(ctx)
 }
 
-// NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
-	if r.nextReleaseVersion != nil {
-		return *r.nextReleaseVersion, nil
+// NextPatchVersion returns the next patch version after the latest stable semver git tag.
+func (r *Version) NextPatchVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:209:1)
+	if r.nextPatchVersion != nil {
+		return *r.nextPatchVersion, nil
 	}
-	q := r.query.Select("nextReleaseVersion")
+	q := r.query.Select("nextPatchVersion")
 
 	var response string
 
@@ -226,7 +218,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:66:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/version/dagger.gen.go
+++ b/version/dagger.gen.go
@@ -58,25 +58,21 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r Version) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Git    *dagger.GitRepository
-		Inputs *dagger.Directory
+		Git *dagger.GitRepository
 	}
 	concrete.Git = r.Git
-	concrete.Inputs = r.Inputs
 	return json.Marshal(&concrete)
 }
 
 func (r *Version) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Git    *dagger.GitRepository
-		Inputs *dagger.Directory
+		Git *dagger.GitRepository
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
 		return err
 	}
 	r.Git = concrete.Git
-	r.Inputs = concrete.Inputs
 	return nil
 }
 
@@ -247,14 +243,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitParent", err))
 				}
 			}
-			var inputs *dagger.Directory
-			if inputArgs["inputs"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["inputs"]), &inputs)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg inputs", err))
-				}
-			}
-			return New(ctx, gitParent, inputs), nil
+			return New(ctx, gitParent), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/version/dagger.gen.go
+++ b/version/dagger.gen.go
@@ -247,13 +247,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitParent", err))
 				}
 			}
-			var git *dagger.GitRepository
-			if inputArgs["git"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["git"]), &git)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg git", err))
-				}
-			}
 			var inputs *dagger.Directory
 			if inputArgs["inputs"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["inputs"]), &inputs)
@@ -261,7 +254,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg inputs", err))
 				}
 			}
-			return New(ctx, gitParent, git, inputs), nil
+			return New(ctx, gitParent, inputs), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/version/dagger.gen.go
+++ b/version/dagger.gen.go
@@ -58,33 +58,25 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r Version) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Git             *dagger.GitRepository
-		GitDir          *dagger.Directory
-		Inputs          *dagger.Directory
-		NextVersionFile *dagger.File
+		Git    *dagger.GitRepository
+		Inputs *dagger.Directory
 	}
 	concrete.Git = r.Git
-	concrete.GitDir = r.GitDir
 	concrete.Inputs = r.Inputs
-	concrete.NextVersionFile = r.NextVersionFile
 	return json.Marshal(&concrete)
 }
 
 func (r *Version) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Git             *dagger.GitRepository
-		GitDir          *dagger.Directory
-		Inputs          *dagger.Directory
-		NextVersionFile *dagger.File
+		Git    *dagger.GitRepository
+		Inputs *dagger.Directory
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
 		return err
 	}
 	r.Git = concrete.Git
-	r.GitDir = concrete.GitDir
 	r.Inputs = concrete.Inputs
-	r.NextVersionFile = concrete.NextVersionFile
 	return nil
 }
 
@@ -228,13 +220,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Version).ImageTag(&parent, ctx)
-		case "NextReleaseVersion":
+		case "NextPatchVersion":
 			var parent Version
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return (*Version).NextReleaseVersion(&parent, ctx)
+			return (*Version).NextPatchVersion(&parent, ctx)
 		case "Version":
 			var parent Version
 			err = json.Unmarshal(parentJSON, &parent)
@@ -255,6 +247,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitParent", err))
 				}
 			}
+			var git *dagger.GitRepository
+			if inputArgs["git"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["git"]), &git)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg git", err))
+				}
+			}
 			var inputs *dagger.Directory
 			if inputArgs["inputs"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["inputs"]), &inputs)
@@ -262,14 +261,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg inputs", err))
 				}
 			}
-			var nextVersionFile *dagger.File
-			if inputArgs["nextVersionFile"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["nextVersionFile"]), &nextVersionFile)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg nextVersionFile", err))
-				}
-			}
-			return New(ctx, gitParent, inputs, nextVersionFile), nil
+			return New(ctx, gitParent, git, inputs), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/version/main.go
+++ b/version/main.go
@@ -26,10 +26,6 @@ func New(
 	// +ignore=["*", "!.git"]
 	gitParent *dagger.Directory,
 
-	// A git repository containing the source code of the artifact to be versioned.
-	// +optional
-	git *dagger.GitRepository,
-
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
 	// This directory is used to compute a digest. If any input changes, the digest changes.
@@ -41,11 +37,10 @@ func New(
 	inputs *dagger.Directory,
 ) *Version {
 	v := &Version{
-		Git:    git,
 		Inputs: inputs.Filter(dagger.DirectoryFilterOpts{Gitignore: true}),
 	}
 
-	if v.Git == nil && gitParent != nil {
+	if gitParent != nil {
 		if gitDir, err := gitParent.Directory(".git").Sync(ctx); err == nil {
 			v.Git = gitDir.AsGit()
 		}

--- a/version/main.go
+++ b/version/main.go
@@ -15,8 +15,19 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+// daggerRepoURL is only used by the no-local-git fallback path.
+//
+// The normal version path should use workspace git metadata. The fallback keeps
+// worktree builds alive until core exposes a worktree-aware Workspace.git API.
 const daggerRepoURL = "https://github.com/dagger/dagger.git"
 
+// New builds the Version helper from the contextual git metadata Dagger can
+// currently provide.
+//
+// Today that metadata arrives as a Directory filtered down to .git. That works
+// for ordinary clones where .git is a directory, but not for linked worktrees
+// where .git is a pointer file. In that case Git remains nil and the public
+// methods use their documented best-effort fallback behavior.
 func New(
 	ctx context.Context,
 
@@ -25,20 +36,8 @@ func New(
 	// +defaultPath="/"
 	// +ignore=["*", "!.git"]
 	gitParent *dagger.Directory,
-
-	// A directory containing all the inputs of the artifact to be versioned.
-	// An input is any file that changes the artifact if it changes.
-	// This directory is used to compute a digest. If any input changes, the digest changes.
-	// - To avoid false positives, only include actual inputs
-	// - To avoid false negatives, include *all* inputs
-	// +optional
-	// +defaultPath="/"
-	// +ignore=["**_test.go", "**/.git*", "**/.venv", "**/.dagger", ".*", "bin", "**/node_modules", "**/testdata/**", "**/.changes", ".changes", "docs", "helm", "release", "version", "modules", "*.md", "LICENSE", "NOTICE", "hack", "!**/.gitignore"]
-	inputs *dagger.Directory,
 ) *Version {
-	v := &Version{
-		Inputs: inputs.Filter(dagger.DirectoryFilterOpts{Gitignore: true}),
-	}
+	v := &Version{}
 
 	if gitParent != nil {
 		if gitDir, err := gitParent.Directory(".git").Sync(ctx); err == nil {
@@ -49,17 +48,28 @@ func New(
 	return v
 }
 
+// Version contains the local git repository used for version decisions.
+//
+// Git is private because callers should not depend on how the module currently
+// obtains workspace git state. The intended replacement is core Workspace.git().
 type Version struct {
 	// +private
 	Git *dagger.GitRepository
-
-	// +private
-	Inputs *dagger.Directory
 }
 
-// Generate a version string from the current context
+// Version generates the release or dev version string for the current checkout.
+//
+// Release commits return their semver tag. Clean untagged commits use the next
+// patch version, the HEAD commit timestamp, and the HEAD commit SHA. Dirty
+// checkouts use the next patch version, wall-clock time, and a digest of the
+// uncommitted patch.
+//
+// If local git metadata cannot be loaded, this falls back to a digestless dirty
+// dev version. That fallback exists for linked worktrees until Workspace.git()
+// can provide worktree-aware git state.
 func (v Version) Version(ctx context.Context) (string, error) {
-	if v.Git == nil {
+	git := v.workspaceGit()
+	if !git.found() {
 		return v.fallbackVersion(ctx)
 	}
 
@@ -70,12 +80,17 @@ func (v Version) Version(ctx context.Context) (string, error) {
 
 	if dirty {
 		// this is a dirty version - git state is dirty
-		// (v<major>.<minor>.<patch>-<timestamp>-dev-<inputdigest>)
+		// (v<major>.<minor>.<patch>-<timestamp>-dev-<patchdigest>)
 		next, err := v.NextPatchVersion(ctx)
 		if err != nil {
 			return "", err
 		}
-		rawDigest, err := v.Inputs.Digest(ctx)
+		// FIXME: Dirty already checked git.uncommitted().IsEmpty above. Keep the
+		// Changeset around so dirty detection and dirty digest generation share
+		// one local value instead of asking the facade for the same changes twice.
+		rawDigest, err := git.uncommitted().AsPatch().Digest(ctx, dagger.FileDigestOpts{
+			ExcludeMetadata: true,
+		})
 		if err != nil {
 			return "", err
 		}
@@ -100,7 +115,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	head := v.Git.Head()
+	head := git.head()
 	commit, err := head.Commit(ctx)
 	if err != nil {
 		return "", err
@@ -112,28 +127,37 @@ func (v Version) Version(ctx context.Context) (string, error) {
 	return fmt.Sprintf("%s-%s-dev-%s", next, pseudoversionTimestamp(commitDate), commit[:12]), nil
 }
 
+// fallbackVersion returns a best-effort dirty dev version when workspace git
+// metadata is unavailable.
+//
+// This path deliberately does not try to fingerprint source files. The old
+// input-directory digest required a separate manually maintained ignore list,
+// which was too easy to let drift from real build inputs. Until Workspace.git()
+// exists, the fallback only uses the upstream release tags to choose the next
+// patch baseline, plus the current time to make the build visibly non-release.
 func (v Version) fallbackVersion(ctx context.Context) (string, error) {
-	next, err := v.NextPatchVersion(ctx)
+	next, err := fallbackNextPatchVersion(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	// Generate a version based on inputs digest
-	rawDigest, err := v.Inputs.Digest(ctx)
-	if err != nil {
-		return "", err
-	}
-	_, digest, ok := strings.Cut(rawDigest, ":")
-	if !ok {
-		return "", fmt.Errorf("invalid digest: %s", rawDigest)
-	}
-
-	return fmt.Sprintf("%s-%s-dev-%s", next, pseudoversionTimestamp(time.Now()), digest[:12]), nil
+	// Without local git metadata, fall back to a best-effort dirty dev version.
+	return fmt.Sprintf("%s-%s-dev", next, pseudoversionTimestamp(time.Now())), nil
 }
 
-// Return the tag to use when auto-downloading the engine image from the CLI
+// ImageTag returns the tag used by CLI auto-downloads for engine images.
+//
+// This is still the legacy image-tag policy: release commits use the current
+// semver tag, and untagged commits use a merge-base commit with main when one
+// can be found. The longer-term plan is to remove this separate image tag path
+// and use Version everywhere.
+//
+// FIXME: Remove ImageTag after engine/CLI build callers use Version for image
+// tagging too. Keeping a separate merge-base-based tag policy makes version
+// behavior harder to reason about and is not part of the Workspace.git facade.
 func (v Version) ImageTag(ctx context.Context) (string, error) {
-	if v.Git == nil {
+	git := v.workspaceGit()
+	if !git.found() {
 		return v.fallbackVersion(ctx)
 	}
 
@@ -147,9 +171,9 @@ func (v Version) ImageTag(ctx context.Context) (string, error) {
 
 	// For untagged builds, find merge-base with main
 	// Try local main first, then origin/main for CI (detached HEAD)
-	head := v.Git.Head()
+	head := git.head()
 	for _, ref := range []string{"main", "origin/main"} {
-		if branch := v.Git.Branch(ref); branch != nil {
+		if branch := git.branch(ref); branch != nil {
 			if mergeBase, err := head.CommonAncestor(branch).Commit(ctx); err == nil {
 				return mergeBase, nil
 			}
@@ -158,122 +182,66 @@ func (v Version) ImageTag(ctx context.Context) (string, error) {
 	return head.Commit(ctx)
 }
 
+// Dirty reports whether the workspace has uncommitted git changes.
+//
+// When local git is unavailable, the module treats the checkout as dirty. That
+// keeps all no-git/worktree fallback versions out of the release-version shape.
 func (v Version) Dirty(ctx context.Context) (bool, error) {
-	if v.Git == nil {
+	git := v.workspaceGit()
+	if !git.found() {
 		return true, nil
 	}
 
-	committed := v.Git.Head().Tree()
-
-	// Overlay local inputs onto committed tree, then diff.
-	// This detects additions and modifications but not deletions.
-	// We use overlay instead of direct diff to avoid false positives from
-	// gitignored files and empty directories that exist locally but not in git.
-	local := committed.WithDirectory("", v.Inputs)
-	changes := committed.Changes(local)
-
-	isEmpty, err := changes.IsEmpty(ctx)
+	isEmpty, err := git.uncommitted().IsEmpty(ctx)
 	if err != nil {
 		return false, err
 	}
 	return !isEmpty, nil
 }
 
+// CurrentTag returns the semver tag currently pointing at HEAD.
+//
+// An empty string means HEAD is not a semver-tagged release commit, or local git
+// metadata is unavailable.
 func (v Version) CurrentTag(ctx context.Context) (string, error) {
-	if v.Git == nil {
-		return "", nil
-	}
-
-	commit, err := v.Git.Head().Commit(ctx)
-	if err != nil {
-		return "", err
-	}
-	tags, err := v.tagsAtCommit(ctx, commit)
-	if err != nil {
-		return "", err
-	}
-	for _, tag := range tags {
-		if semver.IsValid(tag) {
-			return tag, nil
-		}
-	}
-	return "", nil
+	return v.workspaceGit().currentSemverTag(ctx, true)
 }
 
-// NextPatchVersion returns the next patch version after the latest stable semver git tag.
+// NextPatchVersion returns the next patch version after the latest stable semver tag.
+//
+// With workspace git available, tags come from the local repository. Without it,
+// this explicitly uses the upstream Dagger repository as a temporary fallback so
+// direct calls continue to work from linked worktrees.
 func (v Version) NextPatchVersion(ctx context.Context) (string, error) {
-	tag, err := v.latestReleaseTag(ctx)
+	git := v.workspaceGit()
+	if !git.found() {
+		return fallbackNextPatchVersion(ctx)
+	}
+
+	tag, err := git.latestSemverTag(ctx, false)
 	if err != nil {
 		return "", err
 	}
 	return bumpPatchVersion(tag)
 }
 
-func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, error) {
-	tags, err := v.gitTags(ctx, v.Git)
-	if err != nil {
-		return nil, err
-	}
-
-	var matched []string
-	for _, tag := range tags {
-		tagCommit, err := v.Git.Tag(tag).Commit(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if tagCommit == commit {
-			matched = append(matched, tag)
-		}
-	}
-	return matched, nil
-}
-
-func (v Version) latestReleaseTag(ctx context.Context) (string, error) {
-	tags, err := v.gitTags(ctx, v.releaseTagsGit())
+// fallbackNextPatchVersion computes the next patch version from upstream tags.
+//
+// Keep this fallback outside workspaceGit: workspaceGit should describe the
+// local workspace repository only. The hardcoded upstream repository is version
+// module policy for the current worktree stopgap.
+func fallbackNextPatchVersion(ctx context.Context) (string, error) {
+	tag, err := latestSemverTag(ctx, dag.Git(daggerRepoURL), false)
 	if err != nil {
 		return "", err
 	}
-
-	latest := ""
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if !semver.IsValid(tag) || semver.Prerelease(tag) != "" {
-			continue
-		}
-		if latest == "" || semver.Compare(tag, latest) > 0 {
-			latest = tag
-		}
-	}
-	if latest == "" {
-		return "", fmt.Errorf("no stable semver git tag found")
-	}
-	return latest, nil
+	return bumpPatchVersion(tag)
 }
 
-func (v Version) releaseTagsGit() *dagger.GitRepository {
-	if v.Git != nil {
-		return v.Git
-	}
-	return dag.Git(daggerRepoURL)
-}
-
-func (v Version) gitTags(ctx context.Context, git *dagger.GitRepository) ([]string, error) {
-	if git == nil {
-		return nil, fmt.Errorf("git repository not provided")
-	}
-
-	tags, err := git.Tags(ctx, dagger.GitRepositoryTagsOpts{
-		Patterns: []string{"refs/tags/v*"},
-	})
-	if err != nil {
-		return nil, err
-	}
-	for i, tag := range tags {
-		tags[i] = strings.TrimPrefix(tag, "refs/tags/")
-	}
-	return tags, nil
-}
-
+// bumpPatchVersion increments the patch component of a canonical semver tag.
+//
+// The version module uses this to turn the latest released tag into the base for
+// dev versions, e.g. v1.2.3 becomes v1.2.4.
 func bumpPatchVersion(version string) (string, error) {
 	original := version
 	version = semver.Canonical(version)
@@ -294,6 +262,11 @@ func bumpPatchVersion(version string) (string, error) {
 	return fmt.Sprintf("v%s.%s.%d", parts[0], parts[1], patch+1), nil
 }
 
+// refTimestamp returns the committer timestamp for a GitRef.
+//
+// GitRef does not currently expose commit timestamps directly, so this checks
+// out the ref tree and asks git for the HEAD commit timestamp. Workspace.git()
+// should eventually make this a direct GitRef field.
 func refTimestamp(ctx context.Context, head *dagger.GitRef) (time.Time, error) {
 	checkout := head.Tree()
 	status, err := dag.Container().
@@ -313,6 +286,10 @@ func refTimestamp(ctx context.Context, head *dagger.GitRef) (time.Time, error) {
 	return t, nil
 }
 
+// pseudoversionTimestamp formats timestamps the same way Go pseudoversions do.
+//
+// The result is UTC yyyymmddhhmmss and is stable for clean commits because it
+// uses the commit timestamp instead of wall-clock time.
 func pseudoversionTimestamp(t time.Time) string {
 	// go time formatting is bizarre - this translates to "yyyymmddhhmmss"
 	// inspired from: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.22.0:module/pseudo.go

--- a/version/main.go
+++ b/version/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,14 +15,20 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const daggerRepoURL = "https://github.com/dagger/dagger.git"
+
 func New(
 	ctx context.Context,
 
-	// A git repository containing the source code of the artifact to be versioned.
+	// A directory containing the git metadata for the artifact to be versioned.
 	// +optional
 	// +defaultPath="/"
 	// +ignore=["*", "!.git"]
 	gitParent *dagger.Directory,
+
+	// A git repository containing the source code of the artifact to be versioned.
+	// +optional
+	git *dagger.GitRepository,
 
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -32,22 +39,15 @@ func New(
 	// +defaultPath="/"
 	// +ignore=["**_test.go", "**/.git*", "**/.venv", "**/.dagger", ".*", "bin", "**/node_modules", "**/testdata/**", "**/.changes", ".changes", "docs", "helm", "release", "version", "modules", "*.md", "LICENSE", "NOTICE", "hack", "!**/.gitignore"]
 	inputs *dagger.Directory,
-
-	// File containing the next release version (e.g. .changes/.next)
-	// +optional
-	// +defaultPath="/.changes/.next"
-	nextVersionFile *dagger.File,
 ) *Version {
 	v := &Version{
-		Inputs:          inputs.Filter(dagger.DirectoryFilterOpts{Gitignore: true}),
-		NextVersionFile: nextVersionFile,
+		Git:    git,
+		Inputs: inputs.Filter(dagger.DirectoryFilterOpts{Gitignore: true}),
 	}
 
-	if git, err := gitParent.Directory(".git").Sync(ctx); err == nil {
-		repo := git.AsGit()
-		if _, err := repo.Head().Commit(ctx); err == nil {
-			v.Git = repo
-			v.GitDir = git
+	if v.Git == nil && gitParent != nil {
+		if gitDir, err := gitParent.Directory(".git").Sync(ctx); err == nil {
+			v.Git = gitDir.AsGit()
 		}
 	}
 
@@ -56,14 +56,10 @@ func New(
 
 type Version struct {
 	// +private
-	Git    *dagger.GitRepository
-	GitDir *dagger.Directory
+	Git *dagger.GitRepository
 
 	// +private
 	Inputs *dagger.Directory
-
-	// +private
-	NextVersionFile *dagger.File
 }
 
 // Generate a version string from the current context
@@ -80,7 +76,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 	if dirty {
 		// this is a dirty version - git state is dirty
 		// (v<major>.<minor>.<patch>-<timestamp>-dev-<inputdigest>)
-		next, err := v.NextReleaseVersion(ctx)
+		next, err := v.NextPatchVersion(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -105,7 +101,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 
 	// this is a clean, untagged version - git state is clean, but no tag
 	// (v<major>.<minor>.<patch>-<timestamp>-dev-<commit>)
-	next, err := v.NextReleaseVersion(ctx)
+	next, err := v.NextPatchVersion(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -122,18 +118,9 @@ func (v Version) Version(ctx context.Context) (string, error) {
 }
 
 func (v Version) fallbackVersion(ctx context.Context) (string, error) {
-	// Try to get next release version from .changes/.next
-	next := "v0.0.0"
-	if v.NextVersionFile != nil {
-		if content, err := v.NextVersionFile.Contents(ctx); err == nil {
-			for _, line := range strings.Split(content, "\n") {
-				line = strings.TrimSpace(line)
-				if strings.HasPrefix(line, "v") && semver.IsValid(line) {
-					next = line
-					break
-				}
-			}
-		}
+	next, err := v.NextPatchVersion(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	// Generate a version based on inputs digest
@@ -218,25 +205,98 @@ func (v Version) CurrentTag(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+// NextPatchVersion returns the next patch version after the latest stable semver git tag.
+func (v Version) NextPatchVersion(ctx context.Context) (string, error) {
+	tag, err := v.latestReleaseTag(ctx)
+	if err != nil {
+		return "", err
+	}
+	return bumpPatchVersion(tag)
+}
+
 func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, error) {
-	// NOTE: this uses the git dir directly rather than the git repo
-	// since there's no dagger API to do this operation
-	out, err := dag.Container().
-		From("alpine/git:latest").
-		WithWorkdir("/src").
-		WithMountedDirectory(".git", v.GitDir).
-		WithExec([]string{"git", "config", "url.https://github.com/.insteadOf", "git@github.com:"}).
-		WithExec([]string{"git", "fetch", "--tags"}).
-		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
-		Stdout(ctx)
+	tags, err := v.gitTags(ctx, v.Git)
 	if err != nil {
 		return nil, err
 	}
-	out = strings.TrimSpace(out)
-	if out == "" {
-		return nil, nil
+
+	var matched []string
+	for _, tag := range tags {
+		tagCommit, err := v.Git.Tag(tag).Commit(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if tagCommit == commit {
+			matched = append(matched, tag)
+		}
 	}
-	return strings.Split(out, "\n"), nil
+	return matched, nil
+}
+
+func (v Version) latestReleaseTag(ctx context.Context) (string, error) {
+	tags, err := v.gitTags(ctx, v.releaseTagsGit())
+	if err != nil {
+		return "", err
+	}
+
+	latest := ""
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if !semver.IsValid(tag) || semver.Prerelease(tag) != "" {
+			continue
+		}
+		if latest == "" || semver.Compare(tag, latest) > 0 {
+			latest = tag
+		}
+	}
+	if latest == "" {
+		return "", fmt.Errorf("no stable semver git tag found")
+	}
+	return latest, nil
+}
+
+func (v Version) releaseTagsGit() *dagger.GitRepository {
+	if v.Git != nil {
+		return v.Git
+	}
+	return dag.Git(daggerRepoURL)
+}
+
+func (v Version) gitTags(ctx context.Context, git *dagger.GitRepository) ([]string, error) {
+	if git == nil {
+		return nil, fmt.Errorf("git repository not provided")
+	}
+
+	tags, err := git.Tags(ctx, dagger.GitRepositoryTagsOpts{
+		Patterns: []string{"refs/tags/v*"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i, tag := range tags {
+		tags[i] = strings.TrimPrefix(tag, "refs/tags/")
+	}
+	return tags, nil
+}
+
+func bumpPatchVersion(version string) (string, error) {
+	original := version
+	version = semver.Canonical(version)
+	if version == "" {
+		return "", fmt.Errorf("invalid semver: %q", original)
+	}
+
+	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid canonical semver: %q", version)
+	}
+
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid patch version %q: %w", version, err)
+	}
+
+	return fmt.Sprintf("v%s.%s.%d", parts[0], parts[1], patch+1), nil
 }
 
 func refTimestamp(ctx context.Context, head *dagger.GitRef) (time.Time, error) {
@@ -262,22 +322,4 @@ func pseudoversionTimestamp(t time.Time) string {
 	// go time formatting is bizarre - this translates to "yyyymmddhhmmss"
 	// inspired from: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.22.0:module/pseudo.go
 	return t.UTC().Format("20060102150405")
-}
-
-// NextReleaseVersion returns the next release version from .changes/.next
-func (v Version) NextReleaseVersion(ctx context.Context) (string, error) {
-	if v.NextVersionFile == nil {
-		return "", fmt.Errorf("next version file not provided")
-	}
-	content, err := v.NextVersionFile.Contents(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "v") && semver.IsValid(line) {
-			return line, nil
-		}
-	}
-	return "", fmt.Errorf("no valid version found in next version file")
 }

--- a/version/workspace_git.go
+++ b/version/workspace_git.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dagger/dagger/version/internal/dagger"
+	"golang.org/x/mod/semver"
+)
+
+// workspaceGit is the version module's local stand-in for the future
+// Workspace.git API.
+//
+// It is intentionally narrow: every method reflects local workspace git state.
+// Stopgap policy such as querying the hardcoded upstream repository belongs in
+// Version methods, not here.
+type workspaceGit struct {
+	repo *dagger.GitRepository
+}
+
+// workspaceGit adapts the Version object's current private GitRepository field
+// into the local facade used by the rest of the module.
+//
+// When core Workspace.git exists, this should become the only place that needs
+// to change for the version module to consume it.
+func (v Version) workspaceGit() workspaceGit {
+	return workspaceGit{repo: v.Git}
+}
+
+// found reports whether local workspace git metadata is available.
+//
+// In linked worktrees this is currently false because the contextual .git input
+// is a file, not a directory. That is a limitation of the current shim source,
+// not the intended semantics of Workspace.git.
+func (git workspaceGit) found() bool {
+	return git.repo != nil
+}
+
+// head returns the checked-out workspace HEAD.
+//
+// Callers must check found first. Keeping this as a shim method makes the
+// intended future replacement with Workspace.git().head mechanical.
+func (git workspaceGit) head() *dagger.GitRef {
+	return git.repo.Head()
+}
+
+// branch returns a branch ref from the local workspace repository.
+//
+// This only exists for the legacy ImageTag merge-base path. It should disappear
+// when ImageTag is removed and build code uses Version everywhere.
+func (git workspaceGit) branch(name string) *dagger.GitRef {
+	return git.repo.Branch(name)
+}
+
+// uncommitted returns the local workspace changeset using GitRepository's rules.
+//
+// This is the replacement for the old manually filtered inputs directory. The
+// changeset provides both dirty detection and the patch digest for dirty dev
+// versions.
+func (git workspaceGit) uncommitted() *dagger.Changeset {
+	return git.repo.Uncommitted()
+}
+
+// currentSemverTag returns the highest semver tag pointing at workspace HEAD.
+//
+// includePrerelease controls whether pre-release tags such as v1.2.3-rc.1 are
+// eligible. If local git is unavailable or no matching tag points at HEAD, the
+// empty string is returned.
+func (git workspaceGit) currentSemverTag(ctx context.Context, includePrerelease bool) (string, error) {
+	if !git.found() {
+		return "", nil
+	}
+
+	commit, err := git.head().Commit(ctx)
+	if err != nil {
+		return "", err
+	}
+	tags, err := git.tagsAtCommit(ctx, commit)
+	if err != nil {
+		return "", err
+	}
+	tag, ok := latestSemverTagName(tags, includePrerelease)
+	if !ok {
+		return "", nil
+	}
+	return tag, nil
+}
+
+// latestSemverTag returns the highest semver tag in the local workspace repo.
+//
+// Unlike the old helper this does not fall back to the upstream Dagger repo. If
+// the workspace repo is unavailable, callers must choose their own fallback
+// policy explicitly.
+func (git workspaceGit) latestSemverTag(ctx context.Context, includePrerelease bool) (string, error) {
+	if !git.found() {
+		return "", fmt.Errorf("workspace git repository not available")
+	}
+	return latestSemverTag(ctx, git.repo, includePrerelease)
+}
+
+// tagsAtCommit returns all v-prefixed tags that resolve to the given commit.
+//
+// GitRepository does not currently expose "tags at HEAD", so this scans the tag
+// list and resolves each candidate. The caller is responsible for semver
+// filtering.
+func (git workspaceGit) tagsAtCommit(ctx context.Context, commit string) ([]string, error) {
+	tags, err := tagNames(ctx, git.repo)
+	if err != nil {
+		return nil, err
+	}
+
+	var matched []string
+	for _, tag := range tags {
+		tagCommit, err := git.repo.Tag(tag).Commit(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if tagCommit == commit {
+			matched = append(matched, tag)
+		}
+	}
+	return matched, nil
+}
+
+// latestSemverTag returns the highest semver tag in repo.
+//
+// This helper is deliberately repo-oriented, not workspace-oriented. It is used
+// both by workspaceGit and by the explicit no-local-git fallback, which passes
+// the upstream Dagger repo itself.
+func latestSemverTag(ctx context.Context, repo *dagger.GitRepository, includePrerelease bool) (string, error) {
+	tags, err := tagNames(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	tag, ok := latestSemverTagName(tags, includePrerelease)
+	if !ok {
+		if !includePrerelease {
+			return "", fmt.Errorf("no stable semver git tag found")
+		}
+		return "", fmt.Errorf("no semver git tag found")
+	}
+	return tag, nil
+}
+
+// tagNames returns v-prefixed git tag names without the refs/tags/ prefix.
+//
+// The GitRepository API returns refs, but the version module's semver logic
+// expects normal tag names like v1.2.3.
+func tagNames(ctx context.Context, repo *dagger.GitRepository) ([]string, error) {
+	if repo == nil {
+		return nil, fmt.Errorf("git repository not provided")
+	}
+
+	tags, err := repo.Tags(ctx, dagger.GitRepositoryTagsOpts{
+		Patterns: []string{"refs/tags/v*"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i, tag := range tags {
+		tags[i] = strings.TrimPrefix(tag, "refs/tags/")
+	}
+	return tags, nil
+}
+
+// latestSemverTagName selects the highest semver tag from an already-loaded tag list.
+//
+// The boolean return is false when no tag matches the requested prerelease
+// policy. Tags are trimmed before comparison because historical callers trimmed
+// remote tag output defensively.
+func latestSemverTagName(tags []string, includePrerelease bool) (string, bool) {
+	latest := ""
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if !isSemverTag(tag, includePrerelease) {
+			continue
+		}
+		if latest == "" || semver.Compare(tag, latest) > 0 {
+			latest = tag
+		}
+	}
+	return latest, latest != ""
+}
+
+// isSemverTag reports whether a tag is a valid semver tag for the requested policy.
+//
+// Stable-only callers use this to ignore prerelease tags when computing the next
+// patch release baseline.
+func isSemverTag(tag string, includePrerelease bool) bool {
+	if !semver.IsValid(tag) {
+		return false
+	}
+	return includePrerelease || semver.Prerelease(tag) == ""
+}


### PR DESCRIPTION
## Summary

Refactor the `version/` Dagger module so build-time version strings come from git workspace state instead of an ad-hoc inputs filter and `.changes/.next` bookkeeping.

- **derive dev versions from release tags**: Stop reading `.changes/.next` to predict the next release. Derive the next dev-version baseline from the latest `v*` git tag (with patch bumped) so engine/CLI dev versions are no longer coupled to Changie release-note state. Tagged release commits still resolve to the semver tag at HEAD.
- **remove unused `GitRepository` constructor arg**: Drop the public `git *GitRepository` argument from the constructor — no caller passes it; the module already derives its private `GitRepository` from `gitParent.Directory(\".git\").AsGit()`.
- **add workspace git shim**: Drop the `inputs *Directory` argument and base dirty detection on git (`GitRepository.Uncommitted` + digest of `Uncommitted.AsPatch` with metadata excluded). Introduce a small `workspaceGit` shim that exposes only local workspace state (HEAD, branches, uncommitted, current/latest semver tag), mirroring the shape of a future core `Workspace.git` API so the implementation can be swapped without changing callers. Linked git worktrees are still a limitation (contextual `gitParent` exposes `.git` as a file, not a directory); a Version-level fallback emits a digestless `vX.Y.Z-<timestamp>-dev` from upstream tags in that case.

## Test plan

- [ ] CI green on the three engine-dev / cli-dev / release toolchains that re-export the generated `version` bindings
- [ ] Spot-check `dagger version` from a tagged commit, an untagged clean commit, and a dirty workspace
- [ ] Confirm dev version string still changes when uncommitted files change, and stays stable across unrelated `.changes/.next` edits