### PR TITLE
engine: honor OTEL_RESOURCE_ATTRIBUTES in the telemetry resource

### DIFF
--- a/cmd/engine/telemetry.go
+++ b/cmd/engine/telemetry.go
@@ -39,6 +39,7 @@ func init() {
 func InitTelemetry(ctx context.Context) context.Context {
 	otelResource, err := resource.New(ctx,
 		resource.WithHost(),
+		resource.WithFromEnv(),
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("dagger-engine"),
 			semconv.ServiceVersionKey.String(engine.Version),


### PR DESCRIPTION
The engine builds its OTel resource without `resource.WithFromEnv()`, so `OTEL_RESOURCE_ATTRIBUTES` set on the engine is ignored.

Add `resource.WithFromEnv()` so engine spans pick up env-provided resource attributes.