### PR TITLE
fix: allow uninstalling stale local toolchains

### DIFF
--- a/.changes/unreleased/Fixed-20260514-014334.yaml
+++ b/.changes/unreleased/Fixed-20260514-014334.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Allow local toolchains to be uninstalled after their source path is deleted.
+time: 2026-05-14T01:43:34.466428992Z
+custom:
+    Author: paulvinueza30
+    PR: "13143"

--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -943,6 +943,84 @@ func (ToolchainSuite) TestToolchainMultipleVersions(ctx context.Context, t *test
 	})
 }
 
+func (ToolchainSuite) TestToolchainUninstall(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("install then uninstall toolchain", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory(".", c.Host().Directory("./testdata/test-blueprint")).
+			WithDirectory("app", c.Directory()).
+			WithWorkdir("app").
+			With(daggerExec("init")).
+			WithExec([]string{"mkdir", "-p", "toolchains"}).
+			WithExec([]string{"cp", "-r", "../hello", "toolchains/helm-dev"}).
+			With(daggerExec("toolchain", "install", "./toolchains/helm-dev", "--name", "helm"))
+
+		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, string(daggerjson), "helm")
+
+		daggerjson, err = ctr.With(daggerExec("toolchain", "uninstall", "helm")).
+			File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, string(daggerjson), "helm")
+	})
+
+	t.Run("uninstall toolchain after local path is deleted", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory(".", c.Host().Directory("./testdata/test-blueprint")).
+			WithDirectory("app", c.Directory()).
+			WithWorkdir("app").
+			With(daggerExec("init")).
+			WithExec([]string{"mkdir", "-p", "toolchains"}).
+			WithExec([]string{"cp", "-r", "../hello", "toolchains/helm-dev"}).
+			With(daggerExec("toolchain", "install", "./toolchains/helm-dev", "--name", "helm")).
+			WithExec([]string{"rm", "-rf", "toolchains/helm-dev"})
+
+		var err error
+		ctr, err = ctr.With(daggerExec("toolchain", "uninstall", "helm")).Sync(ctx)
+		require.NoError(t, err, "uninstall should succeed even with stale local path")
+
+		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, string(daggerjson), "helm")
+	})
+
+	t.Run("uninstall stale local toolchain preserves other toolchain", func(ctx context.Context, t *testctx.T) {
+		ctr := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithExec([]string{"git", "init"}).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithDirectory(".", c.Host().Directory("./testdata/test-blueprint")).
+			WithDirectory("app", c.Directory()).
+			WithWorkdir("app").
+			With(daggerExec("init")).
+			WithExec([]string{"mkdir", "-p", "toolchains"}).
+			WithExec([]string{"cp", "-r", "../hello", "toolchains/helm-dev"}).
+			With(daggerExec("toolchain", "install", "./toolchains/helm-dev", "--name", "helm")).
+			With(daggerExec("toolchain", "install", "../myblueprint-ts")).
+			WithExec([]string{"rm", "-rf", "toolchains/helm-dev"})
+
+		var err error
+		ctr, err = ctr.With(daggerExec("toolchain", "uninstall", "helm")).Sync(ctx)
+		require.NoError(t, err, "uninstall should succeed even with stale local path")
+
+		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, string(daggerjson), "helm")
+		require.Contains(t, string(daggerjson), "myblueprint-ts")
+	})
+}
+
 func (ToolchainSuite) TestToolchainLocalModuleHints(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/toolchain_test.go
+++ b/core/integration/toolchain_test.go
@@ -912,7 +912,6 @@ func (ToolchainSuite) TestToolchainMultipleVersions(ctx context.Context, t *test
 
 		// Try to list toolchains
 		out, err := modGen.With(daggerExec("toolchain", "list")).Stdout(ctx)
-
 		if err != nil {
 			// If this fails, it might be because the source doesn't exist at v0.19.9
 			// or because symbolic deduplication is still blocking it
@@ -962,12 +961,12 @@ func (ToolchainSuite) TestToolchainUninstall(ctx context.Context, t *testctx.T) 
 
 		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
 		require.NoError(t, err)
-		require.Contains(t, string(daggerjson), "helm")
+		require.Contains(t, daggerjson, "helm")
 
 		daggerjson, err = ctr.With(daggerExec("toolchain", "uninstall", "helm")).
 			File("dagger.json").Contents(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, string(daggerjson), "helm")
+		require.NotContains(t, daggerjson, "helm")
 	})
 
 	t.Run("uninstall toolchain after local path is deleted", func(ctx context.Context, t *testctx.T) {
@@ -991,7 +990,7 @@ func (ToolchainSuite) TestToolchainUninstall(ctx context.Context, t *testctx.T) 
 
 		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, string(daggerjson), "helm")
+		require.NotContains(t, daggerjson, "helm")
 	})
 
 	t.Run("uninstall stale local toolchain preserves other toolchain", func(ctx context.Context, t *testctx.T) {
@@ -1016,8 +1015,8 @@ func (ToolchainSuite) TestToolchainUninstall(ctx context.Context, t *testctx.T) 
 
 		daggerjson, err := ctr.File("dagger.json").Contents(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, string(daggerjson), "helm")
-		require.Contains(t, string(daggerjson), "myblueprint-ts")
+		require.NotContains(t, daggerjson, "helm")
+		require.Contains(t, daggerjson, "myblueprint-ts")
 	})
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -818,10 +818,13 @@ func (s *moduleSourceSchema) loadBlueprintModule(
 				toolchainJobs = toolchainJobs.WithJob(pcfg.Name, func(ctx context.Context) error {
 					toolchain, err := core.ResolveDepToSource(ctx, bk, dag, src, pcfg.Source, pcfg.Pin, pcfg.Name)
 					if err != nil {
-						// don't let a stale toolchain (e.g. deleted local path) block the rest
-						// of the module load; leave a zero entry so uninstall can still work.
-						slog.Warn("failed to resolve toolchain, skipping", "name", pcfg.Name, "source", pcfg.Source, "error", err)
-						return nil
+						if core.FastModuleSourceKindCheck(pcfg.Source, pcfg.Pin) == core.ModuleSourceKindLocal && errors.Is(err, os.ErrNotExist) {
+							// Don't let a stale local toolchain path block uninstall; leave a
+							// zero entry so "dagger toolchain uninstall <name>" can still match.
+							slog.Warn("failed to resolve stale local toolchain, skipping", "name", pcfg.Name, "source", pcfg.Source, "error", err)
+							return nil
+						}
+						return fmt.Errorf("failed to resolve toolchain to source: %w", err)
 					}
 					src.Toolchains[i] = toolchain
 					return nil
@@ -1800,9 +1803,11 @@ func (s *moduleSourceSchema) moduleSourceRemoveItems(
 		// "dagger toolchain uninstall <name>" can still match.
 		var existingName string
 		var existingSymbolic, existingVersion string
+		var existingSourceRootSubpath string
 
 		if existingItem.Self() != nil {
 			existingName = existingItem.Self().ModuleName
+			existingSourceRootSubpath = existingItem.Self().SourceRootSubpath
 			switch existingItem.Self().Kind {
 			case core.ModuleSourceKindLocal:
 				if parentSrc.Kind != core.ModuleSourceKindLocal {
@@ -1863,7 +1868,7 @@ func (s *moduleSourceSchema) moduleSourceRemoveItems(
 				reqModVersion := parsedGitRef.ModVersion
 				if !strings.HasPrefix(reqModVersion, parsedGitRef.RepoRootSubdir) {
 					reqModVersion, _ = strings.CutPrefix(reqModVersion, parsedGitRef.RepoRootSubdir+"/")
-					existingVersion, _ = strings.CutPrefix(existingVersion, existingItem.Self().SourceRootSubpath+"/")
+					existingVersion, _ = strings.CutPrefix(existingVersion, existingSourceRootSubpath+"/")
 				}
 				return nil, fmt.Errorf(
 					"version %q was requested to be uninstalled but the %s %q was installed with %q. Try re-running without specifying the version number",

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -818,7 +818,10 @@ func (s *moduleSourceSchema) loadBlueprintModule(
 				toolchainJobs = toolchainJobs.WithJob(pcfg.Name, func(ctx context.Context) error {
 					toolchain, err := core.ResolveDepToSource(ctx, bk, dag, src, pcfg.Source, pcfg.Pin, pcfg.Name)
 					if err != nil {
-						return fmt.Errorf("failed to resolve toolchain to source: %w", err)
+						// don't let a stale toolchain (e.g. deleted local path) block the rest
+						// of the module load; leave a zero entry so uninstall can still work.
+						slog.Warn("failed to resolve toolchain, skipping", "name", pcfg.Name, "source", pcfg.Source, "error", err)
+						return nil
 					}
 					src.Toolchains[i] = toolchain
 					return nil
@@ -1792,31 +1795,39 @@ func (s *moduleSourceSchema) moduleSourceRemoveItems(
 	var filteredConfigItems []*modules.ModuleConfigDependency
 
 	for i, existingItem := range accessor.getItems(parentSrc) {
-		existingName := existingItem.Self().ModuleName
+		// a toolchain whose local path was deleted resolves to a zero value,
+		// so Self() will be nil. fall back to the config entry's name so
+		// "dagger toolchain uninstall <name>" can still match.
+		var existingName string
 		var existingSymbolic, existingVersion string
 
-		switch existingItem.Self().Kind {
-		case core.ModuleSourceKindLocal:
-			if parentSrc.Kind != core.ModuleSourceKindLocal {
-				return nil, fmt.Errorf("cannot remove local %s from non-local module source kind %s", accessor.typ, parentSrc.Kind)
-			}
-			parentSrcRoot := filepath.Join(parentSrc.Local.ContextDirectoryPath, parentSrc.SourceRootSubpath)
-			itemSrcRoot := filepath.Join(parentSrc.Local.ContextDirectoryPath, existingItem.Self().SourceRootSubpath)
-			var err error
-			existingSymbolic, err = pathutil.LexicalRelativePath(parentSrcRoot, itemSrcRoot)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
+		if existingItem.Self() != nil {
+			existingName = existingItem.Self().ModuleName
+			switch existingItem.Self().Kind {
+			case core.ModuleSourceKindLocal:
+				if parentSrc.Kind != core.ModuleSourceKindLocal {
+					return nil, fmt.Errorf("cannot remove local %s from non-local module source kind %s", accessor.typ, parentSrc.Kind)
+				}
+				parentSrcRoot := filepath.Join(parentSrc.Local.ContextDirectoryPath, parentSrc.SourceRootSubpath)
+				itemSrcRoot := filepath.Join(parentSrc.Local.ContextDirectoryPath, existingItem.Self().SourceRootSubpath)
+				var err error
+				existingSymbolic, err = pathutil.LexicalRelativePath(parentSrcRoot, itemSrcRoot)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get relative path: %w", err)
+				}
 
-		case core.ModuleSourceKindGit:
-			existingSymbolic = existingItem.Self().Git.CloneRef
-			if existingItem.Self().SourceRootSubpath != "" {
-				existingSymbolic += "/" + strings.TrimPrefix(existingItem.Self().SourceRootSubpath, "/")
-			}
-			existingVersion = existingItem.Self().Git.Version
+			case core.ModuleSourceKindGit:
+				existingSymbolic = existingItem.Self().Git.CloneRef
+				if existingItem.Self().SourceRootSubpath != "" {
+					existingSymbolic += "/" + strings.TrimPrefix(existingItem.Self().SourceRootSubpath, "/")
+				}
+				existingVersion = existingItem.Self().Git.Version
 
-		default:
-			return nil, fmt.Errorf("unhandled %s kind: %s", accessor.typ, existingItem.Self().Kind)
+			default:
+				return nil, fmt.Errorf("unhandled %s kind: %s", accessor.typ, existingItem.Self().Kind)
+			}
+		} else if accessor.typ == core.ModuleRelationTypeToolchain {
+			existingName = parentSrc.ConfigToolchains[i].Name
 		}
 
 		keep := true


### PR DESCRIPTION
## Summary

- Fixes #13059.
- Allow local toolchains to be uninstalled after their source path is deleted.
- Preserve other toolchain resolution errors.
- Add integration coverage for toolchain uninstall behavior.

## Testing

- `dagger call engine-dev tests`
- Specific test added for this fix: `dagger call -m ./toolchains/engine-dev test --pkg=./core/integration --run='TestToolchain/TestToolchainUninstall' --test-verbose -d`
- `dag checks 'go:lint'`