### PR TITLE
fix(core): preserve pending lazy container parents

### DIFF
--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/dagger/internal/testutil"
@@ -882,6 +883,74 @@ func (m *Test) ContextGitRef(
 
 		randomB := runChain(ctx, t, engineClientB, hostFileB)
 		require.Equal(t, randomA, randomB, "withExec output should survive engine restart for equivalent host-mounted file input")
+	})
+
+	t.Run("container child exec during concurrent mounted directory parent eval", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		stateKey := "phase7-mounted-dir-parent-eval-race-state-" + identity.NewID()
+
+		hostDir := t.TempDir()
+		gitDir := filepath.Join(hostDir, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o600))
+
+		upstreamSvc, engineSvc, engineClient := startEngine(c, ctx, t, stateKey, engineWithPersistenceTestGC(ctx, t))
+		t.Cleanup(func() { stopEngine(ctx, t, upstreamSvc, engineSvc, engineClient) })
+
+		base := engineClient.Container().From(alpineImage)
+		for i := range 24 {
+			src := engineClient.Directory().WithNewFile("file.txt", fmt.Sprintf("slow-clone-%d\n", i))
+			base = base.WithMountedDirectory(fmt.Sprintf("/slow/%02d", i), src)
+		}
+		var err error
+		base, err = base.Sync(ctx)
+		require.NoError(t, err)
+
+		secret := engineClient.SetSecret("mounted-dir-parent-eval-race-"+identity.NewID(), "secret")
+		source := engineClient.Host().Directory(gitDir)
+
+		for attempt := range 50 {
+			parent := base.
+				WithMountedCache("/root/.cache/uv", engineClient.CacheVolume("phase7-race-uv-"+identity.NewID())).
+				WithMountedCache("/var/cache/foobar/plugins", engineClient.CacheVolume("phase7-race-foobar-"+identity.NewID())).
+				WithWorkdir("/work").
+				WithMountedDirectory(".git", source).
+				WithSecretVariable("FOOBAR_TOKEN", secret)
+
+			parentID, err := parent.ID(ctx)
+			require.NoError(t, err)
+
+			start := make(chan struct{})
+			var eg errgroup.Group
+			eg.Go(func() error {
+				<-start
+				_, err := dagger.Ref[*dagger.Container](engineClient, parentID).Sync(ctx)
+				return err
+			})
+			for worker := range 8 {
+				worker := worker
+				eg.Go(func() error {
+					<-start
+					if worker > 0 {
+						time.Sleep(time.Duration(worker) * time.Millisecond)
+					}
+					out, err := dagger.Ref[*dagger.Container](engineClient, parentID).
+						WithEnvVariable("CACHE_BUSTER", fmt.Sprintf("%d-%d", attempt, worker)).
+						WithExec([]string{"sh", "-ec", "cat .git/HEAD"}).
+						Stdout(ctx)
+					if err != nil {
+						return fmt.Errorf("attempt %d worker %d: %w", attempt, worker, err)
+					}
+					if out != "ref: refs/heads/main\n" {
+						return fmt.Errorf("attempt %d worker %d: unexpected HEAD contents %q", attempt, worker, out)
+					}
+					return nil
+				})
+			}
+			close(start)
+
+			require.NoError(t, eg.Wait(), "attempt %d", attempt)
+		}
 	})
 
 	t.Run("git repository and ref survive restart", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -181,7 +181,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 		// llbtodagger can faithfully apply Docker image config metadata fields that do not yet
 		// have public SDK methods.
 		dagql.NodeFunc("__withImageConfigMetadata", func(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithImageConfigMetadataArgs) (*core.Container, error) {
-			ctr, err := cloneContainerForSchemaChild(ctx, parent)
+			ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 			if err != nil {
 				return nil, err
 			}
@@ -189,7 +189,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			if err != nil {
 				return nil, err
 			}
-			if parent.Self().Lazy != nil {
+			if parentPendingLazy {
 				var healthcheck *dockerspec.HealthcheckConfig
 				if ctr.Config.Healthcheck != nil {
 					hc := *ctr.Config.Healthcheck
@@ -278,7 +278,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.NodeFunc("withDockerHealthcheck", func(ctx context.Context, parent dagql.ObjectResult[*core.Container], args WithHealthcheckArgs) (*core.Container, error) {
-			ctr, err := cloneContainerForSchemaChild(ctx, parent)
+			ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +286,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			if err != nil {
 				return nil, err
 			}
-			if parent.Self().Lazy != nil {
+			if parentPendingLazy {
 				hc := *ctr.Config.Healthcheck
 				hc.Test = slices.Clone(ctr.Config.Healthcheck.Test)
 				ctr.Lazy = &core.ContainerWithHealthcheckLazy{
@@ -309,7 +309,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.NodeFunc("withoutDockerHealthcheck", func(ctx context.Context, parent dagql.ObjectResult[*core.Container], args struct{}) (*core.Container, error) {
-			ctr, err := cloneContainerForSchemaChild(ctx, parent)
+			ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 			if err != nil {
 				return nil, err
 			}
@@ -317,7 +317,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			if err != nil {
 				return nil, err
 			}
-			if parent.Self().Lazy != nil {
+			if parentPendingLazy {
 				ctr.Lazy = &core.ContainerWithoutHealthcheckLazy{
 					LazyState: core.NewLazyState(),
 					Parent:    parent,
@@ -1360,7 +1360,7 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 		}
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -1541,7 +1541,7 @@ type containerGpuArgs struct {
 }
 
 func (s *containerSchema) withGPU(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerGpuArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1549,7 +1549,7 @@ func (s *containerSchema) withGPU(ctx context.Context, parent dagql.ObjectResult
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerSetGPUsLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1560,7 +1560,7 @@ func (s *containerSchema) withGPU(ctx context.Context, parent dagql.ObjectResult
 }
 
 func (s *containerSchema) withAllGPUs(ctx context.Context, parent dagql.ObjectResult[*core.Container], args struct{}) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1569,7 +1569,7 @@ func (s *containerSchema) withAllGPUs(ctx context.Context, parent dagql.ObjectRe
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerSetGPUsLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1585,7 +1585,7 @@ type containerWithEntrypointArgs struct {
 }
 
 func (s *containerSchema) withEntrypoint(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithEntrypointArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1599,7 +1599,7 @@ func (s *containerSchema) withEntrypoint(ctx context.Context, parent dagql.Objec
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithEntrypointLazy{
 			LazyState:       core.NewLazyState(),
 			Parent:          parent,
@@ -1615,7 +1615,7 @@ type containerWithoutEntrypointArgs struct {
 }
 
 func (s *containerSchema) withoutEntrypoint(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutEntrypointArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1629,7 +1629,7 @@ func (s *containerSchema) withoutEntrypoint(ctx context.Context, parent dagql.Ob
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutEntrypointLazy{
 			LazyState:       core.NewLazyState(),
 			Parent:          parent,
@@ -1655,7 +1655,7 @@ type containerWithDefaultArgs struct {
 }
 
 func (s *containerSchema) withDefaultArgs(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithDefaultArgs) (*core.Container, error) {
-	c, err := cloneContainerForSchemaChild(ctx, parent)
+	c, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1672,7 +1672,7 @@ func (s *containerSchema) withDefaultArgs(ctx context.Context, parent dagql.Obje
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		c.Lazy = &core.ContainerWithDefaultArgsLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1683,7 +1683,7 @@ func (s *containerSchema) withDefaultArgs(ctx context.Context, parent dagql.Obje
 }
 
 func (s *containerSchema) withoutDefaultArgs(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (*core.Container, error) {
-	c, err := cloneContainerForSchemaChild(ctx, parent)
+	c, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1695,7 +1695,7 @@ func (s *containerSchema) withoutDefaultArgs(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		c.Lazy = &core.ContainerWithoutDefaultArgsLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1720,7 +1720,7 @@ type containerWithUserArgs struct {
 }
 
 func (s *containerSchema) withUser(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithUserArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1731,7 +1731,7 @@ func (s *containerSchema) withUser(ctx context.Context, parent dagql.ObjectResul
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithUserLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1742,7 +1742,7 @@ func (s *containerSchema) withUser(ctx context.Context, parent dagql.ObjectResul
 }
 
 func (s *containerSchema) withoutUser(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1753,7 +1753,7 @@ func (s *containerSchema) withoutUser(ctx context.Context, parent dagql.ObjectRe
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutUserLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1784,7 +1784,7 @@ func (s *containerSchema) withWorkdir(ctx context.Context, parent dagql.ObjectRe
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1795,7 +1795,7 @@ func (s *containerSchema) withWorkdir(ctx context.Context, parent dagql.ObjectRe
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithWorkdirLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1807,7 +1807,7 @@ func (s *containerSchema) withWorkdir(ctx context.Context, parent dagql.ObjectRe
 }
 
 func (s *containerSchema) withoutWorkdir(ctx context.Context, parent dagql.ObjectResult[*core.Container], _ struct{}) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1818,7 +1818,7 @@ func (s *containerSchema) withoutWorkdir(ctx context.Context, parent dagql.Objec
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutWorkdirLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1845,7 +1845,7 @@ type containerWithVariableArgs struct {
 }
 
 func (s *containerSchema) withEnvVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithVariableArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1860,7 +1860,7 @@ func (s *containerSchema) withEnvVariable(ctx context.Context, parent dagql.Obje
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithEnvVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1892,7 +1892,7 @@ func (s *containerSchema) withEnvFileVariables(ctx context.Context, parent dagql
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -1905,7 +1905,7 @@ func (s *containerSchema) withEnvFileVariables(ctx context.Context, parent dagql
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithEnvFileVariablesLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1925,12 +1925,12 @@ type containerWithVolatileVariableArgs struct {
 }
 
 func (s *containerSchema) withSystemEnvVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithSystemEnvArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
 	ctr.SystemEnvNames = append(ctr.SystemEnvNames, args.Name)
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithSystemEnvVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -1946,12 +1946,12 @@ func (s *containerSchema) withVolatileVariable(ctx context.Context, parent dagql
 		return inst, fmt.Errorf("current call is nil")
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
 	ctr.WithVolatileVariable(args.Name, args.Value)
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithVolatileVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2046,7 +2046,7 @@ type containerWithoutVariableArgs struct {
 }
 
 func (s *containerSchema) withoutEnvVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutVariableArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2066,7 +2066,7 @@ func (s *containerSchema) withoutEnvVariable(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutEnvVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2077,12 +2077,12 @@ func (s *containerSchema) withoutEnvVariable(ctx context.Context, parent dagql.O
 }
 
 func (s *containerSchema) withoutVolatileVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutVariableArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
 	ctr.WithoutVolatileVariable(args.Name)
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutVolatileVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2268,7 +2268,7 @@ type containerWithAnnotationArgs struct {
 }
 
 func (s *containerSchema) withAnnotation(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithAnnotationArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2276,7 +2276,7 @@ func (s *containerSchema) withAnnotation(ctx context.Context, parent dagql.Objec
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithAnnotationLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2292,7 +2292,7 @@ type containerWithoutAnnotationArgs struct {
 }
 
 func (s *containerSchema) withoutAnnotation(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutAnnotationArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2300,7 +2300,7 @@ func (s *containerSchema) withoutAnnotation(ctx context.Context, parent dagql.Ob
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutAnnotationLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2426,7 +2426,7 @@ func (s *containerSchema) withMountedFile(ctx context.Context, parent dagql.Obje
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2465,7 +2465,7 @@ func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, p
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2613,7 +2613,7 @@ func (s *containerSchema) withMountedCache(ctx context.Context, parent dagql.Obj
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2645,7 +2645,7 @@ func (s *containerSchema) withMountedTemp(ctx context.Context, parent dagql.Obje
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2676,7 +2676,7 @@ func (s *containerSchema) withoutMount(ctx context.Context, parent dagql.ObjectR
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2714,7 +2714,7 @@ type containerWithLabelArgs struct {
 }
 
 func (s *containerSchema) withLabel(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithLabelArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2728,7 +2728,7 @@ func (s *containerSchema) withLabel(ctx context.Context, parent dagql.ObjectResu
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithLabelLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2744,7 +2744,7 @@ type containerWithoutLabelArgs struct {
 }
 
 func (s *containerSchema) withoutLabel(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutLabelArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2755,7 +2755,7 @@ func (s *containerSchema) withoutLabel(ctx context.Context, parent dagql.ObjectR
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutLabelLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -2987,18 +2987,20 @@ func ownerNeedsLookup(owner string) bool {
 	return false
 }
 
-func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult[*core.Container]) (*core.Container, error) {
+func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult[*core.Container]) (*core.Container, bool, error) {
+	parentPendingLazy := dagql.HasPendingLazyEvaluation(parent)
+
 	clonedFS, err := core.CloneContainerDirectoryAccessor(ctx, parent.Self().FS)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	clonedMounts, err := core.CloneContainerMounts(ctx, parent.Self().Mounts)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	clonedMeta, err := core.CloneContainerMetaSnapshot(ctx, parent.Self().MetaSnapshot)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	ctr := &core.Container{
 		FS:                 clonedFS,
@@ -3018,7 +3020,7 @@ func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult
 		VolatileEnv:        slices.Clone(parent.Self().VolatileEnv),
 		DefaultArgs:        parent.Self().DefaultArgs,
 	}
-	return ctr, nil
+	return ctr, parentPendingLazy, nil
 }
 
 func expandEnvVar(ctx context.Context, parent *core.Container, input string, expand bool) (string, error) {
@@ -3078,7 +3080,7 @@ func (s *containerSchema) withSecretVariable(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3086,7 +3088,7 @@ func (s *containerSchema) withSecretVariable(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithSecretVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -3102,7 +3104,7 @@ type containerWithoutSecretVariableArgs struct {
 }
 
 func (s *containerSchema) withoutSecretVariable(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutSecretVariableArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3110,7 +3112,7 @@ func (s *containerSchema) withoutSecretVariable(ctx context.Context, parent dagq
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutSecretVariableLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -3144,7 +3146,7 @@ func (s *containerSchema) withMountedSecret(ctx context.Context, parent dagql.Ob
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3205,7 +3207,7 @@ func (s *containerSchema) withDirectory(ctx context.Context, parent dagql.Object
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3248,7 +3250,7 @@ func (s *containerSchema) withFile(ctx context.Context, parent dagql.ObjectResul
 		return inst, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -3353,7 +3355,7 @@ func (s *containerSchema) withoutDirectory(ctx context.Context, parent dagql.Obj
 		return inst, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -3381,7 +3383,7 @@ func (s *containerSchema) withoutFile(ctx context.Context, parent dagql.ObjectRe
 		return inst, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -3466,7 +3468,7 @@ func (s *containerSchema) withNewFile(ctx context.Context, parent dagql.ObjectRe
 		return inst, fmt.Errorf("failed to create new file %s: %w", path, err)
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -3513,7 +3515,7 @@ func (s *containerSchema) withNewFileLegacy(ctx context.Context, parent dagql.Ob
 		return inst, fmt.Errorf("failed to create new file %s: %w", args.Path, err)
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return inst, err
 	}
@@ -3551,7 +3553,7 @@ func (s *containerSchema) withUnixSocket(ctx context.Context, parent dagql.Objec
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3614,7 +3616,7 @@ func (s *containerSchema) withoutUnixSocket(ctx context.Context, parent dagql.Ob
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3869,7 +3871,7 @@ func (s *containerSchema) import_(ctx context.Context, parent dagql.ObjectResult
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3959,7 +3961,7 @@ func (s *containerSchema) withServiceBinding(ctx context.Context, parent dagql.O
 		return nil, err
 	}
 
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -3967,7 +3969,7 @@ func (s *containerSchema) withServiceBinding(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithServiceBindingLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -3986,7 +3988,7 @@ type containerWithExposedPortArgs struct {
 }
 
 func (s *containerSchema) withExposedPort(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithExposedPortArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -4000,7 +4002,7 @@ func (s *containerSchema) withExposedPort(ctx context.Context, parent dagql.Obje
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithExposedPortLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -4016,7 +4018,7 @@ type containerWithoutExposedPortArgs struct {
 }
 
 func (s *containerSchema) withoutExposedPort(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutExposedPortArgs) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -4024,7 +4026,7 @@ func (s *containerSchema) withoutExposedPort(ctx context.Context, parent dagql.O
 	if err != nil {
 		return nil, err
 	}
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithoutExposedPortLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,
@@ -4085,12 +4087,12 @@ func (s *containerSchema) withDefaultTerminalCmd(
 	parent dagql.ObjectResult[*core.Container],
 	args containerWithDefaultTerminalCmdArgs,
 ) (*core.Container, error) {
-	ctr, err := cloneContainerForSchemaChild(ctx, parent)
+	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
 	ctr.DefaultTerminalCmd = args.DefaultTerminalCmdOpts
-	if parent.Self().Lazy != nil {
+	if parentPendingLazy {
 		ctr.Lazy = &core.ContainerWithDefaultTerminalCmdLazy{
 			LazyState: core.NewLazyState(),
 			Parent:    parent,


### PR DESCRIPTION
## What changed

Container schema child constructors now capture `dagql.HasPendingLazyEvaluation(parent)` before cloning parent state, and use that cache-owned pending state to decide whether to install a child lazy wrapper. This replaces the previous checks against `parent.Self().Lazy` across the affected container schema mutation methods.

The PR also adds an integration repro for same-session concurrent child operations from a parent container with a lazily materialized writable directory mount.

## Root cause

Child container methods cloned parent container state and then checked `parent.Self().Lazy != nil` to decide whether the child needed its own lazy wrapper. That pointer is cleared after successful parent lazy evaluation. Under concurrent same-session operations, one request could clone an unevaluated parent mount while another request finished evaluating the parent before the lazy decision happened.

That left the child looking ready while carrying an empty cloned `LazyAccessor` for a writable mounted directory. A later `withExec` then evaluated the child as a no-op and failed while preparing writable mount outputs with `exec directory mount N is missing materialized input`.

## Reproduction

The new integration test runs concurrent operations in one engine client/session. One goroutine forces a shared parent container while sibling goroutines derive children from the same parent ID with `withEnvVariable`, execute `cat .git/HEAD`, and read stdout. Before the fix this reproduced the missing-materialized-input invariant failure.

## Validation

- `go test ./core/schema`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestCachePersistence/TestDiskPersistenceAcrossRestart/container child exec during concurrent mounted directory parent eval'`
- The targeted integration repro passed three consecutive runs after the fix.