### PR TITLE
fix(engine): lease parent layer content for tarball export

### DIFF
--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -663,6 +663,97 @@ func (LocalCacheSuite) TestLocalCachePruneRemoteGitSnapshot(ctx context.Context,
 	require.Equal(t, readmeBeforePrune, readmeAfterPrune)
 }
 
+func (LocalCacheSuite) TestLocalCachePruneDoesNotDropZstdTarballLayerContent(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	engine := devEngineContainer(c, engineWithConfig(ctx, t, engineConfigWithEnabled(false)))
+	engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(engine)).Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engineSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}) })
+
+	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+	require.NoError(t, err)
+
+	newNestedClient := func() *dagger.Client {
+		t.Helper()
+
+		client, err := dagger.Connect(
+			ctx,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+		require.NoError(t, err)
+		return client
+	}
+
+	tarballDigest := func(t *testctx.T, ctr *dagger.Container) string {
+		t.Helper()
+
+		dgst, err := ctr.AsTarball(dagger.ContainerAsTarballOpts{
+			ForcedCompression: dagger.ImageLayerCompressionZstd,
+		}).Digest(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, dgst)
+		return dgst
+	}
+
+	producer := newNestedClient()
+	source := producer.
+		Container().
+		From(golangImage).
+		WithExec([]string{
+			"sh",
+			"-ec",
+			"mkdir -p /work && printf 'zstd prune repro\\n' > /work/source.txt",
+		})
+
+	sourceID, err := source.ID(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, sourceID)
+
+	beforeDigest := tarballDigest(t, source)
+	require.NoError(t, producer.Close())
+
+	pinnedClient := newNestedClient()
+	t.Cleanup(func() { _ = pinnedClient.Close() })
+
+	pinned := dagger.Ref[*dagger.Container](pinnedClient, sourceID)
+	pinned, err = pinned.Sync(ctx)
+	require.NoError(t, err)
+
+	ballastClient := newNestedClient()
+	_, err = ballastClient.
+		Container().
+		From(alpineImage).
+		WithEnvVariable("ZSTD_PRUNE_BALLAST", identity.NewID()).
+		WithExec([]string{
+			"sh",
+			"-ec",
+			"dd if=/dev/urandom of=/ballast bs=1M count=64 status=none",
+		}).
+		Sync(ctx)
+	require.NoError(t, err)
+	require.NoError(t, ballastClient.Close())
+
+	pruneClient := newNestedClient()
+	err = pruneClient.Engine().LocalCache().Prune(ctx, dagger.EngineCachePruneOpts{
+		UseDefaultPolicy: false,
+		MaxUsedSpace:     "1",
+		ReservedSpace:    "0",
+		MinFreeSpace:     "0",
+		TargetSpace:      "1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, pruneClient.Close())
+
+	sourceContents, err := pinned.File("/work/source.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "zstd prune repro\n", sourceContents)
+
+	afterDigest := tarballDigest(t, pinned)
+	require.Equal(t, beforeDigest, afterDigest)
+}
+
 func (LocalCacheSuite) TestLocalCachePruneDoesNotBreakRunningNestedEngineService(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/engine/snapshots/persistent_metadata.go
+++ b/engine/snapshots/persistent_metadata.go
@@ -152,36 +152,43 @@ func (cm *snapshotManager) AttachLease(ctx context.Context, leaseID, snapshotID 
 		return pkgerrors.Wrapf(err, "create owner lease %s", leaseID)
 	}
 
-	_, err = cm.Snapshotter.Stat(ctx, snapshotID)
-	if err != nil {
-		if cerrdefs.IsNotFound(err) {
-			return pkgerrors.Wrap(errNotFound, snapshotID)
+	snapshotIDs := []string{}
+	for currentSnapshotID := snapshotID; currentSnapshotID != ""; {
+		info, err := cm.Snapshotter.Stat(ctx, currentSnapshotID)
+		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				return pkgerrors.Wrap(errNotFound, currentSnapshotID)
+			}
+			return pkgerrors.Wrapf(err, "stat snapshot %s for owner lease %s", currentSnapshotID, leaseID)
 		}
-		return pkgerrors.Wrapf(err, "stat snapshot %s for owner lease %s", snapshotID, leaseID)
+		snapshotIDs = append(snapshotIDs, currentSnapshotID)
+		currentSnapshotID = info.Parent
 	}
 
-	err = cm.LeaseManager.AddResource(ctx, leases.Lease{ID: leaseID}, leases.Resource{
-		ID:   snapshotID,
-		Type: "snapshots/" + cm.Snapshotter.Name(),
-	})
-	if err != nil && !cerrdefs.IsAlreadyExists(err) {
-		return pkgerrors.Wrapf(err, "attach snapshot %s to owner lease %s", snapshotID, leaseID)
-	}
-
-	for dgst := range cm.snapshotContentDigests[snapshotID] {
+	for _, currentSnapshotID := range snapshotIDs {
 		err = cm.LeaseManager.AddResource(ctx, leases.Lease{ID: leaseID}, leases.Resource{
-			ID:   dgst.String(),
-			Type: "content",
+			ID:   currentSnapshotID,
+			Type: "snapshots/" + cm.Snapshotter.Name(),
 		})
 		if err != nil && !cerrdefs.IsAlreadyExists(err) {
-			return pkgerrors.Wrapf(err, "attach content %s to owner lease %s", dgst, leaseID)
+			return pkgerrors.Wrapf(err, "attach snapshot %s to owner lease %s", currentSnapshotID, leaseID)
 		}
-	}
 
-	if cm.snapshotOwnerLeases[snapshotID] == nil {
-		cm.snapshotOwnerLeases[snapshotID] = make(map[string]struct{})
+		for dgst := range cm.snapshotContentDigests[currentSnapshotID] {
+			err = cm.LeaseManager.AddResource(ctx, leases.Lease{ID: leaseID}, leases.Resource{
+				ID:   dgst.String(),
+				Type: "content",
+			})
+			if err != nil && !cerrdefs.IsAlreadyExists(err) {
+				return pkgerrors.Wrapf(err, "attach content %s for snapshot %s to owner lease %s", dgst, currentSnapshotID, leaseID)
+			}
+		}
+
+		if cm.snapshotOwnerLeases[currentSnapshotID] == nil {
+			cm.snapshotOwnerLeases[currentSnapshotID] = make(map[string]struct{})
+		}
+		cm.snapshotOwnerLeases[currentSnapshotID][leaseID] = struct{}{}
 	}
-	cm.snapshotOwnerLeases[snapshotID][leaseID] = struct{}{}
 
 	return nil
 }


### PR DESCRIPTION
## Problem

Container image tarball export can fail after cache pruning when the export needs layer content that is no longer retained by an owner lease. The observed failure was intermittent during engine builds, especially through `Container.asTarball(forcedCompression: Zstd)`, with errors like a missing local content blob or a content digest not found while ensuring the requested compression type.

## Root Cause

Dagger owner leases only retained the snapshot directly attached to a persisted result, plus content digests already recorded for that direct snapshot. Image export walks the full snapshot parent chain, while imported image blobs and generated compression variants are recorded against the individual layer snapshots in that chain. That left parent layer content eligible for prune even when a descendant container result remained retained and usable.

The filesystem snapshot could still be read after prune, but export could fail because the layer blob or zstd compression variant needed to construct the tarball had been reclaimed.

## Fix

When attaching an owner lease, walk the snapshot parent chain and attach each snapshot plus its known content digests to the same containerd lease. Also register the owner lease against each snapshot in the chain, so content recorded later for any ancestor snapshot, including zstd compression variants, is backfilled to the active owner lease.

This keeps tarball-export layer content retained for the same lifetime as the retained container result without changing stale-lease cleanup semantics.

## Validation

Added an integration repro that:

- creates a container and exports it once as a zstd tarball
- closes the producing session
- pins the container in a new session
- creates additional cache pressure
- prunes aggressively
- verifies the pinned filesystem is still readable
- exports the pinned container as a zstd tarball again

Validated with:

- `go test ./engine/snapshots`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='^TestLocalCache/TestLocalCachePruneDoesNotDropZstdTarballLayerContent$'`