### PR TITLE
Attach never-cached module function results

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -7531,6 +7531,24 @@ func (m *Test) ObjsWithNothing() ([]*Test, error) {
 	require.JSONEq(t, `{"objsWithNothing":[null,{"dirs":[null]}]}`, out)
 }
 
+func (ModuleSuite) TestNeverCacheModuleObjectReturn(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen := modInit(t, c, "go", `package main
+
+type Test struct{}
+
+// +cache="never"
+func (m *Test) Touch() *Test {
+	return m
+}
+`)
+
+	out, err := modGen.With(daggerCall("touch")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "Test@")
+}
+
 func (ModuleSuite) TestFunctionCacheControl(ctx context.Context, t *testctx.T) {
 	for _, tc := range []struct {
 		sdk    string

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -128,7 +128,10 @@ func (fn *ModuleFunction) cacheImplicitInputs() []dagql.ImplicitInput {
 
 	var implicitInputs []dagql.ImplicitInput
 	cachePolicy := fn.metadata.derivedCachePolicy(fn.mod.Self())
-	if cachePolicy == FunctionCachePolicyPerSession {
+	switch cachePolicy {
+	case FunctionCachePolicyNever:
+		implicitInputs = append(implicitInputs, dagql.PerCallInput)
+	case FunctionCachePolicyPerSession:
 		implicitInputs = append(implicitInputs, dagql.PerSessionInput)
 	}
 

--- a/core/modfunc_test.go
+++ b/core/modfunc_test.go
@@ -19,6 +19,7 @@ func TestModuleFunctionCacheImplicitInputs(t *testing.T) {
 		name               string
 		mod                *Module
 		fn                 *Function
+		expectCallScope    bool
 		expectSessionScope bool
 	}{
 		{
@@ -53,6 +54,17 @@ func TestModuleFunctionCacheImplicitInputs(t *testing.T) {
 			},
 			expectSessionScope: true,
 		},
+		{
+			name: "explicit never policy",
+			mod: &Module{
+				NameField: "test",
+			},
+			fn: &Function{
+				Name:        "fn",
+				CachePolicy: FunctionCachePolicyNever,
+			},
+			expectCallScope: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			modRes, err := dagql.NewObjectResultForCall(
@@ -79,6 +91,12 @@ func TestModuleFunctionCacheImplicitInputs(t *testing.T) {
 			byName := mapImplicitInputsByName(inputs)
 			_, hasLegacyScopeInput := byName["moduleFunctionScope"]
 			require.False(t, hasLegacyScopeInput, "legacy module scope implicit input should not be present")
+
+			callInput, hasCallInput := byName[dagql.PerCallInput.Name]
+			require.Equal(t, tc.expectCallScope, hasCallInput)
+			if tc.expectCallScope {
+				require.NotEmpty(t, resolveImplicitInputString(t, callInput, sessionCtx))
+			}
 
 			sessionInput, hasSessionInput := byName[dagql.PerSessionInput.Name]
 			require.Equal(t, tc.expectSessionScope, hasSessionInput)

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -308,7 +308,6 @@ func (fn *Function) FieldSpec(ctx context.Context, mod Mod) (dagql.FieldSpec, er
 	spec.IsPersistable = true
 	switch cachePolicy {
 	case FunctionCachePolicyNever:
-		spec.DoNotCache = "function explicitly marked as never cache"
 		spec.IsPersistable = false
 
 	case FunctionCachePolicyPerSession:


### PR DESCRIPTION
## Summary

- make `+cache="never"` module functions use a per-call implicit cache input instead of `DoNotCache`
- keep never-cached module function results non-persistable
- add unit coverage for cache-policy implicit inputs and an integration repro for returning a module object from a never-cached function

## Root Cause

Module functions annotated with `+cache="never"` were translated to dagql `FieldSpec.DoNotCache`. That prevented storage and reuse, but it also routed the call through the detached result path. If the function returned a module object, the CLI still selected the object's `id` field to print a handle. That resolver asks the dagql result for an ID, but `DoNotCache` results are detached and do not have a shared ID, so the call failed with `result *core.ModuleObject is detached`.

## Fix

`FunctionCachePolicyNever` now adds `dagql.PerCallInput` as an implicit input. Each invocation gets a unique call digest, so results are not reused across calls, while the result still goes through normal attachment and can produce an object ID. The typedef remains `IsPersistable=false`, so these results are not persisted across sessions or restarts.

Fixes at least one case of #13246 but unknown if this fixes all possible cases triggering that, tbd by more discussion in that issue

## Tests

- `go test ./core ./dagql ./dagql/call -run 'Cache|ImplicitInput|FunctionCache|PerSession|PerCall' -count=1`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestModule/(TestNeverCacheModuleObjectReturn|TestFunctionCacheControl|TestFunctionCacheControlReturnedContainer)'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestCachePersistence/TestDiskPersistenceAcrossRestart/(function_cache_control_survives_restart|typescript_function_cache_control_survives_restart|contextual_function_cache_survives_restart)'`

Traces:

- https://dagger.cloud/dagger/traces/8415207afa5453c407b3416cbeebbfd9
- https://dagger.cloud/dagger/traces/4deea2353a2bbbbd1fd534ce5895b49c
