### PR TITLE
dang: support v1 and v2, routed by module engineVersion

### DIFF
--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -251,6 +251,44 @@ func (DangSuite) TestInterfaces(_ context.Context, t *testctx.T) {
 	})
 }
 
+// TestVersionedSyntax covers the Dang major version routing: modules pinned
+// to an engineVersion before v0.21.5 are evaluated with Dang v1 (`.{ }` is
+// selection), and modules at v0.21.5+ with Dang v2 (`.{ }` is dot-block
+// application, `.{{ }}` is selection). See core/sdk/dang/README.md.
+func (DangSuite) TestVersionedSyntax(_ context.Context, t *testctx.T) {
+	t.Run("v1 selection for modules pinned before v0.21.5", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "legacy-selection").
+			With(daggerCall("contents")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "old syntax", strings.TrimSpace(out))
+
+		out, err = dangModule(t, c, "legacy-selection").
+			With(daggerCall("size")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "10", strings.TrimSpace(out))
+	})
+
+	t.Run("v2 dot-block and selection for modules at v0.21.5+", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "dot-block").
+			With(daggerCall("double", "--n", "21")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "42", strings.TrimSpace(out))
+
+		out, err = dangModule(t, c, "dot-block").
+			With(daggerCall("contents")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "new syntax", strings.TrimSpace(out))
+	})
+}
+
 func dangModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/dang", moduleName))

--- a/core/integration/testdata/modules/dang/ambient-build/dagger.json
+++ b/core/integration/testdata/modules/dang/ambient-build/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "ambient",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/modules/dang/core-types/dagger.json
+++ b/core/integration/testdata/modules/dang/core-types/dagger.json
@@ -1,1 +1,1 @@
-{"name":"dirs","sdk":{"source":"dang"},"source":"."}
+{"name":"dirs","engineVersion":"v0.21.5","sdk":{"source":"dang"},"source":"."}

--- a/core/integration/testdata/modules/dang/counter/dagger.json
+++ b/core/integration/testdata/modules/dang/counter/dagger.json
@@ -1,1 +1,1 @@
-{"name":"counter","sdk":{"source":"dang"},"source":"."}
+{"name":"counter","engineVersion":"v0.21.5","sdk":{"source":"dang"},"source":"."}

--- a/core/integration/testdata/modules/dang/dependency-modules/dagger.json
+++ b/core/integration/testdata/modules/dang/dependency-modules/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "test",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   },

--- a/core/integration/testdata/modules/dang/dependency-modules/dangchild/dagger.json
+++ b/core/integration/testdata/modules/dang/dependency-modules/dangchild/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "dangchild",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   },

--- a/core/integration/testdata/modules/dang/dot-block/dagger.json
+++ b/core/integration/testdata/modules/dang/dot-block/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "dot-block",
+  "engineVersion": "v0.21.5",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/dot-block/main.dang
+++ b/core/integration/testdata/modules/dang/dot-block/main.dang
@@ -1,0 +1,15 @@
+"""
+Module exercising Dang v2 semantics, which apply to modules with
+engineVersion >= v0.21.5: `.{ }` is dot-block application (piping) and
+`.{{ }}` is GraphQL selection.
+"""
+type DotBlock {
+  pub double(n: Int!): Int! {
+    n.{ _ * 2 }
+  }
+
+  pub contents: String! {
+    let info = Dagger.directory.withNewFile("hello.txt", "new syntax").file("hello.txt").{{contents, size}}
+    info.contents
+  }
+}

--- a/core/integration/testdata/modules/dang/extra-build/dagger.json
+++ b/core/integration/testdata/modules/dang/extra-build/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "extra",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/modules/dang/legacy-selection/dagger.json
+++ b/core/integration/testdata/modules/dang/legacy-selection/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "legacy-selection",
+  "engineVersion": "v0.20.6",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/legacy-selection/main.dang
+++ b/core/integration/testdata/modules/dang/legacy-selection/main.dang
@@ -1,0 +1,16 @@
+"""
+Regression module for Dang v1 semantics: modules pinned to an engineVersion
+before v0.21.5 must keep `.{ }` as GraphQL selection. Do not bump this
+module's engineVersion.
+"""
+type LegacySelection {
+  pub contents: String! {
+    let info = Dagger.directory.withNewFile("hello.txt", "old syntax").file("hello.txt").{contents, size}
+    info.contents
+  }
+
+  pub size: Int! {
+    let info = Dagger.directory.withNewFile("hello.txt", "old syntax").file("hello.txt").{contents, size}
+    info.size
+  }
+}

--- a/core/integration/testdata/modules/dang/loaded-once-app/dagger.json
+++ b/core/integration/testdata/modules/dang/loaded-once-app/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "app",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/modules/dang/lockmod/dagger.json
+++ b/core/integration/testdata/modules/dang/lockmod/dagger.json
@@ -1,1 +1,1 @@
-{"name":"lockmod","sdk":{"source":"dang"},"source":"."}
+{"name":"lockmod","engineVersion":"v0.21.5","sdk":{"source":"dang"},"source":"."}

--- a/core/integration/testdata/modules/dang/nested-build/dagger.json
+++ b/core/integration/testdata/modules/dang/nested-build/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "nested",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/modules/dang/relmod/dagger.json
+++ b/core/integration/testdata/modules/dang/relmod/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "relmod",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/modules/dang/root-self-named/dagger.json
+++ b/core/integration/testdata/modules/dang/root-self-named/dagger.json
@@ -1,1 +1,1 @@
-{"name":"test","sdk":{"source":"dang"},"source":"."}
+{"name":"test","engineVersion":"v0.21.5","sdk":{"source":"dang"},"source":"."}

--- a/core/integration/testdata/modules/dang/self-calls/dagger.json
+++ b/core/integration/testdata/modules/dang/self-calls/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "test",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang",
     "experimental": {

--- a/core/integration/testdata/modules/dang/test-directives/dagger.json
+++ b/core/integration/testdata/modules/dang/test-directives/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-directives",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-enum/dagger.json
+++ b/core/integration/testdata/modules/dang/test-enum/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-enum",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-interface/dagger.json
+++ b/core/integration/testdata/modules/dang/test-interface/dagger.json
@@ -1,8 +1,10 @@
 {
   "name": "test-interface",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang",
-  "include": ["!dep"],
+  "include": [
+    "!dep"
+  ],
   "dependencies": [
     {
       "name": "dep",

--- a/core/integration/testdata/modules/dang/test-interface/dep/dagger.json
+++ b/core/integration/testdata/modules/dang/test-interface/dep/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "dep",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-mismatch/dagger.json
+++ b/core/integration/testdata/modules/dang/test-mismatch/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-mismatch",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-private-arg/dagger.json
+++ b/core/integration/testdata/modules/dang/test-private-arg/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-private-arg",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-scalar/dagger.json
+++ b/core/integration/testdata/modules/dang/test-scalar/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-scalar",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/test-shadowing/dagger.json
+++ b/core/integration/testdata/modules/dang/test-shadowing/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "test-shadowing",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.21.5",
   "sdk": "dang"
 }

--- a/core/integration/testdata/modules/dang/workspace-arg/dagger.json
+++ b/core/integration/testdata/modules/dang/workspace-arg/dagger.json
@@ -1,1 +1,1 @@
-{"name":"workspace-arg","sdk":{"source":"dang"},"source":"."}
+{"name":"workspace-arg","engineVersion":"v0.21.5","sdk":{"source":"dang"},"source":"."}

--- a/core/integration/testdata/services/hello-with-services-dang/dagger.json
+++ b/core/integration/testdata/services/hello-with-services-dang/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-with-services-dang",
-  "engineVersion": "v0.20.1",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/workspaces/contextual/greeter/.dagger/modules/greeter/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/greeter/.dagger/modules/greeter/dagger.json
@@ -1,1 +1,1 @@
-{"name":"greeter","sdk":{"source":"dang"}}
+{"name":"greeter","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/contextual/paths-findup/app/.dagger/modules/paths/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/paths-findup/app/.dagger/modules/paths/dagger.json
@@ -1,1 +1,1 @@
-{"name":"paths","sdk":{"source":"dang"}}
+{"name":"paths","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/contextual/paths-full/app/.dagger/modules/paths/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/paths-full/app/.dagger/modules/paths/dagger.json
@@ -1,1 +1,1 @@
-{"name":"paths","sdk":{"source":"dang"}}
+{"name":"paths","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/contextual/paths-shape/app/.dagger/modules/paths/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/paths-shape/app/.dagger/modules/paths/dagger.json
@@ -1,1 +1,1 @@
-{"name":"paths","sdk":{"source":"dang"}}
+{"name":"paths","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/cwd-only/modules/cwd/dagger.json
+++ b/core/integration/testdata/workspaces/cwd-only/modules/cwd/dagger.json
@@ -1,1 +1,1 @@
-{"name":"cwd","sdk":{"source":"dang"}}
+{"name":"cwd","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/listen-greeter/.dagger/modules/greeter/dagger.json
+++ b/core/integration/testdata/workspaces/listen-greeter/.dagger/modules/greeter/dagger.json
@@ -1,1 +1,1 @@
-{"name":"greeter","sdk":{"source":"dang"}}
+{"name":"greeter","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/ambient-build/.dagger/modules/ambient/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/ambient-build/.dagger/modules/ambient/dagger.json
@@ -1,1 +1,1 @@
-{"name":"ambient","sdk":{"source":"dang"}}
+{"name":"ambient","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/ci/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/ci/dagger.json
@@ -1,1 +1,1 @@
-{"name":"ci","sdk":{"source":"dang"}}
+{"name":"ci","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/lint/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/lint/dagger.json
@@ -1,1 +1,1 @@
-{"name":"lint","sdk":{"source":"dang"}}
+{"name":"lint","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/test/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/ambient/.dagger/modules/test/dagger.json
@@ -1,1 +1,1 @@
-{"name":"test","sdk":{"source":"dang"}}
+{"name":"test","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/canonical-source/.dagger/modules/app/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/canonical-source/.dagger/modules/app/dagger.json
@@ -1,1 +1,1 @@
-{"name":"app","sdk":{"source":"dang"}}
+{"name":"app","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/ctor-overlap/.dagger/modules/ci/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/ctor-overlap/.dagger/modules/ci/dagger.json
@@ -1,1 +1,1 @@
-{"name":"ci","sdk":{"source":"dang"}}
+{"name":"ci","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/deduped/.dagger/modules/app/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/deduped/.dagger/modules/app/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "app",
+  "engineVersion": "v0.21.5",
   "sdk": {
     "source": "dang"
   }

--- a/core/integration/testdata/workspaces/module-loading/entrypoint-greeter/.dagger/modules/greeter/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/entrypoint-greeter/.dagger/modules/greeter/dagger.json
@@ -1,1 +1,1 @@
-{"name":"greeter","sdk":{"source":"dang"}}
+{"name":"greeter","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/multiple-entrypoints/.dagger/modules/alpha/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/multiple-entrypoints/.dagger/modules/alpha/dagger.json
@@ -1,1 +1,1 @@
-{"name":"alpha","sdk":{"source":"dang"}}
+{"name":"alpha","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/multiple-entrypoints/.dagger/modules/beta/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/multiple-entrypoints/.dagger/modules/beta/dagger.json
@@ -1,1 +1,1 @@
-{"name":"beta","sdk":{"source":"dang"}}
+{"name":"beta","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/namespaced/.dagger/modules/build/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/namespaced/.dagger/modules/build/dagger.json
@@ -1,1 +1,1 @@
-{"name":"build","sdk":{"source":"dang"}}
+{"name":"build","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/namespaced/.dagger/modules/lint/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/namespaced/.dagger/modules/lint/dagger.json
@@ -1,1 +1,1 @@
-{"name":"lint","sdk":{"source":"dang"}}
+{"name":"lint","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/module-loading/root-shadow/.dagger/modules/ci/dagger.json
+++ b/core/integration/testdata/workspaces/module-loading/root-shadow/.dagger/modules/ci/dagger.json
@@ -1,1 +1,1 @@
-{"name":"ci","sdk":{"source":"dang"}}
+{"name":"ci","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/single-query-broken/.dagger/modules/bad/dagger.json
+++ b/core/integration/testdata/workspaces/single-query-broken/.dagger/modules/bad/dagger.json
@@ -1,1 +1,1 @@
-{"name":"bad","sdk":{"source":"dang"}}
+{"name":"bad","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/single-query-broken/.dagger/modules/good/dagger.json
+++ b/core/integration/testdata/workspaces/single-query-broken/.dagger/modules/good/dagger.json
@@ -1,1 +1,1 @@
-{"name":"good","sdk":{"source":"dang"}}
+{"name":"good","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/abs-rel/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/abs-rel/dagger.json
@@ -1,1 +1,1 @@
-{"name":"abs-rel","sdk":{"source":"dang"}}
+{"name":"abs-rel","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/escape-dir/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/escape-dir/dagger.json
@@ -1,1 +1,1 @@
-{"name":"escape-dir","sdk":{"source":"dang"}}
+{"name":"escape-dir","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/escape-file/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/escape-file/dagger.json
@@ -1,1 +1,1 @@
-{"name":"escape-file","sdk":{"source":"dang"}}
+{"name":"escape-file","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/filtered/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/filtered/dagger.json
@@ -1,1 +1,1 @@
-{"name":"filtered","sdk":{"source":"dang"}}
+{"name":"filtered","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/finder/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/finder/dagger.json
@@ -1,1 +1,1 @@
-{"name":"finder","sdk":{"source":"dang"}}
+{"name":"finder","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-off/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-off/dagger.json
@@ -1,1 +1,1 @@
-{"name":"gi-off","sdk":{"source":"dang"}}
+{"name":"gi-off","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-root/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-root/dagger.json
@@ -1,1 +1,1 @@
-{"name":"gi-root","sdk":{"source":"dang"}}
+{"name":"gi-root","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-sub/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/gi-sub/dagger.json
@@ -1,1 +1,1 @@
-{"name":"gi-sub","sdk":{"source":"dang"}}
+{"name":"gi-sub","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/lister/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/lister/dagger.json
@@ -1,1 +1,1 @@
-{"name":"lister","sdk":{"source":"dang"}}
+{"name":"lister","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/reader/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/reader/dagger.json
@@ -1,1 +1,1 @@
-{"name":"reader","sdk":{"source":"dang"}}
+{"name":"reader","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-api/.dagger/modules/subdir/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-api/.dagger/modules/subdir/dagger.json
@@ -1,1 +1,1 @@
-{"name":"subdir","sdk":{"source":"dang"}}
+{"name":"subdir","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-entrypoint/.dagger/modules/greeter/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-entrypoint/.dagger/modules/greeter/dagger.json
@@ -1,1 +1,1 @@
-{"name":"greeter","sdk":{"source":"dang"}}
+{"name":"greeter","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/configured/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/configured/dagger.json
@@ -1,1 +1,1 @@
-{"name":"configured","sdk":{"source":"dang"}}
+{"name":"configured","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/hello-world/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/hello-world/dagger.json
@@ -1,1 +1,1 @@
-{"name":"hello-world","sdk":{"source":"dang"}}
+{"name":"hello-world","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/objects/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-managed/.dagger/modules/objects/dagger.json
@@ -1,1 +1,1 @@
-{"name":"objects","sdk":{"source":"dang"}}
+{"name":"objects","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/workspace-managed/modules/cwd/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-managed/modules/cwd/dagger.json
@@ -1,1 +1,1 @@
-{"name":"cwd","sdk":{"source":"dang"}}
+{"name":"cwd","engineVersion":"v0.21.5","sdk":{"source":"dang"}}

--- a/core/sdk/dang/README.md
+++ b/core/sdk/dang/README.md
@@ -1,0 +1,65 @@
+# Dang SDK version support
+
+The engine embeds one copy of the Dang runtime per supported Dang major
+version and routes each module to the version matching its `engineVersion`,
+so existing modules keep the language semantics they were written against.
+
+## Layout
+
+- `../dang_sdk.go` (package `sdk`) — the dispatcher. `dangSDK` owns all
+  version-agnostic `core.SDK` behavior and picks a `dangImpl` per call via
+  `dangImplFor`, comparing the module's `engineVersion` against the
+  `MinimumDangV*ModuleVersion` constants in `engine/version.go`.
+- `shared/` (package `dangshared`) — version-agnostic plumbing (nested-client
+  proxy server, client metadata, error conversion). Must never import
+  `github.com/vito/dang` of any major.
+- `v2/` (package `dangv2`) — the **living** implementation, importing
+  `github.com/vito/dang/v2`. All feature work happens here. New Dagger
+  features always require a new `engineVersion`, which always routes to the
+  newest major — so frozen majors never need feature work.
+- `v1/` (package `dangv1`) — **frozen** snapshot for modules with
+  `engineVersion < v0.21.5` (Dang v1: `.{ }` is selection). Byte-identical to
+  the living package at snapshot time, modulo package clause, doc comments,
+  and dang import paths.
+
+## Maintenance policy
+
+- **Features**: living package only.
+- **Bugfixes in the engine-side glue** (type conversion, call dispatch): fix
+  the living package; backport to frozen packages only if the bug affects old
+  modules.
+- **Bugfixes in Dang itself** for old modules: land on the corresponding
+  maintenance branch upstream (e.g. `release/v1` in vito/dang), tag a patch
+  (e.g. v1.0.x), bump go.mod.
+- **Engine-internal refactors** (`core`, `dagql`, `engine` API churn) will
+  break frozen packages at compile time; apply the same mechanical fix to all
+  copies.
+
+## Adding support for a new Dang major (vN+1)
+
+1. Upstream: tag `vN+1.0.0` on a module path with the new major suffix; keep
+   a maintenance branch for the now-frozen prior major.
+2. Copy the living package to a dir for the new major (e.g. `cp -r v2 v3`),
+   then in `v3/` rewrite the dang import paths to the new major and the
+   package clause to `dangv3`. `v2/` is now frozen — update its package doc to
+   say so (see `v1/sdk.go` for the wording).
+3. Add `MinimumDangV<N+1>ModuleVersion = "<next unreleased dagger version>"`
+   to `engine/version.go`.
+4. Extend the newest-first ladder in `dangImplFor` (`../dang_sdk.go`) with one
+   new case.
+5. `go get github.com/vito/dang/v<N+1>@v<N+1>.0.0`.
+6. Tests: bump the dang testdata module pins under
+   `core/integration/testdata/modules/dang/` to the new gate version so the
+   main suite exercises the living major, and add a pinned regression module
+   for any syntax whose meaning changed (see `legacy-selection/`).
+
+## Caveats
+
+- In-repo dang modules (`toolchains/*`, `cmd/codegen`, `modules/markdownlint`)
+  are pinned to the *released* engine version (the released CLI rejects
+  configs newer than itself), so they route to the previous major until the
+  next dagger release ships. Keep them syntax-neutral across the boundary, or
+  bump them right after the release.
+- An empty/missing `engineVersion` in a `ModuleSource` normalizes to the
+  current engine version (→ newest major); pre-semver configs normalize to
+  v0.11.9 (→ oldest major).

--- a/core/sdk/dang/README.md
+++ b/core/sdk/dang/README.md
@@ -38,7 +38,12 @@ so existing modules keep the language semantics they were written against.
 ## Adding support for a new Dang major (vN+1)
 
 1. Upstream: tag `vN+1.0.0` on a module path with the new major suffix; keep
-   a maintenance branch for the now-frozen prior major.
+   a maintenance branch for the now-frozen prior major. On that maintenance
+   branch, rename the tree-sitter grammar's exported C symbols with a `_vN`
+   suffix (see `pkg/dang/danglang/danglang.go` on `release/v1`): C symbols
+   share one global namespace, so two majors with identical symbol names
+   fail to link into the same binary. The canonical `tree_sitter_dang` names
+   always stay with the living major so editor integrations keep working.
 2. Copy the living package to a dir for the new major (e.g. `cp -r v2 v3`),
    then in `v3/` rewrite the dang import paths to the new major and the
    package clause to `dangv3`. `v2/` is now frozen — update its package doc to

--- a/core/sdk/dang/shared/shared.go
+++ b/core/sdk/dang/shared/shared.go
@@ -1,0 +1,141 @@
+// Package dangshared holds the Dang-version-agnostic plumbing shared by every
+// supported major version of the Dang runtime (core/sdk/dang/v1, v2, ...).
+//
+// Nothing in this package may import github.com/vito/dang (any major); that
+// keeps the per-version packages free to be pure copies of each other with
+// only their dang import paths rewritten. See core/sdk/dang/README.md.
+package dangshared
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/internal/buildkit/identity"
+	telemetry "github.com/dagger/otel-go"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// WithNestedClientServer serves the Dagger API for a nested client on a local
+// listener and calls fn with a GraphQL client pointed at it. The server is
+// shut down when fn returns; any error it hit while serving is returned.
+func WithNestedClientServer(
+	ctx context.Context,
+	query *core.Query,
+	nestedClientMetadata *engine.ClientMetadata,
+	callerClientID string,
+	hostServiceProxyToCaller bool,
+	fnCall *core.FunctionCall,
+	moduleContext dagql.ObjectResult[*core.Module],
+	envContext dagql.ObjectResult[*core.Env],
+	fn func(ctx context.Context, gqlClient graphql.Client) ([]byte, error),
+) ([]byte, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+	defer l.Close()
+
+	httpSrv := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			telemetry.Propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, moduleContext, fnCall, envContext)
+		}),
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer shutdownCancel()
+		_ = httpSrv.Shutdown(shutdownCtx)
+	}()
+
+	srvErrCh := make(chan error, 1)
+	go func() {
+		err := httpSrv.Serve(l)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			srvErrCh <- err
+		}
+		close(srvErrCh)
+	}()
+
+	gqlClient := graphql.NewClient(fmt.Sprintf("http://%s/query", l.Addr()), nil)
+
+	out, err := fn(ctx, gqlClient)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := checkServerError(srvErrCh); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func checkServerError(srvErrCh <-chan error) error {
+	select {
+	case serveErr, ok := <-srvErrCh:
+		if ok && serveErr != nil {
+			return fmt.Errorf("serve nested client: %w", serveErr)
+		}
+	default:
+	}
+	return nil
+}
+
+// NewNestedClientMetadata returns the caller's client metadata along with
+// fresh metadata for a nested client to evaluate Dang code under.
+func NewNestedClientMetadata(ctx context.Context) (*engine.ClientMetadata, *engine.ClientMetadata, error) {
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nestedClientMetadata := &engine.ClientMetadata{
+		ClientID:          identity.NewID(),
+		ClientSecretToken: identity.NewID(),
+		SessionID:         clientMetadata.SessionID,
+		ClientStableID:    identity.NewID(),
+		ClientVersion:     engine.Version,
+		AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
+		LockMode:          clientMetadata.LockMode,
+	}
+
+	return clientMetadata, nestedClientMetadata, nil
+}
+
+// ConvertError converts an error from Dang evaluation into a *core.Error,
+// preserving GraphQL error extensions as error values.
+func ConvertError(rerr error) *core.Error {
+	var gqlErr *gqlerror.Error
+	if errors.As(rerr, &gqlErr) {
+		dagErr := core.NewError(gqlErr.Message)
+		if gqlErr.Extensions != nil {
+			keys := make([]string, 0, len(gqlErr.Extensions))
+			for k := range gqlErr.Extensions {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				val, err := json.Marshal(gqlErr.Extensions[k])
+				if err != nil {
+					fmt.Println("failed to marshal error value:", err)
+				}
+				dagErr = dagErr.WithValue(k, core.JSON(val))
+			}
+		}
+		return dagErr
+	}
+	return core.NewError(rerr.Error())
+}

--- a/core/sdk/dang/v1/helpers.go
+++ b/core/sdk/dang/v1/helpers.go
@@ -1,0 +1,1149 @@
+package dangv1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/dagger/dagger/core"
+	dangshared "github.com/dagger/dagger/core/sdk/dang/shared"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	telemetry "github.com/dagger/otel-go"
+	"github.com/vito/dang/pkg/dang"
+	"github.com/vito/dang/pkg/hm"
+	"github.com/vito/dang/pkg/introspection"
+	"github.com/vito/dang/pkg/ioctx"
+	"github.com/vito/dang/pkg/querybuilder"
+)
+
+type dangSourceRunner func(context.Context, string) (dang.ValueScope, error)
+
+func (r *runtime) eval(
+	ctx context.Context,
+	query *core.Query,
+	schemaFile dagql.Result[*core.File],
+	nestedClientMetadata *engine.ClientMetadata,
+	callerClientID string,
+	hostServiceProxyToCaller bool,
+	fnCall *core.FunctionCall,
+	moduleContext dagql.ObjectResult[*core.Module],
+	envContext dagql.ObjectResult[*core.Env],
+) ([]byte, error) {
+	return evalDangSource(ctx, query, r.modSource, schemaFile, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, fnCall, moduleContext, envContext, func(ctx context.Context, modSrcDir string) (dang.ValueScope, error) {
+		return dang.RunDir(ctx, modSrcDir, false)
+	}, func(ctx context.Context, env dang.ValueScope) ([]byte, error) {
+		if fnCall.ParentName == "" {
+			srv, err := core.CurrentDagqlServer(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("get dagql server: %w", err)
+			}
+			dagMod, err := initDangModule(ctx, srv, env)
+			if err != nil {
+				return nil, fmt.Errorf("init module: %w", err)
+			}
+			return json.Marshal(dagMod)
+		}
+
+		result, err := callDangFunction(ctx, env, fnCall)
+		if err != nil {
+			return nil, err
+		}
+
+		if flushErr := query.Server.FlushSessionTelemetry(ctx); flushErr != nil {
+			slog.Debug("failed to flush telemetry after Dang eval", "error", flushErr)
+		}
+
+		return json.Marshal(result)
+	})
+}
+
+func evalDangSource(
+	ctx context.Context,
+	query *core.Query,
+	modSource dagql.ObjectResult[*core.ModuleSource],
+	schemaFile dagql.Result[*core.File],
+	nestedClientMetadata *engine.ClientMetadata,
+	callerClientID string,
+	hostServiceProxyToCaller bool,
+	fnCall *core.FunctionCall,
+	moduleContext dagql.ObjectResult[*core.Module],
+	envContext dagql.ObjectResult[*core.Env],
+	runSource dangSourceRunner,
+	withEnv func(context.Context, dang.ValueScope) ([]byte, error),
+) ([]byte, error) {
+	return dangshared.WithNestedClientServer(ctx, query, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, fnCall, moduleContext, envContext, func(ctx context.Context, gqlClient graphql.Client) ([]byte, error) {
+		var intro introspection.Response
+		f, err := schemaFile.Self().Open(ctx, dagql.ObjectResult[*core.File]{Result: schemaFile})
+		if err != nil {
+			return nil, fmt.Errorf("open schema file: %w", err)
+		}
+		defer f.Close()
+		if err := json.NewDecoder(f).Decode(&intro); err != nil {
+			return nil, fmt.Errorf("decode schema: %w", err)
+		}
+
+		ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
+			Name:       "Dagger",
+			Client:     gqlClient,
+			Schema:     intro.Schema,
+			AutoImport: true,
+		})
+
+		stdio := telemetry.SpanStdio(ctx, core.InstrumentationLibrary)
+		ctx = ioctx.StdoutToContext(ctx, stdio.Stdout)
+		ctx = ioctx.StderrToContext(ctx, stdio.Stderr)
+
+		modCtx := modSource.Self().ContextDirectory
+		var env dang.ValueScope
+		err = modCtx.Self().Mount(ctx, modCtx, func(path string) error {
+			modSrcDir := filepath.Join(path, modSource.Self().SourceSubpath)
+			env, err = runSource(ctx, modSrcDir)
+			if err != nil {
+				return fmt.Errorf("run dir: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("mount source: %w", err)
+		}
+
+		return withEnv(ctx, env)
+	})
+}
+
+func runDangDirForModuleTypes(ctx context.Context, dirPath string) (dang.ValueScope, error) {
+	env, err := dang.DeclareDir(ctx, dirPath, false)
+	if err != nil {
+		return nil, fmt.Errorf("declare Dang module types: %w", err)
+	}
+	return env, nil
+}
+
+func callDangFunction(ctx context.Context, env dang.ValueScope, fnCall *core.FunctionCall) (dang.Value, error) {
+	inputArgs := make(map[string][]byte, len(fnCall.InputArgs))
+	for _, arg := range fnCall.InputArgs {
+		inputArgs[arg.Name] = []byte(arg.Value)
+	}
+
+	parentModBase, found, err := env.Lookup(ctx, fnCall.ParentName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup parent type %s: %w", fnCall.ParentName, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown parent type: %s", fnCall.ParentName)
+	}
+
+	var parentState map[string]any
+	dec := json.NewDecoder(bytes.NewReader(fnCall.Parent))
+	dec.UseNumber()
+	if err := dec.Decode(&parentState); err != nil {
+		return nil, fmt.Errorf("unmarshal parent: %w", err)
+	}
+
+	parentConstructor := parentModBase.(*dang.ConstructorFunction)
+	parentModType := parentConstructor.ObjectType
+	// Use the class file's captured env so rehydrated method calls keep the
+	// imports that were in scope when the type was declared.
+	parentClosure := parentConstructor.Closure
+
+	var fnType *hm.FunctionType
+	if fnCall.Name == "" {
+		fnType = parentConstructor.FnType
+	} else {
+		fnScheme, found := parentModType.SchemeOf(fnCall.Name)
+		if !found {
+			return nil, fmt.Errorf("unknown function: %s", fnCall.Name)
+		}
+		t, mono := fnScheme.Type()
+		if !mono {
+			return nil, fmt.Errorf("non-monotype function %s", fnCall.Name)
+		}
+		var ok bool
+		fnType, ok = t.(*hm.FunctionType)
+		if !ok {
+			return nil, fmt.Errorf("expected function type, got %T", fnScheme)
+		}
+	}
+
+	var args dang.Record
+	argMap := make(map[string]dang.Value, len(args))
+	for _, arg := range fnType.Arg().(*dang.RecordType).Fields {
+		argType, mono := arg.Value.Type()
+		if !mono {
+			return nil, fmt.Errorf("non-monotype argument %s", arg.Key)
+		}
+		jsonValue, provided := inputArgs[arg.Key]
+		if !provided {
+			continue
+		}
+		dec := json.NewDecoder(bytes.NewReader(jsonValue))
+		dec.UseNumber()
+		var val any
+		if err := dec.Decode(&val); err != nil {
+			return nil, fmt.Errorf("unmarshal arg %s: %w", arg.Key, err)
+		}
+		dangVal, err := anyToDang(ctx, parentClosure, val, argType)
+		if err != nil {
+			return nil, fmt.Errorf("convert arg %s: %w", arg.Key, err)
+		}
+		argMap[arg.Key] = dangVal
+		args = append(args, dang.Keyed[dang.Node]{
+			Key:   arg.Key,
+			Value: &dang.ValueNode{Val: dangVal},
+		})
+	}
+
+	if fnCall.Name == "" {
+		return parentConstructor.Call(ctx, env, argMap)
+	}
+
+	parentModEnv := dang.NewObject(parentModType)
+
+	for name, value := range parentState {
+		scheme, found := parentModType.SchemeOf(name)
+		if !found {
+			return nil, fmt.Errorf("unknown field: %s", name)
+		}
+		fieldType, isMono := scheme.Type()
+		if !isMono {
+			return nil, fmt.Errorf("non-monotype field %s", name)
+		}
+		dangVal, err := anyToDang(ctx, parentClosure, value, fieldType)
+		if err != nil {
+			return nil, fmt.Errorf("convert field %s: %w", name, err)
+		}
+		parentModEnv.Bind(name, dangVal, dang.PrivateVisibility)
+	}
+
+	bodyEnv := dang.CreateOverlayValueScope(parentModEnv, parentClosure)
+	bodyEnv.EnterSelf(parentModEnv)
+	_, err = dang.EvaluateFormsWithPhases(ctx, parentConstructor.ObjectBodyForms, bodyEnv)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating class body for %s: %w", parentConstructor.ObjectName, err)
+	}
+
+	call := &dang.FunCall{
+		Fun: &dang.Select{
+			Receiver: &dang.ValueNode{Val: parentModEnv},
+			Field:    &dang.Symbol{Name: fnCall.Name},
+		},
+		Args: args,
+	}
+	return call.Eval(ctx, bodyEnv)
+}
+
+type dangLocalTypes struct {
+	modules map[*dang.Type]struct{}
+}
+
+func dangEvalModule(env dang.ValueScope) (dang.TypeScope, bool) {
+	modVal, ok := env.(*dang.Object)
+	if !ok {
+		return nil, false
+	}
+	return modVal.Mod, true
+}
+
+func collectDangLocalTypes(env dang.ValueScope) dangLocalTypes {
+	local := dangLocalTypes{modules: map[*dang.Type]struct{}{}}
+	mod, ok := dangEvalModule(env)
+	if !ok {
+		return local
+	}
+	for name, namedType := range mod.NamedTypes() {
+		origin, found := mod.LocalTypeOrigin(name)
+		if !found || origin.Kind != dang.BindingOriginLocal {
+			continue
+		}
+		if localMod, ok := namedType.(*dang.Type); ok {
+			local.modules[localMod] = struct{}{}
+		}
+	}
+	return local
+}
+
+func isDangLocalValueBinding(env dang.ValueScope, name string) bool {
+	mod, ok := dangEvalModule(env)
+	if !ok {
+		return true
+	}
+	origin, found := mod.LocalValueOrigin(name)
+	return !found || origin.Kind == dang.BindingOriginLocal
+}
+
+func (local dangLocalTypes) contains(mod *dang.Type) bool {
+	_, ok := local.modules[mod]
+	return ok
+}
+
+func dangLocalTypeName(name string) string {
+	return "DangSDKLocalType" + name
+}
+
+func withDangLocalName[T dagql.Typed](
+	ctx context.Context,
+	srv *dagql.Server,
+	typeDef dagql.ObjectResult[*core.TypeDef],
+	res dagql.ObjectResult[T],
+	temporaryName string,
+	kind string,
+	withField string,
+	argName string,
+) (dagql.ObjectResult[*core.TypeDef], error) {
+	var renamed dagql.ObjectResult[T]
+	if err := srv.Select(ctx, res, &renamed, dagql.Selector{
+		Field: "__withName",
+		Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(temporaryName)}},
+	}); err != nil {
+		return typeDef, fmt.Errorf("mark local %s type: %w", kind, err)
+	}
+	renamedID, err := core.ResultIDInput(renamed)
+	if err != nil {
+		return typeDef, fmt.Errorf("local %s type ID: %w", kind, err)
+	}
+	var updated dagql.ObjectResult[*core.TypeDef]
+	if err := srv.Select(ctx, typeDef, &updated, dagql.Selector{
+		Field: withField,
+		Args:  []dagql.NamedInput{{Name: argName, Value: renamedID}},
+	}); err != nil {
+		return typeDef, fmt.Errorf("mark local %s typedef: %w", kind, err)
+	}
+	return updated, nil
+}
+
+// markDangLocalType gives a local Dang type a temporary, non-core schema name
+// while preserving its OriginalName. Core's Module.WithObject namespacing later
+// uses OriginalName to produce the final module-prefixed name; the temporary
+// Name only prevents local references like Container from being mistaken for
+// daggercore.Container before namespacing runs.
+func markDangLocalType(ctx context.Context, srv *dagql.Server, typeDef dagql.ObjectResult[*core.TypeDef], name string) (dagql.ObjectResult[*core.TypeDef], error) {
+	if name == "" || typeDef.Self() == nil {
+		return typeDef, nil
+	}
+	temporaryName := dangLocalTypeName(name)
+	switch typeDef.Self().Kind {
+	case core.TypeDefKindObject:
+		return withDangLocalName(ctx, srv, typeDef, typeDef.Self().AsObject.Value, temporaryName, "object", "__withObjectTypeDef", "objectTypeDef")
+	case core.TypeDefKindInterface:
+		return withDangLocalName(ctx, srv, typeDef, typeDef.Self().AsInterface.Value, temporaryName, "interface", "__withInterfaceTypeDef", "interfaceTypeDef")
+	case core.TypeDefKindEnum:
+		return withDangLocalName(ctx, srv, typeDef, typeDef.Self().AsEnum.Value, temporaryName, "enum", "__withEnumTypeDef", "enumTypeDef")
+	default:
+		return typeDef, nil
+	}
+}
+
+func initDangModule(ctx context.Context, srv *dagql.Server, env dang.ValueScope) (res dagql.ObjectResult[*core.Module], _ error) {
+	localTypes := collectDangLocalTypes(env)
+	sels := []dagql.Selector{
+		{
+			Field: "module",
+		},
+	}
+
+	binds := env.Bindings(dang.PublicVisibility)
+	for _, binding := range binds {
+		if !isDangLocalValueBinding(env, binding.Key) {
+			continue
+		}
+		switch val := binding.Value.(type) {
+		case *dang.ConstructorFunction:
+			objDef, err := createObjectTypeDef(ctx, srv, binding.Key, val, env, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create object %s: %w", binding.Key, err)
+			}
+			fnDef, err := createFunction(ctx, srv, val.ObjectType, binding.Key, val.FnType, env, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create constructor for %s: %w", binding.Key, err)
+			}
+			fnDefID, err := fnDef.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get constructor ID for %s: %w", binding.Key, err)
+			}
+
+			var objDefWithCtor dagql.ObjectResult[*core.TypeDef]
+			if err := srv.Select(ctx, objDef, &objDefWithCtor, dagql.Selector{
+				Field: "withConstructor",
+				Args:  []dagql.NamedInput{{Name: "function", Value: dagql.NewID[*core.Function](fnDefID)}},
+			}); err != nil {
+				return res, fmt.Errorf("failed to add constructor to object: %w", err)
+			}
+			objDefWithCtorID, err := objDefWithCtor.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get object typedef ID for %s: %w", binding.Key, err)
+			}
+
+			sels = append(sels, dagql.Selector{
+				Field: "withObject",
+				Args:  []dagql.NamedInput{{Name: "object", Value: dagql.NewID[*core.TypeDef](objDefWithCtorID)}},
+			})
+
+		case *dang.Object:
+			mod, ok := val.Mod.(*dang.Type)
+			if !ok {
+				slog.Warn("skipping non-module module value", "name", binding.Key)
+				break
+			}
+			switch mod.Kind {
+			case dang.EnumKind:
+				enumDef, err := createEnumTypeDef(ctx, srv, binding.Key, val, localTypes)
+				if err != nil {
+					return res, fmt.Errorf("failed to create enum %s: %w", binding.Key, err)
+				}
+				enumDefID, err := enumDef.ID()
+				if err != nil {
+					return res, fmt.Errorf("failed to get enum typedef ID for %s: %w", binding.Key, err)
+				}
+				sels = append(sels, dagql.Selector{
+					Field: "withEnum",
+					Args:  []dagql.NamedInput{{Name: "enum", Value: dagql.NewID[*core.TypeDef](enumDefID)}},
+				})
+			case dang.ScalarKind:
+				slog.Info("skipping scalar module value (handled as string type)", "name", binding.Key)
+			case dang.InterfaceKind:
+				interfaceDef, err := createInterfaceTypeDef(ctx, srv, binding.Key, val, env, localTypes)
+				if err != nil {
+					return res, fmt.Errorf("failed to create interface %s: %w", binding.Key, err)
+				}
+				interfaceDefID, err := interfaceDef.ID()
+				if err != nil {
+					return res, fmt.Errorf("failed to get interface typedef ID for %s: %w", binding.Key, err)
+				}
+				sels = append(sels, dagql.Selector{
+					Field: "withInterface",
+					Args:  []dagql.NamedInput{{Name: "iface", Value: dagql.NewID[*core.TypeDef](interfaceDefID)}},
+				})
+			default:
+				slog.Warn("unknown module kind", "name", binding.Key, "kind", mod.Kind)
+			}
+
+		default:
+			slog.Info("skipping non-class public binding", "name", binding.Key, "type", fmt.Sprintf("%T", val))
+		}
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to select module: %w", err)
+	}
+
+	return res, nil
+}
+
+func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name string, fn *hm.FunctionType, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.Function], error) {
+	var res dagql.ObjectResult[*core.Function]
+
+	retTypeDef, err := dangTypeToTypeDef(ctx, srv, fn.Ret(false), localTypes)
+	if err != nil {
+		return res, fmt.Errorf("failed to convert return type for %s: %w", fn, err)
+	}
+	retTypeDefID, err := retTypeDef.ID()
+	if err != nil {
+		return res, fmt.Errorf("failed to get return type ID for %s: %w", name, err)
+	}
+
+	sels := []dagql.Selector{
+		{
+			Field: "function",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(name)},
+				{Name: "returnType", Value: dagql.NewID[*core.TypeDef](retTypeDefID)},
+			},
+		},
+	}
+
+	if desc, ok := mod.GetDocString(name); ok {
+		sels = append(sels, dagql.Selector{
+			Field: "withDescription",
+			Args:  []dagql.NamedInput{{Name: "description", Value: dagql.String(desc)}},
+		})
+	}
+
+	dirSels, err := functionDirectiveSelectors(ctx, env, mod.GetDirectives(name))
+	if err != nil {
+		return res, fmt.Errorf("directives for %s: %w", name, err)
+	}
+	sels = append(sels, dirSels...)
+
+	args := fn.Arg().(*dang.RecordType)
+	for _, arg := range args.Fields {
+		argType, mono := arg.Value.Type()
+		if !mono {
+			return res, fmt.Errorf("non-monotype argument %s", arg.Key)
+		}
+		typeDef, err := dangTypeToTypeDef(ctx, srv, argType, localTypes)
+		if err != nil {
+			return res, fmt.Errorf("failed to convert argument type for %s: %w", arg.Key, err)
+		}
+
+		if _, isNonNull := argType.(hm.NonNullType); !isNonNull {
+			var optTypeDef dagql.ObjectResult[*core.TypeDef]
+			if err := srv.Select(ctx, typeDef, &optTypeDef, dagql.Selector{
+				Field: "withOptional",
+				Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
+			}); err != nil {
+				return res, fmt.Errorf("failed to make argument optional: %w", err)
+			}
+			typeDef = optTypeDef
+		}
+		typeDefID, err := typeDef.ID()
+		if err != nil {
+			return res, fmt.Errorf("failed to get argument type ID for %s: %w", arg.Key, err)
+		}
+
+		argArgs := []dagql.NamedInput{
+			{Name: "name", Value: dagql.String(arg.Key)},
+			{Name: "typeDef", Value: dagql.NewID[*core.TypeDef](typeDefID)},
+		}
+
+		if doc := args.DocStrings[arg.Key]; doc != "" {
+			argArgs = append(argArgs, dagql.NamedInput{Name: "description", Value: dagql.String(doc)})
+		}
+
+		argArgs, err = applyArgDirectives(ctx, env, argArgs, arg.Key, args.Directives)
+		if err != nil {
+			return res, err
+		}
+
+		sels = append(sels, dagql.Selector{
+			Field: "withArg",
+			Args:  argArgs,
+		})
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to create function: %w", err)
+	}
+
+	return res, nil
+}
+
+// functionDirectiveSelectors converts function-level directives (@check,
+// @generate, @up, @cache) into dagql selectors.
+func functionDirectiveSelectors(ctx context.Context, env dang.ValueScope, directives []*dang.DirectiveApplication) ([]dagql.Selector, error) {
+	var sels []dagql.Selector
+	for _, directive := range directives {
+		switch directive.Name {
+		case "check":
+			sels = append(sels, dagql.Selector{Field: "withCheck"})
+		case "generate":
+			sels = append(sels, dagql.Selector{Field: "withGenerator"})
+		case "up":
+			sels = append(sels, dagql.Selector{Field: "withUp"})
+		case "cache":
+			sel, err := cacheDirectiveSelector(ctx, env, directive)
+			if err != nil {
+				return nil, err
+			}
+			sels = append(sels, sel)
+		}
+	}
+	return sels, nil
+}
+
+// cacheDirectiveSelector converts a @cache directive into a withCachePolicy selector.
+func cacheDirectiveSelector(ctx context.Context, env dang.ValueScope, directive *dang.DirectiveApplication) (dagql.Selector, error) {
+	var policy core.FunctionCachePolicy
+	var ttl string
+	for _, arg := range directive.Args {
+		val, err := evalDirectiveArg(ctx, env, arg.Value)
+		if err != nil {
+			return dagql.Selector{}, fmt.Errorf("failed to evaluate @cache argument %s: %w", arg.Key, err)
+		}
+		switch arg.Key {
+		case "policy":
+			if s, ok := val.(string); ok {
+				policy = core.FunctionCachePolicy(s)
+			}
+		case "ttl":
+			if s, ok := val.(string); ok {
+				ttl = s
+			}
+		}
+	}
+	if policy == "" {
+		policy = core.FunctionCachePolicyDefault
+	}
+	args := []dagql.NamedInput{
+		{Name: "policy", Value: policy},
+	}
+	if ttl != "" {
+		args = append(args, dagql.NamedInput{Name: "timeToLive", Value: dagql.Opt(dagql.String(ttl))})
+	}
+	return dagql.Selector{Field: "withCachePolicy", Args: args}, nil
+}
+
+// applyArgDirectives processes argument-level directives (@defaultPath,
+// @ignorePatterns) and appends the resulting inputs to argArgs.
+func applyArgDirectives(ctx context.Context, env dang.ValueScope, argArgs []dagql.NamedInput, argName string, allDirs []dang.Keyed[[]*dang.DirectiveApplication]) ([]dagql.NamedInput, error) {
+	for _, argDirs := range allDirs {
+		if argDirs.Key != argName {
+			continue
+		}
+		for _, dir := range argDirs.Value {
+			switch dir.Name {
+			case "defaultPath":
+				for _, a := range dir.Args {
+					if a.Key == "path" { // TODO: positional
+						val, err := evalDirectiveArg(ctx, env, a.Value)
+						if err != nil {
+							return nil, fmt.Errorf("@defaultPath.path for %s: %w", argName, err)
+						}
+						if path, ok := val.(string); ok {
+							argArgs = append(argArgs, dagql.NamedInput{Name: "defaultPath", Value: dagql.String(path)})
+						}
+					}
+				}
+			case "ignorePatterns":
+				for _, a := range dir.Args {
+					if a.Key == "patterns" {
+						val, err := evalDirectiveArg(ctx, env, a.Value)
+						if err != nil {
+							return nil, fmt.Errorf("@ignorePatterns.patterns for %s: %w", argName, err)
+						}
+						ignore, ok := val.([]any)
+						if !ok {
+							return nil, fmt.Errorf("@ignorePatterns for %s: expected []any, got %T", argName, val)
+						}
+						var patterns []string
+						for _, p := range ignore {
+							str, ok := p.(string)
+							if !ok {
+								return nil, fmt.Errorf("@ignorePatterns for %s: expected string element, got %T", argName, p)
+							}
+							patterns = append(patterns, str)
+						}
+						if len(patterns) > 0 {
+							argArgs = append(argArgs, dagql.NamedInput{Name: "ignore", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(patterns...))})
+						}
+					}
+				}
+			}
+		}
+	}
+	return argArgs, nil
+}
+
+// evalDirectiveArg evaluates a directive argument AST node through the Dang
+// runtime and converts the resulting Value to a plain Go value.
+func evalDirectiveArg(ctx context.Context, env dang.ValueScope, node dang.Node) (any, error) {
+	val, err := dang.EvalNode(ctx, env, node)
+	if err != nil {
+		return nil, err
+	}
+	return dangValToGo(val)
+}
+
+// dangValToGo converts a Dang Value to a plain Go value.
+func dangValToGo(val dang.Value) (any, error) {
+	switch v := val.(type) {
+	case dang.StringValue:
+		return v.Val, nil
+	case dang.IntValue:
+		return v.Val, nil
+	case dang.BoolValue:
+		return v.Val, nil
+	case dang.EnumValue:
+		return v.Val, nil
+	case dang.ListValue:
+		elements := make([]any, len(v.Elements))
+		for i, elem := range v.Elements {
+			g, err := dangValToGo(elem)
+			if err != nil {
+				return nil, fmt.Errorf("list element %d: %w", i, err)
+			}
+			elements[i] = g
+		}
+		return elements, nil
+	case dang.NullValue:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported directive argument value type: %T", val)
+	}
+}
+
+func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, module *dang.ConstructorFunction, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+	var res dagql.ObjectResult[*core.TypeDef]
+
+	classMod := module.ObjectType
+	withObjectArgs := []dagql.NamedInput{{Name: "name", Value: dagql.String(name)}}
+	if desc := classMod.GetTypeDocString(); desc != "" {
+		withObjectArgs = append(withObjectArgs, dagql.NamedInput{Name: "description", Value: dagql.String(desc)})
+	}
+
+	sels := []dagql.Selector{
+		{Field: "typeDef"},
+		{
+			Field: "withObject",
+			Args:  withObjectArgs,
+		},
+	}
+
+	for _, form := range module.ObjectBodyForms {
+		slot, ok := form.(*dang.FieldDecl)
+		if !ok || slot.Visibility < dang.PublicVisibility {
+			continue
+		}
+
+		bindingName := slot.Name.Name
+		scheme, found := classMod.LocalSchemeOf(bindingName)
+		if !found {
+			return res, fmt.Errorf("missing local slot %s for %s", bindingName, name)
+		}
+
+		slotType, isMono := scheme.Type()
+		if !isMono {
+			return res, fmt.Errorf("non-monotype method %s", bindingName)
+		}
+		switch x := slotType.(type) {
+		case *hm.FunctionType:
+			fnDef, err := createFunction(ctx, srv, classMod, bindingName, x, env, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create method %s for %s: %w", bindingName, name, err)
+			}
+			fnDefID, err := fnDef.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get function ID for %s: %w", bindingName, err)
+			}
+
+			sels = append(sels, dagql.Selector{
+				Field: "withFunction",
+				Args:  []dagql.NamedInput{{Name: "function", Value: dagql.NewID[*core.Function](fnDefID)}},
+			})
+		default:
+			fieldDef, err := dangTypeToTypeDef(ctx, srv, slotType, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create field %s: %w", bindingName, err)
+			}
+			fieldDefID, err := fieldDef.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get field type ID for %s: %w", bindingName, err)
+			}
+
+			fieldArgs := []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(bindingName)},
+				{Name: "typeDef", Value: dagql.NewID[*core.TypeDef](fieldDefID)},
+			}
+
+			if desc, ok := classMod.GetDocString(bindingName); ok {
+				fieldArgs = append(fieldArgs, dagql.NamedInput{Name: "description", Value: dagql.String(desc)})
+			}
+
+			sels = append(sels, dagql.Selector{
+				Field: "withField",
+				Args:  fieldArgs,
+			})
+		}
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to create object typedef: %w", err)
+	}
+	if localTypes.contains(classMod) {
+		var err error
+		res, err = markDangLocalType(ctx, srv, res, name)
+		if err != nil {
+			return res, fmt.Errorf("failed to mark local object typedef: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func dangTypeToTypeDef(ctx context.Context, srv *dagql.Server, dangType hm.Type, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+	var res dagql.ObjectResult[*core.TypeDef]
+
+	sels := []dagql.Selector{{Field: "typeDef"}}
+
+	if nonNull, isNonNull := dangType.(hm.NonNullType); isNonNull {
+		inner, err := dangTypeToTypeDef(ctx, srv, nonNull.Type, localTypes)
+		if err != nil {
+			return res, fmt.Errorf("failed to convert non-null type: %w", err)
+		}
+		if err := srv.Select(ctx, inner, &res, dagql.Selector{
+			Field: "withOptional",
+			Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(false)}},
+		}); err != nil {
+			return res, err
+		}
+		return res, nil
+	}
+
+	sels = append(sels, dagql.Selector{
+		Field: "withOptional",
+		Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
+	})
+
+	switch t := dangType.(type) {
+	case dang.ListType:
+		elemTypeDef, err := dangTypeToTypeDef(ctx, srv, t.Type, localTypes)
+		if err != nil {
+			return res, fmt.Errorf("failed to convert list element type: %w", err)
+		}
+		elemTypeDefID, err := elemTypeDef.ID()
+		if err != nil {
+			return res, fmt.Errorf("failed to get list element type ID: %w", err)
+		}
+		sels = append(sels, dagql.Selector{
+			Field: "withListOf",
+			Args: []dagql.NamedInput{
+				{Name: "elementType", Value: dagql.NewID[*core.TypeDef](elemTypeDefID)},
+			},
+		})
+	case *dang.Type:
+		switch t.Named {
+		case "String":
+			sels = append(sels, dagql.Selector{
+				Field: "withKind",
+				Args:  []dagql.NamedInput{{Name: "kind", Value: core.TypeDefKindString}},
+			})
+		case "Int":
+			sels = append(sels, dagql.Selector{
+				Field: "withKind",
+				Args:  []dagql.NamedInput{{Name: "kind", Value: core.TypeDefKindInteger}},
+			})
+		case "Boolean":
+			sels = append(sels, dagql.Selector{
+				Field: "withKind",
+				Args:  []dagql.NamedInput{{Name: "kind", Value: core.TypeDefKindBoolean}},
+			})
+		case "Void":
+			sels = append(sels, dagql.Selector{
+				Field: "withKind",
+				Args:  []dagql.NamedInput{{Name: "kind", Value: core.TypeDefKindVoid}},
+			})
+		case "":
+			return res, fmt.Errorf("cannot directly expose ad-hoc object type: %s", t)
+		default:
+			switch t.Kind {
+			case dang.EnumKind:
+				sels = append(sels, dagql.Selector{
+					Field: "withEnum",
+					Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(t.Named)}},
+				})
+			case dang.ScalarKind:
+				sels = append(sels, dagql.Selector{
+					Field: "withKind",
+					Args:  []dagql.NamedInput{{Name: "kind", Value: core.TypeDefKindString}},
+				})
+			case dang.InterfaceKind:
+				sels = append(sels, dagql.Selector{
+					Field: "withInterface",
+					Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(t.Named)}},
+				})
+			default:
+				sels = append(sels, dagql.Selector{
+					Field: "withObject",
+					Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(t.Named)}},
+				})
+			}
+		}
+	default:
+		return res, fmt.Errorf("unknown type: %T: %s", dangType, dangType)
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to select typedef: %w", err)
+	}
+	if mod, ok := dangType.(*dang.Type); ok && localTypes.contains(mod) {
+		var err error
+		res, err = markDangLocalType(ctx, srv, res, mod.Named)
+		if err != nil {
+			return res, fmt.Errorf("failed to mark local typedef: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func createEnumTypeDef(ctx context.Context, srv *dagql.Server, name string, enumMod *dang.Object, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+	var res dagql.ObjectResult[*core.TypeDef]
+
+	sels := []dagql.Selector{
+		{Field: "typeDef"},
+		{
+			Field: "withEnum",
+			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(name)}},
+		},
+	}
+
+	for memberName, val := range enumMod.Values {
+		if _, ok := val.(dang.EnumValue); !ok {
+			continue
+		}
+		sels = append(sels, dagql.Selector{
+			Field: "withEnumMember",
+			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(memberName)}},
+		})
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to create enum typedef: %w", err)
+	}
+	if mod, ok := enumMod.Mod.(*dang.Type); ok && localTypes.contains(mod) {
+		var err error
+		res, err = markDangLocalType(ctx, srv, res, name)
+		if err != nil {
+			return res, fmt.Errorf("failed to mark local enum typedef: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func createInterfaceTypeDef(ctx context.Context, srv *dagql.Server, name string, interfaceMod *dang.Object, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+	var res dagql.ObjectResult[*core.TypeDef]
+
+	mod, ok := interfaceMod.Mod.(*dang.Type)
+	if !ok {
+		return res, fmt.Errorf("expected *dang.Type for interface %s, got %T", name, interfaceMod.Mod)
+	}
+
+	sels := []dagql.Selector{
+		{Field: "typeDef"},
+		{
+			Field: "withInterface",
+			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(name)}},
+		},
+	}
+
+	for fieldName, scheme := range mod.Bindings(dang.PublicVisibility) {
+		fieldType, isMono := scheme.Type()
+		if !isMono {
+			return res, fmt.Errorf("non-monotype field %s in interface %s", fieldName, name)
+		}
+		switch x := fieldType.(type) {
+		case *hm.FunctionType:
+			fnDef, err := createFunction(ctx, srv, mod, fieldName, x, env, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create method %s for interface %s: %w", fieldName, name, err)
+			}
+			fnDefID, err := fnDef.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get function ID for %s: %w", fieldName, err)
+			}
+			sels = append(sels, dagql.Selector{
+				Field: "withFunction",
+				Args:  []dagql.NamedInput{{Name: "function", Value: dagql.NewID[*core.Function](fnDefID)}},
+			})
+		default:
+			fieldTypeDef, err := dangTypeToTypeDef(ctx, srv, fieldType, localTypes)
+			if err != nil {
+				return res, fmt.Errorf("failed to create field %s for interface %s: %w", fieldName, name, err)
+			}
+			fieldTypeDefID, err := fieldTypeDef.ID()
+			if err != nil {
+				return res, fmt.Errorf("failed to get field type ID for %s: %w", fieldName, err)
+			}
+			fieldArgs := []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(fieldName)},
+				{Name: "typeDef", Value: dagql.NewID[*core.TypeDef](fieldTypeDefID)},
+			}
+			if desc, ok := mod.GetDocString(fieldName); ok {
+				fieldArgs = append(fieldArgs, dagql.NamedInput{Name: "description", Value: dagql.String(desc)})
+			}
+			sels = append(sels, dagql.Selector{
+				Field: "withField",
+				Args:  fieldArgs,
+			})
+		}
+	}
+
+	if err := srv.Select(ctx, srv.Root(), &res, sels...); err != nil {
+		return res, fmt.Errorf("failed to create interface typedef: %w", err)
+	}
+	if localTypes.contains(mod) {
+		var err error
+		res, err = markDangLocalType(ctx, srv, res, name)
+		if err != nil {
+			return res, fmt.Errorf("failed to mark local interface typedef: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func anyToDang(ctx context.Context, env dang.ValueScope, val any, fieldType hm.Type) (dang.Value, error) {
+	if nonNull, ok := fieldType.(hm.NonNullType); ok {
+		return anyToDang(ctx, env, val, nonNull.Type)
+	}
+	switch v := val.(type) {
+	case string:
+		return stringToDang(ctx, env, v, fieldType)
+	case int:
+		return dang.IntValue{Val: v}, nil
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert json.Number to int64: %w", err)
+		}
+		return dang.IntValue{Val: int(i)}, nil
+	case bool:
+		return dang.BoolValue{Val: v}, nil
+	case []any:
+		return listToDang(ctx, env, v, fieldType)
+	case map[string]any:
+		return mapToDang(ctx, env, v, fieldType)
+	case nil:
+		return dang.NullValue{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", val)
+	}
+}
+
+func stringToDang(ctx context.Context, env dang.ValueScope, val string, fieldType hm.Type) (dang.Value, error) {
+	modType, isMod := fieldType.(*dang.Type)
+	if !isMod {
+		return dang.StringValue{Val: val}, nil
+	}
+	if modType == dang.StringType {
+		return dang.StringValue{Val: val}, nil
+	}
+
+	switch modType.Kind {
+	case dang.EnumKind:
+		return enumStringToDang(ctx, env, val, modType)
+	case dang.ScalarKind:
+		return dang.ScalarValue{Val: val, ScalarType: modType}, nil
+	default:
+		return objectIDToDang(ctx, env, val, modType)
+	}
+}
+
+func enumStringToDang(ctx context.Context, env dang.ValueScope, val string, modType *dang.Type) (dang.Value, error) {
+	enumVal, found, err := env.Lookup(ctx, modType.Named)
+	if err != nil {
+		return nil, fmt.Errorf("lookup enum type %s: %w", modType.Named, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("enum type %s not found in environment", modType.Named)
+	}
+
+	enumMod, ok := enumVal.(*dang.Object)
+	if !ok {
+		return nil, fmt.Errorf("enum type %s not found in environment", modType.Named)
+	}
+
+	member, found, err := enumMod.Lookup(ctx, val)
+	if err != nil {
+		return nil, fmt.Errorf("lookup enum value %s.%s: %w", modType.Named, val, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown enum value %s.%s", modType.Named, val)
+	}
+	return member, nil
+}
+
+func objectIDToDang(ctx context.Context, env dang.ValueScope, id string, modType *dang.Type) (dang.Value, error) {
+	nodeVal, found, err := env.Lookup(ctx, "node")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("node field not found in environment")
+	}
+	nodeFn, ok := nodeVal.(dang.GraphQLFunction)
+	if !ok {
+		return nil, fmt.Errorf("node field is %T, not dang.GraphQLFunction", nodeVal)
+	}
+
+	field := *nodeFn.Field
+	field.TypeRef = &introspection.TypeRef{
+		Kind: introspection.TypeKindNonNull,
+		OfType: &introspection.TypeRef{
+			Kind: introspection.TypeKindObject,
+			Name: modType.Named,
+		},
+	}
+	if schemaType := nodeFn.Schema.Types.Get(modType.Named); schemaType != nil {
+		field.TypeRef.OfType.Kind = schemaType.Kind
+	}
+
+	return dang.GraphQLValue{
+		Name:       "node",
+		TypeName:   modType.Named,
+		Field:      &field,
+		ValType:    hm.NonNullType{Type: modType},
+		Client:     nodeFn.Client,
+		Schema:     nodeFn.Schema,
+		TypeScope:  nodeFn.TypeScope,
+		QueryChain: querybuilder.Query().Select("node").Arg("id", id).InlineFragment(modType.Named),
+	}, nil
+}
+
+func listToDang(ctx context.Context, env dang.ValueScope, vals []any, fieldType hm.Type) (dang.Value, error) {
+	listT, isList := fieldType.(dang.ListType)
+	if !isList {
+		return nil, fmt.Errorf("expected list type, got %T", fieldType)
+	}
+
+	listVal := dang.ListValue{ElemType: listT}
+	for _, item := range vals {
+		itemVal, err := anyToDang(ctx, env, item, listT.Type)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert list item: %w", err)
+		}
+		listVal.Elements = append(listVal.Elements, itemVal)
+	}
+	return listVal, nil
+}
+
+func mapToDang(ctx context.Context, env dang.ValueScope, vals map[string]any, fieldType hm.Type) (dang.Value, error) {
+	mod, isMod := fieldType.(dang.TypeScope)
+	if !isMod {
+		return nil, fmt.Errorf("expected module type, got %T", fieldType)
+	}
+
+	modVal := dang.NewObject(mod)
+	for name, val := range vals {
+		expectedT, found := mod.SchemeOf(name)
+		if !found {
+			return nil, fmt.Errorf("module %q does not have a scheme for %q", mod.Name(), name)
+		}
+		t, isMono := expectedT.Type()
+		if !isMono {
+			return nil, fmt.Errorf("expected monomorphic type, got %T", t)
+		}
+		dangVal, err := anyToDang(ctx, env, val, t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert map item %q: %w", name, err)
+		}
+		modVal.Bind(name, dangVal, dang.PrivateVisibility)
+	}
+
+	if err := evaluateDangClassBody(ctx, env, mod, modVal); err != nil {
+		return nil, err
+	}
+	return modVal, nil
+}
+
+func evaluateDangClassBody(ctx context.Context, env dang.ValueScope, mod dang.TypeScope, modVal *dang.Object) error {
+	if mod.Name() == "" {
+		return nil
+	}
+
+	constructor, found, err := env.Lookup(ctx, mod.Name())
+	if err != nil {
+		return fmt.Errorf("lookup constructor %s: %w", mod.Name(), err)
+	}
+	if !found {
+		return nil
+	}
+
+	constructorFn, ok := constructor.(*dang.ConstructorFunction)
+	if !ok {
+		return nil
+	}
+
+	bodyEnv := dang.CreateOverlayValueScope(modVal, env)
+	bodyEnv.EnterSelf(modVal)
+	_, err = dang.EvaluateFormsWithPhases(ctx, constructorFn.ObjectBodyForms, bodyEnv)
+	if err != nil {
+		return fmt.Errorf("evaluating class body for %s: %w", mod.Name(), err)
+	}
+	return nil
+}

--- a/core/sdk/dang/v1/sdk.go
+++ b/core/sdk/dang/v1/sdk.go
@@ -1,0 +1,123 @@
+// Package dangv1 evaluates Dagger modules written against Dang v1
+// (github.com/vito/dang: `.{ }` is selection, `.{{ }}` does not exist).
+//
+// This is a FROZEN snapshot of the living implementation, taken when Dang v2
+// shipped: it gets no feature work, only compiler-forced updates when engine
+// internals change and critical bugfix backports. See core/sdk/dang/README.md
+// for the maintenance policy.
+package dangv1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/core"
+	dangshared "github.com/dagger/dagger/core/sdk/dang/shared"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/vito/dang/pkg/dang"
+)
+
+// Impl is the Dang v1 implementation behind the dang SDK's version dispatch.
+type Impl struct{}
+
+func (Impl) ModuleTypes(
+	ctx context.Context,
+	deps *core.SchemaBuilder,
+	src dagql.ObjectResult[*core.ModuleSource],
+	scopedMod dagql.ObjectResult[*core.Module],
+) (inst dagql.ObjectResult[*core.Module], rerr error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag for dang module sdk module types: %w", err)
+	}
+
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFileForModule(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get schema introspection json during dang module sdk module types: %w", err)
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("current query: %w", err)
+	}
+
+	clientMetadata, nestedClientMetadata, err := dangshared.NewNestedClientMetadata(ctx)
+	if err != nil {
+		return inst, err
+	}
+
+	runner := dangSourceRunner(func(ctx context.Context, modSrcDir string) (dang.ValueScope, error) {
+		return dang.RunDir(ctx, modSrcDir, false)
+	})
+	if src.Self().SDK.ExperimentalFeatureEnabled(core.ModuleSourceExperimentalFeatureSelfCalls) {
+		runner = runDangDirForModuleTypes
+	}
+
+	_, err = evalDangSource(ctx, query, src, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, nil, scopedMod, dagql.ObjectResult[*core.Env]{}, runner, func(ctx context.Context, env dang.ValueScope) ([]byte, error) {
+		inst, err = initDangModule(ctx, dag, env)
+		if err != nil {
+			return nil, fmt.Errorf("init module: %w", err)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return inst, err
+	}
+	return inst, nil
+}
+
+func (Impl) Runtime(
+	ctx context.Context,
+	deps *core.SchemaBuilder,
+	source dagql.ObjectResult[*core.ModuleSource],
+) (core.ModuleRuntime, error) {
+	return &runtime{
+		deps:      deps,
+		modSource: source,
+	}, nil
+}
+
+// runtime is a native Dang runtime that doesn't use containers
+type runtime struct {
+	deps      *core.SchemaBuilder
+	modSource dagql.ObjectResult[*core.ModuleSource]
+}
+
+func (r *runtime) AsContainer() (dagql.ObjectResult[*core.Container], bool) {
+	// Dang runtime doesn't use containers
+	return dagql.ObjectResult[*core.Container]{}, false
+}
+
+func (r *runtime) Call(
+	ctx context.Context,
+	_ *engineutil.ExecutionMetadata,
+	fnCall *core.FunctionCall,
+	moduleContext dagql.ObjectResult[*core.Module],
+	envContext dagql.ObjectResult[*core.Env],
+) (rerr error) {
+	defer func() {
+		if rerr != nil {
+			rerr = dangshared.ConvertError(rerr)
+		}
+	}()
+
+	clientMetadata, nestedClientMetadata, err := dangshared.NewNestedClientMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return fmt.Errorf("current query: %w", err)
+	}
+	schemaJSONFile, err := r.deps.SchemaIntrospectionJSONFileForModule(ctx)
+	if err != nil {
+		return fmt.Errorf("get schema introspection: %w", err)
+	}
+	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, fnCall, moduleContext, envContext)
+	if err != nil {
+		return err
+	}
+	return fnCall.ReturnValue(ctx, core.JSON(outputBytes))
+}

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -1,33 +1,29 @@
-package sdk
+package dangv2
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net"
-	"net/http"
 	"path/filepath"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/dagger/dagger/core"
+	dangshared "github.com/dagger/dagger/core/sdk/dang/shared"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	telemetry "github.com/dagger/otel-go"
-	"github.com/vito/dang/pkg/dang"
-	"github.com/vito/dang/pkg/hm"
-	"github.com/vito/dang/pkg/introspection"
-	"github.com/vito/dang/pkg/ioctx"
-	"github.com/vito/dang/pkg/querybuilder"
-	"go.opentelemetry.io/otel/propagation"
+	"github.com/vito/dang/v2/pkg/dang"
+	"github.com/vito/dang/v2/pkg/hm"
+	"github.com/vito/dang/v2/pkg/introspection"
+	"github.com/vito/dang/v2/pkg/ioctx"
+	"github.com/vito/dang/v2/pkg/querybuilder"
 )
 
 type dangSourceRunner func(context.Context, string) (dang.ValueScope, error)
 
-func (r *DangRuntime) eval(
+func (r *runtime) eval(
 	ctx context.Context,
 	query *core.Query,
 	schemaFile dagql.Result[*core.File],
@@ -80,87 +76,44 @@ func evalDangSource(
 	runSource dangSourceRunner,
 	withEnv func(context.Context, dang.ValueScope) ([]byte, error),
 ) ([]byte, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, fmt.Errorf("listen: %w", err)
-	}
-	defer l.Close()
-
-	httpSrv := &http.Server{
-		ReadHeaderTimeout: 10 * time.Second,
-		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			telemetry.Propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
-			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, moduleContext, fnCall, envContext)
-		}),
-	}
-	defer func() {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer shutdownCancel()
-		_ = httpSrv.Shutdown(shutdownCtx)
-	}()
-
-	srvErrCh := make(chan error, 1)
-	go func() {
-		err := httpSrv.Serve(l)
-		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
-			srvErrCh <- err
-		}
-		close(srvErrCh)
-	}()
-
-	gqlClient := graphql.NewClient(fmt.Sprintf("http://%s/query", l.Addr()), nil)
-
-	var intro introspection.Response
-	f, err := schemaFile.Self().Open(ctx, dagql.ObjectResult[*core.File]{Result: schemaFile})
-	if err != nil {
-		return nil, fmt.Errorf("open schema file: %w", err)
-	}
-	defer f.Close()
-	if err := json.NewDecoder(f).Decode(&intro); err != nil {
-		return nil, fmt.Errorf("decode schema: %w", err)
-	}
-
-	ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
-		Name:       "Dagger",
-		Client:     gqlClient,
-		Schema:     intro.Schema,
-		AutoImport: true,
-	})
-
-	stdio := telemetry.SpanStdio(ctx, core.InstrumentationLibrary)
-	ctx = ioctx.StdoutToContext(ctx, stdio.Stdout)
-	ctx = ioctx.StderrToContext(ctx, stdio.Stderr)
-
-	modCtx := modSource.Self().ContextDirectory
-	var env dang.ValueScope
-	err = modCtx.Self().Mount(ctx, modCtx, func(path string) error {
-		modSrcDir := filepath.Join(path, modSource.Self().SourceSubpath)
-		env, err = runSource(ctx, modSrcDir)
+	return dangshared.WithNestedClientServer(ctx, query, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, fnCall, moduleContext, envContext, func(ctx context.Context, gqlClient graphql.Client) ([]byte, error) {
+		var intro introspection.Response
+		f, err := schemaFile.Self().Open(ctx, dagql.ObjectResult[*core.File]{Result: schemaFile})
 		if err != nil {
-			return fmt.Errorf("run dir: %w", err)
+			return nil, fmt.Errorf("open schema file: %w", err)
 		}
-		return nil
+		defer f.Close()
+		if err := json.NewDecoder(f).Decode(&intro); err != nil {
+			return nil, fmt.Errorf("decode schema: %w", err)
+		}
+
+		ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
+			Name:       "Dagger",
+			Client:     gqlClient,
+			Schema:     intro.Schema,
+			AutoImport: true,
+		})
+
+		stdio := telemetry.SpanStdio(ctx, core.InstrumentationLibrary)
+		ctx = ioctx.StdoutToContext(ctx, stdio.Stdout)
+		ctx = ioctx.StderrToContext(ctx, stdio.Stderr)
+
+		modCtx := modSource.Self().ContextDirectory
+		var env dang.ValueScope
+		err = modCtx.Self().Mount(ctx, modCtx, func(path string) error {
+			modSrcDir := filepath.Join(path, modSource.Self().SourceSubpath)
+			env, err = runSource(ctx, modSrcDir)
+			if err != nil {
+				return fmt.Errorf("run dir: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("mount source: %w", err)
+		}
+
+		return withEnv(ctx, env)
 	})
-	if err != nil {
-		return nil, fmt.Errorf("mount source: %w", err)
-	}
-
-	if err := checkDangServerError(srvErrCh); err != nil {
-		return nil, err
-	}
-
-	return withEnv(ctx, env)
-}
-
-func checkDangServerError(srvErrCh <-chan error) error {
-	select {
-	case serveErr, ok := <-srvErrCh:
-		if ok && serveErr != nil {
-			return fmt.Errorf("serve nested client: %w", serveErr)
-		}
-	default:
-	}
-	return nil
 }
 
 func runDangDirForModuleTypes(ctx context.Context, dirPath string) (dang.ValueScope, error) {

--- a/core/sdk/dang/v2/sdk.go
+++ b/core/sdk/dang/v2/sdk.go
@@ -1,0 +1,123 @@
+// Package dangv2 evaluates Dagger modules written against Dang v2
+// (github.com/vito/dang/v2: `.{ }` is dot-block application, `.{{ }}` is
+// selection).
+//
+// This is the LIVING implementation: new Dang SDK features land here only.
+// Older majors are frozen snapshots of this package; see
+// core/sdk/dang/README.md for the maintenance policy.
+package dangv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/core"
+	dangshared "github.com/dagger/dagger/core/sdk/dang/shared"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/vito/dang/v2/pkg/dang"
+)
+
+// Impl is the Dang v2 implementation behind the dang SDK's version dispatch.
+type Impl struct{}
+
+func (Impl) ModuleTypes(
+	ctx context.Context,
+	deps *core.SchemaBuilder,
+	src dagql.ObjectResult[*core.ModuleSource],
+	scopedMod dagql.ObjectResult[*core.Module],
+) (inst dagql.ObjectResult[*core.Module], rerr error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag for dang module sdk module types: %w", err)
+	}
+
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFileForModule(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get schema introspection json during dang module sdk module types: %w", err)
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("current query: %w", err)
+	}
+
+	clientMetadata, nestedClientMetadata, err := dangshared.NewNestedClientMetadata(ctx)
+	if err != nil {
+		return inst, err
+	}
+
+	runner := dangSourceRunner(func(ctx context.Context, modSrcDir string) (dang.ValueScope, error) {
+		return dang.RunDir(ctx, modSrcDir, false)
+	})
+	if src.Self().SDK.ExperimentalFeatureEnabled(core.ModuleSourceExperimentalFeatureSelfCalls) {
+		runner = runDangDirForModuleTypes
+	}
+
+	_, err = evalDangSource(ctx, query, src, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, nil, scopedMod, dagql.ObjectResult[*core.Env]{}, runner, func(ctx context.Context, env dang.ValueScope) ([]byte, error) {
+		inst, err = initDangModule(ctx, dag, env)
+		if err != nil {
+			return nil, fmt.Errorf("init module: %w", err)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return inst, err
+	}
+	return inst, nil
+}
+
+func (Impl) Runtime(
+	ctx context.Context,
+	deps *core.SchemaBuilder,
+	source dagql.ObjectResult[*core.ModuleSource],
+) (core.ModuleRuntime, error) {
+	return &runtime{
+		deps:      deps,
+		modSource: source,
+	}, nil
+}
+
+// runtime is a native Dang runtime that doesn't use containers
+type runtime struct {
+	deps      *core.SchemaBuilder
+	modSource dagql.ObjectResult[*core.ModuleSource]
+}
+
+func (r *runtime) AsContainer() (dagql.ObjectResult[*core.Container], bool) {
+	// Dang runtime doesn't use containers
+	return dagql.ObjectResult[*core.Container]{}, false
+}
+
+func (r *runtime) Call(
+	ctx context.Context,
+	_ *engineutil.ExecutionMetadata,
+	fnCall *core.FunctionCall,
+	moduleContext dagql.ObjectResult[*core.Module],
+	envContext dagql.ObjectResult[*core.Env],
+) (rerr error) {
+	defer func() {
+		if rerr != nil {
+			rerr = dangshared.ConvertError(rerr)
+		}
+	}()
+
+	clientMetadata, nestedClientMetadata, err := dangshared.NewNestedClientMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return fmt.Errorf("current query: %w", err)
+	}
+	schemaJSONFile, err := r.deps.SchemaIntrospectionJSONFileForModule(ctx)
+	if err != nil {
+		return fmt.Errorf("get schema introspection: %w", err)
+	}
+	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, fnCall, moduleContext, envContext)
+	if err != nil {
+		return err
+	}
+	return fnCall.ReturnValue(ctx, core.JSON(outputBytes))
+}

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -2,24 +2,51 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"slices"
-	"sort"
 
 	"github.com/dagger/dagger/core"
+	dangv1 "github.com/dagger/dagger/core/sdk/dang/v1"
+	dangv2 "github.com/dagger/dagger/core/sdk/dang/v2"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
-	"github.com/dagger/dagger/engine/engineutil"
-	"github.com/dagger/dagger/internal/buildkit/identity"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-	"github.com/vito/dang/pkg/dang"
 )
 
 type dangSDK struct {
 	root      *core.Query
 	rawConfig map[string]any
+}
+
+// dangImpl is implemented by each supported Dang major version
+// (core/sdk/dang/v1, v2, ...). Unlike core.ModuleTypes, ModuleTypes takes
+// already-scoped values: the scoping helpers are unexported in this package
+// and the version packages can't import it (cycle), so the dispatcher scopes
+// before delegating.
+type dangImpl interface {
+	ModuleTypes(
+		ctx context.Context,
+		deps *core.SchemaBuilder,
+		scopedSrc dagql.ObjectResult[*core.ModuleSource],
+		scopedMod dagql.ObjectResult[*core.Module],
+	) (dagql.ObjectResult[*core.Module], error)
+
+	Runtime(
+		ctx context.Context,
+		deps *core.SchemaBuilder,
+		source dagql.ObjectResult[*core.ModuleSource],
+	) (core.ModuleRuntime, error)
+}
+
+// dangImplFor picks the Dang major version matching the module's engine
+// version: modules pinned before a major's gate keep the semantics they were
+// written against. Newest-first ladder; adding a future major is one case.
+func dangImplFor(src *core.ModuleSource) dangImpl {
+	if engine.CheckVersionCompatibility(
+		engine.BaseVersion(engine.NormalizeVersion(src.EngineVersion)),
+		engine.MinimumDangV2ModuleVersion,
+	) {
+		return dangv2.Impl{}
+	}
+	return dangv1.Impl{}
 }
 
 func (sdk *dangSDK) AsRuntime() (core.Runtime, bool) {
@@ -74,10 +101,7 @@ func (sdk *dangSDK) Runtime(
 	deps *core.SchemaBuilder,
 	source dagql.ObjectResult[*core.ModuleSource],
 ) (core.ModuleRuntime, error) {
-	return &DangRuntime{
-		deps:      deps,
-		modSource: source,
-	}, nil
+	return dangImplFor(source.Self()).Runtime(ctx, deps, source)
 }
 
 func (sdk *dangSDK) ModuleTypes(
@@ -101,123 +125,5 @@ func (sdk *dangSDK) ModuleTypes(
 		return inst, fmt.Errorf("failed to scope module for dang module sdk module types: %w", err)
 	}
 
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFileForModule(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get schema introspection json during dang module sdk module types: %w", err)
-	}
-
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("current query: %w", err)
-	}
-
-	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx)
-	if err != nil {
-		return inst, err
-	}
-
-	runner := dangSourceRunner(func(ctx context.Context, modSrcDir string) (dang.ValueScope, error) {
-		return dang.RunDir(ctx, modSrcDir, false)
-	})
-	if src.Self().SDK.ExperimentalFeatureEnabled(core.ModuleSourceExperimentalFeatureSelfCalls) {
-		runner = runDangDirForModuleTypes
-	}
-
-	_, err = evalDangSource(ctx, query, src, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, nil, scopedMod, dagql.ObjectResult[*core.Env]{}, runner, func(ctx context.Context, env dang.ValueScope) ([]byte, error) {
-		inst, err = initDangModule(ctx, dag, env)
-		if err != nil {
-			return nil, fmt.Errorf("init module: %w", err)
-		}
-		return nil, nil
-	})
-	if err != nil {
-		return inst, err
-	}
-	return inst, nil
-}
-
-func newDangNestedClientMetadata(ctx context.Context) (*engine.ClientMetadata, *engine.ClientMetadata, error) {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	nestedClientMetadata := &engine.ClientMetadata{
-		ClientID:          identity.NewID(),
-		ClientSecretToken: identity.NewID(),
-		SessionID:         clientMetadata.SessionID,
-		ClientStableID:    identity.NewID(),
-		ClientVersion:     engine.Version,
-		AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
-		LockMode:          clientMetadata.LockMode,
-	}
-
-	return clientMetadata, nestedClientMetadata, nil
-}
-
-// DangRuntime is a native Dang runtime that doesn't use containers
-type DangRuntime struct {
-	deps      *core.SchemaBuilder
-	modSource dagql.ObjectResult[*core.ModuleSource]
-}
-
-func (r *DangRuntime) AsContainer() (dagql.ObjectResult[*core.Container], bool) {
-	// Dang runtime doesn't use containers
-	return dagql.ObjectResult[*core.Container]{}, false
-}
-
-func (r *DangRuntime) Call(
-	ctx context.Context,
-	_ *engineutil.ExecutionMetadata,
-	fnCall *core.FunctionCall,
-	moduleContext dagql.ObjectResult[*core.Module],
-	envContext dagql.ObjectResult[*core.Env],
-) (rerr error) {
-	defer func() {
-		if rerr != nil {
-			rerr = convertError(rerr)
-		}
-	}()
-
-	clientMetadata, nestedClientMetadata, err := newDangNestedClientMetadata(ctx)
-	if err != nil {
-		return err
-	}
-
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return fmt.Errorf("current query: %w", err)
-	}
-	schemaJSONFile, err := r.deps.SchemaIntrospectionJSONFileForModule(ctx)
-	if err != nil {
-		return fmt.Errorf("get schema introspection: %w", err)
-	}
-	outputBytes, err := r.eval(ctx, query, schemaJSONFile, nestedClientMetadata, clientMetadata.ClientID, true, fnCall, moduleContext, envContext)
-	if err != nil {
-		return err
-	}
-	return fnCall.ReturnValue(ctx, core.JSON(outputBytes))
-}
-
-func convertError(rerr error) *core.Error {
-	var gqlErr *gqlerror.Error
-	if errors.As(rerr, &gqlErr) {
-		dagErr := core.NewError(gqlErr.Message)
-		if gqlErr.Extensions != nil {
-			keys := make([]string, 0, len(gqlErr.Extensions))
-			for k := range gqlErr.Extensions {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				val, err := json.Marshal(gqlErr.Extensions[k])
-				if err != nil {
-					fmt.Println("failed to marshal error value:", err)
-				}
-				dagErr = dagErr.WithValue(k, core.JSON(val))
-			}
-		}
-		return dagErr
-	}
-	return core.NewError(rerr.Error())
+	return dangImplFor(src.Self()).ModuleTypes(ctx, deps, src, scopedMod)
 }

--- a/engine/version.go
+++ b/engine/version.go
@@ -47,6 +47,11 @@ var (
 	// MinimumDefaultFunctionCachingModuleVersion is the minimum module version at which
 	// we will enable default function caching behavior.
 	MinimumDefaultFunctionCachingModuleVersion = "v0.19.4"
+
+	// MinimumDangV2ModuleVersion is the minimum module engine version that gets
+	// Dang v2 semantics (`.{ }` is dot-block application, `.{{ }}` is
+	// selection); older modules keep Dang v1 semantics (`.{ }` is selection).
+	MinimumDangV2ModuleVersion = "v0.21.5"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/urfave/cli v1.22.17
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
-	github.com/vito/dang v0.0.0-20260603200027-0175bae9eb8f
+	github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/urfave/cli v1.22.17
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
-	github.com/vito/dang v1.0.0
+	github.com/vito/dang v1.0.1
 	github.com/vito/dang/v2 v2.0.0
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,8 @@ require (
 	github.com/urfave/cli v1.22.17
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
-	github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711
+	github.com/vito/dang v1.0.0
+	github.com/vito/dang/v2 v2.0.0
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc95IyCAdU4rZAwOoKwMe6HQW/6M=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
-github.com/vito/dang v1.0.0 h1:6QchjCKMKs9Za3mRExUoD2d3v+QYa9Hv7+988CK4Wjw=
-github.com/vito/dang v1.0.0/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
+github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
+github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
 github.com/vito/dang/v2 v2.0.0 h1:izNyWGUHPg5+J2LgqKUKoE/xXTIFoeeLheHIe1M6SEc=
 github.com/vito/dang/v2 v2.0.0/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,10 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc95IyCAdU4rZAwOoKwMe6HQW/6M=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
-github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711 h1:CMZV9U0q34Z557KbeVDgU2AdlhAvQars8o5z82pNalA=
-github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
+github.com/vito/dang v1.0.0 h1:6QchjCKMKs9Za3mRExUoD2d3v+QYa9Hv7+988CK4Wjw=
+github.com/vito/dang v1.0.0/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
+github.com/vito/dang/v2 v2.0.0 h1:izNyWGUHPg5+J2LgqKUKoE/xXTIFoeeLheHIe1M6SEc=
+github.com/vito/dang/v2 v2.0.0/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc95IyCAdU4rZAwOoKwMe6HQW/6M=
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
-github.com/vito/dang v0.0.0-20260603200027-0175bae9eb8f h1:YBCCKf6bMdIJpO5psNFHoemMG3LkPOE6ZXaXDwmosC8=
-github.com/vito/dang v0.0.0-20260603200027-0175bae9eb8f/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
+github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711 h1:CMZV9U0q34Z557KbeVDgU2AdlhAvQars8o5z82pNalA=
+github.com/vito/dang v0.0.0-20260609154606-7b7d885fb711/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=


### PR DESCRIPTION
This started as a routine `vito/dang` bump, but the bump includes a breaking syntax change ([#101](https://github.com/vito/dang/pull/101)): `.{ }` changed from **object selection** to **dot-block application** (piping), with selection moving to `.{{ }}`. Both forms parse under either version with different meanings, so existing Dang modules would silently change behavior — there is no parse error to catch it.

Instead of breaking old modules, this PR introduces a **multi-version Dang runtime**: the engine now imports both `github.com/vito/dang` (v1, old semantics) and `github.com/vito/dang/v2` (new semantics) and routes each module by its `engineVersion`:

| Module `engineVersion` | Dang major | Semantics |
|---|---|---|
| `< v0.21.5` | v1 | `.{ }` is selection |
| `>= v0.21.5` | v2 | `.{ }` is dot-block application, `.{{ }}` is selection |

## How it works

- `core/sdk/dang_sdk.go` is now a thin dispatcher: `dangSDK` keeps all version-agnostic `core.SDK` behavior and picks a per-major implementation via a new `engine.MinimumDangV2ModuleVersion = "v0.21.5"` gate (same `CheckVersionCompatibility` pattern as the function-caching gate).
- `core/sdk/dang/v2/` is the **living** implementation (all feature work lands here), `core/sdk/dang/v1/` is a **frozen** snapshot — byte-identical except package clause, dang import paths, and doc comments. `core/sdk/dang/shared/` holds the dang-free plumbing (nested-client proxy server, client metadata, error conversion) so the per-major packages stay pure copies.
- This pattern is designed to repeat cheaply: new Dagger features always require a new `engineVersion`, which always routes to the newest major — so frozen majors never need feature work, only compiler-forced updates when engine internals change. When dang v3 ships, supporting it is: copy the living package, rewrite imports, add one constant, add one case to the dispatch ladder. The full recipe lives in `core/sdk/dang/README.md`.

## cgo gotcha

Linking both majors into one cgo-enabled binary collided on the tree-sitter C symbols (`tree_sitter_dang` + external scanner functions) — C symbols share a global namespace, so Go's module-major isolation doesn't help. Fixed upstream in dang **v1.0.1** by renaming the frozen line's symbols with a `_v1` suffix via `#define`s in the cgo preamble; the canonical names stay with v2 so editor integrations are unaffected. The engine binary itself was never affected (it builds with `CGO_ENABLED=0`; dang falls back to pure-Go paths) — only host-side test binaries hit it.

## Tests

- All dang testdata fixtures now pin `engineVersion: v0.21.5` so the main suite exercises the living v2 path (~40 of them previously had *no* engineVersion and would have silently routed to v1).
- New `TestDang/TestVersionedSyntax` proves the routing end-to-end: a `legacy-selection` module pinned to v0.20.6 using `.{ }` selection (v1), and a `dot-block` module at v0.21.5 using `.{ _ * 2 }` piping and `.{{ }}` selection (v2).
- Suites run against a dev engine: `TestDang` (32), `TestModule/TestBuiltinDang*` (9), `TestWorkspace`/`TestContextualWorkspace` (332), `TestUp` dang cases (5) — all green.

> [!NOTE]
> The in-repo Dang modules (`toolchains/*`, `cmd/codegen`, `modules/markdownlint`) are pinned to `v0.21.4` and will route to v1 until v0.21.5 ships (the released CLI rejects newer configs). They use no `.{ }` syntax, so behavior is identical; they should be bumped after the release.

## Upstream changes in this bump

From [`0175bae`](https://github.com/vito/dang/commit/0175bae9eb8f) (2026-06-03) to v1.0.1 / v2.0.0 (2026-06-09).

### Language

- [#92](https://github.com/vito/dang/pull/92) — `pub` keyword is now optional; bindings default to public
- [#100](https://github.com/vito/dang/pull/100) — postfix `!` non-null assertion operator
- [#101](https://github.com/vito/dang/pull/101) — dot-block application `.{ }`, object selection `.{{ }}`, and implicit `_` block parameter (**v2 only**; reverted on the v1 line)
- [#98](https://github.com/vito/dang/pull/98) — `Map` collection type
- [#104](https://github.com/vito/dang/pull/104) — `List.find`
- [#95](https://github.com/vito/dang/pull/95) — `regexp` `Match` is now a plain object with named captures
- [#99](https://github.com/vito/dang/pull/99) — reject operations on generic type params (fix)

### GraphQL / Dagger

- [#87](https://github.com/vito/dang/pull/87) — support plain GraphQL introspection
- [#97](https://github.com/vito/dang/pull/97) — support the new Dagger module config
- [#89](https://github.com/vito/dang/pull/89) — send arguments on nested selection fields (fix)
- [#90](https://github.com/vito/dang/pull/90) — point GraphQL errors at the failing field (fix)

### Docs

- [#93](https://github.com/vito/dang/pull/93) — auto-generate the stdlib reference
- [#94](https://github.com/vito/dang/pull/94) — runnable example REPL per stdlib entry
- [#88](https://github.com/vito/dang/pull/88) — interactive Dang WASM REPL component
- [#84](https://github.com/vito/dang/pull/84) — runnable client-side Dang playground on the front page
- [#86](https://github.com/vito/dang/pull/86) — GitHub GraphQL playground page
- [#96](https://github.com/vito/dang/pull/96) — theme code blocks via CSS for light mode
- [#91](https://github.com/vito/dang/pull/91) — repair broken Ctrl+K search (fix)
- [#85](https://github.com/vito/dang/pull/85) — restore blockquote paragraph spacing (fix)
- [#82](https://github.com/vito/dang/pull/82) — only show feedback button on prose (fix)
- [#83](https://github.com/vito/dang/pull/83) — trim low-value bullets from the overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
