### PR TITLE
fix(sdk/typescript): resolve referenced values in decorator arguments

### DIFF
--- a/sdk/typescript/src/module/introspector/test/scan.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/scan.spec.ts
@@ -123,6 +123,10 @@ describe("scan by reference TypeScript", function () {
       name: "Should correctly scan interfaces",
       directory: "interface",
     },
+    {
+      name: "Should correctly scan decorators",
+      directory: "decorators",
+    },
   ]
 
   for (const test of testCases) {

--- a/sdk/typescript/src/module/introspector/test/testdata/decorators/expected.json
+++ b/sdk/typescript/src/module/introspector/test/testdata/decorators/expected.json
@@ -1,0 +1,291 @@
+{
+  "name": "Decorators",
+  "objects": {
+    "Decorators": {
+      "name": "Decorators",
+      "description": "",
+      "methods": {
+        "withDefaultPath": {
+          "name": "withDefaultPath",
+          "description": "",
+          "arguments": {
+            "source": {
+              "name": "source",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": "."
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Directory"
+          }
+        },
+        "withReferencedDefaultPath": {
+          "name": "withReferencedDefaultPath",
+          "description": "",
+          "arguments": {
+            "source": {
+              "name": "source",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": "/src"
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Directory"
+          }
+        },
+        "withFileDefaultPath": {
+          "name": "withFileDefaultPath",
+          "description": "",
+          "arguments": {
+            "file": {
+              "name": "file",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "File"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": "./README.md"
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "File"
+          }
+        },
+        "withInlinedIgnore": {
+          "name": "withInlinedIgnore",
+          "description": "",
+          "arguments": {
+            "source": {
+              "name": "source",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "ignore": [
+                "foo",
+                "bar",
+                "baz"
+              ]
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Directory"
+          }
+        },
+        "withReferencedIgnore": {
+          "name": "withReferencedIgnore",
+          "description": "",
+          "arguments": {
+            "source": {
+              "name": "source",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "ignore": [
+                "foo",
+                "ref",
+                "bar"
+              ]
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Directory"
+          }
+        },
+        "withDefaultPathAndIgnore": {
+          "name": "withDefaultPathAndIgnore",
+          "description": "",
+          "arguments": {
+            "source": {
+              "name": "source",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": ".",
+              "ignore": [
+                "foo",
+                "ref",
+                "bar"
+              ]
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Directory"
+          }
+        },
+        "withDefaultAddress": {
+          "name": "withDefaultAddress",
+          "description": "",
+          "arguments": {
+            "ctr": {
+              "name": "ctr",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Container"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": true,
+              "defaultAddress": "alpine:3.21"
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Container"
+          }
+        },
+        "withReferencedDefaultAddress": {
+          "name": "withReferencedDefaultAddress",
+          "description": "",
+          "arguments": {
+            "ctr": {
+              "name": "ctr",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Container"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": true,
+              "defaultAddress": "alpine:3.21"
+            }
+          },
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Container"
+          }
+        },
+        "stringAlias": {
+          "name": "withStringAlias",
+          "description": "",
+          "alias": "stringAlias",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "objectAlias": {
+          "name": "withObjectAlias",
+          "description": "",
+          "alias": "objectAlias",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "renamedReference": {
+          "name": "withReferencedAlias",
+          "description": "",
+          "alias": "renamedReference",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "withCache": {
+          "name": "withCache",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "cachedAlias": {
+          "name": "withCacheAndAlias",
+          "description": "",
+          "alias": "cachedAlias",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "checkSomething": {
+          "name": "checkSomething",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "VOID_KIND"
+          }
+        },
+        "generateSomething": {
+          "name": "generateSomething",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Changeset"
+          }
+        },
+        "upSomething": {
+          "name": "upSomething",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "OBJECT_KIND",
+            "name": "Service"
+          }
+        }
+      },
+      "properties": {
+        "version": {
+          "name": "version",
+          "description": "A field exposed with the deprecated `@field` decorator.",
+          "type": {
+            "kind": "STRING_KIND"
+          },
+          "isExposed": true
+        },
+        "aliasedField": {
+          "name": "name",
+          "description": "A field exposed with `@func` using a string alias.",
+          "alias": "aliasedField",
+          "type": {
+            "kind": "STRING_KIND"
+          },
+          "isExposed": true
+        }
+      }
+    }
+  },
+  "enums": {},
+  "interfaces": {}
+}

--- a/sdk/typescript/src/module/introspector/test/testdata/decorators/index.ts
+++ b/sdk/typescript/src/module/introspector/test/testdata/decorators/index.ts
@@ -1,0 +1,158 @@
+import {
+  Changeset,
+  Container,
+  Directory,
+  File,
+  Service,
+} from "../../../../../api/client.gen.js"
+import {
+  argument,
+  check,
+  field,
+  func,
+  generate,
+  object,
+  up,
+} from "../../../../decorators.js"
+
+// Module-level constants referenced from decorators. They exercise the decorator
+// evaluator: it must resolve referenced symbols, not only inlined literals.
+const IGNORE = ["foo", "ref", "bar"]
+const DEFAULT_PATH = "/src"
+const DEFAULT_ADDRESS = "alpine:3.21"
+const ALIAS = "renamedReference"
+const CACHE = "session"
+
+@object()
+export class Decorators {
+  /**
+   * A field exposed with the deprecated `@field` decorator.
+   */
+  @field()
+  version: string = "1.0.0"
+
+  /**
+   * A field exposed with `@func` using a string alias.
+   */
+  @func("aliasedField")
+  name: string = "dagger"
+
+  // --- @argument: defaultPath ---
+
+  @func()
+  withDefaultPath(
+    @argument({ defaultPath: "." })
+    source: Directory,
+  ): Directory {
+    return source
+  }
+
+  @func()
+  withReferencedDefaultPath(
+    @argument({ defaultPath: DEFAULT_PATH })
+    source: Directory,
+  ): Directory {
+    return source
+  }
+
+  @func()
+  withFileDefaultPath(
+    @argument({ defaultPath: "./README.md" })
+    file: File,
+  ): File {
+    return file
+  }
+
+  // --- @argument: ignore ---
+
+  @func()
+  withInlinedIgnore(
+    @argument({ ignore: ["foo", "bar", "baz"] })
+    source: Directory,
+  ): Directory {
+    return source
+  }
+
+  @func()
+  withReferencedIgnore(
+    @argument({ ignore: IGNORE })
+    source: Directory,
+  ): Directory {
+    return source
+  }
+
+  // --- @argument: defaultPath and ignore combined (inlined + referenced) ---
+
+  @func()
+  withDefaultPathAndIgnore(
+    @argument({ defaultPath: ".", ignore: IGNORE })
+    source: Directory,
+  ): Directory {
+    return source
+  }
+
+  // --- @argument: defaultAddress (Container) ---
+
+  @func()
+  withDefaultAddress(
+    @argument({ defaultAddress: "alpine:3.21" })
+    ctr: Container,
+  ): Container {
+    return ctr
+  }
+
+  @func()
+  withReferencedDefaultAddress(
+    @argument({ defaultAddress: DEFAULT_ADDRESS })
+    ctr: Container,
+  ): Container {
+    return ctr
+  }
+
+  // --- @func: alias ---
+
+  @func("stringAlias")
+  withStringAlias(): string {
+    return "aliased"
+  }
+
+  @func({ alias: "objectAlias" })
+  withObjectAlias(): string {
+    return "aliased"
+  }
+
+  @func({ alias: ALIAS })
+  withReferencedAlias(): string {
+    return "aliased"
+  }
+
+  // --- @func: cache ---
+
+  @func({ cache: "never" })
+  withCache(): string {
+    return "cached"
+  }
+
+  @func({ alias: "cachedAlias", cache: CACHE })
+  withCacheAndAlias(): string {
+    return "cached"
+  }
+
+  // --- @check / @generate / @up markers (combined with @func) ---
+
+  @func()
+  @check()
+  checkSomething(): void {}
+
+  @func()
+  @generate()
+  generateSomething(): Changeset {
+    throw new Error("not implemented")
+  }
+
+  @func()
+  @up()
+  upSomething(): Service {
+    throw new Error("not implemented")
+  }
+}

--- a/sdk/typescript/src/module/introspector/typescript_module/ast.ts
+++ b/sdk/typescript/src/module/introspector/typescript_module/ast.ts
@@ -312,8 +312,50 @@ export class AST {
       case "string":
         return argument.getText() as T
       case "object":
-        return eval(`(${argument.getText()})`)
+        return this.resolveDecoratorArgumentValue(argument) as T
     }
+  }
+
+  /**
+   * Resolve the value of a decorator argument expression.
+   *
+   * Decorator arguments may reference module-level constants, e.g.
+   * `@argument({ ignore: IGNORE })` or `@func({ alias: NAME })`. We therefore
+   * cannot simply `eval` the raw text: the referenced symbols are not in scope
+   * and the evaluation would throw. Instead we walk the expression and resolve
+   * each value through {@link resolveParameterDefaultValue}, which already knows
+   * how to follow identifiers, imports and enum members back to their literal
+   * values.
+   */
+  private resolveDecoratorArgumentValue(expression: ts.Expression): any {
+    if (ts.isObjectLiteralExpression(expression)) {
+      const result: Record<string, any> = {}
+
+      for (const property of expression.properties) {
+        if (ts.isPropertyAssignment(property)) {
+          result[this.getPropertyName(property.name)] =
+            this.resolveParameterDefaultValue(property.initializer)
+        } else if (ts.isShorthandPropertyAssignment(property)) {
+          // `{ alias }` shorthand, resolve the value from the identifier.
+          result[property.name.getText()] = this.resolveParameterDefaultValue(
+            property.name,
+          )
+        }
+      }
+
+      return result
+    }
+
+    // Non-object arguments, e.g. the string alias form `@func("alias")`.
+    return this.resolveParameterDefaultValue(expression)
+  }
+
+  private getPropertyName(name: ts.PropertyName): string {
+    if (ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+      return name.text
+    }
+
+    return name.getText()
   }
 
   public unwrapTypeStringFromPromise(type: string): string {


### PR DESCRIPTION
**Problem**

Decorator options were evaluated with `eval()` on the decorator's raw source text:

```ts
// ast.ts — getDecoratorArgument
case "object":
  return eval(`(${argument.getText()})`)
```

Because `eval` runs in an empty scope, any decorator option that referenced a module-level constant threw a `ReferenceError`. For example:

```ts
const IGNORE = ["foo", "bar", "baz"]

@func()
build(@argument({ ignore: IGNORE }) src: Directory): Directory { ... }
```

failed introspection, even though inlined literals (`{ ignore: ["foo", "bar"] }`) worked fine. This affected every option resolved as an object — `@argument`'s `defaultPath` / `ignore` / `defaultAddress` and `@func`'s `alias` / `cache`.

**Fix**

Replaced the `eval` with AST-based resolution that reuses the existing `resolveParameterDefaultValue` machinery (already used for parameter defaults), which knows how to follow identifiers, imports, and enum members back to their literal values. A new `resolveDecoratorArgumentValue` walks the object literal (handling `key: value` and shorthand `{ key }`) and resolves each value through that resolver; the string-alias form `@func("alias")` falls through to the same path, preserving backward compatibility.

**Tests**

Added a `decorators` test case covering, with both inlined and referenced values, every decorator pattern the SDK exposes:
- `@argument` → `defaultPath` (Directory/File), `ignore`, `defaultPath`+`ignore`, `defaultAddress` (Container)
- `@func` → string alias, object alias, `cache`, alias+cache
- `@check` / `@generate` / `@up` markers
- `@field` and aliased-`@func` properties

Registered the case in `scan.spec.ts`. Full SDK test suite passes (97 passing) with no regressions.