### PR TITLE
Narrow workspace module loading for `dagger generate`

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -232,6 +232,45 @@ func (GeneratorsSuite) TestGeneratorsInstalledInWorkspace(ctx context.Context, t
 	}
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. An
+// unrelated broken/stale workspace module must not be loaded just to enumerate
+// generators, so it cannot block regenerating a healthy module -- including the
+// case where running generate is itself the fix for the broken module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the same narrowing for raw single queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger.json
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger.json
@@ -1,0 +1,1 @@
+{"name":"bad","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger.json
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger.json
@@ -1,0 +1,1 @@
+{"name":"good","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,10 @@
+type Good {
+  pub workdir: Directory! @defaultPath(path: ".")
+
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate: Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -42,6 +42,94 @@ func PeekRootFields(r *http.Request) (bool, []string, error) {
 	return true, fields, nil
 }
 
+// PeekWorkspaceGeneratorsInclude reports whether a GraphQL-over-HTTP request is a
+// workspace-generators query of the shape
+//
+//	{ currentWorkspace { generators(include: [...]) ... } }
+//
+// and, if so, returns the literal include patterns while preserving the request
+// body for the real server. Workspace-rooted queries normally require the full
+// workspace schema (every module loaded); recognizing this shape lets the engine
+// narrow module loading to the generators actually requested, e.g.
+// `dagger generate <module>`. It is deliberately conservative: anything other
+// than a single currentWorkspace root field selecting only generators with a
+// literal include list returns false, so loading falls back to all modules.
+func PeekWorkspaceGeneratorsInclude(r *http.Request) (bool, []string, error) {
+	query, operationName, ok, err := peekGraphQLRequestBody(r)
+	if err != nil || !ok {
+		return false, nil, err
+	}
+
+	doc, err := parser.ParseQuery(&ast.Source{Input: query})
+	if err != nil {
+		return false, nil, err
+	}
+
+	op, ok := peekOperation(doc, operationName)
+	if !ok || op.Operation != ast.Query {
+		return false, nil, nil
+	}
+
+	root := singleConcreteField(op.SelectionSet)
+	if root == nil || root.Name != "currentWorkspace" {
+		return false, nil, nil
+	}
+
+	generators := singleConcreteField(root.SelectionSet)
+	if generators == nil || generators.Name != "generators" {
+		return false, nil, nil
+	}
+
+	include, ok := stringListArgument(generators.Arguments, "include")
+	if !ok {
+		return false, nil, nil
+	}
+	return true, include, nil
+}
+
+// singleConcreteField returns the sole non-introspection field in a selection
+// set, or nil if there is not exactly one such field or the set contains
+// fragments. Fragments are treated as "don't narrow" so callers stay on the
+// safe (load-everything) path rather than reasoning about fragment expansion.
+func singleConcreteField(set ast.SelectionSet) *ast.Field {
+	var found *ast.Field
+	for _, selection := range set {
+		field, ok := selection.(*ast.Field)
+		if !ok {
+			return nil
+		}
+		if field.Name == "__typename" {
+			continue
+		}
+		if found != nil {
+			return nil
+		}
+		found = field
+	}
+	return found
+}
+
+// stringListArgument returns the values of a named argument when it is a literal
+// list of strings. Missing, non-list, variable, or non-string arguments return
+// false so callers do not narrow on something they can't resolve statically.
+func stringListArgument(args ast.ArgumentList, name string) ([]string, bool) {
+	arg := args.ForName(name)
+	if arg == nil || arg.Value == nil || arg.Value.Kind != ast.ListValue {
+		return nil, false
+	}
+	values := make([]string, 0, len(arg.Value.Children))
+	for _, child := range arg.Value.Children {
+		if child.Value == nil || child.Value.Kind != ast.StringValue {
+			return nil, false
+		}
+		values = append(values, child.Value.Raw)
+	}
+	if len(values) == 0 {
+		return nil, false
+	}
+	return values, true
+}
+
 func peekGraphQLRequestBody(r *http.Request) (string, string, bool, error) {
 	switch r.Method {
 	case http.MethodGet:

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -62,3 +62,62 @@ func TestPeekRootFieldsRejectsBatch(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, fields)
 }
+
+func TestPeekWorkspaceGeneratorsIncludeMatches(t *testing.T) {
+	t.Parallel()
+
+	body := `{"query":"{ currentWorkspace { generators(include: [\"go-sdk\", \"php-sdk:api\"]) { id } } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceGeneratorsInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"go-sdk", "php-sdk:api"}, include)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestPeekWorkspaceGeneratorsIncludeNonGeneratorsQuery(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { git { head { commit } } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceGeneratorsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceGeneratorsIncludeWithoutIncludeArg(t *testing.T) {
+	t.Parallel()
+
+	// No include argument means "all generators" -- we can't narrow safely.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { generators { list { name } } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceGeneratorsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceGeneratorsIncludeExtraRootField(t *testing.T) {
+	t.Parallel()
+
+	// A sibling root field beyond currentWorkspace means the query needs more
+	// than the requested generators' modules, so narrowing must be skipped.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { generators(include: [\"go-sdk\"]) { id } } version }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceGeneratorsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1388,6 +1388,8 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	}
 	if peekRootFieldsOK {
 		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
+	} else if include, ok := peekWorkspaceGeneratorsInclude(r, client.clientMetadata); ok {
+		client.narrowPendingWorkspaceModulesForGeneratorsInclude(include)
 	}
 	if err := srv.ensureModulesLoaded(ctx, client); err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1431,6 +1433,22 @@ func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata)
 		return false, nil, nil
 	}
 	return dagql.PeekRootFields(r)
+}
+
+// peekWorkspaceGeneratorsInclude narrows module loading for `dagger generate`,
+// which roots its query at currentWorkspace (so the single-query peek treats it
+// as needing the full workspace schema) and keeps the session open rather than
+// declaring SingleQuery. When such a client requests specific generators via an
+// include argument, only those generators' modules need to load.
+func peekWorkspaceGeneratorsInclude(r *http.Request, clientMD *engine.ClientMetadata) ([]string, bool) {
+	if clientMD == nil || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
+		return nil, false
+	}
+	ok, include, err := dagql.PeekWorkspaceGeneratorsInclude(r)
+	if err != nil || !ok {
+		return nil, false
+	}
+	return include, true
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1140,6 +1140,59 @@ func TestGatherModuleLoadRequests(t *testing.T) {
 	require.True(t, loads[2].mod.Entrypoint)
 }
 
+func TestFilterPendingWorkspaceModulesByGeneratorsInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator keeps only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("bare module name keeps only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns keep each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. a generator served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("no matching module loads all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include loads all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesByGeneratorsInclude(mods, nil)
+		require.Equal(t, mods, filtered)
+	})
+}
+
 func TestModuleLoadParallelism(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -922,6 +922,78 @@ func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFiel
 	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
+// narrowPendingWorkspaceModulesForGeneratorsInclude narrows the pending
+// workspace modules to those named by `dagger generate` include patterns (e.g.
+// `dagger generate go-sdk` keeps only the "go-sdk" module). Unlike the
+// single-query peek, a generate query roots at currentWorkspace and so would
+// otherwise require the full workspace schema; this lets it load only the
+// requested generators' modules, so an unrelated broken/stale module cannot
+// block generation. A module's own dependencies still load transitively.
+func (client *daggerClient) narrowPendingWorkspaceModulesForGeneratorsInclude(include []string) {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+
+	if client.modulesLoaded || len(client.pendingModules) == 0 {
+		return
+	}
+	client.pendingModules = filterPendingWorkspaceModulesByGeneratorsInclude(client.pendingModules, include)
+}
+
+// filterPendingWorkspaceModulesByGeneratorsInclude keeps the modules named by
+// generator include patterns. A pattern resolves to a module name in one of two
+// ways:
+//
+//   - "module:generator" — the segment before ':' is the module name.
+//   - "module" (bare) — the whole token, but only when it matches a known
+//     workspace module name. A bare token that is not a module name is assumed
+//     to be a generator served by the entrypoint module (its functions are
+//     proxied onto the Query root), which we can't pin to a single module, so
+//     narrowing is skipped and all modules are kept.
+//
+// If no module ends up matching, narrowing is also skipped so the usual
+// "no such generator" error is reported instead of an empty result.
+func filterPendingWorkspaceModulesByGeneratorsInclude(mods []pendingModule, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	known := make(map[string]struct{}, len(mods))
+	for _, mod := range mods {
+		if mod.Name != "" {
+			known[mod.Name] = struct{}{}
+		}
+	}
+
+	wanted := make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		if modName, _, hasGenerator := strings.Cut(pattern, ":"); hasGenerator {
+			if modName == "" {
+				return mods
+			}
+			wanted[modName] = struct{}{}
+			continue
+		}
+		// Bare token: only safe to narrow if it names a workspace module;
+		// otherwise it likely targets an entrypoint generator, which needs the
+		// entrypoint loaded, so keep everything.
+		if _, ok := known[pattern]; !ok {
+			return mods
+		}
+		wanted[pattern] = struct{}{}
+	}
+
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[mod.Name]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	if len(filtered) == 0 {
+		return mods
+	}
+	return filtered
+}
+
 func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods


### PR DESCRIPTION
## Problem

`dagger generate <module>` loads **every** workspace module just to enumerate generators. A single stale or broken workspace module then blocks regenerating any other module — including the very module you were trying to fix by running `dagger generate`.

The single-query lazy-load mechanism (peek root fields → narrow pending workspace modules) does not help here: `dagger generate` roots its query at `currentWorkspace` (treated as needing the full workspace schema) and keeps the session open rather than declaring `SingleQuery`.

## Fix

Reuse and extend the existing peek/narrow mechanism rather than adding any new client→server contract:

- **`dagql.PeekWorkspaceGeneratorsInclude`** recognizes a request of the shape `{ currentWorkspace { generators(include: [...]) … } }` and returns the literal include patterns, preserving the request body. It is deliberately conservative — any other shape (extra root fields, non-generators selections, fragments, missing/non-literal `include`) disables narrowing.
- **`serveQuery`** calls it as an `else` branch to the existing single-query peek. When matched, it narrows the pending workspace modules to the named modules (`module:generator` or a bare `module` matching a known workspace module) plus their transitive deps. A bare token that is not a module name (an entrypoint-proxied generator), or patterns matching no module, fall back to loading everything.

Net effect: `dagger generate <module>` loads only that module (+ its dependencies), so an unrelated broken/stale module can no longer block generation.

## Tests

- Unit: `dagql` peek matching (including negative shapes) and the `engine/server` pending-module filter.
- Integration: `TestWorkspaceGenerateNarrowsToRequestedModule` with a `generators-broken` fixture (a healthy dang generator module + a module with intentionally invalid source). It asserts `dagger generate good` / `dagger generate -l good` succeed despite the broken module, while a full `dagger generate -l` still loads every module and surfaces the broken one.