### PR TITLE
[1.0-beta] fix: auth private git module deps during SDK-as-module codegen

### DIFF
--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -10,6 +10,10 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -97,6 +101,82 @@ func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T
 		lines = strings.Split(out, "\n")
 		require.Contains(t, lines, "fn     -")
 	})
+}
+
+// TestGeneratePrivateGitDependency verifies that `dagger generate` can resolve a
+// module's private Git dependency.
+//
+// Codegen runs through the go-sdk *module*'s `generate-all` generator
+// (github.com/dagger/go-sdk). That generator executes as module code, i.e. under
+// a nested module client rather than the user's main client. The dependency is
+// resolved inside that nested execution (generatedContextChangeset -> codegen ->
+// loadDependencyModules -> ResolveDepToSource), so the engine must forward the
+// non-module parent client's Git credentials. Before the fix in
+// ResolveDepToSource, the git resolver only authenticated for the main client
+// (core/schema/git.go), and this failed with "git authentication failed" even
+// though `dagger -m <private-ref> ...` and `dagger develop` worked.
+//
+// This runs `dagger` on the host (not nested in a container) so the
+// credential-resolving client has git and the configured credential helper,
+// matching how git credential forwarding is exercised in gitcredential_test.go.
+func (ModuleSuite) TestGeneratePrivateGitDependency(ctx context.Context, t *testctx.T) {
+	// HTTPS GitLab private repo authenticated with a read-only PAT, matching the
+	// originally reported scenario.
+	tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
+
+	workDir := t.TempDir()
+
+	// Isolated git credential helper for the private repo's host.
+	gitConfigPath := filepath.Join(workDir, ".gitconfig")
+	err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials("https://"+tc.expectedHost, "x-token-auth", tc.token())), 0600)
+	require.NoError(t, err)
+
+	// run executes a dagger command on the host in workDir with a git
+	// environment scoped to the isolated credential helper above.
+	run := func(args ...string) ([]byte, error) {
+		cmd := hostDaggerCommandRaw(ctx, t, workDir, args...)
+		env := make([]string, 0, len(os.Environ()))
+		for _, e := range os.Environ() {
+			if !strings.Contains(strings.ToLower(strings.SplitN(e, "=", 2)[0]), "git") {
+				env = append(env, e)
+			}
+		}
+		env = append(env,
+			"GIT_CONFIG_GLOBAL="+gitConfigPath,
+			"GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1",
+			"GIT_TERMINAL_PROMPT=0",
+		)
+		cmd.Env = env
+		out, runErr := cmd.CombinedOutput()
+		if runErr != nil {
+			runErr = fmt.Errorf("%s: %w", out, runErr)
+		}
+		return out, runErr
+	}
+
+	// Initialize a workspace with the go-sdk generator installed.
+	require.NoError(t, exec.Command("git", "-C", workDir, "init").Run())
+	out, err := run("workspace", "init")
+	require.NoError(t, err, string(out))
+	out, err = run("install", "github.com/dagger/go-sdk")
+	require.NoError(t, err, string(out))
+
+	// A Go SDK module (discovered by go-sdk's generate-all) that declares the
+	// private repo as a dependency.
+	daggerJSON := fmt.Sprintf(`{
+  "name": "consumer",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": ".",
+  "dependencies": [ { "name": "dep", "source": %q } ]
+}`, testGitModuleRef(tc, ""))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "dagger.json"), []byte(daggerJSON), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\n\ntype Consumer struct{}\n\nfunc (m *Consumer) Hello() string { return \"hello\" }\n"), 0644))
+
+	out, err = run("generate", "-y", "--progress=plain")
+	require.NoError(t, err, string(out))
+	require.NotContains(t, string(out), "authentication failed")
 }
 
 func (ModuleSuite) TestPrivateDeps(ctx context.Context, t *testctx.T) {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1730,6 +1730,26 @@ type DirModuleSource struct {
 	OriginalSourceRootSubpath string
 }
 
+type moduleDependencyResolutionKey struct{}
+
+// WithModuleDependencyResolution marks ctx as resolving a module's declared
+// dependency or SDK source. This is trusted resolution performed on the user's
+// behalf (the refs come from a module's dagger.json), so the git resolver is
+// permitted to fall back to the session's originating client credentials when
+// the immediate caller is a nested client that doesn't hold them (e.g. a codegen
+// exec during `dagger generate`). It does NOT loosen credential handling for
+// arbitrary git access from module runtime code.
+func WithModuleDependencyResolution(ctx context.Context) context.Context {
+	return context.WithValue(ctx, moduleDependencyResolutionKey{}, true)
+}
+
+// IsModuleDependencyResolution reports whether ctx is resolving a module's
+// declared dependency or SDK source. See WithModuleDependencyResolution.
+func IsModuleDependencyResolution(ctx context.Context) bool {
+	allowed, _ := ctx.Value(moduleDependencyResolutionKey{}).(bool)
+	return allowed
+}
+
 // ResolveDepToSource given a parent module source, load a dependency of it
 // from the given depSrcRef, depPin and depName.
 func ResolveDepToSource(
@@ -1870,6 +1890,16 @@ func ResolveDepToSource(
 
 	case ModuleSourceKindGit:
 		// parent=*, dep=git
+		// Mark this as trusted module dependency/SDK resolution. A module's git
+		// dependencies and git-based SDK are declared in its (trusted) dagger.json
+		// and resolved on the user's behalf, but codegen can run under a nested
+		// client (e.g. a git-less codegen exec during `dagger generate`) that does
+		// not itself hold the user's git credentials. This marker lets the git
+		// resolver fall back to the originating client's credentials (see
+		// core/schema/git.go); without it the resolver only authenticates for the
+		// main client and private dependency resolution fails.
+		ctx = WithModuleDependencyResolution(ctx)
+
 		selectors := []dagql.Selector{{
 			Field: "moduleSource",
 			Args: []dagql.NamedInput{

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -472,10 +472,31 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				})
 				return inst, err
 			}
-		} else if clientMetadata.SSHAuthSocketPath != "" {
-			// For SSH refs, scope the caller's default SSH auth socket and reinvoke so it appears in the DAG.
+		} else {
+			// No explicit socket: scope a default SSH auth socket from a client that
+			// has one. Normally that's the current client; for trusted module
+			// dependency/SDK resolution running under a nested client without a
+			// socket (e.g. a codegen exec during `dagger generate`), fall back to the
+			// session's originating client.
+			sshSocketCtx := ctx
+			sshAuthSocketPath := clientMetadata.SSHAuthSocketPath
+			if sshAuthSocketPath == "" && core.IsModuleDependencyResolution(ctx) {
+				mainClientMetadata, err := parent.Self().MainClientCallerMetadata(ctx)
+				if err != nil {
+					return inst, err
+				}
+				if mainClientMetadata.SSHAuthSocketPath != "" {
+					sshSocketCtx = engine.ContextWithClientMetadata(ctx, mainClientMetadata)
+					sshAuthSocketPath = mainClientMetadata.SSHAuthSocketPath
+				}
+			}
+			if sshAuthSocketPath == "" {
+				return inst, fmt.Errorf("%w: SSH URLs are not supported without an SSH socket", gitutil.ErrGitAuthFailed)
+			}
+
+			// Scope that client's default SSH auth socket and reinvoke so it appears in the DAG.
 			var scopedSock dagql.ObjectResult[*core.Socket]
-			if err := srv.Select(ctx, srv.Root(), &scopedSock,
+			if err := srv.Select(sshSocketCtx, srv.Root(), &scopedSock,
 				dagql.Selector{
 					Field: "host",
 				},
@@ -541,8 +562,6 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				View:  curCall.View,
 			})
 			return inst, err
-		} else {
-			return inst, fmt.Errorf("%w: SSH URLs are not supported without an SSH socket", gitutil.ErrGitAuthFailed)
 		}
 	case gitutil.HTTPProtocol, gitutil.HTTPSProtocol:
 		if args.HTTPAuthToken.Valid {
@@ -558,14 +577,33 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			}
 		}
 		if httpAuthToken.Self() == nil && httpAuthHeader.Self() == nil {
-			// For HTTP refs, try to load client credentials from the git helper
+			// For HTTP refs, try to load client credentials from the git helper.
 			parentClientMetadata, err := parent.Self().NonModuleParentClientMetadata(ctx)
 			if err != nil {
 				return inst, err
 			}
-			if clientMetadata.ClientID != parentClientMetadata.ClientID {
-				// only handle PAT auth if we're the main client
+
+			// Determine which client(s) may supply implicit credentials. Arbitrary
+			// git access from nested module runtime code must not implicitly use the
+			// host's credentials, so by default we only do so when we ARE the
+			// non-module caller. For trusted module dependency/SDK resolution we
+			// additionally fall back to the session's originating client, since
+			// codegen can run under a nested client (e.g. a git-less codegen exec
+			// during `dagger generate`) that doesn't itself hold the user's
+			// credentials.
+			isTrustedDepResolution := core.IsModuleDependencyResolution(ctx)
+			if clientMetadata.ClientID != parentClientMetadata.ClientID && !isTrustedDepResolution {
 				break
+			}
+			credClientMetadatas := []*engine.ClientMetadata{parentClientMetadata}
+			if isTrustedDepResolution {
+				mainClientMetadata, err := parent.Self().MainClientCallerMetadata(ctx)
+				if err != nil {
+					return inst, err
+				}
+				if mainClientMetadata.ClientID != parentClientMetadata.ClientID {
+					credClientMetadatas = append(credClientMetadatas, mainClientMetadata)
+				}
 			}
 
 			// start services if needed, before checking for auth
@@ -595,93 +633,97 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				break
 			}
 
-			// Retrieve credential from host
-			authCtx := engine.ContextWithClientMetadata(ctx, parentClientMetadata)
-			bk, err := parent.Self().Engine(authCtx)
-			if err != nil {
-				return inst, fmt.Errorf("failed to get engine client: %w", err)
-			}
-			credentials, err := bk.GetCredential(authCtx, remote.Scheme, remote.Host, remote.Path)
-			if err != nil {
-				// it's possible to provide auth tokens via chained API calls, so warn now but
-				// don't fail. Auth will be checked again before relevant operations later.
-				slog.Warn("Failed to retrieve git credentials", "error", err)
-				break
-			}
+			// Retrieve credentials, trying each candidate client until one succeeds.
+			for _, credClientMetadata := range credClientMetadatas {
+				authCtx := engine.ContextWithClientMetadata(ctx, credClientMetadata)
+				bk, err := parent.Self().Engine(authCtx)
+				if err != nil {
+					return inst, fmt.Errorf("failed to get engine client: %w", err)
+				}
+				credentials, err := bk.GetCredential(authCtx, remote.Scheme, remote.Host, remote.Path)
+				if err != nil {
+					// it's possible to provide auth tokens via chained API calls, so warn now but
+					// don't fail. Auth will be checked again before relevant operations later.
+					slog.Warn("Failed to retrieve git credentials", "error", err, "clientID", credClientMetadata.ClientID)
+					continue
+				}
 
-			hash := sha256.Sum256([]byte(credentials.Password))
-			secretName := hex.EncodeToString(hash[:])
-			var authToken dagql.ObjectResult[*core.Secret]
-			if err := srv.Select(authCtx, srv.Root(), &authToken,
-				dagql.Selector{
-					Field: "setSecret",
-					Args: []dagql.NamedInput{
-						{
-							Name:  "name",
-							Value: dagql.NewString(secretName),
-						},
-						{
-							Name:  "plaintext",
-							Value: dagql.NewString(credentials.Password),
+				hash := sha256.Sum256([]byte(credentials.Password))
+				secretName := hex.EncodeToString(hash[:])
+				var authToken dagql.ObjectResult[*core.Secret]
+				if err := srv.Select(authCtx, srv.Root(), &authToken,
+					dagql.Selector{
+						Field: "setSecret",
+						Args: []dagql.NamedInput{
+							{
+								Name:  "name",
+								Value: dagql.NewString(secretName),
+							},
+							{
+								Name:  "plaintext",
+								Value: dagql.NewString(credentials.Password),
+							},
 						},
 					},
-				},
-			); err != nil {
-				return inst, fmt.Errorf("failed to create a new secret with the git auth token: %w", err)
-			}
-			authTokenID, err := authToken.ID()
-			if err != nil {
-				return inst, fmt.Errorf("git auth token ID: %w", err)
-			}
+				); err != nil {
+					return inst, fmt.Errorf("failed to create a new secret with the git auth token: %w", err)
+				}
+				authTokenID, err := authToken.ID()
+				if err != nil {
+					return inst, fmt.Errorf("git auth token ID: %w", err)
+				}
 
-			// reinvoke this API with the socket as an explicit arg so it shows up in the DAG
-			selectArgs := []dagql.NamedInput{
-				{
-					Name:  "url",
-					Value: dagql.NewString(remote.String()),
-				},
-				{
-					Name:  "httpAuthToken",
-					Value: dagql.Opt(dagql.NewID[*core.Secret](authTokenID)),
-				},
-			}
-			// Omit blank username; adding it would change the selector hash and kill cache hits.
-			if credentials.Username != "" {
-				selectArgs = append(selectArgs, dagql.NamedInput{
-					Name:  "httpAuthUsername",
-					Value: dagql.NewString(credentials.Username),
+				// reinvoke this API with the token as an explicit arg so it shows up in the DAG
+				selectArgs := []dagql.NamedInput{
+					{
+						Name:  "url",
+						Value: dagql.NewString(remote.String()),
+					},
+					{
+						Name:  "httpAuthToken",
+						Value: dagql.Opt(dagql.NewID[*core.Secret](authTokenID)),
+					},
+				}
+				// Omit blank username; adding it would change the selector hash and kill cache hits.
+				if credentials.Username != "" {
+					selectArgs = append(selectArgs, dagql.NamedInput{
+						Name:  "httpAuthUsername",
+						Value: dagql.NewString(credentials.Username),
+					})
+				}
+				if args.KeepGitDir.Valid {
+					selectArgs = append(selectArgs, dagql.NamedInput{
+						Name:  "keepGitDir",
+						Value: dagql.Opt(args.KeepGitDir.Value),
+					})
+				}
+				if args.Commit != "" {
+					selectArgs = append(selectArgs, dagql.NamedInput{
+						Name:  "commit",
+						Value: dagql.NewString(args.Commit),
+					})
+				}
+				if args.Ref != "" {
+					selectArgs = append(selectArgs, dagql.NamedInput{
+						Name:  "ref",
+						Value: dagql.NewString(args.Ref),
+					})
+				}
+				if args.ExperimentalServiceHost.Valid {
+					selectArgs = append(selectArgs, dagql.NamedInput{
+						Name:  "experimentalServiceHost",
+						Value: dagql.Opt(dagql.NewID[*core.Service](experimentalServiceHostID)),
+					})
+				}
+				err = srv.Select(ctx, parent, &inst, dagql.Selector{
+					Field: "git",
+					Args:  selectArgs,
+					View:  curCall.View,
 				})
+				return inst, err
 			}
-			if args.KeepGitDir.Valid {
-				selectArgs = append(selectArgs, dagql.NamedInput{
-					Name:  "keepGitDir",
-					Value: dagql.Opt(args.KeepGitDir.Value),
-				})
-			}
-			if args.Commit != "" {
-				selectArgs = append(selectArgs, dagql.NamedInput{
-					Name:  "commit",
-					Value: dagql.NewString(args.Commit),
-				})
-			}
-			if args.Ref != "" {
-				selectArgs = append(selectArgs, dagql.NamedInput{
-					Name:  "ref",
-					Value: dagql.NewString(args.Ref),
-				})
-			}
-			if args.ExperimentalServiceHost.Valid {
-				selectArgs = append(selectArgs, dagql.NamedInput{
-					Name:  "experimentalServiceHost",
-					Value: dagql.Opt(dagql.NewID[*core.Service](experimentalServiceHostID)),
-				})
-			}
-			err = srv.Select(ctx, parent, &inst, dagql.Selector{
-				Field: "git",
-				Args:  selectArgs,
-				View:  curCall.View,
-			})
-			return inst, err
+			// no candidate client provided credentials; proceed unauthenticated
+			break
 		}
 	}
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1103,7 +1103,7 @@ dagger module install [options] <module> [flags]
 ### Examples
 
 ```
-dagger module install github.com/shykes/daggerverse/hello@v0.3.0
+dagger mod install github.com/shykes/daggerverse/hello@v0.3.0
 ```
 
 ### Options
@@ -1273,7 +1273,7 @@ dagger module uninstall [options] <module> [flags]
 ### Examples
 
 ```
-dagger module uninstall hello
+dagger mod uninstall hello
 ```
 
 ### Options


### PR DESCRIPTION
## Problem

`dagger generate` against a module that declares a **private git dependency**, using an SDK-as-module (e.g. `github.com/dagger/go-sdk`), fails to authenticate the dependency:

```
export generated context ... failed to resolve dep to source: failed to load git dep:
failed to resolve git src: ... git error: git authentication failed
```
```
git ls-remote --symref https://gitlab.com/<private-repo>.git
remote: HTTP Basic: Access denied.
```

`dagger develop`, a public dependency, and a manual `dagger -m core call git --url <same-private-repo>` all work — so the engine *can* authenticate; it just doesn't on this path.

## Root cause

`dagger generate` runs the go-sdk **module's** `generate-all` generator as module code, i.e. under a *nested module client* rather than the user's main client. The dependency is resolved inside that nested execution:

`go-sdk:generate-all` → `generatedContextChangeset` → `runCodegen` → `loadDependencyModules` → `ResolveDepToSource` → `dag.git(...)`

The git resolver (`core/schema/git.go`) only forwards the host's *implicit* credentials when the current client is the non-module parent client ("only handle PAT auth if we're the main client"). Under the nested generator client the guard skips credential resolution, so the fetch is unauthenticated → access denied.

`dagger develop` / `dagger init` resolve dependencies under the main client, so the guard passes — which is why this only regressed once SDKs moved to modules.

## Fix

Resolve declared git dependencies under the non-module parent client in `ResolveDepToSource` (`core/modulesource.go`), via `engine.ContextWithClientMetadata(ctx, NonModuleParentClientMetadata(ctx))`. This mirrors the existing idempotent idiom already used in this file for local source access (e.g. `LoadUserDefaults`), and is a no-op for top-level (main-client) resolution.

Scoped to **declared-dependency** resolution: a module calling `dag.moduleSource("private-url")` at runtime still fetches its top-level source through the unchanged guard, so this does not grant arbitrary module code implicit access to host credentials.

## Test

`TestGeneratePrivateGitDependency` (`core/integration/module_private_deps_test.go`): a Go-SDK module declaring a private GitLab dependency, generated via `dagger workspace init` → `dagger install github.com/dagger/go-sdk` → `dagger generate`, reusing the existing `getVCSTestCase`/`privateRepoSetup`/`testGitModuleRef` helpers (uses the repo's existing CI git credentials).

## Verification

- `go build ./core/`, `go vet ./core/integration/`, `gofmt` clean.
- Dev engine builds + boots with the change.
- Playground (public dependency): confirmed `dagger generate` drives `go-sdk:generate-all` → `generatedContextChangeset` → `go SDK: run codegen` and regenerates `dagger.gen.go` — i.e. the dependency is resolved inside the nested-client generator, and the change does not break public-dependency generation.
- The private-dependency red→green is exercised by the new integration test in CI (it depends on CI git secrets).

Tracking: dagger/dagger#13296.
