### PR TITLE
fix(core/dotenv): accept `export`-prefixed lines in .env files

### DIFF
--- a/core/dotenv/dotenv.go
+++ b/core/dotenv/dotenv.go
@@ -56,6 +56,11 @@ func NewGraphEvaluator(environ []string, systemLookup func(string) string, noUns
 
 // parseEntry parses a line into a parsedEntry without expanding variables
 func (g *GraphEvaluator) parseEntry(line string) (*parsedEntry, error) {
+	// Strip an optional leading `export` keyword. This is a widely supported
+	// dotenv convention (direnv, `set -a; . ./.env`, shell `source`, and most
+	// .env loaders), so we treat `export KEY=value` the same as `KEY=value`.
+	line = StripExportPrefix(line)
+
 	// Try fast path first for simple assignments
 	if idx := strings.Index(line, "="); idx != -1 {
 		key := line[:idx]
@@ -245,6 +250,7 @@ func AllRaw(environ []string) map[string]string {
 		if kv == "" {
 			continue // skip empty lines
 		}
+		kv = StripExportPrefix(kv)
 		name, value, _ := strings.Cut(kv, "=")
 		vars[name] = value
 	}
@@ -275,6 +281,7 @@ func Exists(environ []string, name string) bool {
 		if kv == "" {
 			continue // skip empty lines
 		}
+		kv = StripExportPrefix(kv)
 		k, _, _ := strings.Cut(kv, "=")
 		if k == name {
 			return true
@@ -285,6 +292,18 @@ func Exists(environ []string, name string) bool {
 
 // simpleKeyRegexp checks if a key is a valid environment variable name
 var simpleKeyRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// exportPrefixRegexp matches a leading `export` keyword (with trailing
+// whitespace), as commonly used in .env files.
+var exportPrefixRegexp = regexp.MustCompile(`^export\s+`)
+
+// StripExportPrefix removes an optional leading `export` keyword from a dotenv
+// line. This is a widely supported convention (direnv, `set -a; . ./.env`,
+// shell `source`, and most .env loaders), so `export KEY=value` is treated the
+// same as `KEY=value`.
+func StripExportPrefix(line string) string {
+	return exportPrefixRegexp.ReplaceAllString(line, "")
+}
 
 // containsShellFeatures checks if a value contains shell features that require parsing
 func containsShellFeatures(value string) bool {

--- a/core/dotenv/dotenv_test.go
+++ b/core/dotenv/dotenv_test.go
@@ -180,6 +180,53 @@ func TestAllExpansion(t *testing.T) {
 			},
 		},
 		{
+			name: "export prefix",
+			environ: []string{
+				"export FOO=bar",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name: "export prefix with quoted value",
+			environ: []string{
+				`export FOO="bar baz"`,
+			},
+			want: map[string]string{
+				"FOO": "bar baz",
+			},
+		},
+		{
+			name: "export prefix with expansion",
+			environ: []string{
+				"export FOO=bar",
+				"export BAZ=$FOO-baz",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "bar-baz",
+			},
+		},
+		{
+			name: "export prefix with extra whitespace",
+			environ: []string{
+				"export   FOO=bar",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name: "key named export-like is not stripped",
+			environ: []string{
+				"exportable=yes",
+			},
+			want: map[string]string{
+				"exportable": "yes",
+			},
+		},
+		{
 			name: "empty line",
 			environ: []string{
 				"",

--- a/core/envfile.go
+++ b/core/envfile.go
@@ -272,6 +272,9 @@ func (ef *EnvFile) WithContents(contents string) (*EnvFile, error) {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
+		// Tolerate the common `export KEY=value` convention by stripping the
+		// leading `export` keyword before parsing.
+		line = dotenv.StripExportPrefix(strings.TrimSpace(line))
 		kv := strings.SplitN(line, "=", 2)
 		k := kv[0]
 		var v string

--- a/core/integration/envfile_test.go
+++ b/core/integration/envfile_test.go
@@ -566,6 +566,34 @@ func (m *Dep) Bar(
 	require.Equal(t, "doodoo", string(decodeOutput), string(callOutput))
 }
 
+// Regression test for https://github.com/dagger/dagger/issues/13291: a `.env`
+// file using the common `export KEY=value` convention must not break env file
+// loading.
+func (EnvFileSuite) TestExportPrefix(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ef := c.File(".env", `export FOO=bar
+export BAZ="qux quux"
+export REF=$FOO-suffix
+PLAIN=plain
+`).AsEnvFile()
+
+	foo, err := ef.Get(ctx, "FOO")
+	require.NoError(t, err)
+	require.Equal(t, "bar", foo)
+
+	baz, err := ef.Get(ctx, "BAZ")
+	require.NoError(t, err)
+	require.Equal(t, "qux quux", baz)
+
+	ref, err := ef.Get(ctx, "REF")
+	require.NoError(t, err)
+	require.Equal(t, "bar-suffix", ref)
+
+	plain, err := ef.Get(ctx, "PLAIN")
+	require.NoError(t, err)
+	require.Equal(t, "plain", plain)
+}
+
 func (EnvFileSuite) TestUpdateVariableWithTheSameValue(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	ef := c.File(".env", "FOO=bar").AsEnvFile().


### PR DESCRIPTION
Auto-loaded .env files (working dir + ancestors) aborted every Dagger command when a line used the common `export KEY=value` convention, with `parse error: "export FOO=bar": not a bare assignment`. The shell parser treats `export FOO=bar` as a command call, so it had no bare assignment.

Strip an optional leading `export` keyword in all dotenv parsing paths (parseEntry, AllRaw, Exists) and in EnvFile.WithContents so the internal representation stores the clean key. `export` is a widely supported dotenv idiom (direnv, `set -a; . ./.env`, shell `source`, most loaders).

Fixes #13291