### PR TITLE
fix(telemetry): don't shallow-clone the user's repo for git labels

### DIFF
--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -198,12 +198,18 @@ func (labels Labels) WithGitLabels(workdir string) Labels {
 	// weird /merge ref in a merge-request
 	if ref, ok := os.LookupEnv("GITHUB_REF"); ok {
 		if strings.HasPrefix(ref, "refs/pull/") {
-			ref = strings.Replace(ref, "/merge", "/head", 1)
-			refCommit, err := fetchRef(repo, workdir, "origin", ref)
-			if err != nil {
-				slog.Warn("failed to fetch branch", "err", err)
+			if headCommit, err := prHeadFromMerge(commit); commit.Hash.String() != head.Hash().String() && err == nil {
+				commit = headCommit
 			} else {
-				commit = refCommit
+				// fall back to fetching the head ref, e.g. for a shallow
+				// checkout where the merge commit's parent isn't available
+				ref = strings.Replace(ref, "/merge", "/head", 1)
+				refCommit, err := fetchRef(repo, workdir, "origin", ref)
+				if err != nil {
+					slog.Warn("failed to fetch branch", "err", err)
+				} else {
+					commit = refCommit
+				}
 			}
 		}
 	}
@@ -549,13 +555,33 @@ func (labels Labels) isCI() bool {
 		labels.eg.Getenv("TF_BUILD") != "" // Azure Pipelines
 }
 
+// prHeadFromMerge returns the pull request head commit for a GitHub-generated
+// refs/pull/N/merge commit. GitHub builds the merge commit with the base branch
+// as its first parent and the PR head as its second parent, so the head commit
+// (equivalent to refs/pull/N/head) can be directly....
+func prHeadFromMerge(merge *object.Commit) (*object.Commit, error) {
+	if merge.NumParents() < 2 {
+		return nil, fmt.Errorf("commit %s is not a merge commit", merge.Hash)
+	}
+	return merge.Parent(1)
+}
+
 func fetchRef(repo *git.Repository, workdir string, remote string, target string) (*object.Commit, error) {
 	target = strings.TrimPrefix(target, "refs/")
 	src := fmt.Sprintf("refs/%s", target)
 	dest := fmt.Sprintf("refs/dagger/%s", target)
 
+	// Only allow shortening history when the repository is *already* shallow.
+	// Passing --depth 1 to a full checkout writes .git/shallow and corrupts it,
+	// breaking subsequent git history operations (merge-base, describe, ...).
+	args := []string{"fetch"}
+	if isShallowRepo(workdir) {
+		args = append(args, "--depth", "1")
+	}
+	args = append(args, remote, fmt.Sprintf("+%s:%s", src, dest))
+
 	// Fetch from the origin remote
-	cmd := exec.Command("git", "fetch", "--depth", "1", remote, fmt.Sprintf("+%s:%s", src, dest))
+	cmd := exec.Command("git", args...)
 	cmd.Dir = workdir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -584,6 +610,16 @@ func fetchRef(repo *git.Repository, workdir string, remote string, target string
 	}
 
 	return branchCommit, nil
+}
+
+func isShallowRepo(workdir string) bool {
+	cmd := exec.Command("git", "rev-parse", "--is-shallow-repository")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 type LabelFlag struct {

--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -196,21 +196,31 @@ func (labels Labels) WithGitLabels(workdir string) Labels {
 	// Checks if the commit is a merge commit in the context of pull request
 	// For now, only GitHub needs to be handled, as GitLab doesn't create this
 	// weird /merge ref in a merge-request
-	if ref, ok := os.LookupEnv("GITHUB_REF"); ok {
-		if strings.HasPrefix(ref, "refs/pull/") {
-			if headCommit, err := prHeadFromMerge(commit); commit.Hash.String() != head.Hash().String() && err == nil {
-				commit = headCommit
-			} else {
-				// fall back to fetching the head ref, e.g. for a shallow
-				// checkout where the merge commit's parent isn't available
-				ref = strings.Replace(ref, "/merge", "/head", 1)
-				refCommit, err := fetchRef(repo, workdir, "origin", ref)
-				if err != nil {
-					slog.Warn("failed to fetch branch", "err", err)
-				} else {
-					commit = refCommit
-				}
+	ref := labels.eg.Getenv("GITHUB_REF")
+	if strings.HasPrefix(ref, "refs/pull/") {
+		githubSHA := labels.eg.Getenv("GITHUB_SHA")
+		isSyntheticMergeCheckout := strings.HasSuffix(ref, "/merge") && githubSHA == head.Hash().String()
+
+		var refCommit *object.Commit
+		var err error
+
+		switch {
+		case isSyntheticMergeCheckout:
+			// GitHub checked out refs/pull/N/merge. Parent 2 is refs/pull/N/head.
+			refCommit, err = prHeadFromMerge(commit)
+			if err != nil {
+				refCommit, err = fetchPRHead(repo, workdir, ref)
 			}
+		default:
+			// This handles shallow checkouts, refs/pull/N/head, and workflows that
+			// checked out the PR head while GITHUB_REF still points at refs/pull/N/merge.
+			refCommit, err = fetchPRHead(repo, workdir, ref)
+		}
+
+		if err != nil {
+			slog.Warn("failed to fetch branch", "err", err)
+		} else {
+			commit = refCommit
 		}
 	}
 
@@ -564,6 +574,11 @@ func prHeadFromMerge(merge *object.Commit) (*object.Commit, error) {
 		return nil, fmt.Errorf("commit %s is not a merge commit", merge.Hash)
 	}
 	return merge.Parent(1)
+}
+
+func fetchPRHead(repo *git.Repository, workdir string, ref string) (*object.Commit, error) {
+	ref = strings.Replace(ref, "/merge", "/head", 1)
+	return fetchRef(repo, workdir, "origin", ref)
 }
 
 func fetchRef(repo *git.Repository, workdir string, remote string, target string) (*object.Commit, error) {

--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -207,6 +207,7 @@ func (labels Labels) WithGitLabels(workdir string) Labels {
 		switch {
 		case isSyntheticMergeCheckout:
 			// GitHub checked out refs/pull/N/merge. Parent 2 is refs/pull/N/head.
+			// This only works checkout is not a shallow clone.
 			refCommit, err = prHeadFromMerge(commit)
 			if err != nil {
 				refCommit, err = fetchPRHead(repo, workdir, ref)
@@ -570,9 +571,6 @@ func (labels Labels) isCI() bool {
 // as its first parent and the PR head as its second parent, so the head commit
 // (equivalent to refs/pull/N/head) can be directly....
 func prHeadFromMerge(merge *object.Commit) (*object.Commit, error) {
-	if merge.NumParents() < 2 {
-		return nil, fmt.Errorf("commit %s is not a merge commit", merge.Hash)
-	}
 	return merge.Parent(1)
 }
 

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -102,47 +103,8 @@ func TestLoadGitRefEnvLabelsForGitHubPullRequestRefs(t *testing.T) {
 		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
 		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
 
-		worktree := cloneRepo(t, repo)
+		worktree := cloneRepo(t, repo, true)
 		t.Setenv("GITHUB_REF", "refs/pull/1/head")
-
-		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
-
-		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
-	})
-
-	t.Run("merge ref without GitHub SHA fetches pull request head", func(t *testing.T) {
-		repo := setupRepo(t)
-		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "second")
-		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "third")
-
-		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
-		mergeRef := run(t, "git", "-C", repo, "rev-parse", "HEAD~")
-		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
-		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", mergeRef)
-
-		worktree := cloneRepo(t, repo)
-		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
-
-		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
-
-		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
-	})
-
-	t.Run("merge ref fetches pull request head when local parent is unavailable", func(t *testing.T) {
-		repo := setupRepo(t)
-		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "second")
-		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "third")
-
-		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
-		mergeRef := run(t, "git", "-C", repo, "rev-parse", "HEAD~")
-		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
-		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", mergeRef)
-
-		worktree := cloneRepo(t, repo)
-		run(t, "git", "-C", worktree, "checkout", mergeRef)
-
-		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
-		t.Setenv("GITHUB_SHA", mergeRef)
 
 		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
 
@@ -173,6 +135,10 @@ func TestLoadGitRefEnvLabelsForGitHubPullRequestRefs(t *testing.T) {
 
 		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(repo)
 
+		isShallow, err := strconv.ParseBool(run(t, "git", "-C", repo, "rev-parse", "--is-shallow-repository"))
+
+		require.Nil(t, err)
+		require.False(t, isShallow, "repository should not be shallow")
 		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
 		require.Equal(t, "pr commit", labels.AsMap()["dagger.io/git.title"])
 	})
@@ -197,7 +163,7 @@ func TestLoadGitRefEnvLabelsForGitHubPullRequestRefs(t *testing.T) {
 		syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
 		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
 
-		worktree := cloneRepo(t, repo)
+		worktree := cloneRepo(t, repo, false)
 		run(t, "git", "-C", worktree, "checkout", prHead)
 
 		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
@@ -579,8 +545,13 @@ func setupRepo(t *testing.T) string {
 	return repo
 }
 
-func cloneRepo(t *testing.T, src string) string {
+func cloneRepo(t *testing.T, src string, shallow bool) string {
 	repo := t.TempDir()
-	run(t, "git", "clone", "file://"+src, repo)
+	args := []string{"clone"}
+	if shallow {
+		args = append(args, "--depth=1")
+	}
+	args = append(args, "file://"+src, repo)
+	run(t, "git", args...)
 	return repo
 }

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -147,6 +147,38 @@ func TestLoadGitRefEnvLabels(t *testing.T) {
 	}
 }
 
+func TestLoadGitRefEnvLabelsDoesNotUseSecondParentForCheckedOutPRHead(t *testing.T) {
+	repo := setupRepo(t)
+
+	run(t, "git", "-C", repo, "checkout", "-b", "side")
+	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "side commit")
+
+	run(t, "git", "-C", repo, "checkout", "main")
+	run(t, "git", "-C", repo, "checkout", "-b", "pr")
+	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
+	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "merge side into pr", "side")
+
+	prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+
+	run(t, "git", "-C", repo, "checkout", "main")
+	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
+
+	syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
+
+	worktree := cloneRepo(t, repo)
+	run(t, "git", "-C", worktree, "checkout", prHead)
+
+	t.Setenv("GITHUB_REF", "refs/pull/1/merge")
+	t.Setenv("GITHUB_SHA", syntheticMerge)
+
+	labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
+
+	require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+	require.Equal(t, "merge side into pr", labels.AsMap()["dagger.io/git.title"])
+}
+
 type mapEnv map[string]string
 
 func (m mapEnv) Getenv(key string) string {

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -147,7 +147,35 @@ func TestLoadGitRefEnvLabels(t *testing.T) {
 	}
 }
 
-func TestLoadGitRefEnvLabelsDoesNotUseSecondParentForCheckedOutPRHead(t *testing.T) {
+func TestLoadGitRefEnvLabelsResolvesPRHeadFromCheckedOutSyntheticMergeWithoutFetch(t *testing.T) {
+	repo := setupRepo(t)
+
+	run(t, "git", "-C", repo, "checkout", "-b", "pr")
+	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
+
+	prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+
+	run(t, "git", "-C", repo, "checkout", "main")
+	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
+
+	syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
+
+	// If the synthetic merge commit and its parents are already present, this
+	// should not need to fetch refs/pull/1/head from origin.
+	run(t, "git", "-C", repo, "remote", "remove", "origin")
+
+	t.Setenv("GITHUB_REF", "refs/pull/1/merge")
+	t.Setenv("GITHUB_SHA", syntheticMerge)
+
+	labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(repo)
+
+	require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+	require.Equal(t, "pr commit", labels.AsMap()["dagger.io/git.title"])
+}
+
+func TestLoadGitRefEnvLabelsKeepsCheckedOutPRHeadMergeCommitWhenGitHubRefIsMerge(t *testing.T) {
 	repo := setupRepo(t)
 
 	run(t, "git", "-C", repo, "checkout", "-b", "side")

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -93,118 +93,121 @@ func TestLoadGitLabels(t *testing.T) {
 	}
 }
 
-func TestLoadGitRefEnvLabels(t *testing.T) {
-	normalRepo := setupRepo(t)
-	run(t, "git", "-C", normalRepo, "commit", "--allow-empty", "-m", "second")
-	run(t, "git", "-C", normalRepo, "commit", "--allow-empty", "-m", "third")
-	repoHead1 := run(t, "git", "-C", normalRepo, "rev-parse", "HEAD~")
-	repoHead2 := run(t, "git", "-C", normalRepo, "rev-parse", "HEAD~~")
-	run(t, "git", "-C", normalRepo, "update-ref", "refs/pull/1/head", repoHead2)
-	run(t, "git", "-C", normalRepo, "update-ref", "refs/pull/1/merge", repoHead1)
+func TestLoadGitRefEnvLabelsForGitHubPullRequestRefs(t *testing.T) {
+	t.Run("head ref fetches pull request head", func(t *testing.T) {
+		repo := setupRepo(t)
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "second")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "third")
 
-	cloneRepo := cloneRepo(t, normalRepo)
+		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
 
-	type Example struct {
-		Name   string
-		Repo   string
-		Env    []string
-		Labels map[string]string
-	}
+		worktree := cloneRepo(t, repo)
+		t.Setenv("GITHUB_REF", "refs/pull/1/head")
 
-	for _, example := range []Example{
-		{
-			Name: "normal branch state",
-			Repo: cloneRepo,
-			Env: []string{
-				// GITHUB_REF overrides the git ref to point to this PR
-				"GITHUB_REF=refs/pull/1/head",
-			},
-			Labels: map[string]string{
-				"dagger.io/git.ref": repoHead2,
-			},
-		},
-		{
-			Name: "normal branch state",
-			Repo: cloneRepo,
-			Env: []string{
-				// same as above, but still use the /head
-				"GITHUB_REF=refs/pull/1/merge",
-			},
-			Labels: map[string]string{
-				"dagger.io/git.ref": repoHead2,
-			},
-		},
-	} {
-		t.Run(example.Name, func(t *testing.T) {
-			for _, e := range example.Env {
-				k, v, _ := strings.Cut(e, "=")
-				t.Setenv(k, v)
-			}
+		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
 
-			labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(example.Repo)
-			require.Subset(t, labels.AsMap(), example.Labels)
-		})
-	}
-}
+		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+	})
 
-func TestLoadGitRefEnvLabelsResolvesPRHeadFromCheckedOutSyntheticMergeWithoutFetch(t *testing.T) {
-	repo := setupRepo(t)
+	t.Run("merge ref without GitHub SHA fetches pull request head", func(t *testing.T) {
+		repo := setupRepo(t)
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "second")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "third")
 
-	run(t, "git", "-C", repo, "checkout", "-b", "pr")
-	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
+		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
+		mergeRef := run(t, "git", "-C", repo, "rev-parse", "HEAD~")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", mergeRef)
 
-	prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
-	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+		worktree := cloneRepo(t, repo)
+		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
 
-	run(t, "git", "-C", repo, "checkout", "main")
-	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
+		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
 
-	syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
-	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
+		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+	})
 
-	// If the synthetic merge commit and its parents are already present, this
-	// should not need to fetch refs/pull/1/head from origin.
-	run(t, "git", "-C", repo, "remote", "remove", "origin")
+	t.Run("merge ref fetches pull request head when local parent is unavailable", func(t *testing.T) {
+		repo := setupRepo(t)
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "second")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "third")
 
-	t.Setenv("GITHUB_REF", "refs/pull/1/merge")
-	t.Setenv("GITHUB_SHA", syntheticMerge)
+		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD~~")
+		mergeRef := run(t, "git", "-C", repo, "rev-parse", "HEAD~")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", mergeRef)
 
-	labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(repo)
+		worktree := cloneRepo(t, repo)
+		run(t, "git", "-C", worktree, "checkout", mergeRef)
 
-	require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
-	require.Equal(t, "pr commit", labels.AsMap()["dagger.io/git.title"])
-}
+		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
+		t.Setenv("GITHUB_SHA", mergeRef)
 
-func TestLoadGitRefEnvLabelsKeepsCheckedOutPRHeadMergeCommitWhenGitHubRefIsMerge(t *testing.T) {
-	repo := setupRepo(t)
+		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
 
-	run(t, "git", "-C", repo, "checkout", "-b", "side")
-	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "side commit")
+		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+	})
 
-	run(t, "git", "-C", repo, "checkout", "main")
-	run(t, "git", "-C", repo, "checkout", "-b", "pr")
-	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
-	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "merge side into pr", "side")
+	t.Run("checked out synthetic merge uses local second parent", func(t *testing.T) {
+		repo := setupRepo(t)
 
-	prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
-	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+		run(t, "git", "-C", repo, "checkout", "-b", "pr")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
 
-	run(t, "git", "-C", repo, "checkout", "main")
-	run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
+		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
 
-	syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
-	run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
+		run(t, "git", "-C", repo, "checkout", "main")
+		run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
 
-	worktree := cloneRepo(t, repo)
-	run(t, "git", "-C", worktree, "checkout", prHead)
+		syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
 
-	t.Setenv("GITHUB_REF", "refs/pull/1/merge")
-	t.Setenv("GITHUB_SHA", syntheticMerge)
+		// If the synthetic merge commit and its parents are already present, this
+		// should not need to fetch refs/pull/1/head from origin.
+		run(t, "git", "-C", repo, "remote", "remove", "origin")
 
-	labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
+		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
+		t.Setenv("GITHUB_SHA", syntheticMerge)
 
-	require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
-	require.Equal(t, "merge side into pr", labels.AsMap()["dagger.io/git.title"])
+		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(repo)
+
+		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+		require.Equal(t, "pr commit", labels.AsMap()["dagger.io/git.title"])
+	})
+
+	t.Run("checked out pull request head merge commit stays on pull request head", func(t *testing.T) {
+		repo := setupRepo(t)
+
+		run(t, "git", "-C", repo, "checkout", "-b", "side")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "side commit")
+
+		run(t, "git", "-C", repo, "checkout", "main")
+		run(t, "git", "-C", repo, "checkout", "-b", "pr")
+		run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "pr commit")
+		run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "merge side into pr", "side")
+
+		prHead := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/head", prHead)
+
+		run(t, "git", "-C", repo, "checkout", "main")
+		run(t, "git", "-C", repo, "merge", "--no-ff", "-m", "synthetic pr merge", "pr")
+
+		syntheticMerge := run(t, "git", "-C", repo, "rev-parse", "HEAD")
+		run(t, "git", "-C", repo, "update-ref", "refs/pull/1/merge", syntheticMerge)
+
+		worktree := cloneRepo(t, repo)
+		run(t, "git", "-C", worktree, "checkout", prHead)
+
+		t.Setenv("GITHUB_REF", "refs/pull/1/merge")
+		t.Setenv("GITHUB_SHA", syntheticMerge)
+
+		labels := telemetry.NewLabels(nil, nil, nil).WithGitLabels(worktree)
+
+		require.Equal(t, prHead, labels.AsMap()["dagger.io/git.ref"])
+		require.Equal(t, "merge side into pr", labels.AsMap()["dagger.io/git.title"])
+	})
 }
 
 type mapEnv map[string]string


### PR DESCRIPTION
In a GitHub pull_request build, WithGitLabels resolved the PR head commit by running `git fetch --depth 1` inside the host checkout. That writes .git/shallow and silently turns a full checkout into a depth-1 clone, breaking later git history operations (merge-base, describe, log, ...).

Resolve the PR head read-only from the merge commit's second parent (refs/pull/N/merge has the base as parent 1 and the PR head as parent 2), which needs no fetch and never mutates the repo. Fall back to a fetch only when that isn't possible, and gate --depth 1 on the repo already being shallow so the fetch can never shallow a full checkout either.

Fixes #13351