### PR TITLE
release: revert idempotency and session-cache release-related functions

### DIFF
--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -33,6 +33,3 @@ builds:
 
 checksum:
   name_template: "checksums.txt"
-
-release:
-  replace_existing_artifacts: true

--- a/core/integration/llmtest/go-programmer/go.mod
+++ b/core/integration/llmtest/go-programmer/go.mod
@@ -1,6 +1,6 @@
 module dagger/go-programmer
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/llmtest/go-programmer/toy-workspace/go.mod
+++ b/core/integration/llmtest/go-programmer/toy-workspace/go.mod
@@ -1,6 +1,6 @@
 module dagger/toy-workspace
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/defaults/foobar/go.mod
+++ b/core/integration/testdata/modules/go/defaults/foobar/go.mod
@@ -1,6 +1,6 @@
 module dagger/foo
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/defaults/go.mod
+++ b/core/integration/testdata/modules/go/defaults/go.mod
@@ -1,6 +1,6 @@
 module dagger/defaults
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/defaults/super-dash-dash/go.mod
+++ b/core/integration/testdata/modules/go/defaults/super-dash-dash/go.mod
@@ -1,6 +1,6 @@
 module dagger/super-dash-dash
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/defaults/superconstructor/go.mod
+++ b/core/integration/testdata/modules/go/defaults/superconstructor/go.mod
@@ -1,6 +1,6 @@
 module dagger/superconstructor
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/ifaces/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/go.mod
@@ -1,6 +1,6 @@
 module dagger/test
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/ifaces/impl/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/impl/go.mod
@@ -1,6 +1,6 @@
 module dagger/main
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/ifaces/test/dep/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/test/dep/go.mod
@@ -1,6 +1,6 @@
 module dagger/dep
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/ifaces/test/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/test/go.mod
@@ -1,6 +1,6 @@
 module dagger/main
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/namespacing/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/namespacing/sub1/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub1/go.mod
@@ -1,6 +1,6 @@
 module sub-1
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/go/namespacing/sub2/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub2/go.mod
@@ -1,6 +1,6 @@
 module sub-2
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/modules/typescript/ifaces/go.mod
+++ b/core/integration/testdata/modules/typescript/ifaces/go.mod
@@ -1,6 +1,6 @@
 module dagger/caller
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/sdks/only-codegen/go.mod
+++ b/core/integration/testdata/sdks/only-codegen/go.mod
@@ -1,6 +1,6 @@
 module dagger/only-codegen
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/sdks/only-runtime/go.mod
+++ b/core/integration/testdata/sdks/only-runtime/go.mod
@@ -1,6 +1,6 @@
 module dagger/only-runtime
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/test-blueprint/hello-with-constructor/go.mod
+++ b/core/integration/testdata/test-blueprint/hello-with-constructor/go.mod
@@ -1,6 +1,6 @@
 module dagger/hello
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/test-blueprint/hello-with-container/go.mod
+++ b/core/integration/testdata/test-blueprint/hello-with-container/go.mod
@@ -1,6 +1,6 @@
 module dagger/hello-with-container
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/test-blueprint/hello-with-objects/go.mod
+++ b/core/integration/testdata/test-blueprint/hello-with-objects/go.mod
@@ -1,6 +1,6 @@
 module dagger/hello-with-objects
 
-go 1.25.2
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/test-blueprint/hello/go.mod
+++ b/core/integration/testdata/test-blueprint/hello/go.mod
@@ -1,6 +1,6 @@
 module dagger/hello
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/core/integration/testdata/test-blueprint/myblueprint-with-dep/go.mod
+++ b/core/integration/testdata/test-blueprint/myblueprint-with-dep/go.mod
@@ -1,6 +1,6 @@
 module dagger/myblueprint-with-dep
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/dagql/idtui/viztest/dep/go.mod
+++ b/dagql/idtui/viztest/dep/go.mod
@@ -1,6 +1,6 @@
 module dagger/dep
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/dagql/idtui/viztest/dep/nested-dep/go.mod
+++ b/dagql/idtui/viztest/dep/nested-dep/go.mod
@@ -1,6 +1,6 @@
 module dagger/nested-dep
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/dagql/idtui/viztest/go.mod
+++ b/dagql/idtui/viztest/go.mod
@@ -1,6 +1,6 @@
 module dagger/viztest
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/alpine/go.mod
+++ b/modules/alpine/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/dev/alpine
 
-go 1.25.0
+go 1.26.1
 
 require (
 	chainguard.dev/apko v0.30.34

--- a/modules/claude/go.mod
+++ b/modules/claude/go.mod
@@ -1,6 +1,6 @@
 module dagger/claude
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/daggerverse/go.mod
+++ b/modules/daggerverse/go.mod
@@ -1,6 +1,6 @@
 module dagger/daggerverse
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/dev/go.mod
+++ b/modules/dev/go.mod
@@ -1,6 +1,6 @@
 module dagger/dev
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/doug/evals/go.mod
+++ b/modules/doug/evals/go.mod
@@ -1,6 +1,6 @@
 module dagger/evals
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/doug/go.mod
+++ b/modules/doug/go.mod
@@ -1,6 +1,6 @@
 module dagger/doug
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evals/facts-workspace/go.mod
+++ b/modules/evals/facts-workspace/go.mod
@@ -1,6 +1,6 @@
 module dagger/facts-workspace
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evals/go.mod
+++ b/modules/evals/go.mod
@@ -1,6 +1,6 @@
 module dagger/evals
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evals/testdata/nested-context-middle/go.mod
+++ b/modules/evals/testdata/nested-context-middle/go.mod
@@ -1,6 +1,6 @@
 module dagger/nested-context-middle
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evals/testdata/nested-context-middle/nested-context-leaf/go.mod
+++ b/modules/evals/testdata/nested-context-middle/nested-context-leaf/go.mod
@@ -1,6 +1,6 @@
 module dagger/nested-context-leaf
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evaluator/eval-workspace/go.mod
+++ b/modules/evaluator/eval-workspace/go.mod
@@ -1,6 +1,6 @@
 module dagger/workspace
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evaluator/examples/go/go.mod
+++ b/modules/evaluator/examples/go/go.mod
@@ -1,6 +1,6 @@
 module dagger/examples
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/evaluator/go.mod
+++ b/modules/evaluator/go.mod
@@ -1,6 +1,6 @@
 module dagger/botsbuildingbots
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/gha/examples/go/go.mod
+++ b/modules/gha/examples/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/gha/examples/go
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/gha/go.mod
+++ b/modules/gha/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/gha
 
-go 1.25.0
+go 1.26.1
 
 require (
 	dario.cat/mergo v1.0.1

--- a/modules/git-releaser/go.mod
+++ b/modules/git-releaser/go.mod
@@ -1,6 +1,6 @@
 module dagger/git-releaser
 
-go 1.25.3
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/git-releaser/main.go
+++ b/modules/git-releaser/main.go
@@ -134,26 +134,6 @@ func (gitrel *GitReleaser) Release(
 		WithDirectory(".", sourceRepo.Ref(sourceTag).Tree(dagger.GitRefTreeOpts{Depth: -1})).
 		WithExec(filterRepoArgs)
 	if !dryRun {
-		localCommit, err := result.
-			WithExec([]string{"git", "rev-parse", sourceTag + "^{}"}).
-			Stdout(ctx)
-		if err != nil {
-			return err
-		}
-		localCommit = strings.TrimSpace(localCommit)
-
-		remoteCommit, exists, err := gitrel.remoteRefCommit(ctx, result, destRemote, destTag)
-		if err != nil {
-			return err
-		}
-		if exists && remoteCommit == localCommit {
-			fmt.Printf("found existing git ref %s at %s; skipping push to %s\n", destTag, remoteCommit, destRemote)
-			return nil
-		}
-		if exists && destTag != "main" {
-			return fmt.Errorf("remote git ref %s already exists at %s, expected %s", destTag, remoteCommit, localCommit)
-		}
-
 		result = result.WithExec([]string{
 			"git",
 			"push",
@@ -199,39 +179,4 @@ func (gitrel *GitReleaser) Release(
 
 	_, err := result.Sync(ctx)
 	return err
-}
-
-func (gitrel *GitReleaser) remoteRefCommit(
-	ctx context.Context,
-	ctr *dagger.Container,
-	remote string,
-	ref string,
-) (string, bool, error) {
-	fetch := ctr.WithExec(
-		[]string{"git", "fetch", "--no-tags", remote, ref},
-		dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeAny},
-	)
-
-	code, err := fetch.ExitCode(ctx)
-	if err != nil {
-		return "", false, err
-	}
-	if code != 0 {
-		stderr, err := fetch.Stderr(ctx)
-		if err != nil {
-			return "", false, err
-		}
-		if strings.Contains(stderr, "couldn't find remote ref") {
-			return "", false, nil
-		}
-		return "", false, fmt.Errorf("failed to fetch remote ref %s from %s: %s", ref, remote, strings.TrimSpace(stderr))
-	}
-
-	commit, err := fetch.
-		WithExec([]string{"git", "rev-parse", "FETCH_HEAD^{}"}).
-		Stdout(ctx)
-	if err != nil {
-		return "", false, err
-	}
-	return strings.TrimSpace(commit), true, nil
 }

--- a/modules/metrics/go.mod
+++ b/modules/metrics/go.mod
@@ -1,6 +1,6 @@
 module dagger/metrics
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/ruff/go.mod
+++ b/modules/ruff/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/ruff
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/modules/wolfi/go.mod
+++ b/modules/wolfi/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/modules/wolfi
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/sdk/elixir/runtime/go.mod
+++ b/sdk/elixir/runtime/go.mod
@@ -1,6 +1,6 @@
 module elixir-sdk
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/sdk/java/runtime/go.mod
+++ b/sdk/java/runtime/go.mod
@@ -1,6 +1,6 @@
 module java-sdk
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/sdk/php/runtime/go.mod
+++ b/sdk/php/runtime/go.mod
@@ -1,6 +1,6 @@
 module php-sdk
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 

--- a/sdk/python/runtime/go.mod
+++ b/sdk/python/runtime/go.mod
@@ -1,6 +1,6 @@
 module python-sdk
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/dagger/otel-go v1.41.0

--- a/sdk/typescript/runtime/go.mod
+++ b/sdk/typescript/runtime/go.mod
@@ -1,6 +1,6 @@
 module typescript-sdk
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/dagger/otel-go v1.41.0

--- a/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PythonSdkDev
-func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	q := r.query.Select("asPythonSdkDev")
 
 	return &PythonSDKDev{
@@ -61,7 +61,7 @@ func (r *Env) WithPythonSDKDevDocsOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type PythonSdkDev in the environment
-func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPythonSdkDevInput")
 	q = q.Arg("name", name)
@@ -74,7 +74,7 @@ func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, descriptio
 }
 
 // Declare a desired PythonSdkDev output to be assigned in the environment
-func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	q := r.query.Select("withPythonSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -109,7 +109,7 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 }
 
 // A toolchain to develop the Dagger Python SDK
-type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	query *querybuilder.Selection
 
 	id            *ID
@@ -140,11 +140,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:313:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:283:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:280:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +159,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:298:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:268:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +169,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:175:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -178,7 +178,7 @@ func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../
 }
 
 // Python container to develop Python SDK
-func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
+func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:17:2)
 	q := r.query.Select("devContainer")
 
 	return &Container{
@@ -187,7 +187,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:351:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:321:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +200,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:104:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:101:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -272,11 +272,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:92:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:89:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +292,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:81:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:75:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +315,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:363:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:333:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:357:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +341,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:330:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:300:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:322:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:292:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +370,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:134:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +379,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:142:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +388,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:150:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +397,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:158:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +406,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:166:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,15 +416,15 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:240:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:243:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:242:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:245:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:233:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:232:1)
 	if r.release != nil {
 		return nil
 	}
@@ -449,7 +449,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:221:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -458,7 +458,7 @@ func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-
 	return q.Execute(ctx)
 }
 
-func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:20:2)
+func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
 	if r.sourcePath != nil {
 		return *r.sourcePath, nil
 	}
@@ -471,7 +471,7 @@ func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // pyth
 }
 
 // Supported Python versions
-func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:22:2)
+func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:21:2)
 	q := r.query.Select("supportedVersions")
 
 	var response []string
@@ -487,11 +487,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:345:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:340:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -509,7 +509,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:116:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -519,7 +519,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:125:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -529,7 +529,7 @@ func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // pytho
 	}
 }
 
-func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
+func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
 	q := r.query.Select("workspace")
 
 	return &Directory{
@@ -756,14 +756,14 @@ type PythonSDKDevOpts struct {
 	//
 	// A workspace containing the SDK source code and other relevant files
 	//
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:46:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:45:2)
 
 	// Default: "sdk/python"
-	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:49:2)
+	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
-func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:25:1)
+func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:24:1)
 	q := r.query.Select("pythonSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument

--- a/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type RustSdkDev
-func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	q := r.query.Select("asRustSdkDev")
 
 	return &RustSDKDev{
@@ -19,7 +19,7 @@ func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../tool
 }
 
 // Create or update a binding of type RustSdkDev in the environment
-func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withRustSdkDevInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description st
 }
 
 // Declare a desired RustSdkDev output to be assigned in the environment
-func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	q := r.query.Select("withRustSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,17 +47,17 @@ type RustSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:41:2)
+	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:40:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/rust"
-	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:44:2)
+	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:43:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
-func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:39:1)
+func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:38:1)
 	q := r.query.Select("rustSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -76,7 +76,7 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 }
 
 // Develop the Dagger Rust SDK (experimental)
-type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	query *querybuilder.Selection
 
 	cargoCheck    *Void
@@ -102,7 +102,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:151:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:150:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -110,7 +110,7 @@ func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolc
 	}
 }
 
-func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:36:2)
+func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:35:2)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -119,7 +119,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:305:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:277:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +129,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:130:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:129:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +139,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:119:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +148,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:155:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:154:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +162,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:74:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:73:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:70:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:69:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -231,7 +231,7 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:247:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:246:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -250,11 +250,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:184:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:183:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:179:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:178:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -270,7 +270,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:114:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:113:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -279,7 +279,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:140:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:139:1)
 	if r.test != nil {
 		return nil
 	}
@@ -288,7 +288,7 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:159:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:158:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{

--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	GitParent *Directory // version (../../../../version/main.go:25:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
+	Inputs *Directory // version (../../../../version/main.go:35:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	NextVersionFile *File // version (../../../../version/main.go:40:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:58:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/cli-dev/publish.go
+++ b/toolchains/cli-dev/publish.go
@@ -170,7 +170,6 @@ func (cli *CliDev) PublishMetadata(
 			Stdin: strings.TrimPrefix(version, "v"),
 		}
 		if semver.Prerelease(version) == "" {
-			// update version pointers
 			ctr = ctr.
 				WithExec([]string{"aws", "s3", "cp", "-", s3Path(awsBucket, "dagger/latest_version")}, cpOpts).
 				WithExec([]string{"aws", "s3", "cp", "-", s3Path(awsBucket, "dagger/versions/latest")}, cpOpts).

--- a/toolchains/docs-dev/docusaurus/dagger/go.mod
+++ b/toolchains/docs-dev/docusaurus/dagger/go.mod
@@ -1,6 +1,6 @@
 module dagger/docusaurus
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/docs-dev/docusaurus/tests/go.mod
+++ b/toolchains/docs-dev/docusaurus/tests/go.mod
@@ -1,6 +1,6 @@
 module dagger/tests
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/docs-dev/go.mod
+++ b/toolchains/docs-dev/go.mod
@@ -1,6 +1,6 @@
 module dagger/docs
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/docs-dev/internal/dagger/dagger-cli.gen.go
+++ b/toolchains/docs-dev/internal/dagger/dagger-cli.gen.go
@@ -235,7 +235,7 @@ func (r *DaggerCli) Reference(opts ...DaggerCliReferenceOpts) *File { // dagger-
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:201:1)
+func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:200:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -18,7 +18,9 @@ type ElixirSdkDev {
 
   pub devContainer: Container! {
     daggerEngine
-      .installClient(withBase(source))
+      .installClient(
+        withBase(source),
+      )
   }
 
   """
@@ -124,32 +126,26 @@ type ElixirSdkDev {
     let version = versionFromTag(tag)
     let ctr = devContainer
 
-    if (dryRun == false and isSemver(version) and hexVersionExists(
-      version.trimPrefix("v"),
-    )) {
-      print("found existing Elixir SDK package dagger " + version.trimPrefix("v") + "; skipping publish")
-    } else {
-      # Update version in mix.exs if this is a valid semver
-      if (isSemver(version)) {
-        let mixFile = "/sdk/elixir/mix.exs"
-        let mixExs = workspace.file(sourcePath + "/mix.exs")
-        let newMixExs = mixExs.withReplaced(
-          "@version \"0.0.0\"",
-          "@version \"" + version.trimPrefix("v") + "\"",
-        )
-        ctr = ctr.withFile(mixFile, newMixExs)
-      }
-
-      # Publish or dry-run
-      let mix = ["mix", "hex.publish", "--yes"]
-      if (dryRun) {
-        mix += ["--dry-run"]
-        ctr = ctr.withEnvVariable("HEX_API_KEY", "")
-      } else if (hexApiKey != null) {
-        ctr = ctr.withSecretVariable("HEX_API_KEY", hexApiKey)
-      }
-      ctr.withExec(mix).sync
+    # Update version in mix.exs if this is a valid semver
+    if (isSemver(version)) {
+      let mixFile = "/sdk/elixir/mix.exs"
+      let mixExs = workspace.file(sourcePath + "/mix.exs")
+      let newMixExs = mixExs.withReplaced(
+        "@version \"0.0.0\"",
+        "@version \"" + version.trimPrefix("v") + "\"",
+      )
+      ctr = ctr.withFile(mixFile, newMixExs)
     }
+
+    # Publish or dry-run
+    let mix = ["mix", "hex.publish", "--yes"]
+    if (dryRun) {
+      mix += ["--dry-run"]
+      ctr = ctr.withEnvVariable("HEX_API_KEY", "")
+    } else if (hexApiKey != null) {
+      ctr = ctr.withSecretVariable("HEX_API_KEY", hexApiKey)
+    }
+    ctr.withExec(mix).sync
     null
   }
 
@@ -210,15 +206,6 @@ type ElixirSdkDev {
       .from("alpine:3")
       .withFile("/bin/is-semver", binary)
       .withExec(["is-semver", version], expect: ReturnType.ANY)
-      .exitCode
-    exitCode == 0
-  }
-
-  let hexVersionExists(version: String!): Boolean! {
-    let exitCode = container
-      .from(baseImage)
-      .withExec(["mix", "local.hex", "--force"])
-      .withExec(["mix", "hex.info", "dagger", version], expect: ReturnType.ANY)
       .exitCode
     exitCode == 0
   }

--- a/toolchains/engine-dev/internal/dagger/dagger-cli.gen.go
+++ b/toolchains/engine-dev/internal/dagger/dagger-cli.gen.go
@@ -235,7 +235,7 @@ func (r *DaggerCli) Reference(opts ...DaggerCliReferenceOpts) *File { // dagger-
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:201:1)
+func (r *DaggerCli) ReleaseDryRun(ctx context.Context) error { // dagger-cli (../../../../toolchains/cli-dev/publish.go:200:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	GitParent *Directory // version (../../../../version/main.go:25:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
+	Inputs *Directory // version (../../../../version/main.go:35:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	NextVersionFile *File // version (../../../../version/main.go:40:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:58:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/notify/go.mod
+++ b/toolchains/engine-dev/notify/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/php-sdk-dev/go.mod
+++ b/toolchains/php-sdk-dev/go.mod
@@ -1,6 +1,6 @@
 module dagger/php-sdk-dev
 
-go 1.25.2
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/python-sdk-dev/dockerd/go.mod
+++ b/toolchains/python-sdk-dev/dockerd/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/python-sdk-dev/go.mod
+++ b/toolchains/python-sdk-dev/go.mod
@@ -1,6 +1,6 @@
 module dagger/python-sdk-dev
 
-go 1.25.2
+go 1.26.1
 
 replace github.com/dagger/dagger => ../..
 

--- a/toolchains/python-sdk-dev/main.go
+++ b/toolchains/python-sdk-dev/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"net/http"
 	"runtime"
 	"strings"
 
@@ -252,20 +251,8 @@ func (t PythonSdkDev) Release(
 		ctr = t.Build("0.0.0") // no default arg in Go, without self call just replicate the default value
 	} else {
 		var url string
-		var indexURL string
 		if pypiRepo == "test" {
 			url = "https://test.pypi.org/legacy/"
-			indexURL = fmt.Sprintf("https://test.pypi.org/pypi/dagger-io/%s/json", strings.TrimPrefix(version, "v"))
-		} else {
-			indexURL = fmt.Sprintf("https://pypi.org/pypi/dagger-io/%s/json", strings.TrimPrefix(version, "v"))
-		}
-		exists, err := packageVersionExists(indexURL)
-		if err != nil {
-			return err
-		}
-		if exists {
-			fmt.Printf("found existing Python SDK package dagger-io %s; skipping publish\n", strings.TrimPrefix(version, "v"))
-			return nil
 		}
 		ctr = t.Publish(pypiToken, strings.TrimPrefix(version, "v"), url)
 	}
@@ -275,23 +262,6 @@ func (t PythonSdkDev) Release(
 	}
 
 	return nil
-}
-
-func packageVersionExists(url string) (bool, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return true, nil
-	case http.StatusNotFound:
-		return false, nil
-	default:
-		return false, fmt.Errorf("unexpected package lookup status %s from %s", resp.Status, url)
-	}
 }
 
 // Bump the Python SDK's Engine dependency

--- a/toolchains/release/apko/go.mod
+++ b/toolchains/release/apko/go.mod
@@ -1,6 +1,6 @@
 module dagger/apko
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 

--- a/toolchains/release/apko/tests/go.mod
+++ b/toolchains/release/apko/tests/go.mod
@@ -1,6 +1,6 @@
 module dagger/apko/tests
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/dagger/otel-go v1.41.0

--- a/toolchains/release/gh/go.mod
+++ b/toolchains/release/gh/go.mod
@@ -1,6 +1,6 @@
 module dagger/gh
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 

--- a/toolchains/release/gh/tests/go.mod
+++ b/toolchains/release/gh/tests/go.mod
@@ -1,6 +1,6 @@
 module dagger/gh/tests
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/dagger/otel-go v1.41.0

--- a/toolchains/release/internal/dagger/cli-dev.gen.go
+++ b/toolchains/release/internal/dagger/cli-dev.gen.go
@@ -235,7 +235,7 @@ func (r *CliDev) Reference(opts ...CliDevReferenceOpts) *File { // cli-dev (../.
 }
 
 // Verify that the CLI builds without actually publishing anything
-func (r *CliDev) ReleaseDryRun(ctx context.Context) error { // cli-dev (../../../../toolchains/cli-dev/publish.go:201:1)
+func (r *CliDev) ReleaseDryRun(ctx context.Context) error { // cli-dev (../../../../toolchains/cli-dev/publish.go:200:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}

--- a/toolchains/release/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/python-sdk-dev.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type PythonSdkDev
-func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Binding) AsPythonSDKDev() *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	q := r.query.Select("asPythonSdkDev")
 
 	return &PythonSDKDev{
@@ -61,7 +61,7 @@ func (r *Env) WithPythonSDKDevDocsOutput(name string, description string) *Env {
 }
 
 // Create or update a binding of type PythonSdkDev in the environment
-func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withPythonSdkDevInput")
 	q = q.Arg("name", name)
@@ -74,7 +74,7 @@ func (r *Env) WithPythonSDKDevInput(name string, value *PythonSDKDev, descriptio
 }
 
 // Declare a desired PythonSdkDev output to be assigned in the environment
-func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+func (r *Env) WithPythonSDKDevOutput(name string, description string) *Env { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	q := r.query.Select("withPythonSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -109,7 +109,7 @@ func (r *Env) WithPythonSDKDevTestForPythonVersionOutput(name string, descriptio
 }
 
 // A toolchain to develop the Dagger Python SDK
-type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:16:6)
+type PythonSDKDev struct { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:15:6)
 	query *querybuilder.Selection
 
 	id            *ID
@@ -140,11 +140,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:313:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:283:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:280:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +159,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:298:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:268:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +169,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:175:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -178,7 +178,7 @@ func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../
 }
 
 // Python container to develop Python SDK
-func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
+func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:17:2)
 	q := r.query.Select("devContainer")
 
 	return &Container{
@@ -187,7 +187,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:351:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:321:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +200,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:104:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:101:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -272,11 +272,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:92:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:89:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +292,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:81:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:75:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +315,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:363:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:333:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:357:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +341,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:327:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:330:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:300:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:322:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:292:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +370,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:134:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +379,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:142:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +388,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:150:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +397,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:158:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +406,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:166:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,15 +416,15 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:240:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:243:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:242:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:245:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:233:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:232:1)
 	if r.release != nil {
 		return nil
 	}
@@ -449,7 +449,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:221:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -458,7 +458,7 @@ func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-
 	return q.Execute(ctx)
 }
 
-func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:20:2)
+func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
 	if r.sourcePath != nil {
 		return *r.sourcePath, nil
 	}
@@ -471,7 +471,7 @@ func (r *PythonSDKDev) SourcePath(ctx context.Context) (string, error) { // pyth
 }
 
 // Supported Python versions
-func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:22:2)
+func (r *PythonSDKDev) SupportedVersions(ctx context.Context) ([]string, error) { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:21:2)
 	q := r.query.Select("supportedVersions")
 
 	var response []string
@@ -487,11 +487,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:345:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:340:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -509,7 +509,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:116:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -519,7 +519,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:125:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -529,7 +529,7 @@ func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // pytho
 	}
 }
 
-func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:19:2)
+func (r *PythonSDKDev) Workspace() *Directory { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:18:2)
 	q := r.query.Select("workspace")
 
 	return &Directory{
@@ -756,14 +756,14 @@ type PythonSDKDevOpts struct {
 	//
 	// A workspace containing the SDK source code and other relevant files
 	//
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:46:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:45:2)
 
 	// Default: "sdk/python"
-	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:49:2)
+	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
-func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:25:1)
+func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:24:1)
 	q := r.query.Select("pythonSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument

--- a/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type RustSdkDev
-func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	q := r.query.Select("asRustSdkDev")
 
 	return &RustSDKDev{
@@ -19,7 +19,7 @@ func (r *Binding) AsRustSDKDev() *RustSDKDev { // rust-sdk-dev (../../../../tool
 }
 
 // Create or update a binding of type RustSdkDev in the environment
-func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withRustSdkDevInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithRustSDKDevInput(name string, value *RustSDKDev, description st
 }
 
 // Declare a desired RustSdkDev output to be assigned in the environment
-func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+func (r *Env) WithRustSDKDevOutput(name string, description string) *Env { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	q := r.query.Select("withRustSdkDevOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,17 +47,17 @@ type RustSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:41:2)
+	Workspace *Workspace // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:40:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/rust"
-	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:44:2)
+	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:43:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
-func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:39:1)
+func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:38:1)
 	q := r.query.Select("rustSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -76,7 +76,7 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 }
 
 // Develop the Dagger Rust SDK (experimental)
-type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:32:6)
+type RustSDKDev struct { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:31:6)
 	query *querybuilder.Selection
 
 	cargoCheck    *Void
@@ -102,7 +102,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:151:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:150:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -110,7 +110,7 @@ func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolc
 	}
 }
 
-func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:36:2)
+func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:35:2)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -119,7 +119,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:305:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:277:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +129,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:130:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:129:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +139,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:119:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +148,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:155:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:154:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +162,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:74:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:73:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:70:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:69:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -231,7 +231,7 @@ func (r *RustSDKDev) UnmarshalJSON(bs []byte) error {
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:247:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:246:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -250,11 +250,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:184:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:183:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:179:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:178:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -270,7 +270,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:114:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:113:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -279,7 +279,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:140:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:139:1)
 	if r.test != nil {
 		return nil
 	}
@@ -288,7 +288,7 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:159:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:158:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:24:2)
+	GitParent *Directory // version (../../../../version/main.go:25:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:34:2)
+	Inputs *Directory // version (../../../../version/main.go:35:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:39:2)
+	NextVersionFile *File // version (../../../../version/main.go:40:2)
 }
 
 // Shared logic for managing Dagger versions
 //
 // In general, it attempts to follow go's psedudoversioning:
 // https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:57:6)
+type Version struct { // version (../../../../version/main.go:58:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:200:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:179:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:153:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:268:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:70:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/main.go
+++ b/toolchains/release/main.go
@@ -136,8 +136,6 @@ func (r *Release) Publish( //nolint:gocyclo
 	if semver.IsValid(tag) {
 		version = tag
 	}
-	isStableRelease := semver.IsValid(version) && semver.Prerelease(version) == ""
-	isPrerelease := semver.IsValid(version) && semver.Prerelease(version) != ""
 
 	report := ReleaseReport{
 		Date:    time.Now().UTC().Format(time.RFC822),
@@ -153,7 +151,7 @@ func (r *Release) Publish( //nolint:gocyclo
 	}
 
 	tags := []string{tag, commit}
-	if isStableRelease {
+	if semver.IsValid(version) && semver.Prerelease(version) == "" {
 		// this is a public release
 		tags = append(tags, "latest")
 	}
@@ -173,7 +171,7 @@ func (r *Release) Publish( //nolint:gocyclo
 		Tag:  tag,
 	}
 	if !dryRun {
-		_, err = dag.CliDev().
+		_, err := dag.CliDev().
 			Publish(tag, goreleaserKey, githubOrgName, dagger.CliDevPublishOpts{
 				GithubToken:        githubToken,
 				AwsAccessKeyID:     awsAccessKeyID,
@@ -202,6 +200,7 @@ func (r *Release) Publish( //nolint:gocyclo
 		return &report, nil
 	}
 
+	isPrerelease := semver.IsValid(version) && semver.Prerelease(version) != ""
 	if isPrerelease {
 		// early-exit if this is a pre-release
 		return &report, nil

--- a/toolchains/release/registry-config/go.mod
+++ b/toolchains/release/registry-config/go.mod
@@ -1,6 +1,6 @@
 module dagger/registry-config
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 

--- a/toolchains/release/registry-config/tests/go.mod
+++ b/toolchains/release/registry-config/tests/go.mod
@@ -1,6 +1,6 @@
 module dagger/registry-config/tests
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/dagger/otel-go v1.41.0

--- a/toolchains/release/util.go
+++ b/toolchains/release/util.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -56,15 +55,6 @@ func (r Release) githubRelease(
 		return nil
 	}
 
-	exists, err := r.githubReleaseExists(ctx, repository, dest, src, token)
-	if err != nil {
-		return err
-	}
-	if exists {
-		fmt.Printf("found existing GitHub release %s; skipping\n", dest)
-		return nil
-	}
-
 	gh := dag.Gh(dagger.GhOpts{
 		Repo:  githubRepo,
 		Token: token,
@@ -79,90 +69,6 @@ func (r Release) githubRelease(
 			Latest:    dagger.GhLatestFalse,
 		},
 	)
-}
-
-func (r Release) githubReleaseExists(
-	ctx context.Context,
-	repository string,
-	tag string,
-	expectedCommit string,
-	token *dagger.Secret,
-) (bool, error) {
-	githubRepo, err := githubRepo(repository)
-	if err != nil {
-		return false, err
-	}
-
-	gh := dag.Gh(dagger.GhOpts{
-		Repo:  githubRepo,
-		Token: token,
-	})
-	releaseExists := true
-	if _, err = gh.Exec([]string{"release", "view", tag, "--json", "tagName"}).Sync(ctx); err != nil {
-		if !isGitHubNotFound(err) {
-			return false, err
-		}
-		releaseExists = false
-	}
-
-	if err := r.verifyGitHubReleaseTag(ctx, githubRepo, tag, expectedCommit, token); err != nil {
-		return false, err
-	}
-	return releaseExists, nil
-}
-
-func (r Release) verifyGitHubReleaseTag(
-	ctx context.Context,
-	githubRepo string,
-	tag string,
-	expectedCommit string,
-	token *dagger.Secret,
-) error {
-	gh := dag.Gh(dagger.GhOpts{
-		Repo:  githubRepo,
-		Token: token,
-	})
-
-	out, err := gh.Exec([]string{
-		"api",
-		fmt.Sprintf("repos/%s/git/ref/tags/%s", githubRepo, tag),
-		"--jq",
-		`.object.type + " " + .object.sha`,
-	}).Stdout(ctx)
-	if err != nil {
-		if isGitHubNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	fields := strings.Fields(out)
-	if len(fields) != 2 {
-		return fmt.Errorf("unexpected GitHub tag response for %s: %q", tag, strings.TrimSpace(out))
-	}
-
-	kind, sha := fields[0], fields[1]
-	if kind != "commit" {
-		return fmt.Errorf("GitHub tag %s points to a %s object %s, expected commit %s", tag, kind, sha, expectedCommit)
-	}
-
-	if sha != expectedCommit {
-		return fmt.Errorf("GitHub tag %s resolves to %s; expected %s", tag, sha, expectedCommit)
-	}
-
-	return nil
-}
-
-func isGitHubNotFound(err error) bool {
-	var execErr *dagger.ExecError
-	if errors.As(err, &execErr) {
-		stderr := strings.ToLower(execErr.Stderr + "\n" + execErr.Stdout)
-		if strings.Contains(stderr, "release not found") || strings.Contains(stderr, "not found") {
-			return true
-		}
-	}
-
-	return false
 }
 
 func githubRepo(repo string) (string, error) {

--- a/toolchains/rust-sdk-dev/go.mod
+++ b/toolchains/rust-sdk-dev/go.mod
@@ -1,6 +1,6 @@
 module dagger/rust-sdk-dev
 
-go 1.25.3
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/toolchains/rust-sdk-dev/main.go
+++ b/toolchains/rust-sdk-dev/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 
@@ -258,39 +257,12 @@ func (t *RustSdkDev) Release(
 		return fmt.Errorf("invalid version %q", version)
 	}
 
-	exists, err := crateVersionExists(rustSdkCrate, versionFlag)
-	if err != nil {
-		return err
-	}
-	if exists {
-		fmt.Printf("found existing Rust SDK crate %s %s; skipping publish\n", rustSdkCrate, versionFlag)
-		return nil
-	}
-
 	_, err = t.releaseContainer(versionFlag).
 		WithSecretVariable("CARGO_REGISTRY_TOKEN", cargoRegistryToken).
 		WithExec([]string{"cargo", "publish", "-p", rustSdkCrate, "-v", "--all-features"}).
 		Sync(ctx)
 
 	return err
-}
-
-func crateVersionExists(crate string, version string) (bool, error) {
-	url := fmt.Sprintf("https://crates.io/api/v1/crates/%s/%s", crate, version)
-	resp, err := http.Get(url)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return true, nil
-	case http.StatusNotFound:
-		return false, nil
-	default:
-		return false, fmt.Errorf("unexpected crate lookup status %s from %s", resp.Status, url)
-	}
 }
 
 func (t *RustSdkDev) releaseContainer(

--- a/toolchains/typescript-sdk-dev/ts-sdk.dang
+++ b/toolchains/typescript-sdk-dev/ts-sdk.dang
@@ -153,40 +153,29 @@ type TypescriptSdkDev {
     } else {
       "prepatch"
     }
-    if (dryRun == false and isSemver(version) and npmVersionExists(versionFlag)) {
-      print("found existing TypeScript SDK package @dagger.io/dagger " + versionFlag + "; skipping publish")
-    } else {
-      let build = nodejsDevContainer
-        .withWorkdir(sourcePath)
-        .withExec(["npm", "run", "build"])
-        .withExec(["npm", "version", versionFlag])
-      # Check that dist/ exists in the build
-      build.directory("dist").entries
-      let publishArgs = ["npm", "publish", "--access", "public"]
-      if (dryRun == true) {
-        publishArgs += ["--dry-run"]
-        # TODO(vito): in dang, if exprs have to have same return type on all
-        # branches, which gets awkward here
-        null
-      } else if (npmToken != null) {
-        let npmrc = [
-          "//registry.npmjs.org/:_authToken=" + npmToken.plaintext,
-          "registry=https://registry.npmjs.org/",
-          "always-auth=true",
-        ].join("\n")
-        build = build.withMountedSecret(".npmrc", setSecret("npmrc", npmrc))
-        null
-      }
-      build.withExec(publishArgs).sync
+    let build = nodejsDevContainer
+      .withWorkdir(sourcePath)
+      .withExec(["npm", "run", "build"])
+      .withExec(["npm", "version", versionFlag])
+    # Check that dist/ exists in the build
+    build.directory("dist").entries
+    let publishArgs = ["npm", "publish", "--access", "public"]
+    if (dryRun == true) {
+      publishArgs += ["--dry-run"]
+      # TODO(vito): in dang, if exprs have to have same return type on all
+      # branches, which gets awkward here
+      null
+    } else if (npmToken != null) {
+      let npmrc = [
+        "//registry.npmjs.org/:_authToken=" + npmToken.plaintext,
+        "registry=https://registry.npmjs.org/",
+        "always-auth=true",
+      ].join("\n")
+      build = build.withMountedSecret(".npmrc", setSecret("npmrc", npmrc))
+      null
     }
+    build.withExec(publishArgs).sync
     null
-  }
-
-  let npmVersionExists(version: String!): Boolean! {
-    let exitCode = nodejsBase
-      .withExec(["npm", "view", "@dagger.io/dagger@" + version, "version"], expect: ReturnType.ANY)
-      .exitCode
-    exitCode == 0
   }
 
   pub isSemver(version: String!): Boolean! {

--- a/version/go.mod
+++ b/version/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/version
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/version/main.go
+++ b/version/main.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+// +cache="session"
 func New(
 	ctx context.Context,
 
@@ -67,6 +68,7 @@ type Version struct {
 }
 
 // Generate a version string from the current context
+// +cache="session"
 func (v Version) Version(ctx context.Context) (string, error) {
 	if v.Git == nil {
 		return v.fallbackVersion(ctx)
@@ -150,6 +152,7 @@ func (v Version) fallbackVersion(ctx context.Context) (string, error) {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
+// +cache="session"
 func (v Version) ImageTag(ctx context.Context) (string, error) {
 	if v.Git == nil {
 		return v.fallbackVersion(ctx)
@@ -197,6 +200,7 @@ func (v Version) Dirty(ctx context.Context) (bool, error) {
 	return !isEmpty, nil
 }
 
+// +cache="session"
 func (v Version) CurrentTag(ctx context.Context) (string, error) {
 	if v.Git == nil {
 		return "", nil
@@ -226,6 +230,8 @@ func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, err
 		WithWorkdir("/src").
 		WithMountedDirectory(".git", v.GitDir).
 		WithExec([]string{"git", "config", "url.https://github.com/.insteadOf", "git@github.com:"}).
+		// Remote tags are mutable, so avoid reusing a stale pre-tag fetch layer.
+		WithEnvVariable("DAGGER_VERSION_CACHE_BUSTER", time.Now().UTC().Format(time.RFC3339Nano)).
 		WithExec([]string{"git", "fetch", "--tags"}).
 		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
 		Stdout(ctx)


### PR DESCRIPTION
Partially reverts #13254.
Does not revert publish.yml, but reverts everything else.

Some release related functions need to have a session-lived cache. Aggressive cache hits caused v0.21.1 release to advertise itself as a v0.21.2-...-dev release