### PR TITLE
Simplify function call return handling

### DIFF
--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -89,12 +89,11 @@ type ContainerExecOpts struct {
 type ContainerExecState struct {
 	LazyState
 
-	Parent             dagql.ObjectResult[*Container]
-	Opts               ContainerExecOpts
-	ExecMD             *engineutil.ExecutionMetadata
-	ModuleContext      dagql.ObjectResult[*Module]
-	FunctionCall       *FunctionCall
-	ExtractModuleError bool
+	Parent        dagql.ObjectResult[*Container]
+	Opts          ContainerExecOpts
+	ExecMD        *engineutil.ExecutionMetadata
+	ModuleContext dagql.ObjectResult[*Module]
+	FunctionCall  *FunctionCall
 }
 
 type ContainerExecLazy struct {
@@ -106,8 +105,6 @@ type persistedContainerExecLazy struct {
 	ModuleContextResultID          uint64                        `json:"moduleContextResultID,omitempty"`
 	Opts                           ContainerExecOpts             `json:"opts"`
 	ExecMD                         *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
-	FunctionCall                   *FunctionCall                 `json:"functionCall,omitempty"`
-	ExtractModuleError             bool                          `json:"extractModuleError,omitempty"`
 	VolatileCacheHitParentResultID uint64                        `json:"volatileCacheHitParentResultID,omitempty"`
 	VolatileCacheHitVolatileEnv    []string                      `json:"volatileCacheHitVolatileEnv,omitempty"`
 }
@@ -160,6 +157,9 @@ func (lazy *ContainerExecLazy) EncodePersisted(ctx context.Context, cache dagql.
 	if lazy == nil || lazy.State == nil {
 		return nil, fmt.Errorf("encode persisted container withExec lazy: nil state")
 	}
+	if lazy.State.FunctionCall != nil {
+		return nil, fmt.Errorf("cannot persist container exec with active function call")
+	}
 	parentID, err := encodePersistedObjectRef(cache, lazy.State.Parent, "container withExec parent")
 	if err != nil {
 		return nil, err
@@ -176,8 +176,6 @@ func (lazy *ContainerExecLazy) EncodePersisted(ctx context.Context, cache dagql.
 		ModuleContextResultID: moduleContextID,
 		Opts:                  lazy.State.Opts,
 		ExecMD:                lazy.State.ExecMD,
-		FunctionCall:          lazy.State.FunctionCall,
-		ExtractModuleError:    lazy.State.ExtractModuleError,
 	})
 }
 
@@ -1159,16 +1157,14 @@ func (container *Container) WithExec(
 	execMD *engineutil.ExecutionMetadata,
 	moduleContext dagql.ObjectResult[*Module],
 	functionCall *FunctionCall,
-	extractModuleError bool,
 ) error {
 	state := &ContainerExecState{
-		LazyState:          NewLazyState(),
-		Parent:             parent,
-		Opts:               opts,
-		ExecMD:             execMD,
-		ModuleContext:      moduleContext,
-		FunctionCall:       functionCall,
-		ExtractModuleError: extractModuleError,
+		LazyState:     NewLazyState(),
+		Parent:        parent,
+		Opts:          opts,
+		ExecMD:        execMD,
+		ModuleContext: moduleContext,
+		FunctionCall:  functionCall,
 	}
 	container.Lazy = &ContainerExecLazy{State: state}
 	container.ImageRef = ""
@@ -1798,9 +1794,6 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			defer releaseResolvedRefs()
 
 			var metaRef bkcache.ImmutableRef
-			var moduleRef bkcache.ImmutableRef
-			var moduleErrID dagql.ID[*Error]
-			haveModuleErrID := false
 			resolveAndTrackFailureRef := func(state *execMountState) (bkcache.ImmutableRef, error) {
 				ref, err := resolveFailureRef(state)
 				if err != nil {
@@ -1810,9 +1803,6 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			}
 			for _, mountState := range mountStates {
 				keepRef := mountState.Dest == engineutil.MetaMountDestPath
-				if state.ExtractModuleError && mountState.Dest == modMetaDirPath {
-					keepRef = true
-				}
 				if !keepRef {
 					continue
 				}
@@ -1826,21 +1816,6 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				}
 				if mountState.Dest == engineutil.MetaMountDestPath {
 					metaRef = ref
-				}
-				if state.ExtractModuleError && mountState.Dest == modMetaDirPath {
-					moduleRef = ref
-				}
-			}
-
-			if state.ExtractModuleError && moduleRef != nil {
-				errID, ok, err := moduleErrorIDFromRef(ctx, engineClient, moduleRef)
-				if err != nil {
-					rerr = errors.Join(rerr, fmt.Errorf("extract module error: %w", err))
-					return
-				}
-				if ok {
-					moduleErrID = errID
-					haveModuleErrID = true
 				}
 			}
 
@@ -2047,12 +2022,6 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				}
 			}
 
-			if haveModuleErrID {
-				rerr = &ModuleExecError{
-					Err:     rerr,
-					ErrorID: moduleErrID,
-				}
-			}
 		}()
 
 		emu, err := getEmulator(ctx, specs.Platform(container.Platform))
@@ -2229,13 +2198,11 @@ func decodePersistedContainerExecLazy(
 		return err
 	}
 	state := &ContainerExecState{
-		LazyState:          NewLazyState(),
-		Parent:             parent,
-		Opts:               persisted.Opts,
-		ExecMD:             persisted.ExecMD,
-		ModuleContext:      moduleContext,
-		FunctionCall:       persisted.FunctionCall,
-		ExtractModuleError: persisted.ExtractModuleError,
+		LazyState:     NewLazyState(),
+		Parent:        parent,
+		Opts:          persisted.Opts,
+		ExecMD:        persisted.ExecMD,
+		ModuleContext: moduleContext,
 	}
 	container.Lazy = &ContainerExecLazy{State: state}
 	container.ImageRef = ""

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -2021,9 +2021,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 					}
 				}
 			}
-
 		}()
-
 		emu, err := getEmulator(ctx, specs.Platform(container.Platform))
 		if err != nil {
 			return err

--- a/core/exec_error.go
+++ b/core/exec_error.go
@@ -2,6 +2,9 @@ package core
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -10,6 +13,7 @@ import (
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 	bkexecutor "github.com/dagger/dagger/internal/buildkit/executor"
 	telemetry "github.com/dagger/otel-go"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -40,25 +44,6 @@ func (e *ExecError) Extensions() map[string]any {
 		"stdout":   e.Stdout,
 		"stderr":   e.Stderr,
 	}
-}
-
-type ModuleExecError struct {
-	Err     error
-	ErrorID dagql.ID[*Error]
-}
-
-func (e *ModuleExecError) Error() string {
-	if e == nil || e.Err == nil {
-		return "module exec error"
-	}
-	return e.Err.Error()
-}
-
-func (e *ModuleExecError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
 }
 
 func execErrorFromMetaRef(
@@ -95,26 +80,61 @@ func execErrorFromMetaRef(
 	return execErr, true, nil
 }
 
-func moduleErrorIDFromRef(
+func functionCallReturnedError(
 	ctx context.Context,
-	client *engineutil.Client,
-	ref bkcache.ImmutableRef,
-) (dagql.ID[*Error], bool, error) {
-	var id dagql.ID[*Error]
-	if ref == nil {
-		return id, false, nil
-	}
-	idBytes, err := readSnapshotPathFromRef(ctx, client, ref, modMetaErrorPath, -1)
+	errID dagql.ID[*Error],
+	execErr error,
+) (*Error, error) {
+	srv, err := CurrentDagqlServer(ctx)
 	if err != nil {
-		return id, false, err
+		return nil, fmt.Errorf("load returned function error: %w", err)
 	}
-	if strings.TrimSpace(string(idBytes)) == "" {
-		return id, false, nil
+
+	errInst, err := errID.Load(ctx, srv)
+	if err != nil {
+		return nil, fmt.Errorf("load returned function error: %w", err)
 	}
-	if err := id.Decode(string(idBytes)); err != nil {
-		return id, false, err
+
+	dagErr := errInst.Self().Clone()
+
+	originCtx := trace.SpanContextFromContext(
+		telemetry.Propagator.Extract(
+			context.Background(),
+			telemetry.AnyMapCarrier(dagErr.Extensions()),
+		),
+	)
+	if !originCtx.IsValid() && execErr != nil {
+		if origins := telemetry.ParseErrorOrigins(execErr.Error()); len(origins) > 0 && origins[0].IsValid() {
+			originCtx = origins[0]
+		}
 	}
-	return id, true, nil
+	if !originCtx.IsValid() {
+		originCtx = trace.SpanContextFromContext(ctx)
+	}
+	if originCtx.IsValid() && len(telemetry.ParseErrorOrigins(dagErr.Message)) == 0 {
+		dagErr.Message = telemetry.TrackOrigin(errors.New(dagErr.Message), originCtx).Error()
+	}
+	if originCtx.IsValid() {
+		extOriginCtx := trace.SpanContextFromContext(
+			telemetry.Propagator.Extract(
+				context.Background(),
+				telemetry.AnyMapCarrier(dagErr.Extensions()),
+			),
+		)
+		if !extOriginCtx.IsValid() {
+			carrier := propagation.MapCarrier{}
+			telemetry.Propagator.Inject(trace.ContextWithSpanContext(context.Background(), originCtx), carrier)
+			for _, key := range carrier.Keys() {
+				valJSON, err := json.Marshal(carrier.Get(key))
+				if err != nil {
+					return nil, fmt.Errorf("marshal error extension %q: %w", key, err)
+				}
+				dagErr = dagErr.WithValue(key, JSON(valJSON))
+			}
+		}
+	}
+
+	return dagErr, nil
 }
 
 func getExecMeta(ctx context.Context, client *engineutil.Client, metaMount bkcache.ImmutableRef) (stdout []byte, stderr []byte, exitCode int, _ error) {

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -12,13 +12,7 @@ import (
 	"github.com/dagger/dagger/dagql/call"
 )
 
-const (
-	modMetaDirPath    = "/.daggermod"
-	modMetaOutputPath = "output.json"
-	modMetaErrorPath  = "error"
-
-	ModuleName = "daggercore"
-)
+const ModuleName = "daggercore"
 
 var TypesToIgnoreForModuleIntrospection = []string{"Host"}
 

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -856,11 +856,11 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 		return nil, fmt.Errorf("marshal parent value: %w", err)
 	}
 
-	fnCall := &FunctionCall{
+	fnCall := newFunctionCall(FunctionCall{
 		Name:      fn.metadata.OriginalName,
 		Parent:    parentJSON,
 		InputArgs: callInputs,
-	}
+	})
 	if fn.objDef != nil {
 		fnCall.ParentName = fn.objDef.OriginalName
 	}
@@ -881,19 +881,37 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Any
 	}
 
 	// Delegate the actual function execution to the runtime
-	outputBytes, err := runtime.Call(ctx, &execMD, fnCall, fn.mod, envContext)
+	err = runtime.Call(ctx, &execMD, fnCall, fn.mod, envContext)
+	returned, returnedSet, returnStateErr := fnCall.returnResult()
+	if returnStateErr != nil {
+		return nil, returnStateErr
+	}
 	if err != nil {
+		if returnedSet && returned.HasError {
+			dagErr, loadErr := functionCallReturnedError(ctx, returned.ErrorID, err)
+			if loadErr != nil {
+				return nil, loadErr
+			}
+			return nil, dagErr
+		}
 		return nil, err
 	}
 
-	var returnValueAny any
-	dec := json.NewDecoder(strings.NewReader(string(outputBytes)))
-	dec.UseNumber()
-	if err := dec.Decode(&returnValueAny); err != nil {
-		return nil, fmt.Errorf("unmarshal result: %w", err)
+	if !returnedSet {
+		if fnCall.Name == "" {
+			return nil, fmt.Errorf("constructor completed without returning a value")
+		}
+		return nil, fmt.Errorf("function %q completed without returning a value", fnCall.Name)
+	}
+	if returned.HasError {
+		dagErr, err := functionCallReturnedError(ctx, returned.ErrorID, nil)
+		if err != nil {
+			return nil, err
+		}
+		return nil, dagErr
 	}
 
-	returnValue, err := fn.returnType.ConvertFromSDKResult(ctx, returnValueAny)
+	returnValue, err := fn.returnType.ConvertFromSDKResult(ctx, returned.Value)
 	if err != nil {
 		return nil, fmt.Errorf("convert return value: %w", err)
 	}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1364,7 +1364,7 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 	if err != nil {
 		return inst, err
 	}
-	err = ctr.WithExec(ctx, parent, args.ContainerExecOpts, md, moduleContext, nil, false)
+	err = ctr.WithExec(ctx, parent, args.ContainerExecOpts, md, moduleContext, nil)
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -251,12 +251,14 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 	dagql.Fields[*core.FunctionCall]{
 		dagql.Func("returnValue", s.functionCallReturnValue).
 			WithInput(dagql.PerClientInput).
+			DoNotCache("Imperatively records the active function call result.").
 			Doc(`Set the return value of the function call to the provided value.`).
 			Args(
 				dagql.Arg("value").Doc(`JSON serialization of the return value.`),
 			),
 		dagql.Func("returnError", s.functionCallReturnError).
 			WithInput(dagql.PerClientInput).
+			DoNotCache("Imperatively records the active function call result.").
 			Doc(`Return an error from the function.`).
 			Args(
 				dagql.Arg("error").Doc(`The error to return.`),

--- a/core/sdk.go
+++ b/core/sdk.go
@@ -2,20 +2,12 @@ package core
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
-	"os"
-	"path"
 	"slices"
 
-	containerdfs "github.com/containerd/continuity/fs"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/engineutil"
-	telemetry "github.com/dagger/otel-go"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 )
 
 /*
@@ -148,15 +140,15 @@ type ModuleRuntime interface {
 
 	// Call executes a function call in this runtime.
 	// The runtime is responsible for preparing the execution environment,
-	// running the function, and returning the result.
-	// Returns the output bytes and the client ID that was used for execution.
+	// running the function, and allowing the function to report its result through
+	// the provided FunctionCall.
 	Call(
 		ctx context.Context,
 		execMD *engineutil.ExecutionMetadata,
 		fnCall *FunctionCall,
 		moduleContext dagql.ObjectResult[*Module],
 		envContext dagql.ObjectResult[*Env],
-	) (outputBytes []byte, err error)
+	) error
 }
 
 /*
@@ -177,58 +169,21 @@ func (r *ContainerRuntime) Call(
 	fnCall *FunctionCall,
 	moduleContext dagql.ObjectResult[*Module],
 	envContext dagql.ObjectResult[*Env],
-) ([]byte, error) {
+) error {
 	hideCtx := dagql.WithSkip(ctx)
 
-	srv, err := CurrentDagqlServer(hideCtx)
-	if err != nil {
-		return nil, fmt.Errorf("current dagql server: %w", err)
-	}
-
-	// Desugar to the canonical server for core API plumbing so that
-	// entrypoint proxies cannot shadow core fields like "directory".
-	coreSrv := srv.Canonical()
-
-	var metaDir dagql.ObjectResult[*Directory]
-	err = coreSrv.Select(hideCtx, coreSrv.Root(), &metaDir,
-		dagql.Selector{
-			Field: "directory",
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create mod metadata directory: %w", err)
-	}
-
-	metaDirID, err := metaDir.ID()
-	if err != nil {
-		return nil, fmt.Errorf("get mod metadata directory ID: %w", err)
-	}
-
-	var ctr dagql.ObjectResult[*Container]
-	err = srv.Select(hideCtx, r.Container, &ctr,
-		dagql.Selector{
-			Field: "withMountedDirectory",
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.String(modMetaDirPath)},
-				{Name: "source", Value: dagql.NewID[*Directory](metaDirID)},
-			},
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("mount function metadir: %w", err)
-	}
-
+	ctr := r.Container
 	clonedFS, err := CloneContainerDirectoryAccessor(hideCtx, ctr.Self().FS)
 	if err != nil {
-		return nil, fmt.Errorf("clone exec rootfs: %w", err)
+		return fmt.Errorf("clone exec rootfs: %w", err)
 	}
 	clonedMounts, err := CloneContainerMounts(hideCtx, ctr.Self().Mounts)
 	if err != nil {
-		return nil, fmt.Errorf("clone exec mounts: %w", err)
+		return fmt.Errorf("clone exec mounts: %w", err)
 	}
 	clonedMeta, err := CloneContainerMetaSnapshot(hideCtx, ctr.Self().MetaSnapshot)
 	if err != nil {
-		return nil, fmt.Errorf("clone exec meta snapshot: %w", err)
+		return fmt.Errorf("clone exec meta snapshot: %w", err)
 	}
 	execCtr := &Container{
 		FS:                 clonedFS,
@@ -258,9 +213,9 @@ func (r *ContainerRuntime) Call(
 		Args:                          []string{},
 		UseEntrypoint:                 true,
 		ExperimentalPrivilegedNesting: true,
-	}, execMD, moduleContext, fnCall, true)
+	}, execMD, moduleContext, fnCall)
 	if err != nil {
-		return nil, fmt.Errorf("exec function: %w", err)
+		return fmt.Errorf("exec function: %w", err)
 	}
 
 	syncCtx := ctx
@@ -269,105 +224,13 @@ func (r *ContainerRuntime) Call(
 	}
 	err = execCtr.Sync(syncCtx)
 	if err != nil {
-		var modExecErr *ModuleExecError
-		if errors.As(err, &modExecErr) {
-			srv, srvErr := CurrentDagqlServer(ctx)
-			if srvErr != nil {
-				return nil, fmt.Errorf("load error instance: %w", srvErr)
-			}
-			errInst, loadErr := modExecErr.ErrorID.Load(ctx, srv)
-			if loadErr != nil {
-				return nil, fmt.Errorf("load error instance: %w", loadErr)
-			}
-			dagErr := errInst.Self().Clone()
-
-			originCtx := trace.SpanContextFromContext(
-				telemetry.Propagator.Extract(
-					context.Background(),
-					telemetry.AnyMapCarrier(dagErr.Extensions()),
-				),
-			)
-			if !originCtx.IsValid() {
-				if origins := telemetry.ParseErrorOrigins(modExecErr.Err.Error()); len(origins) > 0 && origins[0].IsValid() {
-					originCtx = origins[0]
-				}
-			}
-			if !originCtx.IsValid() {
-				originCtx = trace.SpanContextFromContext(ctx)
-			}
-			if originCtx.IsValid() && len(telemetry.ParseErrorOrigins(dagErr.Message)) == 0 {
-				dagErr.Message = telemetry.TrackOrigin(errors.New(dagErr.Message), originCtx).Error()
-			}
-			if originCtx.IsValid() {
-				extOriginCtx := trace.SpanContextFromContext(
-					telemetry.Propagator.Extract(
-						context.Background(),
-						telemetry.AnyMapCarrier(dagErr.Extensions()),
-					),
-				)
-				if !extOriginCtx.IsValid() {
-					carrier := propagation.MapCarrier{}
-					telemetry.Propagator.Inject(trace.ContextWithSpanContext(context.Background(), originCtx), carrier)
-					for _, key := range carrier.Keys() {
-						valJSON, marshalErr := json.Marshal(carrier.Get(key))
-						if marshalErr != nil {
-							return nil, fmt.Errorf("marshal error extension %q: %w", key, marshalErr)
-						}
-						dagErr = dagErr.WithValue(key, JSON(valJSON))
-					}
-				}
-			}
-
-			return nil, dagErr
-		}
 		if fnCall.Name == "" {
-			return nil, fmt.Errorf("call constructor: %w", err)
+			return fmt.Errorf("call constructor: %w", err)
 		}
-		return nil, fmt.Errorf("call function %q: %w", fnCall.Name, err)
+		return fmt.Errorf("call function %q: %w", fnCall.Name, err)
 	}
 
-	var outputDir *Directory
-	for _, ctrMount := range execCtr.Mounts {
-		if ctrMount.Target != modMetaDirPath {
-			continue
-		}
-		if ctrMount.DirectorySource == nil {
-			return nil, fmt.Errorf("function output directory mount %s is missing directory source", modMetaDirPath)
-		}
-		mountedDir, ok := ctrMount.DirectorySource.Peek()
-		if !ok || mountedDir == nil {
-			return nil, fmt.Errorf("function output directory mount %s is missing materialized directory", modMetaDirPath)
-		}
-		outputDir = mountedDir
-		break
-	}
-	if outputDir == nil {
-		return nil, fmt.Errorf("function output directory mount %s not found", modMetaDirPath)
-	}
-
-	snapshot, _ := outputDir.Snapshot.Peek()
-	if snapshot == nil {
-		return nil, fmt.Errorf("function output snapshot is nil")
-	}
-	outputDirPath, _ := outputDir.Dir.Peek()
-
-	root, _, release, err := MountRefCloser(ctx, snapshot, mountRefAsReadOnly)
-	if err != nil {
-		return nil, fmt.Errorf("mount function output snapshot: %w", err)
-	}
-	defer release()
-
-	outputPath, err := containerdfs.RootPath(root, path.Join(outputDirPath, modMetaOutputPath))
-	if err != nil {
-		return nil, fmt.Errorf("resolve function output file path: %w", err)
-	}
-
-	outputBytes, err := os.ReadFile(outputPath)
-	if err != nil {
-		return nil, fmt.Errorf("read function output file: %w", err)
-	}
-
-	return outputBytes, nil
+	return nil
 }
 
 /*

--- a/core/sdk.go
+++ b/core/sdk.go
@@ -162,7 +162,6 @@ func (r *ContainerRuntime) AsContainer() (dagql.ObjectResult[*Container], bool) 
 	return r.Container, true
 }
 
-//nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
 func (r *ContainerRuntime) Call(
 	ctx context.Context,
 	execMD *engineutil.ExecutionMetadata,

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -172,7 +172,7 @@ func (r *DangRuntime) Call(
 	fnCall *core.FunctionCall,
 	moduleContext dagql.ObjectResult[*core.Module],
 	envContext dagql.ObjectResult[*core.Env],
-) (res []byte, rerr error) {
+) (rerr error) {
 	defer func() {
 		if rerr != nil {
 			rerr = convertError(rerr)
@@ -181,22 +181,22 @@ func (r *DangRuntime) Call(
 
 	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("current query: %w", err)
+		return fmt.Errorf("current query: %w", err)
 	}
 	schemaJSONFile, err := r.deps.SchemaIntrospectionJSONFileForModule(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get schema introspection: %w", err)
+		return fmt.Errorf("get schema introspection: %w", err)
 	}
 	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, fnCall, moduleContext, envContext)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return outputBytes, nil
+	return fnCall.ReturnValue(ctx, core.JSON(outputBytes))
 }
 
 func convertError(rerr error) *core.Error {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
-	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/iancoleman/strcase"
@@ -2364,9 +2364,28 @@ type FunctionCall struct {
 	ParentName string                  `field:"true" doc:"The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module."`
 	Parent     JSON                    `field:"true" doc:"The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object."`
 	InputArgs  []*FunctionCallArgValue `field:"true" doc:"The argument values the function is being invoked with."`
+
+	returnState *functionCallReturnState
 }
 
 type persistedFunctionCall FunctionCall
+
+type functionCallReturnState struct {
+	mu     sync.Mutex
+	set    bool
+	result functionCallReturn
+}
+
+type functionCallReturn struct {
+	Value    any
+	ErrorID  dagql.ID[*Error]
+	HasError bool
+}
+
+func newFunctionCall(fnCall FunctionCall) *FunctionCall {
+	fnCall.returnState = &functionCallReturnState{}
+	return &fnCall
+}
 
 var _ dagql.PersistedObject = (*FunctionCall)(nil)
 var _ dagql.PersistedObjectDecoder = (*FunctionCall)(nil)
@@ -2403,49 +2422,54 @@ func (*FunctionCall) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 }
 
 func (fnCall *FunctionCall) ReturnValue(ctx context.Context, val JSON) error {
-	// The return is implemented by exporting the result back to the caller's
-	// filesystem. This ensures that the result is cached as part of the module
-	// function's Exec while also keeping SDKs as agnostic as possible to the
-	// format + location of that result.
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return err
+	_ = ctx
+
+	var returnValue any
+	if val != nil {
+		dec := json.NewDecoder(bytes.NewReader(val.Bytes()))
+		dec.UseNumber()
+		if err := dec.Decode(&returnValue); err != nil {
+			return fmt.Errorf("decode function return value: %w", err)
+		}
 	}
-	bk, err := query.Engine(ctx)
-	if err != nil {
-		return fmt.Errorf("get engine client: %w", err)
-	}
-	return bk.IOReaderExport(
-		ctx,
-		bytes.NewReader(val),
-		filepath.Join(modMetaDirPath, modMetaOutputPath),
-		0o600,
-	)
+	return fnCall.setReturn(functionCallReturn{Value: returnValue})
 }
 
 func (fnCall *FunctionCall) ReturnError(ctx context.Context, errID dagql.ID[*Error]) error {
-	// The return is implemented by exporting the result back to the caller's
-	// filesystem. This ensures that the result is cached as part of the module
-	// function's Exec while also keeping SDKs as agnostic as possible to the
-	// format + location of that result.
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return err
+	_ = ctx
+
+	return fnCall.setReturn(functionCallReturn{
+		ErrorID:  errID,
+		HasError: true,
+	})
+}
+
+func (fnCall *FunctionCall) setReturn(result functionCallReturn) error {
+	if fnCall == nil || fnCall.returnState == nil {
+		return fmt.Errorf("function call is not active")
 	}
-	bk, err := query.Engine(ctx)
-	if err != nil {
-		return fmt.Errorf("get engine client: %w", err)
+
+	fnCall.returnState.mu.Lock()
+	defer fnCall.returnState.mu.Unlock()
+
+	if fnCall.returnState.set {
+		return fmt.Errorf("function call return already set")
 	}
-	enc, err := errID.Encode()
-	if err != nil {
-		return fmt.Errorf("encode error ID: %w", err)
+
+	fnCall.returnState.result = result
+	fnCall.returnState.set = true
+	return nil
+}
+
+func (fnCall *FunctionCall) returnResult() (functionCallReturn, bool, error) {
+	if fnCall == nil || fnCall.returnState == nil {
+		return functionCallReturn{}, false, fmt.Errorf("function call is not active")
 	}
-	return bk.IOReaderExport(
-		ctx,
-		strings.NewReader(enc),
-		filepath.Join(modMetaDirPath, modMetaErrorPath),
-		0o600,
-	)
+
+	fnCall.returnState.mu.Lock()
+	defer fnCall.returnState.mu.Unlock()
+
+	return fnCall.returnState.result, fnCall.returnState.set, nil
 }
 
 type FunctionCallArgValue struct {

--- a/core/typedef_test.go
+++ b/core/typedef_test.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/stretchr/testify/require"
 )
 
 func sampleTypeDefs(t *testing.T) map[TypeDefKind]*TypeDef {
@@ -87,4 +90,47 @@ func TestTypeDefConversions(t *testing.T) {
 			sample.ToType()
 		})
 	}
+}
+
+func TestFunctionCallReturnValueStoresDecodedJSON(t *testing.T) {
+	fnCall := newFunctionCall(FunctionCall{Name: "fn"})
+
+	err := fnCall.ReturnValue(context.Background(), JSON(`{"n":123,"s":"ok"}`))
+	require.NoError(t, err)
+
+	res, ok, err := fnCall.returnResult()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, res.HasError)
+
+	obj, ok := res.Value.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, json.Number("123"), obj["n"])
+	require.Equal(t, "ok", obj["s"])
+}
+
+func TestFunctionCallReturnValueAllowsNull(t *testing.T) {
+	fnCall := newFunctionCall(FunctionCall{Name: "fn"})
+
+	err := fnCall.ReturnValue(context.Background(), JSON(`null`))
+	require.NoError(t, err)
+
+	res, ok, err := fnCall.returnResult()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, res.HasError)
+	require.Nil(t, res.Value)
+}
+
+func TestFunctionCallReturnIsExactlyOnce(t *testing.T) {
+	fnCall := newFunctionCall(FunctionCall{Name: "fn"})
+
+	require.NoError(t, fnCall.ReturnValue(context.Background(), JSON(`"first"`)))
+	require.ErrorContains(t, fnCall.ReturnValue(context.Background(), JSON(`"second"`)), "already set")
+}
+
+func TestFunctionCallReturnRequiresActiveCall(t *testing.T) {
+	fnCall := &FunctionCall{Name: "decoded"}
+
+	require.ErrorContains(t, fnCall.ReturnValue(context.Background(), JSON(`"x"`)), "not active")
 }


### PR DESCRIPTION
## What changed

- Record module function return values and returned errors directly on the active `FunctionCall`.
- Change module runtimes to return only execution errors, then read the recorded `FunctionCall` result after runtime completion.
- Remove the legacy `.daggermod` output/error metadata directory, mount, snapshot, and read-back path.
- Remove module exec error extraction plumbing that existed only to support that metadata-file return path.
- Mark `returnValue` and `returnError` as uncached imperative calls.

## Why

The old return path was a holdover from the pre-Theseus cache model where function results had to be written through container filesystem metadata. In the current model, that makes function execution more convoluted and adds avoidable container output/read-back work for state that belongs to the live function call.

This keeps the public `returnValue` / `returnError` API shape intact while making the engine-side flow match the current architecture.

## Validation

- `go test ./core -run 'TestFunctionCallReturn|TestTypeDefConversions'`
- `go test ./core ./core/schema ./core/sdk`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestModule/TestReturnNil'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestModule/TestConstructor/return error'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestModule'` completed with 494 passed and only the known local `TestModule/TestPrivateGitRepoArgCaching` git-auth failure.
