### PR TITLE
  feat(engine): support local service registries in publish/from

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -4967,9 +4967,16 @@ func (container *Container) FromCanonicalRef(
 	if err != nil {
 		return fmt.Errorf("failed to get registry resolver: %w", err)
 	}
+	network, detach, err := ContainerRegistryNetwork(ctx, container.Services)
+	if err != nil {
+		return err
+	}
+	defer detach()
+
 	pulled, err := rslvr.Pull(ctx, refStr, serverresolver.PullOpts{
 		Platform:    platform.Spec(),
 		ResolveMode: serverresolver.ResolveModeDefault,
+		Network:     network,
 	})
 	if err != nil {
 		return fmt.Errorf("pull image %q: %w", refStr, err)
@@ -6368,8 +6375,13 @@ func (container *Container) Publish(
 	if err != nil {
 		return "", fmt.Errorf("failed to get engine client: %w", err)
 	}
+	network, detach, err := ContainerRegistryNetwork(ctx, container.Services)
+	if err != nil {
+		return "", err
+	}
+	defer detach()
 
-	resp, err := bk.PublishContainerImage(ctx, inputByPlatform, ref, useOCIMediaTypes(mediaTypes), string(forcedCompression))
+	resp, err := bk.PublishContainerImage(ctx, inputByPlatform, ref, useOCIMediaTypes(mediaTypes), string(forcedCompression), network)
 	if err != nil {
 		return "", err
 	}
@@ -6594,6 +6606,50 @@ func (container *Container) WithServiceBinding(ctx context.Context, svc dagql.Ob
 	})
 
 	return container, nil
+}
+
+// ContainerRegistryNetwork starts service bindings for a registry operation and
+// returns the Dagger DNS view that should apply while that operation is running.
+func ContainerRegistryNetwork(ctx context.Context, bindings ServiceBindings) (serverresolver.NetworkConfig, func(), error) {
+	if len(bindings) == 0 {
+		return serverresolver.NetworkConfig{}, func() {}, nil
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return serverresolver.NetworkConfig{}, nil, err
+	}
+	svcs, err := query.Services(ctx)
+	if err != nil {
+		return serverresolver.NetworkConfig{}, nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	detach, _, err := svcs.StartBindings(ctx, bindings)
+	if err != nil {
+		return serverresolver.NetworkConfig{}, nil, err
+	}
+
+	dns, err := DNSConfig(ctx)
+	if err != nil {
+		detach()
+		return serverresolver.NetworkConfig{}, nil, err
+	}
+
+	hostAliases := map[string]string{}
+	for _, binding := range bindings {
+		// Registry refs use the caller's binding aliases, while Dagger DNS knows
+		// the service by its canonical hostname.
+		hostAliases[binding.Hostname] = binding.Hostname
+		aliases := slices.Clone(binding.Aliases)
+		slices.Sort(aliases)
+		for _, alias := range aliases {
+			hostAliases[alias] = binding.Hostname
+		}
+	}
+
+	return serverresolver.NetworkConfig{
+		DNS:         dns,
+		HostAliases: hostAliases,
+	}, detach, nil
 }
 
 func (container *Container) ImageRefOrErr(ctx context.Context) (string, error) {

--- a/core/container.go
+++ b/core/container.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"maps"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -689,11 +690,12 @@ type persistedContainerWithDefaultTerminalCmdLazy struct {
 }
 
 type persistedContainerFromLazy struct {
-	ParentResultID uint64                          `json:"parentResultID"`
-	CanonicalRef   string                          `json:"canonicalRef"`
-	Config         dockerspec.DockerOCIImageConfig `json:"config"`
-	ImageRef       string                          `json:"imageRef,omitempty"`
-	Platform       Platform                        `json:"platform"`
+	ParentResultID   uint64                          `json:"parentResultID"`
+	CanonicalRef     string                          `json:"canonicalRef"`
+	Config           dockerspec.DockerOCIImageConfig `json:"config"`
+	ImageRef         string                          `json:"imageRef,omitempty"`
+	Platform         Platform                        `json:"platform"`
+	RegistryServices []persistedServiceBinding       `json:"registryServices,omitempty"`
 }
 
 type persistedContainerWithRootFSLazy struct {
@@ -4559,7 +4561,7 @@ func decodePersistedContainerLazy(
 		if err != nil {
 			return err
 		}
-		container.Lazy = &ContainerFromImageRefLazy{
+		lazy := &ContainerFromImageRefLazy{
 			Parent:       parent,
 			LazyState:    NewLazyState(),
 			CanonicalRef: persisted.CanonicalRef,
@@ -4568,6 +4570,14 @@ func decodePersistedContainerLazy(
 			Platform:     persisted.Platform,
 			ResolveMode:  serverresolver.ResolveModeDefault,
 		}
+		if len(persisted.RegistryServices) > 0 {
+			services, err := decodePersistedServiceBindings(ctx, dag, "container from registry", persisted.RegistryServices)
+			if err != nil {
+				return err
+			}
+			lazy.RegistryServices = services
+		}
+		container.Lazy = lazy
 		return nil
 	case "withRootfs":
 		var persisted persistedContainerWithRootFSLazy
@@ -6360,6 +6370,7 @@ func (container *Container) Publish(
 	platformVariants []*Container,
 	forcedCompression ImageLayerCompression,
 	mediaTypes ImageMediaTypes,
+	registryServices ServiceBindings,
 ) (string, error) {
 	variants := filterEmptyContainers(append([]*Container{container}, platformVariants...))
 	inputByPlatform, err := getVariantRefs(ctx, variants)
@@ -6375,7 +6386,7 @@ func (container *Container) Publish(
 	if err != nil {
 		return "", fmt.Errorf("failed to get engine client: %w", err)
 	}
-	network, detach, err := ContainerRegistryNetwork(ctx, container.Services)
+	network, detach, err := ContainerRegistryNetwork(ctx, registryServices)
 	if err != nil {
 		return "", err
 	}
@@ -6650,6 +6661,38 @@ func ContainerRegistryNetwork(ctx context.Context, bindings ServiceBindings) (se
 		DNS:         dns,
 		HostAliases: hostAliases,
 	}, detach, nil
+}
+
+func ContainerRegistryServiceBinding(ctx context.Context, ref string, service dagql.ObjectResult[*Service]) (ServiceBindings, error) {
+	if service.Self() == nil {
+		return nil, nil
+	}
+	refName, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image address %s: %w", ref, err)
+	}
+	host := reference.Domain(refName)
+	alias := host
+	// The image ref may include a port, like "registry:5000/app:latest".
+	// Dagger DNS only aliases the hostname, so bind "registry" while leaving
+	// the original ref as "registry:5000/app:latest".
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		alias = h
+	}
+
+	svcDig, err := service.ContentPreferredDigest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	svcHost, err := service.Self().Hostname(ctx, svcDig)
+	if err != nil {
+		return nil, err
+	}
+	return ServiceBindings{{
+		Service:  service,
+		Hostname: svcHost,
+		Aliases:  AliasSet{alias},
+	}}, nil
 }
 
 func (container *Container) ImageRefOrErr(ctx context.Context) (string, error) {

--- a/core/container_image.go
+++ b/core/container_image.go
@@ -86,9 +86,16 @@ func (lazy *ContainerFromImageRefLazy) Evaluate(ctx context.Context, container *
 		if err != nil {
 			return err
 		}
+		network, detach, err := ContainerRegistryNetwork(ctx, container.Services)
+		if err != nil {
+			return err
+		}
+		defer detach()
+
 		pulled, err := rslvr.Pull(ctx, lazy.CanonicalRef, serverresolver.PullOpts{
 			Platform:    lazy.Platform.Spec(),
 			ResolveMode: lazy.ResolveMode,
+			Network:     network,
 		})
 		if err != nil {
 			return fmt.Errorf("pull image %q: %w", lazy.CanonicalRef, err)

--- a/core/container_image.go
+++ b/core/container_image.go
@@ -32,12 +32,13 @@ type LoadedImportedImage struct {
 
 type ContainerFromImageRefLazy struct {
 	LazyState
-	Parent       dagql.ObjectResult[*Container]
-	CanonicalRef string
-	Config       dockerspec.DockerOCIImageConfig
-	ImageRef     string
-	Platform     Platform
-	ResolveMode  serverresolver.ResolveMode
+	Parent           dagql.ObjectResult[*Container]
+	CanonicalRef     string
+	Config           dockerspec.DockerOCIImageConfig
+	ImageRef         string
+	Platform         Platform
+	ResolveMode      serverresolver.ResolveMode
+	RegistryServices ServiceBindings
 }
 
 type dockerfileImageMetaResolver struct {
@@ -86,7 +87,7 @@ func (lazy *ContainerFromImageRefLazy) Evaluate(ctx context.Context, container *
 		if err != nil {
 			return err
 		}
-		network, detach, err := ContainerRegistryNetwork(ctx, container.Services)
+		network, detach, err := ContainerRegistryNetwork(ctx, lazy.RegistryServices)
 		if err != nil {
 			return err
 		}
@@ -137,8 +138,19 @@ func (lazy *ContainerFromImageRefLazy) AttachDependencies(ctx context.Context, a
 	if err != nil {
 		return nil, err
 	}
+	attachments := []dagql.AnyResult{parent}
+	// From may run later, so keep the selected registry service with it.
+	for i := range lazy.RegistryServices {
+		binding := &lazy.RegistryServices[i]
+		service, err := attachServiceResult(attach, binding.Service, "attach container from registry service")
+		if err != nil {
+			return nil, err
+		}
+		binding.Service = service
+		attachments = append(attachments, service)
+	}
 	lazy.Parent = parent
-	return []dagql.AnyResult{parent}, nil
+	return attachments, nil
 }
 
 func (lazy *ContainerFromImageRefLazy) EncodePersisted(ctx context.Context, cache dagql.PersistedObjectCache) (json.RawMessage, error) {
@@ -146,12 +158,17 @@ func (lazy *ContainerFromImageRefLazy) EncodePersisted(ctx context.Context, cach
 	if err != nil {
 		return nil, err
 	}
+	services, err := encodePersistedServiceBindings(cache, "container from registry", lazy.RegistryServices)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(persistedContainerFromLazy{
-		ParentResultID: parentID,
-		CanonicalRef:   lazy.CanonicalRef,
-		Config:         CloneContainerImageConfig(lazy.Config),
-		ImageRef:       lazy.ImageRef,
-		Platform:       lazy.Platform,
+		ParentResultID:   parentID,
+		CanonicalRef:     lazy.CanonicalRef,
+		Config:           CloneContainerImageConfig(lazy.Config),
+		ImageRef:         lazy.ImageRef,
+		Platform:         lazy.Platform,
+		RegistryServices: services,
 	})
 }
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4034,7 +4034,15 @@ func (ContainerSuite) TestPublishAndFromWithRegistryServiceBinding(ctx context.C
 	module := func(ctx context.Context, t *testctx.T, devEngine *dagger.Service) *dagger.Container {
 		return engineClientContainer(ctx, t, c, devEngine).
 			WithWorkdir("/work").
-			With(daggerNonNestedExec("init", "--sdk=go", "--source=.", "--name=test")).
+			WithNewFile("dagger.json", `{"name":"test","engineVersion":"latest","sdk":{"source":"go"},"source":"."}`).
+			WithNewFile("dagger.toml", `[modules.test]
+source = "."
+entrypoint = true
+`).
+			WithNewFile("go.mod", `module dagger/test
+
+go 1.26.1
+`).
 			With(sdkSource("go", `package main
 
 import (

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/containerd/platforms"
+	engineconfig "github.com/dagger/dagger/engine/config"
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	resolverconfig "github.com/dagger/dagger/internal/buildkit/util/resolver/config"
@@ -4025,6 +4026,121 @@ func credentials(r *http.Request) (string, string, bool) {
 		}
 	}
 	require.NoError(t, err)
+}
+
+func (ContainerSuite) TestPublishAndFromWithRegistryServiceBinding(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	module := func(ctx context.Context, t *testctx.T, devEngine *dagger.Service) *dagger.Container {
+		return engineClientContainer(ctx, t, c, devEngine).
+			WithWorkdir("/work").
+			With(daggerNonNestedExec("init", "--sdk=go", "--source=.", "--name=test")).
+			With(sdkSource("go", `package main
+
+import (
+	"context"
+
+	"dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+func (m *Test) CheckHTTP(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
+	return publishAndRead(ctx, registry, ref)
+}
+
+func (m *Test) CheckHTTPS(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
+	return publishAndRead(ctx, registry, ref)
+}
+
+func publishAndRead(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
+	_, err := dag.Container().
+		WithNewFile("/hello.txt", "hello").
+		WithServiceBinding("bound-registry", registry).
+		Publish(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+
+	return dag.Container().
+		WithServiceBinding("bound-registry", registry).
+		From(ref).
+		File("/hello.txt").
+		Contents(ctx)
+}
+`))
+	}
+
+	t.Run("https", func(ctx context.Context, t *testctx.T) {
+		certGen := newGeneratedCerts(c, "ca")
+		registryCert, registryKey := certGen.newServerCerts("bound-registry")
+		registry := c.Container().
+			From("registry:3").
+			WithMountedCache("/var/lib/registry", c.CacheVolume("service-binding-registry-https-"+identity.NewID())).
+			WithFile("/certs/domain.crt", registryCert).
+			WithFile("/certs/domain.key", registryKey).
+			WithEnvVariable("REGISTRY_HTTP_TLS_CERTIFICATE", "/certs/domain.crt").
+			WithEnvVariable("REGISTRY_HTTP_TLS_KEY", "/certs/domain.key").
+			WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+			AsService()
+
+		devEngine := devEngineContainerAsService(devEngineContainer(c,
+			func(ctr *dagger.Container) *dagger.Container {
+				return ctr.WithMountedFile("/usr/local/share/ca-certificates/bound-registry.crt", certGen.caRootCert)
+			},
+			engineWithConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg engineconfig.Config) engineconfig.Config {
+				cfg.Registries = map[string]engineconfig.RegistryConfig{
+					"bound-registry:5000": {
+						RootCAs: []string{"/usr/local/share/ca-certificates/bound-registry.crt"},
+					},
+				}
+				return cfg
+			}),
+		))
+
+		ref := "bound-registry:5000/service-binding-https:" + identity.NewID()
+
+		out, err := module(ctx, t, devEngine).
+			WithServiceBinding("bound-registry", registry).
+			With(daggerNonNestedExec(
+				"call", "check-https",
+				"--registry", "tcp://bound-registry:5000",
+				"--ref", ref,
+			)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello", strings.TrimSpace(out))
+	})
+
+	t.Run("http engine config", func(ctx context.Context, t *testctx.T) {
+		registry := c.Container().
+			From("registry:3").
+			WithMountedCache("/var/lib/registry", c.CacheVolume("service-binding-registry-http-"+identity.NewID())).
+			WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+			AsService()
+
+		devEngine := devEngineContainerAsService(devEngineContainer(c,
+			engineWithBkConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg bkconfig.Config) bkconfig.Config {
+				cfg.Registries = map[string]resolverconfig.RegistryConfig{
+					"bound-registry:5000": {PlainHTTP: ptr(true)},
+				}
+				return cfg
+			}),
+		))
+
+		ref := "bound-registry:5000/service-binding-http:" + identity.NewID()
+
+		out, err := module(ctx, t, devEngine).
+			WithServiceBinding("bound-registry", registry).
+			With(daggerNonNestedExec(
+				"call", "check-http",
+				"--registry", "tcp://bound-registry:5000",
+				"--ref", ref,
+			)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello", strings.TrimSpace(out))
+	})
 }
 
 // Regression test for #11667: Directory/File access on private registry images

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4045,11 +4045,7 @@ import (
 
 type Test struct{}
 
-func (m *Test) CheckHTTP(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
-	return publishAndRead(ctx, registry, ref)
-}
-
-func (m *Test) CheckHTTPS(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
+func (m *Test) Check(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
 	return publishAndRead(ctx, registry, ref)
 }
 
@@ -4103,7 +4099,7 @@ func publishAndRead(ctx context.Context, registry *dagger.Service, ref string) (
 		out, err := module(ctx, t, devEngine).
 			WithServiceBinding("bound-registry", registry).
 			With(daggerNonNestedExec(
-				"call", "check-https",
+				"call", "check",
 				"--registry", "tcp://bound-registry:5000",
 				"--ref", ref,
 			)).
@@ -4112,7 +4108,7 @@ func publishAndRead(ctx context.Context, registry *dagger.Service, ref string) (
 		require.Equal(t, "hello", strings.TrimSpace(out))
 	})
 
-	t.Run("http engine config", func(ctx context.Context, t *testctx.T) {
+	t.Run("plain http engine config", func(ctx context.Context, t *testctx.T) {
 		registry := c.Container().
 			From("registry:3").
 			WithMountedCache("/var/lib/registry", c.CacheVolume("service-binding-registry-http-"+identity.NewID())).
@@ -4133,7 +4129,7 @@ func publishAndRead(ctx context.Context, registry *dagger.Service, ref string) (
 		out, err := module(ctx, t, devEngine).
 			WithServiceBinding("bound-registry", registry).
 			With(daggerNonNestedExec(
-				"call", "check-http",
+				"call", "check",
 				"--registry", "tcp://bound-registry:5000",
 				"--ref", ref,
 			)).

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -4060,15 +4060,17 @@ func (m *Test) Check(ctx context.Context, registry *dagger.Service, ref string) 
 func publishAndRead(ctx context.Context, registry *dagger.Service, ref string) (string, error) {
 	_, err := dag.Container().
 		WithNewFile("/hello.txt", "hello").
-		WithServiceBinding("bound-registry", registry).
-		Publish(ctx, ref)
+		Publish(ctx, ref, dagger.ContainerPublishOpts{
+			RegistryService: registry,
+		})
 	if err != nil {
 		return "", err
 	}
 
 	return dag.Container().
-		WithServiceBinding("bound-registry", registry).
-		From(ref).
+		From(ref, dagger.ContainerFromOpts{
+			RegistryService: registry,
+		}).
 		File("/hello.txt").
 		Contents(ctx)
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -989,6 +989,7 @@ var fromSessionScopeInput = dagql.ImplicitInput{
 	},
 }
 
+//nolint:gocyclo
 func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerFromArgs) (inst dagql.ObjectResult[*core.Container], _ error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1033,9 +1033,16 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		}
 
 		refStr := refName.String()
+		network, detach, err := core.ContainerRegistryNetwork(ctx, parent.Self().Services)
+		if err != nil {
+			return inst, err
+		}
+		defer detach()
+
 		_, _, cfgBytes, err := rslvr.ResolveImageConfig(ctx, refStr, serverresolver.ResolveImageConfigOpts{
 			Platform:    ptr(platform.Spec()),
 			ResolveMode: serverresolver.ResolveModeDefault,
+			Network:     network,
 		})
 		if err != nil {
 			return inst, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refStr, platform.Format(), err)
@@ -1124,9 +1131,16 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		if err != nil {
 			return inst, fmt.Errorf("failed to get registry resolver: %w", err)
 		}
+		network, detach, err := core.ContainerRegistryNetwork(ctx, parent.Self().Services)
+		if err != nil {
+			return inst, err
+		}
+		defer detach()
+
 		_, resolvedDigest, _, err := rslvr.ResolveImageConfig(ctx, refName.String(), serverresolver.ResolveImageConfigOpts{
 			Platform:    ptr(platform.Spec()),
 			ResolveMode: serverresolver.ResolveModeDefault,
+			Network:     network,
 		})
 		if err != nil {
 			return inst, fmt.Errorf("failed to resolve image %q (platform: %q): %w", refName.String(), platform.Format(), err)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -71,6 +71,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("address").Doc(
 					`Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"`,
 				),
+				dagql.Arg("registryService").Doc(
+					`Service to use as the registry endpoint for the image address.`,
+					`The service will be started only for this pull.`),
 			),
 		dagql.NodeFunc("build", s.build).
 			View(BeforeVersion("v0.19.0")).
@@ -705,6 +708,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`Defaults to "OCI", which is compatible with most recent
 				registries, but "Docker" may be needed for older registries without OCI
 				support.`),
+				dagql.Arg("registryService").Doc(
+					`Service to use as the registry endpoint for the image address.`,
+					`The service will be started only for this push.`),
 			),
 
 		dagql.NodeFunc("platform", s.platform).
@@ -941,7 +947,8 @@ func (s *containerSchema) container(ctx context.Context, parent *core.Query, arg
 }
 
 type containerFromArgs struct {
-	Address string
+	Address         string
+	RegistryService dagql.Optional[core.ServiceID]
 }
 
 const lockContainerFromOperation = "container.from"
@@ -996,6 +1003,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		return inst, fmt.Errorf("failed to get registry resolver: %w", err)
 	}
 	platform := parent.Self().Platform
+	var registryServices core.ServiceBindings
 
 	refName, err := reference.ParseNormalizedNamed(args.Address)
 	if err != nil {
@@ -1003,6 +1011,16 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 	}
 	// add a default :latest if no tag or digest, otherwise this is a no-op
 	refName = reference.TagNameOnly(refName)
+	if args.RegistryService.Valid {
+		service, err := args.RegistryService.Value.Load(ctx, srv)
+		if err != nil {
+			return inst, err
+		}
+		registryServices, err = core.ContainerRegistryServiceBinding(ctx, refName.String(), service)
+		if err != nil {
+			return inst, err
+		}
+	}
 
 	if refName, isCanonical := refName.(reference.Canonical); isCanonical {
 		clonedMounts, err := core.CloneContainerMounts(ctx, parent.Self().Mounts)
@@ -1033,7 +1051,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		}
 
 		refStr := refName.String()
-		network, detach, err := core.ContainerRegistryNetwork(ctx, parent.Self().Services)
+		network, detach, err := core.ContainerRegistryNetwork(ctx, registryServices)
 		if err != nil {
 			return inst, err
 		}
@@ -1057,13 +1075,14 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		ctr.ImageRef = refStr
 		ctr.Platform = core.Platform(platforms.Normalize(imgSpec.Platform))
 		ctr.Lazy = &core.ContainerFromImageRefLazy{
-			Parent:       parent,
-			LazyState:    core.NewLazyState(),
-			CanonicalRef: refStr,
-			Config:       core.CloneContainerImageConfig(ctr.Config),
-			ImageRef:     ctr.ImageRef,
-			Platform:     ctr.Platform,
-			ResolveMode:  serverresolver.ResolveModeDefault,
+			Parent:           parent,
+			LazyState:        core.NewLazyState(),
+			CanonicalRef:     refStr,
+			Config:           core.CloneContainerImageConfig(ctr.Config),
+			ImageRef:         ctr.ImageRef,
+			Platform:         ctr.Platform,
+			ResolveMode:      serverresolver.ResolveModeDefault,
+			RegistryServices: registryServices,
 		}
 
 		inst, err = dagql.NewObjectResultForCurrentCall(ctx, srv, ctr)
@@ -1094,12 +1113,18 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 
 	var lookupLock *workspaceLookupLock
 	var rawLock *workspace.Lock
-	lockMode, lookupLock, err := lookupLockForMode(ctx, query, lockContainerFromOperation)
-	if err != nil {
-		return inst, err
-	}
-	if lockMode != workspace.LockModeDisabled {
-		rawLock = lookupLock.lock
+	lockMode := workspace.LockModeDisabled
+	// A ref like "registry:5000/app:latest" can point to different images
+	// depending on registryService, so disable workspace lock entries when
+	// registryService is set.
+	if len(registryServices) == 0 {
+		lockMode, lookupLock, err = lookupLockForMode(ctx, query, lockContainerFromOperation)
+		if err != nil {
+			return inst, err
+		}
+		if lockMode != workspace.LockModeDisabled {
+			rawLock = lookupLock.lock
+		}
 	}
 
 	lockInputs := []any{refName.String(), platform.Format()}
@@ -1131,7 +1156,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		if err != nil {
 			return inst, fmt.Errorf("failed to get registry resolver: %w", err)
 		}
-		network, detach, err := core.ContainerRegistryNetwork(ctx, parent.Self().Services)
+		network, detach, err := core.ContainerRegistryNetwork(ctx, registryServices)
 		if err != nil {
 			return inst, err
 		}
@@ -1170,12 +1195,22 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 	)
 	defer telemetry.EndWithCause(span, nil)
 
+	// We resolved the tag to a digest. Call from again with that digest so the
+	// container ID is stable, and keep registryService so the final pull still
+	// uses the same local registry.
+	fromArgs := []dagql.NamedInput{
+		{Name: "address", Value: dagql.String(refName.String())},
+	}
+	if args.RegistryService.Valid {
+		fromArgs = append(fromArgs, dagql.NamedInput{
+			Name:  "registryService",
+			Value: dagql.Opt(args.RegistryService.Value),
+		})
+	}
 	err = srv.Select(ctx, parent, &inst,
 		dagql.Selector{
 			Field: "from",
-			Args: []dagql.NamedInput{
-				{Name: "address", Value: dagql.String(refName.String())},
-			},
+			Args:  fromArgs,
 		},
 	)
 	if err != nil {
@@ -2365,6 +2400,7 @@ type containerPublishArgs struct {
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
 	MediaTypes        core.ImageMediaTypes `default:"OCI"`
+	RegistryService   dagql.Optional[core.ServiceID]
 }
 
 func (s *containerSchema) publish(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerPublishArgs) (dagql.String, error) {
@@ -2390,6 +2426,17 @@ func (s *containerSchema) publish(ctx context.Context, parent dagql.ObjectResult
 	if err := cache.Evaluate(ctx, evals...); err != nil {
 		return "", err
 	}
+	var registryServices core.ServiceBindings
+	if args.RegistryService.Valid {
+		service, err := args.RegistryService.Value.Load(ctx, srv)
+		if err != nil {
+			return "", err
+		}
+		registryServices, err = core.ContainerRegistryServiceBinding(ctx, args.Address.String(), service)
+		if err != nil {
+			return "", err
+		}
+	}
 	variants := make([]*core.Container, 0, len(variantResults))
 	for _, variant := range variantResults {
 		if variant.Self() != nil {
@@ -2402,6 +2449,7 @@ func (s *containerSchema) publish(ctx context.Context, parent dagql.ObjectResult
 		variants,
 		args.ForcedCompression.Value,
 		args.MediaTypes,
+		registryServices,
 	)
 	if err != nil {
 		return "", err

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -707,6 +707,13 @@ type Container implements Exportable & Node & Syncer {
     Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"
     """
     address: String!
+
+    """
+    Service to use as the registry endpoint for the image address.
+
+    The service will be started only for this pull.
+    """
+    registryService: ID @expectedType(name: "Service")
   ): Container!
 
   """A unique identifier for this Container."""
@@ -781,6 +788,13 @@ type Container implements Exportable & Node & Syncer {
     "Docker" may be needed for older registries without OCI support.
     """
     mediaTypes: ImageMediaTypes = OCIMediaTypes
+
+    """
+    Service to use as the registry endpoint for the image address.
+
+    The service will be started only for this push.
+    """
+    registryService: ID @expectedType(name: "Service")
   ): String!
 
   """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -3106,6 +3106,11 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>address</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
                                 <p>Address of the container image to download, in standard OCI ref format. Example:&quot;registry.dagger.io/engine:latest&quot;</p>
                               </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>registryService</code></span> - <span class="property-type"><a href="#definition-ID"><code>ID</code></a></span></h6>
+                                <p>Service to use as the registry endpoint for the image address.</p>
+                                <p>The service will be started only for this pull.</p>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -3199,6 +3204,11 @@
                                 <h6 class="field-argument-name"><span class="property-name"><code>mediaTypes</code></span> - <span class="property-type"><a href="#definition-ImageMediaTypes"><code>ImageMediaTypes</code></a></span></h6>
                                 <p>Use the specified media types for the published image&#39;s layers.</p>
                                 <p>Defaults to &quot;OCI&quot;, which is compatible with most recent registries, but &quot;Docker&quot; may be needed for older registries without OCI support.</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>registryService</code></span> - <span class="property-type"><a href="#definition-ID"><code>ID</code></a></span></h6>
+                                <p>Service to use as the registry endpoint for the image address.</p>
+                                <p>The service will be started only for this push.</p>
                               </div>
                             </div>
                           </div>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -316,7 +316,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_from">from</a>(string $address)
+                    <a href="#method_from">from</a>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null)
         
                                             <p><p>Download a container image, and apply it to the container state. All previous state will be lost.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -396,7 +396,7 @@
                     string
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_publish">publish</a>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
+                    <a href="#method_publish">publish</a>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null)
         
                                             <p><p>Package the container state as an OCI image, and publish it to a registry</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1781,7 +1781,7 @@
                     <h3 id="method_from">
         <div class="location">at line 286</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>from</strong>(string $address)
+    <strong>from</strong>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null)
         </code>
     </h3>
     <div class="details">    
@@ -1798,6 +1798,11 @@
                     <tr>
                 <td>string</td>
                 <td>$address</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><abbr title="Dagger\Dagger\Service">Service</abbr>|null</td>
+                <td>$registryService</td>
                 <td></td>
             </tr>
             </table>
@@ -1821,7 +1826,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 296</div>
+        <div class="location">at line 299</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1853,7 +1858,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_imageRef">
-        <div class="location">at line 305</div>
+        <div class="location">at line 308</div>
         <code>                    string
     <strong>imageRef</strong>()
         </code>
@@ -1885,7 +1890,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_import">
-        <div class="location">at line 314</div>
+        <div class="location">at line 317</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>import</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $tag = &#039;&#039;)
         </code>
@@ -1932,7 +1937,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_label">
-        <div class="location">at line 327</div>
+        <div class="location">at line 330</div>
         <code>                    string
     <strong>label</strong>(string $name)
         </code>
@@ -1974,7 +1979,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_labels">
-        <div class="location">at line 337</div>
+        <div class="location">at line 340</div>
         <code>                    array
     <strong>labels</strong>()
         </code>
@@ -2006,7 +2011,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_mounts">
-        <div class="location">at line 346</div>
+        <div class="location">at line 349</div>
         <code>                    array
     <strong>mounts</strong>()
         </code>
@@ -2038,7 +2043,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_platform">
-        <div class="location">at line 355</div>
+        <div class="location">at line 358</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>platform</strong>()
         </code>
@@ -2070,9 +2075,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_publish">
-        <div class="location">at line 366</div>
+        <div class="location">at line 369</div>
         <code>                    string
-    <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
+    <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null)
         </code>
     </h3>
     <div class="details">    
@@ -2106,6 +2111,11 @@
                 <td>$mediaTypes</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td><abbr title="Dagger\Dagger\Service">Service</abbr>|null</td>
+                <td>$registryService</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -2127,7 +2137,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_rootfs">
-        <div class="location">at line 389</div>
+        <div class="location">at line 396</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>rootfs</strong>()
         </code>
@@ -2159,7 +2169,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stat">
-        <div class="location">at line 398</div>
+        <div class="location">at line 405</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -2206,7 +2216,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stderr">
-        <div class="location">at line 413</div>
+        <div class="location">at line 420</div>
         <code>                    string
     <strong>stderr</strong>()
         </code>
@@ -2238,7 +2248,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stdout">
-        <div class="location">at line 424</div>
+        <div class="location">at line 431</div>
         <code>                    string
     <strong>stdout</strong>()
         </code>
@@ -2270,7 +2280,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 435</div>
+        <div class="location">at line 442</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -2302,7 +2312,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 445</div>
+        <div class="location">at line 452</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2354,7 +2364,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_up">
-        <div class="location">at line 468</div>
+        <div class="location">at line 475</div>
         <code>                    void
     <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2431,7 +2441,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_user">
-        <div class="location">at line 509</div>
+        <div class="location">at line 516</div>
         <code>                    string
     <strong>user</strong>()
         </code>
@@ -2463,7 +2473,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAnnotation">
-        <div class="location">at line 518</div>
+        <div class="location">at line 525</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
@@ -2510,7 +2520,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultArgs">
-        <div class="location">at line 529</div>
+        <div class="location">at line 536</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultArgs</strong>(array $args)
         </code>
@@ -2552,7 +2562,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultTerminalCmd">
-        <div class="location">at line 539</div>
+        <div class="location">at line 546</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2604,7 +2614,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 558</div>
+        <div class="location">at line 565</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $expand = false, int|null $permissions = null)
         </code>
@@ -2681,7 +2691,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDockerHealthcheck">
-        <div class="location">at line 595</div>
+        <div class="location">at line 602</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDockerHealthcheck</strong>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
         </code>
@@ -2753,7 +2763,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 630</div>
+        <div class="location">at line 637</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2800,7 +2810,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileVariables">
-        <div class="location">at line 643</div>
+        <div class="location">at line 650</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvFileVariables</strong>(<a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a> $source)
         </code>
@@ -2842,7 +2852,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 653</div>
+        <div class="location">at line 660</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -2894,7 +2904,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 667</div>
+        <div class="location">at line 674</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -2936,7 +2946,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 677</div>
+        <div class="location">at line 684</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -3028,7 +3038,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 734</div>
+        <div class="location">at line 741</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -3093,7 +3103,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 757</div>
+        <div class="location">at line 764</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3155,7 +3165,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 782</div>
+        <div class="location">at line 789</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3217,7 +3227,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 807</div>
+        <div class="location">at line 814</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -3264,7 +3274,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 818</div>
+        <div class="location">at line 825</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a> $cache, <abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3331,7 +3341,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 847</div>
+        <div class="location">at line 854</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3393,7 +3403,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 872</div>
+        <div class="location">at line 879</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3450,7 +3460,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 889</div>
+        <div class="location">at line 896</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $source, string|null $owner = &#039;&#039;, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3512,7 +3522,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 914</div>
+        <div class="location">at line 921</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3564,7 +3574,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 930</div>
+        <div class="location">at line 937</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3626,7 +3636,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 955</div>
+        <div class="location">at line 962</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -3678,7 +3688,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 967</div>
+        <div class="location">at line 974</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $directory)
         </code>
@@ -3720,7 +3730,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 977</div>
+        <div class="location">at line 984</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -3767,7 +3777,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 994</div>
+        <div class="location">at line 1001</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a> $service)
         </code>
@@ -3816,7 +3826,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 1005</div>
+        <div class="location">at line 1012</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -3868,7 +3878,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 1019</div>
+        <div class="location">at line 1026</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $expand = false)
         </code>
@@ -3925,7 +3935,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 1040</div>
+        <div class="location">at line 1047</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -3967,7 +3977,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withVolatileVariable">
-        <div class="location">at line 1052</div>
+        <div class="location">at line 1059</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withVolatileVariable</strong>(string $name, string $value)
         </code>
@@ -4014,7 +4024,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 1063</div>
+        <div class="location">at line 1070</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4061,7 +4071,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 1076</div>
+        <div class="location">at line 1083</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -4103,7 +4113,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1086</div>
+        <div class="location">at line 1093</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -4135,7 +4145,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1095</div>
+        <div class="location">at line 1102</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4182,7 +4192,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDockerHealthcheck">
-        <div class="location">at line 1108</div>
+        <div class="location">at line 1115</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDockerHealthcheck</strong>()
         </code>
@@ -4214,7 +4224,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1117</div>
+        <div class="location">at line 1124</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -4256,7 +4266,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1129</div>
+        <div class="location">at line 1136</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -4298,7 +4308,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1139</div>
+        <div class="location">at line 1146</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -4345,7 +4355,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1152</div>
+        <div class="location">at line 1159</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4392,7 +4402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1165</div>
+        <div class="location">at line 1172</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4439,7 +4449,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1178</div>
+        <div class="location">at line 1185</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4481,7 +4491,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1188</div>
+        <div class="location">at line 1195</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4528,7 +4538,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1201</div>
+        <div class="location">at line 1208</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4570,7 +4580,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1211</div>
+        <div class="location">at line 1218</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4612,7 +4622,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1221</div>
+        <div class="location">at line 1228</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4659,7 +4669,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1236</div>
+        <div class="location">at line 1243</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4691,7 +4701,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutVolatileVariable">
-        <div class="location">at line 1245</div>
+        <div class="location">at line 1252</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutVolatileVariable</strong>(string $name)
         </code>
@@ -4733,7 +4743,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1257</div>
+        <div class="location">at line 1264</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -4765,7 +4775,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1266</div>
+        <div class="location">at line 1273</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/engine/engineutil/containerimage.go
+++ b/engine/engineutil/containerimage.go
@@ -139,6 +139,7 @@ func (c *Client) WriteContainerImageTarball(
 
 type resolverPusher struct {
 	resolver *serverresolver.Resolver
+	network  serverresolver.NetworkConfig
 }
 
 func (p resolverPusher) PushImage(
@@ -154,6 +155,7 @@ func (p resolverPusher) PushImage(
 	}, ref, serverresolver.PushOpts{
 		Insecure: opts.Insecure,
 		ByDigest: opts.PushByDigest,
+		Network:  p.network,
 	})
 }
 
@@ -163,6 +165,7 @@ func (c *Client) PublishContainerImage(
 	refName string,
 	useOCIMediaTypes bool,
 	forceCompression string,
+	network serverresolver.NetworkConfig,
 ) (*imageexport.ExportResponse, error) {
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
@@ -184,7 +187,10 @@ func (c *Client) PublishContainerImage(
 	}
 	return imageexport.Export(ctx, imageexport.Deps{
 		Writer: c.imageExportWriter,
-		Pusher: resolverPusher{resolver: resolver},
+		Pusher: resolverPusher{
+			resolver: resolver,
+			network:  network,
+		},
 	}, req, imageexport.ExportOpts{
 		Names:  []string{refName},
 		Push:   true,

--- a/engine/server/registryhosts.go
+++ b/engine/server/registryhosts.go
@@ -18,7 +18,6 @@ import (
 	localcontentstore "github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/dagger/dagger/engine/distconsts"
 	resolverconfig "github.com/dagger/dagger/internal/buildkit/util/resolver/config"
-	"github.com/dagger/dagger/internal/buildkit/util/tracing"
 	"github.com/pkg/errors"
 )
 
@@ -95,8 +94,10 @@ func applyRegistryHostConfig(host string, cfg resolverconfig.RegistryConfig, h d
 		tc.InsecureSkipVerify = true
 	}
 	baseTransport := docker.DefaultHTTPTransport(tc)
+	// Keep the concrete transport here; resolver wraps tracing after any
+	// per-call service DNS transport is installed.
 	h.Client = &http.Client{
-		Transport: tracing.NewTransport(baseTransport),
+		Transport: baseTransport,
 	}
 	explicitTLS := tc.InsecureSkipVerify || tc.RootCAs != nil || len(tc.Certificates) > 0
 
@@ -108,7 +109,7 @@ func applyRegistryHostConfig(host string, cfg resolverconfig.RegistryConfig, h d
 	if explicitTLS && port != "80" {
 		h.Scheme = "https"
 		h.Client = &http.Client{
-			Transport: tracing.NewTransport(docker.NewHTTPFallback(baseTransport)),
+			Transport: docker.NewHTTPFallback(baseTransport),
 		}
 		return h, nil
 	}

--- a/engine/server/resolver/resolver.go
+++ b/engine/server/resolver/resolver.go
@@ -21,6 +21,8 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/dagger/dagger/auth"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
+	"github.com/dagger/dagger/engine/sources/netconfhttp"
+	"github.com/dagger/dagger/internal/buildkit/executor/oci"
 	bkauth "github.com/dagger/dagger/internal/buildkit/session/auth"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/internal/buildkit/util/contentutil"
@@ -65,17 +67,27 @@ type Opts struct {
 type ResolveImageConfigOpts struct {
 	Platform    *ocispecs.Platform
 	ResolveMode ResolveMode
+	Network     NetworkConfig
 }
 
 type PullOpts struct {
 	Platform    ocispecs.Platform
 	ResolveMode ResolveMode
 	LayerLimit  *int
+	Network     NetworkConfig
 }
 
 type PushOpts struct {
 	Insecure bool
 	ByDigest bool
+	Network  NetworkConfig
+}
+
+// NetworkConfig carries the Dagger DNS view used by registry operations for a
+// container with service bindings.
+type NetworkConfig struct {
+	DNS         *oci.DNSConfig
+	HostAliases map[string]string
 }
 
 type PushedImage struct {
@@ -156,7 +168,7 @@ func (r *Resolver) ResolveImageConfig(
 	}
 	key += fmt.Sprintf(":%d", opts.ResolveMode)
 
-	resolved, err := r.resolveConfigG.Do(ctx, key, func(ctx context.Context) (*resolveImageConfigResult, error) {
+	resolve := func(ctx context.Context) (*resolveImageConfigResult, error) {
 		if opts.ResolveMode == ResolveModeDefault {
 			if resolvedRef, dgst, configBytes, found, err := r.tryLocalCanonicalConfig(ctx, ref, opts); err != nil {
 				return nil, err
@@ -169,7 +181,7 @@ func (r *Resolver) ResolveImageConfig(
 			}
 		}
 
-		resolvedRef, rootDesc, resolver, err := r.resolveRemoteRootDescriptor(ctx, ref)
+		resolvedRef, rootDesc, resolver, err := r.resolveRemoteRootDescriptor(ctx, ref, opts.Network)
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +218,20 @@ func (r *Resolver) ResolveImageConfig(
 			digest: rootDesc.Digest,
 			config: configBytes,
 		}, nil
-	})
+	}
+
+	var resolved *resolveImageConfigResult
+	var err error
+	if len(opts.Network.HostAliases) > 0 {
+		// Normal registry refs can be shared through singleflight because the
+		// same ref, platform, and resolve mode go to the same registry endpoint.
+		// Service-bound refs are different: "registry:5000/app:latest" may point
+		// to registryServiceA for one caller and registryServiceB for another, so
+		// the ref string alone is not enough to share an in-flight resolve.
+		resolved, err = resolve(ctx)
+	} else {
+		resolved, err = r.resolveConfigG.Do(ctx, key, resolve)
+	}
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -247,7 +272,7 @@ func (r *Resolver) Pull(ctx context.Context, ref string, opts PullOpts) (_ *Pull
 		}
 	}
 
-	resolvedRef, rootDesc, resolver, err := r.resolveRemoteRootDescriptor(ctx, ref)
+	resolvedRef, rootDesc, resolver, err := r.resolveRemoteRootDescriptor(ctx, ref, opts.Network)
 	if err != nil {
 		return nil, err
 	}
@@ -358,9 +383,9 @@ type localizedImageClosure struct {
 	Nonlayers    []ocispecs.Descriptor
 }
 
-func (r *Resolver) resolveRemoteRootDescriptor(ctx context.Context, ref string) (string, ocispecs.Descriptor, remotes.Resolver, error) {
+func (r *Resolver) resolveRemoteRootDescriptor(ctx context.Context, ref string, network NetworkConfig) (string, ocispecs.Descriptor, remotes.Resolver, error) {
 	resolver := docker.NewResolver(docker.ResolverOptions{
-		Hosts: r.registryHosts(),
+		Hosts: r.registryHosts(network),
 	})
 	resolvedRef, rootDesc, err := resolver.Resolve(ctx, ref)
 	if err != nil {
@@ -576,7 +601,7 @@ func (r *Resolver) PushImage(ctx context.Context, img *PushedImage, ref string, 
 	}
 
 	resolver := docker.NewResolver(docker.ResolverOptions{
-		Hosts: r.pushRegistryHosts(opts.Insecure),
+		Hosts: r.pushRegistryHosts(opts.Insecure, opts.Network),
 	})
 	pusher, err := buildkitpush.Pusher(ctx, resolver, ref)
 	if err != nil {
@@ -692,13 +717,14 @@ func (s *sessionAuthSource) Credentials(ctx context.Context, host string) (Crede
 	}, nil
 }
 
-func (r *Resolver) registryHosts() docker.RegistryHosts {
+func (r *Resolver) registryHosts(network NetworkConfig) docker.RegistryHosts {
 	authorizers := newRegistryHostAuthorizerCache()
 	return func(domain string) ([]docker.RegistryHost, error) {
 		hosts, err := r.registryHostConfigs(domain)
 		if err != nil {
 			return nil, err
 		}
+		hosts = withRegistryHostNetwork(hosts, network)
 		return r.withRegistryHostAuthorizers(hosts, authorizers), nil
 	}
 }
@@ -949,6 +975,37 @@ func resolveLocalManifestDescriptor(
 	}
 }
 
+func withRegistryHostNetwork(hosts []docker.RegistryHost, network NetworkConfig) []docker.RegistryHost {
+	out := cloneRegistryHosts(hosts)
+	for i := range out {
+		// Registry hosts are cached and reused; copy the client before replacing
+		// its transport for this operation's service bindings.
+		client := cloneHTTPClient(out[i].Client)
+		transport := client.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		if len(network.HostAliases) > 0 {
+			if httpTransport, ok := transport.(*http.Transport); ok {
+				transport = netconfhttp.NewDialTransportWithHostAliases(httpTransport, network.DNS, network.HostAliases)
+			}
+		}
+		// Add tracing after any per-call transport changes so the concrete
+		// *http.Transport stays available while service DNS is installed.
+		client.Transport = tracing.NewTransport(transport)
+		out[i].Client = client
+	}
+	return out
+}
+
+func cloneHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	copied := *client
+	return &copied
+}
+
 func resolveManifestDescriptor(
 	ctx context.Context,
 	provider content.Provider,
@@ -1015,7 +1072,7 @@ func hydratePulledDescriptor(desc ocispecs.Descriptor) ocispecs.Descriptor {
 	return desc
 }
 
-func (r *Resolver) pushRegistryHosts(insecure bool) docker.RegistryHosts {
+func (r *Resolver) pushRegistryHosts(insecure bool, network NetworkConfig) docker.RegistryHosts {
 	authorizers := newRegistryHostAuthorizerCache()
 	return func(domain string) ([]docker.RegistryHost, error) {
 		hosts, err := r.registryHostConfigs(domain)
@@ -1025,16 +1082,9 @@ func (r *Resolver) pushRegistryHosts(insecure bool) docker.RegistryHosts {
 		if insecure {
 			for i := range hosts {
 				hosts[i].Scheme = "http"
-				if hosts[i].Client != nil {
-					hosts[i].Client = &http.Client{
-						Transport:     hosts[i].Client.Transport,
-						CheckRedirect: hosts[i].Client.CheckRedirect,
-						Jar:           hosts[i].Client.Jar,
-						Timeout:       hosts[i].Client.Timeout,
-					}
-				}
 			}
 		}
+		hosts = withRegistryHostNetwork(hosts, network)
 		return r.withRegistryHostAuthorizers(hosts, authorizers), nil
 	}
 }

--- a/engine/sources/netconfhttp/transport.go
+++ b/engine/sources/netconfhttp/transport.go
@@ -1,6 +1,7 @@
 package netconfhttp
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
@@ -18,6 +19,38 @@ func NewTransport(rt http.RoundTripper, dns *oci.DNSConfig) http.RoundTripper {
 		resolver:      resolver,
 		searchDomains: domains,
 	}
+}
+
+// NewDialTransportWithHostAliases returns a clone of rt that dials bound
+// service aliases through Dagger DNS while leaving the request host unchanged.
+func NewDialTransportWithHostAliases(rt *http.Transport, dns *oci.DNSConfig, hostAliases map[string]string) *http.Transport {
+	resolver, domains := createResolver(dns)
+
+	// Registry transports may be reused across resolves. Clone before installing
+	// a service-specific DialContext so one binding cannot leak into another.
+	cloned := rt.Clone()
+	dialContext := cloned.DialContext
+	if dialContext == nil {
+		dialer := net.Dialer{}
+		dialContext = dialer.DialContext
+	}
+	cloned.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err == nil {
+			if alias, ok := hostAliases[host]; ok {
+				// Keep the request host and TLS SNI as the registry name; only
+				// the TCP dial target follows the bound service through Dagger DNS.
+				addr, err = resolveHost(ctx, net.JoinHostPort(alias, port), resolver, domains)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		return dialContext(ctx, network, addr)
+	}
+	// A custom DialTLSContext would bypass DialContext for HTTPS requests.
+	cloned.DialTLSContext = nil
+	return cloned
 }
 
 type transport struct {

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -355,10 +355,20 @@ defmodule Dagger.Container do
   @doc """
   Download a container image, and apply it to the container state. All previous state will be lost.
   """
-  @spec from(t(), String.t()) :: Dagger.Container.t()
-  def from(%__MODULE__{} = container, address) do
+  @spec from(t(), String.t(), [{:registry_service, Dagger.Service.t() | nil}]) ::
+          Dagger.Container.t()
+  def from(%__MODULE__{} = container, address, optional_args \\ []) do
     query_builder =
-      container.query_builder |> QB.select("from") |> QB.put_arg("address", address)
+      container.query_builder
+      |> QB.select("from")
+      |> QB.put_arg("address", address)
+      |> QB.maybe_put_arg(
+        "registryService",
+        if(optional_args[:registry_service],
+          do: Dagger.ID.id!(optional_args[:registry_service]),
+          else: nil
+        )
+      )
 
     %Dagger.Container{
       query_builder: query_builder,
@@ -469,7 +479,8 @@ defmodule Dagger.Container do
   @spec publish(t(), String.t(), [
           {:platform_variants, [Dagger.Container.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
-          {:media_types, Dagger.ImageMediaTypes.t() | nil}
+          {:media_types, Dagger.ImageMediaTypes.t() | nil},
+          {:registry_service, Dagger.Service.t() | nil}
         ]) :: {:ok, String.t()} | {:error, term()}
   def publish(%__MODULE__{} = container, address, optional_args \\ []) do
     query_builder =
@@ -485,6 +496,13 @@ defmodule Dagger.Container do
       )
       |> QB.maybe_put_arg("forcedCompression", optional_args[:forced_compression])
       |> QB.maybe_put_arg("mediaTypes", optional_args[:media_types])
+      |> QB.maybe_put_arg(
+        "registryService",
+        if(optional_args[:registry_service],
+          do: Dagger.ID.id!(optional_args[:registry_service]),
+          else: nil
+        )
+      )
 
     Client.execute(container.client, query_builder)
   end

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -2328,9 +2328,23 @@ func (r *Container) File(path string, opts ...ContainerFileOpts) *File {
 	}
 }
 
+// ContainerFromOpts contains options for Container.From
+type ContainerFromOpts struct {
+	// Service to use as the registry endpoint for the image address.
+	//
+	// The service will be started only for this pull.
+	RegistryService *Service
+}
+
 // Download a container image, and apply it to the container state. All previous state will be lost.
-func (r *Container) From(address string) *Container {
+func (r *Container) From(address string, opts ...ContainerFromOpts) *Container {
 	q := r.query.Select("from")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `registryService` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RegistryService) {
+			q = q.Arg("registryService", opts[i].RegistryService)
+		}
+	}
 	q = q.Arg("address", address)
 
 	return &Container{
@@ -2500,6 +2514,10 @@ type ContainerPublishOpts struct {
 	//
 	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
+	// Service to use as the registry endpoint for the image address.
+	//
+	// The service will be started only for this push.
+	RegistryService *Service
 }
 
 // Package the container state as an OCI image, and publish it to a registry
@@ -2522,6 +2540,10 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 		// `mediaTypes` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
 			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+		// `registryService` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RegistryService) {
+			q = q.Arg("registryService", opts[i].RegistryService)
 		}
 	}
 	q = q.Arg("address", address)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -283,10 +283,13 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
     /**
      * Download a container image, and apply it to the container state. All previous state will be lost.
      */
-    public function from(string $address): Container
+    public function from(string $address, ?Service $registryService = null): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('from');
         $innerQueryBuilder->setArgument('address', $address);
+        if (null !== $registryService) {
+        $innerQueryBuilder->setArgument('registryService', $registryService);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -368,6 +371,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?array $platformVariants = null,
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
+        ?Service $registryService = null,
     ): string {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('publish');
         $leafQueryBuilder->setArgument('address', $address);
@@ -379,6 +383,9 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $mediaTypes) {
         $leafQueryBuilder->setArgument('mediaTypes', $mediaTypes);
+        }
+        if (null !== $registryService) {
+        $leafQueryBuilder->setArgument('registryService', $registryService);
         }
         return (string)$this->queryLeaf($leafQueryBuilder, 'publish');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2377,7 +2377,12 @@ class Container(Type):
         _ctx = self._select("file", _args)
         return File(_ctx)
 
-    def from_(self, address: str) -> Self:
+    def from_(
+        self,
+        address: str,
+        *,
+        registry_service: "Service | None" = None,
+    ) -> Self:
         """Download a container image, and apply it to the container state. All
         previous state will be lost.
 
@@ -2386,9 +2391,13 @@ class Container(Type):
         address:
             Address of the container image to download, in standard OCI ref
             format. Example:"registry.dagger.io/engine:latest"
+        registry_service:
+            Service to use as the registry endpoint for the image address.
+            The service will be started only for this pull.
         """
         _args = [
             Arg("address", address),
+            Arg("registryService", registry_service, None),
         ]
         _ctx = self._select("from", _args)
         return Container(_ctx)
@@ -2550,6 +2559,7 @@ class Container(Type):
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
+        registry_service: "Service | None" = None,
     ) -> str:
         """Package the container state as an OCI image, and publish it to a
         registry
@@ -2579,6 +2589,9 @@ class Container(Type):
             Defaults to "OCI", which is compatible with most recent
             registries, but "Docker" may be needed for older registries
             without OCI support.
+        registry_service:
+            Service to use as the registry endpoint for the image address.
+            The service will be started only for this push.
 
         Returns
         -------
@@ -2603,6 +2616,7 @@ class Container(Type):
             ),
             Arg("forcedCompression", forced_compression, None),
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
+            Arg("registryService", registry_service, None),
         ]
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1640,6 +1640,13 @@ pub struct ContainerFileOpts {
     pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ContainerFromOpts {
+    /// Service to use as the registry endpoint for the image address.
+    /// The service will be started only for this pull.
+    #[builder(setter(into, strip_option), default)]
+    pub registry_service: Option<Id>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerImportOpts<'a> {
     /// Identifies the tag to import from the archive, if the archive bundles multiple tags.
     #[builder(setter(into, strip_option), default)]
@@ -1659,6 +1666,10 @@ pub struct ContainerPublishOpts {
     /// Used for multi-platform image.
     #[builder(setter(into, strip_option), default)]
     pub platform_variants: Option<Vec<Id>>,
+    /// Service to use as the registry endpoint for the image address.
+    /// The service will be started only for this push.
+    #[builder(setter(into, strip_option), default)]
+    pub registry_service: Option<Id>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerStatOpts {
@@ -2403,9 +2414,28 @@ impl Container {
     /// # Arguments
     ///
     /// * `address` - Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn from(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("from");
         query = query.arg("address", address.into());
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Download a container image, and apply it to the container state. All previous state will be lost.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn from_opts(&self, address: impl Into<String>, opts: ContainerFromOpts) -> Container {
+        let mut query = self.selection.select("from");
+        query = query.arg("address", address.into());
+        if let Some(registry_service) = opts.registry_service {
+            query = query.arg("registryService", registry_service);
+        }
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2546,6 +2576,9 @@ impl Container {
         }
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
+        }
+        if let Some(registry_service) = opts.registry_service {
+            query = query.arg("registryService", registry_service);
         }
         query.execute(self.graphql_client.clone()).await
     }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -423,6 +423,15 @@ export type ContainerFileOpts = {
   expand?: boolean
 }
 
+export type ContainerFromOpts = {
+  /**
+   * Service to use as the registry endpoint for the image address.
+   *
+   * The service will be started only for this pull.
+   */
+  registryService?: Service
+}
+
 export type ContainerImportOpts = {
   /**
    * Identifies the tag to import from the archive, if the archive bundles multiple tags.
@@ -451,6 +460,13 @@ export type ContainerPublishOpts = {
    * Defaults to "OCI", which is compatible with most recent registries, but "Docker" may be needed for older registries without OCI support.
    */
   mediaTypes?: ImageMediaTypes
+
+  /**
+   * Service to use as the registry endpoint for the image address.
+   *
+   * The service will be started only for this push.
+   */
+  registryService?: Service
 }
 
 export type ContainerStatOpts = {
@@ -4627,9 +4643,12 @@ export class Container extends BaseClient {
   /**
    * Download a container image, and apply it to the container state. All previous state will be lost.
    * @param address Address of the container image to download, in standard OCI ref format. Example:"registry.dagger.io/engine:latest"
+   * @param opts.registryService Service to use as the registry endpoint for the image address.
+   *
+   * The service will be started only for this pull.
    */
-  from = (address: string): Container => {
-    const ctx = this._ctx.select("from", { address })
+  from = (address: string, opts?: ContainerFromOpts): Container => {
+    const ctx = this._ctx.select("from", { address, ...opts })
     return new Container(ctx)
   }
 
@@ -4731,6 +4750,9 @@ export class Container extends BaseClient {
    * @param opts.mediaTypes Use the specified media types for the published image's layers.
    *
    * Defaults to "OCI", which is compatible with most recent registries, but "Docker" may be needed for older registries without OCI support.
+   * @param opts.registryService Service to use as the registry endpoint for the image address.
+   *
+   * The service will be started only for this push.
    */
   publish = async (
     address: string,


### PR DESCRIPTION
Partially fixes https://github.com/dagger/dagger/issues/6411

### Problem

  `WithServiceBinding` works for `container.exec` because exec runs inside Dagger's service network. `Container.Publish` and `Container.From` are different: they talk to registries through the engine resolver/pusher.

  That meant a module could start a local registry service, but image publish/from could not use it directly:

  ```go
  dag.Container().
      WithServiceBinding("registry", registryService).
      Publish(ctx, "registry:5000/app:latest")
```
was impossible until now

### Current changes

  Start the container's service bindings around registry operations (publish, from) and pass the Dagger DNS view into image config resolution, pull, and push.

This makes it possible to publish and get images from local service registries:

#### Publish
```go
  dag.Container().
      WithServiceBinding("registry", registryService).
      Publish(ctx, "registry:5000/app:latest")
```

#### Retrieve
```go
  dag.Container().
      WithServiceBinding("registry", registryService).
      From("registry:5000/app:latest")
```

### Design notes

  #### HTTPS

  For HTTPS registries, we have to keep the registry name from the ref in the request. For example, if the ref is bound to `bound-registry:5000/app:latest`, TLS still needs to check the certificate for `bound-registry`.

  The network connection itself goes to the running registry service behind that name.

  #### singleflight

  Image config resolution uses singleflight to avoid doing the same registry lookup twice at the same time.

  That is safe for normal registries because this key points to the same endpoint:

```text
  ref + platform + resolve mode
```

  With service bindings, the same ref can point to different running services for different callers:

```go
  containerA.WithServiceBinding("registry", registryServiceA).
      From("registry:5000/app:latest")

  containerB.WithServiceBinding("registry", registryServiceB).
      From("registry:5000/app:latest")
```

  So service-bound image config resolves skip singleflight. This is simpler and correct; it only gives up in-flight dedupe for this service path.

  ### Tests

  Added integration coverage for publish/from against a local registry service:

  - HTTPS with a generated CA trusted through engine registry config
  - HTTP with existing engine registry `http=true` config

[A follow-up PR will allow configuring HTTP service bindings as an API inside the module instead of the engine level config, but didn't want to extend too much the scope of that PR](https://discord.com/channels/707636530424053791/1003718839739105300/1511125025900593194) 

  Ran:

```shell
  dagger call engine-dev test --pkg ./engine/server/resolver --run TestDoesNotExist --failfast --timeout 2m
  dagger call engine-dev test --pkg ./core/integration --run TestContainer/TestPublishAndFromWithRegistryServiceBinding --failfast --timeout 8m
  ```