### PR TITLE
Persist trivial core object payloads

### DIFF
--- a/core/address.go
+++ b/core/address.go
@@ -1,10 +1,20 @@
 package core
 
-import "github.com/vektah/gqlparser/v2/ast"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/vektah/gqlparser/v2/ast"
+)
 
 type Address struct {
 	Value string
 }
+
+var _ dagql.PersistedObject = (*Address)(nil)
+var _ dagql.PersistedObjectDecoder = (*Address)(nil)
 
 func (*Address) Type() *ast.Type {
 	return &ast.Type{
@@ -15,4 +25,23 @@ func (*Address) Type() *ast.Type {
 
 func (*Address) TypeDescription() string {
 	return `A standardized address to load containers, directories, secrets, and other object types. Address format depends on the type, and is validated at type selection.`
+}
+
+func (addr *Address) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if addr == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted address: nil address")
+	}
+	return encodePersistedObjectPayload(addr)
+}
+
+func (*Address) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var addr Address
+	if err := json.Unmarshal(payload, &addr); err != nil {
+		return nil, fmt.Errorf("decode persisted address payload: %w", err)
+	}
+	return &addr, nil
 }

--- a/core/directory.go
+++ b/core/directory.go
@@ -3097,6 +3097,9 @@ type Stat struct {
 	Permissions int      `field:"true" doc:"permission bits"`
 }
 
+var _ dagql.PersistedObject = (*Stat)(nil)
+var _ dagql.PersistedObjectDecoder = (*Stat)(nil)
+
 func (*Stat) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "Stat",
@@ -3106,6 +3109,25 @@ func (*Stat) Type() *ast.Type {
 
 func (*Stat) TypeDescription() string {
 	return "A file or directory status object."
+}
+
+func (s *Stat) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if s == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted stat: nil stat")
+	}
+	return encodePersistedObjectPayload(s)
+}
+
+func (*Stat) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var s Stat
+	if err := json.Unmarshal(payload, &s); err != nil {
+		return nil, fmt.Errorf("decode persisted stat payload: %w", err)
+	}
+	return &s, nil
 }
 
 func (s *Stat) IsDir() bool {

--- a/core/envfile.go
+++ b/core/envfile.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -27,6 +28,9 @@ type EnvFile struct {
 	Expand  bool     `json:"expand"`
 }
 
+var _ dagql.PersistedObject = (*EnvFile)(nil)
+var _ dagql.PersistedObjectDecoder = (*EnvFile)(nil)
+
 func (*EnvFile) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "EnvFile",
@@ -36,6 +40,25 @@ func (*EnvFile) Type() *ast.Type {
 
 func (*EnvFile) TypeDescription() string {
 	return "A collection of environment variables."
+}
+
+func (ef *EnvFile) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if ef == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted env file: nil env file")
+	}
+	return encodePersistedObjectPayload(ef)
+}
+
+func (*EnvFile) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var ef EnvFile
+	if err := json.Unmarshal(payload, &ef); err != nil {
+		return nil, fmt.Errorf("decode persisted env file payload: %w", err)
+	}
+	return &ef, nil
 }
 
 // Len returns the number of variables in the EnvFile

--- a/core/error.go
+++ b/core/error.go
@@ -17,6 +17,9 @@ type Error struct {
 	Values  []*ErrorValue `field:"true" doc:"The extensions of the error."`
 }
 
+var _ dagql.PersistedObject = (*Error)(nil)
+var _ dagql.PersistedObjectDecoder = (*Error)(nil)
+
 func NewError(message string) *Error {
 	return &Error{
 		Message: message,
@@ -99,6 +102,25 @@ func (e *Error) Type() *ast.Type {
 	}
 }
 
+func (e *Error) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if e == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted error: nil error")
+	}
+	return encodePersistedObjectPayload(e)
+}
+
+func (*Error) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var e Error
+	if err := json.Unmarshal(payload, &e); err != nil {
+		return nil, fmt.Errorf("decode persisted error payload: %w", err)
+	}
+	return &e, nil
+}
+
 var _ error = (*Error)(nil)
 
 func (e *Error) Error() string {
@@ -122,9 +144,31 @@ type ErrorValue struct {
 	Value JSON   `field:"true" doc:"The value."`
 }
 
+var _ dagql.PersistedObject = (*ErrorValue)(nil)
+var _ dagql.PersistedObjectDecoder = (*ErrorValue)(nil)
+
 func (e *ErrorValue) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "ErrorValue",
 		NonNull:   true,
 	}
+}
+
+func (e *ErrorValue) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if e == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted error value: nil error value")
+	}
+	return encodePersistedObjectPayload(e)
+}
+
+func (*ErrorValue) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var e ErrorValue
+	if err := json.Unmarshal(payload, &e); err != nil {
+		return nil, fmt.Errorf("decode persisted error value payload: %w", err)
+	}
+	return &e, nil
 }

--- a/core/jsonvalue.go
+++ b/core/jsonvalue.go
@@ -1,15 +1,44 @@
 package core
 
-import "github.com/vektah/gqlparser/v2/ast"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/vektah/gqlparser/v2/ast"
+)
 
 // JSONValue is a simple state carrier for JSON-encoded bytes
 type JSONValue struct {
 	Data []byte
 }
 
+var _ dagql.PersistedObject = (*JSONValue)(nil)
+var _ dagql.PersistedObjectDecoder = (*JSONValue)(nil)
+
 func (*JSONValue) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "JSONValue",
 		NonNull:   true,
 	}
+}
+
+func (v *JSONValue) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if v == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted JSON value: nil JSON value")
+	}
+	return encodePersistedObjectPayload(v)
+}
+
+func (*JSONValue) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var v JSONValue
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return nil, fmt.Errorf("decode persisted JSON value payload: %w", err)
+	}
+	return &v, nil
 }

--- a/core/llm.go
+++ b/core/llm.go
@@ -113,11 +113,33 @@ type LLMTokenUsage struct {
 	TotalTokens       int64 `field:"true" json:"total_tokens"`
 }
 
+var _ dagql.PersistedObject = (*LLMTokenUsage)(nil)
+var _ dagql.PersistedObjectDecoder = (*LLMTokenUsage)(nil)
+
 func (*LLMTokenUsage) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "LLMTokenUsage",
 		NonNull:   true,
 	}
+}
+
+func (usage *LLMTokenUsage) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if usage == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted LLM token usage: nil LLM token usage")
+	}
+	return encodePersistedObjectPayload(usage)
+}
+
+func (*LLMTokenUsage) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var usage LLMTokenUsage
+	if err := json.Unmarshal(payload, &usage); err != nil {
+		return nil, fmt.Errorf("decode persisted LLM token usage payload: %w", err)
+	}
+	return &usage, nil
 }
 
 // ModelMessage represents a generic message in the LLM conversation
@@ -1089,12 +1111,33 @@ type LLMVariable struct {
 }
 
 var _ dagql.Typed = (*LLMVariable)(nil)
+var _ dagql.PersistedObject = (*LLMVariable)(nil)
+var _ dagql.PersistedObjectDecoder = (*LLMVariable)(nil)
 
 func (v *LLMVariable) Type() *ast.Type {
 	return &ast.Type{
 		NamedType: "LLMVariable",
 		NonNull:   true,
 	}
+}
+
+func (v *LLMVariable) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if v == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted LLM variable: nil LLM variable")
+	}
+	return encodePersistedObjectPayload(v)
+}
+
+func (*LLMVariable) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var v LLMVariable
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return nil, fmt.Errorf("decode persisted LLM variable payload: %w", err)
+	}
+	return &v, nil
 }
 
 func (llm *LLM) BindResult(ctx context.Context, dag *dagql.Server, name string) (dagql.Nullable[*Binding], error) {

--- a/core/workspace_module.go
+++ b/core/workspace_module.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"sort"
 
+	"github.com/dagger/dagger/dagql"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -12,6 +16,9 @@ type WorkspaceModule struct {
 	Entrypoint bool   `field:"true" doc:"Whether the module is the workspace entrypoint (functions aliased to Query root)."`
 	Source     string `field:"true" doc:"The module source path."`
 }
+
+var _ dagql.PersistedObject = (*WorkspaceModule)(nil)
+var _ dagql.PersistedObjectDecoder = (*WorkspaceModule)(nil)
 
 func (*WorkspaceModule) Type() *ast.Type {
 	return &ast.Type{
@@ -24,12 +31,34 @@ func (*WorkspaceModule) TypeDescription() string {
 	return "A module entry in the workspace configuration."
 }
 
+func (m *WorkspaceModule) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if m == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted workspace module: nil workspace module")
+	}
+	return encodePersistedObjectPayload(m)
+}
+
+func (*WorkspaceModule) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var m WorkspaceModule
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return nil, fmt.Errorf("decode persisted workspace module payload: %w", err)
+	}
+	return &m, nil
+}
+
 // WorkspaceModuleSetting describes one constructor-backed module setting.
 type WorkspaceModuleSetting struct {
 	Key         string `field:"true" doc:"The setting key."`
 	Value       string `field:"true" doc:"The configured value after applying the selected workspace environment, or empty when unset."`
 	Description string `field:"true" doc:"The constructor argument description."`
 }
+
+var _ dagql.PersistedObject = (*WorkspaceModuleSetting)(nil)
+var _ dagql.PersistedObjectDecoder = (*WorkspaceModuleSetting)(nil)
 
 func (*WorkspaceModuleSetting) Type() *ast.Type {
 	return &ast.Type{
@@ -40,6 +69,25 @@ func (*WorkspaceModuleSetting) Type() *ast.Type {
 
 func (*WorkspaceModuleSetting) TypeDescription() string {
 	return "A constructor-backed module setting."
+}
+
+func (s *WorkspaceModuleSetting) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if s == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted workspace module setting: nil workspace module setting")
+	}
+	return encodePersistedObjectPayload(s)
+}
+
+func (*WorkspaceModuleSetting) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var s WorkspaceModuleSetting
+	if err := json.Unmarshal(payload, &s); err != nil {
+		return nil, fmt.Errorf("decode persisted workspace module setting payload: %w", err)
+	}
+	return &s, nil
 }
 
 type WorkspaceModules []*WorkspaceModule


### PR DESCRIPTION
## Summary
- add persisted object encoding/decoding for simple core object payloads
- cover Error/ErrorValue, Address, JSONValue, Stat, EnvFile, WorkspaceModule/Setting, and LLMTokenUsage/Variable

## Testing
- go test ./core