### PR TITLE
gc: prune local cache during disk pressure

### DIFF
--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -382,6 +382,155 @@ func (LocalCacheSuite) TestLocalCacheGC(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (LocalCacheSuite) TestLocalCacheGCRunsDuringDiskPressureWithActiveSession(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const (
+		engineRootSizeBytes = 1536 * 1024 * 1024
+		minFreeBytes        = 900 * 1024 * 1024
+		seedMB              = 192
+		pressureMB          = 512
+		seedSignalBytes     = 96 * 1024 * 1024
+	)
+
+	engine := devEngineContainer(c,
+		engineWithConfig(ctx, t, engineConfigWithGC(
+			"0",
+			fmt.Sprint(minFreeBytes),
+			"4GB",
+			"",
+		)),
+	).WithMountedTemp("/var/lib/dagger", dagger.ContainerWithMountedTempOpts{
+		Size: engineRootSizeBytes,
+	})
+
+	engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(engine)).Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = engineSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}) })
+
+	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+	require.NoError(t, err)
+
+	newNestedClient := func() *dagger.Client {
+		t.Helper()
+
+		client, err := dagger.Connect(
+			ctx,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+		require.NoError(t, err)
+		return client
+	}
+
+	observer := newNestedClient()
+	t.Cleanup(func() { _ = observer.Close() })
+
+	getUsedBytes := func() int {
+		t.Helper()
+
+		usedBytes, err := observer.Engine().LocalCache().EntrySet().DiskSpaceBytes(ctx)
+		require.NoError(t, err)
+		return usedBytes
+	}
+
+	dumpCacheSummary := func() {
+		t.Helper()
+
+		entryCount, err := observer.Engine().LocalCache().EntrySet().EntryCount(ctx)
+		if err != nil {
+			t.Logf("failed to get cache entry count for debugging: %v", err)
+			return
+		}
+		t.Logf("cache entry count: %d", entryCount)
+	}
+
+	waitForUsageAtLeast := func(label string, target int, timeout time.Duration) int {
+		t.Helper()
+
+		deadline := time.Now().Add(timeout)
+		var usedBytes int
+		for {
+			usedBytes = getUsedBytes()
+			if usedBytes >= target {
+				return usedBytes
+			}
+			if time.Now().After(deadline) {
+				dumpCacheSummary()
+				t.Fatalf("%s: expected local cache usage >= %d bytes, got %d", label, target, usedBytes)
+			}
+			t.Logf("%s: local cache usage %d < %d, waiting", label, usedBytes, target)
+			time.Sleep(time.Second)
+		}
+	}
+
+	waitForUsageBelow := func(label string, target int, timeout time.Duration) int {
+		t.Helper()
+
+		deadline := time.Now().Add(timeout)
+		var usedBytes int
+		for {
+			usedBytes = getUsedBytes()
+			if usedBytes < target {
+				return usedBytes
+			}
+			if time.Now().After(deadline) {
+				dumpCacheSummary()
+				t.Fatalf("%s: expected local cache usage < %d bytes, got %d", label, target, usedBytes)
+			}
+			t.Logf("%s: local cache usage %d >= %d, waiting for disk-pressure GC", label, usedBytes, target)
+			time.Sleep(time.Second)
+		}
+	}
+
+	baselineUsedBytes := getUsedBytes()
+
+	seedClient := newNestedClient()
+	_, err = seedClient.
+		Container().
+		From(alpineImage).
+		WithEnvVariable("GC_PRESSURE_SEED", identity.NewID()).
+		WithExec([]string{
+			"sh", "-ec",
+			fmt.Sprintf("dd if=/dev/zero of=/seed bs=1M count=%d status=none", seedMB),
+		}).
+		Sync(ctx)
+	require.NoError(t, err)
+	require.NoError(t, seedClient.Close())
+
+	usedAfterSeed := waitForUsageAtLeast("seed cache", baselineUsedBytes+seedSignalBytes, 30*time.Second)
+
+	// Let the no-pressure session-end GC run before introducing disk pressure.
+	time.Sleep(10 * time.Second)
+	usedAfterNoPressureGC := getUsedBytes()
+	require.GreaterOrEqual(t, usedAfterNoPressureGC, usedAfterSeed-seedSignalBytes/2, "seed should not be pruned before disk pressure exists")
+
+	activeClient := newNestedClient()
+	t.Cleanup(func() { _ = activeClient.Close() })
+
+	pressureSvc, err := activeClient.
+		Container().
+		From(alpineImage).
+		WithEnvVariable("GC_PRESSURE_ACTIVE", identity.NewID()).
+		WithExec([]string{
+			"sh", "-ec",
+			fmt.Sprintf("dd if=/dev/zero of=/pressure bs=1M count=%d status=none", pressureMB),
+		}).
+		WithDefaultArgs([]string{"sh", "-ec", "sleep 300"}).
+		AsService().
+		Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pressureSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}) })
+
+	usedWithPressure := waitForUsageAtLeast("active pressure cache", usedAfterNoPressureGC+seedSignalBytes, 30*time.Second)
+
+	waitForUsageBelow(
+		"disk-pressure gc with active session",
+		usedWithPressure-seedSignalBytes,
+		45*time.Second,
+	)
+}
+
 func (LocalCacheSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	setup := func(ctx context.Context, t *testctx.T) (endpoint string, c2 *dagger.Client, addCacheBlock func(*testctx.T, string, int), getUsedBytes func(*testctx.T) int) {

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -19,6 +19,12 @@ import (
 
 type dagqlCachePrunePolicy = dagql.CachePrunePolicy
 
+const (
+	localCacheSessionGCThrottle      = time.Minute
+	localCacheDiskPressureCheckEvery = 5 * time.Second
+	localCacheDiskPressureGCThrottle = 30 * time.Second
+)
+
 func (srv *Server) EngineLocalCachePolicy() *dagqlCachePrunePolicy {
 	return srv.workerDefaultGCPolicy
 }
@@ -182,6 +188,23 @@ func (srv *Server) gc() {
 	srv.gcmu.Lock()
 	defer srv.gcmu.Unlock()
 
+	srv.gcLocked(context.Background())
+}
+
+func (srv *Server) gcIfDiskPressure() {
+	ctx := context.Background()
+
+	srv.gcmu.Lock()
+	defer srv.gcmu.Unlock()
+
+	if !srv.diskPressureGCNeeded(ctx) {
+		return
+	}
+
+	srv.gcLocked(ctx)
+}
+
+func (srv *Server) gcLocked(ctx context.Context) {
 	if srv.isShuttingDown() {
 		return
 	}
@@ -192,7 +215,7 @@ func (srv *Server) gc() {
 
 	dstat, err := disk.GetDiskStat(srv.rootDir)
 	if err != nil {
-		bklog.G(context.Background()).Warnf("gc skipped: failed to get disk stats: %+v", err)
+		bklog.G(ctx).Warnf("gc skipped: failed to get disk stats: %+v", err)
 		return
 	}
 
@@ -203,13 +226,62 @@ func (srv *Server) gc() {
 		prunePolicies[i].CurrentFreeSpace = dstat.Available
 	}
 
-	report, err := srv.engineCache.Prune(context.Background(), prunePolicies)
+	report, err := srv.engineCache.Prune(ctx, prunePolicies)
 	if err != nil {
-		bklog.G(context.Background()).Errorf("gc error: %+v", err)
+		bklog.G(ctx).Errorf("gc error: %+v", err)
 	}
 	if report.ReclaimedBytes > 0 {
-		bklog.G(context.Background()).Debugf("gc cleaned up %d bytes", report.ReclaimedBytes)
+		bklog.G(ctx).Debugf("gc cleaned up %d bytes", report.ReclaimedBytes)
 	}
+}
+
+func (srv *Server) startDiskPressureGCMonitor() {
+	if srv.engineCache == nil || len(srv.workerGCPolicies) == 0 {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(localCacheDiskPressureCheckEvery)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-srv.shutdownCtx.Done():
+				return
+			case <-ticker.C:
+				if srv.diskPressureGCNeeded(context.Background()) {
+					srv.throttledDiskPressureGC()
+				}
+			}
+		}
+	}()
+}
+
+func (srv *Server) diskPressureGCNeeded(ctx context.Context) bool {
+	if srv.isShuttingDown() {
+		return false
+	}
+
+	if len(srv.workerGCPolicies) == 0 {
+		return false
+	}
+
+	dstat, err := disk.GetDiskStat(srv.rootDir)
+	if err != nil {
+		bklog.G(ctx).Warnf("disk pressure gc skipped: failed to get disk stats: %+v", err)
+		return false
+	}
+
+	return localCacheDiskPressureGCNeeded(srv.workerGCPolicies, dstat)
+}
+
+func localCacheDiskPressureGCNeeded(policies []dagqlCachePrunePolicy, dstat disk.DiskStat) bool {
+	for _, policy := range policies {
+		if policy.MinFreeSpace > 0 && dstat.Available < policy.MinFreeSpace {
+			return true
+		}
+	}
+	return false
 }
 
 func getDagqlGCPolicy(cfg config.Config, bkcfg bkconfig.GCConfig, root string) []dagqlCachePrunePolicy {

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -109,6 +109,25 @@ func TestResolveEngineLocalCachePrunePoliciesUsesAvailableSpaceForMinFree(t *tes
 	require.GreaterOrEqual(t, dstat.Free, prunePolicies[0].MinFreeSpace)
 }
 
+func TestLocalCacheDiskPressureGCNeeded(t *testing.T) {
+	dstat := disk.DiskStat{Available: 100}
+
+	require.False(t, localCacheDiskPressureGCNeeded(nil, dstat))
+	require.False(t, localCacheDiskPressureGCNeeded([]dagqlCachePrunePolicy{
+		{MinFreeSpace: 100},
+	}, dstat))
+	require.True(t, localCacheDiskPressureGCNeeded([]dagqlCachePrunePolicy{
+		{MinFreeSpace: 101},
+	}, dstat))
+	require.True(t, localCacheDiskPressureGCNeeded([]dagqlCachePrunePolicy{
+		{MinFreeSpace: 0},
+		{MinFreeSpace: 101},
+	}, dstat))
+	require.False(t, localCacheDiskPressureGCNeeded([]dagqlCachePrunePolicy{
+		{MaxUsedSpace: 1},
+	}, dstat))
+}
+
 func TestResolveEngineLocalCachePrunePoliciesInvalidSpaceValue(t *testing.T) {
 	dstat := disk.DiskStat{Total: 100 * 1e9}
 

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -132,8 +132,9 @@ type Server struct {
 	//
 	// gc related
 	//
-	throttledGC func()
-	gcmu        sync.Mutex
+	throttledGC             func()
+	throttledDiskPressureGC func()
+	gcmu                    sync.Mutex
 
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelCauseFunc
@@ -409,10 +410,12 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	// setup solver
 	//
 
-	srv.throttledGC = throttle.After(time.Minute, srv.gc)
+	srv.throttledGC = throttle.After(localCacheSessionGCThrottle, srv.gc)
+	srv.throttledDiskPressureGC = throttle.After(localCacheDiskPressureGCThrottle, srv.gcIfDiskPressure)
 	defer func() {
-		time.AfterFunc(time.Second, srv.throttledGC)
+		time.AfterFunc(time.Second, srv.gc)
 	}()
+	srv.startDiskPressureGCMonitor()
 
 	// garbage collect client DBs
 	go srv.gcClientDBs()


### PR DESCRIPTION
## Summary

- add a disk-pressure monitor that triggers local cache GC while sessions are still active
- keep pressure-triggered GC separate from session-end GC throttling, while preserving serialized pruning through the existing GC mutex
- add unit and integration coverage for reclaiming old cache when an active session pushes the engine below min-free space

## Problem

Local cache GC previously ran on startup and after client sessions ended. That left a gap for a long-running or still-active session that allocates enough data to put the engine root below its configured min-free-space target. In that state, the machine can be under disk pressure even though older cache entries are already prunable, but the engine would not attempt to prune them until the active session ended.

That means one large session could consume the remaining disk space and fail the instance, despite there being reclaimable cache from previous sessions.

## Fix

This adds a lightweight disk-pressure monitor that periodically checks the engine root against the resolved local cache GC policies. If available space is below any configured min-free target, it schedules a pressure-specific throttled GC.

The actual prune still runs under the existing GC mutex, so pressure-triggered and session-end prunes cannot run concurrently. The pressure path also re-checks disk state while holding the mutex, which skips stale queued pressure prunes if another GC already relieved the condition.

Startup GC now calls the underlying GC directly so it does not consume the session-end throttle window.

## Tests

- `go test ./engine/server`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestLocalCache/TestLocalCacheGCRunsDuringDiskPressureWithActiveSession'`