### PR TITLE
fix: preserve 1Password secret reference scheme

### DIFF
--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -131,6 +131,14 @@ if [ "$1" != "read" ] || [ "$2" != "-n" ]; then
 	exit 1
 fi
 case "$3" in
+	op://*)
+		;;
+	*)
+		echo "unexpected op secret reference: $3" >&2
+		exit 1
+		;;
+esac
+case "$3" in
 	*ttl=*)
 		echo "ttl query leaked to op ref: $3" >&2
 		exit 1

--- a/engine/client/secretprovider/op.go
+++ b/engine/client/secretprovider/op.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
@@ -66,7 +65,7 @@ func parseOpCacheKey(key string) (string, time.Duration, error) {
 		parsed.RawQuery = query.Encode()
 	}
 
-	return strings.TrimPrefix(parsed.String(), "op://"), ttl, nil
+	return parsed.String(), ttl, nil
 }
 
 func opCacheExpired(entry opCacheEntry) bool {


### PR DESCRIPTION
## Summary

Fix the 1Password secret provider cache-key normalization so the resolver still receives a full `op://...` secret reference after stripping the internal `ttl` query parameter.

The regression came from using the normalized cache key as the resolver input after removing the `op://` prefix, which caused the 1Password SDK/CLI to reject refs such as `vault/item/field` on cache misses or uncached plaintext reads.

This also tightens the existing 1Password integration test fake `op` CLI so it rejects non-`op://` references.

Found and debugged by Marcos Nils.

## Validation

- `go test ./engine/client/secretprovider`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestSecretProvider/TestOnePasswordCache'`
- `git diff --check`