### PR TITLE
fix(test): pin git commit in TestDirectoryName git-directory subtest

### DIFF
--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1514,7 +1514,9 @@ func (DirectorySuite) TestDirectoryName(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("git directory", func(ctx context.Context, t *testctx.T) {
-		dir := c.Git("https://github.com/dagger/dagger#ee32df913f57c876e067bd5ecc159561510b6f50").Head().Tree()
+		// Pin the commit explicitly: a git URL fragment is not honored by .Head()
+		// (which tracks the live default branch), and .dagger no longer exists there.
+		dir := c.Git("https://github.com/dagger/dagger").Commit("ee32df913f57c876e067bd5ecc159561510b6f50").Tree()
 
 		t.Run("root directory", func(ctx context.Context, t *testctx.T) {
 			rootName, err := dir.Name(ctx)


### PR DESCRIPTION
## Problem

`TestDirectoryName`'s `git directory` subtest fetched the tree via:

```go
c.Git("https://github.com/dagger/dagger#ee32df913f57c876e067bd5ecc159561510b6f50").Head().Tree()
```

The core `git().head()` API does **not** honor the URL `#fragment` — it resolves to the live default-branch (`main`) HEAD. So this subtest has always run against **live `main`**, not the pinned commit `ee32df91`. It passed only because `main` happened to contain a `.dagger` directory.

After `.dagger` was removed from `main` (#13228), live `main` no longer has it, so the subtest now fails:

```
failed to make directory content hashed: stat .dagger: no such file or directory
```

(`.entries` and `.file` on `.dagger` fail the same way — it's simply absent from live `main`; the content-hashing path is just the first consumer to notice.)

## Fix

Pin the commit explicitly with `.Commit(sha)` (the idiom already used elsewhere in this suite) so the test is deterministic and exercises the intended historical tree regardless of what `main` points to.

## Verification

Against the pinned commit `ee32df91`, all three assertions hold: root `"/"`, `.dagger` → `".dagger/"`, `sdk/go` → `"go/"`.
