### PR TITLE
fix(layercopy): follow source symlinks when copying directory contents

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3613,7 +3613,7 @@ func (ContainerSuite) TestWithDirectoryToMount(ctx context.Context, t *testctx.T
 	}, strings.Split(strings.Trim(contents, "\n"), "\n"))
 }
 
-func (ContainerSuite) TestAddFile(ctx context.Context, t *testctx.T) {
+func (ContainerSuite) TestAddFileSymlink(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	base := c.Container().From(alpineImage).
@@ -3628,6 +3628,17 @@ func (ContainerSuite) TestAddFile(ctx context.Context, t *testctx.T) {
 	got, err := ctr.File("/target/sub/file").Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
+}
+
+func (ContainerSuite) TestAddDirSrcSymlink(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	rel := c.Container().From(alpineImage).WithExec([]string{"sh", "-c", "mkdir -p /store/real && echo hi > /store/real/marker.txt && ln -s /store/real /store/link"}).Directory("/store/link")
+
+	out, err := c.Container().From(alpineImage).WithDirectory("/release", rel).WithExec([]string{"cat", "/release/marker.txt"}).Stdout(ctx)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
 }
 
 func (ContainerSuite) TestExecError(ctx context.Context, t *testctx.T) {

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -77,7 +77,7 @@ func (c *Copier) Usage() (snapshots.Usage, error) {
 }
 
 func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPath, destPath string, opts CopyOptions) error {
-	if err := src.selectBase(srcPath, false); err != nil {
+	if err := src.selectBase(srcPath, opts.CopyDirContents); err != nil {
 		return err
 	}
 	root := sourceEntry{


### PR DESCRIPTION
A source path that is itself a symlink-to-dir (e.g. `.Directory("/link")` where /link -> /real) was copied verbatim, leaving a dangling symlink in the destination instead of materializing the directory it points to. Follow the final symlink of the base path when CopyDirContents is set so the real directory's contents are copied.