### PR TITLE
Narrow workspace module loading for `dagger generate`/`check`/`up`/`call`

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -108,7 +108,7 @@ func runFunctionList(cmd *cobra.Command, args []string) error {
 			mod, err = initializeCore(ctx, engineClient.Dagger())
 		} else {
 			// -m modules are loaded at engine connect time as extra modules.
-			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true})
+			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true, Include: workspaceModuleScope(args)})
 		}
 		if err != nil {
 			return err

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -323,7 +323,7 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		mod, err = initializeCore(ctx, fc.c.Dagger())
 	} else {
 		// -m modules are loaded at engine connect time as extra modules.
-		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true})
+		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true, Include: workspaceModuleScope(a)})
 	}
 	if err != nil {
 		return err

--- a/cmd/dagger/module_inspect.go
+++ b/cmd/dagger/module_inspect.go
@@ -37,6 +37,19 @@ func initializeCore(ctx context.Context, dag *dagger.Client) (rdef *moduleDef, r
 //
 // The CLI consumes workspace entrypoint methods and module constructors
 // directly from the engine schema's Query root.
+// workspaceModuleScope returns the leading positional token as a
+// currentTypeDefs include hint. Only the first token can name a workspace
+// module (later tokens are functions/arguments within it), so an unrelated
+// broken/stale module is not loaded just to introspect the targeted one. The
+// engine ignores the hint when it does not name a workspace module (e.g. an
+// entrypoint-proxied function or no args), loading every module as before.
+func workspaceModuleScope(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	return args[:1]
+}
+
 func initializeWorkspace(ctx context.Context, dag *dagger.Client, opts ...loadTypeDefsOpts) (rdef *moduleDef, rerr error) {
 	ctx, span := Tracer().Start(ctx, "load workspace: .")
 	defer telemetry.EndWithCause(span, &rerr)
@@ -293,6 +306,12 @@ type loadTypeDefsOpts struct {
 	// HideCore strips core API functions from the Query type, leaving
 	// only module-sourced functions (constructors, entrypoint proxies).
 	HideCore bool
+
+	// Include narrows workspace module loading to the named modules (and their
+	// dependencies) before introspecting, so a single unrelated broken or stale
+	// module cannot block building the command tree. A pattern that does not
+	// name a workspace module is ignored server-side and every module loads.
+	Include []string
 }
 
 // loadTypeDefs loads the objects defined by the given module in an easier to use data structure.
@@ -309,9 +328,13 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client, opts .
 		TypeDefs []*modTypeDef
 	}
 
+	vars := map[string]any{"hideCore": o.HideCore}
+	if len(o.Include) > 0 {
+		vars["include"] = o.Include
+	}
 	err := dag.Do(ctx, &dagger.Request{
 		Query:     loadTypeDefsQuery,
-		Variables: map[string]any{"hideCore": o.HideCore},
+		Variables: vars,
 	}, &dagger.Response{
 		Data: &res,
 	})

--- a/cmd/dagger/typedefs.graphql
+++ b/cmd/dagger/typedefs.graphql
@@ -30,8 +30,8 @@ fragment FieldParts on FieldTypeDef {
   }
 }
 
-query TypeDefs($hideCore: Boolean) {
-	typeDefs: currentTypeDefs(returnAllTypes: true, hideCore: $hideCore) {
+query TypeDefs($hideCore: Boolean, $include: [String!]) {
+	typeDefs: currentTypeDefs(returnAllTypes: true, hideCore: $hideCore, include: $include) {
 		name
 		kind
 		optional

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -337,6 +337,40 @@ func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Conte
 	})
 }
 
+// TestWorkspaceCallNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger call`: targeting a
+// healthy module's function must not load every workspace module just to build
+// the command tree, so an unrelated broken/stale module cannot block the call.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("calling a healthy module's function skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good", "verify", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -232,6 +232,111 @@ func (GeneratorsSuite) TestGeneratorsInstalledInWorkspace(ctx context.Context, t
 	}
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. An
+// unrelated broken/stale workspace module must not be loaded just to enumerate
+// generators, so it cannot block regenerating a healthy module -- including the
+// case where running generate is itself the fix for the broken module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the same narrowing for raw single queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCheckNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate or run a
+// healthy module's checks, so it cannot block checking that module.
+func (GeneratorsSuite) TestWorkspaceCheckNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("check", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("running only the healthy module's checks succeeds", func(ctx context.Context, t *testctx.T) {
+		// --no-generate runs only annotated checks; generate-as-checks are
+		// excluded because the healthy module's generator legitimately reports
+		// pending output (covered by the generate narrowing test), which is
+		// unrelated to whether the broken module was loaded.
+		out, err := base.
+			With(daggerExec("check", "good", "--no-generate", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("checking across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceUpNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger up`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate a healthy
+// module's services. `dagger up` starts services and blocks, so the assertions
+// use list mode (-l), which still loads workspace modules to enumerate services
+// and thus exercises the same narrowing.
+func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("up", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("up", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger.json
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger.json
@@ -1,0 +1,1 @@
+{"name":"bad","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger.json
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger.json
@@ -1,0 +1,1 @@
+{"name":"good","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,29 @@
+type Good {
+  pub workdir: Directory! @defaultPath(path: ".")
+
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate: Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check`.
+  """
+  pub verify: Void @check {
+    workdir.sync
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,18 +1,16 @@
 type Good {
-  pub workdir: Directory! @defaultPath(path: ".")
-
   """
   Regenerate by writing a marker file. Used to prove the module loaded.
   """
-  pub generate: Changeset! @generate {
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
     workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
   }
 
   """
-  A trivial check. Used to prove the module loaded for `dagger check`.
+  A trivial check. Used to prove the module loaded for `dagger check` and
+  `dagger call`.
   """
   pub verify: Void @check {
-    workdir.sync
     null
   }
 

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -238,6 +238,11 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 					`Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).`,
 					`Core types (Container, Directory, etc.) are kept so return types and method chaining still work.`,
 				),
+				dagql.Arg("include").Doc(
+					`Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.`,
+					`Each pattern is a workspace module name or "module:item"; a pattern that does not name a workspace module is ignored and every module is loaded.`,
+					`Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.`,
+				),
 			).
 			Doc(`The TypeDef representations of the objects currently being served in the session.`),
 
@@ -2077,6 +2082,10 @@ func (s *moduleSchema) moduleServe(ctx context.Context, modMeta dagql.ObjectResu
 type currentTypeDefsArgs struct {
 	ReturnAllTypes bool `default:"false"`
 	HideCore       dagql.Optional[dagql.Boolean]
+	// Include is a workspace module-loading hint consumed by the engine before
+	// this resolver runs (it narrows which modules are served); the typedef
+	// computation itself reflects whatever ended up served, so it is ignored here.
+	Include dagql.Optional[dagql.ArrayInput[dagql.String]]
 }
 
 func (s *moduleSchema) currentTypeDefs(ctx context.Context, self *core.Query, args currentTypeDefsArgs) (dagql.ObjectResultArray[*core.TypeDef], error) {

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -42,6 +42,110 @@ func PeekRootFields(r *http.Request) (bool, []string, error) {
 	return true, fields, nil
 }
 
+// workspaceIncludeSelectorFields are the currentWorkspace fields that enumerate
+// module-provided items filtered by an `include` list of `module:item` patterns.
+// They back `dagger generate`, `dagger check`, and `dagger up` respectively.
+// Each normally needs the full workspace schema (every module loaded), but an
+// `include` argument names exactly which modules are required, so module loading
+// can be narrowed to them.
+var workspaceIncludeSelectorFields = map[string]struct{}{
+	"generators": {},
+	"checks":     {},
+	"services":   {},
+}
+
+// PeekWorkspaceSelectorInclude reports whether a GraphQL-over-HTTP request is a
+// workspace item-selection query of the shape
+//
+//	{ currentWorkspace { <generators|checks|services>(include: [...]) ... } }
+//
+// and, if so, returns the literal include patterns while preserving the request
+// body for the real server. Workspace-rooted queries normally require the full
+// workspace schema (every module loaded); recognizing this shape lets the engine
+// narrow module loading to the items actually requested, e.g.
+// `dagger generate <module>`, `dagger check <module>`, or `dagger up <module>`.
+// It is deliberately conservative: anything other than a single currentWorkspace
+// root field selecting only one of those fields with a literal include list
+// returns false, so loading falls back to all modules.
+func PeekWorkspaceSelectorInclude(r *http.Request) (bool, []string, error) {
+	query, operationName, ok, err := peekGraphQLRequestBody(r)
+	if err != nil || !ok {
+		return false, nil, err
+	}
+
+	doc, err := parser.ParseQuery(&ast.Source{Input: query})
+	if err != nil {
+		return false, nil, err
+	}
+
+	op, ok := peekOperation(doc, operationName)
+	if !ok || op.Operation != ast.Query {
+		return false, nil, nil
+	}
+
+	root := singleConcreteField(op.SelectionSet)
+	if root == nil || root.Name != "currentWorkspace" {
+		return false, nil, nil
+	}
+
+	selector := singleConcreteField(root.SelectionSet)
+	if selector == nil {
+		return false, nil, nil
+	}
+	if _, ok := workspaceIncludeSelectorFields[selector.Name]; !ok {
+		return false, nil, nil
+	}
+
+	include, ok := stringListArgument(selector.Arguments, "include")
+	if !ok {
+		return false, nil, nil
+	}
+	return true, include, nil
+}
+
+// singleConcreteField returns the sole non-introspection field in a selection
+// set, or nil if there is not exactly one such field or the set contains
+// fragments. Fragments are treated as "don't narrow" so callers stay on the
+// safe (load-everything) path rather than reasoning about fragment expansion.
+func singleConcreteField(set ast.SelectionSet) *ast.Field {
+	var found *ast.Field
+	for _, selection := range set {
+		field, ok := selection.(*ast.Field)
+		if !ok {
+			return nil
+		}
+		if field.Name == "__typename" {
+			continue
+		}
+		if found != nil {
+			return nil
+		}
+		found = field
+	}
+	return found
+}
+
+// stringListArgument returns the values of a named argument when it is a literal
+// list of strings. Missing, non-list, variable, or non-string arguments return
+// false so callers do not narrow on something they can't resolve statically.
+func stringListArgument(args ast.ArgumentList, name string) ([]string, bool) {
+	arg := args.ForName(name)
+	if arg == nil || arg.Value == nil || arg.Value.Kind != ast.ListValue {
+		return nil, false
+	}
+	values := make([]string, 0, len(arg.Value.Children))
+	for _, child := range arg.Value.Children {
+		if child.Value == nil || child.Value.Kind != ast.StringValue {
+			return nil, false
+		}
+		values = append(values, child.Value.Raw)
+	}
+	if len(values) == 0 {
+		return nil, false
+	}
+	return values, true
+}
+
 func peekGraphQLRequestBody(r *http.Request) (string, string, bool, error) {
 	switch r.Method {
 	case http.MethodGet:

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -13,14 +13,15 @@ import (
 )
 
 type peekGraphQLRequest struct {
-	Query         string `json:"query"`
-	OperationName string `json:"operationName"`
+	Query         string         `json:"query"`
+	OperationName string         `json:"operationName"`
+	Variables     map[string]any `json:"variables"`
 }
 
 // PeekRootFields returns the top-level field names selected by a GraphQL-over-HTTP
 // request while preserving the request body for the real server.
 func PeekRootFields(r *http.Request) (bool, []string, error) {
-	query, operationName, ok, err := peekGraphQLRequestBody(r)
+	query, operationName, _, ok, err := peekGraphQLRequestBody(r)
 	if err != nil || !ok {
 		return ok, nil, err
 	}
@@ -68,7 +69,7 @@ var workspaceIncludeSelectorFields = map[string]struct{}{
 // root field selecting only one of those fields with a literal include list
 // returns false, so loading falls back to all modules.
 func PeekWorkspaceSelectorInclude(r *http.Request) (bool, []string, error) {
-	query, operationName, ok, err := peekGraphQLRequestBody(r)
+	query, operationName, vars, ok, err := peekGraphQLRequestBody(r)
 	if err != nil || !ok {
 		return false, nil, err
 	}
@@ -96,7 +97,49 @@ func PeekWorkspaceSelectorInclude(r *http.Request) (bool, []string, error) {
 		return false, nil, nil
 	}
 
-	include, ok := stringListArgument(selector.Arguments, "include")
+	include, ok := stringListArgument(selector.Arguments, "include", vars)
+	if !ok {
+		return false, nil, nil
+	}
+	return true, include, nil
+}
+
+// PeekWorkspaceTypeDefsInclude reports whether a GraphQL-over-HTTP request is a
+// typedefs introspection of the shape
+//
+//	{ currentTypeDefs(… include: [...]) … }
+//
+// and, if so, returns the literal include patterns while preserving the request
+// body for the real server. `dagger call` and `dagger functions` build their
+// command tree from currentTypeDefs, which otherwise loads every workspace
+// module; recognizing this shape lets the engine narrow module loading to the
+// targeted module so an unrelated broken/stale module cannot block a call. The
+// include argument may be a literal list or a query variable. It is deliberately
+// conservative: anything other than a single currentTypeDefs root field with a
+// resolvable string-list include returns false, so loading falls back to all
+// modules.
+func PeekWorkspaceTypeDefsInclude(r *http.Request) (bool, []string, error) {
+	query, operationName, vars, ok, err := peekGraphQLRequestBody(r)
+	if err != nil || !ok {
+		return false, nil, err
+	}
+
+	doc, err := parser.ParseQuery(&ast.Source{Input: query})
+	if err != nil {
+		return false, nil, err
+	}
+
+	op, ok := peekOperation(doc, operationName)
+	if !ok || op.Operation != ast.Query {
+		return false, nil, nil
+	}
+
+	root := singleConcreteField(op.SelectionSet)
+	if root == nil || root.Name != "currentTypeDefs" {
+		return false, nil, nil
+	}
+
+	include, ok := stringListArgument(root.Arguments, "include", vars)
 	if !ok {
 		return false, nil, nil
 	}
@@ -125,16 +168,33 @@ func singleConcreteField(set ast.SelectionSet) *ast.Field {
 	return found
 }
 
-// stringListArgument returns the values of a named argument when it is a literal
-// list of strings. Missing, non-list, variable, or non-string arguments return
-// false so callers do not narrow on something they can't resolve statically.
-func stringListArgument(args ast.ArgumentList, name string) ([]string, bool) {
+// stringListArgument returns the values of a named argument when it resolves to
+// a non-empty list of strings, either as a literal list or a query variable
+// resolved against vars. Missing, non-list, unresolved-variable, or non-string
+// arguments return false so callers do not narrow on something they can't
+// resolve statically.
+func stringListArgument(args ast.ArgumentList, name string, vars map[string]any) ([]string, bool) {
 	arg := args.ForName(name)
-	if arg == nil || arg.Value == nil || arg.Value.Kind != ast.ListValue {
+	if arg == nil || arg.Value == nil {
 		return nil, false
 	}
-	values := make([]string, 0, len(arg.Value.Children))
-	for _, child := range arg.Value.Children {
+	switch arg.Value.Kind {
+	case ast.ListValue:
+		return stringListFromLiteral(arg.Value)
+	case ast.Variable:
+		raw, ok := vars[arg.Value.Raw]
+		if !ok {
+			return nil, false
+		}
+		return stringListFromAny(raw)
+	default:
+		return nil, false
+	}
+}
+
+func stringListFromLiteral(value *ast.Value) ([]string, bool) {
+	values := make([]string, 0, len(value.Children))
+	for _, child := range value.Children {
 		if child.Value == nil || child.Value.Kind != ast.StringValue {
 			return nil, false
 		}
@@ -146,54 +206,81 @@ func stringListArgument(args ast.ArgumentList, name string) ([]string, bool) {
 	return values, true
 }
 
-func peekGraphQLRequestBody(r *http.Request) (string, string, bool, error) {
+func stringListFromAny(raw any) ([]string, bool) {
+	list, ok := raw.([]any)
+	if !ok || len(list) == 0 {
+		return nil, false
+	}
+	values := make([]string, 0, len(list))
+	for _, item := range list {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		values = append(values, s)
+	}
+	return values, true
+}
+
+func peekGraphQLRequestBody(r *http.Request) (string, string, map[string]any, bool, error) {
 	switch r.Method {
 	case http.MethodGet:
 		query := r.URL.Query().Get("query")
 		if query == "" {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
-		return query, r.URL.Query().Get("operationName"), true, nil
+		return query, r.URL.Query().Get("operationName"), parseVariablesParam(r.URL.Query().Get("variables")), true, nil
 	case http.MethodPost:
 		if r.Body == nil {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			return "", "", false, err
+			return "", "", nil, false, err
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))
 
 		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if err != nil && r.Header.Get("Content-Type") != "" {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
 		if mediaType == "application/graphql" {
 			query := string(body)
 			if strings.TrimSpace(query) == "" {
-				return "", "", false, nil
+				return "", "", nil, false, nil
 			}
-			return query, r.URL.Query().Get("operationName"), true, nil
+			return query, r.URL.Query().Get("operationName"), nil, true, nil
 		}
 		if mediaType != "" && mediaType != "application/json" {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
 
 		trimmed := bytes.TrimSpace(body)
 		if len(trimmed) == 0 || trimmed[0] == '[' {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
 		var payload peekGraphQLRequest
 		if err := json.Unmarshal(trimmed, &payload); err != nil {
-			return "", "", false, err
+			return "", "", nil, false, err
 		}
 		if strings.TrimSpace(payload.Query) == "" {
-			return "", "", false, nil
+			return "", "", nil, false, nil
 		}
-		return payload.Query, payload.OperationName, true, nil
+		return payload.Query, payload.OperationName, payload.Variables, true, nil
 	default:
-		return "", "", false, nil
+		return "", "", nil, false, nil
 	}
+}
+
+func parseVariablesParam(s string) map[string]any {
+	if s == "" {
+		return nil
+	}
+	var vars map[string]any
+	if err := json.Unmarshal([]byte(s), &vars); err != nil {
+		return nil
+	}
+	return vars
 }
 
 func peekOperation(doc *ast.QueryDocument, operationName string) (*ast.OperationDefinition, bool) {

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -62,3 +62,105 @@ func TestPeekRootFieldsRejectsBatch(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, fields)
 }
+
+func TestPeekWorkspaceSelectorIncludeMatchesGenerators(t *testing.T) {
+	t.Parallel()
+
+	body := `{"query":"{ currentWorkspace { generators(include: [\"go-sdk\", \"php-sdk:api\"]) { id } } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"go-sdk", "php-sdk:api"}, include)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestPeekWorkspaceSelectorIncludeMatchesChecks(t *testing.T) {
+	t.Parallel()
+
+	// `dagger check` roots at the same shape via the `checks` field.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { checks(include: [\"go-sdk:lint\"]) { id } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"go-sdk:lint"}, include)
+}
+
+func TestPeekWorkspaceSelectorIncludeMatchesServices(t *testing.T) {
+	t.Parallel()
+
+	// `dagger up` roots at the same shape via the `services` field.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { services(include: [\"web\"]) { id } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"web"}, include)
+}
+
+func TestPeekWorkspaceSelectorIncludeIgnoresSiblingArgs(t *testing.T) {
+	t.Parallel()
+
+	// `checks` carries extra args (noGenerate/onlyGenerate); they must not
+	// disturb extraction of the include list.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { checks(include: [\"go-sdk\"], noGenerate: true) { id } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"go-sdk"}, include)
+}
+
+func TestPeekWorkspaceSelectorIncludeNonSelectorQuery(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { git { head { commit } } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceSelectorIncludeWithoutIncludeArg(t *testing.T) {
+	t.Parallel()
+
+	// No include argument means "all items" -- we can't narrow safely.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { generators { list { name } } } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceSelectorIncludeExtraRootField(t *testing.T) {
+	t.Parallel()
+
+	// A sibling root field beyond currentWorkspace means the query needs more
+	// than the requested items' modules, so narrowing must be skipped.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentWorkspace { generators(include: [\"go-sdk\"]) { id } } version }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -164,3 +164,77 @@ func TestPeekWorkspaceSelectorIncludeExtraRootField(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, include)
 }
+
+func TestPeekWorkspaceTypeDefsIncludeLiteral(t *testing.T) {
+	t.Parallel()
+
+	body := `{"query":"{ typeDefs: currentTypeDefs(returnAllTypes: true, include: [\"good\"]) { name } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"good"}, include)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestPeekWorkspaceTypeDefsIncludeVariable(t *testing.T) {
+	t.Parallel()
+
+	// The CLI sends include as a query variable (like hideCore), so the peek
+	// must resolve it from the request variables.
+	body := `{"query":"query TypeDefs($include: [String!]) { currentTypeDefs(returnAllTypes: true, include: $include) { name } }","variables":{"include":["good"]}}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"good"}, include)
+}
+
+func TestPeekWorkspaceTypeDefsIncludeUnresolvedVariable(t *testing.T) {
+	t.Parallel()
+
+	// include is a variable but absent from variables (e.g. null) -> cannot
+	// narrow, so loading falls back to all modules.
+	body := `{"query":"query TypeDefs($include: [String!]) { currentTypeDefs(returnAllTypes: true, include: $include) { name } }","variables":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceTypeDefsIncludeWithoutIncludeArg(t *testing.T) {
+	t.Parallel()
+
+	// The unscoped introspection (no include) must not narrow.
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentTypeDefs(returnAllTypes: true) { name } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}
+
+func TestPeekWorkspaceTypeDefsIncludeExtraRootField(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/query",
+		strings.NewReader(`{"query":"{ currentTypeDefs(include: [\"good\"]) { name } version }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(req)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, include)
+}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5016,6 +5016,17 @@ type Query implements Node {
     Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
     """
     hideCore: Boolean
+
+    """
+    Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.
+
+    Each pattern is a workspace module name or "module:item"; a pattern that
+    does not name a workspace module is ignored and every module is loaded.
+
+    Used by clients (e.g. the CLI) that target a single module so an unrelated
+    broken or stale module cannot block building the command tree.
+    """
+    include: [String!]
   ): [TypeDef!]!
 
   """Detect and return the current workspace."""

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -590,6 +590,16 @@
                           <p>Core types (Container, Directory, etc.) are kept so return types and method chaining still work.</p>
                         </td>
                       </tr>
+                      <tr>
+                        <td>
+                          <span class="property-name"><code>include</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span>
+                        </td>
+                        <td>
+                          <p>Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.</p>
+                          <p>Each pattern is a workspace module name or &quot;module:item&quot;; a pattern that does not name a workspace module is ignored and every module is loaded.</p>
+                          <p>Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.</p>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/docs/static/reference/php/Dagger/Client.html
+++ b/docs/static/reference/php/Dagger/Client.html
@@ -281,7 +281,7 @@
                     array
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_currentTypeDefs">currentTypeDefs</a>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+                    <a href="#method_currentTypeDefs">currentTypeDefs</a>(bool|null $returnAllTypes = false, bool|null $hideCore = null, array|null $include = null)
         
                                             <p><p>The TypeDef representations of the objects currently being served in the session.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1867,7 +1867,7 @@
                     <h3 id="method_currentTypeDefs">
         <div class="location">at line 133</div>
         <code>                    array
-    <strong>currentTypeDefs</strong>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+    <strong>currentTypeDefs</strong>(bool|null $returnAllTypes = false, bool|null $hideCore = null, array|null $include = null)
         </code>
     </h3>
     <div class="details">    
@@ -1891,6 +1891,11 @@
                 <td>$hideCore</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>array|null</td>
+                <td>$include</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1912,7 +1917,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentWorkspace">
-        <div class="location">at line 148</div>
+        <div class="location">at line 154</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>currentWorkspace</strong>()
         </code>
@@ -1944,7 +1949,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_defaultPlatform">
-        <div class="location">at line 157</div>
+        <div class="location">at line 163</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>defaultPlatform</strong>()
         </code>
@@ -1976,7 +1981,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 166</div>
+        <div class="location">at line 172</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>()
         </code>
@@ -2008,7 +2013,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_engine">
-        <div class="location">at line 175</div>
+        <div class="location">at line 181</div>
         <code>                    <a href="../Dagger/Engine.html"><abbr title="Dagger\Engine">Engine</abbr></a>
     <strong>engine</strong>()
         </code>
@@ -2040,7 +2045,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_env">
-        <div class="location">at line 184</div>
+        <div class="location">at line 190</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>env</strong>(bool|null $privileged = false, bool|null $writable = false)
         </code>
@@ -2087,7 +2092,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envFile">
-        <div class="location">at line 199</div>
+        <div class="location">at line 205</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>envFile</strong>(bool|null $expand = null)
         </code>
@@ -2129,7 +2134,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_error">
-        <div class="location">at line 211</div>
+        <div class="location">at line 217</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>error</strong>(string $message)
         </code>
@@ -2171,7 +2176,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 221</div>
+        <div class="location">at line 227</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $name, string $contents, int|null $permissions = 420)
         </code>
@@ -2223,7 +2228,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_function">
-        <div class="location">at line 235</div>
+        <div class="location">at line 241</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>function</strong>(string $name, <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $returnType)
         </code>
@@ -2270,7 +2275,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedCode">
-        <div class="location">at line 246</div>
+        <div class="location">at line 252</div>
         <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
     <strong>generatedCode</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $code)
         </code>
@@ -2312,7 +2317,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 256</div>
+        <div class="location">at line 262</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>git</strong>(string $url, bool|null $keepGitDir = true, string|null $sshKnownHosts = &#039;&#039;, <abbr title="Dagger\Dagger\Socket">Socket</abbr>|null $sshAuthSocket = null, string|null $httpAuthUsername = &#039;&#039;, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $httpAuthToken = null, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $httpAuthHeader = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -2389,7 +2394,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_host">
-        <div class="location">at line 295</div>
+        <div class="location">at line 301</div>
         <code>                    <a href="../Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a>
     <strong>host</strong>()
         </code>
@@ -2421,7 +2426,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_http">
-        <div class="location">at line 304</div>
+        <div class="location">at line 310</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>http</strong>(string $url, string|null $name = null, int|null $permissions = null, string|null $checksum = null, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $authHeader = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -2488,7 +2493,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 335</div>
+        <div class="location">at line 341</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -2520,7 +2525,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_json">
-        <div class="location">at line 344</div>
+        <div class="location">at line 350</div>
         <code>                    <a href="../Dagger/JsonValue.html"><abbr title="Dagger\JsonValue">JsonValue</abbr></a>
     <strong>json</strong>()
         </code>
@@ -2552,7 +2557,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_llm">
-        <div class="location">at line 353</div>
+        <div class="location">at line 359</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>llm</strong>(string|null $model = null, int|null $maxAPICalls = null)
         </code>
@@ -2599,7 +2604,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadAddressFromID">
-        <div class="location">at line 368</div>
+        <div class="location">at line 374</div>
         <code>                    <a href="../Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a>
     <strong>loadAddressFromID</strong>(<a href="../Dagger/AddressId.html"><abbr title="Dagger\AddressId">AddressId</abbr></a> $id)
         </code>
@@ -2641,7 +2646,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadBindingFromID">
-        <div class="location">at line 378</div>
+        <div class="location">at line 384</div>
         <code>                    <a href="../Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a>
     <strong>loadBindingFromID</strong>(<a href="../Dagger/BindingId.html"><abbr title="Dagger\BindingId">BindingId</abbr></a> $id)
         </code>
@@ -2683,7 +2688,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCacheVolumeFromID">
-        <div class="location">at line 388</div>
+        <div class="location">at line 394</div>
         <code>                    <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a>
     <strong>loadCacheVolumeFromID</strong>(<a href="../Dagger/CacheVolumeId.html"><abbr title="Dagger\CacheVolumeId">CacheVolumeId</abbr></a> $id)
         </code>
@@ -2725,7 +2730,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadChangesetFromID">
-        <div class="location">at line 398</div>
+        <div class="location">at line 404</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>loadChangesetFromID</strong>(<a href="../Dagger/ChangesetId.html"><abbr title="Dagger\ChangesetId">ChangesetId</abbr></a> $id)
         </code>
@@ -2767,7 +2772,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCheckFromID">
-        <div class="location">at line 408</div>
+        <div class="location">at line 414</div>
         <code>                    <a href="../Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a>
     <strong>loadCheckFromID</strong>(<a href="../Dagger/CheckId.html"><abbr title="Dagger\CheckId">CheckId</abbr></a> $id)
         </code>
@@ -2809,7 +2814,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCheckGroupFromID">
-        <div class="location">at line 418</div>
+        <div class="location">at line 424</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
     <strong>loadCheckGroupFromID</strong>(<a href="../Dagger/CheckGroupId.html"><abbr title="Dagger\CheckGroupId">CheckGroupId</abbr></a> $id)
         </code>
@@ -2851,7 +2856,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadClientFilesyncMirrorFromID">
-        <div class="location">at line 428</div>
+        <div class="location">at line 434</div>
         <code>                    <a href="../Dagger/ClientFilesyncMirror.html"><abbr title="Dagger\ClientFilesyncMirror">ClientFilesyncMirror</abbr></a>
     <strong>loadClientFilesyncMirrorFromID</strong>(<a href="../Dagger/ClientFilesyncMirrorId.html"><abbr title="Dagger\ClientFilesyncMirrorId">ClientFilesyncMirrorId</abbr></a> $id)
         </code>
@@ -2893,7 +2898,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCloudFromID">
-        <div class="location">at line 438</div>
+        <div class="location">at line 444</div>
         <code>                    <a href="../Dagger/Cloud.html"><abbr title="Dagger\Cloud">Cloud</abbr></a>
     <strong>loadCloudFromID</strong>(<a href="../Dagger/CloudId.html"><abbr title="Dagger\CloudId">CloudId</abbr></a> $id)
         </code>
@@ -2935,7 +2940,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadContainerFromID">
-        <div class="location">at line 448</div>
+        <div class="location">at line 454</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>loadContainerFromID</strong>(<a href="../Dagger/ContainerId.html"><abbr title="Dagger\ContainerId">ContainerId</abbr></a> $id)
         </code>
@@ -2977,7 +2982,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadCurrentModuleFromID">
-        <div class="location">at line 458</div>
+        <div class="location">at line 464</div>
         <code>                    <a href="../Dagger/CurrentModule.html"><abbr title="Dagger\CurrentModule">CurrentModule</abbr></a>
     <strong>loadCurrentModuleFromID</strong>(<a href="../Dagger/CurrentModuleId.html"><abbr title="Dagger\CurrentModuleId">CurrentModuleId</abbr></a> $id)
         </code>
@@ -3019,7 +3024,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadDiffStatFromID">
-        <div class="location">at line 468</div>
+        <div class="location">at line 474</div>
         <code>                    <a href="../Dagger/DiffStat.html"><abbr title="Dagger\DiffStat">DiffStat</abbr></a>
     <strong>loadDiffStatFromID</strong>(<a href="../Dagger/DiffStatId.html"><abbr title="Dagger\DiffStatId">DiffStatId</abbr></a> $id)
         </code>
@@ -3061,7 +3066,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadDirectoryFromID">
-        <div class="location">at line 478</div>
+        <div class="location">at line 484</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>loadDirectoryFromID</strong>(<a href="../Dagger/DirectoryId.html"><abbr title="Dagger\DirectoryId">DirectoryId</abbr></a> $id)
         </code>
@@ -3103,7 +3108,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheEntryFromID">
-        <div class="location">at line 488</div>
+        <div class="location">at line 494</div>
         <code>                    <a href="../Dagger/EngineCacheEntry.html"><abbr title="Dagger\EngineCacheEntry">EngineCacheEntry</abbr></a>
     <strong>loadEngineCacheEntryFromID</strong>(<a href="../Dagger/EngineCacheEntryId.html"><abbr title="Dagger\EngineCacheEntryId">EngineCacheEntryId</abbr></a> $id)
         </code>
@@ -3145,7 +3150,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheEntrySetFromID">
-        <div class="location">at line 498</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/EngineCacheEntrySet.html"><abbr title="Dagger\EngineCacheEntrySet">EngineCacheEntrySet</abbr></a>
     <strong>loadEngineCacheEntrySetFromID</strong>(<a href="../Dagger/EngineCacheEntrySetId.html"><abbr title="Dagger\EngineCacheEntrySetId">EngineCacheEntrySetId</abbr></a> $id)
         </code>
@@ -3187,7 +3192,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineCacheFromID">
-        <div class="location">at line 508</div>
+        <div class="location">at line 514</div>
         <code>                    <a href="../Dagger/EngineCache.html"><abbr title="Dagger\EngineCache">EngineCache</abbr></a>
     <strong>loadEngineCacheFromID</strong>(<a href="../Dagger/EngineCacheId.html"><abbr title="Dagger\EngineCacheId">EngineCacheId</abbr></a> $id)
         </code>
@@ -3229,7 +3234,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEngineFromID">
-        <div class="location">at line 518</div>
+        <div class="location">at line 524</div>
         <code>                    <a href="../Dagger/Engine.html"><abbr title="Dagger\Engine">Engine</abbr></a>
     <strong>loadEngineFromID</strong>(<a href="../Dagger/EngineId.html"><abbr title="Dagger\EngineId">EngineId</abbr></a> $id)
         </code>
@@ -3271,7 +3276,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnumTypeDefFromID">
-        <div class="location">at line 528</div>
+        <div class="location">at line 534</div>
         <code>                    <a href="../Dagger/EnumTypeDef.html"><abbr title="Dagger\EnumTypeDef">EnumTypeDef</abbr></a>
     <strong>loadEnumTypeDefFromID</strong>(<a href="../Dagger/EnumTypeDefId.html"><abbr title="Dagger\EnumTypeDefId">EnumTypeDefId</abbr></a> $id)
         </code>
@@ -3313,7 +3318,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnumValueTypeDefFromID">
-        <div class="location">at line 538</div>
+        <div class="location">at line 544</div>
         <code>                    <a href="../Dagger/EnumValueTypeDef.html"><abbr title="Dagger\EnumValueTypeDef">EnumValueTypeDef</abbr></a>
     <strong>loadEnumValueTypeDefFromID</strong>(<a href="../Dagger/EnumValueTypeDefId.html"><abbr title="Dagger\EnumValueTypeDefId">EnumValueTypeDefId</abbr></a> $id)
         </code>
@@ -3355,7 +3360,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvFileFromID">
-        <div class="location">at line 548</div>
+        <div class="location">at line 554</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>loadEnvFileFromID</strong>(<a href="../Dagger/EnvFileId.html"><abbr title="Dagger\EnvFileId">EnvFileId</abbr></a> $id)
         </code>
@@ -3397,7 +3402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvFromID">
-        <div class="location">at line 558</div>
+        <div class="location">at line 564</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>loadEnvFromID</strong>(<a href="../Dagger/EnvId.html"><abbr title="Dagger\EnvId">EnvId</abbr></a> $id)
         </code>
@@ -3439,7 +3444,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadEnvVariableFromID">
-        <div class="location">at line 568</div>
+        <div class="location">at line 574</div>
         <code>                    <a href="../Dagger/EnvVariable.html"><abbr title="Dagger\EnvVariable">EnvVariable</abbr></a>
     <strong>loadEnvVariableFromID</strong>(<a href="../Dagger/EnvVariableId.html"><abbr title="Dagger\EnvVariableId">EnvVariableId</abbr></a> $id)
         </code>
@@ -3481,7 +3486,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadErrorFromID">
-        <div class="location">at line 578</div>
+        <div class="location">at line 584</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>loadErrorFromID</strong>(<a href="../Dagger/ErrorId.html"><abbr title="Dagger\ErrorId">ErrorId</abbr></a> $id)
         </code>
@@ -3523,7 +3528,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadErrorValueFromID">
-        <div class="location">at line 588</div>
+        <div class="location">at line 594</div>
         <code>                    <a href="../Dagger/ErrorValue.html"><abbr title="Dagger\ErrorValue">ErrorValue</abbr></a>
     <strong>loadErrorValueFromID</strong>(<a href="../Dagger/ErrorValueId.html"><abbr title="Dagger\ErrorValueId">ErrorValueId</abbr></a> $id)
         </code>
@@ -3565,7 +3570,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadExportableFromID">
-        <div class="location">at line 598</div>
+        <div class="location">at line 604</div>
         <code>                    <a href="../Dagger/Exportable.html"><abbr title="Dagger\Exportable">Exportable</abbr></a>
     <strong>loadExportableFromID</strong>(<a href="../Dagger/ExportableId.html"><abbr title="Dagger\ExportableId">ExportableId</abbr></a> $id)
         </code>
@@ -3607,7 +3612,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFieldTypeDefFromID">
-        <div class="location">at line 608</div>
+        <div class="location">at line 614</div>
         <code>                    <a href="../Dagger/FieldTypeDef.html"><abbr title="Dagger\FieldTypeDef">FieldTypeDef</abbr></a>
     <strong>loadFieldTypeDefFromID</strong>(<a href="../Dagger/FieldTypeDefId.html"><abbr title="Dagger\FieldTypeDefId">FieldTypeDefId</abbr></a> $id)
         </code>
@@ -3649,7 +3654,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFileFromID">
-        <div class="location">at line 618</div>
+        <div class="location">at line 624</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>loadFileFromID</strong>(<a href="../Dagger/FileId.html"><abbr title="Dagger\FileId">FileId</abbr></a> $id)
         </code>
@@ -3691,7 +3696,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionArgFromID">
-        <div class="location">at line 628</div>
+        <div class="location">at line 634</div>
         <code>                    <a href="../Dagger/FunctionArg.html"><abbr title="Dagger\FunctionArg">FunctionArg</abbr></a>
     <strong>loadFunctionArgFromID</strong>(<a href="../Dagger/FunctionArgId.html"><abbr title="Dagger\FunctionArgId">FunctionArgId</abbr></a> $id)
         </code>
@@ -3733,7 +3738,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionCallArgValueFromID">
-        <div class="location">at line 638</div>
+        <div class="location">at line 644</div>
         <code>                    <a href="../Dagger/FunctionCallArgValue.html"><abbr title="Dagger\FunctionCallArgValue">FunctionCallArgValue</abbr></a>
     <strong>loadFunctionCallArgValueFromID</strong>(<a href="../Dagger/FunctionCallArgValueId.html"><abbr title="Dagger\FunctionCallArgValueId">FunctionCallArgValueId</abbr></a> $id)
         </code>
@@ -3775,7 +3780,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionCallFromID">
-        <div class="location">at line 648</div>
+        <div class="location">at line 654</div>
         <code>                    <a href="../Dagger/FunctionCall.html"><abbr title="Dagger\FunctionCall">FunctionCall</abbr></a>
     <strong>loadFunctionCallFromID</strong>(<a href="../Dagger/FunctionCallId.html"><abbr title="Dagger\FunctionCallId">FunctionCallId</abbr></a> $id)
         </code>
@@ -3817,7 +3822,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadFunctionFromID">
-        <div class="location">at line 658</div>
+        <div class="location">at line 664</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>loadFunctionFromID</strong>(<a href="../Dagger/FunctionId.html"><abbr title="Dagger\FunctionId">FunctionId</abbr></a> $id)
         </code>
@@ -3859,7 +3864,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratedCodeFromID">
-        <div class="location">at line 668</div>
+        <div class="location">at line 674</div>
         <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
     <strong>loadGeneratedCodeFromID</strong>(<a href="../Dagger/GeneratedCodeId.html"><abbr title="Dagger\GeneratedCodeId">GeneratedCodeId</abbr></a> $id)
         </code>
@@ -3901,7 +3906,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratorFromID">
-        <div class="location">at line 678</div>
+        <div class="location">at line 684</div>
         <code>                    <a href="../Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a>
     <strong>loadGeneratorFromID</strong>(<a href="../Dagger/GeneratorId.html"><abbr title="Dagger\GeneratorId">GeneratorId</abbr></a> $id)
         </code>
@@ -3943,7 +3948,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGeneratorGroupFromID">
-        <div class="location">at line 688</div>
+        <div class="location">at line 694</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>loadGeneratorGroupFromID</strong>(<a href="../Dagger/GeneratorGroupId.html"><abbr title="Dagger\GeneratorGroupId">GeneratorGroupId</abbr></a> $id)
         </code>
@@ -3985,7 +3990,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGitRefFromID">
-        <div class="location">at line 698</div>
+        <div class="location">at line 704</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
     <strong>loadGitRefFromID</strong>(<a href="../Dagger/GitRefId.html"><abbr title="Dagger\GitRefId">GitRefId</abbr></a> $id)
         </code>
@@ -4027,7 +4032,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadGitRepositoryFromID">
-        <div class="location">at line 708</div>
+        <div class="location">at line 714</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>loadGitRepositoryFromID</strong>(<a href="../Dagger/GitRepositoryId.html"><abbr title="Dagger\GitRepositoryId">GitRepositoryId</abbr></a> $id)
         </code>
@@ -4069,7 +4074,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadHTTPStateFromID">
-        <div class="location">at line 718</div>
+        <div class="location">at line 724</div>
         <code>                    <a href="../Dagger/HTTPState.html"><abbr title="Dagger\HTTPState">HTTPState</abbr></a>
     <strong>loadHTTPStateFromID</strong>(<a href="../Dagger/HTTPStateId.html"><abbr title="Dagger\HTTPStateId">HTTPStateId</abbr></a> $id)
         </code>
@@ -4111,7 +4116,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadHealthcheckConfigFromID">
-        <div class="location">at line 728</div>
+        <div class="location">at line 734</div>
         <code>                    <a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a>
     <strong>loadHealthcheckConfigFromID</strong>(<a href="../Dagger/HealthcheckConfigId.html"><abbr title="Dagger\HealthcheckConfigId">HealthcheckConfigId</abbr></a> $id)
         </code>
@@ -4153,7 +4158,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadHostFromID">
-        <div class="location">at line 738</div>
+        <div class="location">at line 744</div>
         <code>                    <a href="../Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a>
     <strong>loadHostFromID</strong>(<a href="../Dagger/HostId.html"><abbr title="Dagger\HostId">HostId</abbr></a> $id)
         </code>
@@ -4195,7 +4200,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadInputTypeDefFromID">
-        <div class="location">at line 748</div>
+        <div class="location">at line 754</div>
         <code>                    <a href="../Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a>
     <strong>loadInputTypeDefFromID</strong>(<a href="../Dagger/InputTypeDefId.html"><abbr title="Dagger\InputTypeDefId">InputTypeDefId</abbr></a> $id)
         </code>
@@ -4237,7 +4242,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadInterfaceTypeDefFromID">
-        <div class="location">at line 758</div>
+        <div class="location">at line 764</div>
         <code>                    <a href="../Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a>
     <strong>loadInterfaceTypeDefFromID</strong>(<a href="../Dagger/InterfaceTypeDefId.html"><abbr title="Dagger\InterfaceTypeDefId">InterfaceTypeDefId</abbr></a> $id)
         </code>
@@ -4279,7 +4284,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadJSONValueFromID">
-        <div class="location">at line 768</div>
+        <div class="location">at line 774</div>
         <code>                    <a href="../Dagger/JsonValue.html"><abbr title="Dagger\JsonValue">JsonValue</abbr></a>
     <strong>loadJSONValueFromID</strong>(<a href="../Dagger/JsonValueId.html"><abbr title="Dagger\JsonValueId">JsonValueId</abbr></a> $id)
         </code>
@@ -4321,7 +4326,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLLMFromID">
-        <div class="location">at line 778</div>
+        <div class="location">at line 784</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>loadLLMFromID</strong>(<a href="../Dagger/LLMId.html"><abbr title="Dagger\LLMId">LLMId</abbr></a> $id)
         </code>
@@ -4363,7 +4368,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLLMTokenUsageFromID">
-        <div class="location">at line 788</div>
+        <div class="location">at line 794</div>
         <code>                    <a href="../Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a>
     <strong>loadLLMTokenUsageFromID</strong>(<a href="../Dagger/LLMTokenUsageId.html"><abbr title="Dagger\LLMTokenUsageId">LLMTokenUsageId</abbr></a> $id)
         </code>
@@ -4405,7 +4410,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadLabelFromID">
-        <div class="location">at line 798</div>
+        <div class="location">at line 804</div>
         <code>                    <a href="../Dagger/Label.html"><abbr title="Dagger\Label">Label</abbr></a>
     <strong>loadLabelFromID</strong>(<a href="../Dagger/LabelId.html"><abbr title="Dagger\LabelId">LabelId</abbr></a> $id)
         </code>
@@ -4447,7 +4452,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadListTypeDefFromID">
-        <div class="location">at line 808</div>
+        <div class="location">at line 814</div>
         <code>                    <a href="../Dagger/ListTypeDef.html"><abbr title="Dagger\ListTypeDef">ListTypeDef</abbr></a>
     <strong>loadListTypeDefFromID</strong>(<a href="../Dagger/ListTypeDefId.html"><abbr title="Dagger\ListTypeDefId">ListTypeDefId</abbr></a> $id)
         </code>
@@ -4489,7 +4494,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleConfigClientFromID">
-        <div class="location">at line 818</div>
+        <div class="location">at line 824</div>
         <code>                    <a href="../Dagger/ModuleConfigClient.html"><abbr title="Dagger\ModuleConfigClient">ModuleConfigClient</abbr></a>
     <strong>loadModuleConfigClientFromID</strong>(<a href="../Dagger/ModuleConfigClientId.html"><abbr title="Dagger\ModuleConfigClientId">ModuleConfigClientId</abbr></a> $id)
         </code>
@@ -4531,7 +4536,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleFromID">
-        <div class="location">at line 828</div>
+        <div class="location">at line 834</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>loadModuleFromID</strong>(<a href="../Dagger/ModuleId.html"><abbr title="Dagger\ModuleId">ModuleId</abbr></a> $id)
         </code>
@@ -4573,7 +4578,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadModuleSourceFromID">
-        <div class="location">at line 838</div>
+        <div class="location">at line 844</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>loadModuleSourceFromID</strong>(<a href="../Dagger/ModuleSourceId.html"><abbr title="Dagger\ModuleSourceId">ModuleSourceId</abbr></a> $id)
         </code>
@@ -4615,7 +4620,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadObjectTypeDefFromID">
-        <div class="location">at line 848</div>
+        <div class="location">at line 854</div>
         <code>                    <a href="../Dagger/ObjectTypeDef.html"><abbr title="Dagger\ObjectTypeDef">ObjectTypeDef</abbr></a>
     <strong>loadObjectTypeDefFromID</strong>(<a href="../Dagger/ObjectTypeDefId.html"><abbr title="Dagger\ObjectTypeDefId">ObjectTypeDefId</abbr></a> $id)
         </code>
@@ -4657,7 +4662,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadPhpSdkFromID">
-        <div class="location">at line 858</div>
+        <div class="location">at line 864</div>
         <code>                    <a href="../Dagger/PhpSdk.html"><abbr title="Dagger\PhpSdk">PhpSdk</abbr></a>
     <strong>loadPhpSdkFromID</strong>(<a href="../Dagger/PhpSdkId.html"><abbr title="Dagger\PhpSdkId">PhpSdkId</abbr></a> $id)
         </code>
@@ -4699,7 +4704,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadPortFromID">
-        <div class="location">at line 868</div>
+        <div class="location">at line 874</div>
         <code>                    <a href="../Dagger/Port.html"><abbr title="Dagger\Port">Port</abbr></a>
     <strong>loadPortFromID</strong>(<a href="../Dagger/PortId.html"><abbr title="Dagger\PortId">PortId</abbr></a> $id)
         </code>
@@ -4741,7 +4746,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadRemoteGitMirrorFromID">
-        <div class="location">at line 878</div>
+        <div class="location">at line 884</div>
         <code>                    <a href="../Dagger/RemoteGitMirror.html"><abbr title="Dagger\RemoteGitMirror">RemoteGitMirror</abbr></a>
     <strong>loadRemoteGitMirrorFromID</strong>(<a href="../Dagger/RemoteGitMirrorId.html"><abbr title="Dagger\RemoteGitMirrorId">RemoteGitMirrorId</abbr></a> $id)
         </code>
@@ -4783,7 +4788,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSDKConfigFromID">
-        <div class="location">at line 888</div>
+        <div class="location">at line 894</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>loadSDKConfigFromID</strong>(<a href="../Dagger/SDKConfigId.html"><abbr title="Dagger\SDKConfigId">SDKConfigId</abbr></a> $id)
         </code>
@@ -4825,7 +4830,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadScalarTypeDefFromID">
-        <div class="location">at line 898</div>
+        <div class="location">at line 904</div>
         <code>                    <a href="../Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a>
     <strong>loadScalarTypeDefFromID</strong>(<a href="../Dagger/ScalarTypeDefId.html"><abbr title="Dagger\ScalarTypeDefId">ScalarTypeDefId</abbr></a> $id)
         </code>
@@ -4867,7 +4872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSearchResultFromID">
-        <div class="location">at line 908</div>
+        <div class="location">at line 914</div>
         <code>                    <a href="../Dagger/SearchResult.html"><abbr title="Dagger\SearchResult">SearchResult</abbr></a>
     <strong>loadSearchResultFromID</strong>(<a href="../Dagger/SearchResultId.html"><abbr title="Dagger\SearchResultId">SearchResultId</abbr></a> $id)
         </code>
@@ -4909,7 +4914,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSearchSubmatchFromID">
-        <div class="location">at line 918</div>
+        <div class="location">at line 924</div>
         <code>                    <a href="../Dagger/SearchSubmatch.html"><abbr title="Dagger\SearchSubmatch">SearchSubmatch</abbr></a>
     <strong>loadSearchSubmatchFromID</strong>(<a href="../Dagger/SearchSubmatchId.html"><abbr title="Dagger\SearchSubmatchId">SearchSubmatchId</abbr></a> $id)
         </code>
@@ -4951,7 +4956,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSecretFromID">
-        <div class="location">at line 928</div>
+        <div class="location">at line 934</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>loadSecretFromID</strong>(<a href="../Dagger/SecretId.html"><abbr title="Dagger\SecretId">SecretId</abbr></a> $id)
         </code>
@@ -4993,7 +4998,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadServiceFromID">
-        <div class="location">at line 938</div>
+        <div class="location">at line 944</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
     <strong>loadServiceFromID</strong>(<a href="../Dagger/ServiceId.html"><abbr title="Dagger\ServiceId">ServiceId</abbr></a> $id)
         </code>
@@ -5035,7 +5040,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSocketFromID">
-        <div class="location">at line 948</div>
+        <div class="location">at line 954</div>
         <code>                    <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a>
     <strong>loadSocketFromID</strong>(<a href="../Dagger/SocketId.html"><abbr title="Dagger\SocketId">SocketId</abbr></a> $id)
         </code>
@@ -5077,7 +5082,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSourceMapFromID">
-        <div class="location">at line 958</div>
+        <div class="location">at line 964</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>loadSourceMapFromID</strong>(<a href="../Dagger/SourceMapId.html"><abbr title="Dagger\SourceMapId">SourceMapId</abbr></a> $id)
         </code>
@@ -5119,7 +5124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadStatFromID">
-        <div class="location">at line 968</div>
+        <div class="location">at line 974</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>loadStatFromID</strong>(<a href="../Dagger/StatId.html"><abbr title="Dagger\StatId">StatId</abbr></a> $id)
         </code>
@@ -5161,7 +5166,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadSyncerFromID">
-        <div class="location">at line 978</div>
+        <div class="location">at line 984</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>loadSyncerFromID</strong>(<a href="../Dagger/SyncerId.html"><abbr title="Dagger\SyncerId">SyncerId</abbr></a> $id)
         </code>
@@ -5203,7 +5208,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadTerminalFromID">
-        <div class="location">at line 988</div>
+        <div class="location">at line 994</div>
         <code>                    <a href="../Dagger/Terminal.html"><abbr title="Dagger\Terminal">Terminal</abbr></a>
     <strong>loadTerminalFromID</strong>(<a href="../Dagger/TerminalId.html"><abbr title="Dagger\TerminalId">TerminalId</abbr></a> $id)
         </code>
@@ -5245,7 +5250,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadTypeDefFromID">
-        <div class="location">at line 998</div>
+        <div class="location">at line 1004</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>loadTypeDefFromID</strong>(<a href="../Dagger/TypeDefId.html"><abbr title="Dagger\TypeDefId">TypeDefId</abbr></a> $id)
         </code>
@@ -5287,7 +5292,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadUpFromID">
-        <div class="location">at line 1008</div>
+        <div class="location">at line 1014</div>
         <code>                    <a href="../Dagger/Up.html"><abbr title="Dagger\Up">Up</abbr></a>
     <strong>loadUpFromID</strong>(<a href="../Dagger/UpId.html"><abbr title="Dagger\UpId">UpId</abbr></a> $id)
         </code>
@@ -5329,7 +5334,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadUpGroupFromID">
-        <div class="location">at line 1018</div>
+        <div class="location">at line 1024</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>loadUpGroupFromID</strong>(<a href="../Dagger/UpGroupId.html"><abbr title="Dagger\UpGroupId">UpGroupId</abbr></a> $id)
         </code>
@@ -5371,7 +5376,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceFromID">
-        <div class="location">at line 1028</div>
+        <div class="location">at line 1034</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>loadWorkspaceFromID</strong>(<a href="../Dagger/WorkspaceId.html"><abbr title="Dagger\WorkspaceId">WorkspaceId</abbr></a> $id)
         </code>
@@ -5413,7 +5418,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceGitFromID">
-        <div class="location">at line 1038</div>
+        <div class="location">at line 1044</div>
         <code>                    <a href="../Dagger/WorkspaceGit.html"><abbr title="Dagger\WorkspaceGit">WorkspaceGit</abbr></a>
     <strong>loadWorkspaceGitFromID</strong>(<a href="../Dagger/WorkspaceGitId.html"><abbr title="Dagger\WorkspaceGitId">WorkspaceGitId</abbr></a> $id)
         </code>
@@ -5455,7 +5460,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceMigrationFromID">
-        <div class="location">at line 1048</div>
+        <div class="location">at line 1054</div>
         <code>                    <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
     <strong>loadWorkspaceMigrationFromID</strong>(<a href="../Dagger/WorkspaceMigrationId.html"><abbr title="Dagger\WorkspaceMigrationId">WorkspaceMigrationId</abbr></a> $id)
         </code>
@@ -5497,7 +5502,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceMigrationStepFromID">
-        <div class="location">at line 1058</div>
+        <div class="location">at line 1064</div>
         <code>                    <a href="../Dagger/WorkspaceMigrationStep.html"><abbr title="Dagger\WorkspaceMigrationStep">WorkspaceMigrationStep</abbr></a>
     <strong>loadWorkspaceMigrationStepFromID</strong>(<a href="../Dagger/WorkspaceMigrationStepId.html"><abbr title="Dagger\WorkspaceMigrationStepId">WorkspaceMigrationStepId</abbr></a> $id)
         </code>
@@ -5539,7 +5544,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceModuleFromID">
-        <div class="location">at line 1068</div>
+        <div class="location">at line 1074</div>
         <code>                    <a href="../Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a>
     <strong>loadWorkspaceModuleFromID</strong>(<a href="../Dagger/WorkspaceModuleId.html"><abbr title="Dagger\WorkspaceModuleId">WorkspaceModuleId</abbr></a> $id)
         </code>
@@ -5581,7 +5586,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadWorkspaceModuleSettingFromID">
-        <div class="location">at line 1078</div>
+        <div class="location">at line 1084</div>
         <code>                    <a href="../Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a>
     <strong>loadWorkspaceModuleSettingFromID</strong>(<a href="../Dagger/WorkspaceModuleSettingId.html"><abbr title="Dagger\WorkspaceModuleSettingId">WorkspaceModuleSettingId</abbr></a> $id)
         </code>
@@ -5623,7 +5628,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 1088</div>
+        <div class="location">at line 1094</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>module</strong>()
         </code>
@@ -5655,7 +5660,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleRuntime">
-        <div class="location">at line 1094</div>
+        <div class="location">at line 1100</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>moduleRuntime</strong>(<a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a> $modSource, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $introspectionJson)
         </code>
@@ -5703,7 +5708,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 1105</div>
+        <div class="location">at line 1111</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $refString, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
         </code>
@@ -5765,7 +5770,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_node">
-        <div class="location">at line 1132</div>
+        <div class="location">at line 1138</div>
         <code>                    <a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a>
     <strong>node</strong>(<a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
         </code>
@@ -5807,7 +5812,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 1142</div>
+        <div class="location">at line 1148</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>(string $uri, string|null $cacheKey = null)
         </code>
@@ -5854,7 +5859,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecret">
-        <div class="location">at line 1157</div>
+        <div class="location">at line 1163</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecret</strong>(string $name, string $plaintext)
         </code>
@@ -5901,7 +5906,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceDir">
-        <div class="location">at line 1165</div>
+        <div class="location">at line 1171</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>sourceDir</strong>()
         </code>
@@ -5934,7 +5939,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 1174</div>
+        <div class="location">at line 1180</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>sourceMap</strong>(string $filename, int $line, int $column)
         </code>
@@ -5986,7 +5991,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 1186</div>
+        <div class="location">at line 1192</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>
@@ -6018,7 +6023,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 1195</div>
+        <div class="location">at line 1201</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -6050,7 +6055,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_with">
-        <div class="location">at line 1204</div>
+        <div class="location">at line 1210</div>
         <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
     <strong>with</strong>(<abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $sdkSourceDir = null)
         </code>

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1390,6 +1390,8 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
 	} else if include, ok := peekWorkspaceSelectorInclude(r, client.clientMetadata); ok {
 		client.narrowPendingWorkspaceModulesForSelectorInclude(include)
+	} else if include, ok := peekWorkspaceTypeDefsInclude(r, client.clientMetadata); ok {
+		client.narrowPendingWorkspaceModulesForSelectorInclude(include)
 	}
 	if err := srv.ensureModulesLoaded(ctx, client); err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1446,6 +1448,23 @@ func peekWorkspaceSelectorInclude(r *http.Request, clientMD *engine.ClientMetada
 		return nil, false
 	}
 	ok, include, err := dagql.PeekWorkspaceSelectorInclude(r)
+	if err != nil || !ok {
+		return nil, false
+	}
+	return include, true
+}
+
+// peekWorkspaceTypeDefsInclude narrows module loading for `dagger call` and
+// `dagger functions`, which build their command tree from a currentTypeDefs
+// introspection. That query roots at currentTypeDefs (otherwise treated as
+// needing the full workspace schema) and keeps the session open rather than
+// declaring SingleQuery. When such a client scopes the introspection to specific
+// modules via an include argument, only those modules need to load.
+func peekWorkspaceTypeDefsInclude(r *http.Request, clientMD *engine.ClientMetadata) ([]string, bool) {
+	if clientMD == nil || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
+		return nil, false
+	}
+	ok, include, err := dagql.PeekWorkspaceTypeDefsInclude(r)
 	if err != nil || !ok {
 		return nil, false
 	}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1388,6 +1388,8 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	}
 	if peekRootFieldsOK {
 		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
+	} else if include, ok := peekWorkspaceSelectorInclude(r, client.clientMetadata); ok {
+		client.narrowPendingWorkspaceModulesForSelectorInclude(include)
 	}
 	if err := srv.ensureModulesLoaded(ctx, client); err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1431,6 +1433,23 @@ func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata)
 		return false, nil, nil
 	}
 	return dagql.PeekRootFields(r)
+}
+
+// peekWorkspaceSelectorInclude narrows module loading for the workspace commands
+// that enumerate module-provided items -- `dagger generate`, `dagger check`, and
+// `dagger up`. Each roots its query at currentWorkspace (so the single-query peek
+// treats it as needing the full workspace schema) and keeps the session open
+// rather than declaring SingleQuery. When such a client requests specific items
+// via an include argument, only those items' modules need to load.
+func peekWorkspaceSelectorInclude(r *http.Request, clientMD *engine.ClientMetadata) ([]string, bool) {
+	if clientMD == nil || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
+		return nil, false
+	}
+	ok, include, err := dagql.PeekWorkspaceSelectorInclude(r)
+	if err != nil || !ok {
+		return nil, false
+	}
+	return include, true
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1140,6 +1140,68 @@ func TestGatherModuleLoadRequests(t *testing.T) {
 	require.True(t, loads[2].mod.Entrypoint)
 }
 
+func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator keeps only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("module:item works for checks and services too", func(t *testing.T) {
+		t.Parallel()
+
+		// The module-name resolution is identical across generate/check/up: the
+		// segment before ':' is the module name regardless of the item kind.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"rust-sdk:lint", "php-sdk:web"})
+		require.Equal(t, []pendingModule{mods[1], mods[2]}, filtered)
+	})
+
+	t.Run("bare module name keeps only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns keep each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. an item served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("no matching module loads all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include loads all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil)
+		require.Equal(t, mods, filtered)
+	})
+}
+
 func TestModuleLoadParallelism(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -922,6 +922,79 @@ func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFiel
 	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
+// narrowPendingWorkspaceModulesForSelectorInclude narrows the pending workspace
+// modules to those named by `dagger generate`/`check`/`up` include patterns
+// (e.g. `dagger generate go-sdk` keeps only the "go-sdk" module). Unlike the
+// single-query peek, these queries root at currentWorkspace and so would
+// otherwise require the full workspace schema; this lets them load only the
+// requested items' modules, so an unrelated broken/stale module cannot block
+// the operation. A module's own dependencies still load transitively.
+func (client *daggerClient) narrowPendingWorkspaceModulesForSelectorInclude(include []string) {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+
+	if client.modulesLoaded || len(client.pendingModules) == 0 {
+		return
+	}
+	client.pendingModules = filterPendingWorkspaceModulesBySelectorInclude(client.pendingModules, include)
+}
+
+// filterPendingWorkspaceModulesBySelectorInclude keeps the modules named by
+// `dagger generate`/`check`/`up` include patterns. A pattern resolves to a
+// module name in one of two ways:
+//
+//   - "module:item" — the segment before ':' is the module name.
+//   - "module" (bare) — the whole token, but only when it matches a known
+//     workspace module name. A bare token that is not a module name is assumed
+//     to be an item served by the entrypoint module (its functions are proxied
+//     onto the Query root), which we can't pin to a single module, so narrowing
+//     is skipped and all modules are kept.
+//
+// If no module ends up matching, narrowing is also skipped so the usual
+// "no such generator/check/service" error is reported instead of an empty
+// result.
+func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	known := make(map[string]struct{}, len(mods))
+	for _, mod := range mods {
+		if mod.Name != "" {
+			known[mod.Name] = struct{}{}
+		}
+	}
+
+	wanted := make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		if modName, _, hasItem := strings.Cut(pattern, ":"); hasItem {
+			if modName == "" {
+				return mods
+			}
+			wanted[modName] = struct{}{}
+			continue
+		}
+		// Bare token: only safe to narrow if it names a workspace module;
+		// otherwise it likely targets an entrypoint item, which needs the
+		// entrypoint loaded, so keep everything.
+		if _, ok := known[pattern]; !ok {
+			return mods
+		}
+		wanted[pattern] = struct{}{}
+	}
+
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[mod.Name]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	if len(filtered) == 0 {
+		return mods
+	}
+	return filtered
+}
+
 func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -158,7 +158,8 @@ defmodule Dagger.Client do
   """
   @spec current_type_defs(t(), [
           {:return_all_types, boolean() | nil},
-          {:hide_core, boolean() | nil}
+          {:hide_core, boolean() | nil},
+          {:include, [String.t()]}
         ]) :: {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
   def current_type_defs(%__MODULE__{} = client, optional_args \\ []) do
     query_builder =
@@ -166,6 +167,7 @@ defmodule Dagger.Client do
       |> QB.select("currentTypeDefs")
       |> QB.maybe_put_arg("returnAllTypes", optional_args[:return_all_types])
       |> QB.maybe_put_arg("hideCore", optional_args[:hide_core])
+      |> QB.maybe_put_arg("include", optional_args[:include])
       |> QB.select("id")
 
     with {:ok, items} <- Client.execute(client.client, query_builder) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -13055,6 +13055,12 @@ type CurrentTypeDefsOpts struct {
 	//
 	// Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
 	HideCore bool
+	// Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.
+	//
+	// Each pattern is a workspace module name or "module:item"; a pattern that does not name a workspace module is ignored and every module is loaded.
+	//
+	// Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+	Include []string
 }
 
 // The TypeDef representations of the objects currently being served in the session.
@@ -13068,6 +13074,10 @@ func (r *Query) CurrentTypeDefs(ctx context.Context, opts ...CurrentTypeDefsOpts
 		// `hideCore` optional argument
 		if !querybuilder.IsZeroValue(opts[i].HideCore) {
 			q = q.Arg("hideCore", opts[i].HideCore)
+		}
+		// `include` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
 		}
 	}
 

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -130,14 +130,20 @@ class Client extends Client\AbstractClient implements Client\IdAble, Node
     /**
      * The TypeDef representations of the objects currently being served in the session.
      */
-    public function currentTypeDefs(?bool $returnAllTypes = false, ?bool $hideCore = null): array
-    {
+    public function currentTypeDefs(
+        ?bool $returnAllTypes = false,
+        ?bool $hideCore = null,
+        ?array $include = null,
+    ): array {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('currentTypeDefs');
         if (null !== $returnAllTypes) {
         $leafQueryBuilder->setArgument('returnAllTypes', $returnAllTypes);
         }
         if (null !== $hideCore) {
         $leafQueryBuilder->setArgument('hideCore', $hideCore);
+        }
+        if (null !== $include) {
+        $leafQueryBuilder->setArgument('include', $include);
         }
         return (array)$this->queryLeaf($leafQueryBuilder, 'currentTypeDefs');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -13247,6 +13247,7 @@ class Query(Root):
         *,
         return_all_types: bool | None = False,
         hide_core: bool | None = None,
+        include: list[str] | None = None,
     ) -> list["TypeDef"]:
         """The TypeDef representations of the objects currently being served in
         the session.
@@ -13261,10 +13262,20 @@ class Query(Root):
             sourced functions (constructors, entrypoint proxies, etc.).
             Core types (Container, Directory, etc.) are kept so return types
             and method chaining still work.
+        include:
+            Narrow workspace module loading to the named modules (and their
+            dependencies) before computing typedefs.
+            Each pattern is a workspace module name or "module:item"; a
+            pattern that does not name a workspace module is ignored and every
+            module is loaded.
+            Used by clients (e.g. the CLI) that target a single module so an
+            unrelated broken or stale module cannot block building the command
+            tree.
         """
         _args = [
             Arg("returnAllTypes", return_all_types, False),
             Arg("hideCore", hide_core, None),
+            Arg("include", include, None),
         ]
         _ctx = self._select("currentTypeDefs", _args)
         return await _ctx.execute_object_list(TypeDef)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -13121,11 +13121,16 @@ pub struct QueryContainerOpts {
     pub platform: Option<Platform>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct QueryCurrentTypeDefsOpts {
+pub struct QueryCurrentTypeDefsOpts<'a> {
     /// Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
     /// Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
     #[builder(setter(into, strip_option), default)]
     pub hide_core: Option<bool>,
+    /// Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.
+    /// Each pattern is a workspace module name or "module:item"; a pattern that does not name a workspace module is ignored and every module is loaded.
+    /// Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+    #[builder(setter(into, strip_option), default)]
+    pub include: Option<Vec<&'a str>>,
     /// Return the full referenced typedef closure instead of only top-level served typedefs.
     #[builder(setter(into, strip_option), default)]
     pub return_all_types: Option<bool>,
@@ -13407,9 +13412,9 @@ impl Query {
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn current_type_defs_opts(
+    pub async fn current_type_defs_opts<'a>(
         &self,
-        opts: QueryCurrentTypeDefsOpts,
+        opts: QueryCurrentTypeDefsOpts<'a>,
     ) -> Result<Vec<TypeDef>, DaggerError> {
         let mut query = self.selection.select("currentTypeDefs");
         if let Some(return_all_types) = opts.return_all_types {
@@ -13417,6 +13422,9 @@ impl Query {
         }
         if let Some(hide_core) = opts.hide_core {
             query = query.arg("hideCore", hide_core);
+        }
+        if let Some(include) = opts.include {
+            query = query.arg("include", include);
         }
         let query = query.select("id");
         let ids: Vec<Id> = query.execute(self.graphql_client.clone()).await?;

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2336,6 +2336,15 @@ export type ClientCurrentTypeDefsOpts = {
    * Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
    */
   hideCore?: boolean
+
+  /**
+   * Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.
+   *
+   * Each pattern is a workspace module name or "module:item"; a pattern that does not name a workspace module is ignored and every module is loaded.
+   *
+   * Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+   */
+  include?: string[]
 }
 
 export type ClientEnvOpts = {
@@ -12961,6 +12970,11 @@ export class Client extends BaseClient {
    * @param opts.hideCore Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
    *
    * Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
+   * @param opts.include Narrow workspace module loading to the named modules (and their dependencies) before computing typedefs.
+   *
+   * Each pattern is a workspace module name or "module:item"; a pattern that does not name a workspace module is ignored and every module is loaded.
+   *
+   * Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
    */
   currentTypeDefs = async (
     opts?: ClientCurrentTypeDefsOpts,


### PR DESCRIPTION
## Problem

`dagger generate <module>`, `dagger check <module>`, `dagger up <module>`, and `dagger call <module> …` (plus `dagger functions <module>`) each load **every** workspace module — to enumerate generators/checks/services, or to build the command tree from a typedefs introspection. A single stale or broken workspace module then blocks operating on any other module — and for `generate` this includes the very module you were trying to fix by running `dagger generate`.

The single-query lazy-load mechanism (peek root fields → narrow pending workspace modules) does not help here: these commands root their query at `currentWorkspace`/`currentTypeDefs` (treated as needing the full workspace schema) and keep the session open rather than declaring `SingleQuery`.

## Fix

Reuse and extend the existing peek/narrow mechanism rather than adding any new client→server contract:

- **`dagql.PeekWorkspaceSelectorInclude`** recognizes `{ currentWorkspace { <generators|checks|services>(include: [...]) … } }` — backing `generate`/`check`/`up`.
- **`dagql.PeekWorkspaceTypeDefsInclude`** recognizes `{ currentTypeDefs(… include: [...]) … }` — backing `call`/`functions`, which build their command tree from a typedefs introspection. The include argument may be a literal list or a query variable, so the shared request peek now also resolves variables.
- **`currentTypeDefs`** gains an optional `include` argument: a workspace module-loading hint the engine consumes before the resolver runs (the resolver itself ignores it).
- **`serveQuery`** narrows the pending workspace modules to the named modules (`module:item`, or a bare `module` matching a known workspace module) plus their transitive deps, via one shared filter. A bare token that is not a module name (an entrypoint-proxied item), or patterns matching no module, fall back to loading everything.
- **CLI**: `generate`/`check`/`up` pass their `include` patterns; `call`/`functions` pass their leading positional token as the typedefs `include` hint.

Net effect: `dagger generate`/`check`/`up`/`call`/`functions <module>` loads only that module (+ its dependencies), so an unrelated broken/stale module can no longer block the operation.

## Tests

- **Unit:** `dagql` peek matching for `generators`/`checks`/`services` and `currentTypeDefs` (literal + variable include, plus negative shapes), and the `engine/server` pending-module filter.
- **Integration:** `TestWorkspaceGenerate/Check/Up/CallNarrowsToRequestedModule` against a `generators-broken` fixture — a healthy `dang` module exposing a generator, a check, and a service, alongside a module with intentionally invalid source. Each asserts that targeting only the healthy module succeeds despite the broken module, while a full listing still loads every module and surfaces the broken one.
