### PR TITLE
fix(layercopy): materialize resolved parent dirs when writing through…

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3432,6 +3432,23 @@ func (ContainerSuite) TestWithDirectoryToMount(ctx context.Context, t *testctx.T
 	}, strings.Split(strings.Trim(contents, "\n"), "\n"))
 }
 
+func (ContainerSuite) TestAddFile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := c.Container().From(alpineImage).
+		WithExec([]string{"sh", "-c", "mkdir -p /target/sub && ln -s /target/sub /link"})
+
+	const want = "hello through a symlink\n"
+	src := c.Directory().WithNewFile("file", want).File("file")
+	ctr, err := base.WithFile("/link/file", src).Sync(ctx)
+	require.NoError(t, err)
+
+	// the file written through the symlink must be readable at the resolved path
+	got, err := ctr.File("/target/sub/file").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
 func (ContainerSuite) TestExecError(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/util/layercopy/dest_linux.go
+++ b/util/layercopy/dest_linux.go
@@ -112,7 +112,9 @@ func (d *destination) ensureDir(destPath string, src *sourceEntry, opts CopyOpti
 				return "", false, err
 			}
 			rel = cleanRel(rel)
-			if parent := filepath.Dir(destPath); parent != "/" && parent != "." {
+			// Recurse on the parent of the *resolved* path (rel), not destPath:
+			// to handle symlins on dest paths
+			if parent := filepath.Dir(cleanContainerPath(rel)); parent != "/" && parent != "." {
 				if _, _, err := d.ensureDir(parent, nil, CopyOptions{}, false); err != nil {
 					return "", false, err
 				}


### PR DESCRIPTION
… symlinks

When WithFile/WithDirectory writes to a path that traverses a symlinked directory (e.g. ubuntu's /bin -> usr/bin), ensureDir resolved the symlink to the real view path but recursed on the parent of the original destPath instead of the parent of the resolved path. On a fresh overlay layer this skipped materializing intermediate dirs (e.g. usr) in the upperdir, so materializeExistingDir failed with 'mkdir .../usr/bin: no such file or directory'.

Recurse on the parent of the resolved rel so the full parent chain is created in the new layer.