### PR TITLE
fix: allow empty setSecret name

### DIFF
--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -137,6 +137,18 @@ func (SecretSuite) TestSet(ctx context.Context, t *testctx.T) {
 	require.Equal(t, secretName, name)
 }
 
+func (SecretSuite) TestSetWithEmptyName(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	s := c.SetSecret("", "very-secret-text")
+
+	_, err := c.Container().From(alpineImage).
+		WithSecretVariable("SECRET", s).
+		WithExec([]string{"sh", "-ec", `test "$SECRET" = "very-secret-text"`}).
+		Sync(ctx)
+	require.NoError(t, err)
+}
+
 func (SecretSuite) TestUnsetVariable(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/secret.go
+++ b/core/secret.go
@@ -255,7 +255,7 @@ func SecretHandleFromCacheKey(cacheKey string) dagql.SessionResourceHandle {
 }
 
 func SetSecretHandle(name string, accessor string) dagql.SessionResourceHandle {
-	if name == "" || accessor == "" {
+	if accessor == "" {
 		return ""
 	}
 	return dagql.SessionResourceHandle(hashutil.HashStrings(name, accessor))


### PR DESCRIPTION
## Summary
- Allow `setSecret` to derive a session-resource handle when the user-provided name is empty.
- Add integration coverage for using `dag.SetSecret("", ...)` as a container secret variable.

## Root Cause
The session-resource migration rejected empty `setSecret` names before hashing. In v0.20.x, the empty name still participated in the deterministic `hashutil.HashStrings(name, accessor)` digest, so it produced a usable secret identity.

## Testing
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run=TestSecret/TestSetWithEmptyName`